### PR TITLE
test(e2e): make the e2e suite hermetic and document fake fidelity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,13 +54,5 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - name: Install herdr
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -fsSL https://github.com/ogulcancelik/herdr/releases/download/v0.7.5/herdr-linux-x86_64 -o "$HOME/.local/bin/herdr"
-          chmod +x "$HOME/.local/bin/herdr"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Install treehouse
-        run: go install github.com/kunchenguid/treehouse@c0b7f685d4511eec765ab4cbb47583178424eb45
       - name: End-to-end
         run: go test -tags=e2e -timeout=10m ./tests/e2e/...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,7 @@
 version: "2"
 
 run:
+  # Without this tag the //go:build e2e package in tests/e2e is invisible to the
+  # linter entirely, so it is silently unlinted. Do not remove as a "default".
   build-tags:
     - e2e

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+version: "2"
+
+run:
+  build-tags:
+    - e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Run `hand --help` for the full command reference.
 - Use `qmd search` to find historical context in data/ when available. Fall back to reading files directly.
 - Zero comments by default. Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug. Never restate code, narrate what, add banners, or docstring the obvious.
 - Harness/herdr syntax, exit-code enforcement, watch's stdout/errOut split, per-command dashboard rules, and first-run prompt handling are commented at point of use (`internal/herdr`, `internal/harness`, `cmd/root.go`, `cmd/precondition.go`, `internal/watcher`, `cmd/project.go`, `cmd/promote.go`, `cmd/merge.go`, `cmd/launch.go`); SPECS.md's "Exit codes" and each command's spec section own the authoritative tables.
-- Test, release, and write conventions live as doc comments: `tests/e2e` (`fakes_test.go`, `e2e_test.go`), GitHub access via `gh` (`internal/ghutil`), AGENTS.md refresh (`internal/agentsmd`), atomic writes (`internal/atomicfile`).
+- Test, release, and write conventions live as doc comments: `tests/e2e` (`fakes_test.go`, `e2e_test.go`), GitHub access via `gh` (`internal/ghutil`), AGENTS.md refresh (`internal/agentsmd`), atomic writes (`internal/atomicfile`); SPECS.md's "Testing strategy" owns the fake-fidelity rule every faked backend invocation follows.
 - Dev environment is Nix-based (`flake.nix`, `CONTRIBUTING.md`); `make lint`, `go build ./...`, and `go test -race ./...` verify inside `nix develop`.
 
 ## Maintaining this file

--- a/SPECS.md
+++ b/SPECS.md
@@ -1541,6 +1541,8 @@ clean:
 	rm -f hand
 ```
 
+**`.golangci.yaml`:** the tracked file is authoritative - it keeps golangci-lint's default linter set and only sets `run.build-tags: [e2e]`, without which the `//go:build e2e` package in `tests/e2e` is invisible to the linter.
+
 **`.gitignore`:** the tracked file is authoritative - the built binary, the `hand init` runtime directories, Go and Nix build output, worktree tooling files, and editor/OS cruft.
 
 **`flake.nix`:** the tracked file is authoritative - a `packages.default` derivation building the `hand` binary and a `devShells.default` carrying the Go toolchain.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1463,7 +1463,7 @@ jobs:
             checksums.txt
 ```
 
-Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (tests/e2e refuses to run if either resolves for real, see TestMain), then release-please for automated releases.
+Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (tests/e2e runs on a hermetic PATH holding only the real binaries it needs, so neither can resolve for real, see TestMain), then release-please for automated releases.
 
 `.github/dependabot.yaml` - keep Go modules and GitHub Actions up to date:
 ```yaml

--- a/SPECS.md
+++ b/SPECS.md
@@ -1365,14 +1365,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - name: Install herdr
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -fsSL https://github.com/ogulcancelik/herdr/releases/download/v0.7.5/herdr-linux-x86_64 -o "$HOME/.local/bin/herdr"
-          chmod +x "$HOME/.local/bin/herdr"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Install treehouse
-        run: go install github.com/kunchenguid/treehouse@v2.1.0
       - name: End-to-end
         run: go test -tags=e2e -timeout=10m ./tests/e2e/...
 ```
@@ -1471,7 +1463,7 @@ jobs:
             checksums.txt
 ```
 
-Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e with real herdr and treehouse, then release-please for automated releases.
+Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (tests/e2e refuses to run if either resolves for real, see TestMain), then release-please for automated releases.
 
 `.github/dependabot.yaml` - keep Go modules and GitHub Actions up to date:
 ```yaml

--- a/SPECS.md
+++ b/SPECS.md
@@ -1152,6 +1152,8 @@ The agent can parse stdout reliably and read stderr for diagnostics.
 
 ## Testing strategy
 
+Every faked `herdr`, `gh`, `treehouse` or harness invocation, in unit and end-to-end tests alike, carries a comment recording the fake-fidelity contract: what the real tool does on success and on failure - exit code, stream, response shape - and whether the fake mirrors that or deliberately diverges.
+
 ### Unit tests
 
 - State file reading/writing.
@@ -1166,6 +1168,8 @@ The agent can parse stdout reliably and read stderr for diagnostics.
 
 Implemented in `tests/e2e`, which drives the built binary against a scratch home.
 herdr, treehouse, and gh are faked as shell scripts on `PATH` and remote clones are redirected to a local repo, so the suite never touches a real session provider or the network.
+`TestMain` enforces that once for the whole suite: it replaces `PATH` with a hermetic one carrying only the real binaries the suite genuinely runs, then asserts that neither herdr, treehouse, gh nor the worker harness resolves, so a missing fake fails the run loudly instead of quietly answering from the developer's real tools.
+CI therefore installs no real herdr or treehouse.
 
 - Spawn/teardown cycle, including teardown's refusal on unlanded work.
 - Watch event stream with simulated herdr state changes.
@@ -1463,7 +1467,7 @@ jobs:
             checksums.txt
 ```
 
-Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (tests/e2e runs on a hermetic PATH holding only the real binaries it needs, so neither can resolve for real, see TestMain), then release-please for automated releases.
+Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (no real ones installed, see "Integration tests"), then release-please for automated releases.
 
 `.github/dependabot.yaml` - keep Go modules and GitHub Actions up to date:
 ```yaml

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -113,6 +113,8 @@ esac
 `
 
 func TestPRChecksGreenAllPass(t *testing.T) {
+	// Faithful to real gh here: an all-pass `pr checks --json bucket` prints
+	// this array on stdout and exits 0.
 	writeFakeGh(t, `#!/bin/sh
 printf '[{"bucket":"pass"},{"bucket":"skipping"}]'
 `)
@@ -126,6 +128,8 @@ printf '[{"bucket":"pass"},{"bucket":"skipping"}]'
 }
 
 func TestPRChecksGreenFailingCheck(t *testing.T) {
+	// Exit 0 with a "fail" bucket instead of real gh's exit 1, same reason as
+	// fakeGhChecksRed above.
 	writeFakeGh(t, `#!/bin/sh
 printf '[{"bucket":"pass"},{"bucket":"fail"}]'
 `)

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -74,6 +74,11 @@ func writeFakeGh(t *testing.T, script string) {
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+// fakeGhChecksGreenAndMerge always exits 0. Real gh exits 1 on a fail bucket and
+// 8 on pending (prChecksGreen's own doc comment in cmd/merge.go), but
+// prChecksGreen deliberately never consults the exit code once the JSON parses,
+// so an exit-0 fake exercises the same code path a nonzero one would; "pr merge"
+// failing is untested here (see runPRMerge's "gh pr merge failed" error path).
 const fakeGhChecksGreenAndMerge = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -90,6 +95,10 @@ case "$cmd" in
 esac
 `
 
+// fakeGhChecksRed exits 0 with a "fail" bucket rather than real gh's documented
+// exit 1, for the same reason as fakeGhChecksGreenAndMerge: prChecksGreen only
+// looks at the exit code when the JSON fails to parse, so this still exercises
+// the real "trust the JSON over the exit code" behavior the function is built on.
 const fakeGhChecksRed = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -98,15 +98,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Real treehouse writes a banner to stderr ahead of its JSON on "get" (see
-	// internal/worktree/worktree.go's Get doc comment); omitted here for the
-	// same reason as spawn_test.go's setupSpawnHome - the stdout-only
-	// regression it guards against is covered by tests/e2e/fakes_test.go's
-	// writeFakeTreehouse.
-	treehouseScript := "#!/bin/sh\nprintf '{\"path\":\"" + newWorktree + "\"}'\n"
-	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(treehouseScript), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeTreehouseGet(t, bin, newWorktree)
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Chdir(home)
 	return home

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
+// fakeHerdrPromoteScript covers the herdr calls a clean promote makes, same
+// void-command-as-envelope simplification as fakeHerdrSpawnScript in
+// spawn_test.go: real "pane run" succeeds with empty stdout, but callVoid also
+// accepts this envelope, and promote's own logic only checks for a non-nil
+// error, so the exact response shape isn't this test's concern.
 const fakeHerdrPromoteScript = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -42,6 +47,9 @@ case "$cmd" in
 esac
 `
 
+// fakeHerdrPromotePaneWorking only fakes "pane get", reporting the scout's
+// pane as still "working" so promote's precondition check refuses the
+// promotion before any other herdr call is needed.
 const fakeHerdrPromotePaneWorking = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -90,6 +98,11 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Real treehouse writes a banner to stderr ahead of its JSON on "get" (see
+	// internal/worktree/worktree.go's Get doc comment); omitted here for the
+	// same reason as spawn_test.go's setupSpawnHome - the stdout-only
+	// regression it guards against is covered by tests/e2e/fakes_test.go's
+	// writeFakeTreehouse.
 	treehouseScript := "#!/bin/sh\nprintf '{\"path\":\"" + newWorktree + "\"}'\n"
 	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(treehouseScript), 0o755); err != nil {
 		t.Fatal(err)
@@ -210,6 +223,9 @@ func TestPromoteRefusesUnregisteredProject(t *testing.T) {
 // fakeHerdrPromoteLeakScript mirrors fakeHerdrLeakScript for promote: it logs every call and
 // fails "pane run" so the promotion always fails after the new tab exists, with
 // $HERDR_WS_EXISTS_FLAG choosing between the created-workspace and pre-existing-workspace cases.
+// Same bare-exit-1 simplification as fakeHerdrLeakScript in spawn_test.go: promote.go only
+// checks PaneRun's error for non-nil, not its shape, and the real exit-0-plus-error-envelope
+// failure shape is covered at the client level, not here.
 const fakeHerdrPromoteLeakScript = `#!/bin/sh
 echo "$@" >> "$HERDR_CALL_LOG"
 cmd="$1 $2"

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -129,7 +129,9 @@ exit 1
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"missing-task", "hello"})
-	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("got err %v, want not found", err)
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), `task "missing-task" not found`) {
+		t.Fatalf("got err %v, want the task-not-found precondition", err)
 	}
 }

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -23,6 +23,10 @@ func setupSendHome(t *testing.T, herdrScript string) string {
 }
 
 func TestSendHappyPathWhenIdle(t *testing.T) {
+	// "pane send-text"/"pane send-keys" are void commands: real success is
+	// empty stdout, not this envelope (callVoid's doc comment, client.go).
+	// callVoid only checks env.Error, which is nil here, so the extra body is
+	// harmless and this still exercises the real success path.
 	home := setupSendHome(t, `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -53,6 +57,10 @@ esac
 }
 
 func TestSendFailsWhenPaneNotFound(t *testing.T) {
+	// "pane get" is a query command (call(), client.go); call() checks
+	// env.Error before runErr, so this fake would behave identically without
+	// the exit 1 - kept here only because it is a plausible real exit status
+	// for a failed query, not because call() requires it.
 	home := setupSendHome(t, `#!/bin/sh
 printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
 exit 1
@@ -69,6 +77,8 @@ exit 1
 }
 
 func TestSendWaitsWhileBusyThenSends(t *testing.T) {
+	// Same send-text/send-keys envelope simplification as
+	// TestSendHappyPathWhenIdle above.
 	counterFile := filepath.Join(t.TempDir(), "calls")
 	home := setupSendHome(t, `#!/bin/sh
 cmd="$1 $2"

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -118,7 +118,14 @@ esac
 }
 
 func TestSendFailsForUnknownTask(t *testing.T) {
-	setupSendHome(t, "#!/bin/sh\nexit 1\n")
+	// send resolves the task before it ever reaches herdr, so this fake refuses
+	// every invocation instead of imitating a herdr response: a regression that
+	// called herdr first would surface that message here rather than the
+	// expected "not found".
+	setupSendHome(t, `#!/bin/sh
+echo "unexpected herdr invocation: $@" >&2
+exit 1
+`)
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"missing-task", "hello"})

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -60,6 +60,19 @@ case "$cmd" in
 esac
 `
 
+// writeFakeTreehouseGet fakes "treehouse get" as always leasing worktreePath.
+// Real treehouse writes a banner to stderr ahead of its JSON on "get"
+// (internal/worktree/worktree.go's Get doc comment); this fake omits it since
+// worktree.Get's own stdout-only parsing is covered where the banner matters,
+// in tests/e2e/fakes_test.go's writeFakeTreehouse.
+func writeFakeTreehouseGet(t *testing.T, bin, worktreePath string) {
+	t.Helper()
+	script := "#!/bin/sh\nprintf '{\"path\":\"" + worktreePath + "\"}'\n"
+	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 	t.Helper()
 	useFastLaunchPolling(t)
@@ -85,14 +98,7 @@ func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Real treehouse writes a banner to stderr ahead of its JSON on "get"
-	// (internal/worktree/worktree.go's Get doc comment); this fake omits it
-	// since worktree.Get's own stdout-only parsing is covered where the banner
-	// matters, in tests/e2e/fakes_test.go's writeFakeTreehouse.
-	treehouseScript := "#!/bin/sh\nprintf '{\"path\":\"" + worktreePath + "\"}'\n"
-	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(treehouseScript), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeTreehouseGet(t, bin, worktreePath)
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Chdir(home)
 	return home

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -27,8 +27,14 @@ func TestSpawnCleanupReportsAllErrors(t *testing.T) {
 	}
 }
 
-// fakeHerdrSpawnScript reports a pane herdr sees claude running in, painted past its startup
-// frame and showing no first-run dialog, so confirmLaunch confirms the launch on its first poll.
+// fakeHerdrSpawnScript covers the herdr calls a clean spawn makes: it reports a pane herdr sees
+// claude running in, painted past its startup frame and showing no first-run dialog, so
+// confirmLaunch confirms the launch on its first poll. Real herdr answers query commands
+// ("workspace list", "tab create", "pane get") with a JSON envelope and answers void commands
+// ("pane run") with empty stdout on success (internal/herdr/client.go's call/callVoid doc
+// comments); this fake echoes an envelope for "pane run" too, which callVoid also accepts, since
+// this test exercises spawn's own success path, not herdr's response parsing - that parsing is
+// covered at the client level by internal/herdr/client_test.go.
 const fakeHerdrSpawnScript = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -79,6 +85,10 @@ func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Real treehouse writes a banner to stderr ahead of its JSON on "get"
+	// (internal/worktree/worktree.go's Get doc comment); this fake omits it
+	// since worktree.Get's own stdout-only parsing is covered where the banner
+	// matters, in tests/e2e/fakes_test.go's writeFakeTreehouse.
 	treehouseScript := "#!/bin/sh\nprintf '{\"path\":\"" + worktreePath + "\"}'\n"
 	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(treehouseScript), 0o755); err != nil {
 		t.Fatal(err)
@@ -210,6 +220,11 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 // spawn always fails after tab creation. Whether "workspace list" reports an existing
 // workspace is controlled by the presence of $HERDR_WS_EXISTS_FLAG, letting the same script
 // drive both the created-workspace and pre-existing-workspace leak scenarios.
+// "pane run" fails via bare exit 1 rather than real herdr's documented void-command
+// failure shape (empty exit 0 + JSON error envelope, see callVoid's doc comment): spawn.go
+// only branches on whether PaneRun returned a non-nil error, never on its shape, so this
+// tests spawn's cleanup logic, not herdr's envelope parsing - that shape is covered by
+// internal/herdr/client_test.go's TestPaneRunSurfacesErrorEnvelopeEvenOnExitZero.
 const fakeHerdrLeakScript = `#!/bin/sh
 echo "$@" >> "$HERDR_CALL_LOG"
 cmd="$1 $2"

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
+// writeFakeHerdrPaneStatus fakes "pane get" as a query command per
+// internal/herdr/client.go's call() doc comment: a non-null result object on
+// success. It always succeeds; the "herdr unreachable" degrade path is
+// exercised for real (no fake, empty PATH) by
+// TestStatusFleetDegradesToUnknownWhenHerdrUnreachable below.
 func writeFakeHerdrPaneStatus(t *testing.T, status string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -45,6 +45,22 @@ func initGitRepo(t *testing.T, dir string) {
 	run("commit", "-q", "-m", "initial commit")
 }
 
+// writeFakeGHPRState fakes `gh pr view --json state`, which really answers with
+// that JSON object on stdout and exit 0. Real gh writes warnings to stderr
+// ahead of the JSON (internal/ghutil/pr.go's PRIsMerged doc comment); this fake
+// omits them since these tests only check the parsed state, not the
+// stdout/stderr split - that split is covered faithfully by
+// internal/ghutil/pr_test.go's writeFakeGHPRView.
+func writeFakeGHPRState(t *testing.T, prState string) {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\nprintf '{\"state\":\"" + prState + "\"}'\n"
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 // writeFakeTreehouseReturn fakes "treehouse return" as a no-op success (real
 // treehouse's return/init also succeed silently, per internal/worktree.Return's
 // CombinedOutput-based error handling - only its failure path, a nonzero exit
@@ -117,18 +133,7 @@ func TestTeardownShipFailsOnUncommittedChanges(t *testing.T) {
 
 func TestTeardownShipFailsWhenPRNotMerged(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
-	bin := t.TempDir()
-	// Real gh writes warnings to stderr ahead of its JSON on "pr view" (see
-	// internal/ghutil/pr.go's PRIsMerged doc comment), omitted here since this
-	// test only checks the parsed state, not the stdout/stderr split; that
-	// split is covered faithfully by internal/ghutil/pr_test.go's
-	// writeFakeGHPRView.
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(`#!/bin/sh
-printf '{"state":"OPEN"}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeFakeGHPRState(t, "OPEN")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj", PR: "https://example.com/pr/1"}); err != nil {
 		t.Fatal(err)
@@ -145,13 +150,7 @@ printf '{"state":"OPEN"}'
 
 func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(`#!/bin/sh
-printf '{"state":"MERGED"}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeFakeGHPRState(t, "MERGED")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
 		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -45,6 +45,13 @@ func initGitRepo(t *testing.T, dir string) {
 	run("commit", "-q", "-m", "initial commit")
 }
 
+// writeFakeTreehouseReturn fakes "treehouse return" as a no-op success (real
+// treehouse's return/init also succeed silently, per internal/worktree.Return's
+// CombinedOutput-based error handling - only its failure path, a nonzero exit
+// with output, needs the real stream contents, and that's covered directly by
+// internal/worktree/worktree_test.go's TestReturnFailsOnNonZeroExit) and its
+// herdr calls as always-succeeding envelopes, since these teardown tests only
+// exercise which calls get made, not any herdr failure path.
 func writeFakeTreehouseReturn(t *testing.T) {
 	t.Helper()
 	bin := t.TempDir()
@@ -111,6 +118,11 @@ func TestTeardownShipFailsOnUncommittedChanges(t *testing.T) {
 func TestTeardownShipFailsWhenPRNotMerged(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	bin := t.TempDir()
+	// Real gh writes warnings to stderr ahead of its JSON on "pr view" (see
+	// internal/ghutil/pr.go's PRIsMerged doc comment), omitted here since this
+	// test only checks the parsed state, not the stdout/stderr split; that
+	// split is covered faithfully by internal/ghutil/pr_test.go's
+	// writeFakeGHPRView.
 	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(`#!/bin/sh
 printf '{"state":"OPEN"}'
 `), 0o755); err != nil {
@@ -318,6 +330,11 @@ func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
 
 	marker := filepath.Join(t.TempDir(), "herdr-called")
 	bin := t.TempDir()
+	// This and the herdr fakes further down this file all return a non-null
+	// object result for "tab list"/"tab close"/"workspace close", which is
+	// exactly what call() requires for success (client.go); these three are
+	// query commands, not the void pane commands callVoid documents, so there
+	// is no exit-code-vs-envelope split to reproduce here.
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte("#!/bin/sh\ntouch '"+marker+"'\nprintf '{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\"}]}}'\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -31,7 +31,12 @@ func writeFakeGHReleaseView(t *testing.T, tag string) {
 }
 
 // writeFakeGHUpdate fakes the three gh invocations a full `hand update` makes:
-// the tag lookup, the release asset download, and the release notes lookup.
+// the tag lookup and the release notes lookup, both "release view --jq" in the
+// shape writeFakeGHReleaseView documents above, plus the asset download - real
+// `gh release download` leaves only the assets themselves in --dir and writes
+// its progress to stderr, so copying the fixture in and printing nothing is the
+// faithful success shape. The trailing arm mirrors real gh's failure shape too:
+// a diagnostic on stderr and a non-zero exit, never a partial success.
 func writeFakeGHUpdate(t *testing.T, tag, notes, fixtureDir string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/atqamz/secondhand/internal/selfupdate"
 )
 
+// writeFakeGHReleaseView fakes "release view --jq" as real gh's --jq flattens
+// its JSON to the raw field value on stdout (selfupdate.go's runGH callers use
+// --jq .tagName/.body), so a plain string with exit 0 is the faithful shape -
+// no envelope to reproduce here, unlike herdr's call()/callVoid().
 func writeFakeGHReleaseView(t *testing.T, tag string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 )
 
+// fakeHerdrWatchScript fakes "workspace list" as a query command per
+// internal/herdr/client.go's call() doc comment: a non-null result object on
+// success, here an empty workspace list.
 const fakeHerdrWatchScript = `#!/bin/sh
 case "$1 $2" in
 "workspace list")

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -8,6 +8,16 @@ import (
 	"time"
 )
 
+// writeFakeHerdr fakes herdr with the caller's own script body, so each test
+// below picks the response shape it needs. Real herdr answers a query command
+// with a JSON envelope carrying a non-null result object on stdout, answers a
+// void command with empty stdout, and reports failure as an envelope error
+// object that may come with any exit status - which is why call/callVoid
+// (client.go) treat the envelope as authoritative and consult the exit status
+// only when there is no parseable body. The tests here fake each of those
+// shapes verbatim, including both error-envelope-with-exit-1 and
+// error-envelope-with-exit-0; other packages' herdr fakes cite this file rather
+// than re-deriving them.
 func writeFakeHerdr(t *testing.T, script string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -13,11 +13,11 @@ import (
 // with a JSON envelope carrying a non-null result object on stdout, answers a
 // void command with empty stdout, and reports failure as an envelope error
 // object that may come with any exit status - which is why call/callVoid
-// (client.go) treat the envelope as authoritative and consult the exit status
-// only when there is no parseable body. The tests here fake each of those
-// shapes verbatim, including both error-envelope-with-exit-1 and
-// error-envelope-with-exit-0; other packages' herdr fakes cite this file rather
-// than re-deriving them.
+// (client.go) let an error envelope win whenever one is present and fall back
+// to the exit status only when stdout is empty or the envelope parsed clean
+// (env.Error == nil). The tests here fake each of those shapes verbatim,
+// including both error-envelope-with-exit-1 and error-envelope-with-exit-0;
+// other packages' herdr fakes cite this file rather than re-deriving them.
 func writeFakeHerdr(t *testing.T, script string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/internal/selfupdate/notice_test.go
+++ b/internal/selfupdate/notice_test.go
@@ -48,6 +48,8 @@ func TestCheckNoticeUsesFreshCacheWithoutCallingGH(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A refusal fake, not an imitation of gh: a fresh cache must serve the
+	// notice without any gh call at all, so any invocation is the failure.
 	bin := t.TempDir()
 	script := "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n"
 	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
@@ -136,6 +138,8 @@ func TestCheckNoticeSkipsUnparseableCurrentVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Same refusal fake as TestCheckNoticeUsesFreshCacheWithoutCallingGH above;
+	// an unparseable current version must skip the check entirely.
 	bin := t.TempDir()
 	script := "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n"
 	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -43,6 +43,13 @@ func TestIsNewerRejectsInvalidLatest(t *testing.T) {
 	}
 }
 
+// writeFakeGH fakes the two gh calls an update makes. Real `gh release view
+// --json ... --jq` prints the extracted field alone on stdout with exit 0, and
+// `gh release download --dir` writes the assets into that directory while its
+// progress goes to stderr; runGH (selfupdate.go) reads stdout only, so this
+// fake mirrors both by keeping stdout to the payload. On failure real gh exits
+// nonzero with the reason on stderr, which the unexpected-invocation arm below
+// mirrors.
 func writeFakeGH(t *testing.T, tag, fixtureDir string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -30,6 +30,15 @@ const dashboardSkeleton = `# Dashboard
 ## Projects
 `
 
+// writeFakeHerdr fakes the two query commands a tick makes: real herdr answers
+// both with a JSON envelope carrying a non-null result on stdout and exit 0,
+// and reports failures as an envelope error rather than bare stderr
+// (internal/herdr/client.go's call doc comment), which this fake mirrors for
+// success and diverges from for the unexpected-args arm - a bare stderr line
+// and exit 1, so a call shape no test anticipated fails loudly instead of
+// parsing. "pane get" reads its status from statusFile so a test can drive
+// transitions between ticks; failure paths belong to
+// internal/herdr/client_test.go.
 func writeFakeHerdr(t *testing.T, statusFile string) {
 	t.Helper()
 	bin := t.TempDir()
@@ -55,10 +64,16 @@ esac
 	t.Setenv("STATUS_FILE", statusFile)
 }
 
+// writeFakeGh fakes `gh pr view --json state`, the only gh call a tick makes
+// (watcher.go's ghutil.PRIsMerged). Real gh prints that JSON object on stdout
+// with exit 0 and prefixes its own warnings on stderr, so the fake emits a
+// stderr line too: PRIsMerged reads stdout alone, and a CombinedOutput
+// regression there must fail this watcher path as well, not only
+// internal/ghutil/pr_test.go.
 func writeFakeGh(t *testing.T, prState string) {
 	t.Helper()
 	bin := t.TempDir()
-	script := "#!/bin/sh\nprintf '{\"state\":\"" + prState + "\"}'\n"
+	script := "#!/bin/sh\necho 'Warning: gh version is out of date' >&2\nprintf '{\"state\":\"" + prState + "\"}'\n"
 	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -290,7 +290,7 @@ func TestHandleEventSendsLogFailureToErrOut(t *testing.T) {
 
 func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
 	// exit 1 with empty stdout is the faithful crashed-or-missing-binary shape,
-	// which call() handles at internal/herdr/client.go:52-57 (len(trimmed) == 0
+	// which call()'s empty-stdout-plus-runErr branch handles (len(trimmed) == 0
 	// && runErr != nil). It is a distinct shape from herdr's ordinary failure
 	// (exit 0 plus an error envelope), and only this one means "unreachable".
 	bin := t.TempDir()

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -289,6 +289,10 @@ func TestHandleEventSendsLogFailureToErrOut(t *testing.T) {
 }
 
 func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
+	// exit 1 with empty stdout is the faithful crashed-or-missing-binary shape,
+	// which call() handles at internal/herdr/client.go:52-57 (len(trimmed) == 0
+	// && runErr != nil). It is a distinct shape from herdr's ordinary failure
+	// (exit 0 plus an error envelope), and only this one means "unreachable".
 	bin := t.TempDir()
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
+// writeFakeTreehouse fakes "treehouse get"/"return". Get's doc comment above
+// notes the real stderr banner ahead of JSON; these fakes write straight to
+// stdout on success since Get reads stdout alone (cmd.Output()), which is
+// exactly what that separation is for - no banner needed to exercise it
+// faithfully. Failure fakes below write to stderr, matching both Get's
+// separate-stderr-buffer error path and Return's CombinedOutput one.
 func writeFakeTreehouse(t *testing.T, script string) {
 	t.Helper()
 	bin := t.TempDir()

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -25,11 +25,45 @@ import (
 
 var handBin string
 
+// backendsThisSuiteFakes are the tools whose real installs CI used to fetch for
+// this package before every test started writing its own fake onto PATH instead
+// (see fakes_test.go). gh is deliberately not in this list even though some
+// tests fake it too: gh is a ubiquitous, legitimately-installed CLI, so its
+// ambient presence is expected and this check would false-positive on most
+// developer machines; herdr and treehouse are niche tools unique to this
+// project's own use of itself, so an ambient copy is a real signal that the
+// isolation this suite promises has already broken - a reintroduced CI install
+// step, or a developer's own PATH set up to run hand for real.
+var backendsThisSuiteFakes = []string{"herdr", "treehouse"}
+
+// refuseAmbientBackends fails the whole suite once, before any subtest runs
+// and before any test has prepended its own fixture directory to PATH, if a
+// binary this suite fakes already resolves. A stale PATH entry - CI installing
+// a real backend again, or a developer's machine having one installed for
+// actual use - would otherwise let that real binary silently answer in place
+// of a test's fake, so the affected test would pass against reality instead of
+// failing. This runs once here rather than per test because it is a property
+// of the whole run's environment, not of any individual test's setup.
+func refuseAmbientBackends() error {
+	for _, name := range backendsThisSuiteFakes {
+		if path, err := exec.LookPath(name); err == nil {
+			return fmt.Errorf("%s resolves to %s before any test fixture is set up; "+
+				"this suite fakes %s and must not find a real one on PATH", name, path, name)
+		}
+	}
+	return nil
+}
+
 // TestMain builds the hand binary once for the whole package. go test's result
 // cache is keyed on this package's own inputs, not on this nested go build, so
 // changing production code alone will not invalidate a cached e2e run - pass
 // -count=1 when checking red/green behavior after a production-code-only edit.
 func TestMain(m *testing.M) {
+	if err := refuseAmbientBackends(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	dir, err := os.MkdirTemp("", "hand-e2e-")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -25,45 +25,34 @@ import (
 
 var handBin string
 
-// backendsThisSuiteFakes are the tools whose real installs CI used to fetch for
-// this package before every test started writing its own fake onto PATH instead
-// (see fakes_test.go). gh is deliberately not in this list even though some
-// tests fake it too: gh is a ubiquitous, legitimately-installed CLI, so its
-// ambient presence is expected and this check would false-positive on most
-// developer machines; herdr and treehouse are niche tools unique to this
-// project's own use of itself, so an ambient copy is a real signal that the
-// isolation this suite promises has already broken - a reintroduced CI install
-// step, or a developer's own PATH set up to run hand for real.
-var backendsThisSuiteFakes = []string{"herdr", "treehouse"}
+// backendsThisSuiteFakes are the tools hand shells out to that this suite
+// never runs for real. None of them may resolve on the hermetic PATH: a real
+// one would silently answer in place of a test's fake, so the affected test
+// would pass against reality instead of failing.
+var backendsThisSuiteFakes = []string{"herdr", "treehouse", "gh", "no-mistakes"}
 
-// refuseAmbientBackends fails the whole suite once, before any subtest runs
-// and before any test has prepended its own fixture directory to PATH, if a
-// binary this suite fakes already resolves. A stale PATH entry - CI installing
-// a real backend again, or a developer's machine having one installed for
-// actual use - would otherwise let that real binary silently answer in place
-// of a test's fake, so the affected test would pass against reality instead of
-// failing. This runs once here rather than per test because it is a property
-// of the whole run's environment, not of any individual test's setup.
-func refuseAmbientBackends() error {
+// assertNoAmbientBackends checks that invariant once, after TestMain has
+// narrowed PATH to the fixture PATH and before any test runs, so a change that
+// widens realBinsOnPath (or hands a whole directory to buildHermeticPath) fails
+// the run loudly instead of quietly re-admitting a real backend.
+func assertNoAmbientBackends() error {
 	for _, name := range backendsThisSuiteFakes {
 		if path, err := exec.LookPath(name); err == nil {
-			return fmt.Errorf("%s resolves to %s before any test fixture is set up; "+
-				"this suite fakes %s and must not find a real one on PATH", name, path, name)
+			return fmt.Errorf("%s resolves to %s on this suite's hermetic PATH; "+
+				"this suite fakes %s and must not find a real one", name, path, name)
 		}
 	}
 	return nil
 }
 
-// TestMain builds the hand binary once for the whole package. go test's result
-// cache is keyed on this package's own inputs, not on this nested go build, so
-// changing production code alone will not invalidate a cached e2e run - pass
-// -count=1 when checking red/green behavior after a production-code-only edit.
+// TestMain builds the hand binary once for the whole package, then replaces
+// PATH with a hermetic one (see fakes_test.go's buildHermeticPath) so neither
+// the tests nor the hand processes they drive can reach a real herdr,
+// treehouse or gh that happens to be installed. go test's result cache is
+// keyed on this package's own inputs, not on this nested go build, so changing
+// production code alone will not invalidate a cached e2e run - pass -count=1
+// when checking red/green behavior after a production-code-only edit.
 func TestMain(m *testing.M) {
-	if err := refuseAmbientBackends(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
 	dir, err := os.MkdirTemp("", "hand-e2e-")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -74,6 +63,20 @@ func TestMain(m *testing.M) {
 	build.Dir = filepath.Join("..", "..")
 	if out, err := build.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "build hand: %v: %s\n", err, out)
+		os.Exit(1)
+	}
+
+	hermeticPath, err = buildHermeticPath(filepath.Join(dir, "path"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("PATH", hermeticPath); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := assertNoAmbientBackends(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -44,12 +44,15 @@ func buildHermeticPath(dir string) (string, error) {
 	return dir, nil
 }
 
-// binDir returns a directory prepended to the hermetic PATH for the rest of
-// the test, so fake binaries written there are found first.
+// binDir returns a directory prepended to the current PATH for the rest of the
+// test, so fake binaries written there are found first. Prepending keeps this
+// additive - a test can call binDir twice and keep both fake dirs - and stays
+// hermetic only because TestMain runs first: by then PATH is already
+// hermeticPath, so there is no ambient PATH left to inherit here.
 func binDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+hermeticPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return dir
 }
 

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 // realBinsOnPath are the only real executables this suite needs to resolve:
-// git, which both hand and the test helpers shell out to for real, and cat,
-// which the fake herdr scripts below use to read a pane's status file.
-// Everything else hand execs (herdr, treehouse, gh, no-mistakes) is faked per
-// test, so leaving it unreachable turns a missing fake into a loud failure
-// instead of a call against the developer's real tools.
-var realBinsOnPath = []string{"git", "cat"}
+// git, which both hand and the test helpers shell out to for real; sh, which
+// cmd/notify.go execs to run a notify template; and cat, which the fake herdr
+// scripts below use to read a pane's status file. Everything hand execs that is
+// not listed here is faked per test (backendsThisSuiteFakes, e2e_test.go), so
+// leaving those unreachable turns a missing fake into a loud failure instead of
+// a call against the developer's real tools.
+var realBinsOnPath = []string{"git", "sh", "cat"}
 
 // hermeticPath is the PATH every test runs under, built once by TestMain from
 // the inherited PATH. Each needed binary is symlinked in individually rather

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -6,17 +6,49 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// binDir returns a directory prepended to PATH for the rest of the test, so
-// fake binaries written there are found before any real tool of the same name.
+// realBinsOnPath are the only real executables this suite needs to resolve:
+// git, which both hand and the test helpers shell out to for real, and cat,
+// which the fake herdr scripts below use to read a pane's status file.
+// Everything else hand execs (herdr, treehouse, gh, no-mistakes) is faked per
+// test, so leaving it unreachable turns a missing fake into a loud failure
+// instead of a call against the developer's real tools.
+var realBinsOnPath = []string{"git", "cat"}
+
+// hermeticPath is the PATH every test runs under, built once by TestMain from
+// the inherited PATH. Each needed binary is symlinked in individually rather
+// than having its own directory prepended: on a real machine git commonly
+// lives in the same directory as real herdr and treehouse, so exposing that
+// directory would hand the suite straight back the tools it fakes.
+var hermeticPath string
+
+func buildHermeticPath(dir string) (string, error) {
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		return "", err
+	}
+	for _, name := range realBinsOnPath {
+		resolved, err := exec.LookPath(name)
+		if err != nil {
+			return "", fmt.Errorf("resolve %s, which this suite runs for real: %w", name, err)
+		}
+		if err := os.Symlink(resolved, filepath.Join(dir, name)); err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+// binDir returns a directory prepended to the hermetic PATH for the rest of
+// the test, so fake binaries written there are found first.
 func binDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+hermeticPath)
 	return dir
 }
 

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -29,6 +29,11 @@ func TestMergePR(t *testing.T) {
 
 	dir := binDir(t)
 	invocationLog := filepath.Join(t.TempDir(), "gh-invocations.log")
+	// prChecksGreen (cmd/merge.go) never consults gh's exit code once the "pr
+	// checks" JSON parses, so the always-exit-0 fake below exercises the same
+	// path a real fail-bucket exit 1 would; runPRMerge only checks "pr merge"
+	// for a non-nil error, never its stdout, so "ok" stands in for real gh's
+	// actual merge summary line.
 	writeFakeDispatch(t, dir, "gh", invocationLog, "$1 $2", `  "pr checks")
     case "$3" in
       1) echo '[{"bucket":"pass"}]' ;;

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -47,6 +47,11 @@ func TestPromoteScoutToShip(t *testing.T) {
 	dir := binDir(t)
 	newWorktree := filepath.Join(home, "wt-ship-new")
 	invocationLog := filepath.Join(t.TempDir(), "invocations.log")
+	// Return (worktree.go) only checks CombinedOutput's error, never its
+	// content, on success, so the "ok" line stands in harmlessly for real
+	// treehouse return's actual (silent) output; "pane run" below is a void
+	// command whose real success is empty stdout (callVoid doc, client.go) -
+	// callVoid only checks env.Error, so the extra envelope body is harmless.
 	writeFakeDispatch(t, dir, "treehouse", invocationLog, "$1", `  get) printf '{"path":"%s"}\n' `+shellSingleQuote(newWorktree)+` ;;
   return) echo ok ;;`)
 	// The scout's old workspace holds a second tab, so releasing the scout is a


### PR DESCRIPTION
## Intent

Make tests/e2e visible to golangci-lint via .golangci.yaml build-tags without changing the previously-active linter set, stop CI installing real herdr/treehouse for a suite that fakes them and make the isolation guarantee explicit via a suite-setup check rather than per-test, and record the fake-fidelity contract (what the real tool does on success/failure - exit code, stream, response shape - and whether the fake mirrors or deliberately diverges) next to every faked herdr/gh/treehouse invocation across the tree. Land all three as one PR.

Fixes #17

## What Changed

- `TestMain` now replaces `PATH` with a hermetic one holding only the real binaries the suite genuinely runs (`git`, `sh`, `cat`, symlinked in individually rather than by directory), then asserts once that `herdr`, `treehouse`, `gh` and `no-mistakes` do not resolve, so a missing fake fails loudly instead of quietly answering from the developer's real tools; `binDir` still prepends to the (already hermetic) PATH so fake dirs stay additive. This replaces the original design of a per-test ambient-backend-refusal check (each test asserting its own fakes were in play) with one suite-level invariant, which is strictly stronger: it also caught that `sh` was missing from the hermetic PATH, a gap the old per-test guard would never have surfaced because `sh` resolved silently from the inherited PATH. CI's e2e job no longer downloads real `herdr` or `go install`s `treehouse`.
- Added `.golangci.yaml` setting only `run.build-tags: [e2e]`, which puts the `//go:build e2e` package in `tests/e2e` under lint without changing the previously enabled linter set (before/after `golangci-lint linters` diff below is identical). Linting the newly-visible package on the real tree turned up nothing pre-existing - 0 issues - confirming the gap was invisibility, not latent violations; a planted `ineffassign`/`unused` probe (removed after) proves the package is now actually analyzed rather than silently skipped.
- Every faked `herdr`/`gh`/`treehouse`/harness invocation across `cmd`, `internal` and `tests/e2e` now carries a comment recording the real tool's success and failure shape (exit code, stream, response shape) and whether the fake mirrors it or deliberately diverges; `SPECS.md` and `AGENTS.md` record that contract plus the suite-setup isolation check and a `.golangci.yaml` pointer, and the stale real-backend install steps are dropped from SPECS.md's inlined CI block. Writing those notes caught two fakes whose behavior itself was wrong, not just undocumented, and both are corrected here: `internal/watcher/watcher_test.go`'s `writeFakeGh` was missing the stderr warning line real `gh` emits ahead of its JSON, so a regression to `CombinedOutput` (which would fold that warning into the parsed response) could have passed silently; `cmd/send_test.go`'s `TestSendFailsForUnknownTask` faked herdr failure as a bare `exit 1` when `send` never calls herdr for an unknown task at all, so it is now a loud refusal fake that fails the test if herdr is invoked, instead of a fake that happened to return the right shape for the wrong reason.

## Risk Assessment

✅ Low: The follow-up commit only adds documentation and makes one test-helper PATH assignment additive, all four prior findings are correctly resolved with accurate claims, and no production source is touched.

## Testing

Ran the full race-enabled unit suite and the e2e suite green, then produced product-level evidence for each of the three intent strands: a before/after `golangci-lint run ./...` transcript showing a planted violation in the `//go:build e2e` package go from silently unreported to reported (with a diff proving the enabled linter set is unchanged), the verbatim ci.yaml e2e step passing on a PATH stripped of every real herdr/treehouse (and separately passing on this machine where both are installed), and two reverted mutations showing the new TestMain check aborts the run when a real backend is re-admitted and that a missing per-test fake now fails loudly instead of hitting the developer's live herdr. Also swept all 52 fake-binary sites for the fidelity contract - 45 fully documented, 5 thinner (one informational finding, no failures). All mutations reverted, worktree clean, no linter findings acted on.

<details>
<summary>Evidence: golangci-lint: e2e package invisible without the config, linted with it</summary>

<code>=== BASE: repo WITHOUT .golangci.yaml -&gt; tests/e2e silently skipped ===&#10;$ golangci-lint run ./...&#10;0 issues.&#10;exit=0&#10;&#10;=== TARGET: repo WITH .golangci.yaml (run.build-tags: [e2e]) -&gt; tests/e2e analyzed ===&#10;$ golangci-lint run ./...&#10;tests/e2e/zz_lintprobe_test.go:6:2: ineffectual assignment to x (ineffassign)&#10;x := 1&#10;^&#10;tests/e2e/zz_lintprobe_test.go:5:6: func lintProbe is unused (unused)&#10;func lintProbe() int {&#10;^&#10;2 issues:&#10;* ineffassign: 1&#10;* unused: 1&#10;exit=1&#10;&#10;$ golangci-lint run ./... # probe removed, real tree&#10;0 issues.&#10;exit=0</code>

```text
=== A deliberate lint violation is dropped into the //go:build e2e package ===
$ cat tests/e2e/zz_lintprobe_test.go
//go:build e2e

package e2e

func lintProbe() int {
	x := 1
	x = 2
	return x
}

=== BASE: repo WITHOUT .golangci.yaml -> tests/e2e silently skipped ===
$ golangci-lint run ./...
0 issues.
exit=0

=== TARGET: repo WITH .golangci.yaml (run.build-tags: [e2e]) -> tests/e2e analyzed ===
$ golangci-lint run ./...
tests/e2e/zz_lintprobe_test.go:6:2: ineffectual assignment to x (ineffassign)
	x := 1
	^
tests/e2e/zz_lintprobe_test.go:5:6: func lintProbe is unused (unused)
func lintProbe() int {
     ^
2 issues:
* ineffassign: 1
* unused: 1
exit=1
$ golangci-lint run ./...  # probe removed, real tree
0 issues.
exit=0
```
</details>
<details>
<summary>Evidence: Enabled linter set unchanged by the new config</summary>

```text
$ diff lint-enabled-base.txt lint-enabled-target.txt
IDENTICAL ENABLED LINTER SET

Enabled by your configuration linters:
errcheck, govet, ineffassign, staticcheck, unused
```
</details>
<details>
<summary>Evidence: Suite-setup isolation check aborts the run when a real backend is re-admitted</summary>

<code>=== This machine HAS the real backends the suite fakes ===&#10;herdr -&gt; /etc/profiles/per-user/atqa/bin/herdr&#10;treehouse -&gt; /etc/profiles/per-user/atqa/bin/treehouse&#10;gh -&gt; /etc/profiles/per-user/atqa/bin/gh&#10;no-mistakes -&gt; /etc/profiles/per-user/atqa/bin/no-mistakes&#10;&#10;=== Mutation: realBinsOnPath widened to re-admit a real herdr ===&#10;$ go test -tags=e2e -count=1 ./tests/e2e/...&#10;herdr resolves to /tmp/nix-shell.spaTYn/hand-e2e-662803909/path/herdr on this suite&#39;s hermetic PATH; this suite fakes herdr and must not find a real one&#10;FAIL github.com/atqamz/secondhand/tests/e2e 0.457s&#10;exit=1&#10;&#10;=== Mutation reverted: suite green again, real backends still installed ===&#10;$ go test -tags=e2e -count=1 ./tests/e2e/...&#10;ok github.com/atqamz/secondhand/tests/e2e 1.624s&#10;exit=0</code>

```text
warning: Git tree '/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYFJZ67R7FDW2JED9TK0YK0E' is dirty
=== This machine HAS the real backends the suite fakes ===
herdr        -> /etc/profiles/per-user/atqa/bin/herdr
treehouse    -> /etc/profiles/per-user/atqa/bin/treehouse
gh           -> /etc/profiles/per-user/atqa/bin/gh
no-mistakes  -> /etc/profiles/per-user/atqa/bin/no-mistakes

=== Mutation: realBinsOnPath widened to re-admit a real herdr ===
var realBinsOnPath = []string{"git", "sh", "cat", "herdr"}

$ go test -tags=e2e -count=1 ./tests/e2e/...
herdr resolves to /tmp/nix-shell.spaTYn/hand-e2e-662803909/path/herdr on this suite's hermetic PATH; this suite fakes herdr and must not find a real one
FAIL	github.com/atqamz/secondhand/tests/e2e	0.457s
FAIL
exit=1

=== Mutation reverted (realBinsOnPath = git, sh, cat): suite green again, real backends still installed ===
$ go test -tags=e2e -count=1 ./tests/e2e/...
ok  	github.com/atqamz/secondhand/tests/e2e	1.624s
exit=0
```
</details>
<details>
<summary>Evidence: CI e2e step passes with no real herdr/treehouse on PATH</summary>

<code>=== Simulating the CI e2e job on a runner with NO herdr and NO treehouse installed ===&#10;$ command -v herdr treehouse&#10;not-found-exit=1&#10;$ command -v go git&#10;/nix/store/rcz9i4msbg3178grqll9h98b07dwk7zg-go-1.26.5/bin/go&#10;/run/current-system/sw/bin/git&#10;&#10;=== ci.yaml e2e step, verbatim ===&#10;$ go test -tags=e2e -timeout=10m ./tests/e2e/...&#10;ok github.com/atqamz/secondhand/tests/e2e 1.681s&#10;exit=0</code>

```text
=== Simulating the CI e2e job on a runner with NO herdr and NO treehouse installed ===
(PATH entries carrying a real herdr/treehouse were dropped)
$ command -v herdr treehouse; echo not-found=0
not-found-exit=1
$ command -v go git
/nix/store/rcz9i4msbg3178grqll9h98b07dwk7zg-go-1.26.5/bin/go
/run/current-system/sw/bin/git

=== ci.yaml e2e step, verbatim ===
$ go test -tags=e2e -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/secondhand/tests/e2e	1.681s
exit=0
```
</details>
<details>
<summary>Evidence: A missing fake now fails loudly instead of hitting the real herdr</summary>

<code>=== Mutation: the herdr fake is deleted from TestSpawnTeardownCycle ===&#10;(a real herdr IS installed at /etc/profiles/per-user/atqa/bin/herdr)&#10;&#10;$ go test -tags=e2e -count=1 -run TestSpawnTeardownCycle ./tests/e2e/...&#10;--- FAIL: TestSpawnTeardownCycle (0.05s)&#10;spawn_teardown_test.go:32: $ hand spawn task-1 demo&#10;exit 1&#10;stderr: herdr workspace lookup/create failed: herdr workspace list: exec: &#34;herdr&#34;: executable file not found in $PATH:&#10;FAIL&#10;exit=1</code>

```text
warning: Git tree '/home/atqa/.no-mistakes/worktrees/4dde880dca8d/01KYFJZ67R7FDW2JED9TK0YK0E' is dirty
=== Mutation: the herdr fake is deleted from TestSpawnTeardownCycle ===
(a real herdr IS installed at /etc/profiles/per-user/atqa/bin/herdr)

$ go test -tags=e2e -count=1 -run TestSpawnTeardownCycle ./tests/e2e/...
--- FAIL: TestSpawnTeardownCycle (0.05s)
    spawn_teardown_test.go:18: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.ji5Fop/TestSpawnTeardownCycle1410453680/002
          stderr: 
    spawn_teardown_test.go:32: $ hand spawn task-1 demo
          exit 1
          stdout: 
          stderr: herdr workspace lookup/create failed: herdr workspace list: exec: "herdr": executable file not found in $PATH:
    spawn_teardown_test.go:34: spawn: exit 1, stderr "herdr workspace lookup/create failed: herdr workspace list: exec: \"herdr\": executable file not found in $PATH: \n"
FAIL
FAIL	github.com/atqamz/secondhand/tests/e2e	0.512s
FAIL
exit=1

-> hand cannot reach the real herdr: the missing fake is a loud failure,
   not a silent pass against the developer"s live herdr session.
```
</details>
<details>
<summary>Evidence: Full e2e CLI transcript (hand init/spawn/merge/teardown/promote/watch)</summary>

```text
=== RUN   TestSpawnDetectsWorktreeCollision
    collision_test.go:20: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestSpawnDetectsWorktreeCollision3723668309/002
          stderr: 
    collision_test.go:35: $ hand spawn task-1 demo
          exit 0
          stdout: spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/nix-shell.tDGAuf/TestSpawnDetectsWorktreeCollision3723668309/002/wt-shared
          stderr: 
    collision_test.go:40: $ hand spawn task-2 demo
          exit 3
          stdout: 
          stderr: worktree collision: task-1 already holds /tmp/nix-shell.tDGAuf/TestSpawnDetectsWorktreeCollision3723668309/002/wt-shared
--- PASS: TestSpawnDetectsWorktreeCollision (0.05s)
=== RUN   TestDashboardUpdateSplit
    dashboard_split_test.go:30: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestDashboardUpdateSplit621459723/002
          stderr: 
    dashboard_split_test.go:44: $ hand spawn task-1 demo
          exit 0
          stdout: spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/nix-shell.tDGAuf/TestDashboardUpdateSplit621459723/002/wt-shared
          stderr: 
    dashboard_split_test.go:53: $ hand merge task-1 --local
          exit 0
          stdout: merged task-1: local fast-forward into main
          stderr: 
    dashboard_split_test.go:61: $ hand teardown task-1
          exit 0
          stdout: teardown task-1 complete
          stderr: 
    dashboard_split_test.go:83: $ hand promote task-2
          exit 0
          stdout: promoted task-2: scout -> ship project=demo harness=claude
          stderr: 
    dashboard_split_test.go:96: $ hand project add https://example.com/demo2.git --mode direct-pr
          exit 0
          stdout: added project demo2 (https://example.com/demo2.git) mode=direct-pr
          stderr: 
    dashboard_split_test.go:104: $ hand project remove demo2
          exit 0
          stdout: removed project demo2 (clone retained at projects/demo2)
          stderr: 
--- PASS: TestDashboardUpdateSplit (0.29s)
=== RUN   TestExitCodeZeroOnSuccess
    e2e_test.go:285: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeZeroOnSuccess1017819124/002
          stderr: 
    e2e_test.go:289: $ hand --version
          exit 0
          stdout: dev
          stderr: 
    e2e_test.go:289: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeZeroOnSuccess1017819124/002
          stderr: 
    e2e_test.go:289: $ hand project list
          exit 0
          stdout: demo  https://example.com/demo.git  direct-pr
          stderr: 
    e2e_test.go:289: $ hand project
          exit 0
          stdout: Manage the project registry
        
        Usage:
          hand project [flags]
          hand project [command]
        
        Available Commands:
          add         Clone a git repository and register it
          list        List registered projects
          remove      Unregister a project
          sync        Fast-forward project clones to their remote default branch
        
        Flags:
          -h, --help   help for project
        
        Use "hand project [command] --help" for more information about a command.
          stderr: 
    e2e_test.go:289: $ hand --help
          exit 0
          stdout: Talk to one agent. Ship with a crew.
        
        Usage:
          hand [command]
        
        Available Commands:
          completion  Generate the autocompletion script for the specified shell
          help        Help about any command
          init        Initialize secondhand runtime directories
          merge       Merge a task's completed work
          notify      Send an out-of-band notification
          project     Manage the project registry
          promote     Promote a completed scout task into a ship task
          send        Send a text message to a running worker's herdr pane
          spawn       Spawn a worker agent in an isolated worktree
          status      Show fleet overview or single-task detail
          teardown    Clean up a completed task
          update      Self-update the hand binary from GitHub Releases
          watch       Poll herdr agent states and report actionable events
        
        Flags:
          -h, --help      help for hand
          -v, --version   version for hand
        
        Use "hand [command] --help" for more information about a command.
          stderr: 
--- PASS: TestExitCodeZeroOnSuccess (0.02s)
=== RUN   TestExitCodeTwoOnUsageError
    e2e_test.go:300: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeTwoOnUsageError3844182405/002
          stderr: 
=== RUN   TestExitCodeTwoOnUsageError/unknown_command
    e2e_test.go:322: $ hand bogus-command
          exit 2
          stdout: 
          stderr: unknown command "bogus-command" for "hand"
=== RUN   TestExitCodeTwoOnUsageError/unknown_project_subcommand
    e2e_test.go:322: $ hand project bogus
          exit 2
          stdout: 
          stderr: unknown command "bogus" for "hand project"
=== RUN   TestExitCodeTwoOnUsageError/unknown_completion_subcommand
    e2e_test.go:322: $ hand completion bogus
          exit 2
          stdout: 
          stderr: unknown command "bogus" for "hand completion"
=== RUN   TestExitCodeTwoOnUsageError/too_few_args
    e2e_test.go:322: $ hand spawn only-one
          exit 2
          stdout: 
          stderr: accepts 2 arg(s), received 1
=== RUN   TestExitCodeTwoOnUsageError/too_many_args
    e2e_test.go:322: $ hand teardown task-1 extra
          exit 2
          stdout: 
          stderr: accepts 1 arg(s), received 2
=== RUN   TestExitCodeTwoOnUsageError/args_on_argless_command
    e2e_test.go:322: $ hand watch extra
          exit 2
          stdout: 
          stderr: unknown command "extra" for "hand watch"
=== RUN   TestExitCodeTwoOnUsageError/unknown_flag
    e2e_test.go:322: $ hand spawn --bogus task-1 demo
          exit 2
          stdout: 
          stderr: unknown flag: --bogus
=== RUN   TestExitCodeTwoOnUsageError/conflicting_merge_methods
    e2e_test.go:322: $ hand merge task-1 --squash --rebase
          exit 2
          stdout: 
          stderr: only one of --squash, --merge, --rebase may be specified
=== RUN   TestExitCodeTwoOnUsageError/merge_method_with_local
    e2e_test.go:322: $ hand merge task-1 --local --squash
          exit 2
          stdout: 
          stderr: --squash, --merge, --rebase cannot be combined with --local
=== RUN   TestExitCodeTwoOnUsageError/invalid_project_URL
    e2e_test.go:322: $ hand project add not-a-url
          exit 2
          stdout: 
          stderr: invalid project URL "not-a-url": must start with https://, git@, ssh://, or git://
=== RUN   TestExitCodeTwoOnUsageError/invalid_project_mode
    e2e_test.go:322: $ hand project add https://example.com/demo.git --mode bogus
          exit 2
          stdout: 
          stderr: invalid project mode "bogus": must be no-mistakes, direct-pr, or local-only
=== RUN   TestExitCodeTwoOnUsageError/invalid_poll_interval
    e2e_test.go:322: $ hand watch --poll nonsense
          exit 2
          stdout: 
          stderr: invalid poll interval "nonsense": time: invalid duration "nonsense"
--- PASS: TestExitCodeTwoOnUsageError (0.05s)
    --- PASS: TestExitCodeTwoOnUsageError/unknown_command (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/unknown_project_subcommand (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/unknown_completion_subcommand (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/too_few_args (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/too_many_args (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/args_on_argless_command (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/unknown_flag (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/conflicting_merge_methods (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/merge_method_with_local (0.00s)
    --- PASS: TestExitCodeTwoOnUsageError/invalid_project_URL (0.00s)
    -

... [4253 bytes truncated] ...

ple.com/demo.git
          exit 3
          stdout: 
          stderr: project "demo" already registered
=== RUN   TestExitCodeThreeOnPreconditionFailure/project_remove_with_active_task
    e2e_test.go:448: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeThreeOnPreconditionFailureproject_remove_with_activ3344276376/002
          stderr: 
    e2e_test.go:452: $ hand project remove demo
          exit 3
          stdout: 
          stderr: project "demo" has active tasks referencing it
=== RUN   TestExitCodeThreeOnPreconditionFailure/teardown_scout_without_report
    e2e_test.go:448: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeThreeOnPreconditionFailureteardown_scout_without_re3932031166/002
          stderr: 
    e2e_test.go:452: $ hand teardown task-1
          exit 3
          stdout: 
          stderr: report not found at data/task-1/report.md
=== RUN   TestExitCodeThreeOnPreconditionFailure/teardown_ship_without_landed_work
    e2e_test.go:448: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeThreeOnPreconditionFailureteardown_ship_without_lan3768253621/002
          stderr: 
    e2e_test.go:452: $ hand teardown task-1
          exit 3
          stdout: 
          stderr: no PR recorded for task-1 and project is not local-only: work may not be landed
=== RUN   TestExitCodeThreeOnPreconditionFailure/promote_a_task_that_is_not_a_scout
    e2e_test.go:448: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeThreeOnPreconditionFailurepromote_a_task_that_is_no3915157257/002
          stderr: 
    e2e_test.go:452: $ hand promote task-1
          exit 3
          stdout: 
          stderr: task "task-1" is not a scout
=== RUN   TestExitCodeThreeOnPreconditionFailure/merge_an_already_merged_task
    e2e_test.go:448: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeThreeOnPreconditionFailuremerge_an_already_merged_t2099209958/002
          stderr: 
    e2e_test.go:452: $ hand merge task-1
          exit 3
          stdout: 
          stderr: task task-1 already merged
--- PASS: TestExitCodeThreeOnPreconditionFailure (0.16s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/task_not_found (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/teardown_unknown_task (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/merge_unknown_task (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/promote_unknown_task (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/send_to_unknown_task (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/spawn_on_unregistered_project (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/project_sync_unregistered (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/project_remove_unregistered (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/spawn_without_brief (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/project_add_already_registered (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/project_remove_with_active_task (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/teardown_scout_without_report (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/teardown_ship_without_landed_work (0.03s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/promote_a_task_that_is_not_a_scout (0.01s)
    --- PASS: TestExitCodeThreeOnPreconditionFailure/merge_an_already_merged_task (0.01s)
=== RUN   TestExitCodeOneOnGeneralError
=== RUN   TestExitCodeOneOnGeneralError/malformed_watch-interval_config
    e2e_test.go:479: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeOneOnGeneralErrormalformed_watch-interval_config3502800985/002
          stderr: 
    e2e_test.go:483: $ hand watch
          exit 1
          stdout: 
          stderr: invalid poll interval "nonsense": time: invalid duration "nonsense"
=== RUN   TestExitCodeOneOnGeneralError/malformed_stale-threshold_config
    e2e_test.go:479: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestExitCodeOneOnGeneralErrormalformed_stale-threshold_config3387621252/002
          stderr: 
    e2e_test.go:483: $ hand watch --poll 1h
          exit 1
          stdout: 
          stderr: invalid config/stale-threshold "not-a-number": strconv.Atoi: parsing "not-a-number": invalid syntax
--- PASS: TestExitCodeOneOnGeneralError (0.02s)
    --- PASS: TestExitCodeOneOnGeneralError/malformed_watch-interval_config (0.01s)
    --- PASS: TestExitCodeOneOnGeneralError/malformed_stale-threshold_config (0.01s)
=== RUN   TestMergePR
    merge_test.go:19: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestMergePR3653735973/002
          stderr: 
    merge_test.go:46: $ hand merge task-1
          exit 0
          stdout: merged task-1: 1
          stderr: 
    merge_test.go:58: $ hand merge task-2
          exit 3
          stdout: 
          stderr: PR checks for task-2 are not green
--- PASS: TestMergePR (0.03s)
=== RUN   TestProjectLifecycle
    project_test.go:27: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestProjectLifecycle2938299977/005
          stderr: 
    project_test.go:29: $ hand project add https://example.com/demo.git --mode direct-pr
          exit 0
          stdout: added project demo (https://example.com/demo.git) mode=direct-pr
          stderr: 
    project_test.go:52: $ hand project list
          exit 0
          stdout: demo  https://example.com/demo.git  direct-pr
          stderr: 
    project_test.go:62: $ hand project sync demo
          exit 0
          stdout: demo: fast-forwarded to origin/main (was 1 behind)
          stderr: 
    project_test.go:73: $ hand project sync nosuch
          exit 3
          stdout: 
          stderr: project "nosuch" not registered
    project_test.go:76: $ hand project remove demo
          exit 0
          stdout: removed project demo (clone retained at projects/demo)
          stderr: 
--- PASS: TestProjectLifecycle (0.17s)
=== RUN   TestPromoteScoutToShip
    promote_test.go:21: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestPromoteScoutToShip1025684029/002
          stderr: 
    promote_test.go:74: $ hand promote task-1
          exit 3
          stdout: 
          stderr: brief not found at data/task-1/brief.md
    promote_test.go:79: $ hand promote task-1
          exit 0
          stdout: promoted task-1: scout -> ship project=demo harness=claude
          stderr: 
--- PASS: TestPromoteScoutToShip (0.08s)
=== RUN   TestSpawnTeardownCycle
    spawn_teardown_test.go:18: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestSpawnTeardownCycle4176242847/002
          stderr: 
    spawn_teardown_test.go:32: $ hand spawn task-1 demo
          exit 0
          stdout: spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/nix-shell.tDGAuf/TestSpawnTeardownCycle4176242847/002/wt-task-1
          stderr: 
    spawn_teardown_test.go:53: $ hand teardown task-1
          exit 3
          stdout: 
          stderr: branch for task-1 is not merged into the default branch
    spawn_teardown_test.go:62: $ hand merge task-1 --local
          exit 0
          stdout: merged task-1: local fast-forward into main
          stderr: 
    spawn_teardown_test.go:67: $ hand teardown task-1
          exit 0
          stdout: teardown task-1 complete
          stderr: 
--- PASS: TestSpawnTeardownCycle (0.18s)
=== RUN   TestWatchEventStream
    watch_test.go:23: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.tDGAuf/TestWatchEventStream3513325685/002
          stderr: 
--- PASS: TestWatchEventStream (0.15s)
PASS
ok  	github.com/atqamz/secondhand/tests/e2e	1.681s
```
</details>
- Outcome: ⚠️ 1 info across 1 run (9m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `.golangci.yaml:4` - The new `.golangci.yaml` is a tracked repo config that now gates the CI lint job, but nothing records it: SPECS.md&#39;s &#34;Repo scaffolding&#34; section (line ~1441) enumerates the tracked non-generated files (release-please-config.json, .release-please-manifest.json, Makefile, .gitignore, flake.nix, CONTRIBUTING.md, License) and was not extended, and the file itself carries no note that `build-tags: [e2e]` exists solely to make the `//go:build e2e` package in tests/e2e visible to the linter. A future edit that &#34;cleans up&#34; the single non-default setting silently drops tests/e2e out of lint coverage again with no failing signal. Add the file to SPECS.md&#39;s scaffolding list (or a one-line why in the YAML).
- ⚠️ `cmd/update_test.go:33` - Intent requires recording the fake-fidelity contract &#34;next to every faked herdr/gh/treehouse invocation across the tree&#34; - specifically &#34;what the real tool does on success/failure - exit code, stream, response shape - and whether the fake mirrors or deliberately diverges&#34;. `writeFakeGHUpdate` fakes three real gh invocations (`release view --repo`, `release view`, `release download --dir`) plus a failure arm, but its comment only states which calls it covers: &#34;fakes the three gh invocations a full `hand update` makes: the tag lookup, the release asset download, and the release notes lookup.&#34; It never states that real `gh release download` writes progress to stderr while the assets land in --dir, nor that the unexpected-invocation arm&#39;s stderr+exit-1 mirrors real gh failure - both of which the sibling `writeFakeGHReleaseView` (same file, line 19) and `internal/selfupdate/selfupdate_test.go`&#39;s `writeFakeGH` (line 43) do state for the same commands. Either extend this comment or confirm that deferring to the sibling helpers satisfies the criterion.
- ℹ️ `internal/watcher/watcher_test.go:293` - This new comment cites the implementation by line range - &#34;call() handles at internal/herdr/client.go:52-57&#34; - while every other comment added in this change cites by symbol (&#34;callVoid&#39;s doc comment&#34;, &#34;prChecksGreen (cmd/merge.go)&#34;, &#34;TestReturnFailsOnNonZeroExit&#34;). Any edit above line 52 of client.go silently makes the citation point at unrelated code, and nothing fails to flag it. Cite `call()`&#39;s empty-stdout-plus-runErr branch by name instead.
- ℹ️ `tests/e2e/fakes_test.go:52` - `binDir` now rebuilds PATH from `hermeticPath` instead of prepending to the current PATH, so it is no longer additive: a test that calls `binDir` twice (to place fakes in two dirs, e.g. one shared helper dir plus a per-case override) loses the first directory entirely, and the fake written there is simply never found - the failure surfaces as an opaque &#34;executable file not found&#34; from inside the hand subprocess rather than as the dispatch fake&#39;s &#34;unexpected invocation&#34; message. Prepending to `os.Getenv(&#34;PATH&#34;)` keeps the same hermetic guarantee (the base PATH is already hermetic once TestMain has set it) while staying composable.

🔧 Fix: document golangci config, gh update fake shape, composable binDir
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/e2e/fakes_test.go:148` - Fake-fidelity contract coverage is near-complete but two herdr fake sites document only what the fake does, never the real tool&#39;s success/failure shape or whether they mirror or diverge: cmd/promote_test.go:47 (fakeHerdrPromotePaneWorking, &#34;pane get&#34;) and tests/e2e/fakes_test.go:148 (writeFakeHerdrWatch, &#34;workspace list&#34;/&#34;pane get&#34;, also inherited by tests/e2e/watch_test.go:42). Three further sites (cmd/teardown_test.go:379, :423, :436) carry no adjacent note and are covered only by the file-scoped forward reference at cmd/teardown_test.go:332, which does state the real query-command contract - that reads deliberate. Informational only; no test fails because of it.
- <code>`nix develop --command go test -race ./...` (full unit suite, all packages ok)</code>
- <code>`nix develop --command go test -tags=e2e -count=1 -v -timeout=10m ./tests/e2e/...` (verbose e2e transcript, green on a machine with real herdr/treehouse/gh/no-mistakes installed)</code>
- <code>`golangci-lint linters` with and without `.golangci.yaml`, diffed - enabled linter set identical</code>
- <code>`golangci-lint run ./...` with and without `.golangci.yaml` against a planted `ineffassign`/`unused` violation in `tests/e2e/zz_lintprobe_test.go` (probe then deleted)</code>
- <code>`golangci-lint run ./...` on the unmodified tree - 0 issues</code>
- <code>Mutation: `realBinsOnPath` widened to `{git, sh, cat, herdr}` -&gt; `go test -tags=e2e -count=1 ./tests/e2e/...` aborts in TestMain via `assertNoAmbientBackends` (reverted)</code>
- <code>Mutation: herdr fake removed from `TestSpawnTeardownCycle` -&gt; `go test -tags=e2e -run TestSpawnTeardownCycle ./tests/e2e/...` fails with `exec: &#34;herdr&#34;: executable file not found in $PATH` rather than reaching the real herdr (reverted)</code>
- <code>CI simulation: `go test -tags=e2e -count=1 -timeout=10m ./tests/e2e/...` on a PATH with every real-herdr/treehouse directory removed (`command -v herdr treehouse` finds nothing)</code>
- `Tree-wide audit of every faked herdr/gh/treehouse/no-mistakes invocation site for an adjacent real-tool-behaviour + mirror-or-diverge note`
- <code>`git status --porcelain` after each mutation - worktree clean, no transient files left</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `SPECS.md:1240` - Out-of-scope follow-up: SPECS.md still inlines verbatim copies of .github/workflows/ci.yaml and the Makefile, so this change had to edit the same fact twice (the CI e2e job appears in both). The change already adopted the better pattern nearby - .golangci.yaml, .gitignore, flake.nix and CONTRIBUTING.md are reduced to &#34;the tracked file is authoritative&#34; pointers. Proposal for a separate change: replace the inlined ci.yaml and Makefile blocks with the same one-line pointers, keeping only the prose that explains intent. Not done here to keep this pass scoped to what the change made stale.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


