### PR TITLE
feat(cmd): add task lifecycle commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,10 @@ hand
 hand.exe
 
 # runtime (created by hand init in workspace)
-state/
-data/
-projects/
-config/
+/state/
+/data/
+/projects/
+/config/
 
 # Go
 coverage.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Run `hand --help` for the full command reference.
 - For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.
 - Use `qmd search` to find historical context in data/ when available. Fall back to reading files directly.
 - Zero comments by default. Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug. Never restate code, narrate what, add banners, or docstring the obvious.
-- `SPECS.md`'s herdr CLI call templates and claude/opencode harness launch templates are known to be wrong (checked against each tool's `--help`). `internal/herdr/client.go` and `internal/harness/harness.go` are the verified source of truth for that syntax; re-verify against `--help` before trusting SPECS.md for those two areas.
+- `internal/herdr/client.go` and `internal/harness/harness.go` are the source of truth for herdr and verified Claude/OpenCode syntax. Codex, Grok, and Pi templates in `SPECS.md` remain unverified until those binaries are available.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Run `hand --help` for the full command reference.
 - For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.
 - Use `qmd search` to find historical context in data/ when available. Fall back to reading files directly.
 - Zero comments by default. Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug. Never restate code, narrate what, add banners, or docstring the obvious.
+- `SPECS.md`'s herdr CLI call templates and claude/opencode harness launch templates are known to be wrong (checked against each tool's `--help`). `internal/herdr/client.go` and `internal/harness/harness.go` are the verified source of truth for that syntax; re-verify against `--help` before trusting SPECS.md for those two areas.
 
 ## Maintaining this file
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make build
 ./hand project add https://github.com/org/repo
 ```
 
-The remaining lifecycle commands, including `hand spawn`, are specified but not yet implemented.
+The worker lifecycle commands are available, including `hand spawn`, `hand status`, `hand send`, and `hand teardown`.
 
 ## Core concepts
 
@@ -38,12 +38,12 @@ The remaining lifecycle commands, including `hand spawn`, are specified but not 
 | `hand project list` | List registered projects | Available |
 | `hand project remove` | Unregister a project, keeping its clone | Available |
 | `hand project sync` | Fast-forward project clones to their remote default branch | Specified; not yet implemented |
-| `hand spawn` | Spawn a worker agent in an isolated worktree | Specified; not yet implemented |
-| `hand status` | Show fleet overview or single-task detail | Specified; not yet implemented |
-| `hand send` | Send a message to a running worker | Specified; not yet implemented |
+| `hand spawn` | Spawn a worker agent in an isolated worktree | Available |
+| `hand status` | Show fleet overview or single-task detail | Available |
+| `hand send` | Send a message to a running worker | Available |
 | `hand watch` | Blocking watcher that prints actionable fleet events | Specified; not yet implemented |
 | `hand merge` | Merge a task's completed work | Specified; not yet implemented |
-| `hand teardown` | Clean up a completed task, fail-closed on unlanded work | Specified; not yet implemented |
+| `hand teardown` | Clean up a completed task, fail-closed on unlanded work | Available |
 | `hand promote` | Promote a completed scout task into a ship task | Specified; not yet implemented |
 | `hand notify` | Send an out-of-band notification via a configured command | Specified; not yet implemented |
 | `hand update` | Update the installed binary | Specified; not yet implemented |

--- a/SPECS.md
+++ b/SPECS.md
@@ -759,10 +759,11 @@ Each supported harness has a launch command template.
 ### Claude Code
 
 ```sh
-cd <worktree> && claude --print "<brief-path>"
+cd <worktree> && claude --print "Read the brief at <brief-path> and carry out the task it describes."
 ```
 
-The `--print` flag (or equivalent) feeds the brief as the initial prompt.
+The brief path is included in the prompt because `--print` accepts prompt text, not a file path.
+When configured, `--model <name>` and `--effort <level>` are inserted before the prompt.
 
 ### Codex
 
@@ -785,13 +786,15 @@ cd <worktree> && pi "<brief-path>"
 ### OpenCode
 
 ```sh
-cd <worktree> && opencode
+cd <worktree> && opencode run --file "<brief-path>" "Follow the attached brief and complete the task."
 ```
 
-OpenCode reads project instructions automatically; the brief path is included in the project's AGENTS.md or passed via its input mechanism.
+OpenCode runs headlessly through `opencode run`; `--model <name>` and `--variant <effort>` are
+inserted when configured.
 
-Note: exact flags and mechanisms need verification per harness version.
-The harness module should be the single place that constructs these commands, with version-aware flag selection.
+The Claude and OpenCode forms above were verified against the installed CLI versions.
+Codex, Grok, and Pi retain the literal templates above until those binaries are verified.
+The harness module is the single place that constructs these commands.
 
 ## Herdr integration detail
 
@@ -830,34 +833,38 @@ herdr tracks agent state per pane:
 ### Herdr CLI calls
 
 ```sh
-# create workspace
-herdr workspace create --label <project-name>
+# list workspaces
+herdr workspace list
+
+# create workspace without focusing it
+herdr workspace create --no-focus --cwd <project-clone-path> --label <project-name>
 
 # create tab in workspace
-herdr tab create --workspace <ws-id> --label <task-id>
+herdr tab create --workspace <ws-id> --no-focus --cwd <worktree> --label <task-id>
 
-# get pane for tab
-herdr pane list --tab <tab-id>
+# list tabs in workspace
+herdr tab list --workspace <ws-id>
 
-# get agent state
-herdr agent get --pane <pane-id>
-# returns: { "status": "working" | "idle" | "done" | "blocked" }
+# get pane and agent state
+herdr pane get <pane-id>
+# returns agent_status: "working" | "idle" | "done" | "blocked"
 
-# send text to pane
-herdr pane send-keys --pane <pane-id> -- <text> Enter
+# run a command in pane
+herdr pane run <pane-id> <command>
+
+# send text and submit it
+herdr pane send-text <pane-id> <text>
+herdr pane send-keys <pane-id> Enter
 
 # close tab
-herdr tab close --tab <tab-id>
+herdr tab close <tab-id>
 
 # close workspace (if empty)
-herdr workspace close --workspace <ws-id>
-
-# subscribe to events (if available)
-herdr events --pane <pane-id> --filter agent_status_changed
+herdr workspace close <ws-id>
 ```
 
-Note: exact CLI syntax needs verification against the installed herdr version.
-The herdr client module should abstract these into Go function calls and handle version differences internally.
+These calls and the JSON response envelope were verified against the installed herdr version.
+The herdr client abstracts them into Go function calls and validates required response fields.
 
 ## No-mistakes integration
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,10 @@ func newRootCmd(version string) *cobra.Command {
 	root.SetVersionTemplate("{{.Version}}\n")
 	root.AddCommand(newInitCmd())
 	root.AddCommand(newProjectCmd())
+	root.AddCommand(newSpawnCmd())
+	root.AddCommand(newStatusCmd())
+	root.AddCommand(newSendCmd())
+	root.AddCommand(newTeardownCmd())
 	return root
 }
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/state"
+	"github.com/spf13/cobra"
+)
+
+const sendComposerTimeout = 10 * time.Second
+
+func newSendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send <id> <message>",
+		Short: "Send a text message to a running worker's herdr pane",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			message := args[1]
+
+			home, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+
+			t, err := state.Read(home, id)
+			if err != nil {
+				return err
+			}
+
+			client := herdr.NewClient()
+			pane, err := client.PaneGet(t.Herdr.PaneID)
+			if err != nil {
+				return fmt.Errorf("herdr pane %s not found: %w", t.Herdr.PaneID, err)
+			}
+
+			if pane.AgentStatus == herdr.StatusWorking {
+				if err := client.WaitComposerEmpty(t.Herdr.PaneID, sendComposerTimeout); err != nil {
+					return err
+				}
+			}
+
+			if err := client.PaneSendText(t.Herdr.PaneID, message); err != nil {
+				return fmt.Errorf("send message failed: %w", err)
+			}
+			if err := client.PaneSendKeys(t.Herdr.PaneID, "Enter"); err != nil {
+				return fmt.Errorf("submit message failed: %w", err)
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "sent to %s\n", id); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+func setupSendHome(t *testing.T, herdrScript string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Chdir(home)
+
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return home
+}
+
+func TestSendHappyPathWhenIdle(t *testing.T) {
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
+	;;
+"pane send-text")
+	true
+	;;
+"pane send-keys")
+	true
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello worker"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendFailsWhenPaneNotFound(t *testing.T) {
+	home := setupSendHome(t, `#!/bin/sh
+printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
+exit 1
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:gone"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got err %v, want pane not found", err)
+	}
+}
+
+func TestSendWaitsWhileBusyThenSends(t *testing.T) {
+	counterFile := filepath.Join(t.TempDir(), "calls")
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	n=0
+	if [ -f "`+counterFile+`" ]; then n=$(cat "`+counterFile+`"); fi
+	n=$((n+1))
+	echo "$n" > "`+counterFile+`"
+	if [ "$n" -lt 2 ]; then
+		printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'
+	else
+		printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
+	fi
+	;;
+"pane send-text")
+	true
+	;;
+"pane send-keys")
+	true
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendFailsForUnknownTask(t *testing.T) {
+	setupSendHome(t, "#!/bin/sh\nexit 1\n")
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"missing-task", "hello"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got err %v, want not found", err)
+	}
+}

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -30,10 +30,10 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
 	;;
 "pane send-text")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 "pane send-keys")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 *)
 	echo "unexpected herdr args: $@" >&2
@@ -85,10 +85,10 @@ case "$cmd" in
 	fi
 	;;
 "pane send-text")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 "pane send-keys")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 *)
 	echo "unexpected herdr args: $@" >&2

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,17 +80,14 @@ func newSpawnCmd() *cobra.Command {
 			}
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
-				_ = worktree.Return(wt, true)
-				return fmt.Errorf("lock worktree %q: %w", wt, err)
+				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
 			}
 			defer releaseWorktree()
 
 			if conflict, err := worktree.CheckCollision(home, wt, id); err != nil {
-				_ = worktree.Return(wt, true)
-				return err
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			} else if conflict != "" {
-				_ = worktree.Return(wt, true)
-				return fmt.Errorf("worktree collision: %s already holds %s", conflict, wt)
+				return reportSpawnCleanup(fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), worktree.Return(wt, true))
 			}
 
 			client := herdr.NewClient()
@@ -100,17 +98,16 @@ func newSpawnCmd() *cobra.Command {
 				createdWorkspace = err == nil
 			}
 			if err != nil {
-				_ = worktree.Return(wt, true)
-				return fmt.Errorf("herdr workspace lookup/create failed: %w", err)
+				return reportSpawnCleanup(fmt.Errorf("herdr workspace lookup/create failed: %w", err), worktree.Return(wt, true))
 			}
 
 			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
 			if err != nil {
+				cleanupErrs := []error{worktree.Return(wt, true)}
 				if createdWorkspace {
-					_ = client.WorkspaceClose(ws.WorkspaceID)
+					cleanupErrs = append(cleanupErrs, client.WorkspaceClose(ws.WorkspaceID))
 				}
-				_ = worktree.Return(wt, true)
-				return fmt.Errorf("herdr tab create failed: %w", err)
+				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), cleanupErrs...)
 			}
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
@@ -120,15 +117,11 @@ func newSpawnCmd() *cobra.Command {
 				Effort:   effort,
 			})
 			if err != nil {
-				_ = closeTaskTab(client, ws.WorkspaceID, tab.TabID)
-				_ = worktree.Return(wt, true)
-				return err
+				return reportSpawnCleanup(err, closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
 			}
 
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				_ = closeTaskTab(client, ws.WorkspaceID, tab.TabID)
-				_ = worktree.Return(wt, true)
-				return fmt.Errorf("send launch command failed: %w", err)
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
 			}
 
 			kind := state.KindShip
