### PR TITLE
fix(cmd): confirm workers clear first-run dialogs before reporting spawn success

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Run `hand --help` for the full command reference.
 - For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.
 - Use `qmd search` to find historical context in data/ when available. Fall back to reading files directly.
 - Zero comments by default. Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug. Never restate code, narrate what, add banners, or docstring the obvious.
-- Harness/herdr syntax, exit-code enforcement, watch's stdout/errOut split, and per-command dashboard rules are commented at point of use (`internal/herdr`, `internal/harness`, `cmd/root.go`, `cmd/precondition.go`, `internal/watcher`, `cmd/project.go`, `cmd/promote.go`, `cmd/merge.go`); SPECS.md's "Exit codes" and each command's spec section own the authoritative tables.
+- Harness/herdr syntax, exit-code enforcement, watch's stdout/errOut split, per-command dashboard rules, and first-run prompt handling are commented at point of use (`internal/herdr`, `internal/harness`, `cmd/root.go`, `cmd/precondition.go`, `internal/watcher`, `cmd/project.go`, `cmd/promote.go`, `cmd/merge.go`, `cmd/launch.go`); SPECS.md's "Exit codes" and each command's spec section own the authoritative tables.
 - Test, release, and write conventions live as doc comments: `tests/e2e` (`fakes_test.go`, `e2e_test.go`), GitHub access via `gh` (`internal/ghutil`), AGENTS.md refresh (`internal/agentsmd`), atomic writes (`internal/atomicfile`).
 - Dev environment is Nix-based (`flake.nix`, `CONTRIBUTING.md`); `make lint`, `go build ./...`, and `go test -race ./...` verify inside `nix develop`.
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ Currently supported preferences live as plain files under `config/`: default wor
 Run `hand init --setup` to discover installed harnesses and tools and write the defaults interactively.
 
 Workers run their harness interactively so they can be steered and watched.
