### PR TITLE
fix: launch workers interactively and stop leaking herdr workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Builds without an embedded version never print the notice.
 Currently supported preferences live as plain files under `config/`: default worker harness, model, and effort.
 Run `hand init --setup` to discover installed harnesses and tools and write the defaults interactively.
 
+Workers run their harness interactively so they can be steered and watched.
+For Claude Code that means a fresh host needs its two first-run dialogs cleared once: run `claude --dangerously-skip-permissions` inside your treehouse pool root (`~/.treehouse`), accept the trust prompt and the bypass-permissions disclaimer, then quit.
+Otherwise the first worker spawned there sits on a dialog instead of working.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/SPECS.md
+++ b/SPECS.md
@@ -813,6 +813,7 @@ Operator setup before the first spawn on a new host: run `claude --dangerously-s
 once interactively inside the treehouse pool root, accept both dialogs, and quit. Trust is
 inherited by that directory's descendants and the disclaimer accept is global, so this covers
 every later worker. `hand status <id>` prints a task's worktree path if the pool root is unclear.
+Known limitation tracked at https://github.com/atqamz/secondhand/issues/28.
 
 ### Codex
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -763,14 +763,28 @@ The agent should use it when available and read files directly when not.
 Each supported harness has a launch command template.
 `hand spawn` constructs the command, `cd`s into the worktree, and sends it to the herdr pane.
 
+Every template must launch its harness **interactively**, never headless/one-shot.
+`hand send` writes into a running pane, `hand watch` polls pane state to classify a worker as
+working/blocked/idle, and the `no-mistakes` delivery mode drives many turns as the worker
+responds to review/test/document/lint gates.
+A one-shot process (`claude --print`, `opencode run`) answers once and exits: there is nothing
+left to send to, classify, or drive through a gate.
+Any harness template added here must stay resident across the whole task, and must have its
+autonomy/permission flag set so an unattended worker does not stall on a permission prompt.
+
 ### Claude Code
 
 ```sh
-cd <worktree> && claude --print "Read the brief at <brief-path> and carry out the task it describes."
+cd <worktree> && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "Read the brief at <brief-path> and carry out the task it describes."
 ```
 
-The brief path is included in the prompt because `--print` accepts prompt text, not a file path.
+The brief path is included in the prompt because Claude Code takes prompt text, not a file path.
 When configured, `--model <name>` and `--effort <level>` are inserted before the prompt.
+`--dangerously-skip-permissions` is required so the unattended worker does not stall on a
+permission dialog.
+`CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` suppresses the dim predicted-next-prompt ghost text
+Claude Code renders while idle; without it, a supervisor reading the pane can misread ghost text
+as the worker having typed input.
 
 ### Codex
 
@@ -778,11 +792,17 @@ When configured, `--model <name>` and `--effort <level>` are inserted before the
 cd <worktree> && codex --file "<brief-path>"
 ```
 
+Unverified: no `codex` binary was available to check `--help` against.
+Confirm this launches interactively (not one-shot) before relying on it; the template above
+predates that requirement and may need an autonomy flag and a different invocation shape.
+
 ### Grok
 
 ```sh
 cd <worktree> && grok --trust --file "<brief-path>"
 ```
+
+Unverified, same caveat as Codex above.
 
 ### Pi
 
@@ -790,17 +810,26 @@ cd <worktree> && grok --trust --file "<brief-path>"
 cd <worktree> && pi "<brief-path>"
 ```
 
+Unverified, same caveat as Codex above.
+
 ### OpenCode
 
 ```sh
-cd <worktree> && opencode run --file "<brief-path>" "Follow the attached brief and complete the task."
+cd <worktree> && OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt "Read the brief at <brief-path> and carry out the task it describes."
 ```
 
-OpenCode runs headlessly through `opencode run`; `--model <name>` and `--variant <effort>` are
-inserted when configured.
+The bare `opencode` command opens its interactive TUI, unlike `opencode run`, which is
+explicitly headless and exits after one reply.
+`OPENCODE_CONFIG_CONTENT` grants blanket tool permission so the unattended worker does not
+stall on a permission prompt.
+When configured, `--model <name>` is inserted; the bare command has no effort/variant flag, so
+`--effort` has no effect on OpenCode workers.
+The bare command also has no `--file` flag, so the brief path is embedded in the prompt text
+instead of attached.
 
 The Claude and OpenCode forms above were verified against the installed CLI versions.
-Codex, Grok, and Pi retain the literal templates above until those binaries are verified.
+Codex, Grok, and Pi retain unverified templates until those binaries are installable; whoever
+verifies them must confirm interactive (not headless) launch, not just flag names.
 The harness module is the single place that constructs these commands.
 
 ## Herdr integration detail

--- a/SPECS.md
+++ b/SPECS.md
@@ -786,6 +786,20 @@ permission dialog.
 Claude Code renders while idle; without it, a supervisor reading the pane can misread ghost text
 as the worker having typed input.
 
+Interactive launch has two first-run dialogs that headless `--print` skipped, and each stalls an
+unattended worker until it is cleared once per machine:
+
+- The workspace trust dialog. Claude Code only trusts a directory whose path or one of its
+  ancestors has been accepted before, and every treehouse worktree is a fresh path under the
+  pool root (`~/.treehouse/...`).
+- The bypass-permissions disclaimer, a one-time global accept that `--dangerously-skip-permissions`
+  is gated on.
+
+Operator setup before the first spawn on a new host: run `claude --dangerously-skip-permissions`
+once interactively inside the treehouse pool root, accept both dialogs, and quit. Trust is
+inherited by that directory's descendants and the disclaimer accept is global, so this covers
+every later worker. `hand status <id>` prints a task's worktree path if the pool root is unclear.
+
 ### Codex
 
 ```sh

--- a/SPECS.md
+++ b/SPECS.md
@@ -624,13 +624,18 @@ Flags:
 
 Behavior:
 1. Validate the task exists and is a completed scout (has `data/<id>/report.md`, herdr pane is done or dead).
-2. Tear down the scout's herdr tab and worktree.
-3. Create or update `data/<id>/brief.md` - the agent should update it with implementation instructions before calling promote, referencing the scout report.
-4. Acquire a fresh treehouse worktree (with collision guard).
-5. Create a new herdr tab.
-6. Launch the worker.
-7. Update `state/<id>.json`: kind changes from `scout` to `ship`, new worktree and herdr coordinates.
-8. Update `data/dashboard.md`.
+2. Create or update `data/<id>/brief.md` - the agent should update it with implementation instructions before calling promote, referencing the scout report.
+3. Acquire a fresh treehouse worktree (with collision guard).
+4. Create a new herdr tab.
+5. Launch the worker.
+6. Update `state/<id>.json`: kind changes from `scout` to `ship`, new worktree and herdr coordinates.
+7. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.
+
+The scout side is torn down last on purpose: the same rollback contract as `hand spawn` applies up
+to step 6, so a promotion that fails partway still leaves the scout's pane and worktree intact
+instead of stranding the task with nothing to look at.
+`data/dashboard.md` is deliberately left untouched, so the task's row keeps reading `scout` until
+something else rewrites it.
 
 Output:
 ```
@@ -733,7 +738,7 @@ Updated: 2026-07-24T12:30:00Z
 | `hand project add` | Add to Projects |
 | `hand project remove` | Remove from Projects |
 | `hand project sync` | Update project sync status |
-| `hand promote` | Update task kind in Active Tasks |
+| `hand promote` | No update (the row keeps its scout kind) |
 | `hand notify` | No update (notification is a side channel) |
 
 ### Optional: qmd for historical search

--- a/SPECS.md
+++ b/SPECS.md
@@ -287,6 +287,15 @@ Behavior:
 9. Write `state/<id>.json` with all metadata.
 10. Update `data/dashboard.md` with the new task.
 
+Any failure before step 9 leaves nothing behind: the worktree lease returns to treehouse and the
+herdr side is rolled back.
+A workspace this command created is closed whole, because a fresh workspace already holds an
+auto-created root tab and closing only the task's tab would leak it.
+A workspace that already existed is shared with other tasks, so it keeps running and only loses
+the tab this command added.
+Once `state/<id>.json` is written the task owns its worktree and tab, so a later failure such as
+the dashboard update never tears down a task that is already running.
+
 Output:
 ```
 spawned fix-login project=nsr kind=ship harness=claude worktree=/home/user/.treehouse/nsr-abc/1/nsr
