### PR TITLE
docs: cut comments that restate the code below them

### DIFF
--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -20,8 +20,6 @@ var preconditionSentinels = []error{
 	project.ErrNotFound,
 }
 
-// asPrecondition tags err as exit code 3 if it wraps one of preconditionSentinels,
-// otherwise returns it unchanged so it defaults to the general exit code 1.
 func asPrecondition(err error) error {
 	if err == nil {
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,8 +68,6 @@ func guardSubcommandGroups(c *cobra.Command) {
 	}
 }
 
-// usageArgs wraps a cobra.PositionalArgs validator so a mismatch is tagged as
-// exit code 2 (usage error) rather than falling through to the general code 1.
 func usageArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
 	return func(c *cobra.Command, args []string) error {
 		if err := validate(c, args); err != nil {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -68,8 +68,6 @@ exit 1
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-// buildUpdateFixture builds a release-asset directory (binary tarball plus
-// checksums.txt) that Apply's download+verify+extract path will accept.
 func buildUpdateFixture(t *testing.T, binaryContent []byte) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/state/pr.go
+++ b/internal/state/pr.go
@@ -12,7 +12,6 @@ import (
 // nicety.
 var prURLPattern = regexp.MustCompile(`^https://github\.com/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/pull/([0-9]+)$`)
 
-// ValidatePRURL reports whether url is a well-formed GitHub pull request URL.
 func ValidatePRURL(url string) bool {
 	return prURLPattern.MatchString(url)
 }

--- a/internal/state/report.go
+++ b/internal/state/report.go
@@ -41,7 +41,7 @@ func ReportPath(homeDir, id string) string {
 type ReportLine struct {
 	State     string // one of the vocabulary constants above, empty if Malformed
 	Note      string // free text after the first colon, verbatim
-	Raw       string // the original line
+	Raw       string
 	Malformed bool
 }
 
@@ -157,7 +157,6 @@ func LastReportedState(lines []ReportLine) (ReportLine, bool) {
 	return ReportLine{}, false
 }
 
-// ReportTail returns the last n reported lines for a task, oldest first.
 func ReportTail(homeDir, id string, n int) ([]ReportLine, error) {
 	lines, err := ReadReportLines(homeDir, id)
 	if err != nil {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -111,7 +111,6 @@ func lock(homeDir, name string, nonblock bool) (func(), error) {
 	}, nil
 }
 
-// Exists reports whether a task state file exists for id.
 func Exists(homeDir, id string) (bool, error) {
 	if err := ValidateID(id); err != nil {
 		return false, err
@@ -126,7 +125,6 @@ func Exists(homeDir, id string) (bool, error) {
 	return false, fmt.Errorf("stat task state %q: %w", id, err)
 }
 
-// Read loads the state file for id.
 func Read(homeDir, id string) (Task, error) {
 	if err := ValidateID(id); err != nil {
 		return Task{}, err

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -145,8 +145,6 @@ func ClassifyStatus(ts *TaskState, id string, status herdr.Status, probeErr erro
 	return nil
 }
 
-// ClassifyStale fires once per stale window: when a task's status hasn't changed
-// for at least threshold, and it hasn't already been flagged since the last change.
 func ClassifyStale(ts *TaskState, id string, now time.Time, threshold time.Duration) *Event {
 	if !ts.Probed || ts.Stale {
 		return nil
@@ -158,7 +156,6 @@ func ClassifyStale(ts *TaskState, id string, now time.Time, threshold time.Durat
 	return &Event{TaskID: id, Kind: KindStale, Text: fmt.Sprintf("stale %s", id)}
 }
 
-// ClassifyPRMerged fires once, the first time merged is observed true for a task.
 func ClassifyPRMerged(ts *TaskState, id string, merged bool) *Event {
 	if !merged || ts.PRMerged {
 		return nil

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -80,7 +80,6 @@ func writeFakeDispatch(t *testing.T, dir, name, logPath, selector, caseBody stri
 	writeFakeBin(t, dir, name, script)
 }
 
-// shellSingleQuote wraps s for safe embedding as a single-quoted shell literal.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }


### PR DESCRIPTION
## Intent

Remove 12 comment lines across 8 files that restate the code or identifier directly below them (issue #52). Comments-only change, no behavior change.

## What Changed

- Dropped 11 doc comments (14 lines) that restated the identifier or body directly below them, across `cmd/precondition.go`, `cmd/root.go`, `cmd/update_test.go`, `internal/state/pr.go`, `internal/state/report.go`, `internal/state/task.go`, `internal/watcher/events.go`, and `tests/e2e/fakes_test.go`.
- Removed the trailing `// the original line` comment on `ReportLine.Raw` in `internal/state/report.go:44`.
- Comments only: pipeline verification compared base and target `.text` sections (identical) and comment-stripped ASTs per file (no diff), so no behavior changed.

Note: the commit message says "12 comment lines"; the actual delta is 14 pure comment lines plus 1 trailing comment across the 8 files.

## Trade-off

Three of the cuts (`Exists`, `Read`, `ValidatePRURL`) are doc comments on exported identifiers. Go convention favors a doc comment on every exported name; removing these trades that convention for the repository's zero-comments-by-default rule, since each comment only repeated the identifier's own name and added no fact. This is a deliberate trade stated in issue #52, not an oversight.

Closes #52

## Risk Assessment

✅ Low: Pure comment deletion with zero executable-line changes; every removed comment restated adjacent code, and the non-obvious rationale in each touched file (exit-code mapping, watcher fire-once invariant, PR-URL validation risk) is still documented nearby, so CLAUDE.md's pointers remain accurate.

## Testing

Ran the full race test suite and the e2e-tagged suite in the Nix devshell (all green), then produced direct no-behavior-change evidence: the compiled binary's .text section is byte-identical between base and target (whole-file bytes differ only in DWARF/pclntab line tables, expected from deleted lines), comment-stripped ASTs of all 8 changed files are identical, and CLI transcripts from base- and target-built binaries covering every touched code path (usageArgs exit 2, asPrecondition exit 3, ValidatePRURL rejection, subcommand-group guard) are byte-identical. This is a CLI-only Go project with no rendered UI surface, so the end-user artifact is the CLI transcript rather than a screenshot.

<details>
<summary>Evidence: Evidence summary (binary .text hash equality, AST equality, transcript equality, diff line accounting)</summary>

<code>base: 4ba0b6cdc1315f088abb478d013522a9fcd19935&#10;target: da730accf6dc27c7ed2f42178b9435d517fcd2fe&#10;&#10;1) .text section of &#39;hand&#39; binary, built -trimpath -ldflags=-buildid= from each commit:&#10;base sha256 007022fc701a95b17238faad3f48ac5030ebb2d7ca63b5f37afe46c66895aa1f&#10;target sha256 007022fc701a95b17238faad3f48ac5030ebb2d7ca63b5f37afe46c66895aa1f&#10;-&gt; machine code identical; whole-file bytes differ only in DWARF/pclntab line tables&#10;&#10;2) Comment-stripped source per changed file: see ast-diff.txt&#10;&#10;3) CLI transcripts from both binaries: transcript-base.txt vs transcript-target.txt -&gt; byte-identical&#10;&#10;4) 14 removed lines are pure // comments; 1 removed line is &#39;Raw string // the original line&#39; replaced by &#39;Raw string&#39;; 0 other code lines changed; 8 files touched</code>

```text
base:   4ba0b6cdc1315f088abb478d013522a9fcd19935
target: da730accf6dc27c7ed2f42178b9435d517fcd2fe

1) .text section of 'hand' binary, built -trimpath -ldflags=-buildid= from each commit:
   base   sha256 007022fc701a95b17238faad3f48ac5030ebb2d7ca63b5f37afe46c66895aa1f
   target sha256 007022fc701a95b17238faad3f48ac5030ebb2d7ca63b5f37afe46c66895aa1f
   -> machine code identical; whole-file bytes differ only in DWARF/pclntab line tables (line numbers shifted by deleted lines)

2) Comment-stripped source (go/parser without comments -> go/printer), per changed file: see ast-diff.txt

3) CLI transcripts from both binaries: transcript-base.txt vs transcript-target.txt -> byte-identical

4) Diff line accounting:
   14 removed lines are pure // comments; 1 removed line is 'Raw string // the original line' replaced by 'Raw string' (trailing comment stripped, code kept)
   0 other code lines changed; 8 files touched
```
</details>
<details>
<summary>Evidence: CLI transcript (target binary, identical to base) exercising every code path whose comment was deleted</summary>

<code>$ hand init .&#10;initialized secondhand home at &lt;HOME&gt;&#10;[exit 0]&#10;&#10;$ hand status&#10;[exit 0]&#10;&#10;$ hand status alpha extra&#10;accepts at most 1 arg(s), received 2&#10;[exit 2]&#10;&#10;$ hand status no-such-task&#10;task &#34;no-such-task&#34; not found&#10;[exit 3]&#10;&#10;$ hand project remove no-such-proj&#10;project &#34;no-such-proj&#34; not registered&#10;[exit 3]&#10;&#10;$ hand project bogus&#10;unknown command &#34;bogus&#34; for &#34;hand project&#34;&#10;[exit 2]&#10;&#10;$ hand pr no-such-task https://example.com/not-a-pr&#10;invalid PR URL &#34;https://example.com/not-a-pr&#34;: must match https://github.com/&lt;owner&gt;/&lt;repo&gt;/pull/&lt;number&gt;&#10;[exit 2]</code>

```text
$ hand init .
initialized secondhand home at <HOME>
[exit 0]

$ hand status
[exit 0]

$ hand status alpha extra
accepts at most 1 arg(s), received 2
[exit 2]

$ hand status no-such-task
task "no-such-task" not found
[exit 3]

$ hand project remove no-such-proj
project "no-such-proj" not registered
[exit 3]

$ hand project
Manage the project registry

Usage:
  hand project [flags]
  hand project [command]

Available Commands:
  add         Clone a git repository and register it
  list        List registered projects
  remove      Unregister a project
  sync        Fast-forward project clones to their remote default branch

Flags:
  -h, --help   help for project

Use "hand project [command] --help" for more information about a command.
[exit 0]

$ hand project bogus
unknown command "bogus" for "hand project"
[exit 2]

$ hand pr no-such-task https://example.com/not-a-pr
invalid PR URL "https://example.com/not-a-pr": must match https://github.com/<owner>/<repo>/pull/<number>
[exit 2]
```
</details>
<details>
<summary>Evidence: Per-file comment-stripped source comparison (base vs target)</summary>

<code>[cmd/precondition.go] base=455B target=455B&#10;-&gt; code identical after stripping comments&#10;[cmd/root.go] base=2401B target=2401B&#10;-&gt; code identical after stripping comments&#10;[cmd/update_test.go] base=8239B target=8239B&#10;-&gt; code identical after stripping comments&#10;[internal/state/pr.go] base=592B target=592B&#10;-&gt; code identical after stripping comments&#10;[internal/state/report.go] base=2863B target=2863B&#10;-&gt; code identical after stripping comments&#10;[internal/state/task.go] base=4865B target=4865B&#10;-&gt; code identical after stripping comments&#10;[internal/watcher/events.go] base=5158B target=5158B&#10;-&gt; code identical after stripping comments&#10;[tests/e2e/fakes_test.go] base=4916B target=4916B&#10;-&gt; code identical after stripping comments</code>

```text
[cmd/precondition.go] base=455B target=455B
  -> code identical after stripping comments
[cmd/root.go] base=2401B target=2401B
  -> code identical after stripping comments
[cmd/update_test.go] base=8239B target=8239B
  -> code identical after stripping comments
[internal/state/pr.go] base=592B target=592B
  -> code identical after stripping comments
[internal/state/report.go] base=2863B target=2863B
  -> code identical after stripping comments
[internal/state/task.go] base=4865B target=4865B
  -> code identical after stripping comments
[internal/watcher/events.go] base=5158B target=5158B
  -> code identical after stripping comments
[tests/e2e/fakes_test.go] base=4916B target=4916B
  -> code identical after stripping comments
```
</details>
<details>
<summary>Evidence: Reproduction scripts (comment-stripping tool + CLI transcript driver)</summary>

```text
package main

import (
	"fmt"
	"go/parser"
	"go/printer"
	"go/token"
	"os"
)

func main() {
	fset := token.NewFileSet()
	f, err := parser.ParseFile(fset, os.Args[1], nil, 0)
	if err != nil {
		fmt.Fprintln(os.Stderr, err)
		os.Exit(1)
	}
	f.Comments = nil
	if err := printer.Fprint(os.Stdout, fset, f); err != nil {
		fmt.Fprintln(os.Stderr, err)
		os.Exit(1)
	}
}
```
</details>
- Outcome: ⚠️ 1 info across 1 run (4m45s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/state/report.go:44` - Commit/intent describes &#34;12 comment lines across 8 files&#34;, but the diff removes 14 comment-only lines (11 distinct comments) plus one inline trailing comment on ReportLine.Raw. File count (8) is correct; only the line count is off. Worth correcting in the PR body for an accurate record - no code impact.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/state/report.go:44` - Intent states &#34;12 comment lines&#34; but the diff removes 14 pure comment lines plus one trailing comment (`Raw string // the original line` -&gt; `Raw string`), i.e. 15 comment lines total across the 8 files. Substance matches intent (comments-only, no behavior change); only the count in the description is off.
- `nix develop -c go build ./...`
- <code>`nix develop -c go test -race ./...` (all packages)</code>
- <code>`nix develop -c go test -tags=e2e -timeout=10m ./tests/e2e/...` (covers touched tests/e2e/fakes_test.go)</code>
- <code>Built `hand` from base 4ba0b6c and target da730ac with `go build -trimpath -ldflags=-buildid=`, then compared `.text` sections via `objcopy --only-section=.text` + `sha256sum` -&gt; identical</code>
- `Comment-stripped source comparison: go/parser (no ParseComments) + go/printer per changed file, base vs target diff -> empty for all 8 files (/tmp/no-mistakes-evidence/01KYH2JABFKPTMKSNJENS36471/stripcomments.go)`
- <code>Manual CLI transcript against both binaries in a fresh `hand init .` home: `hand status`, `hand status alpha extra` (exit 2), `hand status no-such-task` (exit 3), `hand project remove no-such-proj` (exit 3), `hand project`, `hand project bogus` (exit 2), `hand pr no-such-task https://example.com/not-a-pr` (invalid PR URL) -&gt; transcripts byte-identical</code>
- <code>`git diff -U0 4ba0b6c da730ac` line accounting: 14 removed pure-comment lines, 1 trailing comment stripped, 0 other code lines changed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

