### PR TITLE
ci: allow manual dispatch of release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:

--- a/SPECS.md
+++ b/SPECS.md
@@ -1321,20 +1321,21 @@ jobs:
         run: go test -tags=e2e -timeout=10m ./tests/e2e/...
 ```
 
-`.github/workflows/release.yaml` - runs on push to main:
+`.github/workflows/release.yaml` - runs on push to main, and manually via `workflow_dispatch` (used to re-run release-please after a conflicted release PR is rebased):
 ```yaml
 name: Release
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Intent

Add workflow_dispatch to the Release GitHub Actions workflow's on: block so it can be re-triggered manually. Fixes github issue #20: release-please's release PR got left conflicted (an unrelated PR edited flake.nix near the x-release-please-version line, then the next push-triggered Release run logged 'PR #8 remained the same' without rebasing) and there was no way to re-run the workflow without a manual rebase. Scope is strictly the on: block - no changes to jobs, steps, permissions, or any other file.

## What Changed

- Added `workflow_dispatch` to the Release workflow's `on:` block so release-please can be re-triggered by hand after a release PR is left conflicted, instead of waiting for the next push to `main`.
- Changed the release concurrency group from `release-${{ github.ref }}` to the constant `release`, so a manual dispatch on any ref serializes against push-triggered runs rather than getting its own queue.
- Synced the embedded `release.yaml` listing in `SPECS.md` with both changes and noted the manual re-run path in the surrounding prose.

Review flagged that a dispatched re-run may still no-op if release-please recomputes identical PR content, so unblocking a conflicted PR can still need the release branch deleted or rebased; the trigger is a prerequisite, not a guaranteed fix. Verification of the live dispatch (`gh workflow run Release --ref main`) is only possible after this lands on the default branch - the pre-change state was confirmed to reject with HTTP 422, and the post-change trigger resolution was checked with `act --list workflow_dispatch`.

## Risk Assessment

✅ Low: Two-line CI workflow change that adds a manual trigger and tightens the concurrency group to a constant, which closes the only race the trigger introduced and leaves no other release run path unserialized.

## Testing

No baseline suite was relevant since the diff touches only a GitHub Actions YAML file and no Go code, so I exercised the trigger itself: I first reproduced the reported gap end-to-end against the live public repo, where `gh workflow run Release --ref main` is rejected with HTTP 422 \"Workflow does not have 'workflow_dispatch' trigger\", then used a real GitHub-workflow parser to show that a `workflow_dispatch` event resolves zero jobs on the base file but the full release-please/build/publish pipeline with this change, with the `push` trigger unchanged. A structural diff confirmed permissions and every job and step are untouched. Everything passed; the two open items are the unauthorized `concurrency.group` rewrite that rode along in the review commit, and the fact that a real dispatched run or a screenshot of the Actions \"Run workflow\" button is only obtainable after this lands on the default branch, since GitHub does not expose workflow_dispatch from a feature branch - that is why there is no visual artifact.

<details>
<summary>Evidence: Release workflow_dispatch evidence transcript (live 422 before-state, before/after event-to-job resolution, scope diff)</summary>

<code>############ 1. BEFORE: reproduce the gap against the live repo ############&#10;$ gh workflow run Release --ref main # main == base state, no workflow_dispatch&#10;could not create workflow dispatch event: HTTP 422: Workflow does not have &#39;workflow_dispatch&#39; trigger (https://api.github.com/repos/atqamz/secondhand/actions/workflows/319695126/dispatches)&#10;exit=1&#10;&#10;############ 2. Which jobs each event triggers (nektos/act workflow parser) ############&#10;--- BEFORE (origin/main release.yaml) :: event=workflow_dispatch ---&#10;Stage Job ID Job name Workflow name Workflow file Events&#10;&#10;--- AFTER (this change) :: event=workflow_dispatch ---&#10;Stage Job ID Job name Workflow name Workflow file Events&#10;0 release-please Release Please Release release.yaml push,workflow_dispatch&#10;1 build Build (${{ matrix.goos }}/${{ matrix.goarch }}) Release release.yaml push,workflow_dispatch&#10;2 publish Publish release assets Release release.yaml push,workflow_dispatch</code>