-For Claude Code that means a fresh host needs its two first-run dialogs cleared once: run `claude --dangerously-skip-permissions` inside your treehouse pool root (`~/.treehouse`), accept the trust prompt and the bypass-permissions disclaimer, then quit.
-Otherwise the first worker spawned there sits on a dialog instead of working.
+For Claude Code that means first-run dialogs, and `hand spawn` and `hand promote` answer the workspace-trust and bypass-permissions ones for you, then confirm the worker is actually running before reporting success.
+A worker that never comes up fails the spawn instead of being reported as started.
+The exception is Claude Code's managed-settings approval prompt on hosts with organization-managed settings: accepting it is a host-wide trust decision, so `hand` refuses it and tells you to accept it yourself once and respawn.
 
 ## Contributing
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -827,12 +827,17 @@ real pane and observed being labeled. For codex, pi and grok it rests on herdr's
 detection manifests, read but not exercised, because no binary for those is installed on this host.
 Pane text is used only to spot dialogs (`internal/harness`'s `FirstRunPromptsFor`): a known one is
 answered, and success needs the pane to hold a live agent and stay free of both known dialogs and
-the harness's generic unrecognized-dialog fallback for the settle window. That text is the pane's
-visible viewport (`pane read --source visible`), not its scrollback, because scrollback cannot tell
-a dialog that is up right now from one already answered - and answering text the harness has moved
-past sends keys into a live session. A harness's readiness signature is a secondary shortcut - on a
-pane already holding a live agent, the harness's own paint means there is nothing left to settle
-for.
+the harness's generic unrecognized-dialog fallback for the settle window. A harness's readiness
+signature is a secondary shortcut - on a pane already holding a live agent, the harness's own paint
+means there is nothing left to settle for.
+
+That text is read from the pane's recent scrollback (`pane read --source recent`), not its visible
+viewport, because a pane in an unattached herdr session is too short to show a whole dialog - 23
+rows against 61 in an attached one - and what it clips is the lower half, where the option and
+footer lines that identify a dialog live. Scrollback therefore keeps showing a dialog that has
+already been answered, so re-answering is prevented by answering each catalogued dialog at most once
+per launch, rather than by comparing frames or ranking which match is most recent. If keys never
+land and a dialog stays up, hand sends nothing further and runs out the poll window instead.
 
 Two outcomes are not success. A pane with no agent, or one still showing a dialog, when the poll
 window elapses fails the spawn/promote with that pane content and what held it up; for a harness

--- a/SPECS.md
+++ b/SPECS.md
@@ -284,10 +284,12 @@ Behavior:
    - Tab naming: task ID.
 7. Construct the harness launch command from the template (see harness section).
 8. Send the launch command to the herdr pane.
-9. Write `state/<id>.json` with all metadata.
-10. Update `data/dashboard.md` with the new task.
+9. Confirm the worker actually started: poll the pane, answering any known first-run dialog,
+   until it goes quiet or the poll window elapses (see Harness launch templates).
+10. Write `state/<id>.json` with all metadata.
+11. Update `data/dashboard.md` with the new task.
 
-Any failure before step 9 leaves nothing behind: the worktree lease returns to treehouse and the
+Any failure before step 10 leaves nothing behind: the worktree lease returns to treehouse and the
 herdr side is rolled back.
 A workspace this command created is closed whole, because a fresh workspace already holds an
 auto-created root tab and closing only the task's tab would leak it.
@@ -309,6 +311,8 @@ Errors:
 - Worktree collision with another active task (names the conflicting task).
 - Herdr tab creation failed (herdr not running, session error).
 - Harness not recognized.
+- Worker never cleared a first-run prompt within the poll window (pane content included in the
+  error).
 
 State file written (`state/fix-login.json`):
 ```json
@@ -627,7 +631,7 @@ Behavior:
 2. Create or update `data/<id>/brief.md` - the agent should update it with implementation instructions before calling promote, referencing the scout report.
 3. Acquire a fresh treehouse worktree (with collision guard).
 4. Create a new herdr tab.
-5. Launch the worker.
+5. Launch the worker and confirm it started (same as `hand spawn`).
 6. Update `state/<id>.json`: kind changes from `scout` to `ship`, new worktree and herdr coordinates.
 7. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.
 
@@ -800,20 +804,21 @@ permission dialog.
 Claude Code renders while idle; without it, a supervisor reading the pane can misread ghost text
 as the worker having typed input.
 
-Interactive launch has two first-run dialogs that headless `--print` skipped, and each stalls an
-unattended worker until it is cleared once per machine:
+Interactive launch has two first-run dialogs that headless `--print` skipped:
 
 - The workspace trust dialog. Claude Code only trusts a directory whose path or one of its
   ancestors has been accepted before, and every treehouse worktree is a fresh path under the
-  pool root (`~/.treehouse/...`).
+  pool root (`~/.treehouse/...`), so this dialog appears on every spawn, not just a fresh host.
 - The bypass-permissions disclaimer, a one-time global accept that `--dangerously-skip-permissions`
   is gated on.
 
-Operator setup before the first spawn on a new host: run `claude --dangerously-skip-permissions`
-once interactively inside the treehouse pool root, accept both dialogs, and quit. Trust is
-inherited by that directory's descendants and the disclaimer accept is global, so this covers
-every later worker. `hand status <id>` prints a task's worktree path if the pool root is unclear.
-Known limitation tracked at https://github.com/atqamz/secondhand/issues/28.
+`hand spawn` and `hand promote` clear both automatically: after sending the launch command, each
+polls the pane and answers any dialog matching a known signature (`internal/harness`'s
+`FirstRunPromptsFor`), then confirms the pane has gone quiet - neither a known dialog nor the
+harness's generic unrecognized-dialog fallback still matching - before reporting success. A pane
+still showing an unrecognized prompt when the poll window elapses fails the spawn/promote with
+that pane content in the error, instead of reporting success for a worker that never started.
+See `cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were chosen.
 
 ### Codex
 
@@ -938,6 +943,8 @@ Responses come in two shapes, and the client validates each one differently:
 - **Void commands** (`pane run`, `pane send-text`, `pane send-keys`) print nothing on success.
   A failure prints a JSON error envelope whose exit code cannot be trusted on its own, so any
   non-empty body is parsed for that envelope before the exit status is consulted.
+- **`pane read`** is a third shape: plain scrollback text on success, and on failure a bare
+  `{"code","message"}` object rather than the `{"error":{...}}` envelope the other two shapes use.
 
 The herdr client abstracts these into Go function calls; `internal/herdr` keeps one entry point
 per shape and is the source of truth for which command uses which.

--- a/SPECS.md
+++ b/SPECS.md
@@ -827,16 +827,19 @@ real pane and observed being labeled. For codex, pi and grok it rests on herdr's
 detection manifests, read but not exercised, because no binary for those is installed on this host.
 Pane text is used only to spot dialogs (`internal/harness`'s `FirstRunPromptsFor`): a known one is
 answered, and success needs the pane to hold a live agent and stay free of both known dialogs and
-the harness's generic unrecognized-dialog fallback for the settle window. Among answerable known
-dialogs on one screen the latest match in the scrollback wins, since that is the one actually
-painted now. A harness's readiness signature is a secondary shortcut - on a pane already holding a
-live agent, the harness's own paint means there is nothing left to settle for.
+the harness's generic unrecognized-dialog fallback for the settle window. That text is the pane's
+visible viewport (`pane read --source visible`), not its scrollback, because scrollback cannot tell
+a dialog that is up right now from one already answered - and answering text the harness has moved
+past sends keys into a live session. A harness's readiness signature is a secondary shortcut - on a
+pane already holding a live agent, the harness's own paint means there is nothing left to settle
+for.
 
 Two outcomes are not success. A pane with no agent, or one still showing a dialog, when the poll
 window elapses fails the spawn/promote with that pane content and what held it up; for a harness
-whose agent detection has not been exercised, that failure says so by name instead of claiming the
-harness never started. A recognized-but-refused dialog fails immediately, naming what a human has
-to accept. See `cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were
+whose agent detection has not been exercised, that failure names the unexercised detection first
+and the possibility of a harness that exited on a dialog second, since an unrecognized process is
+the likelier cause. A recognized-but-refused dialog fails immediately, naming what a human has to
+accept. See `cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were
 chosen.
 
 A harness with no catalogued signatures at all is confirmed on agent presence alone, so an agent
@@ -966,7 +969,7 @@ Responses come in two shapes, and the client validates each one differently:
 - **Void commands** (`pane run`, `pane send-text`, `pane send-keys`) print nothing on success.
   A failure prints a JSON error envelope whose exit code cannot be trusted on its own, so any
   non-empty body is parsed for that envelope before the exit status is consulted.
-- **`pane read`** is a third shape: plain scrollback text on success, and on failure a bare
+- **`pane read`** is a third shape: plain pane text on success, and on failure a bare
   `{"code","message"}` object rather than the `{"error":{...}}` envelope the other two shapes use.
 
 The herdr client abstracts these into Go function calls; `internal/herdr` keeps one entry point

--- a/SPECS.md
+++ b/SPECS.md
@@ -284,8 +284,9 @@ Behavior:
    - Tab naming: task ID.
 7. Construct the harness launch command from the template (see harness section).
 8. Send the launch command to the herdr pane.
-9. Confirm the worker actually started: poll the pane, answering any known first-run dialog,
-   until it goes quiet or the poll window elapses (see Harness launch templates).
+9. Confirm the worker actually started: poll the pane until the harness paints, answering any
+   known first-run dialog, until it goes quiet or the poll window elapses (see Harness launch
+   templates).
 10. Write `state/<id>.json` with all metadata.
 11. Update `data/dashboard.md` with the new task.
 
@@ -311,8 +312,8 @@ Errors:
 - Worktree collision with another active task (names the conflicting task).
 - Herdr tab creation failed (herdr not running, session error).
 - Harness not recognized.
-- Worker never cleared a first-run prompt within the poll window (pane content included in the
-  error).
+- Worker never confirmed started within the poll window, or is waiting on a first-run prompt hand
+  refuses to answer (pane content and the blocking prompt included in the error).
 
 State file written (`state/fix-login.json`):
 ```json
@@ -804,21 +805,31 @@ permission dialog.
 Claude Code renders while idle; without it, a supervisor reading the pane can misread ghost text
 as the worker having typed input.
 
-Interactive launch has two first-run dialogs that headless `--print` skipped:
+Interactive launch has first-run dialogs that headless `--print` skipped:
 
 - The workspace trust dialog. Claude Code only trusts a directory whose path or one of its
   ancestors has been accepted before, and every treehouse worktree is a fresh path under the
   pool root (`~/.treehouse/...`), so this dialog appears on every spawn, not just a fresh host.
 - The bypass-permissions disclaimer, a one-time global accept that `--dangerously-skip-permissions`
   is gated on.
+- The settings-trust dialog, shown for a project that ships settings requiring approval.
+  It is recognized but deliberately not answered: accepting it activates whatever hooks and
+  commands the checked-out branch ships, which is the operator's call, not hand's.
 
-`hand spawn` and `hand promote` clear both automatically: after sending the launch command, each
-polls the pane and answers any dialog matching a known signature (`internal/harness`'s
-`FirstRunPromptsFor`), then confirms the pane has gone quiet - neither a known dialog nor the
-harness's generic unrecognized-dialog fallback still matching - before reporting success. A pane
-still showing an unrecognized prompt when the poll window elapses fails the spawn/promote with
-that pane content in the error, instead of reporting success for a worker that never started.
-See `cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were chosen.
+`hand spawn` and `hand promote` clear the answerable ones automatically. After sending the launch
+command, each polls the pane and waits for the harness's own readiness signature
+(`internal/harness`'s `FirstRunPromptsFor`) before judging anything: the echoed launch command is
+not evidence the harness started, so a cold start slower than the settle window is never mistaken
+for a clean one. From then on it answers any dialog matching a known signature and confirms the
+pane has gone quiet - neither a known dialog nor the harness's generic unrecognized-dialog
+fallback still matching - before reporting success.
+
+Three outcomes are not success. A pane still showing a prompt when the poll window elapses fails
+the spawn/promote with that pane content and which prompt held it up. A recognized-but-refused
+dialog fails immediately, naming what a human has to accept. A harness with no verified
+signatures at all (every harness except claude) cannot be confirmed either way, so the launch is
+reported with a warning on stderr rather than a silent pass. See `cmd/launch.go`'s
+`confirmLaunch` for the polling/timeout values and why they were chosen.
 
 ### Codex
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -822,17 +822,26 @@ Interactive launch has first-run dialogs that headless `--print` skipped:
 command, each polls the pane. Whether a worker is running is herdr's answer, not the screen's:
 herdr reports an agent on a pane only while a harness process is in its foreground, so a harness
 that painted a dialog and then exited leaves the text behind but no agent, and is never mistaken
-for a started worker. That holds for every harness, not only the ones with catalogued signatures.
+for a started worker. That labeling is verified empirically for claude and opencode, each run in a
+real pane and observed being labeled. For codex, pi and grok it rests on herdr's shipped agent
+detection manifests, read but not exercised, because no binary for those is installed on this host.
 Pane text is used only to spot dialogs (`internal/harness`'s `FirstRunPromptsFor`): a known one is
 answered, and success needs the pane to hold a live agent and stay free of both known dialogs and
-the harness's generic unrecognized-dialog fallback for the settle window. A harness's readiness
-signature is a secondary shortcut - on a pane already holding a live agent, the harness's own
-paint means there is nothing left to settle for.
+the harness's generic unrecognized-dialog fallback for the settle window. Among answerable known
+dialogs on one screen the latest match in the scrollback wins, since that is the one actually
+painted now. A harness's readiness signature is a secondary shortcut - on a pane already holding a
+live agent, the harness's own paint means there is nothing left to settle for.
 
 Two outcomes are not success. A pane with no agent, or one still showing a dialog, when the poll
-window elapses fails the spawn/promote with that pane content and what held it up. A
-recognized-but-refused dialog fails immediately, naming what a human has to accept. See
-`cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were chosen.
+window elapses fails the spawn/promote with that pane content and what held it up; for a harness
+whose agent detection has not been exercised, that failure says so by name instead of claiming the
+harness never started. A recognized-but-refused dialog fails immediately, naming what a human has
+to accept. See `cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were
+chosen.
+
+A harness with no catalogued signatures at all is confirmed on agent presence alone, so an agent
+parked on a dialog hand cannot recognize is reported as started. That is a known, accepted gap, and
+the reason the catalogue matters for every harness added, not only claude.
 
 ### Codex
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -818,6 +818,11 @@ Interactive launch has first-run dialogs that headless `--print` skipped:
   interception for every run on the host, so it is recognized but deliberately not answered. The
   operator accepts it once on the host, then respawns.
 
+Their signatures (`internal/harness`) must stay case-sensitive and keep their distinguishing anchors
+- `Bypass\s+Permissions\s+mode`, not a bare `bypass permissions` - because Claude Code's status line
+permanently contains the string `bypass permissions`, so a case-insensitive or unanchored loosening
+would match a dialog in every pane forever and break every spawn.
+
 `hand spawn` and `hand promote` clear the answerable ones automatically. After sending the launch
 command, each polls the pane. Whether a worker is running is herdr's answer, not the screen's:
 herdr reports an agent on a pane only while a harness process is in its foreground, so a harness
@@ -834,10 +839,19 @@ means there is nothing left to settle for.
 That text is read from the pane's recent scrollback (`pane read --source recent`), not its visible
 viewport, because a pane in an unattached herdr session is too short to show a whole dialog - 23
 rows against 61 in an attached one - and what it clips is the lower half, where the option and
-footer lines that identify a dialog live. Scrollback therefore keeps showing a dialog that has
-already been answered, so re-answering is prevented by answering each catalogued dialog at most once
-per launch, rather than by comparing frames or ranking which match is most recent. If keys never
-land and a dialog stays up, hand sends nothing further and runs out the poll window instead.
+footer lines that identify a dialog live.
+
+Reading scrollback rests on a measured premise: Claude Code erases an answered first-run dialog in
+place rather than scrolling it away, so a recent-scrollback read does not carry answered dialogs
+forward. Measured on 2026-07-26 against a real `hand spawn`ed worker pane on the Claude Code version
+installed on this host, reading 200 lines of retained scrollback: no trust-dialog, bypass-disclaimer
+or `Enter to confirm` text remained anywhere in it. A read that still matches a catalogued dialog is
+therefore treated as that dialog still being up, and the launch runs out its poll window rather than
+being confirmed. If that premise stops holding on a later Claude Code version, spawn fails on the
+deadline instead of confirming a healthy worker. That direction is chosen, not an oversight: a wrong
+deadline failure is loud and fixable, while confirming an unread dialog is issue #28 itself.
+Independently of the read, each catalogued dialog is answered at most once per launch, so retained
+text can cost a timeout but can never send a second round of keys into a live agent's composer.
 
 Two outcomes are not success. A pane with no agent, or one still showing a dialog, when the poll
 window elapses fails the spawn/promote with that pane content and what held it up; for a harness

--- a/SPECS.md
+++ b/SPECS.md
@@ -939,7 +939,7 @@ herdr tracks agent state per pane:
 
 | hand command | herdr operation |
 |---|---|
-| `hand spawn` | create workspace (if needed) + create tab + send launch command |
+| `hand spawn` | create workspace (if needed) + create tab + send launch command + poll pane state and read pane text until the worker is confirmed started, sending keys to answer first-run dialogs |
 | `hand status` | get agent state for pane |
 | `hand send` | check composer empty + send keys to pane |
 | `hand teardown` | close tab (+ close workspace if empty) |
@@ -962,7 +962,11 @@ herdr tab list --workspace <ws-id>
 
 # get pane and agent state
 herdr pane get <pane-id>
+# returns agent: detected harness name, empty when no harness runs in the pane
 # returns agent_status: "working" | "idle" | "done" | "blocked"
+
+# read the pane's recent scrollback as plain text
+herdr pane read <pane-id> --source recent --lines <n>
 
 # run a command in pane
 herdr pane run <pane-id> <command>

--- a/SPECS.md
+++ b/SPECS.md
@@ -284,9 +284,9 @@ Behavior:
    - Tab naming: task ID.
 7. Construct the harness launch command from the template (see harness section).
 8. Send the launch command to the herdr pane.
-9. Confirm the worker actually started: poll the pane until the harness paints, answering any
-   known first-run dialog, until it goes quiet or the poll window elapses (see Harness launch
-   templates).
+9. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
+   no first-run dialog is left, answering any known dialog along the way, or the poll window
+   elapses (see Harness launch templates).
 10. Write `state/<id>.json` with all metadata.
 11. Update `data/dashboard.md` with the new task.
 
@@ -812,24 +812,27 @@ Interactive launch has first-run dialogs that headless `--print` skipped:
   pool root (`~/.treehouse/...`), so this dialog appears on every spawn, not just a fresh host.
 - The bypass-permissions disclaimer, a one-time global accept that `--dangerously-skip-permissions`
   is gated on.
-- The settings-trust dialog, shown for a project that ships settings requiring approval.
-  It is recognized but deliberately not answered: accepting it activates whatever hooks and
-  commands the checked-out branch ships, which is the operator's call, not hand's.
+- The managed-settings security dialog ("Managed settings require approval"), shown when this
+  host has managed settings configured by the organization's IT administration. It has nothing
+  to do with the checked-out repository: accepting it grants arbitrary code execution and prompt
+  interception for every run on the host, so it is recognized but deliberately not answered. The
+  operator accepts it once on the host, then respawns.
 
 `hand spawn` and `hand promote` clear the answerable ones automatically. After sending the launch
-command, each polls the pane and waits for the harness's own readiness signature
-(`internal/harness`'s `FirstRunPromptsFor`) before judging anything: the echoed launch command is
-not evidence the harness started, so a cold start slower than the settle window is never mistaken
-for a clean one. From then on it answers any dialog matching a known signature and confirms the
-pane has gone quiet - neither a known dialog nor the harness's generic unrecognized-dialog
-fallback still matching - before reporting success.
+command, each polls the pane. Whether a worker is running is herdr's answer, not the screen's:
+herdr reports an agent on a pane only while a harness process is in its foreground, so a harness
+that painted a dialog and then exited leaves the text behind but no agent, and is never mistaken
+for a started worker. That holds for every harness, not only the ones with catalogued signatures.
+Pane text is used only to spot dialogs (`internal/harness`'s `FirstRunPromptsFor`): a known one is
+answered, and success needs the pane to hold a live agent and stay free of both known dialogs and
+the harness's generic unrecognized-dialog fallback for the settle window. A harness's readiness
+signature is a secondary shortcut - on a pane already holding a live agent, the harness's own
+paint means there is nothing left to settle for.
 
-Three outcomes are not success. A pane still showing a prompt when the poll window elapses fails
-the spawn/promote with that pane content and which prompt held it up. A recognized-but-refused
-dialog fails immediately, naming what a human has to accept. A harness with no verified
-signatures at all (every harness except claude) cannot be confirmed either way, so the launch is
-reported with a warning on stderr rather than a silent pass. See `cmd/launch.go`'s
-`confirmLaunch` for the polling/timeout values and why they were chosen.
+Two outcomes are not success. A pane with no agent, or one still showing a dialog, when the poll
+window elapses fails the spawn/promote with that pane content and what held it up. A
+recognized-but-refused dialog fails immediately, naming what a human has to accept. See
+`cmd/launch.go`'s `confirmLaunch` for the polling/timeout values and why they were chosen.
 
 ### Codex
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -1,82 +1,137 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/harness"
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/spf13/cobra"
 )
 
-// confirmLaunch waits for a freshly launched pane to clear any first-run dialog before
-// reporting the spawn/promote as successful. herdr's agent_status reports "idle" the instant
-// the harness process starts, even while it's sitting unanswered on a dialog, so it cannot
-// distinguish "stuck" from "done" - only the pane's own text can. A pane is judged started once
-// it goes quiet: launchQuietReads consecutive reads with neither a known prompt nor the
-// harness's generic unrecognized-dialog fallback matching. Any known prompt is answered and
-// resets the quiet count; an unrecognized match also resets it without being answered, so a
-// dialog no one has catalogued yet still eventually fails loudly instead of being reported as a
-// successful launch. launchQuietReads * launchPollInterval (5s) covers the slowest first paint
-// seen in testing with real claude on a cold start, and launchTimeout (60s) is the outer bound
-// for a pane stuck repeating the same prompt.
-const (
-	launchPollInterval = 1 * time.Second
-	launchQuietReads   = 6
-	launchTimeout      = 60 * time.Second
-	launchReadLines    = 60
-	// launchKeySettle gives the harness's TUI time to re-render a focus change before the next
-	// key arrives; sending a multi-key answer (e.g. Down, Enter) in one burst can land the
-	// confirm key before the focus move is drawn, confirming the wrong option.
-	launchKeySettle = 300 * time.Millisecond
-)
+// launchPoll holds confirmLaunch's timings. They are a package var rather than consts so tests
+// can shrink the poll window instead of sleeping through a real one.
+type launchPoll struct {
+	Interval   time.Duration
+	QuietReads int
+	Timeout    time.Duration
+	KeySettle  time.Duration
+	ReadLines  int
+}
 
+// QuietReads * Interval is the settle window a pane must stay dialog-free for after the harness
+// first paints, sized to the slowest gap between frames seen in testing with real claude, and
+// Timeout is the outer bound for a pane that never starts or never clears a dialog. KeySettle
+// gives the harness's TUI time to re-render a focus change before the next key arrives; sending
+// a multi-key answer (e.g. Down, Enter) in one burst can land the confirm key before the focus
+// move is drawn, confirming the wrong option.
+var launchPolling = launchPoll{
+	Interval:   1 * time.Second,
+	QuietReads: 6,
+	Timeout:    60 * time.Second,
+	KeySettle:  300 * time.Millisecond,
+	ReadLines:  60,
+}
+
+// errLaunchUnconfirmable reports the one outcome that is neither success nor failure: the
+// harness has no verified pane signatures, so nothing about its pane can be read as "started".
+// confirmLaunchOrWarn downgrades it to a warning; it must never be reported as a confirmation.
+var errLaunchUnconfirmable = errors.New("harness has no verified first-run pane signatures")
+
+// confirmLaunch waits for a freshly launched pane to clear any first-run dialog before the
+// spawn/promote is reported successful. herdr's agent_status reports "idle" the instant the
+// harness process starts, even while it sits unanswered on a dialog, so only the pane's own
+// text can tell "stuck" from "started".
+//
+// Confirmation is two-staged. First the pane must show that the harness itself painted -
+// either its readiness signature or a dialog, which is equally proof of a drawn frame. The
+// echoed launch command alone does not count, or a cold start slower than the settle window
+// would be confirmed moments before the trust dialog appears, which is the exact failure this
+// function exists to remove. Only then does the quiet count run: QuietReads consecutive reads
+// with neither a known prompt nor the generic unrecognized-dialog fallback matching. A known
+// prompt is answered and resets the count; an unrecognized match resets it without being
+// answered, so an uncatalogued dialog fails loudly instead of passing as a started worker. A
+// prompt catalogued as refused (one hand will not answer for the operator) fails immediately
+// with its own reason rather than waiting out the timeout as an unknown dialog.
 func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	prompts := harness.FirstRunPromptsFor(harnessName)
-	deadline := time.Now().Add(launchTimeout)
+	if prompts.Ready == nil {
+		return errLaunchUnconfirmable
+	}
+
+	deadline := time.Now().Add(launchPolling.Timeout)
+	ready := false
 	quiet := 0
+	stall := "the harness never painted a startup frame"
 
 	for {
-		text, err := client.PaneRead(paneID, launchReadLines)
+		text, err := client.PaneRead(paneID, launchPolling.ReadLines)
 		if err != nil {
 			return err
 		}
 
-		answered, err := answerKnownPrompt(client, paneID, prompts, text)
-		if err != nil {
-			return err
+		prompt, known := matchFirstRunPrompt(prompts.Known, text)
+		unrecognized := !known && prompts.Unrecognized != nil && prompts.Unrecognized.MatchString(text)
+		if !ready && (known || unrecognized || prompts.Ready.MatchString(text)) {
+			ready = true
+			stall = "the harness started but its pane never went quiet"
 		}
 
 		switch {
-		case answered:
+		case known && prompt.Refuse != "":
+			return fmt.Errorf("worker is waiting on the %s prompt: %s", prompt.Name, prompt.Refuse)
+		case known:
+			if err := answerFirstRunPrompt(client, paneID, prompt); err != nil {
+				return err
+			}
 			quiet = 0
-		case prompts.Unrecognized != nil && prompts.Unrecognized.MatchString(text):
+			stall = fmt.Sprintf("answering the %s prompt is not clearing it", prompt.Name)
+		case unrecognized:
 			quiet = 0
-		default:
+			stall = "the pane is showing a dialog no known signature covers"
+		case ready:
 			quiet++
-			if quiet >= launchQuietReads {
+			if quiet >= launchPolling.QuietReads {
 				return nil
 			}
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("worker still on an unrecognized prompt after %s:\n%s", launchTimeout, text)
+			return fmt.Errorf("not confirmed started within %s: %s:\n%s", launchPolling.Timeout, stall, text)
 		}
-		time.Sleep(launchPollInterval)
+		time.Sleep(launchPolling.Interval)
 	}
 }
 
-func answerKnownPrompt(client *herdr.Client, paneID string, prompts harness.FirstRunPrompts, text string) (bool, error) {
-	for _, prompt := range prompts.Known {
-		if !prompt.Match.MatchString(text) {
-			continue
-		}
-		for _, key := range prompt.Keys {
-			if err := client.PaneSendKeys(paneID, key); err != nil {
-				return true, fmt.Errorf("answer %s prompt: %w", prompt.Name, err)
-			}
-			time.Sleep(launchKeySettle)
-		}
-		return true, nil
+// confirmLaunchOrWarn confirms the launch for the spawn-shaped commands, reporting the one case
+// hand cannot decide - a harness with no verified pane signatures - as a warning on stderr, so
+// the operator is told the worker was launched but never observed instead of being handed a
+// success the pane was never checked for.
+func confirmLaunchOrWarn(cmd *cobra.Command, client *herdr.Client, paneID, harnessName string) error {
+	err := confirmLaunch(client, paneID, harnessName)
+	if errors.Is(err, errLaunchUnconfirmable) {
+		_, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: cannot confirm the %s worker started: %v\n", harnessName, err)
+		return printErr
 	}
-	return false, nil
+	return err
+}
+
+func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.FirstRunPrompt, bool) {
+	for _, prompt := range known {
+		if prompt.Match.MatchString(text) {
+			return prompt, true
+		}
+	}
+	return harness.FirstRunPrompt{}, false
+}
+
+func answerFirstRunPrompt(client *herdr.Client, paneID string, prompt harness.FirstRunPrompt) error {
+	for _, key := range prompt.Keys {
+		if err := client.PaneSendKeys(paneID, key); err != nil {
+			return fmt.Errorf("answer %s prompt: %w", prompt.Name, err)
+		}
+		time.Sleep(launchPolling.KeySettle)
+	}
+	return nil
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -41,10 +41,12 @@ var launchPolling = launchPoll{
 // exactly one job here, spotting dialogs: a known prompt is answered and resets the quiet count,
 // the generic unrecognized-dialog fallback resets it without being answered so an uncatalogued
 // dialog fails loudly, and a prompt catalogued as refused fails immediately with its own reason.
-// The text is the visible viewport, not scrollback, because a modal dialog is on screen now by
-// definition - it leaves the viewport the instant the harness repaints, so there is no answered
-// dialog left to re-answer. Ready is a cheap secondary signal - with the agent already confirmed
-// present, the harness's own paint leaves the quiet window nothing to wait for.
+// The text is recent scrollback rather than the visible viewport because an unattached pane is too
+// short to show a whole dialog and would clip the very lines that identify it (see
+// herdr.PaneRead), which means a dialog already answered can still be in the read. Each catalogued
+// dialog is therefore answered at most once per launch, so lingering text can never make hand type
+// into a session that has moved on. Ready is a cheap secondary signal - with the agent already
+// confirmed present, the harness's own paint leaves the quiet window nothing to wait for.
 //
 // The gate is only as good as herdr's labeling of the harness, which is why a pane that is never
 // labeled says so by name (see harness.AgentDetectionVerified) instead of failing as a bare
@@ -53,7 +55,7 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	prompts := harness.FirstRunPromptsFor(harnessName)
 	deadline := time.Now().Add(launchPolling.Timeout)
 	quiet := 0
-	answered := ""
+	answered := map[string]bool{}
 	sawAgent := false
 	detected := harness.AgentDetectionVerified(harnessName)
 	noAgent := "the harness never started in the pane"
@@ -74,12 +76,12 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 
 		sawAgent = sawAgent || pane.Agent != ""
 
-		prompt, known := matchFirstRunPrompt(prompts.Known, text)
+		prompt, known := matchFirstRunPrompt(prompts.Known, text, answered)
 		switch {
 		case pane.Agent == "":
 			quiet = 0
 			switch {
-			case (known || answered != "") && (sawAgent || detected):
+			case (known || len(answered) > 0) && (sawAgent || detected):
 				stall = "the harness exited on a first-run dialog instead of starting up"
 			case known:
 				stall = fmt.Sprintf("%s, so the %s dialog on screen may be a harness herdr never recognized rather than one that exited", noAgent, prompt.Name)
@@ -91,13 +93,11 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 		case known && prompt.Refuse != "":
 			return fmt.Errorf("worker is waiting on the %s prompt: %s", prompt.Name, prompt.Refuse)
 		case known:
-			// Answering again on a frame byte-identical to the one already answered would inject
-			// the keys into whatever the harness moved on to; only a repaint means it is stuck.
-			if text != answered {
+			if !answered[prompt.Name] {
 				if err := answerFirstRunPrompt(client, paneID, prompt); err != nil {
 					return err
 				}
-				answered = text
+				answered[prompt.Name] = true
 			}
 			quiet = 0
 			stall = fmt.Sprintf("answering the %s prompt is not clearing it", prompt.Name)
@@ -121,11 +121,13 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	}
 }
 
-// matchFirstRunPrompt reports which catalogued dialog the pane's viewport is showing. A refused
-// prompt wins over an answerable one wherever either sits in the catalogue, so a screen carrying
-// both signatures is never answered into. Answerable entries need no such tie-break: two modal
-// dialogs cannot occupy one viewport at once, so at most one of them is really on screen.
-func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.FirstRunPrompt, bool) {
+// matchFirstRunPrompt reports which catalogued dialog the pane read is showing, given the dialogs
+// this launch has already answered. A refused prompt wins over an answerable one wherever either
+// sits in the catalogue, so a read carrying both signatures is never answered into. Among
+// answerable ones an unanswered dialog wins over an already-answered one, so the text of a dialog
+// just cleared cannot hide the next dialog behind it in the same read; otherwise catalogue order
+// decides, which for claude is the order it paints them in.
+func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string, answered map[string]bool) (harness.FirstRunPrompt, bool) {
 	var match harness.FirstRunPrompt
 	found := false
 	for _, prompt := range known {
@@ -135,7 +137,7 @@ func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.F
 		if prompt.Refuse != "" {
 			return prompt, true
 		}
-		if !found {
+		if !found || (answered[match.Name] && !answered[prompt.Name]) {
 			match, found = prompt, true
 		}
 	}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/harness"
 	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/spf13/cobra"
 )
 
 // launchPoll holds confirmLaunch's timings. They are a package var rather than consts so tests
@@ -20,12 +18,12 @@ type launchPoll struct {
 	ReadLines  int
 }
 
-// QuietReads * Interval is the settle window a pane must stay dialog-free for after the harness
-// first paints, sized to the slowest gap between frames seen in testing with real claude, and
-// Timeout is the outer bound for a pane that never starts or never clears a dialog. KeySettle
-// gives the harness's TUI time to re-render a focus change before the next key arrives; sending
-// a multi-key answer (e.g. Down, Enter) in one burst can land the confirm key before the focus
-// move is drawn, confirming the wrong option.
+// QuietReads * Interval is the settle window a pane must stay dialog-free for, sized to the
+// slowest gap between frames seen in testing with real claude, and Timeout is the outer bound
+// for a pane that never starts or never clears a dialog. KeySettle gives the harness's TUI time
+// to re-render a focus change before the next key arrives; sending a multi-key answer (e.g.
+// Down, Enter) in one burst can land the confirm key before the focus move is drawn, confirming
+// the wrong option.
 var launchPolling = launchPoll{
 	Interval:   1 * time.Second,
 	QuietReads: 6,
@@ -34,67 +32,66 @@ var launchPolling = launchPoll{
 	ReadLines:  60,
 }
 
-// errLaunchUnconfirmable reports the one outcome that is neither success nor failure: the
-// harness has no verified pane signatures, so nothing about its pane can be read as "started".
-// confirmLaunchOrWarn downgrades it to a warning; it must never be reported as a confirmation.
-var errLaunchUnconfirmable = errors.New("harness has no verified first-run pane signatures")
-
-// confirmLaunch waits for a freshly launched pane to clear any first-run dialog before the
-// spawn/promote is reported successful. herdr's agent_status reports "idle" the instant the
-// harness process starts, even while it sits unanswered on a dialog, so only the pane's own
-// text can tell "stuck" from "started".
+// confirmLaunch waits for a freshly launched pane to hold a live harness with no first-run
+// dialog left on it before the spawn/promote is reported successful.
 //
-// Confirmation is two-staged. First the pane must show that the harness itself painted -
-// either its readiness signature or a dialog, which is equally proof of a drawn frame. The
-// echoed launch command alone does not count, or a cold start slower than the settle window
-// would be confirmed moments before the trust dialog appears, which is the exact failure this
-// function exists to remove. Only then does the quiet count run: QuietReads consecutive reads
-// with neither a known prompt nor the generic unrecognized-dialog fallback matching. A known
-// prompt is answered and resets the count; an unrecognized match resets it without being
-// answered, so an uncatalogued dialog fails loudly instead of passing as a started worker. A
-// prompt catalogued as refused (one hand will not answer for the operator) fails immediately
-// with its own reason rather than waiting out the timeout as an unknown dialog.
+// Liveness is herdr's answer, not the screen's: herdr reports an agent on a pane only while a
+// harness process runs in it, so a harness that painted a dialog and then exited leaves its text
+// in the scrollback but no agent, and can never be mistaken for a started worker. That holds for
+// every harness, not just the ones whose screens hand can read. Pane text has exactly one job
+// here, spotting dialogs: a known prompt is answered and resets the quiet count, the generic
+// unrecognized-dialog fallback resets it without being answered so an uncatalogued dialog fails
+// loudly, and a prompt catalogued as refused fails immediately with its own reason. Ready is a
+// cheap secondary signal - with the agent already confirmed present, the harness's own paint
+// leaves the quiet window nothing to wait for.
 func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	prompts := harness.FirstRunPromptsFor(harnessName)
-	if prompts.Ready == nil {
-		return errLaunchUnconfirmable
-	}
-
 	deadline := time.Now().Add(launchPolling.Timeout)
-	ready := false
 	quiet := 0
-	stall := "the harness never painted a startup frame"
+	answered := ""
+	stall := "the harness never started in the pane"
 
 	for {
+		pane, err := client.PaneGet(paneID)
+		if err != nil {
+			return err
+		}
 		text, err := client.PaneRead(paneID, launchPolling.ReadLines)
 		if err != nil {
 			return err
 		}
 
 		prompt, known := matchFirstRunPrompt(prompts.Known, text)
-		unrecognized := !known && prompts.Unrecognized != nil && prompts.Unrecognized.MatchString(text)
-		if !ready && (known || unrecognized || prompts.Ready.MatchString(text)) {
-			ready = true
-			stall = "the harness started but its pane never went quiet"
-		}
-
 		switch {
+		case pane.Agent == "":
+			quiet = 0
+			if answered != "" || known {
+				stall = "the harness exited on a first-run dialog instead of starting up"
+			}
 		case known && prompt.Refuse != "":
 			return fmt.Errorf("worker is waiting on the %s prompt: %s", prompt.Name, prompt.Refuse)
 		case known:
-			if err := answerFirstRunPrompt(client, paneID, prompt); err != nil {
-				return err
+			// Answering again on a frame byte-identical to the one already answered would inject
+			// the keys into whatever the harness moved on to; only a repaint means it is stuck.
+			if text != answered {
+				if err := answerFirstRunPrompt(client, paneID, prompt); err != nil {
+					return err
+				}
+				answered = text
 			}
 			quiet = 0
 			stall = fmt.Sprintf("answering the %s prompt is not clearing it", prompt.Name)
-		case unrecognized:
+		case prompts.Unrecognized != nil && prompts.Unrecognized.MatchString(text):
 			quiet = 0
 			stall = "the pane is showing a dialog no known signature covers"
-		case ready:
+		case prompts.Ready != nil && prompts.Ready.MatchString(text):
+			return nil
+		default:
 			quiet++
 			if quiet >= launchPolling.QuietReads {
 				return nil
 			}
+			stall = "the harness started but its pane never went quiet"
 		}
 
 		if time.Now().After(deadline) {
@@ -104,26 +101,24 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	}
 }
 
-// confirmLaunchOrWarn confirms the launch for the spawn-shaped commands, reporting the one case
-// hand cannot decide - a harness with no verified pane signatures - as a warning on stderr, so
-// the operator is told the worker was launched but never observed instead of being handed a
-// success the pane was never checked for.
-func confirmLaunchOrWarn(cmd *cobra.Command, client *herdr.Client, paneID, harnessName string) error {
-	err := confirmLaunch(client, paneID, harnessName)
-	if errors.Is(err, errLaunchUnconfirmable) {
-		_, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: cannot confirm the %s worker started: %v\n", harnessName, err)
-		return printErr
-	}
-	return err
-}
-
+// matchFirstRunPrompt reports which catalogued dialog the pane text is showing. A refused prompt
+// wins over an answerable one wherever either sits in the catalogue, so a screen carrying both
+// signatures is never answered into.
 func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.FirstRunPrompt, bool) {
+	var match harness.FirstRunPrompt
+	found := false
 	for _, prompt := range known {
-		if prompt.Match.MatchString(text) {
+		if !prompt.Match.MatchString(text) {
+			continue
+		}
+		if prompt.Refuse != "" {
 			return prompt, true
 		}
+		if !found {
+			match, found = prompt, true
+		}
 	}
-	return harness.FirstRunPrompt{}, false
+	return match, found
 }
 
 func answerFirstRunPrompt(client *herdr.Client, paneID string, prompt harness.FirstRunPrompt) error {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/atqamz/secondhand/internal/herdr"
+)
+
+// confirmLaunch waits for a freshly launched pane to clear any first-run dialog before
+// reporting the spawn/promote as successful. herdr's agent_status reports "idle" the instant
+// the harness process starts, even while it's sitting unanswered on a dialog, so it cannot
+// distinguish "stuck" from "done" - only the pane's own text can. A pane is judged started once
+// it goes quiet: launchQuietReads consecutive reads with neither a known prompt nor the
+// harness's generic unrecognized-dialog fallback matching. Any known prompt is answered and
+// resets the quiet count; an unrecognized match also resets it without being answered, so a
+// dialog no one has catalogued yet still eventually fails loudly instead of being reported as a
+// successful launch. launchQuietReads * launchPollInterval (5s) covers the slowest first paint
+// seen in testing with real claude on a cold start, and launchTimeout (60s) is the outer bound
+// for a pane stuck repeating the same prompt.
+const (
+	launchPollInterval = 1 * time.Second
+	launchQuietReads   = 6
+	launchTimeout      = 60 * time.Second
+	launchReadLines    = 60
+	// launchKeySettle gives the harness's TUI time to re-render a focus change before the next
+	// key arrives; sending a multi-key answer (e.g. Down, Enter) in one burst can land the
+	// confirm key before the focus move is drawn, confirming the wrong option.
+	launchKeySettle = 300 * time.Millisecond
+)
+
+func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
+	prompts := harness.FirstRunPromptsFor(harnessName)
+	deadline := time.Now().Add(launchTimeout)
+	quiet := 0
+
+	for {
+		text, err := client.PaneRead(paneID, launchReadLines)
+		if err != nil {
+			return err
+		}
+
+		answered, err := answerKnownPrompt(client, paneID, prompts, text)
+		if err != nil {
+			return err
+		}
+
+		switch {
+		case answered:
+			quiet = 0
+		case prompts.Unrecognized != nil && prompts.Unrecognized.MatchString(text):
+			quiet = 0
+		default:
+			quiet++
+			if quiet >= launchQuietReads {
+				return nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("worker still on an unrecognized prompt after %s:\n%s", launchTimeout, text)
+		}
+		time.Sleep(launchPollInterval)
+	}
+}
+
+func answerKnownPrompt(client *herdr.Client, paneID string, prompts harness.FirstRunPrompts, text string) (bool, error) {
+	for _, prompt := range prompts.Known {
+		if !prompt.Match.MatchString(text) {
+			continue
+		}
+		for _, key := range prompt.Keys {
+			if err := client.PaneSendKeys(paneID, key); err != nil {
+				return true, fmt.Errorf("answer %s prompt: %w", prompt.Name, err)
+			}
+			time.Sleep(launchKeySettle)
+		}
+		return true, nil
+	}
+	return false, nil
+}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -42,11 +42,13 @@ var launchPolling = launchPoll{
 // the generic unrecognized-dialog fallback resets it without being answered so an uncatalogued
 // dialog fails loudly, and a prompt catalogued as refused fails immediately with its own reason.
 // The text is recent scrollback rather than the visible viewport because an unattached pane is too
-// short to show a whole dialog and would clip the very lines that identify it (see
-// herdr.PaneRead), which means a dialog already answered can still be in the read. Each catalogued
-// dialog is therefore answered at most once per launch, so lingering text can never make hand type
-// into a session that has moved on. Ready is a cheap secondary signal - with the agent already
-// confirmed present, the harness's own paint leaves the quiet window nothing to wait for.
+// short to show a whole dialog and would clip the very lines that identify it (see herdr.PaneRead).
+// That is safe to match against because claude erases an answered first-run dialog in place rather
+// than leaving it behind in scrollback, measured against a real spawned worker pane (see SPECS.md).
+// A dialog still matching after it was answered is therefore treated as a dialog still up: the
+// launch runs out its deadline instead of being confirmed. Ready is a cheap secondary signal - with
+// the agent already confirmed present, the harness's own paint leaves the quiet window nothing to
+// wait for.
 //
 // The gate is only as good as herdr's labeling of the harness, which is why a pane that is never
 // labeled says so by name (see harness.AgentDetectionVerified) instead of failing as a bare
@@ -55,6 +57,8 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	prompts := harness.FirstRunPromptsFor(harnessName)
 	deadline := time.Now().Add(launchPolling.Timeout)
 	quiet := 0
+	// A dialog's keys go out once per launch whatever later reads hold: a second send lands in a
+	// live agent's composer, so retained text can cost a timeout but never injected keystrokes.
 	answered := map[string]bool{}
 	sawAgent := false
 	detected := harness.AgentDetectionVerified(harnessName)
@@ -76,7 +80,7 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 
 		sawAgent = sawAgent || pane.Agent != ""
 
-		prompt, known := matchFirstRunPrompt(prompts.Known, text, answered)
+		prompt, known := matchFirstRunPrompt(prompts.Known, text)
 		switch {
 		case pane.Agent == "":
 			quiet = 0
@@ -100,7 +104,7 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 				answered[prompt.Name] = true
 			}
 			quiet = 0
-			stall = fmt.Sprintf("answering the %s prompt is not clearing it", prompt.Name)
+			stall = fmt.Sprintf("the %s prompt was answered, its text is still in the pane, and the harness never became ready", prompt.Name)
 		case prompts.Unrecognized != nil && prompts.Unrecognized.MatchString(text):
 			quiet = 0
 			stall = "the pane is showing a dialog no known signature covers"
@@ -121,13 +125,11 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	}
 }
 
-// matchFirstRunPrompt reports which catalogued dialog the pane read is showing, given the dialogs
-// this launch has already answered. A refused prompt wins over an answerable one wherever either
-// sits in the catalogue, so a read carrying both signatures is never answered into. Among
-// answerable ones an unanswered dialog wins over an already-answered one, so the text of a dialog
-// just cleared cannot hide the next dialog behind it in the same read; otherwise catalogue order
-// decides, which for claude is the order it paints them in.
-func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string, answered map[string]bool) (harness.FirstRunPrompt, bool) {
+// matchFirstRunPrompt reports which catalogued dialog the pane read is showing. A refused prompt
+// wins over an answerable one wherever either sits in the catalogue, so a read carrying both
+// signatures is never answered into. Answerable entries are taken in catalogue order, which for
+// claude is the order it paints them in.
+func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.FirstRunPrompt, bool) {
 	var match harness.FirstRunPrompt
 	found := false
 	for _, prompt := range known {
@@ -137,7 +139,7 @@ func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string, answered m
 		if prompt.Refuse != "" {
 			return prompt, true
 		}
-		if !found || (answered[match.Name] && !answered[prompt.Name]) {
+		if !found {
 			match, found = prompt, true
 		}
 	}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -37,12 +37,14 @@ var launchPolling = launchPoll{
 //
 // Liveness is herdr's answer, not the screen's: herdr reports an agent on a pane only while a
 // harness process runs in it, so a harness that painted a dialog and then exited leaves its text
-// in the scrollback but no agent, and can never be mistaken for a started worker. Pane text has
+// on screen but no agent, and can never be mistaken for a started worker. Pane text has
 // exactly one job here, spotting dialogs: a known prompt is answered and resets the quiet count,
 // the generic unrecognized-dialog fallback resets it without being answered so an uncatalogued
 // dialog fails loudly, and a prompt catalogued as refused fails immediately with its own reason.
-// Ready is a cheap secondary signal - with the agent already confirmed present, the harness's own
-// paint leaves the quiet window nothing to wait for.
+// The text is the visible viewport, not scrollback, because a modal dialog is on screen now by
+// definition - it leaves the viewport the instant the harness repaints, so there is no answered
+// dialog left to re-answer. Ready is a cheap secondary signal - with the agent already confirmed
+// present, the harness's own paint leaves the quiet window nothing to wait for.
 //
 // The gate is only as good as herdr's labeling of the harness, which is why a pane that is never
 // labeled says so by name (see harness.AgentDetectionVerified) instead of failing as a bare
@@ -53,7 +55,11 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	quiet := 0
 	answered := ""
 	sawAgent := false
-	noAgent := noAgentStall(harnessName)
+	detected := harness.AgentDetectionVerified(harnessName)
+	noAgent := "the harness never started in the pane"
+	if !detected {
+		noAgent = fmt.Sprintf("no agent detected in pane; herdr agent detection for harness %s has not been exercised", harnessName)
+	}
 	stall := noAgent
 
 	for {
@@ -73,8 +79,10 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 		case pane.Agent == "":
 			quiet = 0
 			switch {
-			case known || answered != "":
+			case (known || answered != "") && (sawAgent || detected):
 				stall = "the harness exited on a first-run dialog instead of starting up"
+			case known:
+				stall = fmt.Sprintf("%s, so the %s dialog on screen may be a harness herdr never recognized rather than one that exited", noAgent, prompt.Name)
 			case sawAgent:
 				stall = "the harness started and then exited"
 			default:
@@ -113,36 +121,22 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	}
 }
 
-// noAgentStall explains a pane that herdr never reported an agent on. For a harness whose
-// labeling has been exercised that means the harness itself never came up; for one whose
-// labeling has not, hand cannot tell that apart from herdr failing to recognize the process, and
-// says so rather than blaming the harness.
-func noAgentStall(harnessName string) string {
-	if harness.AgentDetectionVerified(harnessName) {
-		return "the harness never started in the pane"
-	}
-	return fmt.Sprintf("no agent detected in pane; herdr agent detection for harness %s has not been exercised", harnessName)
-}
-
-// matchFirstRunPrompt reports which catalogued dialog the pane text is showing. A refused prompt
-// wins over an answerable one wherever either sits in the catalogue, so a screen carrying both
-// signatures is never answered into. Among answerable ones the latest match in the read wins:
-// scrollback is chronological, so the last signature painted is the dialog actually on screen,
-// and answering an earlier one blind can send a fatal Enter to the wrong prompt.
+// matchFirstRunPrompt reports which catalogued dialog the pane's viewport is showing. A refused
+// prompt wins over an answerable one wherever either sits in the catalogue, so a screen carrying
+// both signatures is never answered into. Answerable entries need no such tie-break: two modal
+// dialogs cannot occupy one viewport at once, so at most one of them is really on screen.
 func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.FirstRunPrompt, bool) {
 	var match harness.FirstRunPrompt
 	found := false
-	at := -1
 	for _, prompt := range known {
-		loc := prompt.Match.FindStringIndex(text)
-		if loc == nil {
+		if !prompt.Match.MatchString(text) {
 			continue
 		}
 		if prompt.Refuse != "" {
 			return prompt, true
 		}
-		if loc[0] > at {
-			match, found, at = prompt, true, loc[0]
+		if !found {
+			match, found = prompt, true
 		}
 	}
 	return match, found

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -66,7 +66,7 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	if !detected {
 		noAgent = fmt.Sprintf("no agent detected in pane; herdr agent detection for harness %s has not been exercised", harnessName)
 	}
-	stall := noAgent
+	var stall string
 
 	for {
 		pane, err := client.PaneGet(paneID)

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -37,19 +37,24 @@ var launchPolling = launchPoll{
 //
 // Liveness is herdr's answer, not the screen's: herdr reports an agent on a pane only while a
 // harness process runs in it, so a harness that painted a dialog and then exited leaves its text
-// in the scrollback but no agent, and can never be mistaken for a started worker. That holds for
-// every harness, not just the ones whose screens hand can read. Pane text has exactly one job
-// here, spotting dialogs: a known prompt is answered and resets the quiet count, the generic
-// unrecognized-dialog fallback resets it without being answered so an uncatalogued dialog fails
-// loudly, and a prompt catalogued as refused fails immediately with its own reason. Ready is a
-// cheap secondary signal - with the agent already confirmed present, the harness's own paint
-// leaves the quiet window nothing to wait for.
+// in the scrollback but no agent, and can never be mistaken for a started worker. Pane text has
+// exactly one job here, spotting dialogs: a known prompt is answered and resets the quiet count,
+// the generic unrecognized-dialog fallback resets it without being answered so an uncatalogued
+// dialog fails loudly, and a prompt catalogued as refused fails immediately with its own reason.
+// Ready is a cheap secondary signal - with the agent already confirmed present, the harness's own
+// paint leaves the quiet window nothing to wait for.
+//
+// The gate is only as good as herdr's labeling of the harness, which is why a pane that is never
+// labeled says so by name (see harness.AgentDetectionVerified) instead of failing as a bare
+// timeout.
 func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	prompts := harness.FirstRunPromptsFor(harnessName)
 	deadline := time.Now().Add(launchPolling.Timeout)
 	quiet := 0
 	answered := ""
-	stall := "the harness never started in the pane"
+	sawAgent := false
+	noAgent := noAgentStall(harnessName)
+	stall := noAgent
 
 	for {
 		pane, err := client.PaneGet(paneID)
@@ -61,12 +66,19 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 			return err
 		}
 
+		sawAgent = sawAgent || pane.Agent != ""
+
 		prompt, known := matchFirstRunPrompt(prompts.Known, text)
 		switch {
 		case pane.Agent == "":
 			quiet = 0
-			if answered != "" || known {
+			switch {
+			case known || answered != "":
 				stall = "the harness exited on a first-run dialog instead of starting up"
+			case sawAgent:
+				stall = "the harness started and then exited"
+			default:
+				stall = noAgent
 			}
 		case known && prompt.Refuse != "":
 			return fmt.Errorf("worker is waiting on the %s prompt: %s", prompt.Name, prompt.Refuse)
@@ -101,21 +113,36 @@ func confirmLaunch(client *herdr.Client, paneID, harnessName string) error {
 	}
 }
 
+// noAgentStall explains a pane that herdr never reported an agent on. For a harness whose
+// labeling has been exercised that means the harness itself never came up; for one whose
+// labeling has not, hand cannot tell that apart from herdr failing to recognize the process, and
+// says so rather than blaming the harness.
+func noAgentStall(harnessName string) string {
+	if harness.AgentDetectionVerified(harnessName) {
+		return "the harness never started in the pane"
+	}
+	return fmt.Sprintf("no agent detected in pane; herdr agent detection for harness %s has not been exercised", harnessName)
+}
+
 // matchFirstRunPrompt reports which catalogued dialog the pane text is showing. A refused prompt
 // wins over an answerable one wherever either sits in the catalogue, so a screen carrying both
-// signatures is never answered into.
+// signatures is never answered into. Among answerable ones the latest match in the read wins:
+// scrollback is chronological, so the last signature painted is the dialog actually on screen,
+// and answering an earlier one blind can send a fatal Enter to the wrong prompt.
 func matchFirstRunPrompt(known []harness.FirstRunPrompt, text string) (harness.FirstRunPrompt, bool) {
 	var match harness.FirstRunPrompt
 	found := false
+	at := -1
 	for _, prompt := range known {
-		if !prompt.Match.MatchString(text) {
+		loc := prompt.Match.FindStringIndex(text)
+		if loc == nil {
 			continue
 		}
 		if prompt.Refuse != "" {
 			return prompt, true
 		}
-		if !found {
-			match, found = prompt, true
+		if loc[0] > at {
+			match, found, at = prompt, true, loc[0]
 		}
 	}
 	return match, found

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/herdr"
+)
+
+// useFastLaunchPolling shrinks confirmLaunch's poll window for the rest of the test, so a
+// command test costs milliseconds instead of sleeping through the real settle window.
+func useFastLaunchPolling(t *testing.T) {
+	t.Helper()
+	previous := launchPolling
+	launchPolling = launchPoll{
+		Interval:   time.Millisecond,
+		QuietReads: 3,
+		Timeout:    150 * time.Millisecond,
+		KeySettle:  time.Millisecond,
+		ReadLines:  60,
+	}
+	t.Cleanup(func() { launchPolling = previous })
+}
+
+// fakeLaunchPane installs a herdr fake that replays frames as successive "pane read" responses,
+// repeating the last one once they run out, and appends every key sent to a log the test reads
+// back. That is enough to drive confirmLaunch through a scripted pane lifecycle.
+func fakeLaunchPane(t *testing.T, frames ...string) (keyLog string) {
+	t.Helper()
+	dir := t.TempDir()
+	framesDir := filepath.Join(dir, "frames")
+	if err := os.MkdirAll(framesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, frame := range frames {
+		if err := os.WriteFile(filepath.Join(framesDir, strconv.Itoa(i)), []byte(frame), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	keyLog = filepath.Join(dir, "keys.log")
+	script := `#!/bin/sh
+case "$1 $2" in
+"pane read")
+	n=$(cat "$LAUNCH_FRAME_COUNTER" 2>/dev/null || echo 0)
+	echo $((n + 1)) > "$LAUNCH_FRAME_COUNTER"
+	last=$(($LAUNCH_FRAME_COUNT - 1))
+	[ "$n" -gt "$last" ] && n=$last
+	cat "$LAUNCH_FRAMES_DIR/$n"
+	;;
+"pane send-keys")
+	shift 3
+	echo "$@" >> "$LAUNCH_KEY_LOG"
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("LAUNCH_FRAMES_DIR", framesDir)
+	t.Setenv("LAUNCH_FRAME_COUNT", strconv.Itoa(len(frames)))
+	t.Setenv("LAUNCH_FRAME_COUNTER", filepath.Join(dir, "counter"))
+	t.Setenv("LAUNCH_KEY_LOG", keyLog)
+	return keyLog
+}
+
+const (
+	launchEchoFrame     = "$ cd '/tmp/wt' && claude --dangerously-skip-permissions 'Read the brief'"
+	launchReadyFrame    = "Welcome to Claude Code\n\n> \n  ? for shortcuts"
+	launchTrustFrame    = "Do you trust the files in this folder?\n> 1. Yes, I trust this folder\n  2. No\n\nEnter to confirm"
+	launchBypassFrame   = "WARNING: Bypass Permissions mode\n  1. Yes, I accept\n> 2. No, exit\n\nEnter to confirm"
+	launchSettingsFrame = "Settings requiring approval:\n  hooks\n> 1. Yes, I trust these settings\n  2. No, exit Claude Code\n\nEnter to confirm"
+	launchUnknownFrame  = "Some brand new dialog\n> 1. Sure\n  2. Nope\n\nEnter to confirm"
+)
+
+func TestConfirmLaunch(t *testing.T) {
+	tests := []struct {
+		name    string
+		harness string
+		frames  []string
+		wantErr string
+		// wantKeys is the whole key log, unless wantKeysRepeat marks a prompt the pane keeps
+		// re-showing, where it is only the first answer of however many the loop sent.
+		wantKeys       string
+		wantKeysRepeat bool
+	}{
+		{
+			name:    "quiet pane after the harness paints",
+			harness: "claude",
+			frames:  []string{launchReadyFrame},
+		},
+		{
+			// A bare Enter on the bypass dialog lands on "No, exit" and quits claude, so the
+			// Down that moves focus to "Yes, I accept" must be sent first and on its own.
+			name:     "answers the bypass prompt with Down before Enter",
+			harness:  "claude",
+			frames:   []string{launchBypassFrame, launchReadyFrame},
+			wantKeys: "Down\nEnter\n",
+		},
+		{
+			name:     "answers the workspace trust prompt",
+			harness:  "claude",
+			frames:   []string{launchTrustFrame, launchReadyFrame},
+			wantKeys: "Enter\n",
+		},
+		{
+			name:    "refuses the settings trust prompt instead of answering it",
+			harness: "claude",
+			frames:  []string{launchSettingsFrame},
+			wantErr: "waiting on the settings trust prompt",
+		},
+		{
+			name:    "an unrecognized dialog keeps resetting the quiet count",
+			harness: "claude",
+			frames:  []string{launchUnknownFrame},
+			wantErr: "no known signature covers",
+		},
+		{
+			name:           "an answered prompt that never clears is not blamed on an unknown dialog",
+			harness:        "claude",
+			frames:         []string{launchBypassFrame},
+			wantErr:        "answering the bypass permissions prompt is not clearing it",
+			wantKeys:       "Down\nEnter\n",
+			wantKeysRepeat: true,
+		},
+		{
+			name:    "the echoed launch command alone is not a started worker",
+			harness: "claude",
+			frames:  []string{launchEchoFrame},
+			wantErr: "never painted a startup frame",
+		},
+		{
+			name:    "a harness with no signatures is unconfirmable, not confirmed",
+			harness: "opencode",
+			frames:  []string{launchReadyFrame},
+			wantErr: errLaunchUnconfirmable.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useFastLaunchPolling(t)
+			keyLog := fakeLaunchPane(t, tt.frames...)
+
+			err := confirmLaunch(herdr.NewClient(), "wA:pC", tt.harness)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("confirmLaunch() = %v, want success", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("confirmLaunch() = nil, want error containing %q", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("confirmLaunch() = %v, want error containing %q", err, tt.wantErr)
+			}
+
+			keys, readErr := os.ReadFile(keyLog)
+			if readErr != nil && !os.IsNotExist(readErr) {
+				t.Fatal(readErr)
+			}
+			if tt.wantKeysRepeat {
+				if !strings.HasPrefix(string(keys), tt.wantKeys) {
+					t.Fatalf("keys sent = %q, want it to start with %q", keys, tt.wantKeys)
+				}
+			} else if string(keys) != tt.wantKeys {
+				t.Fatalf("keys sent = %q, want %q", keys, tt.wantKeys)
+			}
+		})
+	}
+}

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -185,30 +185,22 @@ func TestConfirmLaunch(t *testing.T) {
 			wantErr: "no known signature covers",
 		},
 		{
-			name:     "an answered prompt that never clears is answered exactly once",
+			// claude erases an answered dialog in place, so a read that still matches one means the
+			// dialog is still up. Keys go out once either way, and the launch fails on the deadline
+			// rather than being confirmed.
+			name:     "a dialog still matching after its answer fails instead of confirming",
 			harness:  "claude",
 			frames:   []launchFrame{live(launchBypassFrame)},
-			wantErr:  "answering the bypass permissions prompt is not clearing it",
+			wantErr:  "the bypass permissions prompt was answered, its text is still in the pane, and the harness never became ready",
 			wantKeys: "Down\nEnter\n",
 		},
 		{
-			// A recent-scrollback read keeps showing an answered dialog next to the frames that
-			// replaced it. Re-sending its keys there types into a live session, so an answer goes
-			// out once per dialog per launch and not once per frame that still matches.
-			name:     "a dialog lingering in scrollback after its answer is not answered again",
+			// claude's real first run: trust, then the bypass disclaimer, then the REPL with both
+			// dialogs erased. Each is answered once, in the order the catalogue lists them, and the
+			// worker is confirmed.
+			name:     "both first-run dialogs are answered in order and the launch is confirmed",
 			harness:  "claude",
-			frames:   []launchFrame{live(launchTrustFrame), live(launchTrustFrame + "\n" + launchReadyFrame)},
-			wantErr:  "answering the workspace trust prompt is not clearing it",
-			wantKeys: "Enter\n",
-		},
-		{
-			// claude paints trust first and bypass second, and the read holding both is the normal
-			// case once trust is answered - the dialog still waiting has to win over the one already
-			// dealt with, or hand answers nothing for the rest of the launch.
-			name:     "the next dialog is answered even while the answered one is still in the read",
-			harness:  "claude",
-			frames:   []launchFrame{live(launchTrustFrame), live(launchTrustFrame + "\n" + launchBypassFrame), live(launchTrustFrame + "\n" + launchReadyFrame)},
-			wantErr:  "answering the workspace trust prompt is not clearing it",
+			frames:   []launchFrame{live(launchTrustFrame), live(launchBypassFrame), live(launchReadyFrame)},
 			wantKeys: "Enter\nDown\nEnter\n",
 		},
 		{

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -204,14 +204,6 @@ func TestConfirmLaunch(t *testing.T) {
 			wantKeys: "Enter\n",
 		},
 		{
-			// Both dialogs are on screen, bypass painted first: answering by catalogue order sends
-			// this screen's trust Enter into the bypass dialog, where it lands on "No, exit".
-			name:     "the latest answerable dialog on screen is the one answered",
-			harness:  "claude",
-			frames:   []launchFrame{live(launchBypassFrame + "\n" + launchTrustFrame), live(launchReadyFrame)},
-			wantKeys: "Enter\n",
-		},
-		{
 			// codex has no verified agent detection, so "no agent" cannot be blamed on the harness
 			// without also naming the thing hand has not checked.
 			name:    "an unverified harness that is never labeled names the unexercised detection",

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -185,13 +185,31 @@ func TestConfirmLaunch(t *testing.T) {
 			wantErr: "no known signature covers",
 		},
 		{
-			// An unchanged frame is a dialog that has not repainted, so the answer is sent once
-			// and not re-injected on every poll for the rest of the timeout.
 			name:     "an answered prompt that never clears is answered exactly once",
 			harness:  "claude",
 			frames:   []launchFrame{live(launchBypassFrame)},
 			wantErr:  "answering the bypass permissions prompt is not clearing it",
 			wantKeys: "Down\nEnter\n",
+		},
+		{
+			// A recent-scrollback read keeps showing an answered dialog next to the frames that
+			// replaced it. Re-sending its keys there types into a live session, so an answer goes
+			// out once per dialog per launch and not once per frame that still matches.
+			name:     "a dialog lingering in scrollback after its answer is not answered again",
+			harness:  "claude",
+			frames:   []launchFrame{live(launchTrustFrame), live(launchTrustFrame + "\n" + launchReadyFrame)},
+			wantErr:  "answering the workspace trust prompt is not clearing it",
+			wantKeys: "Enter\n",
+		},
+		{
+			// claude paints trust first and bypass second, and the read holding both is the normal
+			// case once trust is answered - the dialog still waiting has to win over the one already
+			// dealt with, or hand answers nothing for the rest of the launch.
+			name:     "the next dialog is answered even while the answered one is still in the read",
+			harness:  "claude",
+			frames:   []launchFrame{live(launchTrustFrame), live(launchTrustFrame + "\n" + launchBypassFrame), live(launchTrustFrame + "\n" + launchReadyFrame)},
+			wantErr:  "answering the workspace trust prompt is not clearing it",
+			wantKeys: "Enter\nDown\nEnter\n",
 		},
 		{
 			// Issue #28's actual timeline: the pane starts as a bash prompt echoing the launch

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -193,6 +193,32 @@ func TestConfirmLaunch(t *testing.T) {
 			wantErr:  "answering the bypass permissions prompt is not clearing it",
 			wantKeys: "Down\nEnter\n",
 		},
+		{
+			// Issue #28's actual timeline: the pane starts as a bash prompt echoing the launch
+			// command, claude comes up a beat later on the trust dialog, then settles. pane.Agent
+			// is tested before the answer branch, so a regression there stops dialog-answering
+			// while every single-frame case above still passes.
+			name:     "a dialog that appears after a cold start is still answered",
+			harness:  "claude",
+			frames:   []launchFrame{exited(launchEchoFrame), live(launchTrustFrame), live(launchReadyFrame)},
+			wantKeys: "Enter\n",
+		},
+		{
+			// Both dialogs are on screen, bypass painted first: answering by catalogue order sends
+			// this screen's trust Enter into the bypass dialog, where it lands on "No, exit".
+			name:     "the latest answerable dialog on screen is the one answered",
+			harness:  "claude",
+			frames:   []launchFrame{live(launchBypassFrame + "\n" + launchTrustFrame), live(launchReadyFrame)},
+			wantKeys: "Enter\n",
+		},
+		{
+			// codex has no verified agent detection, so "no agent" cannot be blamed on the harness
+			// without also naming the thing hand has not checked.
+			name:    "an unverified harness that is never labeled names the unexercised detection",
+			harness: "codex",
+			frames:  []launchFrame{exited("$ cd '/tmp/wt' && codex --file '/tmp/brief.md'")},
+			wantErr: "no agent detected in pane; herdr agent detection for harness codex has not been exercised",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -26,10 +26,21 @@ func useFastLaunchPolling(t *testing.T) {
 	t.Cleanup(func() { launchPolling = previous })
 }
 
-// fakeLaunchPane installs a herdr fake that replays frames as successive "pane read" responses,
-// repeating the last one once they run out, and appends every key sent to a log the test reads
-// back. That is enough to drive confirmLaunch through a scripted pane lifecycle.
-func fakeLaunchPane(t *testing.T, frames ...string) (keyLog string) {
+// launchFrame is one poll's worth of pane state: what "pane read" shows and what agent, if any,
+// "pane get" reports running there. An empty agent is a pane holding no harness process.
+type launchFrame struct {
+	text  string
+	agent string
+}
+
+func live(text string) launchFrame   { return launchFrame{text: text, agent: "claude"} }
+func exited(text string) launchFrame { return launchFrame{text: text} }
+
+// fakeLaunchPane installs a herdr fake that replays frames as successive polls, repeating the
+// last one once they run out, and appends every key sent to a log the test reads back. A poll is
+// a "pane get" followed by a "pane read", so the get arm advances the frame and the read arm
+// serves whatever the get arm landed on.
+func fakeLaunchPane(t *testing.T, frames ...launchFrame) (keyLog string) {
 	t.Helper()
 	dir := t.TempDir()
 	framesDir := filepath.Join(dir, "frames")
@@ -37,19 +48,28 @@ func fakeLaunchPane(t *testing.T, frames ...string) (keyLog string) {
 		t.Fatal(err)
 	}
 	for i, frame := range frames {
-		if err := os.WriteFile(filepath.Join(framesDir, strconv.Itoa(i)), []byte(frame), 0o644); err != nil {
+		base := filepath.Join(framesDir, strconv.Itoa(i))
+		if err := os.WriteFile(base, []byte(frame.text), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(base+".agent", []byte(frame.agent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 	keyLog = filepath.Join(dir, "keys.log")
 	script := `#!/bin/sh
+last=$(($LAUNCH_FRAME_COUNT - 1))
 case "$1 $2" in
-"pane read")
+"pane get")
 	n=$(cat "$LAUNCH_FRAME_COUNTER" 2>/dev/null || echo 0)
 	echo $((n + 1)) > "$LAUNCH_FRAME_COUNTER"
-	last=$(($LAUNCH_FRAME_COUNT - 1))
 	[ "$n" -gt "$last" ] && n=$last
-	cat "$LAUNCH_FRAMES_DIR/$n"
+	echo "$n" > "$LAUNCH_FRAME_CURRENT"
+	agent=$(cat "$LAUNCH_FRAMES_DIR/$n.agent")
+	printf '{"result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"%s","agent_status":"idle"}}}' "$3" "$agent"
+	;;
+"pane read")
+	cat "$LAUNCH_FRAMES_DIR/$(cat "$LAUNCH_FRAME_CURRENT")"
 	;;
 "pane send-keys")
 	shift 3
@@ -69,6 +89,7 @@ esac
 	t.Setenv("LAUNCH_FRAMES_DIR", framesDir)
 	t.Setenv("LAUNCH_FRAME_COUNT", strconv.Itoa(len(frames)))
 	t.Setenv("LAUNCH_FRAME_COUNTER", filepath.Join(dir, "counter"))
+	t.Setenv("LAUNCH_FRAME_CURRENT", filepath.Join(dir, "current"))
 	t.Setenv("LAUNCH_KEY_LOG", keyLog)
 	return keyLog
 }
@@ -76,73 +97,101 @@ esac
 const (
 	launchEchoFrame     = "$ cd '/tmp/wt' && claude --dangerously-skip-permissions 'Read the brief'"
 	launchReadyFrame    = "Welcome to Claude Code\n\n> \n  ? for shortcuts"
+	launchBypassOnFrame = "> \n  secondhand (fm/x)\n  bypass permissions on (shift+tab to cycle)"
 	launchTrustFrame    = "Do you trust the files in this folder?\n> 1. Yes, I trust this folder\n  2. No\n\nEnter to confirm"
 	launchBypassFrame   = "WARNING: Bypass Permissions mode\n  1. Yes, I accept\n> 2. No, exit\n\nEnter to confirm"
-	launchSettingsFrame = "Settings requiring approval:\n  hooks\n> 1. Yes, I trust these settings\n  2. No, exit Claude Code\n\nEnter to confirm"
+	launchSettingsFrame = "Managed settings require approval\n\nSettings requiring approval:\n  hooks\n> 1. Yes, I trust these settings\n  2. No, exit Claude Code\n\nEnter to confirm"
 	launchUnknownFrame  = "Some brand new dialog\n> 1. Sure\n  2. Nope\n\nEnter to confirm"
 )
 
 func TestConfirmLaunch(t *testing.T) {
 	tests := []struct {
-		name    string
-		harness string
-		frames  []string
-		wantErr string
-		// wantKeys is the whole key log, unless wantKeysRepeat marks a prompt the pane keeps
-		// re-showing, where it is only the first answer of however many the loop sent.
-		wantKeys       string
-		wantKeysRepeat bool
+		name     string
+		harness  string
+		frames   []launchFrame
+		wantErr  string
+		wantKeys string
 	}{
 		{
-			name:    "quiet pane after the harness paints",
+			name:    "a live agent on a quiet pane is confirmed",
 			harness: "claude",
-			frames:  []string{launchReadyFrame},
+			frames:  []launchFrame{live(launchReadyFrame)},
+		},
+		{
+			name:    "the bypass-mode footer also reads as claude having started",
+			harness: "claude",
+			frames:  []launchFrame{live(launchBypassOnFrame)},
+		},
+		{
+			// The point of taking liveness from herdr: nothing on this screen is recognizable,
+			// but herdr reports a harness running on the pane, so the worker did start.
+			name:    "a live agent whose screen text is unrecognizable is still confirmed",
+			harness: "claude",
+			frames:  []launchFrame{live(launchEchoFrame)},
+		},
+		{
+			// A harness with no catalogued signatures at all is confirmed the same way, rather
+			// than being reported as unconfirmable.
+			name:    "a harness with no signatures is confirmed on agent presence",
+			harness: "opencode",
+			frames:  []launchFrame{{text: "opencode ready", agent: "opencode"}},
+		},
+		{
+			// The failure this whole function exists for: the dialog text is still on screen but
+			// the harness behind it is gone, so there is no worker to confirm.
+			name:    "a harness that exited on a dialog is not confirmed",
+			harness: "claude",
+			frames:  []launchFrame{exited(launchBypassFrame)},
+			wantErr: "the harness exited on a first-run dialog instead of starting up",
+		},
+		{
+			name:    "leftover startup text from an exited harness is not confirmed",
+			harness: "claude",
+			frames:  []launchFrame{exited(launchReadyFrame)},
+			wantErr: "the harness never started in the pane",
 		},
 		{
 			// A bare Enter on the bypass dialog lands on "No, exit" and quits claude, so the
 			// Down that moves focus to "Yes, I accept" must be sent first and on its own.
 			name:     "answers the bypass prompt with Down before Enter",
 			harness:  "claude",
-			frames:   []string{launchBypassFrame, launchReadyFrame},
+			frames:   []launchFrame{live(launchBypassFrame), live(launchReadyFrame)},
 			wantKeys: "Down\nEnter\n",
 		},
 		{
 			name:     "answers the workspace trust prompt",
 			harness:  "claude",
-			frames:   []string{launchTrustFrame, launchReadyFrame},
+			frames:   []launchFrame{live(launchTrustFrame), live(launchReadyFrame)},
 			wantKeys: "Enter\n",
 		},
 		{
-			name:    "refuses the settings trust prompt instead of answering it",
+			name:    "refuses the managed settings prompt instead of answering it",
 			harness: "claude",
-			frames:  []string{launchSettingsFrame},
-			wantErr: "waiting on the settings trust prompt",
+			frames:  []launchFrame{live(launchSettingsFrame)},
+			wantErr: "waiting on the managed settings prompt",
+		},
+		{
+			// The refused signature is catalogued after the answerable one, so answering by list
+			// order would send keys into a dialog hand has decided not to answer.
+			name:    "a refused prompt wins over an answerable one on the same screen",
+			harness: "claude",
+			frames:  []launchFrame{live(launchTrustFrame + "\n" + launchSettingsFrame)},
+			wantErr: "waiting on the managed settings prompt",
 		},
 		{
 			name:    "an unrecognized dialog keeps resetting the quiet count",
 			harness: "claude",
-			frames:  []string{launchUnknownFrame},
+			frames:  []launchFrame{live(launchUnknownFrame)},
 			wantErr: "no known signature covers",
 		},
 		{
-			name:           "an answered prompt that never clears is not blamed on an unknown dialog",
-			harness:        "claude",
-			frames:         []string{launchBypassFrame},
-			wantErr:        "answering the bypass permissions prompt is not clearing it",
-			wantKeys:       "Down\nEnter\n",
-			wantKeysRepeat: true,
-		},
-		{
-			name:    "the echoed launch command alone is not a started worker",
-			harness: "claude",
-			frames:  []string{launchEchoFrame},
-			wantErr: "never painted a startup frame",
-		},
-		{
-			name:    "a harness with no signatures is unconfirmable, not confirmed",
-			harness: "opencode",
-			frames:  []string{launchReadyFrame},
-			wantErr: errLaunchUnconfirmable.Error(),
+			// An unchanged frame is a dialog that has not repainted, so the answer is sent once
+			// and not re-injected on every poll for the rest of the timeout.
+			name:     "an answered prompt that never clears is answered exactly once",
+			harness:  "claude",
+			frames:   []launchFrame{live(launchBypassFrame)},
+			wantErr:  "answering the bypass permissions prompt is not clearing it",
+			wantKeys: "Down\nEnter\n",
 		},
 	}
 
@@ -165,11 +214,7 @@ func TestConfirmLaunch(t *testing.T) {
 			if readErr != nil && !os.IsNotExist(readErr) {
 				t.Fatal(readErr)
 			}
-			if tt.wantKeysRepeat {
-				if !strings.HasPrefix(string(keys), tt.wantKeys) {
-					t.Fatalf("keys sent = %q, want it to start with %q", keys, tt.wantKeys)
-				}
-			} else if string(keys) != tt.wantKeys {
+			if string(keys) != tt.wantKeys {
 				t.Fatalf("keys sent = %q, want %q", keys, tt.wantKeys)
 			}
 		})

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -153,7 +153,7 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
-			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
+			if err := confirmLaunchOrWarn(cmd, client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
 

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -153,6 +153,10 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
+			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
+			}
+
 			// Dashboard is deliberately left untouched: the task's row stays
 			// KindScout even though the underlying task becomes a ship task.
 			t.Kind = state.KindShip

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -153,7 +153,7 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
-			if err := confirmLaunchOrWarn(cmd, client, pane.PaneID, harnessName); err != nil {
+			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -32,6 +32,9 @@ case "$cmd" in
 "pane run")
 	printf '{"id":"cli:1","result":{}}'
 	;;
+"pane read")
+	printf ''
+	;;
 *)
 	echo "unexpected herdr args: $@" >&2
 	exit 1

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -33,7 +33,7 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{}}'
 	;;
 "pane read")
-	printf ''
+	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
 	;;
 *)
 	echo "unexpected herdr args: $@" >&2
@@ -57,6 +57,7 @@ esac
 
 func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string) string {
 	t.Helper()
+	useFastLaunchPolling(t)
 	home := t.TempDir()
 
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -15,7 +15,7 @@ const fakeHerdrPromoteScript = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
 "pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pOld","tab_id":"wA:tOld","workspace_id":"wA","agent_status":"done"}}}'
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tOld","workspace_id":"wA","agent":"claude","agent_status":"done"}}}' "$3"
 	;;
 "tab list")
 	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tOld","workspace_id":"wA"},{"tab_id":"wA:tOther","workspace_id":"wA"}]}}'

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -139,7 +139,7 @@ func newSpawnCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
-			if err := confirmLaunchOrWarn(cmd, client, pane.PaneID, harnessName); err != nil {
+			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
 

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -139,6 +139,10 @@ func newSpawnCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
+			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
+			}
+
 			kind := state.KindShip
 			if scout {
 				kind = state.KindScout

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -139,7 +139,7 @@ func newSpawnCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
 
-			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
+			if err := confirmLaunchOrWarn(cmd, client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
 

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -27,6 +27,8 @@ func TestSpawnCleanupReportsAllErrors(t *testing.T) {
 	}
 }
 
+// fakeHerdrSpawnScript reports a claude pane that has painted its startup frame and shows no
+// first-run dialog, so confirmLaunch confirms the launch on its first read.
 const fakeHerdrSpawnScript = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -40,7 +42,7 @@ case "$cmd" in
  printf '{"id":"cli:1","result":{}}'
 	;;
 "pane read")
-	printf ''
+	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
 	;;
 *)
 	echo "unexpected herdr args: $@" >&2
@@ -51,6 +53,7 @@ esac
 
 func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 	t.Helper()
+	useFastLaunchPolling(t)
 	home := t.TempDir()
 
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
@@ -253,6 +256,61 @@ func setupSpawnLeakEnv(t *testing.T, workspaceExists bool) string {
 	}
 	t.Setenv("HERDR_WS_EXISTS_FLAG", flag)
 	return callLog
+}
+
+// fakeHerdrStuckPaneScript launches fine but reports a pane sitting on a dialog nothing
+// answers, the shape confirmLaunch must fail rather than record as a spawned task.
+const fakeHerdrStuckPaneScript = `#!/bin/sh
+echo "$@" >> "$HERDR_CALL_LOG"
+cmd="$1 $2"
+case "$cmd" in
+"workspace list")
+	printf '{"id":"cli:1","result":{"workspaces":[]}}'
+	;;
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	;;
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+	;;
+"pane run")
+	printf '{"id":"cli:1","result":{}}'
+	;;
+"pane read")
+	printf 'Some brand new dialog\n> 1. Sure\n  2. Nope\n\nEnter to confirm\n'
+	;;
+"workspace close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func TestSpawnRollsBackWhenWorkerNeverStarts(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, fakeHerdrStuckPaneScript)
+	callLog := setupSpawnLeakEnv(t, false)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "confirm worker started") {
+		t.Fatalf("got err %v, want the spawn to fail on launch confirmation", err)
+	}
+
+	if exists, existsErr := state.Exists(home, "task-1"); existsErr != nil || exists {
+		t.Fatalf("state written for a worker that never started: exists=%v err=%v", exists, existsErr)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace hand created to be closed", calls)
+	}
 }
 
 func TestSpawnFailureClosesWorkspaceItCreated(t *testing.T) {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -27,8 +27,8 @@ func TestSpawnCleanupReportsAllErrors(t *testing.T) {
 	}
 }
 
-// fakeHerdrSpawnScript reports a claude pane that has painted its startup frame and shows no
-// first-run dialog, so confirmLaunch confirms the launch on its first read.
+// fakeHerdrSpawnScript reports a pane herdr sees claude running in, painted past its startup
+// frame and showing no first-run dialog, so confirmLaunch confirms the launch on its first poll.
 const fakeHerdrSpawnScript = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
@@ -40,6 +40,9 @@ case "$cmd" in
 	;;
 "pane run")
  printf '{"id":"cli:1","result":{}}'
+	;;
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"claude","agent_status":"idle"}}}' "$3"
 	;;
 "pane read")
 	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
@@ -275,6 +278,9 @@ case "$cmd" in
 	;;
 "pane run")
 	printf '{"id":"cli:1","result":{}}'
+	;;
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"claude","agent_status":"idle"}}}' "$3"
 	;;
 "pane read")
 	printf 'Some brand new dialog\n> 1. Sure\n  2. Nope\n\nEnter to confirm\n'

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -39,6 +39,9 @@ case "$cmd" in
 "pane run")
  printf '{"id":"cli:1","result":{}}'
 	;;
+"pane read")
+	printf ''
+	;;
 *)
 	echo "unexpected herdr args: $@" >&2
 	exit 1

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -43,8 +43,9 @@ type FirstRunPrompt struct {
 // screen" that no Known entry matches. Ready is the harness's own startup paint, a secondary
 // signal that a pane herdr already reports a running agent on has finished starting; a harness
 // with no Ready signature is still confirmed, just by waiting out the settle window. A zero
-// value means no dialog on this harness is recognized, so any dialog it stops on runs out the
-// launch timeout rather than being answered.
+// value leaves the launch confirmed on agent presence alone, so a harness with no catalogued
+// signatures that parks on a dialog is still reported as started - a known, accepted gap, and
+// the reason the catalogue matters for every harness added here, not only claude.
 type FirstRunPrompts struct {
 	Ready        *regexp.Regexp
 	Known        []FirstRunPrompt
@@ -94,6 +95,22 @@ var firstRunPrompts = map[string]FirstRunPrompts{
 // has none.
 func FirstRunPromptsFor(name string) FirstRunPrompts {
 	return firstRunPrompts[name]
+}
+
+// agentDetectionVerified lists the harnesses whose panes herdr has been observed labeling with
+// an agent, by running the real binary in a real pane. The others ship a detection manifest
+// under herdr's agent-detection state dir, read but never exercised here because no binary for
+// them is installed on this host.
+var agentDetectionVerified = map[string]bool{
+	Claude:   true,
+	OpenCode: true,
+}
+
+// AgentDetectionVerified reports whether herdr's agent labeling has actually been exercised
+// against name. A launch that never sees an agent means something different for the two cases,
+// and the failure has to say which.
+func AgentDetectionVerified(name string) bool {
+	return agentDetectionVerified[name]
 }
 
 type Options struct {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -28,7 +28,7 @@ func IsSupported(name string) bool {
 }
 
 // FirstRunPrompt is one interactive dialog a harness may show before it starts reading the
-// brief. Match is checked against the pane's recent scrollback text. Exactly one of Keys and
+// brief. Match is checked against the pane's visible viewport text. Exactly one of Keys and
 // Refuse is set: Keys answer the dialog unattended, while a non-empty Refuse marks a dialog
 // that is recognized but deliberately left for a human, and its text says why.
 type FirstRunPrompt struct {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -3,6 +3,7 @@ package harness
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -24,6 +25,56 @@ var supported = map[string]bool{
 
 func IsSupported(name string) bool {
 	return supported[name]
+}
+
+// FirstRunPrompt is one interactive dialog a harness may show before it starts reading the
+// brief, along with the keys that answer it. Match is checked against the pane's recent
+// scrollback text.
+type FirstRunPrompt struct {
+	Name  string
+	Match *regexp.Regexp
+	Keys  []string
+}
+
+// FirstRunPrompts is a harness's known first-run dialogs plus a generic fallback pattern for
+// recognizing "some dialog is still on screen" even when it doesn't match any Known entry.
+// Unrecognized being nil means any non-blank pane content is treated as a possible unanswered
+// dialog until it goes quiet - the safe default for a harness with no verified signatures.
+type FirstRunPrompts struct {
+	Known        []FirstRunPrompt
+	Unrecognized *regexp.Regexp
+}
+
+// firstRunPrompts holds verified signatures per harness. Only claude has been verified against
+// a real first run (see cmd/launch.go); every other harness gets the empty value, which
+// confirmLaunch treats as "confirm the pane goes quiet, answer nothing."
+var firstRunPrompts = map[string]FirstRunPrompts{
+	Claude: {
+		Known: []FirstRunPrompt{
+			{
+				Name:  "workspace trust",
+				Match: regexp.MustCompile(`Yes,\s+I\s+trust\s+this\s+folder`),
+				Keys:  []string{"Enter"},
+			},
+			{
+				// Defaults focus to "No, exit" - a blind Enter declines it, so this needs Down
+				// first to reach "Yes, I accept" before confirming.
+				Name:  "bypass permissions",
+				Match: regexp.MustCompile(`Bypass\s+Permissions\s+mode`),
+				Keys:  []string{"Down", "Enter"},
+			},
+		},
+		// Both dialogs above end in this footer, wrapped or not; a harness update that
+		// reshuffles their wording still trips this fallback instead of confirmLaunch mistaking
+		// the dialog for a finished worker.
+		Unrecognized: regexp.MustCompile(`Enter\s+to\s+confirm`),
+	},
+}
+
+// FirstRunPromptsFor returns name's known first-run dialogs, or the empty value (answer
+// nothing, just confirm the pane goes quiet) if name has none verified.
+func FirstRunPromptsFor(name string) FirstRunPrompts {
+	return firstRunPrompts[name]
 }
 
 type Options struct {
@@ -68,8 +119,9 @@ func Build(name string, opts Options) (string, error) {
 // predicted-next-prompt ghost text, which would otherwise read to a pane-watching supervisor
 // as the worker having typed input while actually idle. Interactive claude also gates on two
 // first-run dialogs that --print skipped (workspace trust, bypass-permissions disclaimer); both
-// are one-time host setup, documented under Harness launch templates in SPECS.md. Known
-// limitation tracked at https://github.com/atqamz/secondhand/issues/28.
+// are one-time host setup, documented under Harness launch templates in SPECS.md. Their
+// signatures live in firstRunPrompts above, and cmd/launch.go's confirmLaunch clears them
+// after every spawn/promote instead of leaving them for an operator to notice and answer.
 func buildClaude(o Options) string {
 	args := []string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false", "claude", "--dangerously-skip-permissions"}
 	if o.Model != "" {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -28,28 +28,36 @@ func IsSupported(name string) bool {
 }
 
 // FirstRunPrompt is one interactive dialog a harness may show before it starts reading the
-// brief, along with the keys that answer it. Match is checked against the pane's recent
-// scrollback text.
+// brief. Match is checked against the pane's recent scrollback text. Exactly one of Keys and
+// Refuse is set: Keys answer the dialog unattended, while a non-empty Refuse marks a dialog
+// that is recognized but deliberately left for a human, and its text says why.
 type FirstRunPrompt struct {
-	Name  string
-	Match *regexp.Regexp
-	Keys  []string
+	Name   string
+	Match  *regexp.Regexp
+	Keys   []string
+	Refuse string
 }
 
-// FirstRunPrompts is a harness's known first-run dialogs plus a generic fallback pattern for
-// recognizing "some dialog is still on screen" even when it doesn't match any Known entry.
-// Unrecognized being nil means any non-blank pane content is treated as a possible unanswered
-// dialog until it goes quiet - the safe default for a harness with no verified signatures.
+// FirstRunPrompts is a harness's verified pane signatures. Ready is the harness's own startup
+// paint, the proof that the pane holds harness output rather than just the echoed launch
+// command. Known are the dialogs whose exact wording is catalogued, and Unrecognized is a
+// generic fallback for "some dialog is still on screen" that no Known entry matches. A zero
+// value (Ready nil) means the harness has no verified signatures at all, so a launch cannot be
+// confirmed either way - never that it silently passed.
 type FirstRunPrompts struct {
+	Ready        *regexp.Regexp
 	Known        []FirstRunPrompt
 	Unrecognized *regexp.Regexp
 }
 
 // firstRunPrompts holds verified signatures per harness. Only claude has been verified against
-// a real first run (see cmd/launch.go); every other harness gets the empty value, which
-// confirmLaunch treats as "confirm the pane goes quiet, answer nothing."
+// a real first run (see cmd/launch.go); every other harness gets the zero value.
 var firstRunPrompts = map[string]FirstRunPrompts{
 	Claude: {
+		// claude's own startup paint: the splash banner, or the composer footer hint once the
+		// REPL is up. Neither string can come from the echoed launch command, so matching one
+		// is proof claude itself drew a frame rather than the pane merely being slow to start.
+		Ready: regexp.MustCompile(`Welcome\s+to\s+Claude\s+Code|\?\s+for\s+shortcuts`),
 		Known: []FirstRunPrompt{
 			{
 				Name:  "workspace trust",
@@ -63,16 +71,23 @@ var firstRunPrompts = map[string]FirstRunPrompts{
 				Match: regexp.MustCompile(`Bypass\s+Permissions\s+mode`),
 				Keys:  []string{"Down", "Enter"},
 			},
+			{
+				// Accepting this one activates whatever hooks and commands the checked-out
+				// branch happens to ship, so hand will not accept it on the operator's behalf.
+				Name:   "settings trust",
+				Match:  regexp.MustCompile(`Settings\s+requiring\s+approval|Yes,\s+I\s+trust\s+these\s+settings`),
+				Refuse: "the project ships settings requiring approval, which hand will not accept for you; approve them once by running claude in the project clone yourself, then respawn",
+			},
 		},
-		// Both dialogs above end in this footer, wrapped or not; a harness update that
+		// Every dialog above ends in this footer, wrapped or not; a harness update that
 		// reshuffles their wording still trips this fallback instead of confirmLaunch mistaking
-		// the dialog for a finished worker.
+		// the dialog for a started worker.
 		Unrecognized: regexp.MustCompile(`Enter\s+to\s+confirm`),
 	},
 }
 
-// FirstRunPromptsFor returns name's known first-run dialogs, or the empty value (answer
-// nothing, just confirm the pane goes quiet) if name has none verified.
+// FirstRunPromptsFor returns name's verified first-run signatures, or the zero value if name
+// has none.
 func FirstRunPromptsFor(name string) FirstRunPrompts {
 	return firstRunPrompts[name]
 }
@@ -117,11 +132,12 @@ func Build(name string, opts Options) (string, error) {
 // --print). --dangerously-skip-permissions is required or an unattended worker stalls on a
 // permission prompt. CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false suppresses claude's dim
 // predicted-next-prompt ghost text, which would otherwise read to a pane-watching supervisor
-// as the worker having typed input while actually idle. Interactive claude also gates on two
-// first-run dialogs that --print skipped (workspace trust, bypass-permissions disclaimer); both
-// are one-time host setup, documented under Harness launch templates in SPECS.md. Their
-// signatures live in firstRunPrompts above, and cmd/launch.go's confirmLaunch clears them
-// after every spawn/promote instead of leaving them for an operator to notice and answer.
+// as the worker having typed input while actually idle. Interactive claude also gates on
+// first-run dialogs that --print skipped (workspace trust, bypass-permissions disclaimer), and
+// a fresh worktree path means the trust one appears on every spawn, not just on a fresh host -
+// documented under Harness launch templates in SPECS.md. Their signatures live in
+// firstRunPrompts above, and cmd/launch.go's confirmLaunch clears them after every
+// spawn/promote instead of leaving them for an operator to notice and answer.
 func buildClaude(o Options) string {
 	args := []string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false", "claude", "--dangerously-skip-permissions"}
 	if o.Model != "" {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -28,7 +28,7 @@ func IsSupported(name string) bool {
 }
 
 // FirstRunPrompt is one interactive dialog a harness may show before it starts reading the
-// brief. Match is checked against the pane's visible viewport text. Exactly one of Keys and
+// brief. Match is checked against the pane's recent scrollback text. Exactly one of Keys and
 // Refuse is set: Keys answer the dialog unattended, while a non-empty Refuse marks a dialog
 // that is recognized but deliberately left for a human, and its text says why.
 type FirstRunPrompt struct {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -38,12 +38,13 @@ type FirstRunPrompt struct {
 	Refuse string
 }
 
-// FirstRunPrompts is a harness's verified pane signatures. Ready is the harness's own startup
-// paint, the proof that the pane holds harness output rather than just the echoed launch
-// command. Known are the dialogs whose exact wording is catalogued, and Unrecognized is a
-// generic fallback for "some dialog is still on screen" that no Known entry matches. A zero
-// value (Ready nil) means the harness has no verified signatures at all, so a launch cannot be
-// confirmed either way - never that it silently passed.
+// FirstRunPrompts is a harness's verified pane signatures. Known are the dialogs whose exact
+// wording is catalogued, and Unrecognized is a generic fallback for "some dialog is still on
+// screen" that no Known entry matches. Ready is the harness's own startup paint, a secondary
+// signal that a pane herdr already reports a running agent on has finished starting; a harness
+// with no Ready signature is still confirmed, just by waiting out the settle window. A zero
+// value means no dialog on this harness is recognized, so any dialog it stops on runs out the
+// launch timeout rather than being answered.
 type FirstRunPrompts struct {
 	Ready        *regexp.Regexp
 	Known        []FirstRunPrompt
@@ -51,13 +52,14 @@ type FirstRunPrompts struct {
 }
 
 // firstRunPrompts holds verified signatures per harness. Only claude has been verified against
-// a real first run (see cmd/launch.go); every other harness gets the zero value.
+// a real first run (see cmd/launch.go); every other harness gets the zero value until one is.
 var firstRunPrompts = map[string]FirstRunPrompts{
 	Claude: {
-		// claude's own startup paint: the splash banner, or the composer footer hint once the
-		// REPL is up. Neither string can come from the echoed launch command, so matching one
-		// is proof claude itself drew a frame rather than the pane merely being slow to start.
-		Ready: regexp.MustCompile(`Welcome\s+to\s+Claude\s+Code|\?\s+for\s+shortcuts`),
+		// claude's own startup paint: the splash banner, or one of the two composer footer hints
+		// once the REPL is up (the bypass-mode line replaces the shortcuts hint whenever the
+		// footer is wide enough to show it). None of these can come from the echoed launch
+		// command, so matching one means claude itself drew a frame.
+		Ready: regexp.MustCompile(`Welcome\s+to\s+Claude\s+Code|\?\s+for\s+shortcuts|bypass\s+permissions\s+on`),
 		Known: []FirstRunPrompt{
 			{
 				Name:  "workspace trust",
@@ -72,11 +74,13 @@ var firstRunPrompts = map[string]FirstRunPrompts{
 				Keys:  []string{"Down", "Enter"},
 			},
 			{
-				// Accepting this one activates whatever hooks and commands the checked-out
-				// branch happens to ship, so hand will not accept it on the operator's behalf.
-				Name:   "settings trust",
-				Match:  regexp.MustCompile(`Settings\s+requiring\s+approval|Yes,\s+I\s+trust\s+these\s+settings`),
-				Refuse: "the project ships settings requiring approval, which hand will not accept for you; approve them once by running claude in the project clone yourself, then respawn",
+				// Nothing to do with the checked-out repo: this is claude's security dialog for
+				// managed settings this host's organization policy applies to every run, and
+				// accepting it grants arbitrary code execution and prompt interception. That is
+				// a trust decision about the host, so hand will not make it for the operator.
+				Name:   "managed settings",
+				Match:  regexp.MustCompile(`Managed\s+settings\s+require\s+approval|Yes,\s+I\s+trust\s+these\s+settings`),
+				Refuse: "this host has managed settings claude requires approval for, which hand will not accept for you; run claude yourself on this host once and accept the managed-settings prompt, then respawn",
 			},
 		},
 		// Every dialog above ends in this footer, wrapped or not; a harness update that

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -150,3 +150,53 @@ func TestShellQuoteEscapesSingleQuotes(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 }
+
+// TestFirstRunPromptsClaude pins the shape confirmLaunch depends on: a readiness signature to
+// gate on, answerable dialogs carrying keys, and the settings-trust dialog catalogued as
+// recognized-but-refused so it fails fast instead of looking uncatalogued.
+func TestFirstRunPromptsClaude(t *testing.T) {
+	prompts := FirstRunPromptsFor(Claude)
+	if prompts.Ready == nil || prompts.Unrecognized == nil {
+		t.Fatalf("got %+v, want readiness and unrecognized signatures", prompts)
+	}
+	if !prompts.Ready.MatchString("Welcome to Claude Code") || !prompts.Ready.MatchString("? for shortcuts") {
+		t.Fatal("readiness signature matches neither claude startup frame")
+	}
+	if prompts.Ready.MatchString("cd '/tmp/wt' && claude --dangerously-skip-permissions 'Read the brief'") {
+		t.Fatal("readiness signature matches the echoed launch command, so a pane that never started reads as ready")
+	}
+
+	byName := map[string]FirstRunPrompt{}
+	for _, prompt := range prompts.Known {
+		if (len(prompt.Keys) == 0) == (prompt.Refuse == "") {
+			t.Fatalf("prompt %q must set exactly one of Keys and Refuse, got %+v", prompt.Name, prompt)
+		}
+		byName[prompt.Name] = prompt
+	}
+
+	bypass := byName["bypass permissions"]
+	if !bypass.Match.MatchString("WARNING: Bypass Permissions mode") {
+		t.Fatal("bypass permissions signature does not match the dialog")
+	}
+	if strings.Join(bypass.Keys, ",") != "Down,Enter" {
+		t.Fatalf("bypass permissions keys = %v, want Down before Enter (a bare Enter lands on \"No, exit\" and quits claude)", bypass.Keys)
+	}
+	if got := byName["workspace trust"]; strings.Join(got.Keys, ",") != "Enter" {
+		t.Fatalf("workspace trust keys = %v, want Enter", got.Keys)
+	}
+	settings := byName["settings trust"]
+	if settings.Refuse == "" {
+		t.Fatal("settings trust must be refused, not answered on the operator's behalf")
+	}
+	if !settings.Match.MatchString("Settings requiring approval:") || !settings.Match.MatchString("Yes, I trust these settings") {
+		t.Fatal("settings trust signature does not match the dialog")
+	}
+}
+
+func TestFirstRunPromptsUnverifiedHarness(t *testing.T) {
+	for _, name := range []string{Codex, Grok, Pi, OpenCode, "nonexistent"} {
+		if FirstRunPromptsFor(name).Ready != nil {
+			t.Errorf("FirstRunPromptsFor(%q) claims a verified readiness signature", name)
+		}
+	}
+}

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -195,6 +195,21 @@ func TestFirstRunPromptsClaude(t *testing.T) {
 	}
 }
 
+// TestAgentDetectionVerified pins the two harnesses actually run in a real pane and observed
+// being labeled by herdr; the rest must stay false until each is exercised the same way.
+func TestAgentDetectionVerified(t *testing.T) {
+	for _, name := range []string{Claude, OpenCode} {
+		if !AgentDetectionVerified(name) {
+			t.Errorf("AgentDetectionVerified(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{Codex, Grok, Pi, "nonexistent"} {
+		if AgentDetectionVerified(name) {
+			t.Errorf("AgentDetectionVerified(%q) = true, want false until herdr detection is exercised against it", name)
+		}
+	}
+}
+
 func TestFirstRunPromptsUnverifiedHarness(t *testing.T) {
 	for _, name := range []string{Codex, Grok, Pi, OpenCode, "nonexistent"} {
 		if got := FirstRunPromptsFor(name); got.Ready != nil || got.Known != nil || got.Unrecognized != nil {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -151,16 +151,18 @@ func TestShellQuoteEscapesSingleQuotes(t *testing.T) {
 	}
 }
 
-// TestFirstRunPromptsClaude pins the shape confirmLaunch depends on: a readiness signature to
-// gate on, answerable dialogs carrying keys, and the settings-trust dialog catalogued as
-// recognized-but-refused so it fails fast instead of looking uncatalogued.
+// TestFirstRunPromptsClaude pins the shape confirmLaunch depends on: a startup signature for
+// each frame claude settles into, answerable dialogs carrying keys, and the managed-settings
+// dialog catalogued as recognized-but-refused so it fails fast instead of looking uncatalogued.
 func TestFirstRunPromptsClaude(t *testing.T) {
 	prompts := FirstRunPromptsFor(Claude)
 	if prompts.Ready == nil || prompts.Unrecognized == nil {
 		t.Fatalf("got %+v, want readiness and unrecognized signatures", prompts)
 	}
-	if !prompts.Ready.MatchString("Welcome to Claude Code") || !prompts.Ready.MatchString("? for shortcuts") {
-		t.Fatal("readiness signature matches neither claude startup frame")
+	for _, frame := range []string{"Welcome to Claude Code", "? for shortcuts", "bypass permissions on (shift+tab to cycle)"} {
+		if !prompts.Ready.MatchString(frame) {
+			t.Errorf("readiness signature does not match claude startup frame %q", frame)
+		}
 	}
 	if prompts.Ready.MatchString("cd '/tmp/wt' && claude --dangerously-skip-permissions 'Read the brief'") {
 		t.Fatal("readiness signature matches the echoed launch command, so a pane that never started reads as ready")
@@ -184,19 +186,19 @@ func TestFirstRunPromptsClaude(t *testing.T) {
 	if got := byName["workspace trust"]; strings.Join(got.Keys, ",") != "Enter" {
 		t.Fatalf("workspace trust keys = %v, want Enter", got.Keys)
 	}
-	settings := byName["settings trust"]
-	if settings.Refuse == "" {
-		t.Fatal("settings trust must be refused, not answered on the operator's behalf")
+	managed := byName["managed settings"]
+	if managed.Refuse == "" {
+		t.Fatal("managed settings must be refused, not answered on the operator's behalf")
 	}
-	if !settings.Match.MatchString("Settings requiring approval:") || !settings.Match.MatchString("Yes, I trust these settings") {
-		t.Fatal("settings trust signature does not match the dialog")
+	if !managed.Match.MatchString("Managed settings require approval") || !managed.Match.MatchString("Yes, I trust these settings") {
+		t.Fatal("managed settings signature does not match the dialog")
 	}
 }
 
 func TestFirstRunPromptsUnverifiedHarness(t *testing.T) {
 	for _, name := range []string{Codex, Grok, Pi, OpenCode, "nonexistent"} {
-		if FirstRunPromptsFor(name).Ready != nil {
-			t.Errorf("FirstRunPromptsFor(%q) claims a verified readiness signature", name)
+		if got := FirstRunPromptsFor(name); got.Ready != nil || got.Known != nil || got.Unrecognized != nil {
+			t.Errorf("FirstRunPromptsFor(%q) = %+v, want no unverified signatures", name, got)
 		}
 	}
 }

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -249,15 +249,18 @@ func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
 // than visible so a first-run dialog is still captured even in a pane too short to fit it in
 // the current viewport. Unlike every command above, herdr's own contract for pane read is a
 // third shape: raw text on success, and on failure a bare {"code","message"} object rather than
-// the {"error":{...}} envelope call and callVoid expect.
+// the {"error":{...}} envelope call and callVoid expect. That body is checked ahead of the exit
+// status for the same reason callVoid checks its envelope first - herdr's exit code cannot be
+// trusted on its own - and here a failure read as pane text would confirm a worker no one
+// observed.
 func (c *Client) PaneRead(paneID string, lines int) (string, error) {
 	args := []string{"pane", "read", paneID, "--source", "recent", "--lines", strconv.Itoa(lines)}
 	stdout, stderr, runErr := c.run(args...)
+	var eb errorBody
+	if json.Unmarshal(stdout, &eb) == nil && eb.Code != "" && eb.Message != "" {
+		return "", fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), eb.Code, eb.Message)
+	}
 	if runErr != nil {
-		var eb errorBody
-		if json.Unmarshal(stdout, &eb) == nil && eb.Message != "" {
-			return "", fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), eb.Code, eb.Message)
-		}
 		return "", fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
 	}
 	return string(stdout), nil

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -245,21 +245,24 @@ func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
 	return c.callVoid(args...)
 }
 
-// PaneRead returns the pane's visible viewport as plain text. Its one caller asks whether a
-// modal dialog is up right now, and only the viewport answers that: scrollback cannot tell a
-// dialog still on screen from one already answered, so a --source recent read can re-send keys
-// into a live session over text the harness has moved past. --source recent was chosen first
-// because it also captures a dialog in a pane too short to show it, but that pane fails
-// unsafely under recent (keys into a live session, launch reported clean) and safely under
-// visible (nothing matches, the launch times out and rolls back with the pane content in the
-// error). Unlike every command above, herdr's own contract for pane read is a
-// third shape: raw text on success, and on failure a bare {"code","message"} object rather than
-// the {"error":{...}} envelope call and callVoid expect. That body is checked ahead of the exit
-// status for the same reason callVoid checks its envelope first - herdr's exit code cannot be
-// trusted on its own - and here a failure read as pane text would confirm a worker no one
-// observed.
+// PaneRead returns the pane's recent scrollback as plain text. Its one caller looks for first-run
+// dialogs, and the answerable part of a dialog is its lower half - claude's trust dialog is only
+// recognizable by its "Yes, I trust this folder" option and the generic fallback only by the
+// "Enter to confirm" footer - so a viewport too short to hold the whole dialog clips exactly the
+// text that has to match. That is not hypothetical: a pane measures 23 rows in an unattached herdr
+// session against 61 in an attached one, and hand spawns headlessly with nothing attached.
+// --source visible was tried for this call and reverted for that reason; a clipped dialog matches
+// nothing, and an unmatched dialog under a live agent is confirmed as started, so the short pane
+// fails silently and wrongly. Re-answering a dialog whose text lingers in scrollback is prevented
+// in cmd/launch.go instead, by answering each catalogued dialog at most once per launch.
+//
+// Unlike every command above, herdr's own contract for pane read is a third shape: raw text on
+// success, and on failure a bare {"code","message"} object rather than the {"error":{...}} envelope
+// call and callVoid expect. That body is checked ahead of the exit status for the same reason
+// callVoid checks its envelope first - herdr's exit code cannot be trusted on its own - and here a
+// failure read as pane text would confirm a worker no one observed.
 func (c *Client) PaneRead(paneID string, lines int) (string, error) {
-	args := []string{"pane", "read", paneID, "--source", "visible", "--lines", strconv.Itoa(lines)}
+	args := []string{"pane", "read", paneID, "--source", "recent", "--lines", strconv.Itoa(lines)}
 	stdout, stderr, runErr := c.run(args...)
 	var eb errorBody
 	if json.Unmarshal(stdout, &eb) == nil && eb.Code != "" && eb.Message != "" {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -245,16 +245,21 @@ func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
 	return c.callVoid(args...)
 }
 
-// PaneRead returns the pane's recent scrollback as plain text, using --source recent rather
-// than visible so a first-run dialog is still captured even in a pane too short to fit it in
-// the current viewport. Unlike every command above, herdr's own contract for pane read is a
+// PaneRead returns the pane's visible viewport as plain text. Its one caller asks whether a
+// modal dialog is up right now, and only the viewport answers that: scrollback cannot tell a
+// dialog still on screen from one already answered, so a --source recent read can re-send keys
+// into a live session over text the harness has moved past. --source recent was chosen first
+// because it also captures a dialog in a pane too short to show it, but that pane fails
+// unsafely under recent (keys into a live session, launch reported clean) and safely under
+// visible (nothing matches, the launch times out and rolls back with the pane content in the
+// error). Unlike every command above, herdr's own contract for pane read is a
 // third shape: raw text on success, and on failure a bare {"code","message"} object rather than
 // the {"error":{...}} envelope call and callVoid expect. That body is checked ahead of the exit
 // status for the same reason callVoid checks its envelope first - herdr's exit code cannot be
 // trusted on its own - and here a failure read as pane text would confirm a worker no one
 // observed.
 func (c *Client) PaneRead(paneID string, lines int) (string, error) {
-	args := []string{"pane", "read", paneID, "--source", "recent", "--lines", strconv.Itoa(lines)}
+	args := []string{"pane", "read", paneID, "--source", "visible", "--lines", strconv.Itoa(lines)}
 	stdout, stderr, runErr := c.run(args...)
 	var eb errorBody
 	if json.Unmarshal(stdout, &eb) == nil && eb.Code != "" && eb.Message != "" {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -242,6 +243,24 @@ func (c *Client) PaneSendText(paneID, text string) error {
 func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
 	args := append([]string{"pane", "send-keys", paneID}, keys...)
 	return c.callVoid(args...)
+}
+
+// PaneRead returns the pane's recent scrollback as plain text, using --source recent rather
+// than visible so a first-run dialog is still captured even in a pane too short to fit it in
+// the current viewport. Unlike every command above, herdr's own contract for pane read is a
+// third shape: raw text on success, and on failure a bare {"code","message"} object rather than
+// the {"error":{...}} envelope call and callVoid expect.
+func (c *Client) PaneRead(paneID string, lines int) (string, error) {
+	args := []string{"pane", "read", paneID, "--source", "recent", "--lines", strconv.Itoa(lines)}
+	stdout, stderr, runErr := c.run(args...)
+	if runErr != nil {
+		var eb errorBody
+		if json.Unmarshal(stdout, &eb) == nil && eb.Message != "" {
+			return "", fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), eb.Code, eb.Message)
+		}
+		return "", fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
+	}
+	return string(stdout), nil
 }
 
 // WaitComposerEmpty polls the pane until the agent is no longer "working" or timeout elapses.

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -191,3 +191,26 @@ func TestTabListParsesResult(t *testing.T) {
 		t.Fatalf("got %+v", tabs)
 	}
 }
+
+func TestPaneReadReturnsScrollback(t *testing.T) {
+	writeFakeHerdr(t, `printf 'Welcome to Claude Code\n'`)
+	c := NewClient()
+	got, err := c.PaneRead("wA:pB", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Welcome to Claude Code" {
+		t.Fatalf("got %q, want the pane text", got)
+	}
+}
+
+// TestPaneReadRejectsErrorBodyOnExitZero pins that the bare {code,message} failure body is
+// honored even when herdr exits 0: read as pane text it would look like a dialog-free pane and
+// confirm a worker no one ever observed.
+func TestPaneReadRejectsErrorBodyOnExitZero(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"code":"pane_not_found","message":"no such pane"}'; exit 0`)
+	c := NewClient()
+	if _, err := c.PaneRead("wA:pB", 60); err == nil || !strings.Contains(err.Error(), "pane_not_found") {
+		t.Fatalf("got err %v, want pane_not_found", err)
+	}
+}

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -192,8 +192,14 @@ func TestTabListParsesResult(t *testing.T) {
 	}
 }
 
-func TestPaneReadReturnsScrollback(t *testing.T) {
-	writeFakeHerdr(t, `printf 'Welcome to Claude Code\n'`)
+// TestPaneReadReadsVisibleViewport pins --source visible: a scrollback read cannot tell a dialog
+// that is up now from one already answered, so confirmLaunch would answer text the harness has
+// moved past and send keys into a live session.
+func TestPaneReadReadsVisibleViewport(t *testing.T) {
+	writeFakeHerdr(t, `case "$*" in
+*"--source visible"*) printf 'Welcome to Claude Code\n' ;;
+*) echo "unexpected read args: $*" >&2; exit 1 ;;
+esac`)
 	c := NewClient()
 	got, err := c.PaneRead("wA:pB", 60)
 	if err != nil {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -192,12 +192,12 @@ func TestTabListParsesResult(t *testing.T) {
 	}
 }
 
-// TestPaneReadReadsVisibleViewport pins --source visible: a scrollback read cannot tell a dialog
-// that is up now from one already answered, so confirmLaunch would answer text the harness has
-// moved past and send keys into a live session.
-func TestPaneReadReadsVisibleViewport(t *testing.T) {
+// TestPaneReadReadsRecentScrollback pins --source recent: a 23-row unattached pane clips the option
+// and footer lines that identify a first-run dialog, and a dialog that matches nothing is confirmed
+// as a started worker.
+func TestPaneReadReadsRecentScrollback(t *testing.T) {
 	writeFakeHerdr(t, `case "$*" in
-*"--source visible"*) printf 'Welcome to Claude Code\n' ;;
+*"--source recent"*) printf 'Welcome to Claude Code\n' ;;
 *) echo "unexpected read args: $*" >&2; exit 1 ;;
 esac`)
 	c := NewClient()

--- a/internal/herdr/types.go
+++ b/internal/herdr/types.go
@@ -25,9 +25,14 @@ type Tab struct {
 	Label       string `json:"label"`
 }
 
+// Agent names the harness herdr detects running in the pane, and is empty when the pane holds
+// no agent - a bare shell, or one whose harness has exited. AgentStatus is "unknown" in that
+// case, but it is also "unknown" for a pane herdr has not classified yet, so Agent is the field
+// to test for a running harness.
 type Pane struct {
 	PaneID      string `json:"pane_id"`
 	TabID       string `json:"tab_id"`
 	WorkspaceID string `json:"workspace_id"`
+	Agent       string `json:"agent"`
 	AgentStatus Status `json:"agent_status"`
 }

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -93,15 +93,15 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 
 	// "pane run"/"send-text"/"send-keys" are void commands: real herdr writes
 	// nothing to stdout on success, unlike every query command above. "pane read" reports a
-	// blank pane so confirmLaunch's poll loop goes quiet on its first read, matching no
-	// first-run dialog since this fake never shows one.
+	// claude pane that has painted its startup frame and shows no first-run dialog, which is
+	// what confirmLaunch's poll loop needs to confirm the launch.
 	body := fmt.Sprintf(`  "workspace list") echo %s ;;
   "workspace create") echo %s ;;
   "tab create") echo %s ;;
   "pane run") ;;
   "pane send-text") ;;
   "pane send-keys") ;;
-  "pane read") ;;
+  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
   "tab list") echo %s ;;
   "tab close") echo %s ;;
   "workspace close") echo %s ;;

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -92,13 +92,16 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 	paneGet := herdrOK(t, map[string]any{"pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": status}})
 
 	// "pane run"/"send-text"/"send-keys" are void commands: real herdr writes
-	// nothing to stdout on success, unlike every query command above.
+	// nothing to stdout on success, unlike every query command above. "pane read" reports a
+	// blank pane so confirmLaunch's poll loop goes quiet on its first read, matching no
+	// first-run dialog since this fake never shows one.
 	body := fmt.Sprintf(`  "workspace list") echo %s ;;
   "workspace create") echo %s ;;
   "tab create") echo %s ;;
   "pane run") ;;
   "pane send-text") ;;
   "pane send-keys") ;;
+  "pane read") ;;
   "tab list") echo %s ;;
   "tab close") echo %s ;;
   "workspace close") echo %s ;;

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -89,12 +89,12 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 	tabList := herdrOK(t, map[string]any{"tabs": []any{map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label}}})
 	tabClose := herdrOK(t, map[string]any{"type": "ok"})
 	workspaceClose := herdrOK(t, map[string]any{"type": "ok"})
