### PR TITLE
docs: record minimum treehouse version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ flowchart TD
 
 - Go 1.26.5 or newer (build only)
 - [herdr](https://github.com/ogulcancelik/herdr) - terminal multiplexer with semantic agent state
-- [treehouse](https://github.com/kunchenguid/treehouse) - git worktree pool manager
+- [treehouse](https://github.com/kunchenguid/treehouse) v2.1.0 or newer - git worktree pool manager
 - [gh](https://github.com/cli/cli) - GitHub CLI, used for PR and release operations
 
 Optional:


### PR DESCRIPTION
## Summary

The code bug is gone because treehouse v2.1.0 restored the `--json` flag to `treehouse get --lease`. This change records the version floor in the README so the failure is not rediscovered on fresh installs using v2.0.0 or v2.0.1.

Closes #41