```text
Issue #20 - Release workflow cannot be re-run without a push to main
repo: atqamz/secondhand (public)   workflow id 319695126 "Release"

############ 1. BEFORE: reproduce the gap against the live repo ############
$ gh workflow run Release --ref main       # main == base state, no workflow_dispatch
could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger (https://api.github.com/repos/atqamz/secondhand/actions/workflows/319695126/dispatches)
exit=1

############ 2. Which jobs each event triggers (nektos/act workflow parser) ############
--- BEFORE (origin/main release.yaml) :: event=push ---
Stage  Job ID          Job name                                         Workflow name  Workflow file  Events
0      release-please  Release Please                                   Release        release.yaml   push  
1      build           Build (${{ matrix.goos }}/${{ matrix.goarch }})  Release        release.yaml   push  
2      publish         Publish release assets                           Release        release.yaml   push  

--- BEFORE (origin/main release.yaml) :: event=workflow_dispatch ---
Stage  Job ID  Job name  Workflow name  Workflow file  Events

--- AFTER  (this change) :: event=push ---
Stage  Job ID          Job name                                         Workflow name  Workflow file  Events                
0      release-please  Release Please                                   Release        release.yaml   push,workflow_dispatch
1      build           Build (${{ matrix.goos }}/${{ matrix.goarch }})  Release        release.yaml   push,workflow_dispatch
2      publish         Publish release assets                           Release        release.yaml   push,workflow_dispatch

--- AFTER  (this change) :: event=workflow_dispatch ---
Stage  Job ID          Job name                                         Workflow name  Workflow file  Events                
0      release-please  Release Please                                   Release        release.yaml   push,workflow_dispatch
1      build           Build (${{ matrix.goos }}/${{ matrix.goarch }})  Release        release.yaml   push,workflow_dispatch
2      publish         Publish release assets                           Release        release.yaml   push,workflow_dispatch

############ 3. Scope check ############
$ git diff --stat 170dd98..0f7b0eb
 .github/workflows/release.yaml | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

diff --git a/.github/workflows/release.yaml b/.github/workflows/release.yaml
index 5253c90..67b48d8 100644
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,13 +3,14 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (4m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `.github/workflows/release.yaml:6` - Adding workflow_dispatch introduces a concurrency bypass: the group key is `release-${{ github.ref }}` (line 13), so a manual dispatch from any ref other than refs/heads/main gets its own group and is not serialized against queued/in-flight push runs on main. Because release-please-action sets no `target-branch`, it still targets the repository default branch, so two runs can create/force-push the release branch and tag main&#39;s release concurrently. Resolving this would require keying concurrency on the release target rather than github.ref (e.g. a fixed group, or github.event.repository.default_branch), which falls outside the intent&#39;s stated &#34;strictly the on: block&#34; scope - hence flagged rather than fixed.
- ℹ️ `.github/workflows/release.yaml:6` - The dispatch trigger runs the identical release-please step that already logged &#39;PR #8 remained the same&#39; on the push-triggered run described in issue #20. release-please skips updating a release PR when the recomputed PR content is unchanged, so a manual re-run is likely to no-op again and leave the PR conflicted. The trigger is a prerequisite for recovery but probably not sufficient on its own; unblocking the conflicted PR may still need the release branch deleted (so release-please recreates it) or a rebase. Noting only - a workflow-level fix would exceed the intent&#39;s on:-block-only scope.

🔧 Fix: ci: serialize release runs with constant concurrency group
1 info still open:
- ℹ️ `.github/workflows/release.yaml:13` - The intent states &#34;Scope is strictly the on: block - no changes to jobs, steps, permissions, or any other file&#34;, and the diff also changes `concurrency.group` from `release-${{ github.ref }}` to `release`. This is not an unauthorized deviation: it was explicitly requested in the previous review round (&#39;Make the concurrency group a constant: group: release ... A constant group serializes every release run regardless of trigger or ref&#39;), and it is required for correctness once workflow_dispatch can run on any ref. Recorded only so the scope expansion relative to the original intent text is visible; no action needed.

</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `.github/workflows/release.yaml:13` - Commit 0f7b0eb also changes `concurrency.group` from `release-${{ github.ref }}` to a constant `release`, which is outside the intent&#39;s declared scope (&#34;strictly the on: block&#34;). It is a real behavior change: every Release run now serializes into one global queue instead of one queue per ref. It is arguably needed so a manual dispatch on a non-main ref cannot run release-please concurrently with a push-triggered run, but the intent does not authorize it. Decide whether to keep it or revert to the per-ref group.
- ⚠️ `.github/workflows/release.yaml:6` - The conclusive end-user artifact - a real dispatched Release run, or a screenshot of the &#34;Run workflow&#34; button in the Actions tab - cannot be produced before merge, because GitHub only honors workflow_dispatch once the workflow file exists on the default branch. I verified the live before-state (HTTP 422 &#34;Workflow does not have &#39;workflow_dispatch&#39; trigger&#34;) and proved the after-state trigger resolution with a real workflow parser, but did not push or merge to obtain the post-merge proof. Confirm after merging that `gh workflow run Release --ref main` succeeds.
- <code>`gh issue view 20` to confirm the required behavior from the issue body</code>
- <code>`gh workflow run Release --ref main` against atqamz/secondhand - live reproduction of the pre-change gap, rejected with HTTP 422 &#34;Workflow does not have &#39;workflow_dispatch&#39; trigger&#34;</code>
- <code>`act --list push -W .github/workflows/release.yaml` and `act --list workflow_dispatch -W .github/workflows/release.yaml` (nektos/act 0.2.89) run against both the `origin/main` file and the changed file, comparing which jobs each event resolves</code>
- <code>`git diff --stat 170dd98..0f7b0eb` plus a byte-comparison of the `permissions:`/`jobs:` region of both file versions to verify the change touches nothing but the `on:` and `concurrency:` blocks</code>
- <code>`git status --porcelain` to confirm no transient files were left in the worktree</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `SPECS.md:1252` - Out-of-scope follow-up: SPECS.md&#39;s &#34;Workflow files&#34; section embeds ~100 lines of ci.yaml and release.yaml verbatim, so every CI edit silently makes it stale (this change is the proof - both the on: block and the concurrency group drifted). Per the placement policy these are duplicates of a schema-backed source and should be reduced to a short pointer to .github/workflows/, keeping only the prose contract (triggers, build matrix, artifacts) in SPECS.md. Not done here to keep this change minimal.
- ℹ️ `.github/workflows/release.yaml:13` - Judgment call: the user intent restricts scope to the on: block, but target commit 0f7b0eb also changed concurrency.group from release-${{ github.ref }} to a constant release. I documented it in SPECS.md as-is (with the serialize rationale in the prose intro) rather than adding a YAML comment, since a comment would itself edit outside the stated scope. Confirm the concurrency change is intended, or drop it to match the intent.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


Fixes #20
