### PR TITLE
fix(cmd): parse subprocess stdout only and pad CLI table columns with tabwriter

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -277,7 +277,7 @@ Behavior:
 1. Validate project exists in registry.
 2. Validate no active task with this ID exists.
 3. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
-4. Acquire a treehouse worktree: `treehouse get <project-clone-path>`.
+4. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
 5. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in `state/*.json`. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
 6. Create a herdr tab in the project's workspace.
    - Workspace naming: one workspace per project, named after the project.

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/project"
@@ -254,13 +255,13 @@ func newProjectListCmd() *cobra.Command {
 				return enc.Encode(out)
 			}
 
-			w := cmd.OutOrStdout()
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			for _, p := range projects {
-				if _, err := fmt.Fprintf(w, "%-12s%-40s%s\n", p.Name, p.URL, p.Mode); err != nil {
+				if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", p.Name, p.URL, p.Mode); err != nil {
 					return err
 				}
 			}
-			return nil
+			return w.Flush()
 		},
 	}
 

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -178,6 +178,33 @@ func TestProjectRemoveRefusesUnregistered(t *testing.T) {
 	}
 }
 
+func TestProjectListColumnsDoNotMergeAtFieldWidth(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(home)
+
+	url := "https://github.com/atqamz/secondhand.git"
+	if err := project.Add(home, project.Project{Name: "secondhand", URL: url, Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newProjectListCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.String(), url+" ") {
+		t.Fatalf("project list output = %q, want %q followed by a column separator before the mode", out.String(), url)
+	}
+	if strings.Contains(out.String(), url+"no-mistakes") {
+		t.Fatalf("project list output = %q, URL and mode columns merged", out.String())
+	}
+}
+
 func TestReserveCloneDestinationIsAtomic(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "projects", "repo")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"text/tabwriter"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/herdr"
@@ -82,13 +83,13 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		return enc.Encode(rows)
 	}
 
-	w := cmd.OutOrStdout()
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	for _, r := range rows {
-		if _, err := fmt.Fprintf(w, "%-16s%-12s%-8s%-12s%s\n", r.ID, r.Project, r.Kind, r.AgentState, formatAge(r.CreatedAt)); err != nil {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.ID, r.Project, r.Kind, r.AgentState, formatAge(r.CreatedAt)); err != nil {
 			return err
 		}
 	}
-	return nil
+	return w.Flush()
 }
 
 func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON bool) error {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -42,6 +42,32 @@ func TestStatusFleetListsAllTasks(t *testing.T) {
 	}
 }
 
