### PR TITLE
docs: document CLI workflows and Nix builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ When available, write `data/fix-login/brief.md` before spawning; `hand spawn` re
 | `hand notify` | Send an out-of-band notification via a configured command | Specified; not yet implemented |
 | `hand update` | Update the installed binary | Specified; not yet implemented |
 
-Run `hand --help` or `hand <command> --help` for full details.
+Run `hand --help` for details on currently available commands.
 
 ## Architecture
 
@@ -96,7 +96,7 @@ From releases: download the binary for your platform from the [releases page](ht
 
 ## Configuration
 
-Local preferences live as plain files under `config/`: default worker harness, model, effort, notification command, and watcher timings.
+Currently supported preferences live as plain files under `config/`: default worker harness, model, and effort.
 Run `hand init --setup` to discover installed harnesses and tools and write the defaults interactively.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Talk to one agent. Ship with a crew.
 Secondhand is a single Go CLI binary, `hand`, that orchestrates a fleet of coding agents across projects.
 A supervisory agent runs in the secondhand directory, records tasks in a markdown backlog, and calls `hand` to spawn autonomous workers into isolated git worktrees.
 The CLI owns lifecycle correctness, state management, and process supervision.
-It was born from firstmate, an agent fleet supervisor built as 34K lines of shell, and rebuilds that concept as a clean CLI.
+It was born from [firstmate](https://github.com/kunchenguid/firstmate), an agent fleet supervisor built as 34K lines of shell, and rebuilds that concept as a clean CLI.
 
 ## Quick start
 
@@ -69,8 +69,8 @@ flowchart TD
 ## Requirements
 
 - Go 1.26.5 or newer (build only)
-- [herdr](https://github.com/yes2games/herdr) - terminal multiplexer with semantic agent state
-- [treehouse](https://github.com/yes2games/treehouse) - git worktree pool manager
+- [herdr](https://github.com/ogulcancelik/herdr) - terminal multiplexer with semantic agent state
+- [treehouse](https://github.com/kunchenguid/treehouse) - git worktree pool manager
 - `gh` - GitHub CLI, used for PR operations
 
 Optional:

--- a/README.md
+++ b/README.md
@@ -53,27 +53,17 @@ Run `hand --help` or `hand <command> --help` for full details.
 
 ## Architecture
 
-```
-              user
-                |  chat: requests, decisions, "merge it"
-                v
-    +---------------------------+
-    | supervisory agent         |
-    | reads AGENTS.md + data/   |
-    | edits data/backlog.md     |
-    | calls `hand` commands     |
-    +--+----------+----------+--+
-       |          |          |
-       v          v          v
-    [task-1]   [task-2]   [task-N]    herdr tabs
-    [worker]   [worker]   [worker]    one autonomous agent each
-       |          |          |
-       v          v          v
-    treehouse worktrees (isolated git checkouts)
-       |
-       +-- ship: branch -> PR -> merge -> teardown
-       |
-       +-- scout: investigate -> report.md -> teardown
+```mermaid
+flowchart TD
+    user[User] -->|"requests, decisions, merge it"| supervisor["Supervisory agent<br/>reads AGENTS.md and data/<br/>edits data/backlog.md<br/>calls hand commands"]
+    supervisor --> task1["Task 1 worker<br/>herdr tab"]
+    supervisor --> task2["Task 2 worker<br/>herdr tab"]
+    supervisor --> taskN["Task N worker<br/>herdr tab"]
+    task1 --> worktrees["Treehouse worktrees<br/>isolated git checkouts"]
+    task2 --> worktrees
+    taskN --> worktrees
+    worktrees --> ship["Ship: branch to PR to merge to teardown"]
+    worktrees --> scout["Scout: investigate to report.md to teardown"]
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ make build
 ```
 
 The remaining lifecycle commands, including `hand spawn`, are specified but not yet implemented.
-When available, write `data/fix-login/brief.md` before spawning; `hand spawn` refuses to start a worker without a brief.
 
 ## Core concepts
 
@@ -71,12 +70,12 @@ flowchart TD
 - Go 1.26.5 or newer (build only)
 - [herdr](https://github.com/ogulcancelik/herdr) - terminal multiplexer with semantic agent state
 - [treehouse](https://github.com/kunchenguid/treehouse) - git worktree pool manager
-- `gh` - GitHub CLI, used for PR operations
+- [gh](https://github.com/cli/cli) - GitHub CLI, used for PR operations
 
 Optional:
 
 - [no-mistakes](https://github.com/yes2games/no-mistakes) - validation pipeline for projects in `no-mistakes` mode
-- `qmd` - search over historical task data
+- [qmd](https://github.com/tobi/qmd) - search over historical task data
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ cd secondhand
 make build
 ./hand init --setup
 ./hand project add https://github.com/org/repo
-./hand spawn fix-login repo
 ```
 
-Write `data/fix-login/brief.md` before spawning; `hand spawn` refuses to start a worker without a brief.
+The remaining lifecycle commands, including `hand spawn`, are specified but not yet implemented.
+When available, write `data/fix-login/brief.md` before spawning; `hand spawn` refuses to start a worker without a brief.
 
 ## Core concepts
 
@@ -39,7 +39,7 @@ Write `data/fix-login/brief.md` before spawning; `hand spawn` refuses to start a
 | `hand project list` | List registered projects |
 | `hand project remove` | Unregister a project, keeping its clone |
 | `hand project sync` | Fast-forward project clones to their remote default branch |
-| `hand spawn` | Spawn a worker agent in an isolated worktree |
+| `hand spawn` | Spawn a worker agent in an isolated worktree (specified; not yet implemented) |
 | `hand status` | Show fleet overview or single-task detail |
 | `hand send` | Send a message to a running worker |
 | `hand watch` | Blocking watcher that prints actionable fleet events |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It was born from firstmate, an agent fleet supervisor built as 34K lines of shel
 ## Quick start
 
 ```sh
-git clone https://github.com/yes2games/secondhand
+git clone https://github.com/atqamz/secondhand
 cd secondhand
 make build
 ./hand init --setup
@@ -47,6 +47,7 @@ When available, write `data/fix-login/brief.md` before spawning; `hand spawn` re
 | `hand teardown` | Clean up a completed task, fail-closed on unlanded work |
 | `hand promote` | Promote a completed scout task into a ship task |
 | `hand notify` | Send an out-of-band notification via a configured command |
+| `hand update` | Update the installed binary (specified; not yet implemented) |
 
 Run `hand --help` or `hand <command> --help` for full details.
 
@@ -101,7 +102,7 @@ From nix:
 nix build
 ```
 
-From releases: download the binary for your platform from the [releases page](https://github.com/yes2games/secondhand/releases).
+From releases: download the binary for your platform from the [releases page](https://github.com/atqamz/secondhand/releases).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ From source:
 make build
 ```
 
+Set `VERSION` to embed a release version in the binary:
+
+```sh
+make build VERSION=0.1.0
+```
+
 From nix:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,59 +2,116 @@
 
 Talk to one agent. Ship with a crew.
 
-Secondhand is a Go CLI for orchestrating coding agents.
-The binary is named `hand`.
+Secondhand is a single Go CLI binary, `hand`, that orchestrates a fleet of coding agents across projects.
+A supervisory agent runs in the secondhand directory, records tasks in a markdown backlog, and calls `hand` to spawn autonomous workers into isolated git worktrees.
+The CLI owns lifecycle correctness, state management, and process supervision.
+It was born from firstmate, an agent fleet supervisor built as 34K lines of shell, and rebuilds that concept as a clean CLI.
 
-## Status
+## Quick start
 
-The repository currently provides runtime initialization and project registry commands.
+```sh
+git clone https://github.com/yes2games/secondhand
+cd secondhand
+make build
+./hand init --setup
+./hand project add https://github.com/org/repo
+./hand spawn fix-login repo
+```
+
+Write `data/fix-login/brief.md` before spawning; `hand spawn` refuses to start a worker without a brief.
+
+## Core concepts
+
+- **Projects**: git repositories cloned under `projects/` and registered in `data/projects.md`. Each has a delivery mode: `no-mistakes`, `direct-pr`, or `local-only`.
+- **Tasks**: units of work identified by a unique ID. Ship tasks produce a branch and PR; scout tasks investigate and produce `data/<id>/report.md`.
+- **Briefs**: task instructions at `data/<id>/brief.md`, written by the supervisory agent before spawning a worker.
+- **herdr tabs**: each worker runs in its own herdr tab. herdr provides semantic agent state (working/idle/done/blocked) and push events, so no terminal scraping.
+- **treehouse worktrees**: workers operate in isolated git checkouts acquired from a treehouse pool, never in the project clone itself.
+- **Dashboard**: `data/dashboard.md` is the living fleet overview, auto-maintained by `hand`. The agent reads it for context; the user watches it for visibility.
+- **Backlog**: `data/backlog.md` is a plain markdown task queue, read and edited directly by the supervisory agent.
+
+## CLI overview
+
+| Command | Description |
+| --- | --- |
+| `hand init` | Initialize runtime directories and skeleton files; `--setup` runs interactive first-time configuration |
+| `hand project add` | Clone and register a repository |
+| `hand project list` | List registered projects |
+| `hand project remove` | Unregister a project, keeping its clone |
+| `hand project sync` | Fast-forward project clones to their remote default branch |
+| `hand spawn` | Spawn a worker agent in an isolated worktree |
+| `hand status` | Show fleet overview or single-task detail |
+| `hand send` | Send a message to a running worker |
+| `hand watch` | Blocking watcher that prints actionable fleet events |
+| `hand merge` | Merge a task's completed work |
+| `hand teardown` | Clean up a completed task, fail-closed on unlanded work |
+| `hand promote` | Promote a completed scout task into a ship task |
+| `hand notify` | Send an out-of-band notification via a configured command |
+
+Run `hand --help` or `hand <command> --help` for full details.
+
+## Architecture
+
+```
+              user
+                |  chat: requests, decisions, "merge it"
+                v
+    +---------------------------+
+    | supervisory agent         |
+    | reads AGENTS.md + data/   |
+    | edits data/backlog.md     |
+    | calls `hand` commands     |
+    +--+----------+----------+--+
+       |          |          |
+       v          v          v
+    [task-1]   [task-2]   [task-N]    herdr tabs
+    [worker]   [worker]   [worker]    one autonomous agent each
+       |          |          |
+       v          v          v
+    treehouse worktrees (isolated git checkouts)
+       |
+       +-- ship: branch -> PR -> merge -> teardown
+       |
+       +-- scout: investigate -> report.md -> teardown
+```
 
 ## Requirements
 
-- Go 1.26.5 or newer
+- Go 1.26.5 or newer (build only)
+- [herdr](https://github.com/yes2games/herdr) - terminal multiplexer with semantic agent state
+- [treehouse](https://github.com/yes2games/treehouse) - git worktree pool manager
+- `gh` - GitHub CLI, used for PR operations
 
-## Build
+Optional:
+
+- [no-mistakes](https://github.com/yes2games/no-mistakes) - validation pipeline for projects in `no-mistakes` mode
+- `qmd` - search over historical task data
+
+## Installation
+
+From source:
 
 ```sh
 make build
 ```
 
-Run the binary:
+From nix:
 
 ```sh
-./hand --help
-./hand --version
-./hand init
-./hand init --setup
-./hand project add https://github.com/org/repo
-./hand project list
-./hand project remove repo
+nix build
 ```
 
-`hand init` creates the `state/`, `data/`, `projects/`, and `config/` runtime directories,
-plus skeleton backlog, project registry, and dashboard files.
-The command is idempotent and accepts an optional target path.
+From releases: download the binary for your platform from the [releases page](https://github.com/yes2games/secondhand/releases).
 
-`hand init --setup` discovers supported harnesses and tools on `PATH`, then interactively
-selects the default worker harness, model, and effort and writes them under `config/`.
-`hand project add` clones and registers a repository, `hand project list` displays the
-registry (use `--json` for JSON), and `hand project remove` unregisters a project without
-deleting its clone.
+## Configuration
 
-The build embeds the version supplied through `VERSION`:
+Local preferences live as plain files under `config/`: default worker harness, model, effort, notification command, and watcher timings.
+Run `hand init --setup` to discover installed harnesses and tools and write the defaults interactively.
 
-```sh
-make build VERSION=0.1.0
-```
+## Contributing
 
-## Development
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-```sh
-make test
-make lint
-make e2e
-```
+## License
 
-The E2E target is reserved for the future integration suite.
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution guidelines.
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -53,17 +53,27 @@ Run `hand --help` or `hand <command> --help` for full details.
 
 ## Architecture
 
-```mermaid
-flowchart TD
-    user[User] -->|requests, decisions, merge it| supervisor[Supervisory agent<br/>reads AGENTS.md and data/<br/>edits data/backlog.md<br/>calls hand commands]
-    supervisor --> task1[Task 1 worker<br/>herdr tab]
-    supervisor --> task2[Task 2 worker<br/>herdr tab]
-    supervisor --> taskN[Task N worker<br/>herdr tab]
-    task1 --> worktrees[Treehouse worktrees<br/>isolated git checkouts]
-    task2 --> worktrees
-    taskN --> worktrees
-    worktrees --> ship[Ship: branch -> PR -> merge -> teardown]
-    worktrees --> scout[Scout: investigate -> report.md -> teardown]
+```
+              user
+                |  chat: requests, decisions, "merge it"
+                v
+    +---------------------------+
+    | supervisory agent         |
+    | reads AGENTS.md + data/   |
+    | edits data/backlog.md     |
+    | calls `hand` commands     |
+    +--+----------+----------+--+
+       |          |          |
+       v          v          v
+    [task-1]   [task-2]   [task-N]    herdr tabs
+    [worker]   [worker]   [worker]    one autonomous agent each
+       |          |          |
+       v          v          v
+    treehouse worktrees (isolated git checkouts)
+       |
+       +-- ship: branch -> PR -> merge -> teardown
+       |
+       +-- scout: investigate -> report.md -> teardown
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -32,48 +32,38 @@ When available, write `data/fix-login/brief.md` before spawning; `hand spawn` re
 
 ## CLI overview
 
-| Command | Description |
-| --- | --- |
-| `hand init` | Initialize runtime directories and skeleton files; `--setup` runs interactive first-time configuration |
-| `hand project add` | Clone and register a repository |
-| `hand project list` | List registered projects |
-| `hand project remove` | Unregister a project, keeping its clone |
-| `hand project sync` | Fast-forward project clones to their remote default branch |
-| `hand spawn` | Spawn a worker agent in an isolated worktree (specified; not yet implemented) |
-| `hand status` | Show fleet overview or single-task detail |
-| `hand send` | Send a message to a running worker |
-| `hand watch` | Blocking watcher that prints actionable fleet events |
-| `hand merge` | Merge a task's completed work |
-| `hand teardown` | Clean up a completed task, fail-closed on unlanded work |
-| `hand promote` | Promote a completed scout task into a ship task |
-| `hand notify` | Send an out-of-band notification via a configured command |
-| `hand update` | Update the installed binary (specified; not yet implemented) |
+| Command | Description | Status |
+| --- | --- | --- |
+| `hand init` | Initialize runtime directories and skeleton files; `--setup` runs interactive first-time configuration | Available |
+| `hand project add` | Clone and register a repository | Available |
+| `hand project list` | List registered projects | Available |
+| `hand project remove` | Unregister a project, keeping its clone | Available |
+| `hand project sync` | Fast-forward project clones to their remote default branch | Specified; not yet implemented |
+| `hand spawn` | Spawn a worker agent in an isolated worktree | Specified; not yet implemented |
+| `hand status` | Show fleet overview or single-task detail | Specified; not yet implemented |
+| `hand send` | Send a message to a running worker | Specified; not yet implemented |
+| `hand watch` | Blocking watcher that prints actionable fleet events | Specified; not yet implemented |
+| `hand merge` | Merge a task's completed work | Specified; not yet implemented |
+| `hand teardown` | Clean up a completed task, fail-closed on unlanded work | Specified; not yet implemented |
+| `hand promote` | Promote a completed scout task into a ship task | Specified; not yet implemented |
+| `hand notify` | Send an out-of-band notification via a configured command | Specified; not yet implemented |
+| `hand update` | Update the installed binary | Specified; not yet implemented |
 
 Run `hand --help` or `hand <command> --help` for full details.
 
 ## Architecture
 
-```
-              user
-                |  chat: requests, decisions, "merge it"
-                v
-    +---------------------------+
-    | supervisory agent         |
-    | reads AGENTS.md + data/   |
-    | edits data/backlog.md     |
-    | calls `hand` commands     |
-    +--+----------+----------+--+
-       |          |          |
-       v          v          v
-    [task-1]   [task-2]   [task-N]    herdr tabs
-    [worker]   [worker]   [worker]    one autonomous agent each
-       |          |          |
-       v          v          v
-    treehouse worktrees (isolated git checkouts)
-       |
-       +-- ship: branch -> PR -> merge -> teardown
-       |
-       +-- scout: investigate -> report.md -> teardown
+```mermaid
+flowchart TD
+    user[User] -->|requests, decisions, merge it| supervisor[Supervisory agent<br/>reads AGENTS.md and data/<br/>edits data/backlog.md<br/>calls hand commands]
+    supervisor --> task1[Task 1 worker<br/>herdr tab]
+    supervisor --> task2[Task 2 worker<br/>herdr tab]
+    supervisor --> taskN[Task N worker<br/>herdr tab]
+    task1 --> worktrees[Treehouse worktrees<br/>isolated git checkouts]
+    task2 --> worktrees
+    taskN --> worktrees
+    worktrees --> ship[Ship: branch -> PR -> merge -> teardown]
+    worktrees --> scout[Scout: investigate -> report.md -> teardown]
 ```
 
 ## Requirements

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
             pname = "secondhand";
             inherit version;
             src = ./.;
-            vendorHash = null; # update after first go mod tidy
+            vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
             ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
           };
         }


### PR DESCRIPTION
## Intent

README for secondhand, now addressing captain PR review feedback on PR 4: (1) link gh to github.com/cli/cli, (2) remove the confusing 'When available, write data/fix-login/brief.md...' line from quick start (captain asked what it was; briefs are already covered in Core concepts), (3) link qmd to github.com/tobi/qmd, (4) architecture diagram must stay a mermaid flowchart per explicit user instruction 'for any diagram, use mermaid format' - do not revert to the ASCII diagram from SPECS.md. All prior decisions stand: repo links to atqamz/secondhand, herdr links to ogulcancelik/herdr, treehouse to kunchenguid/treehouse, firstmate mention links to kunchenguid/firstmate, CLI table marks unimplemented commands, under 200 lines, no emojis, only README.md touched (plus pipeline's own flake fixes already on branch).

## What Changed
- Reworked README with quick start, core concepts, CLI command status, architecture, requirements, installation, configuration, and contribution details.
- Added links for required and optional tooling and documented `VERSION` overrides and Nix builds.
- Set the Go vendoring hash in `flake.nix` so the documented Nix build path is reproducible.

## Risk Assessment

✅ Low: Changes are limited to README documentation and a previously corrected Nix vendoring hash; no material correctness or behavioral risks found.

## Testing

Nix package build, Go unit/race tests, placeholder E2E tests, CLI quick-start path, structural README checks, and rendered HTML evidence all succeeded. Initial Go commands inherited `GOFLAGS=-mod=vendor`; clearing that environment setting resolved the repository vendoring mismatch without source changes.

<details>
<summary>Evidence: Rendered README HTML</summary>

```text
<h1 id="secondhand">Secondhand</h1>
<p>Talk to one agent. Ship with a crew.</p>
<p>Secondhand is a single Go CLI binary, <code>hand</code>, that
orchestrates a fleet of coding agents across projects. A supervisory
agent runs in the secondhand directory, records tasks in a markdown
backlog, and calls <code>hand</code> to spawn autonomous workers into
isolated git worktrees. The CLI owns lifecycle correctness, state
management, and process supervision. It was born from <a
href="https://github.com/kunchenguid/firstmate">firstmate</a>, an agent
fleet supervisor built as 34K lines of shell, and rebuilds that concept
as a clean CLI.</p>
<h2 id="quick-start">Quick start</h2>
<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> clone https://github.com/atqamz/secondhand</span>
<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> secondhand</span>
<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="fu">make</span> build</span>
<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="ex">./hand</span> init <span class="at">--setup</span></span>
<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="ex">./hand</span> project add https://github.com/org/repo</span></code></pre></div>
<p>The remaining lifecycle commands, including <code>hand spawn</code>,
are specified but not yet implemented.</p>
<h2 id="core-concepts">Core concepts</h2>
<ul>
<li><strong>Projects</strong>: git repositories cloned under
<code>projects/</code> and registered in <code>data/projects.md</code>.
Each has a delivery mode: <code>no-mistakes</code>,
<code>direct-pr</code>, or <code>local-only</code>.</li>
<li><strong>Tasks</strong>: units of work identified by a unique ID.
Ship tasks produce a branch and PR; scout tasks investigate and produce
<code>data/&lt;id&gt;/report.md</code>.</li>
<li><strong>Briefs</strong>: task instructions at
<code>data/&lt;id&gt;/brief.md</code>, written by the supervisory agent
before spawning a worker.</li>
<li><strong>herdr tabs</strong>: each worker runs in its own herdr tab.
herdr provides semantic agent state (working/idle/done/blocked) and push
events, so no terminal scraping.</li>
<li><strong>treehouse worktrees</strong>: workers operate in isolated
git checkouts acquired from a treehouse pool, never in the project clone
itself.</li>
<li><strong>Dashboard</strong>: <code>data/dashboard.md</code> is the
living fleet overview, auto-maintained by <code>hand</code>. The agent
reads it for context; the user watches it for visibility.</li>
<li><strong>Backlog</strong>: <code>data/backlog.md</code> is a plain
markdown task queue, read and edited directly by the supervisory
agent.</li>
</ul>
<h2 id="cli-overview">CLI overview</h2>
<table>
<thead>
<tr>
<th>Command</th>
<th>Description</th>
<th>Status</th>
</tr>
</thead>
<tbody>
<tr>
<td><code>hand init</code></td>
<td>Initialize runtime directories and skeleton files;
<code>--setup</code> runs interactive first-time configuration</td>
<td>Available</td>
</tr>
<tr>
<td><code>hand project add</code></td>
<td>Clone and register a repository</td>
<td>Available</td>
</tr>
<tr>
<td><code>hand project list</code></td>
<td>List registered projects</td>
<td>Available</td>
</tr>
<tr>
<td><code>hand project remove</code></td>
<td>Unregister a project, keeping its clone</td>
<td>Available</td>
</tr>
<tr>
<td><code>hand project sync</code></td>
<td>Fast-forward project clones to their remote default branch</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand spawn</code></td>
<td>Spawn a worker agent in an isolated worktree</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand status</code></td>
<td>Show fleet overview or single-task detail</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand send</code></td>
<td>Send a message to a running worker</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand watch</code></td>
<td>Blocking watcher that prints actionable fleet events</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand merge</code></td>
<td>Merge a task's completed work</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand teardown</code></td>
<td>Clean up a completed task, fail-closed on unlanded work</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand promote</code></td>
<td>Promote a completed scout task into a ship task</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand notify</code></td>
<td>Send an out-of-band notification via a configured command</td>
<td>Specified; not yet implemented</td>
</tr>
<tr>
<td><code>hand update</code></td>
<td>Update the installed binary</td>
<td>Specified; not yet implemented</td>
</tr>
</tbody>
</table>
<p>Run <code>hand --help</code> for details on currently available
commands.</p>
<h2 id="architecture">Architecture</h2>
<pre class="mermaid"><code>flowchart TD
    user[User] --&gt;|&quot;requests, decisions, merge it&quot;| supervisor[&quot;Supervisory agent&lt;br/&gt;reads AGENTS.md and data/&lt;br/&gt;edits data/backlog.md&lt;br/&gt;calls hand commands&quot;]
    supervisor --&gt; task1[&quot;Task 1 worker&lt;br/&gt;herdr tab&quot;]
    supervisor --&gt; task2[&quot;Task 2 worker&lt;br/&gt;herdr tab&quot;]
    supervisor --&gt; taskN[&quot;Task N worker&lt;br/&gt;herdr tab&quot;]
    task1 --&gt; worktrees[&quot;Treehouse worktrees&lt;br/&gt;isolated git checkouts&quot;]
    task2 --&gt; worktrees
    taskN --&gt; worktrees
    worktrees --&gt; ship[&quot;Ship: branch to PR to merge to teardown&quot;]
    worktrees --&gt; scout[&quot;Scout: investigate to report.md to teardown&quot;]</code></pre>
<h2 id="requirements">Requirements</h2>
<ul>
<li>Go 1.26.5 or newer (build only)</li>
<li><a href="https://github.com/ogulcancelik/herdr">herdr</a> - terminal
multiplexer with semantic agent state</li>
<li><a href="https://github.com/kunchenguid/treehouse">treehouse</a> -
git worktree pool manager</li>
<li><a href="https://github.com/cli/cli">gh</a> - GitHub CLI, used for
PR operations</li>
</ul>
<p>Optional:</p>
<ul>
<li><a href="https://github.com/yes2games/no-mistakes">no-mistakes</a> -
validation pipeline for projects in <code>no-mistakes</code> mode</li>
<li><a href="https://github.com/tobi/qmd">qmd</a> - search over
historical task data</li>
</ul>
<h2 id="installation">Installation</h2>
<p>From source:</p>
<div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="fu">make</span> build</span></code></pre></div>
<p>From nix:</p>
<div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">nix</span> build</span></code></pre></div>
<p>From releases: download the binary for your platform from the <a
href="https://github.com/atqamz/secondhand/releases">releases
page</a>.</p>
<h2 id="configuration">Configuration</h2>
<p>Currently supported preferences live as plain files under
<code>config/</code>: default worker harness, model, and effort. Run
<code>hand init --setup</code> to discover installed harnesses and tools
and write the defaults interactively.</p>
<h2 id="contributing">Contributing</h2>
<p>See <a href="CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
<h2 id="license">License</h2>
<p><a href="LICENSE">MIT</a></p>
```
</details>
<details>
<summary>Evidence: CLI end-to-end transcript</summary>

```text
$ hand --help
Talk to one agent. Ship with a crew.

Usage:
  hand [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  init        Initialize secondhand runtime directories
  project     Manage the project registry

Flags:
  -h, --help      help for hand
  -v, --version   version for hand

Use "hand [command] --help" for more information about a command.

$ hand init
initialized secondhand home at /tmp/no-mistakes-evidence/01KYAM19GDXNVB21GP74F1RFMN/runtime

$ hand project list
```
</details>
<details>
<summary>Evidence: README intent checks</summary>

```text
README structural checks
line_count_lt_200: PASS
gh_link: PASS
qmd_link: PASS
herdr_link: PASS
treehouse_link: PASS
firstmate_link: PASS
mermaid_diagram: PASS
quick_start_brief_line_absent: PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAM19GDXNVB21GP74F1RFMN/flake.lock:1` - `flake.lock` is an empty file, so the newly documented `nix build` path fails when Nix tries to parse the lock file. Generate a valid lock file with the nixpkgs input, or remove this empty lock file.

🔧 Fix: Remove invalid empty flake lockfile
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix build --accept-flake-config --no-link`
- `nix develop --accept-flake-config --command env GOFLAGS= go test -race ./...`
- `nix develop --accept-flake-config --command env GOFLAGS= go test -tags=e2e -timeout=10m ./tests/e2e/...`
- <code>Built `hand`, then ran `hand --help`, `hand init`, and `hand project list` in an isolated runtime.</code>
- `Ran README link, Mermaid, line-count, and quick-start brief checks.`
- `Rendered README.md to HTML with Pandoc.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