@@ -913,8 +922,19 @@ herdr tab close <tab-id>
 herdr workspace close <ws-id>
 ```
 
-These calls and the JSON response envelope were verified against the installed herdr version.
-The herdr client abstracts them into Go function calls and validates required response fields.
+These calls and their responses were verified against the installed herdr version.
+Responses come in two shapes, and the client validates each one differently:
+
+- **Query commands** print a JSON envelope carrying a non-null `result` object; a missing or null
+  result is an error.
+  `tab close` and `workspace close` belong here too: they answer with a `{"type":"ok"}` result
+  rather than staying silent.
+- **Void commands** (`pane run`, `pane send-text`, `pane send-keys`) print nothing on success.
+  A failure prints a JSON error envelope whose exit code cannot be trusted on its own, so any
+  non-empty body is parsed for that envelope before the exit status is consulted.
+
+The herdr client abstracts these into Go function calls; `internal/herdr` keeps one entry point
+per shape and is the source of truth for which command uses which.
 
 ## No-mistakes integration
 

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -23,7 +23,7 @@ func newPromoteCmd() *cobra.Command {
 		Use:   "promote <id>",
 		Short: "Promote a completed scout task into a ship task",
 		Args:  usageArgs(cobra.ExactArgs(1)),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := args[0]
 			home, err := os.Getwd()
 			if err != nil {
@@ -119,14 +119,25 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("herdr workspace lookup/create failed: %w", err), worktree.Return(wt, true))
 			}
 
+			// Same rollback contract as hand spawn: until state.Write records the promotion,
+			// this call owns the new workspace or tab and must undo it on any failure; after
+			// that the promoted task owns them and later warnings must not tear them down.
+			promoted := false
+			var tabID string
+			defer func() {
+				if promoted {
+					return
+				}
+				if closeErr := rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, tabID); closeErr != nil {
+					err = reportSpawnCleanup(err, closeErr)
+				}
+			}()
+
 			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
 			if err != nil {
-				cleanupErrs := []error{worktree.Return(wt, true)}
-				if createdWorkspace {
-					cleanupErrs = append(cleanupErrs, client.WorkspaceClose(ws.WorkspaceID))
-				}
-				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), cleanupErrs...)
+				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), worktree.Return(wt, true))
 			}
+			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree: wt,
@@ -135,11 +146,11 @@ func newPromoteCmd() *cobra.Command {
 				Effort:   effort,
 			})
 			if err != nil {
-				return reportSpawnCleanup(err, closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
 			// Dashboard is deliberately left untouched: the task's row stays
@@ -156,8 +167,9 @@ func newPromoteCmd() *cobra.Command {
 				PaneID:      pane.PaneID,
 			}
 			if err := state.Write(home, t); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
 			}
+			promoted = true
 
 			if err := closeTaskTab(client, oldWorkspaceID, oldTabID); err != nil && !errors.Is(err, errTaskTabNotFound) {
 				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: herdr tab close failed: %v\n", err); printErr != nil {

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/atqamz/secondhand/internal/project"
@@ -199,6 +200,100 @@ func TestPromoteRefusesUnregisteredProject(t *testing.T) {
 	var exitErr *ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
 		t.Fatalf("got %v, want ExitError code 3", err)
+	}
+}
+
+// fakeHerdrPromoteLeakScript mirrors fakeHerdrLeakScript for promote: it logs every call and
+// fails "pane run" so the promotion always fails after the new tab exists, with
+// $HERDR_WS_EXISTS_FLAG choosing between the created-workspace and pre-existing-workspace cases.
+const fakeHerdrPromoteLeakScript = `#!/bin/sh
+echo "$@" >> "$HERDR_CALL_LOG"
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pOld","tab_id":"wA:tOld","workspace_id":"wA","agent_status":"done"}}}'
+	;;
+"workspace list")
+	if [ -e "$HERDR_WS_EXISTS_FLAG" ]; then
+		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":2}]}}'
+	else
+		printf '{"id":"cli:1","result":{"workspaces":[]}}'
+	fi
+	;;
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	;;
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
+	;;
+"pane run")
+	exit 1
+	;;
+"workspace close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+"tab list")
+	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tOld","workspace_id":"wA"},{"tab_id":"wA:tNew","workspace_id":"wA"}]}}'
+	;;
+"tab close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func TestPromoteFailureClosesWorkspaceItCreated(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	home := setupPromoteHome(t, oldWt, newWt, fakeHerdrPromoteLeakScript)
+	callLog := setupSpawnLeakEnv(t, false)
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected promote to fail")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace hand created to be closed", calls)
+	}
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != state.KindScout {
+		t.Fatalf("kind = %q, want the task left as a scout", got.Kind)
+	}
+}
+
+func TestPromoteFailureKeepsPreexistingWorkspace(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	setupPromoteHome(t, oldWt, newWt, fakeHerdrPromoteLeakScript)
+	callLog := setupSpawnLeakEnv(t, true)
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected promote to fail")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(calls), "workspace close") {
+		t.Fatalf("calls = %q, want the pre-existing shared workspace left open", calls)
+	}
+	if !strings.Contains(string(calls), "tab close wA:tNew") {
+		t.Fatalf("calls = %q, want only the new tab closed", calls)
 	}
 }
 

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -27,7 +27,7 @@ func newSpawnCmd() *cobra.Command {
 		Use:   "spawn <id> <project>",
 		Short: "Spawn a worker agent in an isolated worktree",
 		Args:  usageArgs(cobra.ExactArgs(2)),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := args[0]
 			projectName := args[1]
 
@@ -103,14 +103,39 @@ func newSpawnCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("herdr workspace lookup/create failed: %w", err), worktree.Return(wt, true))
 			}
 
+			// spawned disarms the rollback below once state.Write has durably recorded the
+			// task: from that point its workspace and tab are owned by the running task, not
+			// by this call, even if a later step (dashboard update) fails. Before that point,
+			// a single deferred rollback - rather than repeating the createdWorkspace check at
+			// every exit - closes whichever of workspace or tab this call is responsible for:
+			// a workspace hand created, or (when the workspace was pre-existing and shared)
+			// just the tab hand added to it.
+			spawned := false
+			tabCreated := false
+			var tabID string
+			defer func() {
+				if spawned {
+					return
+				}
+				if createdWorkspace {
+					if closeErr := client.WorkspaceClose(ws.WorkspaceID); closeErr != nil {
+						err = reportSpawnCleanup(err, closeErr)
+					}
+					return
+				}
+				if tabCreated {
+					if closeErr := closeTaskTab(client, ws.WorkspaceID, tabID); closeErr != nil {
+						err = reportSpawnCleanup(err, closeErr)
+					}
+				}
+			}()
+
 			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
 			if err != nil {
-				cleanupErrs := []error{worktree.Return(wt, true)}
-				if createdWorkspace {
-					cleanupErrs = append(cleanupErrs, client.WorkspaceClose(ws.WorkspaceID))
-				}
-				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), cleanupErrs...)
+				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), worktree.Return(wt, true))
 			}