@@ -154,17 +147,7 @@ func newSpawnCmd() *cobra.Command {
 				CreatedAt: time.Now().UTC().Format(time.RFC3339),
 			}
 			if err := state.Write(home, task); err != nil {
-				cleanupErrs := []string{}
-				if err := closeTaskTab(client, ws.WorkspaceID, tab.TabID); err != nil {
-					cleanupErrs = append(cleanupErrs, fmt.Sprintf("close herdr tab: %v", err))
-				}
-				if err := worktree.Return(wt, true); err != nil {
-					cleanupErrs = append(cleanupErrs, fmt.Sprintf("return worktree: %v", err))
-				}
-				if len(cleanupErrs) > 0 {
-					return fmt.Errorf("write task state: %w; cleanup failed: %s", err, strings.Join(cleanupErrs, "; "))
-				}
-				return fmt.Errorf("write task state: %w", err)
+				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
 			}
 
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "spawned %s project=%s kind=%s harness=%s worktree=%s\n", id, proj.Name, kind, harnessName, wt); err != nil {
@@ -179,6 +162,14 @@ func newSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
 	return cmd
+}
+
+func reportSpawnCleanup(cause error, cleanupErrs ...error) error {
+	cleanupErr := errors.Join(cleanupErrs...)
+	if cleanupErr == nil {
+		return cause
+	}
+	return fmt.Errorf("%w; cleanup failed: %w", cause, cleanupErr)
 }
 
 func configDefault(home, name, fallback string) string {

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -143,7 +143,7 @@ func newSpawnCmd() *cobra.Command {
 			}
 			if err := state.Write(home, task); err != nil {
 				cleanupErrs := []string{}
-				if err := client.TabClose(tab.TabID); err != nil {
+				if err := closeTaskTab(client, ws.WorkspaceID, tab.TabID); err != nil {
 					cleanupErrs = append(cleanupErrs, fmt.Sprintf("close herdr tab: %v", err))
 				}
 				if err := worktree.Return(wt, true); err != nil {

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/harness"
@@ -14,6 +15,8 @@ import (
 	"github.com/atqamz/secondhand/internal/worktree"
 	"github.com/spf13/cobra"
 )
+
+var workspaceCreateMu sync.Mutex
 
 func newSpawnCmd() *cobra.Command {
 	var scout bool
@@ -82,21 +85,24 @@ func newSpawnCmd() *cobra.Command {
 			}
 
 			client := herdr.NewClient()
+			workspaceCreateMu.Lock()
 			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
+			createdWorkspace := false
+			if err == nil && !found {
+				ws, err = client.WorkspaceCreate(clonePath, proj.Name)
+				createdWorkspace = err == nil
+			}
+			workspaceCreateMu.Unlock()
 			if err != nil {
 				_ = worktree.Return(wt, true)
-				return fmt.Errorf("herdr workspace lookup failed: %w", err)
-			}
-			if !found {
-				ws, err = client.WorkspaceCreate(clonePath, proj.Name)
-				if err != nil {
-					_ = worktree.Return(wt, true)
-					return fmt.Errorf("herdr workspace create failed: %w", err)
-				}
+				return fmt.Errorf("herdr workspace lookup/create failed: %w", err)
 			}
 
 			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
 			if err != nil {
+				if createdWorkspace {
+					_ = client.WorkspaceClose(ws.WorkspaceID)
+				}
 				_ = worktree.Return(wt, true)
 				return fmt.Errorf("herdr tab create failed: %w", err)
 			}
@@ -108,13 +114,13 @@ func newSpawnCmd() *cobra.Command {
 				Effort:   effort,
 			})
 			if err != nil {
-				_ = client.TabClose(tab.TabID)
+				_ = closeTaskTab(client, ws.WorkspaceID, tab.TabID)
 				_ = worktree.Return(wt, true)
 				return err
 			}
 
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				_ = client.TabClose(tab.TabID)
+				_ = closeTaskTab(client, ws.WorkspaceID, tab.TabID)
 				_ = worktree.Return(wt, true)
 				return fmt.Errorf("send launch command failed: %w", err)
 			}

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/harness"
@@ -15,8 +14,6 @@ import (
 	"github.com/atqamz/secondhand/internal/worktree"
 	"github.com/spf13/cobra"
 )
-
-var workspaceCreateMu sync.Mutex
 
 func newSpawnCmd() *cobra.Command {
 	var scout bool
@@ -69,12 +66,23 @@ func newSpawnCmd() *cobra.Command {
 			if effort == "" {
 				effort = configDefault(home, "effort", "")
 			}
+			releaseProject, err := state.Lock(home, "project:"+proj.Name)
+			if err != nil {
+				return fmt.Errorf("lock project %q: %w", proj.Name, err)
+			}
+			defer releaseProject()
 
 			clonePath := filepath.Join(home, "projects", proj.Name)
 			wt, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
 			}
+			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
+			if err != nil {
+				_ = worktree.Return(wt, true)
+				return fmt.Errorf("lock worktree %q: %w", wt, err)
+			}
+			defer releaseWorktree()
 
 			if conflict, err := worktree.CheckCollision(home, wt, id); err != nil {
 				_ = worktree.Return(wt, true)
@@ -85,14 +93,12 @@ func newSpawnCmd() *cobra.Command {
 			}
 
 			client := herdr.NewClient()
-			workspaceCreateMu.Lock()
 			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
 			createdWorkspace := false
 			if err == nil && !found {
 				ws, err = client.WorkspaceCreate(clonePath, proj.Name)
 				createdWorkspace = err == nil
 			}
-			workspaceCreateMu.Unlock()
 			if err != nil {
 				_ = worktree.Return(wt, true)
 				return fmt.Errorf("herdr workspace lookup/create failed: %w", err)

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/secondhand/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+func newSpawnCmd() *cobra.Command {
+	var scout bool
+	var harnessName string
+	var model string
+	var effort string
+
+	cmd := &cobra.Command{
+		Use:   "spawn <id> <project>",
+		Short: "Spawn a worker agent in an isolated worktree",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			projectName := args[1]
+
+			home, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+
+			proj, exists, err := project.Find(home, projectName)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return fmt.Errorf("project %q not registered", projectName)
+			}
+
+			if active, err := state.Exists(home, id); err != nil {
+				return err
+			} else if active {
+				return fmt.Errorf("task %q already active", id)
+			}
+
+			briefRel := filepath.Join("data", id, "brief.md")
+			briefAbs := filepath.Join(home, briefRel)
+			if _, err := os.Stat(briefAbs); err != nil {
+				return fmt.Errorf("brief not found at %s", briefRel)
+			}
+
+			if harnessName == "" {
+				harnessName = configDefault(home, "harness", "claude")
+			}
+			if !harness.IsSupported(harnessName) {
+				return fmt.Errorf("harness %q not recognized", harnessName)
+			}
+			if model == "" {
+				model = configDefault(home, "model", "")
+			}
+			if effort == "" {
+				effort = configDefault(home, "effort", "")
+			}
+
+			clonePath := filepath.Join(home, "projects", proj.Name)
+			wt, err := worktree.Get(clonePath, "hand:"+id)
+			if err != nil {
+				return fmt.Errorf("acquire treehouse worktree: %w", err)
+			}
+
+			if conflict, err := worktree.CheckCollision(home, wt, id); err != nil {
+				_ = worktree.Return(wt, true)
+				return err
+			} else if conflict != "" {
+				_ = worktree.Return(wt, true)
+				return fmt.Errorf("worktree collision: %s already holds %s", conflict, wt)
+			}
+
+			client := herdr.NewClient()
+			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
+			if err != nil {
+				_ = worktree.Return(wt, true)
+				return fmt.Errorf("herdr workspace lookup failed: %w", err)
+			}
+			if !found {
+				ws, err = client.WorkspaceCreate(clonePath, proj.Name)
+				if err != nil {
+					_ = worktree.Return(wt, true)
+					return fmt.Errorf("herdr workspace create failed: %w", err)
+				}
+			}
+
+			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
+			if err != nil {
+				_ = worktree.Return(wt, true)
+				return fmt.Errorf("herdr tab create failed: %w", err)
+			}
+
+			launchCmd, err := harness.Build(harnessName, harness.Options{
+				Worktree: wt,
+				Brief:    briefAbs,
+				Model:    model,
+				Effort:   effort,
+			})
+			if err != nil {
+				_ = client.TabClose(tab.TabID)
+				_ = worktree.Return(wt, true)
+				return err
+			}
+
+			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
+				_ = client.TabClose(tab.TabID)
+				_ = worktree.Return(wt, true)
+				return fmt.Errorf("send launch command failed: %w", err)
+			}
+
+			kind := state.KindShip
+			if scout {
+				kind = state.KindScout
+			}
+
+			task := state.Task{
+				ID:       id,
+				Project:  proj.Name,
+				Kind:     kind,
+				Harness:  harnessName,
+				Model:    model,
+				Effort:   effort,
+				Worktree: wt,
+				Brief:    briefRel,
+				Herdr: state.Herdr{
+					Session:     "default",
+					WorkspaceID: ws.WorkspaceID,
+					TabID:       tab.TabID,
+					PaneID:      pane.PaneID,
+				},
+				CreatedAt: time.Now().UTC().Format(time.RFC3339),
+			}
+			if err := state.Write(home, task); err != nil {
+				return fmt.Errorf("write task state: %w", err)
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "spawned %s project=%s kind=%s harness=%s worktree=%s\n", id, proj.Name, kind, harnessName, wt); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&scout, "scout", false, "mark as scout task (deliverable is a report, not a PR)")
+	cmd.Flags().StringVar(&harnessName, "harness", "", "agent harness to launch (default: config/harness, or claude)")
+	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
+	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
+	return cmd
+}
+
+func configDefault(home, name, fallback string) string {
+	data, err := os.ReadFile(filepath.Join(home, "config", name))
+	if err != nil {
+		return fallback
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -42,11 +42,11 @@ func newSpawnCmd() *cobra.Command {
 				return fmt.Errorf("project %q not registered", projectName)
 			}
 
-			if active, err := state.Exists(home, id); err != nil {
+			releaseClaim, err := state.Claim(home, id)
+			if err != nil {
 				return err
-			} else if active {
-				return fmt.Errorf("task %q already active", id)
 			}
+			defer releaseClaim()
 
 			briefRel := filepath.Join("data", id, "brief.md")
 			briefAbs := filepath.Join(home, briefRel)
@@ -142,6 +142,16 @@ func newSpawnCmd() *cobra.Command {
 				CreatedAt: time.Now().UTC().Format(time.RFC3339),
 			}
 			if err := state.Write(home, task); err != nil {
+				cleanupErrs := []string{}
+				if err := client.TabClose(tab.TabID); err != nil {
+					cleanupErrs = append(cleanupErrs, fmt.Sprintf("close herdr tab: %v", err))
+				}
+				if err := worktree.Return(wt, true); err != nil {
+					cleanupErrs = append(cleanupErrs, fmt.Sprintf("return worktree: %v", err))
+				}
+				if len(cleanupErrs) > 0 {
+					return fmt.Errorf("write task state: %w; cleanup failed: %s", err, strings.Join(cleanupErrs, "; "))
+				}
 				return fmt.Errorf("write task state: %w", err)
 			}
 

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,22 @@ import (
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 )
+
+func TestSpawnCleanupReportsAllErrors(t *testing.T) {
+	cause := errors.New("spawn failed")
+	cleanup := errors.New("cleanup failed")
+
+	err := reportSpawnCleanup(cause, cleanup)
+	if !errors.Is(err, cause) {
+		t.Fatalf("error %v does not preserve cause", err)
+	}
+	if !errors.Is(err, cleanup) {
+		t.Fatalf("error %v does not preserve cleanup failure", err)
+	}
+	if !strings.Contains(err.Error(), "cleanup failed") {
+		t.Fatalf("error %v does not report cleanup failure", err)
+	}
+}
 
 const fakeHerdrSpawnScript = `#!/bin/sh
 cmd="$1 $2"

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -20,7 +20,7 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
 	;;
 "pane run")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 *)
 	echo "unexpected herdr args: $@" >&2

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+const fakeHerdrSpawnScript = `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"workspace list")
+	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":1}]}}'
+	;;
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+	;;
+"pane run")
+	true
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func setupSpawnHome(t *testing.T, worktreePath string) string {
+	t.Helper()
+	home := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "myproj", URL: "https://example.com/myproj.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "brief.md"), []byte("do the thing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(fakeHerdrSpawnScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	treehouseScript := "#!/bin/sh\nprintf '{\"path\":\"" + worktreePath + "\"}'\n"
+	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(treehouseScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Chdir(home)
+	return home
+}
+
+func TestSpawnHappyPath(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Project != "myproj" || got.Kind != state.KindShip || got.Harness != "claude" {
+		t.Fatalf("got %+v", got)
+	}
+	if got.Worktree != wt {
+		t.Fatalf("got worktree %q, want %q", got.Worktree, wt)
+	}
+	if got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tB" || got.Herdr.PaneID != "wA:pC" {
+		t.Fatalf("got herdr %+v", got.Herdr)
+	}
+}
+
+func TestSpawnScoutFlag(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj", "--scout"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != state.KindScout {
+		t.Fatalf("got kind %q, want scout", got.Kind)
+	}
+}
+
+func TestSpawnRejectsUnregisteredProject(t *testing.T) {
+	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "unknown-proj"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("got err %v, want not registered", err)
+	}
+}
+
+func TestSpawnRejectsAlreadyActiveTask(t *testing.T) {
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+	if err := state.Write(home, state.Task{ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "already active") {
+		t.Fatalf("got err %v, want already active", err)
+	}
+}
+
+func TestSpawnRejectsMissingBrief(t *testing.T) {
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+	if err := os.Remove(filepath.Join(home, "data", "task-1", "brief.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "brief not found") {
+		t.Fatalf("got err %v, want brief not found", err)
+	}
+}
+
+func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
+	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj", "--harness", "nonexistent"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not recognized") {
+		t.Fatalf("got err %v, want not recognized", err)
+	}
+}
+
+func TestSpawnDetectsWorktreeCollision(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt)
+	if err := state.Write(home, state.Task{ID: "other-task", Worktree: wt}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "collision") {
+		t.Fatalf("got err %v, want collision", err)
+	}
+
+	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
+		t.Fatalf("state written after collision: exists=%v err=%v", exists, err)
+	}
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newStatusCmd() *cobra.Command {
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "status [id]",
+		Short: "Show fleet overview or single-task detail",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+			client := herdr.NewClient()
+
+			if len(args) == 1 {
+				return runStatusSingle(cmd, home, client, args[0], asJSON)
+			}
+			return runStatusFleet(cmd, home, client, asJSON)
+		},
+	}
+
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	return cmd
+}
+
+// paneAgentStatus degrades gracefully to "unknown" when herdr is unreachable or the
+// pane can't be queried, per SPECS.md's fail-open policy for read operations.
+func paneAgentStatus(client *herdr.Client, paneID string) string {
+	if paneID == "" {
+		return string(herdr.StatusUnknown)
+	}
+	pane, err := client.PaneGet(paneID)
+	if err != nil || pane.AgentStatus == "" {
+		return string(herdr.StatusUnknown)
+	}
+	return string(pane.AgentStatus)
+}
+
+type statusJSON struct {
+	ID         string      `json:"id"`
+	Project    string      `json:"project"`
+	Kind       string      `json:"kind"`
+	Harness    string      `json:"harness,omitempty"`
+	AgentState string      `json:"agent_state"`
+	Worktree   string      `json:"worktree"`
+	Herdr      state.Herdr `json:"herdr"`
+	PR         string      `json:"pr"`
+	CreatedAt  string      `json:"created_at"`
+}
+
+func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool) error {
+	tasks, err := state.List(home)
+	if err != nil {
+		return err
+	}
+
+	rows := make([]statusJSON, 0, len(tasks))
+	for _, t := range tasks {
+		rows = append(rows, statusJSON{
+			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
+			AgentState: paneAgentStatus(client, t.Herdr.PaneID),
+			Worktree:   t.Worktree, Herdr: t.Herdr, PR: t.PR, CreatedAt: t.CreatedAt,
+		})
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	}
+
+	w := cmd.OutOrStdout()
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(w, "%-16s%-12s%-8s%-12s%s\n", r.ID, r.Project, r.Kind, r.AgentState, formatAge(r.CreatedAt)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON bool) error {
+	t, err := state.Read(home, id)
+	if err != nil {
+		return err
+	}
+	agentState := paneAgentStatus(client, t.Herdr.PaneID)
+
+	if asJSON {
+		out := statusJSON{
+			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
+			AgentState: agentState, Worktree: t.Worktree, Herdr: t.Herdr, PR: t.PR, CreatedAt: t.CreatedAt,
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	pr := t.PR
+	if pr == "" {
+		pr = "(none)"
+	}
+
+	w := cmd.OutOrStdout()
+	lines := []string{
+		fmt.Sprintf("Task:       %s", t.ID),
+		fmt.Sprintf("Project:    %s", t.Project),
+		fmt.Sprintf("Kind:       %s", t.Kind),
+		fmt.Sprintf("Harness:    %s", t.Harness),
+		fmt.Sprintf("Model:      %s", t.Model),
+		fmt.Sprintf("State:      %s", agentState),
+		fmt.Sprintf("Worktree:   %s", t.Worktree),
+		fmt.Sprintf("Herdr:      %s / %s", t.Herdr.Session, t.Herdr.TabID),
+		fmt.Sprintf("Created:    %s", formatAge(t.CreatedAt)),
+		fmt.Sprintf("PR:         %s", pr),
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatAge(createdAt string) string {
+	t, err := time.Parse(time.RFC3339, createdAt)
+	if err != nil {
+		return "unknown"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+func writeFakeHerdrPaneStatus(t *testing.T, status string) {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\nprintf '{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"" + status + "\"}}}'\n"
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestStatusFleetListsAllTasks(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "working")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "task-1") || !strings.Contains(out.String(), "working") {
+		t.Fatalf("got %q, want task-1 and working", out.String())
+	}
+}
+
+func TestStatusFleetDegradesToUnknownWhenHerdrUnreachable(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	t.Setenv("PATH", t.TempDir())
+
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "unknown") {
+		t.Fatalf("got %q, want unknown", out.String())
+	}
+}
+
+func TestStatusSingleTaskDetail(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, Harness: "claude",
+		Herdr: state.Herdr{Session: "default", TabID: "wA:tB", PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Task:       task-1") || !strings.Contains(out.String(), "State:      idle") {
+		t.Fatalf("got %q", out.String())
+	}
+}
+
+func TestStatusSingleTaskJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "blocked")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"agent_state": "blocked"`) {
+		t.Fatalf("got %q, want agent_state blocked", out.String())
+	}
+}
+
+func TestStatusSingleTaskMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+
+	cmd := newStatusCmd()
+	cmd.SetArgs([]string{"missing-task"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got err %v, want not found", err)
+	}
+}

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/secondhand/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+func newTeardownCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "teardown <id>",
+		Short: "Clean up a completed task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			home, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+
+			t, err := state.Read(home, id)
+			if err != nil {
+				return err
+			}
+
+			if !force {
+				if err := checkLandedWork(home, t); err != nil {
+					return err
+				}
+			}
+
+			client := herdr.NewClient()
+			if err := closeTaskTab(client, t.Herdr.WorkspaceID, t.Herdr.TabID); err != nil {
+				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: herdr tab close failed: %v\n", err); printErr != nil {
+					return printErr
+				}
+			}
+
+			if err := worktree.Return(t.Worktree, force); err != nil {
+				return err
+			}
+
+			if err := state.Delete(home, id); err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "teardown %s complete\n", id); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "skip landed-work checks")
+	return cmd
+}
+
+func checkLandedWork(home string, t state.Task) error {
+	if t.Kind == state.KindScout {
+		reportPath := filepath.Join("data", t.ID, "report.md")
+		if _, err := os.Stat(filepath.Join(home, reportPath)); err != nil {
+			return fmt.Errorf("report not found at %s", reportPath)
+		}
+		return nil
+	}
+
+	dirty, err := hasUncommittedChanges(t.Worktree)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("uncommitted changes in worktree %s", t.Worktree)
+	}
+
+	if t.PR != "" {
+		merged, err := prIsMerged(t.PR)
+		if err != nil {
+			return err
+		}
+		if !merged {
+			return fmt.Errorf("PR %s is not merged", t.PR)
+		}
+		return nil
+	}
+
+	proj, exists, err := project.Find(home, t.Project)
+	if err != nil {
+		return err
+	}
+	if exists && proj.Mode == project.ModeLocalOnly {
+		merged, err := branchIsMerged(filepath.Join(home, "projects", t.Project), t.Worktree)
+		if err != nil {
+			return err
+		}
+		if !merged {
+			return fmt.Errorf("branch for %s is not merged into the default branch", t.ID)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("no PR recorded for %s and project is not local-only: work may not be landed", t.ID)
+}
+
+func hasUncommittedChanges(worktreePath string) (bool, error) {
+	c := exec.Command("git", "status", "--porcelain")
+	c.Dir = worktreePath
+	out, err := c.Output()
+	if err != nil {
+		return false, fmt.Errorf("git status failed: %w", err)
+	}
+	return len(strings.TrimSpace(string(out))) > 0, nil
+}
+
+func prIsMerged(pr string) (bool, error) {
+	out, err := exec.Command("gh", "pr", "view", pr, "--json", "state").CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("gh pr view failed: %s", strings.TrimSpace(string(out)))
+	}
+	var body struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		return false, fmt.Errorf("parse gh pr view output: %w", err)
+	}
+	return body.State == "MERGED", nil
+}
+
+func branchIsMerged(clonePath, worktreePath string) (bool, error) {
+	branch, err := currentBranch(worktreePath)
+	if err != nil {
+		return false, err
+	}
+
+	c := exec.Command("git", "branch", "--merged")
+	c.Dir = clonePath
+	out, err := c.Output()
+	if err != nil {
+		return false, fmt.Errorf("git branch --merged failed: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "*")) == branch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func currentBranch(worktreePath string) (string, error) {
+	c := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	c.Dir = worktreePath
+	out, err := c.Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse failed: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// closeTaskTab closes the task's tab, or the whole workspace if this was its last tab
+// (herdr refuses to close a workspace's only tab directly).
+func closeTaskTab(client *herdr.Client, workspaceID, tabID string) error {
+	tabs, err := client.TabList(workspaceID)
+	if err != nil {
+		return err
+	}
+	if len(tabs) <= 1 {
+		return client.WorkspaceClose(workspaceID)
+	}
+	return client.TabClose(tabID)
+}

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -47,6 +47,11 @@ func newTeardownCmd() *cobra.Command {
 					return err
 				}
 			}
+			releaseProject, err := state.Lock(home, "project:"+t.Project)
+			if err != nil {
+				return fmt.Errorf("lock project %q: %w", t.Project, err)
+			}
+			defer releaseProject()
 
 			client := herdr.NewClient()
 			if err := closeTaskTab(client, t.Herdr.WorkspaceID, t.Herdr.TabID); err != nil {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -158,18 +158,56 @@ func branchIsMerged(clonePath, worktreePath string) (bool, error) {
 		return false, err
 	}
 
-	c := exec.Command("git", "branch", "--merged")
+	defaultBranch, err := defaultBranch(clonePath)
+	if err != nil {
+		return false, err
+	}
+	c := exec.Command("git", "branch", "--merged", defaultBranch)
 	c.Dir = clonePath
 	out, err := c.Output()
 	if err != nil {
-		return false, fmt.Errorf("git branch --merged failed: %w", err)
+		return false, fmt.Errorf("git branch --merged %s failed: %w", defaultBranch, err)
 	}
 	for _, line := range strings.Split(string(out), "\n") {
-		if strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "*")) == branch {
+		line = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(line), "*+"))
+		if line == branch {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func defaultBranch(clonePath string) (string, error) {
+	c := exec.Command("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	c.Dir = clonePath
+	out, err := c.Output()
+	if err == nil {
+		branch := strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")
+		if branch != "" {
+			return branch, nil
+		}
+	}
+
+	c = exec.Command("git", "remote", "show", "origin")
+	c.Dir = clonePath
+	out, err = c.Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 3 && fields[0] == "HEAD" && fields[1] == "branch:" && fields[2] != "" {
+				return fields[2], nil
+			}
+		}
+	}
+
+	for _, branch := range []string{"main", "master"} {
+		c = exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+		c.Dir = clonePath
+		if err := c.Run(); err == nil {
+			return branch, nil
+		}
+	}
+	return "", fmt.Errorf("resolve default branch failed")
 }
 
 func currentBranch(worktreePath string) (string, error) {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -31,6 +31,11 @@ func newTeardownCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)
 			}
+			release, err := state.Lock(home, "task:"+id)
+			if err != nil {
+				return fmt.Errorf("lock task %q: %w", id, err)
+			}
+			defer release()
 
 			t, err := state.Read(home, id)
 			if err != nil {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,6 +15,8 @@ import (
 	"github.com/atqamz/secondhand/internal/worktree"
 	"github.com/spf13/cobra"
 )
+
+var errTaskTabNotFound = errors.New("task tab not found")
 
 func newTeardownCmd() *cobra.Command {
 	var force bool
@@ -42,6 +45,9 @@ func newTeardownCmd() *cobra.Command {
 
 			client := herdr.NewClient()
 			if err := closeTaskTab(client, t.Herdr.WorkspaceID, t.Herdr.TabID); err != nil {
+				if errors.Is(err, errTaskTabNotFound) {
+					return err
+				}
 				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: herdr tab close failed: %v\n", err); printErr != nil {
 					return printErr
 				}
@@ -173,7 +179,17 @@ func closeTaskTab(client *herdr.Client, workspaceID, tabID string) error {
 	if err != nil {
 		return err
 	}
-	if len(tabs) <= 1 {
+	found := false
+	for _, tab := range tabs {
+		if tab.TabID == tabID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("%w: herdr tab %s not found in workspace %s", errTaskTabNotFound, tabID, workspaceID)
+	}
+	if len(tabs) == 1 {
 		return client.WorkspaceClose(workspaceID)
 	}
 	return client.TabClose(tabID)

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	run := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		c.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com")
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v: %s", args, err, out)
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-q", "-m", "initial commit")
+}
+
+func writeFakeTreehouseReturn(t *testing.T) {
+	t.Helper()
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte("#!/bin/sh\ntrue\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"tab list")
+	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
+	;;
+"tab close")
+	true
+	;;
+"workspace close")
+	true
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func setupTeardownHome(t *testing.T) (home, worktree string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Chdir(home)
+	worktree = filepath.Join(t.TempDir(), "wt")
+	initGitRepo(t, worktree)
+	writeFakeTreehouseReturn(t)
+	return home, worktree
+}
+
+func TestTeardownShipFailsOnUncommittedChanges(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := os.WriteFile(filepath.Join(worktree, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Fatalf("got err %v, want uncommitted changes", err)
+	}
+}
+
+func TestTeardownShipFailsWhenPRNotMerged(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(`#!/bin/sh
+printf '{"state":"OPEN"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj", PR: "https://example.com/pr/1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not merged") {
+		t.Fatalf("got err %v, want not merged", err)
+	}
+}
+
+func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(`#!/bin/sh
+printf '{"state":"MERGED"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
+		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	}
+}
+
+func TestTeardownShipLocalOnlyFailsWhenBranchNotMerged(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	clonePath := filepath.Join(t.TempDir(), "clone")
+	initGitRepo(t, clonePath)
+
+	worktree := filepath.Join(t.TempDir(), "wt")
+	c := exec.Command("git", "clone", "-q", clonePath, worktree)
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git clone failed: %v: %s", err, out)
+	}
+	branch := exec.Command("git", "checkout", "-q", "-b", "task-1-branch")
+	branch.Dir = worktree
+	if out, err := branch.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout failed: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("wip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commit := exec.Command("git", "add", "feature.txt")
+	commit.Dir = worktree
+	if out, err := commit.CombinedOutput(); err != nil {
+		t.Fatalf("git add failed: %v: %s", err, out)
+	}
+	commitCmd := exec.Command("git", "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "-m", "wip")
+	commitCmd.Dir = worktree
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit failed: %v: %s", err, out)
+	}
+
+	writeFakeTreehouseReturn(t)
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "myproj", URL: "https://example.com/myproj.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(clonePath, filepath.Join(home, "projects", "myproj")); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not merged into the default branch") {
+		t.Fatalf("got err %v, want branch not merged", err)
+	}
+}
+
+func TestTeardownScoutFailsWhenReportMissing(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "report not found") {
+		t.Fatalf("got err %v, want report not found", err)
+	}
+}
+
+func TestTeardownScoutSucceedsWhenReportPresent(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := os.WriteFile(filepath.Join(worktree, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
+		t.Fatalf("state still exists after forced teardown: %v %v", exists, err)
+	}
+}
+
+func TestTeardownClosesWorkspaceWhenLastTab(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"tab list")
+	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
+	;;
+"workspace close")
+	true
+	;;
+"tab close")
+	echo "should not close a tab when it is the last one" >&2
+	exit 1
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -191,6 +191,42 @@ func TestTeardownShipLocalOnlyFailsWhenBranchNotMerged(t *testing.T) {
 	}
 }
 
+func TestBranchIsMergedUsesOriginDefaultBranch(t *testing.T) {
+	clonePath := filepath.Join(t.TempDir(), "clone")
+	initGitRepo(t, clonePath)
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v: %s", args, err, out)
+		}
+	}
+	runGit(clonePath, "branch", "release")
+	runGit(clonePath, "branch", "task-1")
+	runGit(clonePath, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runGit(clonePath, "update-ref", "refs/remotes/origin/main", "refs/heads/main")
+
+	worktreePath := filepath.Join(t.TempDir(), "worktree")
+	runGit(clonePath, "worktree", "add", "-q", worktreePath, "task-1")
+	if err := os.WriteFile(filepath.Join(worktreePath, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(worktreePath, "add", "feature.txt")
+	runGit(worktreePath, "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "-m", "feature")
+	runGit(clonePath, "merge", "--no-ff", "-q", "task-1", "-m", "merge task")
+	runGit(clonePath, "checkout", "-q", "release")
+
+	merged, err := branchIsMerged(clonePath, worktreePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !merged {
+		t.Fatal("task branch should be merged into origin default branch")
+	}
+}
+
 func TestTeardownScoutFailsWhenReportMissing(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree}); err != nil {

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/atqamz/secondhand/internal/herdr"
 	"github.com/atqamz/secondhand/internal/project"
@@ -240,6 +241,60 @@ func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
 	}
 	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
 		t.Fatalf("state still exists after forced teardown: %v %v", exists, err)
+	}
+}
+
+func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	marker := filepath.Join(t.TempDir(), "herdr-called")
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte("#!/bin/sh\ntouch '"+marker+"'\nprintf '{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\"}]}}'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	releaseProject, err := state.Lock(home, "project:myproj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			releaseProject()
+		}
+	}()
+
+	result := make(chan error, 1)
+	go func() {
+		cmd := newTeardownCmd()
+		cmd.SetArgs([]string{"task-1", "--force"})
+		result <- cmd.Execute()
+	}()
+
+	select {
+	case <-result:
+		t.Fatal("teardown completed while project lock was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("herdr invoked while project lock was held: %v", err)
+	}
+
+	releaseProject()
+	released = true
+	if err := <-result; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/secondhand/internal/herdr"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 )
@@ -47,10 +48,10 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
 	;;
 "tab close")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 "workspace close")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 *)
 	echo "unexpected herdr args: $@" >&2
@@ -252,7 +253,7 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
 	;;
 "workspace close")
-	true
+ printf '{"id":"cli:1","result":{}}'
 	;;
 "tab close")
 	echo "should not close a tab when it is the last one" >&2
@@ -283,5 +284,19 @@ esac
 	cmd.SetArgs([]string{"task-1"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCloseTaskTabRejectsStaleTab(t *testing.T) {
+	writeFakeTreehouseReturn(t)
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
+printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:other","workspace_id":"wA"}]}}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if err := closeTaskTab(herdr.NewClient(), "wA", "wA:missing"); err == nil {
+		t.Fatal("stale tab was accepted")
 	}
 }

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -215,7 +215,7 @@ func TestBranchIsMergedUsesOriginDefaultBranch(t *testing.T) {
 	}
 	runGit(worktreePath, "add", "feature.txt")
 	runGit(worktreePath, "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "-m", "feature")
-	runGit(clonePath, "merge", "--no-ff", "-q", "task-1", "-m", "merge task")
+	runGit(clonePath, "-c", "user.name=test", "-c", "user.email=test@example.com", "merge", "--no-ff", "-q", "task-1", "-m", "merge task")
 	runGit(clonePath, "checkout", "-q", "release")
 
 	merged, err := branchIsMerged(clonePath, worktreePath)

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -300,3 +300,27 @@ printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:other","workspace_id":"wA"
 		t.Fatal("stale tab was accepted")
 	}
 }
+
+func TestCloseTaskTabClosesWorkspaceForSoleTab(t *testing.T) {
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
+case "$1 $2" in
+"tab list")
+ printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
+ ;;
+"workspace close")
+ printf '{"id":"cli:1","result":{}}'
+ ;;
+*)
+ echo "unexpected herdr args: $@" >&2
+ exit 1
+ ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if err := closeTaskTab(herdr.NewClient(), "wA", "wA:tB"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,0 +1,103 @@
+// Package harness constructs the per-harness command used to launch a worker agent.
+package harness
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	Claude   = "claude"
+	Codex    = "codex"
+	Grok     = "grok"
+	Pi       = "pi"
+	OpenCode = "opencode"
+)
+
+var supported = map[string]bool{
+	Claude:   true,
+	Codex:    true,
+	Grok:     true,
+	Pi:       true,
+	OpenCode: true,
+}
+
+func IsSupported(name string) bool {
+	return supported[name]
+}
+
+type Options struct {
+	Worktree string
+	Brief    string
+	Model    string
+	Effort   string
+}
+
+// Build constructs the shell command that cds into the worktree and launches the harness
+// against the brief. Flags verified against the installed CLI (--help) are used where
+// available; unverified harnesses fall back to the SPECS.md template syntax.
+func Build(name string, opts Options) (string, error) {
+	var launch string
+	switch name {
+	case Claude:
+		launch = buildClaude(opts)
+	case Codex:
+		launch = buildCodex(opts)
+	case Grok:
+		launch = buildGrok(opts)
+	case Pi:
+		launch = buildPi(opts)
+	case OpenCode:
+		launch = buildOpenCode(opts)
+	default:
+		return "", fmt.Errorf("harness %q not recognized", name)
+	}
+	return fmt.Sprintf("cd %s && %s", shellQuote(opts.Worktree), launch), nil
+}
+
+// buildClaude reads the brief itself: claude --print takes the prompt as a positional
+// argument, not a file path (verified via `claude --help`), so the brief-path template
+// in SPECS.md would otherwise send the literal path string as the prompt text.
+func buildClaude(o Options) string {
+	args := []string{"claude", "--print"}
+	if o.Model != "" {
+		args = append(args, "--model", shellQuote(o.Model))
+	}
+	if o.Effort != "" {
+		args = append(args, "--effort", shellQuote(o.Effort))
+	}
+	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
+	args = append(args, shellQuote(prompt))
+	return strings.Join(args, " ")
+}
+
+func buildCodex(o Options) string {
+	return fmt.Sprintf("codex --file %s", shellQuote(o.Brief))
+}
+
+func buildGrok(o Options) string {
+	return fmt.Sprintf("grok --trust --file %s", shellQuote(o.Brief))
+}
+
+func buildPi(o Options) string {
+	return fmt.Sprintf("pi %s", shellQuote(o.Brief))
+}
+
+// buildOpenCode uses `opencode run` (verified via `opencode --help`) rather than the bare
+// `opencode` template in SPECS.md, which would open an interactive TUI instead of running
+// headless. --file attaches the brief to the initial message.
+func buildOpenCode(o Options) string {
+	args := []string{"opencode", "run", "--file", shellQuote(o.Brief)}
+	if o.Model != "" {
+		args = append(args, "--model", shellQuote(o.Model))
+	}
+	if o.Effort != "" {
+		args = append(args, "--variant", shellQuote(o.Effort))
+	}
+	args = append(args, shellQuote("Follow the attached brief and complete the task."))
+	return strings.Join(args, " ")
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -55,9 +55,8 @@ func Build(name string, opts Options) (string, error) {
 	return fmt.Sprintf("cd %s && %s", shellQuote(opts.Worktree), launch), nil
 }
 
-// buildClaude reads the brief itself: claude --print takes the prompt as a positional
-// argument, not a file path (verified via `claude --help`), so the brief-path template
-// in SPECS.md would otherwise send the literal path string as the prompt text.
+// buildClaude passes the brief path in a prompt because claude --print accepts prompt text,
+// not a file path (verified via `claude --help`).
 func buildClaude(o Options) string {
 	args := []string{"claude", "--print"}
 	if o.Model != "" {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -1,0 +1,111 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildUnrecognizedHarness(t *testing.T) {
+	if _, err := Build("nonexistent", Options{}); err == nil {
+		t.Fatal("expected error for unrecognized harness")
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+		if !IsSupported(name) {
+			t.Errorf("IsSupported(%q) = false, want true", name)
+		}
+	}
+	if IsSupported("nonexistent") {
+		t.Error("IsSupported(nonexistent) = true, want false")
+	}
+}
+
+func TestBuildAlwaysCdsIntoWorktree(t *testing.T) {
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/wt/brief.md"})
+		if err != nil {
+			t.Fatalf("Build(%q) error: %v", name, err)
+		}
+		if !strings.HasPrefix(got, "cd '/tmp/wt' && ") {
+			t.Errorf("Build(%q) = %q, want cd prefix", name, got)
+		}
+	}
+}
+
+func TestBuildClaude(t *testing.T) {
+	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/data/fix-login/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cd '/tmp/wt' && claude --print 'Read the brief at /tmp/data/fix-login/brief.md and carry out the task it describes.'"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildClaudeWithModelAndEffort(t *testing.T) {
+	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "sonnet", Effort: "low"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "--model 'sonnet'") || !strings.Contains(got, "--effort 'low'") {
+		t.Fatalf("got %q, want --model and --effort flags", got)
+	}
+}
+
+func TestBuildCodex(t *testing.T) {
+	got, err := Build(Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cd '/tmp/wt' && codex --file '/tmp/brief.md'"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildGrok(t *testing.T) {
+	got, err := Build(Grok, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cd '/tmp/wt' && grok --trust --file '/tmp/brief.md'"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildPi(t *testing.T) {
+	got, err := Build(Pi, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cd '/tmp/wt' && pi '/tmp/brief.md'"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildOpenCode(t *testing.T) {
+	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cd '/tmp/wt' && opencode run --file '/tmp/brief.md' 'Follow the attached brief and complete the task.'"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestShellQuoteEscapesSingleQuotes(t *testing.T) {
+	got, err := Build(Pi, Options{Worktree: "/tmp/wt", Brief: "/tmp/it's/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `cd '/tmp/wt' && pi '/tmp/it'\''s/brief.md'`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -1,0 +1,197 @@
+package herdr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Client struct{}
+
+func NewClient() *Client {
+	return &Client{}
+}
+
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type envelope struct {
+	Result json.RawMessage `json:"result"`
+	Error  *errorBody      `json:"error"`
+}
+
+func (c *Client) call(args ...string) (json.RawMessage, error) {
+	cmd := exec.Command("herdr", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	trimmed := bytes.TrimSpace(stdout.Bytes())
+	if len(trimmed) == 0 {
+		if runErr != nil {
+			return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, strings.TrimSpace(stderr.String()))
+		}
+		return nil, nil
+	}
+
+	var env envelope
+	if err := json.Unmarshal(trimmed, &env); err != nil {
+		return nil, fmt.Errorf("herdr %s: parse response: %w", strings.Join(args, " "), err)
+	}
+	if env.Error != nil {
+		return nil, fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), env.Error.Code, env.Error.Message)
+	}
+	return env.Result, nil
+}
+
+func (c *Client) WorkspaceList() ([]Workspace, error) {
+	res, err := c.call("workspace", "list")
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Workspaces []Workspace `json:"workspaces"`
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return nil, fmt.Errorf("parse workspace list: %w", err)
+	}
+	return body.Workspaces, nil
+}
+
+// FindWorkspaceByLabel returns the workspace whose label matches, if any.
+func (c *Client) FindWorkspaceByLabel(label string) (Workspace, bool, error) {
+	workspaces, err := c.WorkspaceList()
+	if err != nil {
+		return Workspace{}, false, err
+	}
+	for _, w := range workspaces {
+		if w.Label == label {
+			return w, true, nil
+		}
+	}
+	return Workspace{}, false, nil
+}
+
+func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, error) {
+	args := []string{"workspace", "create", "--no-focus"}
+	if cwd != "" {
+		args = append(args, "--cwd", cwd)
+	}
+	if label != "" {
+		args = append(args, "--label", label)
+	}
+	res, err := c.call(args...)
+	if err != nil {
+		return Workspace{}, err
+	}
+	var body struct {
+		Workspace Workspace `json:"workspace"`
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return Workspace{}, fmt.Errorf("parse workspace create: %w", err)
+	}
+	return body.Workspace, nil
+}
+
+func (c *Client) WorkspaceClose(workspaceID string) error {
+	_, err := c.call("workspace", "close", workspaceID)
+	return err
+}
+
+func (c *Client) TabList(workspaceID string) ([]Tab, error) {
+	res, err := c.call("tab", "list", "--workspace", workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Tabs []Tab `json:"tabs"`
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return nil, fmt.Errorf("parse tab list: %w", err)
+	}
+	return body.Tabs, nil
+}
+
+func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
+	args := []string{"tab", "create", "--workspace", workspaceID, "--no-focus"}
+	if cwd != "" {
+		args = append(args, "--cwd", cwd)
+	}
+	if label != "" {
+		args = append(args, "--label", label)
+	}
+	res, err := c.call(args...)
+	if err != nil {
+		return Tab{}, Pane{}, err
+	}
+	var body struct {
+		Tab      Tab  `json:"tab"`
+		RootPane Pane `json:"root_pane"`
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return Tab{}, Pane{}, fmt.Errorf("parse tab create: %w", err)
+	}
+	return body.Tab, body.RootPane, nil
+}
+
+func (c *Client) TabClose(tabID string) error {
+	_, err := c.call("tab", "close", tabID)
+	return err
+}
+
+func (c *Client) PaneGet(paneID string) (Pane, error) {
+	res, err := c.call("pane", "get", paneID)
+	if err != nil {
+		return Pane{}, err
+	}
+	var body struct {
+		Pane Pane `json:"pane"`
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return Pane{}, fmt.Errorf("parse pane get: %w", err)
+	}
+	return body.Pane, nil
+}
+
+// PaneRun types command into the pane followed by Enter.
+func (c *Client) PaneRun(paneID, command string) error {
+	_, err := c.call("pane", "run", paneID, command)
+	return err
+}
+
+func (c *Client) PaneSendText(paneID, text string) error {
+	_, err := c.call("pane", "send-text", paneID, text)
+	return err
+}
+
+func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
+	args := append([]string{"pane", "send-keys", paneID}, keys...)
+	_, err := c.call(args...)
+	return err
+}
+
+// WaitComposerEmpty polls the pane until the agent is no longer "working" or timeout elapses.
+// There is no herdr primitive for "not working", so this polls pane state directly
+// rather than depending on a single-target wait command.
+func (c *Client) WaitComposerEmpty(paneID string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		pane, err := c.PaneGet(paneID)
+		if err != nil {
+			return err
+		}
+		if pane.AgentStatus != StatusWorking {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("composer not empty after %s", timeout)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -53,10 +53,14 @@ func (c *Client) call(args ...string) (json.RawMessage, error) {
 	if len(env.Result) == 0 {
 		return nil, fmt.Errorf("herdr %s: response missing result", strings.Join(args, " "))
 	}
-	if string(bytes.TrimSpace(env.Result)) == "null" {
+	result := bytes.TrimSpace(env.Result)
+	if string(result) == "null" {
 		return nil, fmt.Errorf("herdr %s: response has null result", strings.Join(args, " "))
 	}
-	return env.Result, nil
+	if result[0] != '{' {
+		return nil, fmt.Errorf("herdr %s: response result is not an object", strings.Join(args, " "))
+	}
+	return result, nil
 }
 
 func (c *Client) WorkspaceList() ([]Workspace, error) {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -53,6 +53,9 @@ func (c *Client) call(args ...string) (json.RawMessage, error) {
 	if len(env.Result) == 0 {
 		return nil, fmt.Errorf("herdr %s: response missing result", strings.Join(args, " "))
 	}
+	if string(bytes.TrimSpace(env.Result)) == "null" {
+		return nil, fmt.Errorf("herdr %s: response has null result", strings.Join(args, " "))
+	}
 	return env.Result, nil
 }
 
@@ -66,6 +69,9 @@ func (c *Client) WorkspaceList() ([]Workspace, error) {
 	}
 	if err := json.Unmarshal(res, &body); err != nil {
 		return nil, fmt.Errorf("parse workspace list: %w", err)
+	}
+	if body.Workspaces == nil {
+		return nil, fmt.Errorf("parse workspace list: missing workspaces")
 	}
 	return body.Workspaces, nil
 }
@@ -102,6 +108,9 @@ func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, error) {
 	if err := json.Unmarshal(res, &body); err != nil {
 		return Workspace{}, fmt.Errorf("parse workspace create: %w", err)
 	}
+	if body.Workspace.WorkspaceID == "" {
+		return Workspace{}, fmt.Errorf("parse workspace create: missing workspace")
+	}
 	return body.Workspace, nil
 }
 
@@ -120,6 +129,9 @@ func (c *Client) TabList(workspaceID string) ([]Tab, error) {
 	}
 	if err := json.Unmarshal(res, &body); err != nil {
 		return nil, fmt.Errorf("parse tab list: %w", err)
+	}
+	if body.Tabs == nil {
+		return nil, fmt.Errorf("parse tab list: missing tabs")
 	}
 	return body.Tabs, nil
 }
@@ -143,6 +155,9 @@ func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
 	if err := json.Unmarshal(res, &body); err != nil {
 		return Tab{}, Pane{}, fmt.Errorf("parse tab create: %w", err)
 	}
+	if body.Tab.TabID == "" || body.RootPane.PaneID == "" {
+		return Tab{}, Pane{}, fmt.Errorf("parse tab create: missing tab or root pane")
+	}
 	return body.Tab, body.RootPane, nil
 }
 