-	paneGet := herdrOK(t, map[string]any{"pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": status}})
+	paneGet := herdrOK(t, map[string]any{"pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent": "claude", "agent_status": status}})
 
 	// "pane run"/"send-text"/"send-keys" are void commands: real herdr writes
-	// nothing to stdout on success, unlike every query command above. "pane read" reports a
-	// claude pane that has painted its startup frame and shows no first-run dialog, which is
-	// what confirmLaunch's poll loop needs to confirm the launch.
+	// nothing to stdout on success, unlike every query command above. "pane get" reports claude
+	// running in the pane and "pane read" a startup frame with no first-run dialog on it, which
+	// is what confirmLaunch's poll loop needs to confirm the launch.
 	body := fmt.Sprintf(`  "workspace list") echo %s ;;
   "workspace create") echo %s ;;
   "tab create") echo %s ;;

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -55,7 +55,7 @@ func TestPromoteScoutToShip(t *testing.T) {
   "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-new","label":"demo","tab_count":1}}}' ;;
   "tab create") echo '{"result":{"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"demo"},"root_pane":{"pane_id":"pane-new","tab_id":"tab-new","workspace_id":"ws-new","agent_status":"working"}}}' ;;
   "pane run") echo '{"result":{}}' ;;
-  "pane read") ;;
+  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
   "tab list")
     case "$4" in
       ws-old) echo '{"result":{"tabs":[{"tab_id":"tab-old","workspace_id":"ws-old","label":"demo"},{"tab_id":"tab-other","workspace_id":"ws-old","label":"other"}]}}' ;;

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -65,7 +65,7 @@ func TestPromoteScoutToShip(t *testing.T) {
     ;;
   "tab close") echo '{"result":{}}' ;;
   "workspace close") echo '{"result":{}}' ;;
-  "pane get") echo '{"result":{"pane":{"pane_id":"pane-old","tab_id":"tab-old","workspace_id":"ws-old","agent_status":"done"}}}' ;;`)
+  "pane get") printf '{"result":{"pane":{"pane_id":"%s","tab_id":"tab-old","workspace_id":"ws-old","agent":"claude","agent_status":"done"}}}\n' "$3" ;;`)
 
 	missingBrief := runHand(t, home, "promote", "task-1")
 	assertInvocation(t, missingBrief, 3, "brief not found at data/task-1/brief.md")

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -55,6 +55,7 @@ func TestPromoteScoutToShip(t *testing.T) {
   "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-new","label":"demo","tab_count":1}}}' ;;
   "tab create") echo '{"result":{"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"demo"},"root_pane":{"pane_id":"pane-new","tab_id":"tab-new","workspace_id":"ws-new","agent_status":"working"}}}' ;;
   "pane run") echo '{"result":{}}' ;;
+  "pane read") ;;
   "tab list")
     case "$4" in
       ws-old) echo '{"result":{"tabs":[{"tab_id":"tab-old","workspace_id":"ws-old","label":"demo"},{"tab_id":"tab-other","workspace_id":"ws-old","label":"other"}]}}' ;;


### PR DESCRIPTION
## Intent

fix hand spawn so it survives claude's first-run trust/bypass-permissions dialogs instead of reporting success for a worker that never started (issue #28)

## What Changed

- `hand spawn` and `hand promote` now call a new `confirmLaunch` (`cmd/launch.go`) after launching a pane: it polls herdr for a live agent, answers catalogued first-run dialogs once each, and only reports success once the pane holds a running harness with no dialog left on it - otherwise it fails and rolls back the worktree and herdr workspace.
- Added a per-harness first-run signature catalogue in `internal/harness` (claude's workspace-trust and bypass-permissions dialogs get answered, managed-settings approval is deliberately refused with an operator-facing reason, an uncatalogued dialog matching the generic `Enter to confirm` footer fails loudly) plus `AgentDetectionVerified` so a never-labeled pane names that cause instead of failing as a bare timeout.
- Added `herdr.PaneRead` (recent scrollback, error-body parsed ahead of exit status) and a `Pane.Agent` field for liveness; poll timings live in a package var so tests shrink the settle window. Covered by new table tests in `cmd/launch_test.go`, `cmd/spawn_test.go`, and `internal/harness/harness_test.go`, with SPECS.md/README/AGENTS.md updated to document the launch-confirmation behavior and its accepted gaps.

## Risk Assessment

✅ Low: b9d1ced is a docs-plus-tests commit that carries out the previous round's accepted decision, and it lands all of it. Verified line by line against HEAD: matchFirstRunPrompt (cmd/launch.go:132) is back to plain first-catalogue-match with the Refuse early-return, the answered-prompt parameter and the unanswered-preference tie-break are gone, and no conditional confirm path was added; the answer-once map survives with the single-line rationale at its definition (cmd/launch.go:60-62); the stall string (cmd/launch.go:107) now states only what is observable ("the %s prompt was answered, its text is still in the pane, and the harness never became ready") and names no cause; the two premise tests are deleted, not softened, replaced by "both first-run dialogs are answered in order and the launch is confirmed" (cmd/launch_test.go:201-205, frames trust -> bypass -> ready, keys "Enter\nDown\nEnter\n", no wantErr), and one deadline-failure case is retained (cmd/launch_test.go:191-196); SPECS.md:844-854 records the premise as measured on 2026-07-26 against a real hand-spawned worker pane with the chosen-direction consequence spelled out, and SPECS.md:821-824 adds the case-sensitivity/anchor sentence next to the dialog catalogue. Grepped for the old stall wording and found no stale copies in tests, e2e fakes, or docs. Behavior narrows rather than widens: the only reachable difference from 7266ed8 is that a read holding two answerable dialogs resolves to the first catalogue entry instead of preferring the unanswered one, which is unreachable under the erasure premise the author just measured and deliberately adopted, and which fails toward a loud deadline rather than a false confirm. Intent conformance holds - the change still makes hand answer claude's trust and bypass dialogs and refuse to report success for a pane with no live agent or a dialog still up (issue #28); nothing in the diff contradicts a required or forbidden behavior, so no ask-user finding is warranted. Residual exposure is the accepted trade already decided in earlier rounds: answer-once means a keystroke swallowed by a not-yet-listening TUI costs a spawn timeout with no retry, and a future Claude Code version that stops erasing dialogs in place turns healthy spawns into deadline failures - both loud, both documented, neither a false success. Working tree is clean at the target commit.

## Testing

Baseline build, full `go test -race ./...` and the `-tags=e2e` suite all pass, and the focused confirmLaunch/spawn tests cover every dialog case. For product-level proof I drove the built binaries end-to-end against a real `claude` process in a real terminal pane (herdr swapped for a tmux-backed stand-in so the operator's live session was untouched, treehouse faked to lease a fresh path): the pre-fix binary printed `spawned task-base ... exit 0` while claude was still parked on the "Yes, I trust this folder" dialog, whereas the fixed binary answered the dialog with a single `Enter`, confirmed only after the REPL came up, and the worker went on to read the brief and reply READY. The never-started case (`--harness codex`, no binary) failed loudly with pane content and exit 1 on the fixed binary, wrote no state and no dashboard row, and closed the workspace it created, while the base binary reported success over a bare bash prompt. This is a CLI/TUI surface, so the reviewer-visible artifacts are terminal pane captures and command transcripts rather than screenshots or GIFs; no browser or graphical surface is involved.

<details>
<summary>Evidence: Evidence index (how each artifact was produced, base vs target)</summary>

```text
# Evidence: `hand spawn` survives claude's first-run dialogs (issue #28)