+func TestStatusFleetColumnsDoNotMergeAtFieldWidth(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "working")
+
+	id := "task-aaaaaaaaaaa"
+	if err := state.Write(home, state.Task{ID: id, Project: "myproject12", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), id+"myproject12") {
+		t.Fatalf("got %q, ID and project columns merged", out.String())
+	}
+	if !strings.Contains(out.String(), id+" ") {
+		t.Fatalf("got %q, want %q followed by a column separator", out.String(), id)
+	}
+}
+
 func TestStatusFleetDegradesToUnknownWhenHerdrUnreachable(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/internal/ghutil/pr.go
+++ b/internal/ghutil/pr.go
@@ -1,8 +1,8 @@
 // Package ghutil shells out to the gh CLI for PR access rather than calling the
 // REST API directly; internal/selfupdate follows the same convention for
-// GitHub Releases. Tests fake gh with a shell script on PATH (see writeFakeGH
-// in internal/selfupdate/selfupdate_test.go and the same pattern in
-// cmd/status_test.go for herdr).
+// GitHub Releases. Tests fake gh with a shell script on PATH (see writeFakeGHPRView
+// in pr_test.go; the same pattern covers releases in
+// internal/selfupdate/selfupdate_test.go and herdr in cmd/status_test.go).
 package ghutil
 
 import (
@@ -14,6 +14,9 @@ import (
 	"strings"
 )
 
+// PRIsMerged reports whether the PR is merged. gh writes warnings to stderr ahead of
+// the JSON, so the payload must be read from stdout alone; CombinedOutput here corrupts
+// the parse (issue #21).
 func PRIsMerged(ctx context.Context, pr string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "state")
 	var stderr bytes.Buffer

--- a/internal/ghutil/pr.go
+++ b/internal/ghutil/pr.go
@@ -20,7 +20,7 @@ func PRIsMerged(ctx context.Context, pr string) (bool, error) {
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return false, fmt.Errorf("gh pr view failed: %s", strings.TrimSpace(stderr.String()))
+		return false, fmt.Errorf("gh pr view failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	var body struct {
 		State string `json:"state"`

--- a/internal/ghutil/pr.go
+++ b/internal/ghutil/pr.go
@@ -6,6 +6,7 @@
 package ghutil
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,9 +15,12 @@ import (
 )
 
 func PRIsMerged(ctx context.Context, pr string) (bool, error) {
-	out, err := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "state").CombinedOutput()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "state")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		return false, fmt.Errorf("gh pr view failed: %s", strings.TrimSpace(string(out)))
+		return false, fmt.Errorf("gh pr view failed: %s", strings.TrimSpace(stderr.String()))
 	}
 	var body struct {
 		State string `json:"state"`

--- a/internal/ghutil/pr_test.go
+++ b/internal/ghutil/pr_test.go
@@ -1,0 +1,58 @@
+package ghutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFakeGHPRView fakes `gh pr view --json state`, emitting a stderr line
+// ahead of the JSON payload so a CombinedOutput regression at the call site
+// fails the parse the same way real gh's progress output does.
+func writeFakeGHPRView(t *testing.T, state string, exitCode int, stderrLine string) {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\n"
+	if stderrLine != "" {
+		script += fmt.Sprintf("echo %q >&2\n", stderrLine)
+	}
+	if exitCode != 0 {
+		script += fmt.Sprintf("exit %d\n", exitCode)
+	} else {
+		script += fmt.Sprintf("printf '{\"state\":\"%s\"}\\n'\n", state)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+}
+
+func TestPRIsMergedIgnoresStderrNoise(t *testing.T) {
+	for _, c := range []struct {
+		state string
+		want  bool
+	}{{"MERGED", true}, {"OPEN", false}} {
+		writeFakeGHPRView(t, c.state, 0, "Warning: gh version 2.40.0 is out of date")
+		got, err := PRIsMerged(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("PRIsMerged with state %s: %v", c.state, err)
+		}
+		if got != c.want {
+			t.Errorf("PRIsMerged with state %s = %v, want %v", c.state, got, c.want)
+		}
+	}
+}
+
+func TestPRIsMergedReportsExitStatusWithoutStderr(t *testing.T) {
+	writeFakeGHPRView(t, "", 1, "")
+	_, err := PRIsMerged(context.Background(), "42")
+	if err == nil {
+		t.Fatal("want error when gh exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Fatalf("got %q, want the exit status in the message", err)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -13,6 +13,8 @@ import (
 
 // Get acquires a worktree from the project clone's treehouse pool.
 // clonePath must be the project clone directory (treehouse resolves the pool from cwd).
+// treehouse writes banners to stderr ahead of the JSON, so the payload must be read
+// from stdout alone; CombinedOutput here corrupts every parse (issue #21).
 func Get(clonePath, leaseHolder string) (string, error) {
 	args := []string{"get", "--lease", "--json"}
 	if leaseHolder != "" {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -2,6 +2,7 @@
 package worktree
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -19,9 +20,11 @@ func Get(clonePath, leaseHolder string) (string, error) {
 	}
 	cmd := exec.Command("treehouse", args...)
 	cmd.Dir = clonePath
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("treehouse get failed: %s", strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("treehouse get failed: %s", strings.TrimSpace(stderr.String()))
 	}
 
 	var lease struct {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -24,7 +24,7 @@ func Get(clonePath, leaseHolder string) (string, error) {
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("treehouse get failed: %s", strings.TrimSpace(stderr.String()))
+		return "", fmt.Errorf("treehouse get failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
 	var lease struct {

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -145,7 +145,7 @@ func setPaneStatus(t *testing.T, statusDir, paneID, status string) {
 // CombinedOutput regression at the call site fails the suite.
 func writeFakeTreehouse(t *testing.T, dir, worktreePath string) {
 	t.Helper()
-	body := fmt.Sprintf(`  get) echo '🌳 treehouse' >&2; printf '{"path":"%%s"}\n' %s ;;
+	body := fmt.Sprintf(`  get) echo 'treehouse 0.7.4' >&2; printf '{"path":"%%s"}\n' %s ;;
   return) echo ok ;;
   init) echo ok ;;`, shellSingleQuote(worktreePath))
 	writeFakeDispatch(t, dir, "treehouse", "", "$1", body)

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -140,9 +140,12 @@ func setPaneStatus(t *testing.T, statusDir, paneID, status string) {
 // writeFakeTreehouse writes a treehouse fake that always leases worktreePath
 // and no-ops on return/init, matching worktree.Get/Return and
 // treehouseInitIfNeeded's invocation shapes ("get"/"return"/"init" as $1).
+// "get" writes a banner line to stderr before its JSON, mirroring real
+// treehouse's documented "all banners go to stderr" behavior, so a
+// CombinedOutput regression at the call site fails the suite.
 func writeFakeTreehouse(t *testing.T, dir, worktreePath string) {
 	t.Helper()
-	body := fmt.Sprintf(`  get) printf '{"path":"%%s"}\n' %s ;;
+	body := fmt.Sprintf(`  get) echo '🌳 treehouse' >&2; printf '{"path":"%%s"}\n' %s ;;
   return) echo ok ;;
   init) echo ok ;;`, shellSingleQuote(worktreePath))
 	writeFakeDispatch(t, dir, "treehouse", "", "$1", body)


### PR DESCRIPTION
## Intent

Fix two hand CLI defects found by a real dogfood run against live treehouse 0.7.4 and the released 0.1.0 binary. (1) worktree.Get and ghutil.PRIsMerged used cmd.CombinedOutput() and then json.Unmarshal'd the combined bytes; treehouse writes a banner to stderr before its JSON, so any banner corrupts the parse and every real spawn failed with 'invalid character looking for beginning of value' (issue #21, hard blocker - nothing could be dispatched). Fixed both call sites to use cmd.Output() for the parsed stdout and a separate stderr buffer for error messages only. Deliberately audited every other CombinedOutput() call site in the repo (cmd/merge.go, cmd/project.go, cmd/notify.go, worktree.Return) and left them alone since they only build error strings, never parse the bytes - this was an explicit scope constraint, not an oversight. Added a stderr banner to the fake treehouse in tests/e2e so a regression here fails the suite; verified test-first (it failed against the pre-fix code reproducing the exact reported error, then passed after the fix). (2) cmd/project.go's project list command used fmt.Fprintf with %-12s%-40s%s width verbs, which pad to a minimum width but add no separator once a field is at or past that width, so a URL of 40+ chars ran directly into the mode with no whitespace (issue #22). Fixed by switching to text/tabwriter, which always inserts padding regardless of field length. Added a unit test with a 40-char URL reproducing the exact glued-together output from the bug report, verified test-first the same way. Two separate commits, each independently passing go test -race ./... and the e2e suite: commit 1 fixes #21 plus regression test, commit 2 fixes #22 plus regression test. No behavior change beyond these two defects; .github/workflows/ untouched; no restructuring of the subprocess helpers into a new abstraction.

## What Changed

- `worktree.Get` and `ghutil.PRIsMerged` now run subprocesses with `cmd.Output()` and a separate stderr buffer, so a banner or warning on stderr no longer corrupts the JSON they unmarshal; the exec error is wrapped alongside the stderr text in the failure message (issue #21, which broke every real spawn with `invalid character looking for beginning of value`). Other `CombinedOutput()` call sites were left alone since they only build error strings.
- `hand project list` and `hand status` switched from `%-Ns` width verbs to `text/tabwriter`, so an over-width field (a 40+ char project URL, a long task ID) no longer runs straight into the next column with no whitespace (issue #22).
- Added regression coverage: unit tests for the glued-column output in `cmd/project_test.go` and `cmd/status_test.go`, first tests for `ghutil.PRIsMerged` with a fake `gh` emitting stderr before its JSON, and a stderr banner in the e2e fake treehouse so a revert fails the suite. SPECS.md wording updated for the stdout-only parsing.

## Risk Assessment

✅ Low: The follow-up commit cleanly resolves all four prior findings with targeted regression tests, introduces no new logic beyond error wrapping and a tabwriter swap, and the remaining items are cosmetic test-convention and error-string polish.

## Testing

<code>Ran the full race-enabled unit suite and the e2e suite on the target commit (all green), then drove the real `hand` binary end-to-end against fake treehouse/herdr/gh that write banners to stderr before their JSON, comparing a pre-fix build to the fixed build in the same scenario: pre-fix `hand spawn` dies with the reported JSON parse error and `hand teardown` dies with \&#34;invalid character &#39;W&#39; looking for beginning of value\&#34;, while the fixed binary completes the whole spawn -&gt; status -&gt; teardown lifecycle and writes the merged completion into data/dashboard.md; pre-fix `hand project list` prints the 40-char URL glued to the mode and the fixed build separates them, same for `hand status` with a long task id. I also confirmed test-first validity by reverting only the four fixed source files and watching all four new tests plus the e2e spawn tests fail, then restoring the worktree to clean. CLI transcripts are captured as text and rendered as SVG terminal images since this is a terminal surface and no browser or image converter is available in this environment; the local treehouse is v2.1.0 rather than the dogfooded 0.7.4, so the stderr banner is reproduced with a fake rather than the real 0.7.4 binary.</code>

- Evidence: hand spawn/teardown vs stderr-bannering treehouse and gh (before/after, rendered terminal) (local file: <code>/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/lifecycle-before-after.svg</code>)
- Evidence: gh pr view stderr warning breaks teardown pre-fix (rendered terminal) (local file: <code>/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/gh-teardown-before-after.svg</code>)
- Evidence: project list / status column merge at field width (before/after, rendered terminal) (local file: <code>/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/columns-before-after.svg</code>)
- Evidence: hand status with a 19-char task id, three rows (before/after, rendered terminal) (local file: <code>/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/status-multirow.svg</code>)
<details>
<summary>Evidence: CLI transcript: issue #21 and #22 before vs after</summary>

<code>### PRE-FIX binary&#10;$ hand project list&#10;secondhand https://github.com/atqamz/secondhand.gitno-mistakes&#10;$ hand spawn wt-001 secondhand&#10;acquire treehouse worktree: parse treehouse get output: invalid character &#39;e&#39; in literal true (expecting &#39;u&#39;)&#10;[exit 1]&#10;&#10;### FIXED binary&#10;$ hand project list&#10;secondhand https://github.com/atqamz/secondhand.git no-mistakes&#10;$ hand spawn wt-001 secondhand&#10;spawned wt-001 project=secondhand kind=ship harness=claude worktree=.../wt&#10;[exit 0]&#10;$ hand status&#10;wt-001 secondhand ship working just now&#10;$ hand teardown wt-001&#10;teardown wt-001 complete&#10;[exit 0]</code>

```text
### PRE-FIX binary
=== issue #22: project list, URL is 40 chars wide ===
$ hand project list
secondhand  https://github.com/atqamz/secondhand.gitno-mistakes
[exit 0]

=== issue #21: spawn against treehouse that banners on stderr ===
$ hand spawn wt-001 secondhand
acquire treehouse worktree: parse treehouse get output: invalid character 'e' in literal true (expecting 'u')
[exit 1]

=== hand status ===
$ hand status
[exit 0]

=== teardown: gh pr view warns on stderr before its JSON ===
sed: can't read /tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/scratch-before/home/state/wt-001.json: No such file or directory
$ hand teardown wt-001
task "wt-001" not found
[exit 3]

### FIXED binary
=== issue #22: project list, URL is 40 chars wide ===
$ hand project list
secondhand  https://github.com/atqamz/secondhand.git  no-mistakes
[exit 0]

=== issue #21: spawn against treehouse that banners on stderr ===
$ hand spawn wt-001 secondhand
spawned wt-001 project=secondhand kind=ship harness=claude worktree=/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/scratch-after/wt
[exit 0]

=== hand status ===
$ hand status
wt-001  secondhand  ship  working  just now
[exit 0]

=== teardown: gh pr view warns on stderr before its JSON ===
$ hand teardown wt-001
teardown wt-001 complete
[exit 0]
```
</details>
<details>
<summary>Evidence: gh teardown repro transcript</summary>

<code>### PRE-FIX binary (CombinedOutput)&#10;$ gh pr view 42 --json state&#10;Warning: gh version 2.40.0 is out of date&#10;{&#34;state&#34;:&#34;MERGED&#34;}&#10;$ hand teardown wt-002&#10;parse gh pr view output: invalid character &#39;W&#39; looking for beginning of value&#10;[exit 1]&#10;&#10;### FIXED binary&#10;$ hand teardown wt-002&#10;teardown wt-002 complete&#10;[exit 0]</code>

```text
### PRE-FIX binary (CombinedOutput)
spawned wt-002 project=secondhand kind=ship harness=claude worktree=/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/scratch-gh-before/wt

$ gh pr view 42 --json state   # what the real tool looks like here
Warning: gh version 2.40.0 is out of date
{"state":"MERGED"}

$ hand teardown wt-002
parse gh pr view output: invalid character 'W' looking for beginning of value
[exit 1]

### FIXED binary
spawned wt-002 project=secondhand kind=ship harness=claude worktree=/tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/scratch-gh-after/wt

$ gh pr view 42 --json state   # what the real tool looks like here
Warning: gh version 2.40.0 is out of date
{"state":"MERGED"}

$ hand teardown wt-002
teardown wt-002 complete
[exit 0]
```
</details>
<details>
<summary>Evidence: New regression tests failing against pre-fix sources</summary>

<code>--- FAIL: TestPRIsMergedIgnoresStderrNoise: parse gh pr view output: invalid character &#39;W&#39; looking for beginning of value&#10;--- FAIL: TestPRIsMergedReportsExitStatusWithoutStderr: got &#34;gh pr view failed: &#34;, want the exit status in the message&#10;--- FAIL: TestProjectListColumnsDoNotMergeAtFieldWidth: output = &#34;secondhand https://github.com/atqamz/secondhand.gitno-mistakes\n&#34;&#10;--- FAIL: TestStatusFleetColumnsDoNotMergeAtFieldWidth: got &#34;task-aaaaaaaaaaamyproject12 ship working 1d ago\n&#34;&#10;--- FAIL: TestSpawnTeardownCycle (e2e): spawn exit 1, &#34;parse treehouse get output: invalid character &#39;e&#39; in literal true&#34;</code>

```text
### new regression tests run against PRE-FIX source (expected: FAIL)
warning: Git tree '/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYEN7ENFYD50AW79NANRDWJP' is dirty
--- FAIL: TestPRIsMergedIgnoresStderrNoise (0.00s)
    pr_test.go:41: PRIsMerged with state MERGED: parse gh pr view output: invalid character 'W' looking for beginning of value
--- FAIL: TestPRIsMergedReportsExitStatusWithoutStderr (0.00s)
    pr_test.go:56: got "gh pr view failed: ", want the exit status in the message
FAIL
FAIL	github.com/atqamz/secondhand/internal/ghutil	0.016s
--- FAIL: TestProjectListColumnsDoNotMergeAtFieldWidth (0.00s)
    project_test.go:201: project list output = "secondhand  https://github.com/atqamz/secondhand.gitno-mistakes\n", want "https://github.com/atqamz/secondhand.git" followed by a column separator before the mode
--- FAIL: TestStatusFleetColumnsDoNotMergeAtFieldWidth (0.01s)
    status_test.go:64: got "task-aaaaaaaaaaamyproject12 ship    working     1d ago\n", ID and project columns merged
FAIL
FAIL	github.com/atqamz/secondhand/cmd	0.015s
FAIL

### e2e suite against PRE-FIX source (expected: FAIL on spawn parse)
          stderr: acquire treehouse worktree: parse treehouse get output: invalid character 'e' in literal true (expecting 'u')
    collision_test.go:37: spawn task-1: exit 1, stderr "acquire treehouse worktree: parse treehouse get output: invalid character 'e' in literal true (expecting 'u')\n"
--- FAIL: TestSpawnTeardownCycle (0.05s)
    spawn_teardown_test.go:18: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.SWqfwY/TestSpawnTeardownCycle3502023144/002
          stderr: 
    spawn_teardown_test.go:32: $ hand spawn task-1 demo
          exit 1
          stdout: 
          stderr: acquire treehouse worktree: parse treehouse get output: invalid character 'e' in literal true (expecting 'u')
    spawn_teardown_test.go:34: spawn: exit 1, stderr "acquire treehouse worktree: parse treehouse get output: invalid character 'e' in literal true (expecting 'u')\n"
FAIL
FAIL	github.com/atqamz/secondhand/tests/e2e	0.505s
FAIL
```
</details>
<details>
<summary>Evidence: dashboard.md after the fixed lifecycle run</summary>

<code>## Recent Completions&#10;- wt-001: secondhand | ship | merged | PR https://github.com/atqamz/secondhand/pull/42</code>

```text
# Dashboard

Updated: 2026-07-26T07:42:24Z

## Active Tasks
| id | project | kind | state | age | pr |
|---|---|---|---|---|---|

## Pending Decisions

## Recent Events

## Recent Completions
- wt-001: secondhand | ship | merged | PR https://github.com/atqamz/secondhand/pull/42

## Projects
```
</details>
<details>
<summary>Evidence: Reproduction scripts (fakes for treehouse 0.7.4 / herdr / gh)</summary>

```text
#!/usr/bin/env bash
# Live dogfood scenario for issues #21 and #22.
# Usage: scenario.sh <hand-binary> <scratch-root>
# Fakes stand in for treehouse 0.7.4, herdr and gh; every one of them writes a
# banner/warning to stderr ahead of its JSON, exactly like the real tools do.
set -u

HAND=$1
ROOT=$2
rm -rf "$ROOT"
mkdir -p "$ROOT/bin" "$ROOT/home/data/wt-001" "$ROOT/home/projects/secondhand" "$ROOT/wt"

cat >"$ROOT/bin/treehouse" <<EOF
#!/bin/sh
case "\$1" in
  get)
    echo 'treehouse 0.7.4' >&2
    echo 'pool: /home/atqa/.no-mistakes/worktrees/4dde880dca8d' >&2
    printf '{"path":"$ROOT/wt","branch":"fm/demo","holder":"hand:wt-001"}\n'
    ;;
  return) echo 'treehouse 0.7.4' >&2; echo ok ;;
  init) echo ok ;;
esac
EOF

cat >"$ROOT/bin/herdr" <<'EOF'
#!/bin/sh
case "$1 $2" in
  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
  "workspace create") echo '{"result":{"workspace":{"workspace_id":"w-1","label":"secondhand","tab_count":1}}}' ;;
  "tab create") echo '{"result":{"tab":{"tab_id":"t-1","workspace_id":"w-1","label":"wt-001"},"root_pane":{"pane_id":"w-1:p-1","tab_id":"t-1","workspace_id":"w-1","agent_status":"working"}}}' ;;
  "pane run") echo '{"result":{}}' ;;
  "pane get") echo '{"result":{"pane":{"pane_id":"w-1:p-1","tab_id":"t-1","workspace_id":"w-1","agent_status":"working"}}}' ;;
  "tab list") echo '{"result":{"tabs":[{"tab_id":"t-1","workspace_id":"w-1","label":"wt-001"}]}}' ;;
  "tab close") echo '{"result":{}}' ;;
  "workspace close") echo '{"result":{}}' ;;
esac
EOF

cat >"$ROOT/bin/gh" <<'EOF'
#!/bin/sh
echo 'Warning: gh version 2.40.0 is out of date' >&2
echo '{"state":"MERGED"}'
EOF

chmod +x "$ROOT/bin"/*
export PATH="$ROOT/bin:$PATH"

cd "$ROOT/wt" && git init -q -b main . && git -c user.email=a@b -c user.name=a commit -q --allow-empty -m init
cd "$ROOT/home" || exit 1
"$HAND" init >/dev/null

cat >data/projects.md <<'EOF'
# Projects

- secondhand: https://github.com/atqamz/secondhand.git mode=no-mistakes
EOF
echo 'ship it' >data/wt-001/brief.md

run() { echo "\$ hand $*"; "$HAND" "$@" 2>&1; echo "[exit $?]"; echo; }

echo "=== issue #22: project list, URL is 40 chars wide ==="
run project list

echo "=== issue #21: spawn against treehouse that banners on stderr ==="
run spawn wt-001 secondhand

echo "=== hand status ==="
run status

echo "=== teardown: gh pr view warns on stderr before its JSON ==="
sed -i 's|"pr": ""|"pr": "https://github.com/atqamz/secondhand/pull/42"|' "$ROOT/home/state/wt-001.json"
run teardown wt-001
```
</details>
- Outcome: ⚠️ 1 info across 1 run (6m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `internal/worktree/worktree.go:27` - internal/worktree/worktree.go:27 and internal/ghutil/pr.go:23 build the failure message from the stderr buffer alone and discard the `err` returned by `cmd.Output()`. When the subprocess fails without writing to stderr - binary not on PATH (`exec.ErrNotFound`), or the process killed by the 30s context deadline in internal/watcher/watcher.go:89 / the ctx in cmd/teardown.go:130 - the user gets a bare `treehouse get failed: ` / `gh pr view failed: ` with zero diagnostic, and the exit code is lost. This also diverges from the repo&#39;s own convention in internal/herdr/client.go:38, which wraps `runErr` with `%w` alongside stderr. Wrap the exec error too, e.g. `fmt.Errorf(&#34;treehouse get failed: %w: %s&#34;, err, strings.TrimSpace(stderr.String()))`.
- ⚠️ `cmd/status.go:87` - cmd/status.go:87 still uses `fmt.Fprintf(w, &#34;%-16s%-12s%-8s%-12s%s\n&#34;, r.ID, r.Project, r.Kind, r.AgentState, ...)` - the exact minimum-width-verb bug just fixed in cmd/project.go:260. Task IDs have no length bound (internal/state/task.go:37 validates charset only, not length), so a 16-char ID glues straight into the project name, and a 12-char project name glues into the kind. Same root cause, same one-line tabwriter fix. Left unfixed here, presumably because the intent scoped the change to `project list` only - flagging so you can decide whether to fold it in or track it separately.
- ℹ️ `internal/ghutil/pr.go:21` - The ghutil.PRIsMerged half of the stdout/stderr fix has no regression guard. The treehouse half is covered by the stderr banner added to the fake in tests/e2e/fakes_test.go:148, but no test anywhere in the repo fakes `gh pr view --json state` (the only gh fakes are `gh pr checks` in tests/e2e/merge_test.go:32 and `gh release view` in internal/selfupdate), so PRIsMerged is entirely untested and a revert to CombinedOutput there would pass the suite. A small unit test with a fake gh emitting a stderr line before its JSON would make the two halves symmetric.
- ℹ️ `tests/e2e/fakes_test.go:148` - The fake treehouse banner uses an emoji (`echo &#39;🌳 treehouse&#39; &gt;&amp;2`), which violates the global no-emoji-in-code rule and is the only emoji in the entire repo (grep for U+1F300-U+1FAFF returns this line alone). The test&#39;s purpose - putting any non-JSON bytes on stderr ahead of the payload - is served identically by a plain ASCII banner such as `echo &#39;treehouse 0.7.4&#39; &gt;&amp;2`.

🔧 Fix: wrap subprocess exec errors, tabwriter for status, add ghutil tests
2 infos still open:
- ℹ️ `internal/ghutil/pr_test.go:29` - writeFakeGHPRView replaces PATH outright (`t.Setenv(&#34;PATH&#34;, bin)`) whereas every other fake-binary helper in the repo prepends and preserves it - internal/selfupdate/selfupdate_test.go:71 and cmd/status_test.go:20 both use `bin + string(os.PathListSeparator) + os.Getenv(&#34;PATH&#34;)`. It works today only because the fake&#39;s shebang is the absolute `/bin/sh` and PRIsMerged shells out to nothing but `gh`; any future test in this package that invokes a bare command name will fail with a confusing &#34;executable file not found&#34;. Match the existing prepend form.
- ℹ️ `internal/ghutil/pr.go:23` - With the `%w: %s` format, an exec failure that writes nothing to stderr now renders a dangling separator: `gh pr view failed: exit status 1: ` (same at internal/worktree/worktree.go:27 for `treehouse get failed: exit status 1: `). TestPRIsMergedReportsExitStatusWithoutStderr exercises exactly this path and asserts only on the substring, so the trailing artifact is baked in. Appending the stderr clause only when the buffer is non-empty keeps the diagnostic without the stray suffix.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `cmd/status.go:86` - cmd/status.go also switched from %-16s-style width verbs to text/tabwriter in the third commit, which changes `hand status` column spacing for every user. The intent text only names cmd/project.go for the #22 fix, so this is a third user-visible output change beyond the two described defects. Verified as correct and covered by a new regression test (TestStatusFleetColumnsDoNotMergeAtFieldWidth); flagging only so the scope statement matches the diff.
- <code>`nix develop -c go test -race ./...` (full unit suite, all packages pass)</code>
- <code>`nix develop -c go test -tags=e2e -timeout=10m ./tests/e2e/...` (e2e suite passes with the new stderr-banner treehouse fake)</code>
- <code>`nix develop -c go test ./internal/ghutil/ ./cmd/ -run &#39;TestPRIsMerged|TestProjectListColumnsDoNotMerge|TestStatusFleetColumnsDoNotMerge&#39;` against base-commit sources - all four new tests FAIL as expected, then restored and pass</code>
- <code>`nix develop -c go test -tags=e2e -run TestSpawn ./tests/e2e/...` against base-commit sources - fails with &#39;parse treehouse get output: invalid character&#39;, confirming the e2e fake now guards the regression</code>
- `Manual live CLI: built hand-before/hand-after, ran /tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/scenario.sh (hand init, project list, spawn, status, teardown) against both binaries with fake treehouse/herdr/gh that banner on stderr`
- <code>Manual live CLI: /tmp/no-mistakes-evidence/01KYEN7ENFYD50AW79NANRDWJP/scenario-gh.sh isolating `hand teardown` over `gh pr view --json state` with a stderr warning, before vs after</code>
- <code>Manual `hand status` with a 19-char task id across three rows, before vs after, to show tabwriter never glues id into project</code>
- <code>Audited remaining CombinedOutput() call sites (cmd/merge.go, cmd/project.go, cmd/notify.go, worktree.Return) - none parse the bytes, matching the stated scope constraint; `git status --porcelain` clean at finish</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `SPECS.md:226` - SPECS.md&#39;s `hand project list` (line ~226) and `hand status` (line ~350) sample outputs depict fixed-width padded columns, matching the old %-12s/%-40s/%-16s verbs. The commands now use text/tabwriter, so real column widths fit the content. Left unchanged as a judgment call: the samples were already not byte-exact and read as illustrative aligned output, which tabwriter still produces. Regenerate them from real output if the spec is meant to be literal.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>



Fixes #21
Fixes #22