@@ -161,6 +176,9 @@ func (c *Client) PaneGet(paneID string) (Pane, error) {
 	}
 	if err := json.Unmarshal(res, &body); err != nil {
 		return Pane{}, fmt.Errorf("parse pane get: %w", err)
+	}
+	if body.Pane.PaneID == "" {
+		return Pane{}, fmt.Errorf("parse pane get: missing pane")
 	}
 	return body.Pane, nil
 }

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -37,7 +37,7 @@ func (c *Client) call(args ...string) (json.RawMessage, error) {
 		if runErr != nil {
 			return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, strings.TrimSpace(stderr.String()))
 		}
-		return nil, nil
+		return nil, fmt.Errorf("herdr %s: empty response", strings.Join(args, " "))
 	}
 
 	var env envelope
@@ -46,6 +46,12 @@ func (c *Client) call(args ...string) (json.RawMessage, error) {
 	}
 	if env.Error != nil {
 		return nil, fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), env.Error.Code, env.Error.Message)
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, strings.TrimSpace(stderr.String()))
+	}
+	if len(env.Result) == 0 {
+		return nil, fmt.Errorf("herdr %s: response missing result", strings.Join(args, " "))
 	}
 	return env.Result, nil
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -70,16 +70,16 @@ func TestCallFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 	}
 }
 