End-to-end runs of the built `hand` binary driving a **real `claude` process in a real terminal
pane**. `herdr` was replaced by `bin/herdr`, a stand-in backed by a private tmux server
(`tmux -L handevi`), so the operator's live herdr session was not touched; `bin/treehouse` leases a
fresh directory (a fresh worktree path is exactly what makes claude paint its trust dialog).
Everything else - `hand` itself, `claude`, the dialogs, the keystrokes - is real.

Base = 170dd99 (pre-fix), Target = b9d1ced (with the fix).

## 1. Pre-fix: success reported for a worker parked on the trust dialog

`transcript-base-spawn.txt`

    $ hand spawn task-base demo    # base commit
    spawned task-base project=demo kind=ship harness=claude worktree=.../wt-base
    exit: 0

`pane-base-after-spawn.txt` - the pane 15s later, real claude, never started work:

     ❯ 1. Yes, I trust this folder
       2. No, exit
     Enter to confirm · Esc to cancel

`dashboard-after-base-spawn.txt` records `task-base` as an active worker anyway.

## 2. Post-fix: the dialog is answered and the worker actually runs

`transcript-target-spawn.txt` - same flow, target commit, exit 0 after the pane cleared.
`herdr-calls-target.log` shows the fix at work: poll, spot the dialog, answer it once, re-poll:

    herdr pane run %2 cd '.../wt-target' && ... claude --dangerously-skip-permissions '...'
    herdr pane get %2
    herdr pane read %2 --source recent --lines 60
    herdr pane get %2
    herdr pane read %2 --source recent --lines 60
    herdr pane send-keys %2 Enter
    herdr pane get %2
    herdr pane read %2 --source recent --lines 60

