### PR TITLE
feat(cmd): add hand update self-update and startup version notice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Run `hand --help` for the full command reference.
 - Exit codes (SPECS.md "Exit codes") are enforced via `cmd.ExitError` (`cmd/root.go`), unwrapped in `Execute()`. Return `&ExitError{Err: ..., Code: 3}` for precondition failures (red CI, unlanded work, missing brief); plain errors default to code 1.
 - Dashboard maintenance (SPECS.md's per-command update rules) is only partially implemented: `project add/remove/sync` update `data/dashboard.md` via `updateDashboardProjects`; `spawn`/`teardown`/`merge`/`promote` deliberately do not touch the Active Tasks/Events sections. Follow this precedent rather than building it out unilaterally.
 - GitHub Releases access (`hand update`, `internal/selfupdate`) shells out to the `gh` CLI rather than calling the REST API directly, matching `internal/ghutil`'s existing convention. Tests fake `gh` with a shell script on `PATH` (see `writeFakeGH` in `internal/selfupdate/selfupdate_test.go`), the same pattern `cmd/status_test.go` uses for `herdr`.
+- `hand update` implements SPECS.md's update flow only partially: it deliberately does not re-run `hand init` to refresh the AGENTS.md template and does not print release notes. This is a recorded scope-down, not an oversight; follow this precedent rather than building it out unilaterally.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Run `hand --help` for the full command reference.
 - `internal/herdr/client.go` and `internal/harness/harness.go` are the source of truth for herdr and verified Claude/OpenCode syntax. Codex, Grok, and Pi templates in `SPECS.md` remain unverified until those binaries are available.
 - Exit codes (SPECS.md "Exit codes") are enforced via `cmd.ExitError` (`cmd/root.go`), unwrapped in `Execute()`. Return `&ExitError{Err: ..., Code: 3}` for precondition failures (red CI, unlanded work, missing brief); plain errors default to code 1.
 - Dashboard maintenance (SPECS.md's per-command update rules) is only partially implemented: `project add/remove/sync` update `data/dashboard.md` via `updateDashboardProjects`; `spawn`/`teardown`/`merge`/`promote` deliberately do not touch the Active Tasks/Events sections. Follow this precedent rather than building it out unilaterally.
+- GitHub Releases access (`hand update`, `internal/selfupdate`) shells out to the `gh` CLI rather than calling the REST API directly, matching `internal/ghutil`'s existing convention. Tests fake `gh` with a shell script on `PATH` (see `writeFakeGH` in `internal/selfupdate/selfupdate_test.go`), the same pattern `cmd/status_test.go` uses for `herdr`.
 
 ## Maintaining this file
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The worker lifecycle commands are available, including `hand spawn`, `hand statu
 | `hand teardown` | Clean up a completed task, fail-closed on unlanded work | Available |
 | `hand promote` | Promote a completed scout task into a ship task | Available |
 | `hand notify` | Send an out-of-band notification via a configured command | Available |
-| `hand update` | Update the installed binary | Specified; not yet implemented |
+| `hand update` | Update the installed binary from the latest GitHub Release; `--check` reports availability without installing | Available |
 
 Run `hand --help` for details on currently available commands.
 
@@ -70,7 +70,7 @@ flowchart TD
 - Go 1.26.5 or newer (build only)
 - [herdr](https://github.com/ogulcancelik/herdr) - terminal multiplexer with semantic agent state
 - [treehouse](https://github.com/kunchenguid/treehouse) - git worktree pool manager
-- [gh](https://github.com/cli/cli) - GitHub CLI, used for PR operations
+- [gh](https://github.com/cli/cli) - GitHub CLI, used for PR and release operations
 
 Optional:
 
@@ -98,6 +98,12 @@ nix build
 ```
 
 From releases: download the binary for your platform from the [releases page](https://github.com/atqamz/secondhand/releases).
+
+To update an installed binary, run `hand update`.
+It downloads the release asset for the current OS and architecture, verifies its SHA256 checksum, and replaces the running binary in place.
+`hand update --check` reports whether an update is available without installing it.
+Every other command run in a workspace prints a one-line notice to stderr when a newer release exists, checked at most once a day and cached in `state/.version-check`.
+Builds without an embedded version never print the notice.
 
 ## Configuration
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ func newRootCmd(version string) *cobra.Command {
 			}
 			if home, err := os.Getwd(); err == nil {
 				if notice := selfupdate.CheckNotice(home, selfupdate.Repo, version); notice != "" {
-					fmt.Fprintln(cmd.ErrOrStderr(), notice)
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), notice)
 				}
 			}
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/atqamz/secondhand/internal/selfupdate"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +14,17 @@ func newRootCmd(version string) *cobra.Command {
 		Use:     "hand",
 		Short:   "Talk to one agent. Ship with a crew.",
 		Version: version,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Name() == "update" {
+				return nil
+			}
+			if home, err := os.Getwd(); err == nil {
+				if notice := selfupdate.CheckNotice(home, selfupdate.Repo, version); notice != "" {
+					fmt.Fprintln(cmd.ErrOrStderr(), notice)
+				}
+			}
+			return nil
+		},
 	}
 	root.SetVersionTemplate("{{.Version}}\n")
 	root.AddCommand(newInitCmd())
@@ -25,6 +37,7 @@ func newRootCmd(version string) *cobra.Command {
 	root.AddCommand(newMergeCmd())
 	root.AddCommand(newPromoteCmd())
 	root.AddCommand(newNotifyCmd())
+	root.AddCommand(newUpdateCmd(version))
 	return root
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -63,6 +63,31 @@ func TestStatusFleetDegradesToUnknownWhenHerdrUnreachable(t *testing.T) {
 	}
 }
 