-func TestPaneRunSucceedsOnEmptyStdout(t *testing.T) {
-	writeFakeHerdr(t, `true`)
+func TestPaneRunRequiresResultEnvelope(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{}}'`)
 	c := NewClient()
 	if err := c.PaneRun("wA:pB", "echo hi"); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestPaneSendTextSucceedsOnEmptyStdout(t *testing.T) {
-	writeFakeHerdr(t, `true`)
+func TestPaneSendTextRequiresResultEnvelope(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{}}'`)
 	c := NewClient()
 	if err := c.PaneSendText("wA:pB", "hello"); err != nil {
 		t.Fatal(err)
@@ -92,6 +92,7 @@ if [ "$1" != "pane" ] || [ "$2" != "send-keys" ] || [ "$3" != "wA:pB" ] || [ "$4
 	echo "unexpected args: $@" >&2
 	exit 1
 fi
+printf '{"id":"cli:1","result":{}}'
 `)
 	c := NewClient()
 	if err := c.PaneSendKeys("wA:pB", "Enter"); err != nil {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -78,6 +78,14 @@ func TestCallRejectsNullResult(t *testing.T) {
 	}
 }
 
+func TestCallRejectsNonObjectResult(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":[]}'`)
+	c := NewClient()
+	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "not an object") {
+		t.Fatalf("got err %v, want non-object result failure", err)
+	}
+}
+
 func TestPaneRunRequiresResultEnvelope(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{}}'`)
 	c := NewClient()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -70,6 +70,14 @@ func TestCallFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 	}
 }
 