`pane-target-after-spawn.txt` - dialog gone, claude REPL up, brief being read.
`pane-target-worker-working.txt` - the worker completed the brief (`● READY`), i.e. spawn only
reported success once a worker that really runs was on the pane.

## 3. Post-fix: a worker that never starts fails loudly and rolls back

`transcript-target-never-started.txt` (`--harness codex`, no codex binary on this host):

    confirm worker started: not confirmed started within 1m0s: no agent detected in pane;
    herdr agent detection for harness codex has not been exercised:
    ... bash: command not found: codex
    exit: 1

No `state/task-fail.json` was written, no dashboard row was added, and the workspace hand created
was closed (the tmux session was gone afterwards).

`transcript-base-never-started.txt` / `pane-base-never-started.txt` - the same scenario on the base
commit reports `spawned task-fail-base ... harness=codex`, exit 0, over a bare bash prompt.

## How it was produced

    bin/herdr, bin/treehouse          stand-ins described above
    home/                             hand home used for the runs (data/, state/)
    wt-base, wt-target, wt-fail*      leased worktree dirs
```
</details>
<details>
<summary>Evidence: Pre-fix: spawn reports success (CLI transcript)</summary>

<code>$ hand spawn task-base demo # hand built from base commit 170dd99 (pre-fix)&#10;spawned task-base project=demo kind=ship harness=claude worktree=.../wt-base&#10;exit: 0</code>

```text
$ hand spawn task-base demo    # hand built from base commit 170dd99 (pre-fix)
spawned task-base project=demo kind=ship harness=claude worktree=/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-base
exit: 0
```
</details>
<details>
<summary>Evidence: Pre-fix: the pane 15s later - real claude still on the trust dialog</summary>

<code>Accessing workspace:&#10;/tmp/.../wt-base&#10;Quick safety check: Is this a project you created or one you trust? ...&#10;❯ 1. Yes, I trust this folder&#10;2. No, exit&#10;Enter to confirm · Esc to cancel</code>

```text
cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-base' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude -
-dangerously-skip-permissions 'Read the brief at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-bas
e/brief.md and carry out the task it describes.'