+func TestStatusFleetJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "working")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"id": "task-1"`) || !strings.Contains(out.String(), `"agent_state": "working"`) {
+		t.Fatalf("got %q, want JSON array with task-1 and agent_state working", out.String())
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out.String()), "[") {
+		t.Fatalf("got %q, want JSON array", out.String())
+	}
+}
+
 func TestStatusSingleTaskDetail(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/atqamz/secondhand/internal/selfupdate"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd(version string) *cobra.Command {
+	var checkOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Self-update the hand binary from GitHub Releases",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			latest, err := selfupdate.LatestTag(selfupdate.Repo)
+			if err != nil {
+				return err
+			}
+			newer, err := selfupdate.IsNewer(latest, version)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			if !newer {
+				_, err := fmt.Fprintf(out, "hand %s is up to date\n", version)
+				return err
+			}
+
+			if checkOnly {
+				_, err := fmt.Fprintf(out, "update available: %s -> %s\n", version, latest)
+				return err
+			}
+
+			if err := selfupdate.Apply(selfupdate.Repo, latest); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(out, "updated hand %s -> %s\n", version, latest)
+			return err
+		},
+	}
+
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "check whether an update is available without installing")
+	return cmd
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -66,6 +66,22 @@ func TestUpdateWithoutCheckSkipsInstallWhenUpToDate(t *testing.T) {
 	}
 }
 
+func TestUpdateCheckReportsAvailableUpdateForDevBuild(t *testing.T) {
+	writeFakeGHReleaseView(t, "v0.5.0")
+
+	cmd := newUpdateCmd("dev")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	want := "update available: dev -> v0.5.0\n"
+	if out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
 func TestUpdatePropagatesLatestTagError(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFakeGHReleaseView(t *testing.T, tag string) {
+	t.Helper()
+	bin := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' %q\n", tag)
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestUpdateCheckReportsAvailableUpdate(t *testing.T) {
+	writeFakeGHReleaseView(t, "v0.5.0")
+
+	cmd := newUpdateCmd("v0.1.0")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	want := "update available: v0.1.0 -> v0.5.0\n"
+	if out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
+func TestUpdateCheckReportsUpToDate(t *testing.T) {
+	writeFakeGHReleaseView(t, "v0.1.0")
+
+	cmd := newUpdateCmd("v0.1.0")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	want := "hand v0.1.0 is up to date\n"
+	if out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
+func TestUpdateWithoutCheckSkipsInstallWhenUpToDate(t *testing.T) {
+	writeFakeGHReleaseView(t, "v0.1.0")
+
+	cmd := newUpdateCmd("v0.1.0")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	want := "hand v0.1.0 is up to date\n"
+	if out.String() != want {
+		t.Fatalf("got %q, want %q", out.String(), want)
+	}
+}
+
+func TestUpdatePropagatesLatestTagError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	cmd := newUpdateCmd("v0.1.0")
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("want error when gh is unreachable")
+	}
+}

--- a/internal/selfupdate/notice.go
+++ b/internal/selfupdate/notice.go
@@ -24,7 +24,16 @@ type versionCache struct {
 // available, or "" when up to date or when the check can't be completed. It
 // is bounded by checkTimeout and never fails the caller: startup version
 // checks must be non-blocking and non-fatal per SPECS.md.
+//
+// A currentVersion that isn't semver (a build without ldflags, defaulting to
+// "dev") never gets a notice: there is no released version to compare against,
+// so nagging a from-source build would be noise. `hand update` still resolves
+// and installs the latest release for such builds.
 func CheckNotice(home, repo, currentVersion string) string {
+	if _, _, _, err := parseSemver(currentVersion); err != nil {
+		return ""
+	}
+
 	stateDir := filepath.Join(home, "state")
 	if _, err := os.Stat(stateDir); err != nil {
 		return ""
@@ -39,11 +48,13 @@ func CheckNotice(home, repo, currentVersion string) string {
 		ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
 		defer cancel()
 		tag, err := latestTag(ctx, repo)
+		// Cache failures too, so an unreachable or black-holed network costs
+		// one checkTimeout stall per interval instead of one per command.
+		_ = writeCache(cachePath, versionCache{CheckedAt: now, Latest: tag})
 		if err != nil {
 			return ""
 		}
 		latest = tag
-		_ = writeCache(cachePath, versionCache{CheckedAt: now, Latest: tag})
 	}
 
 	newer, err := IsNewer(latest, currentVersion)

--- a/internal/selfupdate/notice.go
+++ b/internal/selfupdate/notice.go
@@ -1,0 +1,74 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const cacheFile = ".version-check"
+
+const checkInterval = 24 * time.Hour
+
+const checkTimeout = 2 * time.Second
+
+type versionCache struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+}
+
+// CheckNotice returns a one-line stderr notice when a newer hand release is
+// available, or "" when up to date or when the check can't be completed. It
+// is bounded by checkTimeout and never fails the caller: startup version
+// checks must be non-blocking and non-fatal per SPECS.md.
+func CheckNotice(home, repo, currentVersion string) string {
+	stateDir := filepath.Join(home, "state")
+	if _, err := os.Stat(stateDir); err != nil {
+		return ""
+	}
+	cachePath := filepath.Join(stateDir, cacheFile)
+
+	now := time.Now()
+	latest := ""
+	if cache, err := readCache(cachePath); err == nil && now.Sub(cache.CheckedAt) < checkInterval {
+		latest = cache.Latest
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+		defer cancel()
+		tag, err := latestTag(ctx, repo)
+		if err != nil {
+			return ""
+		}
+		latest = tag
+		_ = writeCache(cachePath, versionCache{CheckedAt: now, Latest: tag})
+	}
+
+	newer, err := IsNewer(latest, currentVersion)
+	if err != nil || !newer {
+		return ""
+	}
+	return fmt.Sprintf("A new version of hand is available: %s -> %s\nRun \"hand update\" to update", currentVersion, latest)
+}
+
+func readCache(path string) (versionCache, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return versionCache{}, err
+	}
+	var cache versionCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return versionCache{}, err
+	}
+	return cache, nil
+}
+
+func writeCache(path string, cache versionCache) error {
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/selfupdate/notice_test.go
+++ b/internal/selfupdate/notice_test.go
@@ -1,0 +1,103 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCheckNoticeSkipsWithoutStateDir(t *testing.T) {
+	home := t.TempDir()
+	writeFakeGH(t, "v0.5.0", t.TempDir())
+
+	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+		t.Fatalf("got %q, want empty notice without state dir", notice)
+	}
+}
+
+func TestCheckNoticeReturnsMessageWhenNewer(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGH(t, "v0.5.0", t.TempDir())
+
+	notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0")
+	want := "A new version of hand is available: v0.1.0 -> v0.5.0\nRun \"hand update\" to update"
+	if notice != want {
+		t.Fatalf("got %q, want %q", notice, want)
+	}
+}
+
+func TestCheckNoticeEmptyWhenUpToDate(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGH(t, "v0.1.0", t.TempDir())
+
+	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+		t.Fatalf("got %q, want empty notice when up to date", notice)
+	}
+}
+
+func TestCheckNoticeUsesFreshCacheWithoutCallingGH(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := t.TempDir()
+	script := "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := writeCache(filepath.Join(home, "state", cacheFile), versionCache{
+		CheckedAt: time.Now(),
+		Latest:    "v0.5.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0")
+	want := "A new version of hand is available: v0.1.0 -> v0.5.0\nRun \"hand update\" to update"
+	if notice != want {
+		t.Fatalf("got %q, want %q", notice, want)
+	}
+}
+
+func TestCheckNoticeRefreshesStaleCache(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGH(t, "v0.6.0", t.TempDir())
+
+	if err := writeCache(filepath.Join(home, "state", cacheFile), versionCache{
+		CheckedAt: time.Now().Add(-25 * time.Hour),
+		Latest:    "v0.5.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0")
+	want := "A new version of hand is available: v0.1.0 -> v0.6.0\nRun \"hand update\" to update"
+	if notice != want {
+		t.Fatalf("got %q, want %q", notice, want)
+	}
+}
+
+func TestCheckNoticeEmptyWhenGHUnreachable(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+		t.Fatalf("got %q, want empty notice when gh unreachable", notice)
+	}
+}

--- a/internal/selfupdate/notice_test.go
+++ b/internal/selfupdate/notice_test.go
@@ -101,3 +101,52 @@ func TestCheckNoticeEmptyWhenGHUnreachable(t *testing.T) {
 		t.Fatalf("got %q, want empty notice when gh unreachable", notice)
 	}
 }
+
+func TestCheckNoticeCachesFailedCheck(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+		t.Fatalf("got %q, want empty notice when gh unreachable", notice)
+	}
+
+	cache, err := readCache(filepath.Join(home, "state", cacheFile))
+	if err != nil {
+		t.Fatalf("failed check did not write cache: %v", err)
+	}
+	if cache.CheckedAt.IsZero() {
+		t.Fatal("cache has zero CheckedAt, want the failed attempt recorded")
+	}
+	if cache.Latest != "" {
+		t.Fatalf("got cached latest %q, want empty after a failed check", cache.Latest)
+	}
+
+	writeFakeGH(t, "v0.5.0", t.TempDir())
+	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+		t.Fatalf("got %q, want empty notice while the failed check is still cached", notice)
+	}
+}
+
+func TestCheckNoticeSkipsUnparseableCurrentVersion(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := t.TempDir()
+	script := "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if notice := CheckNotice(home, "atqamz/secondhand", "dev"); notice != "" {
+		t.Fatalf("got %q, want empty notice for an unversioned build", notice)
+	}
+	if _, err := os.Stat(filepath.Join(home, "state", cacheFile)); err == nil {
+		t.Fatal("want no version check for an unversioned build")
+	}
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,222 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const Repo = "atqamz/secondhand"
+
+const binaryName = "hand"
+
+func AssetName() string {
+	return fmt.Sprintf("%s-%s-%s.tar.gz", binaryName, runtime.GOOS, runtime.GOARCH)
+}
+
+func LatestTag(repo string) (string, error) {
+	return latestTag(context.Background(), repo)
+}
+
+func latestTag(ctx context.Context, repo string) (string, error) {
+	out, err := runGH(ctx, "release", "view", "--repo", repo, "--json", "tagName", "--jq", ".tagName")
+	if err != nil {
+		return "", fmt.Errorf("query latest release: %w", err)
+	}
+	if out == "" {
+		return "", fmt.Errorf("query latest release: empty tag name")
+	}
+	return out, nil
+}
+
+// IsNewer reports whether latest is newer than current. A current version that
+// doesn't parse as semver (e.g. "dev", an unversioned local build) is always
+// considered outdated, since there's no way to prove it already matches latest.
+func IsNewer(latest, current string) (bool, error) {
+	lMajor, lMinor, lPatch, err := parseSemver(latest)
+	if err != nil {
+		return false, fmt.Errorf("parse latest version %q: %w", latest, err)
+	}
+	cMajor, cMinor, cPatch, err := parseSemver(current)
+	if err != nil {
+		return true, nil
+	}
+	if lMajor != cMajor {
+		return lMajor > cMajor, nil
+	}
+	if lMinor != cMinor {
+		return lMinor > cMinor, nil
+	}
+	return lPatch > cPatch, nil
+}
+
+func parseSemver(s string) (major, minor, patch int, err error) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, fmt.Errorf("invalid version %q", s)
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("invalid version %q", s)
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], nil
+}
+
+// Apply downloads the release tagged tag from repo, verifies its checksum, and
+// replaces the running binary in place. The replacement is atomic: the new
+// binary is written to a temp file in the same directory as the running
+// binary, then renamed over it, so a crash mid-update never leaves a partial
+// binary at the real path.
+// executableOverride lets tests point Apply at a fake binary path instead of
+// the real test binary produced by `go test`.
+var executableOverride = os.Executable
+
+func Apply(repo, tag string) error {
+	execPath, err := executableOverride()
+	if err != nil {
+		return fmt.Errorf("locate running binary: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("resolve running binary path: %w", err)
+	}
+
+	assetName := AssetName()
+
+	tmpDir, err := os.MkdirTemp("", "hand-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := downloadAssets(context.Background(), repo, tag, tmpDir, assetName, "checksums.txt"); err != nil {
+		return fmt.Errorf("download release assets: %w", err)
+	}
+	if err := verifyChecksum(tmpDir, assetName); err != nil {
+		return err
+	}
+
+	tmpBinary := filepath.Join(filepath.Dir(execPath), ".hand-update-"+tag)
+	if err := extractBinary(filepath.Join(tmpDir, assetName), tmpBinary); err != nil {
+		return err
+	}
+	defer os.Remove(tmpBinary)
+
+	if err := os.Rename(tmpBinary, execPath); err != nil {
+		return fmt.Errorf("replace running binary: %w", err)
+	}
+	return nil
+}
+
+func downloadAssets(ctx context.Context, repo, tag, dir string, patterns ...string) error {
+	args := []string{"release", "download", tag, "--repo", repo, "--dir", dir, "--clobber"}
+	for _, p := range patterns {
+		args = append(args, "--pattern", p)
+	}
+	_, err := runGH(ctx, args...)
+	return err
+}
+
+func verifyChecksum(dir, assetName string) error {
+	data, err := os.ReadFile(filepath.Join(dir, "checksums.txt"))
+	if err != nil {
+		return fmt.Errorf("read checksums.txt: %w", err)
+	}
+
+	want := ""
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[len(fields)-1], "*")
+		if name == assetName {
+			want = fields[0]
+			break
+		}
+	}
+	if want == "" {
+		return fmt.Errorf("checksums.txt has no entry for %s", assetName)
+	}
+
+	f, err := os.Open(filepath.Join(dir, assetName))
+	if err != nil {
+		return fmt.Errorf("open %s: %w", assetName, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash %s: %w", assetName, err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("checksum mismatch for %s: want %s, got %s", assetName, want, got)
+	}
+	return nil
+}
+
+func extractBinary(tarGzPath, destPath string) error {
+	f, err := os.Open(tarGzPath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", tarGzPath, err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("open gzip stream in %s: %w", tarGzPath, err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("%s not found in %s", binaryName, tarGzPath)
+		}
+		if err != nil {
+			return fmt.Errorf("read %s: %w", tarGzPath, err)
+		}
+		if hdr.Typeflag != tar.TypeReg || filepath.Base(hdr.Name) != binaryName {
+			continue
+		}
+
+		out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+		if err != nil {
+			return fmt.Errorf("write %s: %w", destPath, err)
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			out.Close()
+			return fmt.Errorf("write %s: %w", destPath, err)
+		}
+		return out.Close()
+	}
+}
+
+func runGH(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -103,7 +103,7 @@ func Apply(repo, tag string) error {
 	if err != nil {
 		return fmt.Errorf("create temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	if err := downloadAssets(context.Background(), repo, tag, tmpDir, assetName, "checksums.txt"); err != nil {
 		return fmt.Errorf("download release assets: %w", err)
@@ -117,7 +117,7 @@ func Apply(repo, tag string) error {
 		return fmt.Errorf("stage new binary: %w", err)
 	}
 	tmpBinary := staged.Name()
-	defer os.Remove(tmpBinary)
+	defer func() { _ = os.Remove(tmpBinary) }()
 	if err := staged.Close(); err != nil {
 		return fmt.Errorf("stage new binary: %w", err)
 	}
@@ -167,7 +167,7 @@ func verifyChecksum(dir, assetName string) error {
 	if err != nil {
 		return fmt.Errorf("open %s: %w", assetName, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
@@ -185,13 +185,13 @@ func extractBinary(tarGzPath, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("open %s: %w", tarGzPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
 		return fmt.Errorf("open gzip stream in %s: %w", tarGzPath, err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 
 	tr := tar.NewReader(gz)
 	for {
@@ -211,7 +211,7 @@ func extractBinary(tarGzPath, destPath string) error {
 			return fmt.Errorf("write %s: %w", destPath, err)
 		}
 		if _, err := io.Copy(out, tr); err != nil {
-			out.Close()
+			_ = out.Close()
 			return fmt.Errorf("write %s: %w", destPath, err)
 		}
 		if err := out.Close(); err != nil {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -112,11 +112,19 @@ func Apply(repo, tag string) error {
 		return err
 	}
 
-	tmpBinary := filepath.Join(filepath.Dir(execPath), ".hand-update-"+tag)
+	staged, err := os.CreateTemp(filepath.Dir(execPath), ".hand-update-*")
+	if err != nil {
+		return fmt.Errorf("stage new binary: %w", err)
+	}
+	tmpBinary := staged.Name()
+	defer os.Remove(tmpBinary)
+	if err := staged.Close(); err != nil {
+		return fmt.Errorf("stage new binary: %w", err)
+	}
+
 	if err := extractBinary(filepath.Join(tmpDir, assetName), tmpBinary); err != nil {
 		return err
 	}
-	defer os.Remove(tmpBinary)
 
 	if err := os.Rename(tmpBinary, execPath); err != nil {
 		return fmt.Errorf("replace running binary: %w", err)
@@ -206,7 +214,12 @@ func extractBinary(tarGzPath, destPath string) error {
 			out.Close()
 			return fmt.Errorf("write %s: %w", destPath, err)
 		}
-		return out.Close()
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("write %s: %w", destPath, err)
+		}
+		// OpenFile's mode only applies when it creates the file, and the
+		// staging path already exists.
+		return os.Chmod(destPath, 0o755)
 	}
 }
 

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -233,8 +233,12 @@ func TestExtractBinaryMissingFromArchive(t *testing.T) {
 	if _, err := tw.Write([]byte("abc")); err != nil {
 		t.Fatal(err)
 	}
-	tw.Close()
-	gz.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	archivePath := filepath.Join(dir, "archive.tar.gz")
 	if err := os.WriteFile(archivePath, tarBuf.Bytes(), 0o644); err != nil {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,183 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v0.4.0", "v0.3.1", true},
+		{"v0.3.1", "v0.4.0", false},
+		{"v0.3.1", "v0.3.1", false},
+		{"v1.0.0", "v0.9.9", true},
+		{"v0.1.2", "v0.1.1", true},
+		{"v0.4.0", "dev", true},
+		{"0.4.0", "0.3.1", true},
+	}
+	for _, c := range cases {
+		got, err := IsNewer(c.latest, c.current)
+		if err != nil {
+			t.Fatalf("IsNewer(%q, %q): %v", c.latest, c.current, err)
+		}
+		if got != c.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestIsNewerRejectsInvalidLatest(t *testing.T) {
+	if _, err := IsNewer("not-a-version", "v0.3.1"); err == nil {
+		t.Fatal("want error for unparseable latest version")
+	}
+}
+
+func writeFakeGH(t *testing.T, tag, fixtureDir string) {
+	t.Helper()
+	bin := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  printf '%%s' %q
+  exit 0
+fi
+if [ "$1" = "release" ] && [ "$2" = "download" ]; then
+  dir=""
+  prev=""
+  for a in "$@"; do
+    if [ "$prev" = "--dir" ]; then dir="$a"; fi
+    prev="$a"
+  done
+  cp %q/* "$dir"/
+  exit 0
+fi
+echo "unexpected gh invocation: $@" >&2
+exit 1
+`, tag, fixtureDir)
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func buildFixture(t *testing.T, binaryContent []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	assetName := AssetName()
+
+	var tarBuf bytes.Buffer
+	gz := gzip.NewWriter(&tarBuf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: binaryName, Mode: 0o755, Size: int64(len(binaryContent))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binaryContent); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, assetName), tarBuf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(tarBuf.Bytes())
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
+	if err := os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(checksums), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLatestTag(t *testing.T) {
+	writeFakeGH(t, "v0.5.0", t.TempDir())
+	tag, err := LatestTag("atqamz/secondhand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v0.5.0" {
+		t.Fatalf("got %q, want v0.5.0", tag)
+	}
+}
+
+func TestApplyReplacesRunningBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("update binary layout targets unix asset names")
+	}
+
+	fixture := buildFixture(t, []byte("new binary contents"))
+	writeFakeGH(t, "v0.5.0", fixture)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "hand")
+	if err := os.WriteFile(execPath, []byte("old binary contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := executableOverride
+	executableOverride = func() (string, error) { return execPath, nil }
+	defer func() { executableOverride = restore }()
+
+	if err := Apply("atqamz/secondhand", "v0.5.0"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new binary contents" {
+		t.Fatalf("got %q, want new binary contents", got)
+	}
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	assetName := AssetName()
+	if err := os.WriteFile(filepath.Join(dir, assetName), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte("deadbeef  "+assetName+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyChecksum(dir, assetName); err == nil {
+		t.Fatal("want checksum mismatch error")
+	}
+}
+
+func TestExtractBinaryMissingFromArchive(t *testing.T) {
+	dir := t.TempDir()
+	var tarBuf bytes.Buffer
+	gz := gzip.NewWriter(&tarBuf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "other-file", Mode: 0o644, Size: 3}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte("abc")); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gz.Close()
+
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	if err := os.WriteFile(archivePath, tarBuf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := extractBinary(archivePath, filepath.Join(dir, "out")); err == nil {
+		t.Fatal("want error when binary missing from archive")
+	}
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -142,6 +142,70 @@ func TestApplyReplacesRunningBinary(t *testing.T) {
 	if string(got) != "new binary contents" {
 		t.Fatalf("got %q, want new binary contents", got)
 	}
+
+	info, err := os.Stat(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("got mode %v, want 0755", info.Mode().Perm())
+	}
+
+	entries, err := os.ReadDir(execDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries in install dir, want only the replaced binary", len(entries))
+	}
+}
+
+func TestApplyLeavesNoStagedFileWhenExtractionFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("update binary layout targets unix asset names")
+	}
+
+	fixture := t.TempDir()
+	assetName := AssetName()
+	payload := []byte("not a gzip stream")
+	if err := os.WriteFile(filepath.Join(fixture, assetName), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(payload)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
+	if err := os.WriteFile(filepath.Join(fixture, "checksums.txt"), []byte(checksums), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGH(t, "v0.5.0", fixture)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "hand")
+	if err := os.WriteFile(execPath, []byte("old binary contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := executableOverride
+	executableOverride = func() (string, error) { return execPath, nil }
+	defer func() { executableOverride = restore }()
+
+	if err := Apply("atqamz/secondhand", "v0.5.0"); err == nil {
+		t.Fatal("want error when the asset is not a valid archive")
+	}
+
+	entries, err := os.ReadDir(execDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries in install dir, want no staged leftovers", len(entries))
+	}
+	got, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old binary contents" {
+		t.Fatalf("got %q, want the running binary left untouched", got)
+	}
 }
 
 func TestVerifyChecksumMismatch(t *testing.T) {


### PR DESCRIPTION
## Intent

Implement two new hand CLI features per SPECS.md: (1) hand update / hand update --check for self-updating the running binary from GitHub Releases (query latest tag via gh CLI, compare semver against ldflags-embedded main.version, download OS/arch-specific tarball asset + checksums.txt, verify SHA256, atomically replace the running binary via temp-file-then-rename in the same directory), plus a non-blocking daily-cached startup notice on stderr wired into root's PersistentPreRunE when a newer release exists (cached in state/.version-check, 24h TTL, 2s network timeout, silently skipped if state/ dir absent or gh unreachable). Deliberately scoped down from the full SPECS.md flow (lines 1116-1147): did NOT implement re-running hand init to refresh AGENTS.md template or printing release notes, since the delegated task's explicit Requirements list omitted those items. (2) hand status --json was investigated and found already fully implemented in cmd/status.go (both fleet-array and single-task-object JSON paths, including agent_state graceful degradation to "unknown") from an earlier PR - no code change was needed there, so I only added the one missing test case (fleet-wide --json) since it had no prior coverage. Followed existing repo conventions: internal/selfupdate shells out to the gh CLI (matching internal/ghutil's exec.Command pattern) rather than calling the GitHub REST API directly, since this codebase already established that convention and CLAUDE.md prefers project convention over personal preference and gh CLI over raw HTTP for GitHub ops. Tests fake gh via a shell script on PATH, mirroring the existing writeFakeHerdrPaneStatus pattern in cmd/status_test.go. Zero comments except one WHY-comment on the IsNewer dev-version fallback and one on the atomic-replace rationale. gofmt, go vet, go build, and CGO_ENABLED=1 go test -race ./... all verified clean, plus manual end-to-end smoke testing of hand update --check (both up-to-date and update-available paths, and the real unreachable-repo error path) and the startup notice/cache behavior.

## What Changed

- New `hand update` command plus `internal/selfupdate`: resolves the latest release tag via the `gh` CLI, compares it against the ldflags-embedded version, downloads the OS/arch tarball asset and `checksums.txt`, verifies SHA256, and atomically replaces the running binary via temp-file-then-rename in the install directory. `--check` reports availability without installing.
- Wired a non-blocking version notice into root's `PersistentPreRunE`: prints a one-line stderr notice when a newer release exists, cached in `state/.version-check` with a 24h TTL and a 2s network timeout, skipped when `state/` is absent, on `hand update` itself, and for builds without an embedded version. Failed probes are cached too, so an unreachable `gh` does not re-stall every command.
- Added tests for the new package and command, plus a fleet-wide `hand status --json` case (that path was already implemented and needed no code change), and documented `hand update` in README.md and the gh-CLI/scope-down conventions in AGENTS.md.

## Risk Assessment

✅ Low: The branch is additive (new internal/selfupdate package, new update command, one added test) with the round-1 concerns now fixed and covered by targeted tests, and the only cross-cutting surface - the root startup notice - is bounded by a 2s timeout, cached for 24h including failures, and silently skipped outside a workspace or on unversioned builds.

## Testing

<code>Ran the full `go test -race ./...` suite (all green after putting a nix-store gcc on PATH for cgo) plus the targeted selfupdate/update/status-JSON tests, then drove both features end-to-end as a user would: two real ldflags-versioned `hand` binaries and a fake `gh` serving a properly packaged release let me watch `hand update` actually replace the running binary in place (v0.1.0 -&gt; v0.2.0, sha256 matching the release build, no leftover staging file), reject a tampered asset on checksum without touching the installed binary, and request the correct OS/arch asset pattern; the startup notice printed SPECS.md&#39;s exact wording on stderr with stdout still jq-parseable, cached to state/.version-check with a verified 24h TTL, and stayed silent for missing state/, unreachable or hanging gh, dev builds, and `hand update` itself; `hand status --json` produced valid fleet-array and single-task-object output including agent_state degrading to &#34;unknown&#34;. CLI transcripts for all of this are saved as artifacts. No test failures; one informational note that the 2s timeout lacks cmd.WaitDelay hardening, which only bites if gh leaves a grandchild holding stdout.</code>

<details>
<summary>Evidence: hand update end-to-end: in-place self-replacement of the running binary</summary>

<code>$ hand --version # installed build, ldflags-embedded main.version&#10;v0.1.0&#10;&#10;$ hand update --check&#10;update available: v0.1.0 -&gt; v0.2.0&#10;exit=0&#10;&#10;$ sha256sum $(command -v hand) # before update&#10;ab36e4737065fbb78c9eee3efd1f87bcc39572754fdfbf9d1f060cdb7a619a46 /tmp/hand-e2e-kaob/bin/hand&#10;&#10;$ hand update&#10;updated hand v0.1.0 -&gt; v0.2.0&#10;exit=0&#10;&#10;$ hand --version # same path, now the new binary&#10;v0.2.0&#10;&#10;$ sha256sum $(command -v hand) # after update -&gt; matches release build&#10;70b46aa0e43d46740792b39bec6cfe0385425eca2fb65e4c9d20432d1f7ffb74 /tmp/hand-e2e-kaob/bin/hand&#10;&#10;$ hand update --check # now up to date&#10;hand v0.2.0 is up to date&#10;&#10;$ ls -a $(dirname hand) # no leftover staging temp files&#10;.&#10;..&#10;hand</code>

```text
$ hand --version    # installed build, ldflags-embedded main.version
v0.1.0

$ hand update --check
update available: v0.1.0 -> v0.2.0
exit=0

$ sha256sum $(command -v hand)   # before update
ab36e4737065fbb78c9eee3efd1f87bcc39572754fdfbf9d1f060cdb7a619a46  /tmp/hand-e2e-kaob/bin/hand

$ hand update
updated hand v0.1.0 -> v0.2.0
exit=0

$ hand --version    # same path, now the new binary
v0.2.0

$ sha256sum $(command -v hand)   # after update -> matches release build
70b46aa0e43d46740792b39bec6cfe0385425eca2fb65e4c9d20432d1f7ffb74  /tmp/hand-e2e-kaob/bin/hand

$ hand update --check   # now up to date
hand v0.2.0 is up to date

$ ls -a $(dirname hand)   # no leftover staging temp files
.
..
hand
```
</details>
<details>
<summary>Evidence: SHA256 verification rejects a tampered release asset, binary left intact</summary>

<code>$ # release asset tampered with after checksums.txt was generated&#10;$ hand --version&#10;v0.1.0&#10;&#10;$ hand update&#10;Error: checksum mismatch for hand-linux-amd64.tar.gz: want 46e2b5cc3c2ad6f1acbccb37e3dd5a64413604f89ff722a6c48529d6bc341b6f, got e6b95821bcc5253385d882be50ef529aedece64bd79e964401b3e45845c6518d&#10;exit=1&#10;&#10;$ hand --version # running binary untouched after the failed update&#10;v0.1.0&#10;&#10;$ ls -a $(dirname hand) # no partial/staged binary left behind&#10;.&#10;..&#10;hand</code>

```text
$ # release asset tampered with after checksums.txt was generated
$ hand --version
v0.1.0

$ hand update
Error: checksum mismatch for hand-linux-amd64.tar.gz: want 46e2b5cc3c2ad6f1acbccb37e3dd5a64413604f89ff722a6c48529d6bc341b6f, got e6b95821bcc5253385d882be50ef529aedece64bd79e964401b3e45845c6518d
Usage:
  hand update [flags]

Flags:
      --check   check whether an update is available without installing
  -h, --help    help for update

checksum mismatch for hand-linux-amd64.tar.gz: want 46e2b5cc3c2ad6f1acbccb37e3dd5a64413604f89ff722a6c48529d6bc341b6f, got e6b95821bcc5253385d882be50ef529aedece64bd79e964401b3e45845c6518d
exit=1

$ hand --version   # running binary untouched after the failed update
v0.1.0

$ ls -a $(dirname hand)   # no partial/staged binary left behind
.
..
hand
```
</details>
<details>
<summary>Evidence: Startup version notice on stderr + daily cache in state/.version-check</summary>

<code>$ # fresh workspace, no state/ dir yet -&gt; check is silently skipped&#10;$ hand status&#10;gh calls so far: 0&#10;&#10;$ hand init&#10;(workspace created)&#10;config data projects state&#10;&#10;$ hand status # state/ exists now -&gt; startup notice on stderr&#10;A new version of hand is available: v0.1.0 -&gt; v0.2.0&#10;Run &#34;hand update&#34; to update&#10;&#10;$ cat state/.version-check&#10;{&#34;checked_at&#34;:&#34;2026-07-25T08:13:45.862729085+07:00&#34;,&#34;latest&#34;:&#34;v0.2.0&#34;}&#10;gh calls so far: 1&#10;&#10;$ hand status # second run within 24h TTL: notice served from cache&#10;A new version of hand is available: v0.1.0 -&gt; v0.2.0&#10;Run &#34;hand update&#34; to update&#10;gh calls so far: 1 &lt;- unchanged, no new network hit&#10;&#10;$ hand status --json 2&gt;/dev/null # stdout stays clean and machine-parseable&#10;[]&#10;&#10;$ gh calls made:&#10;gh release view --repo atqamz/secondhand --json tagName --jq .tagName</code>

```text
$ # fresh workspace, no state/ dir yet -> check is silently skipped
$ hand status
gh calls so far: 0

$ hand init
(workspace created)
.
..
config
data
projects
state

$ hand status        # state/ exists now -> startup notice on stderr
A new version of hand is available: v0.1.0 -> v0.2.0
Run "hand update" to update

$ cat state/.version-check
{"checked_at":"2026-07-25T08:13:45.862729085+07:00","latest":"v0.2.0"}
gh calls so far: 1

$ hand status        # second run within 24h TTL: notice served from cache
A new version of hand is available: v0.1.0 -> v0.2.0
Run "hand update" to update
gh calls so far: 1   <- unchanged, no new network hit

$ hand status --json 2>/dev/null    # stdout stays clean and machine-parseable
[]

$ gh calls made:
gh release view --repo atqamz/secondhand --json tagName --jq .tagName
```
</details>
<details>
<summary>Evidence: Notice edge cases: unreachable gh, 2s timeout bound, TTL expiry, self-skip, dev build</summary>

<code>$ GH_FAIL=1 hand status&#10;exit=0 (no notice, command still succeeds)&#10;$ cat state/.version-check # failed check cached too&#10;{&#34;checked_at&#34;:&#34;2026-07-25T08:16:02.40426195+07:00&#34;,&#34;latest&#34;:&#34;&#34;}&#10;gh calls: 1&#10;$ GH_FAIL=1 hand status # second run: failure is cached, no repeated network stall&#10;exit=0&#10;gh calls: 1 &lt;- unchanged&#10;&#10;$ PATH=&lt;gh that hangs forever&gt; hand status&#10;exit=0 elapsed=2011ms (killed at the 2s bound, no notice, command still succeeds)&#10;&#10;$ # --- 24h TTL expiry forces a re-check ---&#10;A new version of hand is available: v0.1.0 -&gt; v0.2.0&#10;Run &#34;hand update&#34; to update&#10;gh calls: 1 &lt;- re-queried after the 24h TTL&#10;&#10;$ hand update --check&#10;update available: v0.1.0 -&gt; v0.2.0&#10;(exactly one line above: no duplicate startup notice)&#10;&#10;$ hand-dev --version&#10;dev&#10;$ hand-dev status&#10;exit=0 (silent)</code>

```text
$ # --- github unreachable ---
$ GH_FAIL=1 hand status
exit=0  (no notice, command still succeeds)
$ cat state/.version-check   # failed check cached too
{"checked_at":"2026-07-25T08:16:02.40426195+07:00","latest":""}
gh calls: 1
$ GH_FAIL=1 hand status      # second run: failure is cached, no repeated network stall
exit=0
gh calls: 1   <- unchanged

$ # --- github hanging: startup check is bounded by the 2s timeout ---
$ PATH=<gh that hangs forever> hand status
exit=0  elapsed=2011ms  (killed at the 2s bound, no notice, command still succeeds)

$ # --- 24h TTL expiry forces a re-check ---
A new version of hand is available: v0.1.0 -> v0.2.0
Run "hand update" to update
gh calls: 1   <- re-queried after the 24h TTL

$ # --- hand update never nags about itself ---
$ hand update --check
update available: v0.1.0 -> v0.2.0
(exactly one line above: no duplicate startup notice)

$ # --- unversioned dev build (no ldflags) is never nagged ---
$ hand-dev --version
dev
$ hand-dev status
exit=0  (silent)
```
</details>
<details>
<summary>Evidence: hand status --json: fleet array, single-task object, agent_state degradation</summary>

<code>$ hand status # human-readable fleet table&#10;api-refactor secondhand ship working 15h ago&#10;deps-scout secondhand scout working just now&#10;&#10;$ hand status --json # fleet-wide array&#10;[&#10;{&#10;&#34;id&#34;: &#34;api-refactor&#34;,&#10;&#34;project&#34;: &#34;secondhand&#34;,&#10;&#34;kind&#34;: &#34;ship&#34;,&#10;&#34;harness&#34;: &#34;claude&#34;,&#10;&#34;agent_state&#34;: &#34;working&#34;,&#10;&#34;worktree&#34;: &#34;/home/atqa/worktrees/api-refactor&#34;,&#10;&#34;herdr&#34;: { &#34;session&#34;: &#34;fleet&#34;, &#34;workspace_id&#34;: &#34;w1&#34;, &#34;tab_id&#34;: &#34;t1&#34;, &#34;pane_id&#34;: &#34;wA:pB&#34; },&#10;&#34;pr&#34;: &#34;https://github.com/atqamz/secondhand/pull/42&#34;,&#10;&#34;created_at&#34;: &#34;2026-07-24T10:00:00Z&#34;&#10;},&#10;...&#10;]&#10;&#10;$ hand status --json | jq -r &#34;.[] | .id + \&#34; \&#34; + .agent_state&#34; # parses as valid JSON&#10;api-refactor working&#10;deps-scout working&#10;&#10;$ PATH=&lt;no herdr&gt; hand status --json | jq -r ... # degrades to &#34;unknown&#34;&#10;api-refactor unknown&#10;deps-scout unknown</code>

```text
$ hand status            # human-readable fleet table
api-refactor    secondhand  ship    working     15h ago
deps-scout      secondhand  scout   working     just now

$ hand status --json     # fleet-wide array
[
  {
    "id": "api-refactor",
    "project": "secondhand",
    "kind": "ship",
    "harness": "claude",
    "agent_state": "working",
    "worktree": "/home/atqa/worktrees/api-refactor",
    "herdr": {
      "session": "fleet",
      "workspace_id": "w1",
      "tab_id": "t1",
      "pane_id": "wA:pB"
    },
    "pr": "https://github.com/atqamz/secondhand/pull/42",
    "created_at": "2026-07-24T10:00:00Z"
  },
  {
    "id": "deps-scout",
    "project": "secondhand",
    "kind": "scout",
    "harness": "opencode",
    "agent_state": "working",
    "worktree": "",
    "herdr": {
      "session": "fleet",
      "workspace_id": "w1",
      "tab_id": "t2",
      "pane_id": "wA:pC"
    },
    "pr": "",
    "created_at": "2026-07-25T02:30:00Z"
  }
]

$ hand status api-refactor --json    # single-task object
{
  "id": "api-refactor",
  "project": "secondhand",
  "kind": "ship",
  "harness": "claude",
  "agent_state": "working",
  "worktree": "/home/atqa/worktrees/api-refactor",
  "herdr": {
    "session": "fleet",
    "workspace_id": "w1",
    "tab_id": "t1",
    "pane_id": "wA:pB"
  },
  "pr": "https://github.com/atqamz/secondhand/pull/42",
  "created_at": "2026-07-24T10:00:00Z"
}

$ hand status --json | jq -r ".[] | .id + \" \" + .agent_state"   # parses as valid JSON
api-refactor  working
deps-scout  working

$ PATH=<no herdr> hand status --json | jq -r ".[] | .id + \" \" + .agent_state"   # degrades to "unknown"
api-refactor  unknown
deps-scout  unknown
```
</details>
<details>
<summary>Evidence: gh invocations issued by hand update (OS/arch-specific asset + checksums)</summary>

<code>$ uname -m; hand --version&#10;x86_64&#10;v0.1.0&#10;&#10;$ hand update&#10;updated hand v0.1.0 -&gt; v0.2.0&#10;&#10;$ hand --version # same file on disk, new version&#10;v0.2.0&#10;&#10;$ # gh invocations the update made:&#10;gh release view --repo atqamz/secondhand --json tagName --jq .tagName&#10;gh release download v0.2.0 --repo atqamz/secondhand --dir /tmp/hand-update-2417482091 --clobber --pattern hand-linux-amd64.tar.gz --pattern checksums.txt</code>

```text
$ uname -m; hand --version
x86_64
v0.1.0

$ hand update
updated hand v0.1.0 -> v0.2.0

$ hand --version   # same file on disk, new version
v0.2.0

$ # gh invocations the update made (OS/arch-specific asset + checksums):
gh release view --repo atqamz/secondhand --json tagName --jq .tagName
gh release download v0.2.0 --repo atqamz/secondhand --dir /tmp/hand-update-2417482091 --clobber --pattern hand-linux-amd64.tar.gz --pattern checksums.txt
```
</details>
- Outcome: ⚠️ 1 info across 1 run (8m14s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/selfupdate/notice.go:43` - internal/selfupdate/notice.go:43 - when `latestTag` fails the function returns &#34;&#34; without writing the cache, so nothing records that a check was attempted. Every subsequent `hand` command in a workspace re-invokes `gh release view` and blocks for the full 2s `checkTimeout` when the network black-holes or GitHub is slow, adding a repeated 2s stall to every command (including `hand watch`, `hand status --json` in scripts). This contradicts the function&#39;s own doc comment claim that startup checks are non-blocking, and SPECS.md line 1144 (&#34;Non-blocking, non-fatal&#34;). Fix: write the cache with `CheckedAt: now` (empty/unchanged `Latest`) on failure too, so a failed probe backs off instead of retrying on every invocation.
- ℹ️ `internal/selfupdate/selfupdate.go:115` - internal/selfupdate/selfupdate.go:115-119 - the staging path is a deterministic `.hand-update-&lt;tag&gt;` in the install directory, and `defer os.Remove(tmpBinary)` is registered only after `extractBinary` returns successfully. If extraction fails partway (`io.Copy` error), a partial file is left behind in the install dir (e.g. ~/.local/bin/.hand-update-v0.5.0) with no cleanup. The fixed name also means two concurrent `hand update` runs share it: one can `O_TRUNC` the file while the other renames, putting a truncated binary at the real path. Use `os.CreateTemp(filepath.Dir(execPath), &#34;.hand-update-*&#34;)` and register the remove defer immediately after creation.
- ℹ️ `internal/selfupdate/selfupdate.go:64` - internal/selfupdate/selfupdate.go:64 - `IsNewer` treats any unparseable current version as outdated, and `main.go` defaults `version` to &#34;dev&#34;. Consequence: every from-source install (a documented install path, SPECS.md lines 1090-1096) shows the daily startup nag &#34;A new version of hand is available: dev -&gt; vX.Y.Z&#34; in any workspace with state/, and `hand update` on a locally built binary silently replaces the contributor&#39;s own build with the released one. Documented as deliberate in the WHY comment; confirm this is the intended behavior for source builds rather than treating an unparseable version as &#34;unknown, stay quiet&#34;.
- ℹ️ `AGENTS.md:32` - AGENTS.md:32 - the new entry records only the gh-CLI convention, not that `hand update` deliberately omits SPECS.md steps 4-5 (re-run `hand init` to refresh the AGENTS.md template, print release notes). The file&#39;s existing precedent explicitly documents deliberate partial implementations (&#34;Dashboard maintenance ... is only partially implemented ... Follow this precedent rather than building it out unilaterally&#34;) so a future agent does not read the SPECS gap as a bug or build it out unilaterally. Add one clause noting the scope-down.

🔧 Fix: fix update staging, cache failed checks, skip dev nag
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/selfupdate/selfupdate.go:226` - The 2s startup version-check timeout is enforced only by exec.CommandContext killing the gh process; cmd.WaitDelay is not set in internal/selfupdate/selfupdate.go:runGH. If gh leaves any child process holding the inherited stdout pipe (credential helper, wrapper script), cmd.Wait blocks past the deadline and the &#34;non-blocking&#34; startup notice stalls every hand command. Verified the realistic case is fine: a single-process hanging gh is bounded at 2011ms. Reproduced the unbounded case only with a shell-script gh that spawned `sleep 60` as a grandchild (60030ms). Informational, not a test failure.
- <code>`CGO_ENABLED=1 go test -race ./...` (full suite, gcc sourced from nix store)</code>
- <code>`CGO_ENABLED=1 go test -race -v ./internal/selfupdate/...` (15 tests)</code>
- `CGO_ENABLED=1 go test -race -run 'Update|StatusFleetJSON' -v ./cmd/`
- <code>Built real binaries: `go build -ldflags &#34;-s -w -X main.version=v0.1.0&#34;` and `v0.2.0`, packaged v0.2.0 as `hand-linux-amd64.tar.gz` + `sha256sum ... &gt; checksums.txt` mirroring .github/workflows/release.yaml</code>
- <code>Manual E2E with a fake `gh` on PATH: `hand update --check` -&gt; `hand update` -&gt; `hand --version` -&gt; `hand update --check`, plus `sha256sum` and `ls -a` on the install dir before/after to prove in-place atomic replacement with no leftover `.hand-update-*` file</code>
- <code>Manual E2E: appended bytes to the release tarball after checksums.txt generation, ran `hand update`, confirmed `checksum mismatch` error, exit 1, unchanged running binary, no staged file</code>
- <code>Manual E2E startup notice: `hand status` before/after `hand init` (state/ dir absent vs present), inspected `state/.version-check`, counted gh invocations across repeated runs to prove the 24h cache</code>
- <code>Manual E2E notice edge cases: `GH_FAIL=1 hand status` (unreachable, failure cached), hanging gh timed with `date +%s%N` (2011ms bound), stale-timestamp cache forcing re-query, `hand update --check` self-skip, unversioned `dev` build silence</code>
- <code>Manual E2E: `hand status`, `hand status --json`, `hand status &lt;id&gt; --json`, and `PATH=/nonexistent hand status --json`, each piped through `jq` to confirm valid JSON and agent_state values</code>
- <code>`git status --porcelain` to confirm no build artifacts left in the worktree</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `SPECS.md:1126` - SPECS.md &#34;Self-update: hand update&#34; still specifies steps the implementation deliberately omits (re-run `hand init` to refresh AGENTS.md, print release notes) and shows sample output (`current:`/`latest:`/`updated AGENTS.md template`) that does not match `cmd/update.go`. AGENTS.md records the scope-down, so I left SPECS.md as the unimplemented target rather than rewriting the spec to match code. Judgment call: if SPECS.md is meant to track shipped behavior, the section needs an explicit &#34;not implemented&#34; annotation on steps 4-5 and a corrected example.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/selfupdate/selfupdate_test.go:236` - golangci-lint (errcheck, enabled by default and run by `make lint` / the CI Lint job) fails on unchecked `tw.Close()` (line 236) and `gz.Close()` (line 237) in the tar fixture helper. Left unfixed because this pass must not modify test files; the mechanical fix is the repo&#39;s `_ = tw.Close()` convention. CI lint is red until applied.

🔧 Fix: check tar writer close errors in selfupdate test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