+			tabCreated = true
+			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree: wt,
@@ -119,11 +144,11 @@ func newSpawnCmd() *cobra.Command {
 				Effort:   effort,
 			})
 			if err != nil {
-				return reportSpawnCleanup(err, closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
 			kind := state.KindShip
@@ -149,8 +174,9 @@ func newSpawnCmd() *cobra.Command {
 				CreatedAt: time.Now().UTC().Format(time.RFC3339),
 			}
 			if err := state.Write(home, task); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), closeTaskTab(client, ws.WorkspaceID, tab.TabID), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
 			}
+			spawned = true
 
 			dashPath := filepath.Join(home, "data", "dashboard.md")
 			if err := dashboard.Update(dashPath, dashboard.UpdateOpts{AddActiveTask: &dashboard.ActiveTask{

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -107,26 +107,15 @@ func newSpawnCmd() *cobra.Command {
 			// task: from that point its workspace and tab are owned by the running task, not
 			// by this call, even if a later step (dashboard update) fails. Before that point,
 			// a single deferred rollback - rather than repeating the createdWorkspace check at
-			// every exit - closes whichever of workspace or tab this call is responsible for:
-			// a workspace hand created, or (when the workspace was pre-existing and shared)
-			// just the tab hand added to it.
+			// every exit - undoes whatever this call created.
 			spawned := false
-			tabCreated := false
 			var tabID string
 			defer func() {
 				if spawned {
 					return
 				}
-				if createdWorkspace {
-					if closeErr := client.WorkspaceClose(ws.WorkspaceID); closeErr != nil {
-						err = reportSpawnCleanup(err, closeErr)
-					}
-					return
-				}
-				if tabCreated {
-					if closeErr := closeTaskTab(client, ws.WorkspaceID, tabID); closeErr != nil {
-						err = reportSpawnCleanup(err, closeErr)
-					}
+				if closeErr := rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, tabID); closeErr != nil {
+					err = reportSpawnCleanup(err, closeErr)
 				}
 			}()
 
@@ -134,7 +123,6 @@ func newSpawnCmd() *cobra.Command {
 			if err != nil {
 				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), worktree.Return(wt, true))
 			}
-			tabCreated = true
 			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
@@ -197,6 +185,20 @@ func newSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
 	return cmd
+}
+
+// rollbackHerdr undoes the herdr side of a failed spawn-shaped lifecycle: a workspace this
+// call created goes away whole (WorkspaceCreate auto-creates a root tab, so closeTaskTab's
+// sole-tab shortcut would never fire and the workspace would leak), while a pre-existing
+// workspace is shared with other tasks and only loses the tab this call added to it.
+func rollbackHerdr(client *herdr.Client, createdWorkspace bool, workspaceID, tabID string) error {
+	if createdWorkspace {
+		return client.WorkspaceClose(workspaceID)
+	}
+	if tabID == "" {
+		return nil
+	}
+	return closeTaskTab(client, workspaceID, tabID)
 }
 
 func reportSpawnCleanup(cause error, cleanupErrs ...error) error {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -46,7 +46,7 @@ case "$cmd" in
 esac
 `
 
-func setupSpawnHome(t *testing.T, worktreePath string) string {
+func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 	t.Helper()
 	home := t.TempDir()
 
@@ -67,7 +67,7 @@ func setupSpawnHome(t *testing.T, worktreePath string) string {
 	}
 
 	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(fakeHerdrSpawnScript), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	treehouseScript := "#!/bin/sh\nprintf '{\"path\":\"" + worktreePath + "\"}'\n"
@@ -81,7 +81,7 @@ func setupSpawnHome(t *testing.T, worktreePath string) string {
 
 func TestSpawnHappyPath(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt)
+	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj"})
@@ -106,7 +106,7 @@ func TestSpawnHappyPath(t *testing.T) {
 
 func TestSpawnScoutFlag(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt)
+	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj", "--scout"})
@@ -124,7 +124,7 @@ func TestSpawnScoutFlag(t *testing.T) {
 }
 
 func TestSpawnRejectsUnregisteredProject(t *testing.T) {
-	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "unknown-proj"})
@@ -136,7 +136,7 @@ func TestSpawnRejectsUnregisteredProject(t *testing.T) {
 }
 
 func TestSpawnRejectsAlreadyActiveTask(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
 	if err := state.Write(home, state.Task{ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestSpawnRejectsAlreadyActiveTask(t *testing.T) {
 }
 
 func TestSpawnRejectsMissingBrief(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
 	if err := os.Remove(filepath.Join(home, "data", "task-1", "brief.md")); err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestSpawnRejectsMissingBrief(t *testing.T) {
 }
 
 func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
-	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"))
+	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj", "--harness", "nonexistent"})
@@ -181,7 +181,7 @@ func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
 
 func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt)
+	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
 	if err := state.Write(home, state.Task{ID: "other-task", Worktree: wt}); err != nil {
 		t.Fatal(err)
 	}
@@ -194,5 +194,103 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 
 	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
 		t.Fatalf("state written after collision: exists=%v err=%v", exists, err)
+	}
+}
+
+// fakeHerdrLeakScript logs every invocation to $HERDR_CALL_LOG and fails "pane run" so a
+// spawn always fails after tab creation. Whether "workspace list" reports an existing
+// workspace is controlled by the presence of $HERDR_WS_EXISTS_FLAG, letting the same script
+// drive both the created-workspace and pre-existing-workspace leak scenarios.
+const fakeHerdrLeakScript = `#!/bin/sh
+echo "$@" >> "$HERDR_CALL_LOG"
+cmd="$1 $2"
+case "$cmd" in
+"workspace list")
+	if [ -e "$HERDR_WS_EXISTS_FLAG" ]; then
+		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":2}]}}'
+	else
+		printf '{"id":"cli:1","result":{"workspaces":[]}}'
+	fi
+	;;
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	;;
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+	;;
+"pane run")
+	exit 1
+	;;
+"workspace close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+"tab list")
+	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:root","workspace_id":"wA","label":"root"},{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}]}}'
+	;;
+"tab close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func setupSpawnLeakEnv(t *testing.T, workspaceExists bool) string {
+	t.Helper()
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	flag := filepath.Join(t.TempDir(), "ws-exists")
+	if workspaceExists {
+		if err := os.WriteFile(flag, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HERDR_WS_EXISTS_FLAG", flag)
+	return callLog
+}
+
+func TestSpawnFailureClosesWorkspaceItCreated(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	setupSpawnHome(t, wt, fakeHerdrLeakScript)
+	callLog := setupSpawnLeakEnv(t, false)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected spawn to fail")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace hand created to be closed", calls)
+	}
+}
+
+func TestSpawnFailureKeepsPreexistingWorkspace(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	setupSpawnHome(t, wt, fakeHerdrLeakScript)
+	callLog := setupSpawnLeakEnv(t, true)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected spawn to fail")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(calls), "workspace close") {
+		t.Fatalf("calls = %q, want the pre-existing shared workspace left open", calls)
+	}
+	if !strings.Contains(string(calls), "tab close wA:tB") {
+		t.Fatalf("calls = %q, want the task's own tab closed", calls)
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -66,7 +66,9 @@ func Build(name string, opts Options) (string, error) {
 // --print). --dangerously-skip-permissions is required or an unattended worker stalls on a
 // permission prompt. CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false suppresses claude's dim
 // predicted-next-prompt ghost text, which would otherwise read to a pane-watching supervisor
-// as the worker having typed input while actually idle.
+// as the worker having typed input while actually idle. Interactive claude also gates on two
+// first-run dialogs that --print skipped (workspace trust, bypass-permissions disclaimer); both
+// are one-time host setup, documented under Harness launch templates in SPECS.md.
 func buildClaude(o Options) string {
 	args := []string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false", "claude", "--dangerously-skip-permissions"}
 	if o.Model != "" {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -34,10 +34,13 @@ type Options struct {
 }
 
 // Build constructs the shell command that cds into the worktree and launches the harness
-// against the brief. Flags verified against the installed CLI (--help) are used where
-// available - claude and opencode - and this file is the source of truth for those two.
-// Codex, Grok, and Pi have no binary available yet, so they fall back to the SPECS.md
-// template syntax and must be re-verified once installable.
+// against the brief. Every launch must be interactive, not one-shot: hand send steers a
+// running pane, hand watch classifies its lifecycle, and a no-mistakes pipeline drives many
+// turns, none of which a one-shot process can do. Flags verified against the installed CLI
+// (--help) are used where available - claude and opencode - and this file is the source of
+// truth for those two. Codex, Grok, and Pi have no binary available yet, so they fall back to
+// the SPECS.md template syntax and must be re-verified for interactive launch, not just
+// flag names, once installable.
 func Build(name string, opts Options) (string, error) {
 	var launch string
 	switch name {
@@ -57,10 +60,15 @@ func Build(name string, opts Options) (string, error) {
 	return fmt.Sprintf("cd %s && %s", shellQuote(opts.Worktree), launch), nil
 }
 
-// buildClaude passes the brief path in a prompt because claude --print accepts prompt text,
-// not a file path (verified via `claude --help`).
+// buildClaude launches claude interactively (no --print) so the pane stays resident for
+// hand send and hand watch across a multi-turn no-mistakes pipeline (verified via
+// `claude --help`: --model, --effort, and --dangerously-skip-permissions all apply outside
+// --print). --dangerously-skip-permissions is required or an unattended worker stalls on a
+// permission prompt. CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false suppresses claude's dim
+// predicted-next-prompt ghost text, which would otherwise read to a pane-watching supervisor
+// as the worker having typed input while actually idle.
 func buildClaude(o Options) string {
-	args := []string{"claude", "--print"}
+	args := []string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false", "claude", "--dangerously-skip-permissions"}
 	if o.Model != "" {
 		args = append(args, "--model", shellQuote(o.Model))
 	}
@@ -84,18 +92,19 @@ func buildPi(o Options) string {
 	return fmt.Sprintf("pi %s", shellQuote(o.Brief))
 }
 
-// buildOpenCode uses `opencode run` (verified via `opencode --help`) rather than the bare
-// `opencode` template in SPECS.md, which would open an interactive TUI instead of running
-// headless. --file attaches the brief to the initial message.
+// buildOpenCode uses the bare `opencode` command (verified via `opencode --help`), which opens
+// an interactive TUI, rather than `opencode run`, which is explicitly headless and exits after
+// one reply. OPENCODE_CONFIG_CONTENT grants blanket tool permission so an unattended worker
+// does not stall on a permission prompt. The bare command has no --file flag and no
+// effort/variant flag, so the brief path is embedded in --prompt text instead, and Effort is
+// not applied here.
 func buildOpenCode(o Options) string {
-	args := []string{"opencode", "run", "--file", shellQuote(o.Brief)}
+	args := []string{"OPENCODE_CONFIG_CONTENT=" + shellQuote(`{"permission":{"*":"allow"}}`), "opencode"}
 	if o.Model != "" {
 		args = append(args, "--model", shellQuote(o.Model))
 	}
-	if o.Effort != "" {
-		args = append(args, "--variant", shellQuote(o.Effort))
-	}
-	args = append(args, shellQuote("Follow the attached brief and complete the task."))
+	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
+	args = append(args, "--prompt", shellQuote(prompt))
 	return strings.Join(args, " ")
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -68,7 +68,8 @@ func Build(name string, opts Options) (string, error) {
 // predicted-next-prompt ghost text, which would otherwise read to a pane-watching supervisor
 // as the worker having typed input while actually idle. Interactive claude also gates on two
 // first-run dialogs that --print skipped (workspace trust, bypass-permissions disclaimer); both
-// are one-time host setup, documented under Harness launch templates in SPECS.md.
+// are one-time host setup, documented under Harness launch templates in SPECS.md. Known
+// limitation tracked at https://github.com/atqamz/secondhand/issues/28.
 func buildClaude(o Options) string {
 	args := []string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false", "claude", "--dangerously-skip-permissions"}
 	if o.Model != "" {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -39,7 +39,7 @@ func TestBuildClaude(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "cd '/tmp/wt' && claude --print 'Read the brief at /tmp/data/fix-login/brief.md and carry out the task it describes.'"
+	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/data/fix-login/brief.md and carry out the task it describes.'"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
@@ -50,8 +50,24 @@ func TestBuildClaudeWithModelAndEffort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(got, "--model 'sonnet'") || !strings.Contains(got, "--effort 'low'") {
-		t.Fatalf("got %q, want --model and --effort flags", got)
+	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'sonnet' --effort 'low' 'Read the brief at /tmp/brief.md and carry out the task it describes.'"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// TestBuildClaudeNeverHeadless guards against a silent regression to --print,
+// which would strand hand send and hand watch with no running pane to steer.
+func TestBuildClaudeNeverHeadless(t *testing.T) {
+	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "--print") {
+		t.Fatalf("got %q, want no --print (headless) flag", got)
+	}
+	if !strings.Contains(got, "--dangerously-skip-permissions") {
+		t.Fatalf("got %q, want --dangerously-skip-permissions so an unattended worker never stalls on a permission prompt", got)
 	}
 }
 
@@ -93,9 +109,34 @@ func TestBuildOpenCode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "cd '/tmp/wt' && opencode run --file '/tmp/brief.md' 'Follow the attached brief and complete the task.'"
+	want := "cd '/tmp/wt' && OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\"}}' opencode --prompt 'Read the brief at /tmp/brief.md and carry out the task it describes.'"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildOpenCodeWithModel(t *testing.T) {
+	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "opus"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "--model 'opus'") {
+		t.Fatalf("got %q, want --model flag", got)
+	}
+}
+
+// TestBuildOpenCodeNeverHeadless guards against a silent regression to
+// `opencode run`, which exits after one reply and leaves no pane to steer.
+func TestBuildOpenCodeNeverHeadless(t *testing.T) {
+	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "opencode run") {
+		t.Fatalf("got %q, want no headless \"opencode run\" invocation", got)
+	}
+	if !strings.Contains(got, `OPENCODE_CONFIG_CONTENT`) {
+		t.Fatalf("got %q, want OPENCODE_CONFIG_CONTENT so an unattended worker never stalls on a permission prompt", got)
 	}
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -25,30 +25,46 @@ type envelope struct {
 	Error  *errorBody      `json:"error"`
 }
 
-func (c *Client) call(args ...string) (json.RawMessage, error) {
+// run execs herdr and returns its trimmed stdout and trimmed stderr alongside
+// the process error, letting call and callVoid share one invocation path.
+func (c *Client) run(args ...string) ([]byte, string, error) {
 	cmd := exec.Command("herdr", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	runErr := cmd.Run()
+	return bytes.TrimSpace(stdout.Bytes()), strings.TrimSpace(stderr.String()), runErr
+}
 
-	trimmed := bytes.TrimSpace(stdout.Bytes())
+func parseEnvelope(args []string, trimmed []byte) (envelope, error) {
+	var env envelope
+	if err := json.Unmarshal(trimmed, &env); err != nil {
+		return envelope{}, fmt.Errorf("herdr %s: parse response: %w", strings.Join(args, " "), err)
+	}
+	return env, nil
+}
+
+// call is for query commands, whose real herdr response is always a JSON
+// envelope carrying a non-null result object.
+func (c *Client) call(args ...string) (json.RawMessage, error) {
+	trimmed, stderr, runErr := c.run(args...)
+
 	if len(trimmed) == 0 {
 		if runErr != nil {
-			return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, strings.TrimSpace(stderr.String()))
+			return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
 		}
 		return nil, fmt.Errorf("herdr %s: empty response", strings.Join(args, " "))
 	}
 
-	var env envelope
-	if err := json.Unmarshal(trimmed, &env); err != nil {
-		return nil, fmt.Errorf("herdr %s: parse response: %w", strings.Join(args, " "), err)
+	env, err := parseEnvelope(args, trimmed)
+	if err != nil {
+		return nil, err
 	}
 	if env.Error != nil {
 		return nil, fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), env.Error.Code, env.Error.Message)
 	}
 	if runErr != nil {
-		return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
 	}
 	if len(env.Result) == 0 {
 		return nil, fmt.Errorf("herdr %s: response missing result", strings.Join(args, " "))
@@ -61,6 +77,33 @@ func (c *Client) call(args ...string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("herdr %s: response result is not an object", strings.Join(args, " "))
 	}
 	return result, nil
+}
+
+// callVoid is for void commands (pane run/send-text/send-keys), whose real
+// herdr response is empty stdout on success and a JSON error envelope - with
+// exit code 0 - on failure, so the error envelope must be checked ahead of
+// (and independent from) the process exit status.
+func (c *Client) callVoid(args ...string) error {
+	trimmed, stderr, runErr := c.run(args...)
+
+	if len(trimmed) == 0 {
+		if runErr != nil {
+			return fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
+		}
+		return nil
+	}
+
+	env, err := parseEnvelope(args, trimmed)
+	if err != nil {
+		return err
+	}
+	if env.Error != nil {
+		return fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), env.Error.Code, env.Error.Message)
+	}
+	if runErr != nil {
+		return fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
+	}
+	return nil
 }
 
 func (c *Client) WorkspaceList() ([]Workspace, error) {
@@ -189,19 +232,16 @@ func (c *Client) PaneGet(paneID string) (Pane, error) {
 
 // PaneRun types command into the pane followed by Enter.
 func (c *Client) PaneRun(paneID, command string) error {
-	_, err := c.call("pane", "run", paneID, command)
-	return err
+	return c.callVoid("pane", "run", paneID, command)
 }
 
 func (c *Client) PaneSendText(paneID, text string) error {
-	_, err := c.call("pane", "send-text", paneID, text)
-	return err
+	return c.callVoid("pane", "send-text", paneID, text)
 }
 
 func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
 	args := append([]string{"pane", "send-keys", paneID}, keys...)
-	_, err := c.call(args...)
-	return err
+	return c.callVoid(args...)
 }
 
 // WaitComposerEmpty polls the pane until the agent is no longer "working" or timeout elapses.

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -81,21 +81,29 @@ func TestCallRejectsNullResult(t *testing.T) {
 func TestCallRejectsNonObjectResult(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","result":[]}'`)
 	c := NewClient()
-	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "not an object") {
+	if _, err := c.PaneGet("wA:pB"); err == nil || !strings.Contains(err.Error(), "not an object") {
 		t.Fatalf("got err %v, want non-object result failure", err)
 	}
 }
 
-func TestPaneRunRequiresResultEnvelope(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{}}'`)
+func TestPaneRunSucceedsOnEmptyStdout(t *testing.T) {
+	writeFakeHerdr(t, ``)
 	c := NewClient()
 	if err := c.PaneRun("wA:pB", "echo hi"); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestPaneSendTextRequiresResultEnvelope(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{}}'`)
+func TestPaneRunSurfacesErrorEnvelopeEvenOnExitZero(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"pane missing"}}'`)
+	c := NewClient()
+	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "pane missing") {
+		t.Fatalf("got err %v, want pane missing", err)
+	}
+}
+
+func TestPaneSendTextSucceedsOnEmptyStdout(t *testing.T) {
+	writeFakeHerdr(t, ``)
 	c := NewClient()
 	if err := c.PaneSendText("wA:pB", "hello"); err != nil {
 		t.Fatal(err)
@@ -108,11 +116,26 @@ if [ "$1" != "pane" ] || [ "$2" != "send-keys" ] || [ "$3" != "wA:pB" ] || [ "$4
 	echo "unexpected args: $@" >&2
 	exit 1
 fi
-printf '{"id":"cli:1","result":{}}'
 `)
 	c := NewClient()
 	if err := c.PaneSendKeys("wA:pB", "Enter"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPaneSendKeysSucceedsOnEmptyStdout(t *testing.T) {
+	writeFakeHerdr(t, ``)
+	c := NewClient()
+	if err := c.PaneSendKeys("wA:pB", "Enter"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCallVoidFailsOnNonZeroExitWithNoStdout(t *testing.T) {
+	writeFakeHerdr(t, `echo "binary crashed" >&2; exit 1`)
+	c := NewClient()
+	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "binary crashed") {
+		t.Fatalf("got err %v, want binary crashed failure", err)
 	}
 }
 

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -86,22 +86,25 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 		"tab":       map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label},
 		"root_pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": status},
 	})
-	paneRun := herdrOK(t, map[string]any{})
 	tabList := herdrOK(t, map[string]any{"tabs": []any{map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label}}})
-	tabClose := herdrOK(t, map[string]any{})
-	workspaceClose := herdrOK(t, map[string]any{})
+	tabClose := herdrOK(t, map[string]any{"type": "ok"})
+	workspaceClose := herdrOK(t, map[string]any{"type": "ok"})
 	paneGet := herdrOK(t, map[string]any{"pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": status}})
 
+	// "pane run"/"send-text"/"send-keys" are void commands: real herdr writes
+	// nothing to stdout on success, unlike every query command above.
 	body := fmt.Sprintf(`  "workspace list") echo %s ;;
   "workspace create") echo %s ;;
   "tab create") echo %s ;;
-  "pane run") echo %s ;;
+  "pane run") ;;
+  "pane send-text") ;;
+  "pane send-keys") ;;
   "tab list") echo %s ;;
   "tab close") echo %s ;;
   "workspace close") echo %s ;;
   "pane get") echo %s ;;`,
 		shellSingleQuote(workspaceList), shellSingleQuote(workspaceCreate), shellSingleQuote(tabCreate),
-		shellSingleQuote(paneRun), shellSingleQuote(tabList), shellSingleQuote(tabClose),
+		shellSingleQuote(tabList), shellSingleQuote(tabClose),
 		shellSingleQuote(workspaceClose), shellSingleQuote(paneGet))
 	writeFakeDispatch(t, dir, "herdr", "", "$1 $2", body)
 }


### PR DESCRIPTION
## Intent

Fix three hand CLI lifecycle defects found during a dogfood run against real herdr 0.7.4, tracked as GitHub issues #25, #26, #27, landed as three separate commits in this order. (1) Fixes #25: internal/herdr/client.go's call() treated empty stdout as an error for every command, but real herdr returns empty stdout on success for void commands (pane run, pane send-text, pane send-keys) and only emits JSON for query commands and for failures (an error envelope, whose exit code cannot be trusted alone). Split the client into call() (query path, unchanged: requires a non-null JSON result object) and a new callVoid() (void path: empty stdout is success, but a non-empty body is still parsed for an error envelope before trusting empty/nonempty status). This was verified against the real installed herdr 0.7.4 binary via an isolated lab session, not just reasoned about from the fake - lab verification found workspace/tab close return non-empty {"type":"ok"} envelopes, so those two stay on the query path; only PaneRun/PaneSendText/PaneSendKeys are void. The e2e fake herdr (tests/e2e/fakes_test.go) previously wrapped every command in a JSON envelope, masking this bug; it was corrected to mirror the real split (empty stdout for the three void commands), and I deliberately verified via git stash that the fake-only fix made the pre-fix production code fail the suite before applying the production fix, per an explicit review requirement. (2) Fixes #26: workers were launched headless (claude --print, opencode run), which cannot be steered by hand send, classified by hand watch, or driven through a multi-turn no-mistakes pipeline - a one-shot process has no resident pane. internal/harness/harness.go's buildClaude/buildOpenCode were changed to launch interactively instead, using flag shapes verified against each installed binary's own --help output (not copied blindly from any reference): claude --dangerously-skip-permissions (required so an unattended worker never stalls on a permission prompt) with CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false (suppresses ghost predicted-next-prompt text that would otherwise read to a pane-watching supervisor as the worker having typed input while idle), and opencode's bare (non-run) form with OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' - deliberately dropping opencode's --file and --effort/variant support since the bare command has neither, folding the brief path into --prompt text instead. Codex/Grok/Pi builders were deliberately left unverified/headless-shaped (no binaries installed yet to verify against), and SPECS.md's Harness launch templates section was updated to state the interactive-not-headless requirement plus this caveat, so a future implementer does not reintroduce headless launch. Tests assert the exact constructed command per harness, plus a regression guard that fails if --print or 'opencode run' ever reappear. (3) Fixes #27: cmd/spawn.go's RunE correctly closed a freshly created herdr workspace when TabCreate failed, but ignored createdWorkspace in the later harness.Build and PaneRun failure paths (and, found while fixing this, an identical gap in the state.Write failure path) - so any of those failures leaked the workspace. Root cause: WorkspaceCreate auto-creates a root tab, so a freshly created workspace already has 2 tabs by the time TabCreate adds the task's own tab, meaning closeTaskTab's 'close the whole workspace if this was its last tab' heuristic never fires for a newly created workspace - it only ever closed the task's own tab, leaking the root tab and thus the whole workspace. Replaced the repeated per-branch createdWorkspace checks with one deferred rollback (named RunE return, defer closure) that closes the workspace hand created, or - when the workspace already existed and is shared with other tasks - just the tab hand added to it; the rollback is disarmed once state.Write durably records the task as spawned, so later failures (e.g. dashboard update) never roll back a task that is already live, matching the pre-existing worktree-release behavior at that same point. Added unit tests asserting the workspace is closed when hand created it and left untouched when it pre-existed (a shared workspace must never be closed). Each of the three commits builds and passes go test -race ./..., go test -tags e2e -race ./tests/e2e/..., and make lint independently. No changes were made under .github/workflows/.

## What Changed

- `internal/herdr/client.go` splits its single `call()` into a query path (still requires a non-null JSON result) and a new `callVoid()` used by `PaneRun`/`PaneSendText`/`PaneSendKeys`, where real herdr returns empty stdout on success and only emits a JSON envelope on error; the e2e fake herdr in `tests/e2e/fakes_test.go` was corrected to mirror that split instead of wrapping every command in an envelope.
- `internal/harness/harness.go` builds interactive launch commands for claude (`--dangerously-skip-permissions` plus `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false`) and opencode (bare form with `OPENCODE_CONFIG_CONTENT` permission allow, brief path folded into `--prompt`, no `--file`/effort support) rather than headless `claude --print` / `opencode run`, so a spawned worker stays resident and can be steered by `hand send` and classified by `hand watch`; tests pin the exact command per harness and guard against `--print`/`opencode run` reappearing.
- `cmd/spawn.go` and `cmd/promote.go` replace their scattered per-branch cleanup with one deferred rollback that closes a workspace hand created (or only the tab it added to a pre-existing shared workspace) on any failure up to `state.Write`, and disarms once the task is durably recorded; `SPECS.md` and `README.md` document the interactive-launch requirement, claude's one-time first-run dialogs, herdr response shapes, and correct the `hand promote` teardown-order and dashboard notes.

## Risk Assessment

✅ Low: The two prior warnings are resolved correctly - the promote workspace leak now shares one deduplicated rollback helper with spawn and is covered by created-vs-pre-existing workspace tests, and the claude first-run dialog gates are documented as accurate one-time operator setup - leaving a well-bounded, test-covered change with no substantiated defects remaining.

## Testing

Ran the full unit and e2e suites green as a baseline, then built an isolated real-herdr 0.7.4 lab session to exercise the three fixes the way an operator would. A protocol probe confirmed the void/query split the client now encodes (pane run/send-text/send-keys give empty stdout with exit 0; tab close and workspace close give non-empty {"type":"ok"}), and confirmed workspace create already ships a root tab, which is the root cause behind the #27 leak. Driving the real hand binary against that session, spawn placed an interactive claude command in a resident pane and hand send successfully steered it, which headless --print could not do; the opencode harness produced the bare TUI form with the expected env-based permission grant. Injecting a pane-run error envelope showed the fixed binary leaves zero leaked workspaces where the base binary leaks one, and a pre-existing shared workspace survives with only the task tab removed. I also independently reproduced the author's claim that the corrected e2e fake alone makes the pre-fix production code fail. Lab session and scratch files were removed afterward; the user's default herdr session was never touched and the worktree is clean. No actionable issues found.

<details>
<summary>Evidence: Real herdr 0.7.4 protocol probe: void vs query command response shapes</summary>

<code>$ herdr pane run w1:p2 echo hello-from-lab&#10;exit : 0&#10;stdout : &lt;EMPTY&gt;&#10;&#10;$ herdr pane send-text w1:p2 typed text&#10;exit : 0&#10;stdout : &lt;EMPTY&gt;&#10;&#10;$ herdr pane send-keys w1:p2 Enter&#10;exit : 0&#10;stdout : &lt;EMPTY&gt;&#10;&#10;--- QUERY commands: expect non-empty JSON ---&#10;$ herdr tab close w1:t2&#10;exit : 0&#10;stdout : {&#34;id&#34;:&#34;cli:tab:close&#34;,&#34;result&#34;:{&#34;type&#34;:&#34;ok&#34;}}&#10;&#10;$ herdr workspace close w1&#10;exit : 0&#10;stdout : {&#34;id&#34;:&#34;cli:workspace:close&#34;,&#34;result&#34;:{&#34;type&#34;:&#34;ok&#34;}}</code>

```text
=== herdr herdr 0.7.4 protocol probe (isolated session 'nm-verify-01KYERS') ===

$ herdr workspace create --label handlab --cwd /tmp --no-focus
  exit   : 0
  stdout : {"id":"cli:workspace:create","result":{"root_pane":{"agent_status":"unknown","cwd":"/tmp","focused":true,"foreground_cwd":"/tmp","pane_id":"w1:p1","revision":0,"scroll":{"max_offset_from_bottom":0,"offset_from_bottom":0,"viewport_rows":24},"tab_id":"w1:t1","terminal_id":"term_6577fc63f9cc31","workspace_id":"w1"},"tab":{"agent_status":"unknown","focused":true,"label":"1","number":1,"pane_count":1,"tab_id":"w1:t1","workspace_id":"w1"},"type":"workspace_created","workspace":{"active_tab_id":"w1:t1","agent_status":"unknown","focused":true,"label":"handlab","number":1,"pane_count":1,"tab_count":1,"workspace_id":"w1"}}}

# workspace_id=w1

$ herdr tab create --workspace w1 --cwd /tmp --label task --no-focus
  exit   : 0
  stdout : {"id":"cli:tab:create","result":{"root_pane":{"agent_status":"unknown","cwd":"/tmp","focused":false,"foreground_cwd":"/tmp","pane_id":"w1:p2","revision":0,"scroll":{"max_offset_from_bottom":0,"offset_from_bottom":0,"viewport_rows":23},"tab_id":"w1:t2","terminal_id":"term_6577fc63fe8c42","workspace_id":"w1"},"tab":{"agent_status":"unknown","focused":false,"label":"task","number":2,"pane_count":1,"tab_id":"w1:t2","workspace_id":"w1"},"type":"tab_created"}}

# tab_id=w1:t2 pane_id=w1:p2

--- VOID commands: expect EMPTY stdout, exit 0 ---
$ herdr pane run w1:p2 echo hello-from-lab
  exit   : 0
  stdout : <EMPTY>

$ herdr pane send-text w1:p2 typed text
  exit   : 0
  stdout : <EMPTY>

$ herdr pane send-keys w1:p2 Enter
  exit   : 0
  stdout : <EMPTY>

--- QUERY commands: expect non-empty JSON ---
$ herdr tab list --workspace w1
  exit   : 0
  stdout : {"id":"cli:tab:list","result":{"tabs":[{"agent_status":"unknown","focused":true,"label":"1","number":1,"pane_count":1,"tab_id":"w1:t1","workspace_id":"w1"},{"agent_status":"unknown","focused":false,"label":"task","number":2,"pane_count":1,"tab_id":"w1:t2","workspace_id":"w1"}],"type":"tab_list"}}

$ herdr tab close w1:t2
  exit   : 0
  stdout : {"id":"cli:tab:close","result":{"type":"ok"}}

$ herdr workspace close w1
  exit   : 0
  stdout : {"id":"cli:workspace:close","result":{"type":"ok"}}
```
</details>
<details>
<summary>Evidence: hand spawn + hand send driving a resident interactive worker (real herdr)</summary>

<code>$ hand spawn task-1 demo&#10;spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/nm-lab/homeG/wt-task-1&#10;exit=0&#10;&#10;$ hand send task-1 &#39;status report please&#39;&#10;sent to task-1&#10;exit=0&#10;&#10;$ herdr pane read w8:p2 (what the worker pane actually shows)&#10;cd &#39;/tmp/nm-lab/homeG/wt-task-1&#39; &amp;&amp; CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions &#39;Read the brief at /tmp/nm-lab/homeG/data/task-1/brief.md and carry out the task it describes.&#39;&#10;[stub claude] CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false&#10;[stub claude] argv: claude --dangerously-skip-permissions Read the brief at ...&#10;[stub claude] interactive session resident, waiting for input&#10;status report please&#10;[stub claude] received: status report please</code>

```text
lab: real herdr 0.7.4, isolated session 'nm-verify-01KYERS'; 'claude' on the herdr server PATH is a stub that echoes its argv and stays resident on stdin

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/nm-lab/homeG/wt-task-1
  exit=0

$ hand send task-1 'status report please'
sent to task-1
  exit=0

$ hand status task-1
  Task:       task-1
  Project:    demo
  Kind:       ship
  Harness:    claude
  Model:      
  State:      idle
  Worktree:   /tmp/nm-lab/homeG/wt-task-1
  Herdr:      default / w8:t2
  Created:    just now
  PR:         (none)

$ herdr pane read w8:p2   (what the worker pane actually shows)
  cd '/tmp/nm-lab/homeG/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/nm-lab/homeG/data/task-1/brief.md and carry out the task it describes.'
  
  [atqa@sfx14:/tmp/nm-lab/homeG/wt-task-1]$ cd '/tmp/nm-lab/homeG/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/nm-lab/homeG/data/task-1/brief.md and carry out the task it describes.'
  [stub claude] CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false
  [stub claude] argv: claude --dangerously-skip-permissions Read the brief at /tmp/nm-lab/homeG/data/task-1/brief.md and carry out the task it describes.
  [stub claude] interactive session resident, waiting for input
  status report please
  [stub claude] received: status report please
$ herdr workspace list   (spawn's workspace, root tab + task tab)
  {"id":"cli:workspace:list","result":{"type":"workspace_list","workspaces":[{"active_tab_id":"w8:t1","agent_status":"idle","focused":true,"label":"demo","number":1,"pane_count":2,"tab_count":2,"workspace_id":"w8"}]}}
```
</details>
<details>
<summary>Evidence: Workspace-leak scenarios: fixed vs pre-fix binary against real herdr</summary>

<code>S2 pre-fix binary (649fa02), happy path -- issue #25&#10;send launch command failed: herdr pane run w2:p2 cd &#39;...&#39; &amp;&amp; claude --print &#39;...&#39;: empty response&#10;spawn exit=1&#10;workspaces after : 1&#10;&#10;S3 fixed binary, PaneRun fails, workspace created by hand -- issue #27&#10;send launch command failed: ...: pane_busy: injected lab failure&#10;workspaces after : 0 &lt;- want 0, no leak&#10;&#10;S4 pre-fix binary, PaneRun fails, workspace created by hand -- issue #27 (bug reproduced)&#10;workspaces after : 1 &lt;- leaked workspace still present&#10;&#10;S5 fixed binary, PaneRun fails, workspace pre-existed and is shared&#10;pre-existing workspace w5 with 2 tabs (root + other-task)&#10;workspaces after : 1 &lt;- want 1, shared workspace survives&#10;tabs after : 1 other-task &lt;- task-1 tab removed only</code>

```text
lab: real herdr 0.7.4 in isolated session 'nm-verify-01KYERS'
workers launched against stub claude on the herdr server's PATH

################ S2  pre-fix binary (649fa02), happy path -- issue #25 ################
  workspaces before: 0
  send launch command failed: herdr pane run w2:p2 cd '/tmp/nm-lab/homeB/wt-task-1' && claude --print 'Read the brief at /tmp/nm-lab/homeB/data/task-1/brief.md and carry out the task it describes.': empty response
  spawn exit=1
  workspaces after : 1
    "label":"demo","number":1,"pane_count":1,"tab_count":1,"workspace_id":"w2"

################ S3  fixed binary, PaneRun fails, workspace created by hand -- issue #27 ################
  workspaces before: 0
  send launch command failed: herdr pane run w3:p2 cd '/tmp/nm-lab/homeC/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/nm-lab/homeC/data/task-1/brief.md and carry out the task it describes.': pane_busy: injected lab failure
  workspaces after : 0   <- want 0, no leak

################ S4  pre-fix binary, PaneRun fails, workspace created by hand -- issue #27 (bug reproduced) ################
  workspaces before: 0
  send launch command failed: herdr pane run w4:p2 cd '/tmp/nm-lab/homeD/wt-task-1' && claude --print 'Read the brief at /tmp/nm-lab/homeD/data/task-1/brief.md and carry out the task it describes.': pane_busy: injected lab failure
  workspaces after : 1   <- leaked workspace still present
    "label":"demo","number":1,"pane_count":1,"tab_count":1,"workspace_id":"w4"

################ S5  fixed binary, PaneRun fails, workspace pre-existed and is shared ################
  pre-existing workspace w5 with 2 tabs (root + other-task)
  send launch command failed: herdr pane run w5:p3 cd '/tmp/nm-lab/homeE/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/nm-lab/homeE/data/task-1/brief.md and carry out the task it describes.': pane_busy: injected lab failure
  workspaces after : 1   <- want 1, shared workspace survives
    "label":"demo","number":1,"pane_count":2,"tab_count":2,"workspace_id":"w5"
  tabs after       : 1 other-task    <- task-1 tab removed only

final workspaces in lab: 0
```
</details>
<details>
<summary>Evidence: Harness flag shapes read from the installed claude and opencode binaries</summary>

<code>=== claude --version ===&#10;2.1.214 (Claude Code)&#10;Claude Code - starts an interactive session by default, use -p/--print for&#10;--dangerously-skip-permissions Bypass all permission checks.&#10;--effort &lt;level&gt; Effort level for the current session&#10;--model &lt;model&gt; Model for the current session.&#10;&#10;=== opencode --version ===&#10;1.18.3&#10;(bare TUI form exposes -m/--model and --prompt; no --file, no --variant)&#10;-m, --model model to use in the format of provider/model&#10;--prompt prompt to use&#10;&#10;=== opencode run --help: headless one-shot form (rejected by the fix) ===</code>

```text
=== claude --version ===
2.1.214 (Claude Code)

=== claude --help: flags used by buildClaude, and --print's scope ===
Claude Code - starts an interactive session by default, use -p/--print for
  --dangerously-skip-permissions        Bypass all permission checks.
  --effort <level>                      Effort level for the current session
  --model <model>                       Model for the current session. Provide
  -p, --print                           Print response and exit (useful for

=== opencode --version ===
1.18.3

=== opencode --help: bare (TUI) form options ===
Options:
  -h, --help          show help                                                            [boolean]
  -v, --version       show version number                                                  [boolean]
      --print-logs    print logs to stderr                                                 [boolean]
      --log-level     log level                 [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
      --pure          run without external plugins                                         [boolean]
      --port          port to listen on                                        [number] [default: 0]
      --hostname      hostname to listen on                          [string] [default: "127.0.0.1"]
      --mdns          enable mDNS service discovery (defaults hostname to 0.0.0.0)
                                                                          [boolean] [default: false]
      --mdns-domain   custom domain name for mDNS service (default: opencode.local)
                                                                [string] [default: "opencode.local"]
      --cors          additional domains to allow for CORS                     [array] [default: []]
  -m, --model         model to use in the format of provider/model                          [string]
  -c, --continue      continue the last session                                            [boolean]
  -s, --session       session id to continue                                                [string]
      --fork          fork the session when continuing (use with --continue or --session)  [boolean]
      --prompt        prompt to use                                                         [string]
      --agent         agent to use                                                          [string]
      --auto          auto-approve permissions that are not explicitly denied (dangerous!)
                                                                          [boolean] [default: false]
      --mini          start the minimal interactive interface             [boolean] [default: false]
      --no-replay     disable mini session history replay on resume and after resize       [boolean]
      --replay-limit  cap visible mini replay to the newest N messages                      [number]

=== opencode run --help: headless one-shot form (rejected by the fix) ===
opencode run [message..]

run opencode with a message

Positionals:
  message  message to send                                                     [array] [default: []]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `cmd/promote.go:138` - cmd/promote.go duplicates the spawn lifecycle and still has the exact leak #27 fixed: when it creates the workspace (line 115, createdWorkspace=true) and then harness.Build (138), PaneRun (142), or state.Write (159) fails, it calls closeTaskTab instead of WorkspaceClose. Per this change&#39;s own root-cause analysis, WorkspaceCreate auto-creates a root tab, so TabList returns 2 tabs, closeTaskTab&#39;s sole-tab shortcut never fires, and only the task tab is closed - the root tab and thus the whole workspace leak. The same deferred-rollback pattern applies verbatim.
- ⚠️ `internal/harness/harness.go:71` - Switching claude from --print to interactive reintroduces two first-run interactive gates that --print skipped, both of which stall an unattended worker - the exact failure the change targets. (1) The workspace trust prompt: claude&#39;s trust check returns true unconditionally in print mode, but in interactive mode it requires projects[&lt;dir&gt;].hasTrustDialogAccepted on the cwd or an ancestor; a freshly leased treehouse worktree path has never been trusted, so the first spawn there blocks on the trust screen. (2) --dangerously-skip-permissions itself is gated on a one-time global disclaimer (bypassPermissionsModeAccepted / skipDangerousModePermissionPrompt); until it is accepted, interactive claude shows the &#34;WARNING: Claude Code running in Bypass Permissions mode&#34; Yes/No dialog (the binary&#39;s own message for --bg is &#34;requires accepting the disclaimer first. Run `claude --dangerously-skip-permissions` once interactively&#34;). A lab verification on a machine where both were already accepted would not surface either. Worth pre-trusting the worktree path (or documenting the one-time operator setup) so the first spawn on a fresh host does not hang.
- ℹ️ `SPECS.md:902` - The herdr integration section still asserts a single uniform response contract - &#34;These calls and the JSON response envelope were verified against the installed herdr version&#34; - which is precisely the assumption #25 disproved. The listed pane run / send-text / send-keys calls return empty stdout on success and only emit an envelope on error. This section, not the Harness section, is where a future implementer looks up the herdr response contract.
- ℹ️ `internal/harness/harness.go:102` - opencode 1.18.3 exposes a native `--auto` flag on the bare TUI command (&#34;auto-approve permissions that are not explicitly denied&#34;), which covers the unattended-worker case without injecting a JSON config document through OPENCODE_CONFIG_CONTENT. The env-var form is strictly broader (it overrides explicit deny rules too), so this is a deliberate-tradeoff question rather than a pure simplification, but the native flag is the simpler shape if blanket-override is not actually required.
- ℹ️ `internal/harness/harness.go:101` - Effort is now silently dropped for the opencode harness (bare opencode has no effort/variant flag). `hand spawn --harness opencode --effort high` still records Effort in the task state and prints nothing, so the operator cannot tell the setting had no effect. A one-line warning to stderr when Effort is set for a harness that cannot apply it would make the documented limitation visible at the point of use.

🔧 Fix: fix promote workspace leak; document claude first-run gates
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`nix develop -c go test -race ./...` (full unit suite, green)</code>
- <code>`nix develop -c go test -tags e2e -race -timeout 10m ./tests/e2e/...` (green)</code>
- `nix develop -c go test -race -count=1 -v -run 'TestBuildClaude|TestBuildOpenCode|TestPaneRun|TestPaneSend|TestCallVoid|TestSpawnFailure|TestPromoteFailure' ./internal/harness/... ./internal/herdr/... ./cmd/...`
- <code>Real-herdr protocol probe in isolated session: `herdr --session &lt;lab&gt; workspace create|tab create|pane run|pane send-text|pane send-keys|tab list|tab close|workspace close`, capturing stdout/exit per command</code>
- <code>Pre-fix regression repro for #25: base commit 649fa02 source + target `tests/e2e/fakes_test.go` -&gt; `go test -tags e2e -count=1 -run TestSpawnTeardownCycle ./tests/e2e/...` fails with `herdr pane run ...: empty response`</code>
- <code>End-to-end `hand spawn task-1 demo` against real herdr via a session-forwarding shim, then `herdr pane read &lt;pane&gt;` to confirm the interactive claude command is resident in the pane</code>
- <code>`hand send task-1 &#39;status report please&#39;` then `herdr pane read` to confirm the resident worker received the steer (PaneSendText/PaneSendKeys void path)</code>
- <code>`hand spawn task-1 demo --harness opencode --model anthropic/claude-sonnet-5` then `herdr pane read` to confirm the bare `opencode --model ... --prompt ...` form with OPENCODE_CONFIG_CONTENT</code>
- <code>`hand status task-1` against the live lab task</code>
- <code>#27 leak scenarios against real herdr with an injected `pane run` error envelope (exit 0): fixed binary with hand-created workspace, base binary with hand-created workspace, fixed binary with pre-existing shared workspace; `herdr workspace list` / `tab list` inspected before and after each</code>
- <code>`claude --version` / `claude --help` and `opencode --version` / `opencode --help` / `opencode run --help` to verify the flag shapes buildClaude and buildOpenCode construct</code>
- <code>`git diff --stat 649fa02..ee82b55` to confirm no `.github/workflows/` changes</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `SPECS.md:627` - The `hand promote` Behavior list contradicts cmd/promote.go in two pre-existing ways, and both now sit next to the rollback contract this change documented. Step 2 says the scout&#39;s herdr tab and worktree are torn down before the new tab is created, but promote.go closes the old tab (line 174) and returns the old worktree (line 179) only after state.Write succeeds - that ordering is exactly what makes the new deferred rollback safe, since an early teardown would leave a failed promotion with no pane at all. Step 8 says promote updates data/dashboard.md, but promote.go deliberately leaves it untouched (comment at line 156). Both mismatches predate this change, so I left them rather than widen its scope; worth a small follow-up doc fix to the promote spec section.

🔧 Fix: correct hand promote spec teardown order and dashboard rule
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