[atqa@sfx14:/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-base]$ cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MB
WRKJRSQAND9/wt-base' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief
 at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-base/brief.md and carry out the task it describe
s.'

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Accessing workspace:

 /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-base

 Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source
 project, or work from your team). If not, take a moment to review what's in this folder first.

 Claude Code'll be able to read, edit, and execute files here.

 Security guide

 ❯ 1. Yes, I trust this folder
   2. No, exit

 Enter to confirm · Esc to cancel
```
</details>
<details>
<summary>Evidence: Post-fix: herdr calls showing the dialog polled, answered once, re-polled</summary>

<code>herdr pane run %2 cd &#39;.../wt-target&#39; &amp;&amp; CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions &#39;Read the brief ...&#39;&#10;herdr pane get %2&#10;herdr pane read %2 --source recent --lines 60&#10;herdr pane get %2&#10;herdr pane read %2 --source recent --lines 60&#10;herdr pane send-keys %2 Enter&#10;herdr pane get %2&#10;herdr pane read %2 --source recent --lines 60</code>

```text
herdr workspace list
herdr workspace create --no-focus --cwd /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/projects/demo --label demo
herdr tab create --workspace wE --no-focus --cwd /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-target --label task-target
herdr pane run %2 cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-target' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-target/brief.md and carry out the task it describes.'
herdr pane get %2
herdr pane read %2 --source recent --lines 60
herdr pane get %2
herdr pane read %2 --source recent --lines 60
herdr pane send-keys %2 Enter
herdr pane get %2
herdr pane read %2 --source recent --lines 60
```
</details>
<details>
<summary>Evidence: Post-fix: pane after spawn - dialog cleared, claude REPL live, brief being read</summary>

```text
cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-target' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude
 --dangerously-skip-permissions 'Read the brief at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-t
