### PR TITLE
docs(test): state real herdr contract in two fake-fidelity notes

### DIFF
--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -47,9 +47,13 @@ case "$cmd" in
 esac
 `
 
-// fakeHerdrPromotePaneWorking only fakes "pane get", reporting the scout's
-// pane as still "working" so promote's precondition check refuses the
-// promotion before any other herdr call is needed.
+// fakeHerdrPromotePaneWorking only fakes "pane get", a query command per
+// internal/herdr/client.go's call() doc comment: real success is a non-null
+// result object on exit 0, real failure a non-zero exit or an error envelope
+// (full contract at cmd/status_test.go's writeFakeHerdrPaneStatus). This fake
+// only exercises success, reporting the scout's pane as still "working" so
+// promote's precondition check refuses the promotion before any other herdr
+// call is needed; it mirrors the real success shape.
 const fakeHerdrPromotePaneWorking = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -153,6 +153,11 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 // "pane get <id>" reports whatever status currently sits in statusDir/<id>,
 // letting the test drive independent, per-task status transitions while
 // `hand watch` polls in the background just by rewriting one file per task.
+// Both are query commands per internal/herdr/client.go's call() doc comment:
+// real success is a non-null result object on exit 0, real failure a non-zero
+// exit or an error envelope. This fake always succeeds for both, mirroring
+// the real success shape; the failure path is exercised for real elsewhere
+// (see cmd/status_test.go's writeFakeHerdrPaneStatus for the full contract).
 // Every invocation is appended to logPath so the test can tell "the watcher
 // has polled this pane" apart from "the watcher hasn't got there yet".
 func writeFakeHerdrWatch(t *testing.T, dir, statusDir, logPath string) {


### PR DESCRIPTION
## Summary

- `cmd/promote_test.go`'s `fakeHerdrPromotePaneWorking` now states real `herdr pane get`'s contract (query command per `internal/herdr/client.go`'s `call()` doc comment) and that this fake mirrors the real success shape, pointing at `cmd/status_test.go`'s `writeFakeHerdrPaneStatus` for the full contract instead of restating it.
- `tests/e2e/fakes_test.go`'s `writeFakeHerdrWatch` (inherited by `tests/e2e/watch_test.go` and `tests/e2e/report_watch_test.go`) now states the same contract for both `workspace list` and `pane get`, and that the failure path is exercised for real elsewhere.
- No behaviour change; `cmd/teardown_test.go`'s three sites are left untouched per the issue.

Closes #39

## Test plan

- `go test -race ./...`
- `go test -race -tags=e2e ./tests/e2e/...`
- `make lint`