+func TestCallRejectsNullResult(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":null}'`)
+	c := NewClient()
+	if _, err := c.WorkspaceList(); err == nil || !strings.Contains(err.Error(), "null result") {
+		t.Fatalf("got err %v, want null result failure", err)
+	}
+}
+
 func TestPaneRunRequiresResultEnvelope(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{}}'`)
 	c := NewClient()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -1,0 +1,153 @@
+package herdr
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeFakeHerdr(t *testing.T, script string) {
+	t.Helper()
+	bin := t.TempDir()
+	path := filepath.Join(bin, "herdr")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestWorkspaceListParsesResult(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"proj","tab_count":2}]}}'`)
+	c := NewClient()
+	got, err := c.WorkspaceList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].WorkspaceID != "wA" || got[0].Label != "proj" || got[0].TabCount != 2 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestFindWorkspaceByLabelFound(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"proj"}]}}'`)
+	c := NewClient()
+	ws, found, err := c.FindWorkspaceByLabel("proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || ws.WorkspaceID != "wA" {
+		t.Fatalf("got %+v, %v", ws, found)
+	}
+}
+
+func TestFindWorkspaceByLabelNotFound(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspaces":[]}}'`)
+	c := NewClient()
+	_, found, err := c.FindWorkspaceByLabel("proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatal("expected found = false")
+	}
+}
+
+func TestCallReturnsErrorOnEnvelopeError(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"not_found","message":"pane missing"}}'; exit 1`)
+	c := NewClient()
+	if _, err := c.PaneGet("wA:pB"); err == nil || !strings.Contains(err.Error(), "pane missing") {
+		t.Fatalf("got err %v, want pane missing", err)
+	}
+}
+
+func TestCallFailsOnNonZeroExitWithNoStdout(t *testing.T) {
+	writeFakeHerdr(t, `echo "binary crashed" >&2; exit 1`)
+	c := NewClient()
+	if _, err := c.PaneGet("wA:pB"); err == nil || !strings.Contains(err.Error(), "binary crashed") {
+		t.Fatalf("got err %v, want binary crashed failure", err)
+	}
+}
+
+func TestPaneRunSucceedsOnEmptyStdout(t *testing.T) {
+	writeFakeHerdr(t, `true`)
+	c := NewClient()
+	if err := c.PaneRun("wA:pB", "echo hi"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPaneSendTextSucceedsOnEmptyStdout(t *testing.T) {
+	writeFakeHerdr(t, `true`)
+	c := NewClient()
+	if err := c.PaneSendText("wA:pB", "hello"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPaneSendKeysPassesKeys(t *testing.T) {
+	writeFakeHerdr(t, `
+if [ "$1" != "pane" ] || [ "$2" != "send-keys" ] || [ "$3" != "wA:pB" ] || [ "$4" != "Enter" ]; then
+	echo "unexpected args: $@" >&2
+	exit 1
+fi
+`)
+	c := NewClient()
+	if err := c.PaneSendKeys("wA:pB", "Enter"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTabCreateParsesTabAndRootPane(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'`)
+	c := NewClient()
+	tab, pane, err := c.TabCreate("wA", "/tmp/wt", "task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tab.TabID != "wA:tB" || pane.PaneID != "wA:pC" || pane.AgentStatus != StatusIdle {
+		t.Fatalf("got tab=%+v pane=%+v", tab, pane)
+	}
+}
+
+func TestPaneGetParsesAgentStatus(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'`)
+	c := NewClient()
+	pane, err := c.PaneGet("wA:pB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pane.AgentStatus != StatusWorking {
+		t.Fatalf("got %q, want working", pane.AgentStatus)
+	}
+}
+
+func TestWaitComposerEmptyReturnsWhenIdle(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'`)
+	c := NewClient()
+	if err := c.WaitComposerEmpty("wA:pB", time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'`)
+	c := NewClient()
+	err := c.WaitComposerEmpty("wA:pB", 10*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "composer not empty") {
+		t.Fatalf("got err %v, want composer not empty timeout", err)
+	}
+}
+
+func TestTabListParsesResult(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'`)
+	c := NewClient()
+	tabs, err := c.TabList("wA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tabs) != 1 || tabs[0].TabID != "wA:tB" {
+		t.Fatalf("got %+v", tabs)
+	}
+}

--- a/internal/herdr/types.go
+++ b/internal/herdr/types.go
@@ -1,0 +1,31 @@
+// Package herdr wraps the herdr CLI for workspace, tab, and pane operations.
+package herdr
+
+type Status string
+
+const (
+	StatusIdle    Status = "idle"
+	StatusWorking Status = "working"
+	StatusBlocked Status = "blocked"
+	StatusDone    Status = "done"
+	StatusUnknown Status = "unknown"
+)
+
+type Workspace struct {
+	WorkspaceID string `json:"workspace_id"`
+	Label       string `json:"label"`
+	TabCount    int    `json:"tab_count"`
+}
+
+type Tab struct {
+	TabID       string `json:"tab_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Label       string `json:"label"`
+}
+
+type Pane struct {
+	PaneID      string `json:"pane_id"`
+	TabID       string `json:"tab_id"`
+	WorkspaceID string `json:"workspace_id"`
+	AgentStatus Status `json:"agent_status"`
+}

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 )
 
 func Dir(homeDir string) string {
@@ -15,11 +16,65 @@ func Dir(homeDir string) string {
 }
 
 func Path(homeDir, id string) string {
+	if err := ValidateID(id); err != nil {
+		return ""
+	}
 	return filepath.Join(Dir(homeDir), id+".json")
+}
+
+func ValidateID(id string) error {
+	if id == "" || id == "." || id == ".." || filepath.Base(id) != id {
+		return fmt.Errorf("invalid task ID %q", id)
+	}
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return fmt.Errorf("invalid task ID %q", id)
+	}
+	return nil
+}
+
+func Claim(homeDir, id string) (func(), error) {
+	if err := ValidateID(id); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(Dir(homeDir), 0o755); err != nil {
+		return nil, fmt.Errorf("create state directory: %w", err)
+	}
+	lock, err := os.OpenFile(filepath.Join(Dir(homeDir), "."+id+".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open task lock: %w", err)
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lock.Close()
+		if err == syscall.EWOULDBLOCK {
+			return nil, fmt.Errorf("task %q already active", id)
+		}
+		return nil, fmt.Errorf("lock task: %w", err)
+	}
+	active, err := Exists(homeDir, id)
+	if err != nil {
+		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		_ = lock.Close()
+		return nil, err
+	}
+	if active {
+		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		_ = lock.Close()
+		return nil, fmt.Errorf("task %q already active", id)
+	}
+	return func() {
+		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		_ = lock.Close()
+	}, nil
 }
 
 // Exists reports whether a task state file exists for id.
 func Exists(homeDir, id string) (bool, error) {
+	if err := ValidateID(id); err != nil {
+		return false, err
+	}
 	_, err := os.Stat(Path(homeDir, id))
 	if err == nil {
 		return true, nil
@@ -32,6 +87,9 @@ func Exists(homeDir, id string) (bool, error) {
 
 // Read loads the state file for id.
 func Read(homeDir, id string) (Task, error) {
+	if err := ValidateID(id); err != nil {
+		return Task{}, err
+	}
 	data, err := os.ReadFile(Path(homeDir, id))
 	if os.IsNotExist(err) {
 		return Task{}, fmt.Errorf("task %q not found", id)
@@ -43,11 +101,17 @@ func Read(homeDir, id string) (Task, error) {
 	if err := json.Unmarshal(data, &t); err != nil {
 		return Task{}, fmt.Errorf("parse task state %q: %w", id, err)
 	}
+	if t.ID != id {
+		return Task{}, fmt.Errorf("task state %q has mismatched ID %q", id, t.ID)
+	}
 	return t, nil
 }
 
 // Write persists t atomically (write to temp file, then rename).
 func Write(homeDir string, t Task) error {
+	if err := ValidateID(t.ID); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(Dir(homeDir), 0o755); err != nil {
 		return fmt.Errorf("create state directory: %w", err)
 	}
@@ -120,6 +184,9 @@ func List(homeDir string) ([]Task, error) {
 
 // Delete removes the state file for id.
 func Delete(homeDir, id string) error {
+	if err := ValidateID(id); err != nil {
+		return err
+	}
 	if err := os.Remove(Path(homeDir, id)); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("task %q not found", id)

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -1,0 +1,130 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func Dir(homeDir string) string {
+	return filepath.Join(homeDir, "state")
+}
+
+func Path(homeDir, id string) string {
+	return filepath.Join(Dir(homeDir), id+".json")
+}
+
+// Exists reports whether a task state file exists for id.
+func Exists(homeDir, id string) (bool, error) {
+	_, err := os.Stat(Path(homeDir, id))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat task state %q: %w", id, err)
+}
+
+// Read loads the state file for id.
+func Read(homeDir, id string) (Task, error) {
+	data, err := os.ReadFile(Path(homeDir, id))
+	if os.IsNotExist(err) {
+		return Task{}, fmt.Errorf("task %q not found", id)
+	}
+	if err != nil {
+		return Task{}, fmt.Errorf("read task state %q: %w", id, err)
+	}
+	var t Task
+	if err := json.Unmarshal(data, &t); err != nil {
+		return Task{}, fmt.Errorf("parse task state %q: %w", id, err)
+	}
+	return t, nil
+}
+
+// Write persists t atomically (write to temp file, then rename).
+func Write(homeDir string, t Task) error {
+	if err := os.MkdirAll(Dir(homeDir), 0o755); err != nil {
+		return fmt.Errorf("create state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode task state %q: %w", t.ID, err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(Dir(homeDir), "."+t.ID+".json-")
+	if err != nil {
+		return fmt.Errorf("create temp state file: %w", err)
+	}
+	tmpName := tmp.Name()
+	removeTemp := func() { _ = os.Remove(tmpName) }
+
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		removeTemp()
+		return fmt.Errorf("chmod temp state file: %w", err)
+	}
+	n, err := tmp.Write(data)
+	if err != nil {
+		_ = tmp.Close()
+		removeTemp()
+		return fmt.Errorf("write temp state file: %w", err)
+	}
+	if n != len(data) {
+		_ = tmp.Close()
+		removeTemp()
+		return io.ErrShortWrite
+	}
+	if err := tmp.Close(); err != nil {
+		removeTemp()
+		return fmt.Errorf("close temp state file: %w", err)
+	}
+	if err := os.Rename(tmpName, Path(homeDir, t.ID)); err != nil {
+		removeTemp()
+		return fmt.Errorf("rename temp state file: %w", err)
+	}
+	return nil
+}
+
+// List returns all active tasks, sorted by ID. Returns nil if the state directory doesn't exist.
+func List(homeDir string) ([]Task, error) {
+	entries, err := os.ReadDir(Dir(homeDir))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read state directory: %w", err)
+	}
+
+	var tasks []Task
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".json")
+		t, err := Read(homeDir, id)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].ID < tasks[j].ID })
+	return tasks, nil
+}
+
+// Delete removes the state file for id.
+func Delete(homeDir, id string) error {
+	if err := os.Remove(Path(homeDir, id)); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("task %q not found", id)
+		}
+		return fmt.Errorf("remove task state %q: %w", id, err)
+	}
+	return nil
+}

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,15 +40,8 @@ func Claim(homeDir, id string) (func(), error) {
 	if err := ValidateID(id); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(Dir(homeDir), 0o755); err != nil {
-		return nil, fmt.Errorf("create state directory: %w", err)
-	}
-	lock, err := os.OpenFile(filepath.Join(Dir(homeDir), "."+id+".lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	release, err := lock(homeDir, "task:"+id, true)
 	if err != nil {
-		return nil, fmt.Errorf("open task lock: %w", err)
-	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		_ = lock.Close()
 		if err == syscall.EWOULDBLOCK {
 			return nil, fmt.Errorf("task %q already active", id)
 		}
@@ -55,18 +49,40 @@ func Claim(homeDir, id string) (func(), error) {
 	}
 	active, err := Exists(homeDir, id)
 	if err != nil {
-		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
-		_ = lock.Close()
+		release()
 		return nil, err
 	}
 	if active {
-		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
-		_ = lock.Close()
+		release()
 		return nil, fmt.Errorf("task %q already active", id)
 	}
+	return release, nil
+}
+
+func Lock(homeDir, name string) (func(), error) {
+	return lock(homeDir, name, false)
+}
+
+func lock(homeDir, name string, nonblock bool) (func(), error) {
+	if err := os.MkdirAll(Dir(homeDir), 0o755); err != nil {
+		return nil, fmt.Errorf("create state directory: %w", err)
+	}
+	lockName := fmt.Sprintf(".%x.lock", sha256.Sum256([]byte(name)))
+	file, err := os.OpenFile(filepath.Join(Dir(homeDir), lockName), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock: %w", err)
+	}
+	flags := syscall.LOCK_EX
+	if nonblock {
+		flags |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(file.Fd()), flags); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
 	return func() {
-		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
-		_ = lock.Close()
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
 	}, nil
 }
 

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -1,0 +1,153 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	task := Task{
+		ID: "fix-login", Project: "nsr", Kind: KindShip, Harness: "claude",
+		Model: "sonnet", Effort: "low", Worktree: "/tmp/wt", Brief: "data/fix-login/brief.md",
+		Herdr:     Herdr{Session: "default", WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pC"},
+		CreatedAt: "2026-07-24T10:00:00Z",
+	}
+
+	if err := Write(dir, task); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(dir, "fix-login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != task {
+		t.Fatalf("got %+v, want %+v", got, task)
+	}
+}
+
+func TestReadMissingTask(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Read(dir, "missing"); err == nil {
+		t.Fatal("expected error for missing task")
+	}
+}
+
+func TestExists(t *testing.T) {
+	dir := t.TempDir()
+	if exists, err := Exists(dir, "fix-login"); err != nil || exists {
+		t.Fatalf("Exists = %v, %v, want false, nil", exists, err)
+	}
+
+	if err := Write(dir, Task{ID: "fix-login"}); err != nil {
+		t.Fatal(err)
+	}
+	if exists, err := Exists(dir, "fix-login"); err != nil || !exists {
+		t.Fatalf("Exists = %v, %v, want true, nil", exists, err)
+	}
+}
+
+func TestListSortedAndEmpty(t *testing.T) {
+	dir := t.TempDir()
+	tasks, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tasks != nil {
+		t.Fatalf("got %+v, want nil for missing state dir", tasks)
+	}
+
+	for _, id := range []string{"zebra", "apple", "mango"} {
+		if err := Write(dir, Task{ID: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tasks, err = List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("got %d tasks, want 3", len(tasks))
+	}
+	want := []string{"apple", "mango", "zebra"}
+	for i, id := range want {
+		if tasks[i].ID != id {
+			t.Errorf("tasks[%d].ID = %q, want %q", i, tasks[i].ID, id)
+		}
+	}
+}
+
+func TestListIgnoresNonJSONFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(Dir(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(Dir(dir), "events.log"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(dir, Task{ID: "fix-login"}); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "fix-login" {
+		t.Fatalf("got %+v", tasks)
+	}
+}
+
+func TestListFailsClosedOnMalformedState(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(Dir(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(Dir(dir), "broken.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := List(dir); err == nil {
+		t.Fatal("expected malformed state file to fail closed")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Task{ID: "fix-login"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Delete(dir, "fix-login"); err != nil {
+		t.Fatal(err)
+	}
+	if exists, err := Exists(dir, "fix-login"); err != nil || exists {
+		t.Fatalf("Exists after delete = %v, %v, want false, nil", exists, err)
+	}
+}
+
+func TestDeleteMissingTask(t *testing.T) {
+	dir := t.TempDir()
+	if err := Delete(dir, "missing"); err == nil {
+		t.Fatal("expected error for missing task")
+	}
+}
+
+func TestWriteOverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Task{ID: "fix-login", Harness: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(dir, Task{ID: "fix-login", Harness: "codex"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(dir, "fix-login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Harness != "codex" {
+		t.Fatalf("got harness %q, want codex", got.Harness)
+	}
+}

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -156,6 +157,23 @@ func TestClaimIsExclusive(t *testing.T) {
 	if _, err := Claim(dir, "task-1"); err == nil {
 		t.Fatal("second claim succeeded")
 	}
+}
+
+func TestLockIsExclusive(t *testing.T) {
+	dir := t.TempDir()
+	release, err := Lock(dir, "project:myproj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lock(dir, "project:myproj", true); err != syscall.EWOULDBLOCK {
+		t.Fatalf("second lock error = %v, want EWOULDBLOCK", err)
+	}
+	release()
+	second, err := Lock(dir, "project:myproj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second()
 }
 
 func TestWriteOverwritesExisting(t *testing.T) {

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -134,6 +134,30 @@ func TestDeleteMissingTask(t *testing.T) {
 	}
 }
 
+func TestRejectsUnsafeIDs(t *testing.T) {
+	dir := t.TempDir()
+	for _, id := range []string{"../escape", "nested/task", "", "."} {
+		if err := Write(dir, Task{ID: id}); err == nil {
+			t.Errorf("Write accepted unsafe ID %q", id)
+		}
+		if _, err := Read(dir, id); err == nil {
+			t.Errorf("Read accepted unsafe ID %q", id)
+		}
+	}
+}
+
+func TestClaimIsExclusive(t *testing.T) {
+	dir := t.TempDir()
+	release, err := Claim(dir, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if _, err := Claim(dir, "task-1"); err == nil {
+		t.Fatal("second claim succeeded")
+	}
+}
+
 func TestWriteOverwritesExisting(t *testing.T) {
 	dir := t.TempDir()
 	if err := Write(dir, Task{ID: "fix-login", Harness: "claude"}); err != nil {

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -1,0 +1,28 @@
+// Package state manages per-task metadata in state/<id>.json.
+package state
+
+const (
+	KindShip  = "ship"
+	KindScout = "scout"
+)
+
+type Herdr struct {
+	Session     string `json:"session"`
+	WorkspaceID string `json:"workspace_id"`
+	TabID       string `json:"tab_id"`
+	PaneID      string `json:"pane_id"`
+}
+
+type Task struct {
+	ID        string `json:"id"`
+	Project   string `json:"project"`
+	Kind      string `json:"kind"`
+	Harness   string `json:"harness"`
+	Model     string `json:"model"`
+	Effort    string `json:"effort"`
+	Worktree  string `json:"worktree"`
+	Brief     string `json:"brief"`
+	Herdr     Herdr  `json:"herdr"`
+	PR        string `json:"pr"`
+	CreatedAt string `json:"created_at"`
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,0 +1,69 @@
+// Package worktree wraps treehouse worktree acquisition and the spawn collision guard.
+package worktree
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+// Get acquires a worktree from the project clone's treehouse pool.
+// clonePath must be the project clone directory (treehouse resolves the pool from cwd).
+func Get(clonePath, leaseHolder string) (string, error) {
+	args := []string{"get", "--lease", "--json"}
+	if leaseHolder != "" {
+		args = append(args, "--lease-holder", leaseHolder)
+	}
+	cmd := exec.Command("treehouse", args...)
+	cmd.Dir = clonePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("treehouse get failed: %s", strings.TrimSpace(string(out)))
+	}
+
+	var lease struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(out, &lease); err != nil {
+		return "", fmt.Errorf("parse treehouse get output: %w", err)
+	}
+	if lease.Path == "" {
+		return "", fmt.Errorf("treehouse get returned no worktree path")
+	}
+	return lease.Path, nil
+}
+
+// Return releases a worktree back to its treehouse pool.
+func Return(worktreePath string, force bool) error {
+	args := []string{"return", worktreePath}
+	if force {
+		args = append(args, "--force")
+	}
+	out, err := exec.Command("treehouse", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("treehouse return failed: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// CheckCollision cross-checks worktreePath against every other active task's recorded
+// worktree path, guarding against the stale-lease-after-crash bug (firstmate #947).
+// It returns the ID of the conflicting task, or "" if there is no collision.
+func CheckCollision(homeDir, worktreePath, excludeID string) (string, error) {
+	tasks, err := state.List(homeDir)
+	if err != nil {
+		return "", err
+	}
+	for _, t := range tasks {
+		if t.ID == excludeID {
+			continue
+		}
+		if t.Worktree == worktreePath {
+			return t.ID, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,0 +1,132 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+func writeFakeTreehouse(t *testing.T, script string) {
+	t.Helper()
+	bin := t.TempDir()
+	path := filepath.Join(bin, "treehouse")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestGetParsesLeasePath(t *testing.T) {
+	writeFakeTreehouse(t, `printf '{"path":"/tmp/wt-1"}'`)
+	got, err := Get(t.TempDir(), "hand:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/wt-1" {
+		t.Fatalf("got %q, want /tmp/wt-1", got)
+	}
+}
+
+func TestGetPassesLeaseHolder(t *testing.T) {
+	writeFakeTreehouse(t, `
+if [ "$4" != "--lease-holder" ] || [ "$5" != "hand:task-1" ]; then
+	echo "unexpected args: $@" >&2
+	exit 1
+fi
+printf '{"path":"/tmp/wt-1"}'
+`)
+	if _, err := Get(t.TempDir(), "hand:task-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetFailsOnNonZeroExit(t *testing.T) {
+	writeFakeTreehouse(t, `echo "pool exhausted" >&2; exit 1`)
+	if _, err := Get(t.TempDir(), ""); err == nil || !strings.Contains(err.Error(), "pool exhausted") {
+		t.Fatalf("got err %v, want pool exhausted failure", err)
+	}
+}
+
+func TestGetFailsOnMissingPath(t *testing.T) {
+	writeFakeTreehouse(t, `printf '{}'`)
+	if _, err := Get(t.TempDir(), ""); err == nil {
+		t.Fatal("expected error for missing path in lease response")
+	}
+}
+
+func TestReturnPassesForceFlag(t *testing.T) {
+	writeFakeTreehouse(t, `
+if [ "$1" != "return" ] || [ "$2" != "/tmp/wt-1" ] || [ "$3" != "--force" ]; then
+	echo "unexpected args: $@" >&2
+	exit 1
+fi
+`)
+	if err := Return("/tmp/wt-1", true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReturnFailsOnNonZeroExit(t *testing.T) {
+	writeFakeTreehouse(t, `echo "worktree busy" >&2; exit 1`)
+	if err := Return("/tmp/wt-1", false); err == nil || !strings.Contains(err.Error(), "worktree busy") {
+		t.Fatalf("got err %v, want worktree busy failure", err)
+	}
+}
+
+func TestCheckCollisionDetectsConflict(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conflict, err := CheckCollision(home, "/tmp/wt-shared", "new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "other-task" {
+		t.Fatalf("got conflict %q, want other-task", conflict)
+	}
+}
+
+func TestCheckCollisionExcludesOwnTask(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.Task{ID: "same-task", Worktree: "/tmp/wt-shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conflict, err := CheckCollision(home, "/tmp/wt-shared", "same-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "" {
+		t.Fatalf("got conflict %q, want none", conflict)
+	}
+}
+
+func TestCheckCollisionNoConflict(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-other"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conflict, err := CheckCollision(home, "/tmp/wt-shared", "new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "" {
+		t.Fatalf("got conflict %q, want none", conflict)
+	}
+}
+
+func TestCheckCollisionEmptyStateDir(t *testing.T) {
+	conflict, err := CheckCollision(t.TempDir(), "/tmp/wt-shared", "new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "" {
+		t.Fatalf("got conflict %q, want none", conflict)
+	}
+}


### PR DESCRIPTION
## Intent

Implement hand spawn, status, send, and teardown CLI commands per SPECS.md, plus the supporting internal packages (state, herdr, worktree, harness). Key deliberate decisions: SPECS.md's herdr CLI call templates and its claude/opencode harness launch templates are documented as unverified/wrong in SPECS.md itself, so I empirically verified real herdr CLI behavior (workspace/tab/pane subcommands, JSON envelope, agent_status field) and real claude/opencode --help output against live binaries, and implemented internal/herdr/client.go and internal/harness/harness.go to match reality rather than the spec's literal templates (codex/grok/pi harness builders were left following the literal SPECS.md templates since those binaries were not installed to verify against - this is a known gap, not an oversight). teardown fails closed (errors out) for ship tasks with no recorded PR when the project is not local-only, since landed-work status can't be determined in that case - this is intentional per SPECS.md's fail-closed philosophy for destructive operations, not a bug. Collision guard cross-checks the acquired treehouse worktree path against every other active task's state file (firstmate #947 stale-lease bug). Also fixed an unrelated .gitignore bug: the runtime-directory ignore patterns (state/, data/, projects/, config/) were unanchored and were silently excluding the new internal/state Go package; anchored them to the repo root. Full unit test suite added for all new packages and commands using fake binaries on PATH (herdr, treehouse, git, gh), all passing, plus go vet and gofmt clean. data/dashboard.md updates are explicitly out of scope for this task (deferred).

## What Changed
- Added `hand spawn`, `status`, `send`, and `teardown` commands with task state, herdr, harness, and worktree integrations.
- Hardened lifecycle operations with filesystem-boundary validation, cross-process locking, cleanup rollback, response validation, and safe teardown checks.
- Added comprehensive unit coverage and synchronized README/specification and agent documentation with verified integration behavior.

## Risk Assessment

✅ Low: Current changes are limited to aggregating spawn cleanup errors and preserving both primary and cleanup failures; no material correctness or regression risk found in the reviewed diff.

## Testing

After using Nix-provided Go and GCC because Go was not initially on PATH, exercised race-tested packages plus the tagged e2e target, then demonstrated the complete CLI lifecycle with actual command output and persisted-state cleanup evidence. No linters or static analysis were run.

<details>
<summary>Evidence: CLI lifecycle transcript</summary>

```text
secondhand CLI lifecycle transcript (built target binary, temporary fake herdr/treehouse)

$ hand init
initialized secondhand home at /tmp/no-mistakes-evidence/01KYAHRPMY4HH7QT2J6PC9MAEP/home

$ hand spawn task-1 demo --scout
spawned task-1 project=demo kind=scout harness=claude worktree=/tmp/secondhand-demo-worktree

$ hand status task-1
Task:       task-1
Project:    demo
Kind:       scout
Harness:    claude
Model:
State:      idle
Worktree:   /tmp/secondhand-demo-worktree
Herdr:      default / wA:tB
Created:    just now
PR:         (none)

$ hand send task-1 'Continue and report findings'
sent to task-1

$ hand teardown task-1
teardown task-1 complete

$ test ! -e state/task-1.json
state/task-1.json absent after teardown
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (7) ✅</summary>

- 🚨 `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/internal/state/task.go:16` - `Path` joins unchecked task IDs directly into the state directory, while CLI commands accept IDs without validation; an ID such as `../data/projects.md` can make `spawn`, `status`, `send`, or `teardown` read, overwrite, or delete files outside `state/` (and `spawn` similarly escapes via `data/&lt;id&gt;/brief.md`). Validate IDs and enforce path containment before filesystem operations.
- 🚨 `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:144` - The worker is launched and its worktree/tab are live before `state.Write`; if state persistence fails, command returns an error while leaving an untracked agent and leased worktree behind, and a retry can create another worker. Roll back the tab/worktree on state-write failure or persist/claim state before launching.
- 🚨 `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/teardown.go:176` - The code decides whether to close the workspace from `len(tabs)` without checking that `tabID` is present. If a stale task points to a closed tab while one unrelated tab remains, teardown closes the entire workspace and destroys that other worker. Verify the target tab is listed before choosing workspace-close versus tab-close, and fail safely when it is absent.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/internal/herdr/client.go:35` - `call` treats an empty successful stdout as success and does not reject a nonzero exit when stdout contains a JSON result. Mutating callers can therefore report successful workspace/tab/pane operations without a valid response, leaving state inconsistent with herdr. Require a valid envelope and propagate `runErr` unless the response explicitly represents the handled error.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:45` - The active-ID check and later state write are not atomic. Concurrent `spawn` invocations for the same ID can both pass `Exists`, launch two agents, and overwrite one state file, orphaning the other worker. Add an atomic state claim or lock spanning the check and creation.

🔧 Fix: Harden task lifecycle and filesystem boundaries
2 issues (1 error, 1 warning) still open:
- 🚨 `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:146` - State-write rollback always calls `TabClose`, but herdr refuses closing a workspace&#39;s only tab directly. When the newly created task is the workspace&#39;s sole tab and `state.Write` fails, cleanup leaves the workspace/tab (and possibly running worker) alive despite returning an error. Reuse `closeTaskTab(client, ws.WorkspaceID, tab.TabID)` so last-tab cleanup closes the workspace.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/internal/herdr/client.go:53` - Envelope validation only checks that `result` is present, so a malformed successful response with `&#34;result&#34;: null` is accepted. `WorkspaceList` then treats null as an empty list, causing spawn to create duplicate workspaces; mutating calls can likewise report success without a usable result. Require non-null, operation-appropriate result data before returning success.

🔧 Fix: Harden spawn rollback and herdr responses
3 issues (1 error, 2 warnings) still open:
- 🚨 `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:111` - Failure cleanup after harness construction or pane launch calls `TabClose` directly. Herdr rejects closing a workspace&#39;s only tab, so when spawn created the project&#39;s first tab these error paths leave the tab/workspace behind while returning the worktree and reporting failure. Use `closeTaskTab` consistently and close a newly created empty workspace when appropriate.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:85` - Two concurrent spawns for different task IDs in a project can both observe no workspace, then each execute `WorkspaceCreate`. This violates the one-workspace-per-project invariant and strands tabs in duplicate workspaces. Serialize workspace lookup/create per project or re-list and reuse an existing workspace after create races.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/internal/herdr/client.go:53` - Generic response validation accepts any non-null JSON value as `result`; calls that do not decode a typed result (`PaneRun`, send operations, and close operations) therefore treat malformed results such as `[]` or `0` as success. A failed launch or cleanup can then be reported as successful and leave state inconsistent with herdr. Require the expected result shape for each operation, or at minimum reject non-object results for these calls.

🔧 Fix: Harden spawn cleanup and herdr response validation
3 issues (1 error, 2 warnings) still open:
- 🚨 `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/teardown.go:35` - Teardown reads and later deletes task state without acquiring the task claim lock used by spawn. If teardown deletes the old state while a new spawn for the same ID claims it, teardown can close/return the old resources and then delete the newly written state, leaving the new worker untracked; serialize teardown with spawn using the same lifecycle lock.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:88` - `workspaceCreateMu` only serializes goroutines within one process. Two concurrent `hand spawn` processes can both observe no workspace at line 89 and create duplicate workspaces for one project, violating the one-workspace-per-project invariant and stranding tabs; use an inter-process project lock or re-list and reuse after creation races.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:79` - The worktree collision check is not an atomic reservation with the later state write. Concurrent spawns with different IDs can both pass `CheckCollision` for the same path before either state file is written, allowing two workers to use one worktree when treehouse returns a stale or duplicated lease; reserve the path under a shared inter-process lock before proceeding.

🔧 Fix: Serialize lifecycle operations across processes
1 warning still open:
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/teardown.go:34` - Teardown acquires only the task lock, while spawn serializes workspace/tab creation with a per-project lock. A concurrent spawn for another task can create a tab after `closeTaskTab` lists the existing tabs but before it closes the last-tab workspace, allowing teardown to close the workspace containing the new worker. Acquire the same project lock around teardown&#39;s herdr and worktree lifecycle operations.

🔧 Fix: Serialize teardown with project lifecycle lock
1 warning still open:
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/teardown.go:161` - `git branch --merged` checks branches merged into whatever branch is currently checked out in the project clone, not necessarily its default branch. A clone left on another branch can reject work merged into the default branch or accept work merged only into that unrelated branch; resolve the default branch and pass it to `git branch --merged &lt;default&gt;` (or compare commit ancestry explicitly).

🔧 Fix: Use default branch for teardown merge checks
1 warning still open:
- ⚠️ `/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYAHRPMY4HH7QT2J6PC9MAEP/cmd/spawn.go:128` - Spawn failure paths discard cleanup errors from `closeTaskTab`, `WorkspaceClose`, and `worktree.Return`; if herdr or treehouse cleanup fails, the command reports only the original error while leaving tabs, workspaces, or leases behind. Aggregate cleanup failures consistently, as done in the state-write rollback.

🔧 Fix: Aggregate spawn cleanup failures
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix shell nixpkgs#go_1_26 nixpkgs#gcc -c env CGO_ENABLED=1 go test -race ./...`
- `nix shell nixpkgs#go_1_26 -c go test -tags=e2e -timeout=10m ./tests/e2e/...`
- <code>Built binary with `nix shell nixpkgs#go_1_26 -c go build -o .../hand .`</code>
- <code>Ran `hand init`, `hand spawn task-1 demo --scout`, `hand status task-1`, `hand send task-1 &#39;Continue and report findings&#39;`, `hand teardown task-1` using temporary fake herdr/treehouse binaries</code>
- <code>Verified `state/task-1.json` was absent after teardown</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