arget/brief.md and carry out the task it describes.'

[atqa@sfx14:/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-target]$ cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5
MBWRKJRSQAND9/wt-target' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the b
rief at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-target/brief.md and carry out the task it de
scribes.'
╭─── Claude Code v2.1.214 ─────────────────────────────────────────────────────────────────────────────────────────────╮
│                                             │ Tips for getting started                                               │
│              Welcome back Atqa!             │ Ask Claude to create a new app or clone a repository                   │
│                                             │ ────────────────────────────────────────────────────────────────────── │
│                   ▐▛███▜▌                   │ What's new                                                             │
│                  ▝▜█████▛▘                  │ Claude no longer runs the `/verify` and `/code-review` skills on its … │
│                    ▘▘ ▝▝                    │ Fixed single-segment `dir/**` allow rules like `Edit(src/**)` auto-ap… │
│                                             │ Fixed a permission-check bypass affecting commands run in Windows Pow… │
│      claude-opus-5 · Claude Team · Y2G      │ /release-notes for more                                                │
│   /…/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-target   │                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

 ⚠ 3 MCP servers need authentication · run /mcp

❯ Read the brief at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-target/brief.md and carry out
  the task it describes.

● I'll start by reading the brief.

● Reading 1 file… (ctrl+o to expand)
  ⎿  /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-target/brief.md

* Schlepping… (5s · ↓ 33 tokens)

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
❯ 
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  claude-opus-5 (200K context) | wt-target                                                            ● high · /effort
   00%   11%   04.00 | high |  25.6K
  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent
```
</details>
<details>
<summary>Evidence: Post-fix: the worker really started and finished the brief</summary>

<code>❯ Read the brief at .../task-target/brief.md and carry out the task it describes.&#10;● I&#39;ll start by reading the brief.&#10;Read 1 file (ctrl+o to expand)&#10;● READY&#10;✻ Crunched for 6s&#10;⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent</code>

```text

❯ Read the brief at /tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-target/brief.md and carry out
  the task it describes.

● I'll start by reading the brief.

  Read 1 file (ctrl+o to expand)

● READY

✻ Crunched for 6s

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
❯ 
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  claude-opus-5 (200K context) | wt-target
   00%   11%   04.00 | high |  25.7K
  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent
```
</details>
<details>
<summary>Evidence: Post-fix: worker that never starts fails loudly with pane content</summary>

<code>$ hand spawn task-fail demo --harness codex&#10;confirm worker started: not confirmed started within 1m0s: no agent detected in pane; herdr agent detection for harness codex has not been exercised:&#10;... bash: command not found: codex&#10;exit: 1</code>

```text
$ hand spawn task-fail demo --harness codex    # harness binary absent: the worker never starts
confirm worker started: not confirmed started within 1m0s: no agent detected in pane; herdr agent detection for harness codex has not been exercised:
cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-fail' && codex --file '/tmp/no-mistakes-evidence/01KYF1ZKQEG
R5MBWRKJRSQAND9/home/data/task-fail/brief.md'

[atqa@sfx14:/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-fail]$ cd '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MB
WRKJRSQAND9/wt-fail' && codex --file '/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/home/data/task-fail/brief.md'
bash: command not found: codex

[atqa@sfx14:/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-fail]$
exit: 1
```
</details>
<details>
<summary>Evidence: Pre-fix: same never-started scenario reported as spawned</summary>

<code>$ hand spawn task-fail-base demo --harness codex # base commit&#10;spawned task-fail-base project=demo kind=ship harness=codex worktree=.../wt-fail-base&#10;exit: 0</code>

```text
$ hand spawn task-fail-base demo --harness codex    # same scenario on base commit 170dd99 (pre-fix)
spawned task-fail-base project=demo kind=ship harness=codex worktree=/tmp/no-mistakes-evidence/01KYF1ZKQEGR5MBWRKJRSQAND9/wt-fail-base
exit: 0
```
</details>
<details>
<summary>Evidence: Dashboard after the runs - no row for the rolled-back task-fail spawn</summary>

```text
# Dashboard

Updated: 2026-07-26T16:24:45Z

## Active Tasks
| id | project | kind | state | age | pr |
|---|---|---|---|---|---|
| task-base | demo | ship | idle | just now | - |
| task-target | demo | ship | idle | just now | - |
| task-fail-base | demo | ship | idle | just now | - |

## Pending Decisions

## Recent Events

## Recent Completions

## Projects
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 7 issues found → auto-fixed (6) ✅</summary>

- ⚠️ `cmd/launch.go:56` - confirmLaunch starts counting quiet reads immediately after `pane run` and returns success after 6 consecutive non-matching reads (~5s), with no positive signal that the harness ever painted anything. On a cold claude start slower than ~5s the pane holds only the echoed shell command, nothing matches Known or Unrecognized, quiet hits 6 and spawn reports success - then the trust dialog paints unanswered, which is exactly the failure mode the change targets. Consider requiring one positive readiness signature (claude&#39;s composer/footer, or at minimum one non-empty post-launch frame) before quiet counting begins.
- ⚠️ `internal/harness/harness.go:51` - claude 2.1.214 has a third startup dialog the Known list misses: `Settings requiring approval:` with confirm label `Yes, I trust these settings` / cancel `No, exit Claude Code` (verified in the installed bundle). It fires for a worktree whose repo ships settings requiring approval. Its footer matches Unrecognized, so confirmLaunch resets quiet forever, times out at 60s, and rolls back the worktree and herdr tab - spawn hard-fails for those projects. It fails loudly rather than falsely succeeding, but auto-accepting settings trust (which enables repo-supplied hooks) is a judgment call, so decide whether to catalogue it with `Enter` or leave it as a deliberate hard failure.
- ⚠️ `internal/harness/harness.go:41` - The FirstRunPrompts doc says &#34;Unrecognized being nil means any non-blank pane content is treated as a possible unanswered dialog until it goes quiet&#34;, but confirmLaunch never inspects blankness: with Unrecognized nil the second switch case is always false, so quiet increments regardless of pane content. For every non-claude harness confirmLaunch is therefore a fixed ~5s sleep that always reports success. The sentence also contradicts lines 49-50 and FirstRunPromptsFor&#39;s own doc (&#34;answer nothing, just confirm the pane goes quiet&#34;); implementing it literally would fail every non-claude spawn, since a launched pane always echoes the command. Fix the comment.
- ℹ️ `cmd/launch.go:62` - The timeout error always says &#34;worker still on an unrecognized prompt&#34;, but the deadline is also reached when a Known prompt keeps matching and being re-answered - e.g. a harness update reorders the options so `Down, Enter` no longer dismisses the dialog, or send-keys is accepted but ignored. The operator then gets a diagnosis pointing at an uncatalogued dialog while the pane content shows a known one. Track which branch last reset quiet and word the error accordingly.
- ⚠️ `cmd/launch.go:22` - The new launch-confirmation logic has no test exercising it: both cmd fakes and both e2e fakes return an empty `pane read`, so nothing covers answering a Known prompt (key order `Down` before `Enter` matters - a bare Enter on the bypass dialog exits claude), the Unrecognized reset, or the timeout-plus-rollback path. Because launchPollInterval/launchQuietReads are consts they also cannot be shortened from tests, so each of the ~10 spawn/promote test invocations now burns &gt;=5s of real sleep. Making the timings injectable (package vars or a small struct) both unblocks a table test over answerKnownPrompt/confirmLaunch and keeps the suite fast.
- ℹ️ `internal/harness/harness.go:122` - buildClaude&#39;s doc comment still calls both first-run dialogs &#34;one-time host setup&#34;, which the same change contradicts in SPECS.md (&#34;this dialog appears on every spawn, not just a fresh host&#34;, since every treehouse worktree is a fresh path). Drop or reword that clause so the comment matches the spec text it points at.
- ℹ️ `internal/herdr/client.go:256` - PaneRead only looks for the bare `{&#34;code&#34;,&#34;message&#34;}` body when the process exit code is non-zero, while callVoid&#39;s doc (and SPECS.md) state herdr&#39;s exit code &#34;cannot be trusted on its own&#34; for the void shape. I confirmed `pane read` exits 1 for pane_not_found and for an invalid --source, so this is a defensive gap rather than a live bug - but if any pane read failure ever exits 0, confirmLaunch would treat the JSON error object as pane text, match no prompt, go quiet and report success for a worker it never observed. Parsing the error body before consulting the exit status costs nothing and removes that false-success path.

🔧 Fix: gate launch confirmation on harness readiness signal
6 issues (3 warnings, 3 infos) still open:
- ⚠️ `internal/harness/harness.go:79` - The refused prompt is mislabeled and its remediation is wrong. In claude 2.1.214 this dialog is the managed-settings security dialog: the component is dispatched under the key `managed-settings-security` via `showStandaloneSecurityDialog`, its title is `Managed settings require approval`, and its body reads &#34;Only accept if you trust your organization&#39;s IT administration and expect these settings to be configured.&#34; It is host/org policy, not &#34;settings the checked-out branch ships&#34;, so (a) the stated rationale (&#34;activates whatever hooks and commands the checked-out branch happens to ship&#34;) is inaccurate, and (b) the advice in the Refuse text - &#34;approve them once by running claude in the project clone yourself, then respawn&#34; - sends the operator to the wrong place, since nothing about the project clone governs a managed-settings accept. Every spawn on such a host fails with that message, so it needs to be right. SPECS.md:808-810 and the body of issue #34 carry the same mischaracterization. Refusing to auto-accept may still be the correct call; the naming, reason, and fix-it instruction need to describe managed settings.
- ⚠️ `cmd/launch.go:76` - A dialog match alone satisfies the readiness gate (`known || unrecognized || Ready.MatchString`), and readiness is sticky, so a harness that paints a dialog and then exits is still confirmed. Concrete path: a future claude release defaults the bypass dialog&#39;s focus to &#34;Yes, I accept&#34; instead of &#34;No, exit&#34; - confirmLaunch sends `Down` (moving focus to &#34;No, exit&#34;) then `Enter`, claude quits, the pane falls back to the shell prompt, no signature matches, quiet reaches QuietReads and spawn reports success plus writes state for a dead worker. That is the failure the function exists to remove, in the highest-risk case (hand answered the dialog wrongly). Requiring the Ready signature itself to have matched at least once - not merely &#34;some dialog was on screen&#34; - before returning nil, or re-checking that herdr still reports an agent in the pane, closes it.
- ⚠️ `internal/harness/harness.go:60` - Both Ready alternatives are weakly observable through `pane read`, and a miss tears down a healthy worker after the full 60s. `? for shortcuts` is absent from every live idle claude pane on this host - they render a custom statusLine plus `bypass permissions on` where the hint would be - and while `Welcome to Claude Code` is the real startup banner in the bundle, it is absent from a hand-spawned worker pane whose entire retained scrollback is only ~190 lines, i.e. claude erases it during the session. For a worker spawned into an already-trusted path with the disclaimer already accepted (no dialog to fall back on), if the banner is gone by the first read the gate never opens and the spawn fails with &#34;the harness never painted a startup frame&#34; and rolls back a working worker. The `bypass permissions on` footer was present on every live claude pane observed and is guaranteed by hand&#39;s own `--dangerously-skip-permissions` launch, so adding it to the Ready alternation would make the gate robust. (I could not launch a fresh claude to capture its first frames without writing user-level state, so this rests on live-pane plus bundle evidence.)
- ℹ️ `cmd/launch.go:120` - matchFirstRunPrompt returns the first Known entry that matches, and `workspace trust` precedes `settings trust`, so a read window holding both dialogs&#39; text answers the trust prompt with `Enter` while the refused dialog is what is actually focused - accepting the managed-settings prompt hand deliberately refuses. Real panes do not appear to retain answered dialog text (verified against a live hand-spawned pane), so co-occurrence in one 60-line `--source recent` window is unlikely, but the refusal should not depend on catalogue ordering: scan all matches and let any Refuse entry win over any answerable one.
- ℹ️ `cmd/launch.go:85` - The answer branch fires on every read whose text still matches, with no guard that the frame changed since the last answer. If herdr&#39;s recent scrollback lags claude&#39;s redraw by more than one poll interval, the same prompt is answered twice: for the bypass entry that sends a second `Down` plus `Enter` into a claude that is already working on the brief, where Down navigates prompt history and Enter submits - so hand can inject a stray submission into the worker&#39;s session it then reports as cleanly started. Skipping the re-answer while the pane text is byte-identical to the frame just answered avoids it.
- ℹ️ `tests/e2e/fakes_test.go:104` - The injectable timings fix the in-process cmd tests (setupSpawnHome calls useFastLaunchPolling, so even the stuck-pane rollback test is fast), but the e2e suite drives the compiled binary, which cannot see the package var - so each of the ~5 e2e spawns plus the promote sleeps through the real 5s settle window, roughly 25-30s added to the suite. Noting the residual cost only; an env-var override would be the way to remove it if it becomes annoying.

🔧 Fix: confirm launch from herdr agent presence, not pane text
4 issues (1 warning, 3 infos) still open:
- ⚠️ `internal/harness/harness.go:46` - The doc says &#34;A zero value means no dialog on this harness is recognized, so any dialog it stops on runs out the launch timeout rather than being answered&#34;, but the code does the opposite: with Known nil, Unrecognized nil and Ready nil, confirmLaunch&#39;s first three text cases can never fire, so a live agent parked on an uncatalogued dialog falls to the default branch, quiet reaches QuietReads and the launch is reported successful. A codex/grok/pi/opencode worker wedged on its own first-run dialog is confirmed as started - the exact false success this change exists to remove, just narrowed to non-claude harnesses. SPECS.md:832 carries the same overstatement (&#34;A pane with no agent, or one still showing a dialog, when the poll window elapses fails the spawn/promote&#34;): a dialog no signature covers does not fail anything. Since the round-2 decision to confirm signature-less harnesses on agent presence alone is deliberate, the fix is to state the real limitation in both places rather than to change behavior.
- ℹ️ `cmd/launch.go:66` - Liveness now gates every harness, and a pane herdr never labels fails the spawn after the full 60s timeout and rolls back the worktree plus the herdr workspace/tab - where the previous commit warned on stderr and succeeded. That is only safe if herdr labels the pane for each supported harness. I confirmed the mechanism for claude (foreground-process hint over /proc/&lt;pid&gt;/cmdline, plus manifests for codex/opencode/pi/grok in ~/.local/state/herdr/agent-detection/remote/), but the claim at launch.go:41 and SPECS.md:825 that this &#34;holds for every harness&#34; is unverified for the other four, and cmd/launch_test.go:135&#39;s opencode case proves nothing about it because the fake hardcodes `agent: &#34;opencode&#34;`. opencode is the only other harness installed on this host, so it is the one cheap end-to-end check; codex/grok/pi have no binary yet, so worst case they hard-fail once installable instead of warning.
- ℹ️ `cmd/launch.go:107` - Refuse now wins over answerable entries, but among answerable entries matchFirstRunPrompt still returns the first catalogue match, and &#34;workspace trust&#34; (Keys: Enter) precedes &#34;bypass permissions&#34; (Keys: Down, Enter). PaneRead deliberately reads 60 lines of --source recent scrollback, not just the viewport, so if trust text ever survives alongside the bypass dialog in one window, hand sends a bare Enter into a dialog focused on &#34;No, exit&#34; and quits claude - after which the agent disappears and the spawn fails at the 60s timeout. I could not reproduce the co-occurrence: two live claude panes retain 190 and 396 lines of scrollback with no `trust this folder`, `Bypass Permissions` or `Enter to confirm` text at all, so claude erases answered dialogs. Cheap hardening: pick the signature whose match sits latest in the text instead of first in the catalogue.
- ℹ️ `cmd/launch_test.go:107` - Every table case starts with a frame that already has an agent, so nothing covers the real issue-#28 timeline: the first polls see bash (no agent, echoed launch command), then claude appears with the trust dialog, then the REPL. That sequence matters because `case pane.Agent == &#34;&#34;` is checked before the answer branch, so a regression that makes the agent look absent while a dialog is up would silently stop hand answering dialogs and every current case would still pass. The frames helper already expresses it: exited(launchEchoFrame), live(launchTrustFrame), live(launchReadyFrame) with wantKeys &#34;Enter\n&#34;.

🔧 Fix: narrow agent-detection claims and answer latest on-screen dialog
3 infos still open:
- ℹ️ `cmd/launch.go:137` - The comment at 129-131 and SPECS.md:830-832 state that among answerable dialogs &#34;the latest match in the read wins&#34; because &#34;scrollback is chronological, so the last signature painted is the dialog actually on screen&#34;, but FindStringIndex returns each signature&#39;s FIRST occurrence, so the ranking compares first-appearances rather than latest paints. A frame where one signature appears twice (early paint plus a later repaint) with a second signature in between ranks the stale early paint and can answer the older dialog. Not reproducible against claude&#39;s real order (trust then bypass, and round-3 evidence shows claude erases answered dialogs from retained scrollback), so this is precision rather than a live bug: switch to FindAllStringIndex(text, -1) and compare the last match&#39;s index so the code does what its own rule says.
- ℹ️ `cmd/launch.go:76` - In the no-agent branch, `case known || answered != &#34;&#34;` is checked before `case sawAgent`, and `answered != &#34;&#34;` already implies sawAgent (the answer branch only runs with an agent present), so the only distinct input to that first case is `known &amp;&amp; !sawAgent`: herdr never labeled the pane, yet a catalogued dialog is on screen. That reports &#34;the harness exited on a first-run dialog instead of starting up&#34; and discards the unexercised-detection message this commit added noAgentStall for - the failure mode is far more likely to be herdr not recognizing the process than a harness that painted a dialog while never being labeled at all. Unreachable today (claude is the only harness with signatures and its detection is verified), but it activates the moment issue #36&#39;s work adds a catalogue for codex/pi/grok. Gate the dialog-exit wording on sawAgent and let !sawAgent fall through to noAgent.
- ℹ️ `cmd/launch.go:88` - The ordering fix only matters if two dialog signatures can sit in one PaneRead window, but if that premise holds the following poll is unguarded: after the later dialog is answered and cleared, the earlier dialog&#39;s text is still inside the 60-line `--source recent` read, the frame is no longer byte-identical to `answered`, so hand sends that prompt&#39;s keys again - into a claude that is now at its REPL. Concretely with claude&#39;s real order: frame N holds trust (early) plus bypass (late) and bypass is answered correctly with Down+Enter; frame N+1 holds the live REPL plus lingering trust text, so hand sends a bare Enter, submitting whatever is in the composer. Round 3 could not reproduce lingering dialog text (two live panes, 190 and 396 retained lines, no dialog text at all), which is also why the ordering change is hard to trigger - the two stand or fall together. `--source recent` is a documented deliberate choice at internal/herdr/client.go:248-250 (a viewport read would miss a dialog in a short pane), so the tradeoff is the author&#39;s call: either require the matched signature to be the tail of the read before answering, or record that co-occurrence is accepted as unreachable and the ordering rule is belt-and-braces.

🔧 Fix: read pane viewport for dialog detection, drop match ordering
3 issues (1 error, 1 warning, 1 info) still open:
- 🚨 `internal/herdr/client.go:262` - Intent: &#34;fix hand spawn so it survives claude&#39;s first-run trust/bypass-permissions dialogs instead of reporting success for a worker that never started (issue #28)&#34;. The contradicting hunk is `args := []string{&#34;pane&#34;, &#34;read&#34;, paneID, &#34;--source&#34;, &#34;visible&#34;, &#34;--lines&#34;, strconv.Itoa(lines)}`. Claude&#39;s two answerable signatures sit in the LOWER half of their dialogs - workspace trust matches only the option label `Yes, I trust this folder`, and the `Unrecognized` fallback matches only the footer `Enter to confirm` - so a viewport that cannot hold the whole dialog clips exactly the text hand needs. This is not hypothetical: the orchestrator&#39;s own real-claude lab result is on screen in pane wM:pP (&#34;This visible-viewport read cuts off before the dialog&#39;s answer options and footer&#34;, &#34;the dialog&#39;s answerable text (the options and footer) falls outside the 23-row visible viewport; only the header is visible&#34;), and it stopped with a recorded needs-decision on this exact point. Trace the consequence: agent labeled (round-3 established claude IS labeled while parked on the trust dialog), known=false (option clipped), Unrecognized=false (footer clipped), Ready=false (no banner or footer hint while a modal is up) -&gt; the default branch at cmd/launch.go:109-113 increments quiet and returns nil after QuietReads. The spawn reports success for a worker wedged on an unanswered trust dialog, which is issue #28 verbatim and the one failure the intent forbids. Under the previous commit&#39;s `--source recent` the option text was in scrollback and the dialog got answered. Mitigating fact: every hand-created pane I measured on this host is 61 rows, where claude&#39;s dialogs fit, so the regression is conditional on viewport height - but hand is driven headlessly by this very pipeline, where a detached herdr session can default to ~24 rows, which is the geometry the lab hit. Resolve the geometry question before merging (measure what hand&#39;s own TabCreate pane gets in a detached session), and note that no test covers a clipped dialog: a `live(&lt;trust header only&gt;)` frame asserting failure would pin it.
- ⚠️ `internal/herdr/client.go:253` - The new PaneRead doc asserts the too-short pane &#34;fails ... safely under visible (nothing matches, the launch times out and rolls back with the pane content in the error)&#34;, and SPECS.md:829-832 carries the same framing. There is no such timeout: with a live agent and no signature match, cmd/launch.go:109-113 hits the default branch, quiet reaches QuietReads and confirmLaunch returns nil - a reported success, not a rollback. The claimed safety property is the entire justification recorded for choosing visible over recent, so the comment currently documents behavior the code does not have; a future maintainer reading it will believe unmatched dialogs are caught. This is wrong independently of the clipping question in the finding above: ANY dialog no signature covers is reported as started, which is the same accepted gap already documented for signature-less harnesses at SPECS.md:842-844. Reword both places to say the unmatched case is confirmed on agent presence, or make the code actually fail when a dialog was seen and never cleared.
- ℹ️ `cmd/launch.go:70` - `--lines` has no effect on a `--source visible` read. Measured against real herdr on pane wM:pP (viewport_rows 61): `--lines 2`, `--lines 5`, `--lines 60` and `--lines 200` all return the identical 60-line viewport. So launchPolling.ReadLines (cmd/launch.go:32) and PaneRead&#39;s `lines` parameter are now dead knobs that still appear in the herdr argv, and the shrunk value in useFastLaunchPolling (cmd/launch_test.go:24) implies a bound the real command ignores. Harmless today, but a stale knob reads as a size guard that does not exist - drop the parameter and the field, or note at PaneRead that herdr ignores --lines for a viewport read.

🔧 Fix: read recent scrollback, answer each dialog once per launch
1 warning still open:
- ⚠️ `cmd/launch.go:95` - The commit&#39;s own premise is that a recent-scrollback read &#34;means a dialog already answered can still be in the read&#34; (cmd/launch.go:46, SPECS.md:837). Where that premise holds, the launch cannot succeed: with a live agent and lingering answered-dialog text, `case known:` (line 95) matches the already-answered prompt, skips the keys, sets `quiet = 0` and stall &#34;answering the workspace trust prompt is not clearing it&#34; (lines 102-103), so the Ready short-circuit at line 107 is never reached and confirmLaunch runs out the 60s deadline - spawn/promote fails and rolls back a worker that started fine and answered its dialogs correctly. Reordering that one case is not enough: every claude dialog signature ships alongside the `Enter to confirm` footer, so the same lingering text also trips `prompts.Unrecognized` at line 104 and resets quiet there too. The two new tests assert exactly this outcome as intended (cmd/launch_test.go:198-203 and 208-213 both expect `wantErr: &#34;answering the workspace trust prompt is not clearing it&#34;` after trust, and in the second case bypass, were answered), and the second one&#39;s comment calls that read &#34;the normal case once trust is answered&#34; - i.e. by the change&#39;s own description the normal claude first run ends in a 60s timeout instead of a confirmed worker, which is the opposite direction of &#34;fix hand spawn so it survives claude&#39;s first-run trust/bypass-permissions dialogs&#34;. Empirically the premise did not reproduce: I read the full 190-line retained scrollback of a real hand-spawned claude worker pane (wP:p2, treehouse worktree secondhand-dc08b5/2, `--source recent --lines 200`) and it contains the echoed launch command and the startup banner but no `trust this folder`, `Bypass Permissions` or `Enter to confirm` text at all - claude erases answered dialogs in place while keeping surrounding lines. So today this is latent rather than live, but the design records lingering as expected while treating it as fatal, and it is one claude rendering change away from failing every spawn. Decide which way to go: either the premise is real, and an already-answered dialog must stop blocking (e.g. confirm when the agent is live, Ready matches, and every matching catalogued dialog is in `answered`, with the Unrecognized fallback likewise ignored once its text is explained by an answered dialog), or the premise is not real, in which case say so and drop the two tests that assert a healthy launch failing. Also note the stall wording is wrong in that state - the prompt was cleared, only its scrollback text remains.

🔧 Fix: drop lingering answered-dialog premise, assert healthy launch confirms
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go build ./...` and `go test -race ./...` (full unit suite, all packages green)</code>
- `go test -tags=e2e -timeout=10m ./tests/e2e/...`
- <code>`go test -race ./cmd/ -run &#39;TestConfirmLaunch|TestSpawn&#39; -v` (all 16 confirmLaunch cases plus spawn rollback)</code>
- <code>Manual end-to-end: built `hand` from base 170dd99 and target b9d1ced, ran `hand spawn task-base demo` / `hand spawn task-target demo` against a real `claude` launched in a real terminal pane (herdr replaced by a tmux-backed stand-in, treehouse faked to lease a fresh dir so claude paints its trust dialog)</code>
- <code>Manual failure path: `hand spawn task-fail demo --harness codex` on the target binary (harness binary absent), then checked `state/` and `data/dashboard.md` for rollback and that the created workspace was closed</code>
- <code>Captured pane contents with `tmux capture-pane -p` after each spawn and the herdr call log showing `pane read` / `pane send-keys Enter`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


## Rounds 4-6 lab verification (decision-5/decision-6 addendum)

Additional verification done directly against a real cold `claude` start in an isolated herdr lab
session (separate tmux server from the operator's, never the `default` fleet session), on top of the
pipeline's own base-vs-target evidence above.

**Round 4 stop condition (why `--source visible` was rejected):** measured `viewport_rows` for a pane
created the same way in an attached herdr session (61 rows) versus a fresh unattached lab session (23
rows), no size flags either way. Pane height tracks whether a terminal client is attached, not
something `hand` controls since it spawns headlessly - so a visible-viewport read cannot be relied on
to show a whole dialog. Confirmed dialog detection stays on `--source recent` for this reason
(`cmd/launch.go:44-47`, `SPECS.md`).

**Round 5/6 confirmations, real claude, this round's code (`confirmLaunch` at `b9d1ced`):**

1. Normal path, `--source recent` restored: cold claude start with the workspace-trust dialog freshly
   reset (`.claude.json` projects entry deleted) answered both the trust and bypass-permissions
   dialogs and confirmed in 4.09s. Post-run diff of `.claude.json`/`settings.json` showed both
   dialogs were genuinely answered live (`projects` entry populated,
   `skipDangerousModePermissionPrompt` flipped true), and the post-confirm scrollback read carried
   zero lingering dialog text - the round-4 stale-re-answer scenario (both dialogs' text still in the
   recent window once the REPL is live) cannot arise, since answered dialogs are erased in place.
2. Agent-presence readiness, exited direction: launched real claude directly as a pane's foreground
   process, waited for herdr to report it as the pane's live agent, then killed the OS process
   directly (bypassing the pane) while its dialog was still on screen. `confirmLaunch` correctly
   returned an error within the 15s test deadline rather than confirming - it never reports success
   once herdr's agent signal is gone, regardless of what dialog text remains.
3. Agent-presence readiness, live direction: covered by (1) - a live worker with the agent present
   confirms normally.

Lab session and throwaway verification harness torn down after use; nothing from this addendum is
part of the committed diff.
