### PR TITLE
feat(cmd): surface PR merge state in hand status

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -540,8 +540,8 @@ Behavior (PR merge, default):
 4. Refuse if checks are not green.
 5. Run `gh pr merge <number> --repo <owner/repo> --squash` (or specified method).
 6. Update `state/<id>.json` with merge status.
-7. Update `data/dashboard.md`.
-8. Run `hand project sync <project>` to fast-forward the project clone.
+7. Run `hand project sync <project>` to fast-forward the project clone.
+8. Refresh the dashboard's Projects section, only if that sync advanced the clone.
 
 Behavior (local merge, `--local`):
 1. Read `state/<id>.json` for worktree and project.

--- a/SPECS.md
+++ b/SPECS.md
@@ -366,7 +366,8 @@ Behavior (fleet overview):
 1. List all `state/*.json` files.
 2. For each, query herdr for current agent state.
 3. If agent state is `idle` or `done` (herdr's two spellings of "pane stopped being busy" - see "Agent state" below), consult the task's last report line (see "Report channel"): no report, or the last line was still `working`, appends ` (unreported)`; any other terminal report appends ` (reported: <state>)`; a report file that exists but can't be read appends ` (report unreadable)`, never ` (unreported)` - an I/O fault is not evidence the worker never reported. Any other agent state is printed unadorned.
-4. Print one line per task.
+4. If the task has a recorded PR, append its merge state to the same column: ` (merged)` when `hand` performed the merge, ` (merged, external)` when only `hand watch`'s own `gh` poll saw it merged. It is appended whatever the agent state is, since a merged PR is a fact about the PR rather than about the pane.
+5. Print one line per task.
 
 Output (fleet overview):
 ```
@@ -375,6 +376,7 @@ dark-mode       nsr     ship    blocked     45m ago
 stuck-task      nsr     ship    idle (unreported)      1h ago
 paused-task     nsr     ship    idle (reported: needs-decision)   30m ago
 investigate     nsr     scout   done (reported: done)      10m ago
+shipped-fix     nsr     ship    done (reported: done) (merged, external)   5m ago
 ```
 
 Behavior (single task):
@@ -402,6 +404,8 @@ Report history (reported by worker, not verified current truth):
   needs-decision: two ways to fix the race, ask-user found both risky
 ```
 
+The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the same merge suffix the fleet overview appends: `PR:         https://github.com/org/repo/pull/42 (merged, external)`.
+
 The "Report history" label is deliberate: these lines are the worker's own claims about itself, not something `hand` has verified, same caution as the `done`-vs-`reported-done` distinction in `hand watch`.
 
 Output (JSON, single task):
@@ -415,6 +419,8 @@ Output (JSON, single task):
   "worktree": "/home/user/.treehouse/nsr-abc/1/nsr",
   "herdr": {"session": "default", "tab_id": "wA:tB", "pane_id": "wA:pC"},
   "pr": "",
+  "merged": false,
+  "pr_merged_observed": false,
   "created_at": "2026-07-24T08:00:00Z",
   "reported": {"state": "needs-decision", "note": "two ways to fix the race, ask-user found both risky"},
   "report_history": ["working: added the retry loop", "needs-decision: two ways to fix the race, ask-user found both risky"]
@@ -544,7 +550,8 @@ Behavior (local merge, `--local`):
 4. In the project clone: `git merge --ff-only <task-branch>`.
 5. Refuse if fast-forward is not possible (diverged branches).
 6. Update `state/<id>.json` with merge status.
-7. Update `data/dashboard.md`.
+
+A local merge writes no dashboard row.
 
 Output:
 ```
@@ -847,7 +854,7 @@ Updated: 2026-07-24T12:30:00Z
 | `hand status` | Refresh agent states in Active Tasks (only when dashboard is stale) |
 | `hand send` | No update |
 | `hand teardown` | Move from Active Tasks to Recent Completions (keep last 10), drop the task's Pending Decisions entry |
-| `hand merge` | Update PR status, add to Recent Events |
+| `hand merge` | Refresh Projects when the follow-up project sync advanced the clone. `--local`: no update |
 | `hand pr` | Set PR on the task's row |
 | `hand watch` | Update agent states, add actionable events to Recent Events (keep last 20), update Pending Decisions, auto-record a PR seen on the report channel |
 | `hand project add` | Add to Projects |

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -48,7 +48,7 @@ func newMergeCmd() *cobra.Command {
 				return asPrecondition(err)
 			}
 
-			if t.Merged {
+			if t.MergeExecuted {
 				return &ExitError{Err: fmt.Errorf("task %s already merged", t.ID), Code: 3}
 			}
 
@@ -104,8 +104,8 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 		return fmt.Errorf("gh pr merge failed: %s", strings.TrimSpace(string(out)))
 	}
 
-	t.Merged = true
-	t.MergedAt = time.Now().UTC().Format(time.RFC3339)
+	t.MergeExecuted = true
+	t.MergeExecutedAt = time.Now().UTC().Format(time.RFC3339)
 	if err := state.Write(home, t); err != nil {
 		return fmt.Errorf("write task state: %w", err)
 	}
@@ -177,8 +177,8 @@ func runLocalMerge(cmd *cobra.Command, home string, t state.Task) error {
 		return &ExitError{Err: fmt.Errorf("fast-forward not possible: %s", strings.TrimSpace(string(out))), Code: 3}
 	}
 
-	t.Merged = true
-	t.MergedAt = time.Now().UTC().Format(time.RFC3339)
+	t.MergeExecuted = true
+	t.MergeExecutedAt = time.Now().UTC().Format(time.RFC3339)
 	if err := state.Write(home, t); err != nil {
 		return fmt.Errorf("write task state: %w", err)
 	}

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -185,7 +185,7 @@ func TestMergePRRefusesRedCI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Merged {
+	if got.MergeExecuted {
 		t.Fatal("want task not marked merged")
 	}
 }
@@ -209,10 +209,10 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Merged {
+	if !got.MergeExecuted {
 		t.Fatal("want task marked merged")
 	}
-	if got.MergedAt == "" {
+	if got.MergeExecutedAt == "" {
 		t.Fatal("want merged_at set")
 	}
 }
@@ -279,7 +279,7 @@ func TestMergeLocalFastForwardSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Merged {
+	if !got.MergeExecuted {
 		t.Fatal("want task marked merged")
 	}
 }
@@ -328,7 +328,7 @@ func TestMergeLocalRefusesWhenNotFastForwardable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Merged {
+	if got.MergeExecuted {
 		t.Fatal("want task not marked merged")
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -75,10 +75,6 @@ type statusJSON struct {
 	ReportHistory  []string      `json:"report_history,omitempty"`
 }
 
-// mergeSuffix distinguishes who merged the PR: hand itself (MergeExecuted) or
-// something else that hand watch's own gh poll saw (MergeAnnounced) - the same
-// wording that recorded a human merging in the GitHub web UI as a normal path
-// rather than an incident.
 func mergeSuffix(t state.Task) string {
 	switch {
 	case t.PR == "":

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -60,17 +60,36 @@ type reportedJSON struct {
 }
 
 type statusJSON struct {
-	ID            string        `json:"id"`
-	Project       string        `json:"project"`
-	Kind          string        `json:"kind"`
-	Harness       string        `json:"harness,omitempty"`
-	AgentState    string        `json:"agent_state"`
-	Worktree      string        `json:"worktree"`
-	Herdr         state.Herdr   `json:"herdr"`
-	PR            string        `json:"pr"`
-	CreatedAt     string        `json:"created_at"`
-	Reported      *reportedJSON `json:"reported,omitempty"`
-	ReportHistory []string      `json:"report_history,omitempty"`
+	ID             string        `json:"id"`
+	Project        string        `json:"project"`
+	Kind           string        `json:"kind"`
+	Harness        string        `json:"harness,omitempty"`
+	AgentState     string        `json:"agent_state"`
+	Worktree       string        `json:"worktree"`
+	Herdr          state.Herdr   `json:"herdr"`
+	PR             string        `json:"pr"`
+	MergeExecuted  bool          `json:"merged"`
+	MergeAnnounced bool          `json:"pr_merged_observed"`
+	CreatedAt      string        `json:"created_at"`
+	Reported       *reportedJSON `json:"reported,omitempty"`
+	ReportHistory  []string      `json:"report_history,omitempty"`
+}
+
+// mergeSuffix distinguishes who merged the PR: hand itself (MergeExecuted) or
+// something else that hand watch's own gh poll saw (MergeAnnounced) - the same
+// wording that recorded a human merging in the GitHub web UI as a normal path
+// rather than an incident.
+func mergeSuffix(t state.Task) string {
+	switch {
+	case t.PR == "":
+		return ""
+	case t.MergeExecuted:
+		return " (merged)"
+	case t.MergeAnnounced:
+		return " (merged, external)"
+	default:
+		return ""
+	}
 }
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool) error {
@@ -92,10 +111,11 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		rows = append(rows, statusJSON{
 			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
 			AgentState: agentState,
-			Worktree:   t.Worktree, Herdr: t.Herdr, PR: t.PR, CreatedAt: t.CreatedAt,
+			Worktree:   t.Worktree, Herdr: t.Herdr, PR: t.PR,
+			MergeExecuted: t.MergeExecuted, MergeAnnounced: t.MergeAnnounced, CreatedAt: t.CreatedAt,
 			Reported: reportedFrom(last, len(lines) > 0, readErr),
 		})
-		suffixes = append(suffixes, reportSuffix(agentState, reported, reportedOK, readErr))
+		suffixes = append(suffixes, reportSuffix(agentState, reported, reportedOK, readErr)+mergeSuffix(t))
 	}
 
 	if asJSON {
@@ -179,7 +199,8 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	if asJSON {
 		out := statusJSON{
 			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
-			AgentState: agentState, Worktree: t.Worktree, Herdr: t.Herdr, PR: t.PR, CreatedAt: t.CreatedAt,
+			AgentState: agentState, Worktree: t.Worktree, Herdr: t.Herdr, PR: t.PR,
+			MergeExecuted: t.MergeExecuted, MergeAnnounced: t.MergeAnnounced, CreatedAt: t.CreatedAt,
 			Reported: reportedFrom(last, len(tail) > 0, readErr), ReportHistory: history,
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
@@ -190,6 +211,8 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	pr := t.PR
 	if pr == "" {
 		pr = "(none)"
+	} else {
+		pr += mergeSuffix(t)
 	}
 	reported := "(none)"
 	switch {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -141,6 +141,142 @@ func TestStatusSingleTaskDetail(t *testing.T) {
 	}
 }
 
+func TestStatusSingleTaskDetailShowsMergeStateForAMergedPR(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
+		PR: "https://github.com/a/b/pull/1", MergeExecuted: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "PR:         https://github.com/a/b/pull/1 (merged)") {
+		t.Fatalf("got %q, want PR line marked merged", out.String())
+	}
+}
+
+func TestStatusSingleTaskDetailUnmergedPRIsUnchanged(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
+		PR: "https://github.com/a/b/pull/1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "PR:         https://github.com/a/b/pull/1\n") {
+		t.Fatalf("got %q, want unmarked PR line", out.String())
+	}
+}
+
+func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
+	cases := []struct {
+		name             string
+		merged           bool
+		prMergedObserved bool
+		want             string
+		wantNot          []string
+	}{
+		{"neither", false, false, "PR:         https://github.com/a/b/pull/1\n", []string{"merged"}},
+		{"handMerged", true, false, "PR:         https://github.com/a/b/pull/1 (merged)\n", []string{"external"}},
+		{"observedOnly", false, true, "PR:         https://github.com/a/b/pull/1 (merged, external)\n", nil},
+		{"both", true, true, "PR:         https://github.com/a/b/pull/1 (merged)\n", []string{"external"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Chdir(home)
+			writeFakeHerdrPaneStatus(t, "idle")
+
+			if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+				Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
+				PR: "https://github.com/a/b/pull/1", MergeExecuted: c.merged, MergeAnnounced: c.prMergedObserved}); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := newStatusCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs([]string{"task-1"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			got := out.String()
+			if !strings.Contains(got, c.want) {
+				t.Fatalf("got %q, want to contain %q", got, c.want)
+			}
+			for _, absent := range c.wantNot {
+				if strings.Contains(got, absent) {
+					t.Fatalf("got %q, want no occurrence of %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestStatusFleetOverviewRendersMergeMarker(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
+		PR: "https://github.com/a/b/pull/1", MergeAnnounced: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "(merged, external)") {
+		t.Fatalf("got %q, want the fleet overview to carry the merge marker", out.String())
+	}
+}
+
+func TestStatusFleetOverviewTaskWithNoPRIsUnaffected(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "merged") {
+		t.Fatalf("got %q, want no merge marker without a PR", out.String())
+	}
+}
+
 func TestStatusSingleTaskJSON(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -141,52 +141,6 @@ func TestStatusSingleTaskDetail(t *testing.T) {
 	}
 }
 
-func TestStatusSingleTaskDetailShowsMergeStateForAMergedPR(t *testing.T) {
-	home := t.TempDir()
-	t.Chdir(home)
-	writeFakeHerdrPaneStatus(t, "idle")
-
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-		PR: "https://github.com/a/b/pull/1", MergeExecuted: true}); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := newStatusCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"task-1"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.String(), "PR:         https://github.com/a/b/pull/1 (merged)") {
-		t.Fatalf("got %q, want PR line marked merged", out.String())
-	}
-}
-
-func TestStatusSingleTaskDetailUnmergedPRIsUnchanged(t *testing.T) {
-	home := t.TempDir()
-	t.Chdir(home)
-	writeFakeHerdrPaneStatus(t, "idle")
-
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-		PR: "https://github.com/a/b/pull/1"}); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := newStatusCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"task-1"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.String(), "PR:         https://github.com/a/b/pull/1\n") {
-		t.Fatalf("got %q, want unmarked PR line", out.String())
-	}
-}
-
 func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 	cases := []struct {
 		name             string

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -24,22 +24,25 @@ type Task struct {
 	Brief    string `json:"brief"`
 	Herdr    Herdr  `json:"herdr"`
 	PR       string `json:"pr"`
-	Merged   bool   `json:"merged"`
-	MergedAt string `json:"merged_at"`
+	// MergeExecuted records that hand itself ran the merge - not that the PR is
+	// merged, since a PR merged by other means leaves this false and is what
+	// MergeAnnounced records instead.
+	MergeExecuted   bool   `json:"merged"`
+	MergeExecutedAt string `json:"merged_at"`
 	// ReportOffset is how far hand watch has consumed the task's report file.
 	// It is durable so a watcher restart resumes exactly where it stopped
 	// instead of replaying every line the previous run already surfaced.
 	ReportOffset int64 `json:"report_offset"`
-	// PRMergedObserved records that hand watch's own gh poll already announced
-	// this PR merged. Distinct from Merged, which means hand performed the
-	// merge; a restarted watcher needs to know the announcement went out.
-	PRMergedObserved bool `json:"pr_merged_observed"`
+	// MergeAnnounced records that hand watch's own gh poll already emitted the
+	// merge announcement, distinct from MergeExecuted: a restarted watcher needs
+	// to know the announcement went out even when hand itself never ran the merge.
+	MergeAnnounced bool `json:"pr_merged_observed"`
 	// DoneVerified records that hand watch already announced the verified "done"
-	// line for this task. Durable for the same reason PRMergedObserved is:
-	// evidence can land while the watcher is down (hand merge writes Merged
-	// without touching the dashboard), and a restart that re-derived this from
-	// current evidence would conclude the line had already gone out and never
-	// print it.
+	// line for this task. Durable for the same reason MergeAnnounced is:
+	// evidence can land while the watcher is down (hand merge writes
+	// MergeExecuted without touching the dashboard), and a restart that
+	// re-derived this from current evidence would conclude the line had already
+	// gone out and never print it.
 	DoneVerified bool   `json:"done_verified"`
 	CreatedAt    string `json:"created_at"`
 }

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -233,7 +233,7 @@ func doneText(id, note string, verified bool) string {
 // merge happened, and a scout task lands by producing the data/<id>/report.md that
 // hand promote itself requires.
 //
-// So the ship check reads t.Merged first and asks nothing further: it is only ever
+// So the ship check reads t.MergeExecuted first and asks nothing further: it is only ever
 // written after a merge actually happened, whether through a PR or a local
 // fast-forward that leaves no PR at all. A recorded PR the watcher's own poll saw
 // merged is that same evidence arriving the other way. Narrowing this to one route
@@ -241,7 +241,7 @@ func doneText(id, note string, verified bool) string {
 func doneVerified(home string, ts *TaskState, t state.Task) bool {
 	switch t.Kind {
 	case state.KindShip:
-		return t.Merged || (t.PR != "" && ts.PRMerged)
+		return t.MergeExecuted || (t.PR != "" && ts.PRMerged)
 	case state.KindScout:
 		_, err := os.Stat(filepath.Join(home, "data", t.ID, "report.md"))
 		return err == nil

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -233,11 +233,12 @@ func doneText(id, note string, verified bool) string {
 // merge happened, and a scout task lands by producing the data/<id>/report.md that
 // hand promote itself requires.
 //
-// So the ship check reads t.MergeExecuted first and asks nothing further: it is only ever
-// written after a merge actually happened, whether through a PR or a local
-// fast-forward that leaves no PR at all. A recorded PR the watcher's own poll saw
-// merged is that same evidence arriving the other way. Narrowing this to one route
-// is what made the check silently always-false for a whole class of task twice.
+// So the ship check reads t.MergeExecuted first and asks nothing further: it is
+// only ever written after a merge actually happened, whether through a PR or a
+// local fast-forward that leaves no PR at all. A recorded PR the watcher's own
+// poll saw merged is that same evidence arriving the other way. Narrowing this to
+// one route is what made the check silently always-false for a whole class of
+// task twice.
 func doneVerified(home string, ts *TaskState, t state.Task) bool {
 	switch t.Kind {
 	case state.KindShip:

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -218,8 +218,8 @@ func TestClassifyReportDoneVerifiedOnlyWithCompletionEvidence(t *testing.T) {
 	}{
 		{name: "ship with no PR recorded", task: state.Task{ID: "task-1", Kind: state.KindShip}},
 		{name: "ship with PR recorded but not merged", task: state.Task{ID: "task-1", Kind: state.KindShip, PR: "https://github.com/a/b/pull/1"}},
-		{name: "ship with PR recorded and merged", task: state.Task{ID: "task-1", Kind: state.KindShip, PR: "https://github.com/a/b/pull/1", Merged: true}, verified: true},
-		{name: "ship merged locally, which leaves no PR at all", task: state.Task{ID: "task-1", Kind: state.KindShip, Merged: true}, verified: true},
+		{name: "ship with PR recorded and merged", task: state.Task{ID: "task-1", Kind: state.KindShip, PR: "https://github.com/a/b/pull/1", MergeExecuted: true}, verified: true},
+		{name: "ship merged locally, which leaves no PR at all", task: state.Task{ID: "task-1", Kind: state.KindShip, MergeExecuted: true}, verified: true},
 		{name: "scout with no report.md", task: state.Task{ID: "task-1", Kind: state.KindScout}},
 		{name: "scout with its report.md deliverable", task: state.Task{ID: "task-1", Kind: state.KindScout}, scoutFound: true, verified: true},
 	}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -153,8 +153,8 @@ func resumeTaskState(home string, t state.Task, status herdr.Status, now time.Ti
 	ts.CreatedAt = t.CreatedAt
 	ts.ReportOffset = t.ReportOffset
 	ts.PersistedOffset = t.ReportOffset
-	ts.PRMerged = t.PRMergedObserved
-	ts.PersistedPRMerged = t.PRMergedObserved
+	ts.PRMerged = t.MergeAnnounced
+	ts.PersistedPRMerged = t.MergeAnnounced
 	ts.DoneVerified = t.DoneVerified
 	ts.PersistedDoneVerified = t.DoneVerified
 
@@ -370,7 +370,7 @@ func syncTaskState(home, id string, ts *TaskState, errOut io.Writer) {
 		return
 	}
 	t.ReportOffset = ts.ReportOffset
-	t.PRMergedObserved = t.PRMergedObserved || ts.PRMerged
+	t.MergeAnnounced = t.MergeAnnounced || ts.PRMerged
 	t.DoneVerified = t.DoneVerified || ts.DoneVerified
 	if err := state.Write(home, t); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: persist task %s failed: %v\n", id, err)

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -223,7 +223,7 @@ func TestTickUpdatesDashboardToDoneOnlyOnceAReportedDoneIsVerified(t *testing.T)
 
 	home := setupWatcherHome(t, state.Task{
 		ID: "task-1", Project: "nsr", Kind: state.KindShip,
-		PR: "https://github.com/atqamz/secondhand/pull/1", Merged: true,
+		PR: "https://github.com/atqamz/secondhand/pull/1", MergeExecuted: true,
 		Herdr: state.Herdr{PaneID: "p1"},
 	})
 	dashPath := filepath.Join(home, "data", "dashboard.md")
@@ -880,8 +880,8 @@ func TestTickAnnouncesPRMergedBeforePersistingIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !task.PRMergedObserved {
-		t.Fatal("task.PRMergedObserved = false, want the announced merge persisted after the fact")
+	if !task.MergeAnnounced {
+		t.Fatal("task.MergeAnnounced = false, want the announced merge persisted after the fact")
 	}
 }
 
@@ -900,7 +900,7 @@ func (w *stateAtWriteWriter) Write(p []byte) (int, error) {
 	if err != nil {
 		w.t.Fatal(err)
 	}
-	w.observed[strings.TrimSpace(string(p))] = task.PRMergedObserved
+	w.observed[strings.TrimSpace(string(p))] = task.MergeAnnounced
 	return w.buf.Write(p)
 }
 
@@ -1056,7 +1056,7 @@ func TestTickAnnouncesAVerifiedDoneAfterARestartThatMissedTheEvidence(t *testing
 	if task.DoneVerified {
 		t.Fatal("task.DoneVerified = true, want the unverified report to leave the marker unset")
 	}
-	task.Merged = true
+	task.MergeExecuted = true
 	if err := state.Write(home, task); err != nil {
 		t.Fatal(err)
 	}
@@ -1176,7 +1176,7 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	}
 
 	// hand merge lands the evidence the ship's own done needs.
-	task.Merged = true
+	task.MergeExecuted = true
 	if err := state.Write(home, task); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -435,7 +435,7 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			name: "merge an already merged task",
 			setup: func(t *testing.T, home string) {
 				registerProject(t, home, "demo", "direct-pr")
-				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Merged: true}); err != nil {
+				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, MergeExecuted: true}); err != nil {
 					t.Fatal(err)
 				}
 			},

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -51,8 +51,8 @@ func TestMergePR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !task1.Merged || task1.MergedAt == "" {
-		t.Fatalf("task-1 state = %+v, want Merged=true and MergedAt set", task1)
+	if !task1.MergeExecuted || task1.MergeExecutedAt == "" {
+		t.Fatalf("task-1 state = %+v, want MergeExecuted=true and MergeExecutedAt set", task1)
 	}
 
 	refused := runHand(t, home, "merge", "task-2")
@@ -61,8 +61,8 @@ func TestMergePR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if task2.Merged {
-		t.Fatalf("task-2 state = %+v, want Merged=false after refused merge (red checks must never reach gh pr merge)", task2)
+	if task2.MergeExecuted {
+		t.Fatalf("task-2 state = %+v, want MergeExecuted=false after refused merge (red checks must never reach gh pr merge)", task2)
 	}
 
 	logData, err := os.ReadFile(invocationLog)


### PR DESCRIPTION
## Summary

- `hand status` now shows PR merge state directly, in both the fleet overview and single-task
  detail: `state.Task`'s `MergeExecuted` (hand ran the merge) and `MergeAnnounced` (hand watch's
  own `gh` poll saw someone else merge it) render as a distinguishable, non-accusatory suffix on
  the PR column - ` (merged)` or ` (merged, external)`. It reads `state.Task` directly on every
  invocation, so this closes #51 on its own, with no dashboard change.
- Folds in #58: renames `state.Task`'s `Merged`/`MergedAt`/`PRMergedObserved` to
  `MergeExecuted`/`MergeExecutedAt`/`MergeAnnounced`. JSON tags are byte-identical (`merged`,
  `merged_at`, `pr_merged_observed`) - Go identifier rename only, no schema change, no migration.

## Why the dashboard half is gone

This PR originally also wired the merge marker into `internal/dashboard`'s `Render`/`Parse` round
trip, `hand merge`'s post-merge reconcile, and `hand watch`'s `pr-merged` handling. Dropped
entirely: #62 deletes `data/dashboard.md` and `internal/dashboard` outright rather than fixing the
read-modify-write round trip that this PR's own gate review had already found losing this exact
flag when a row's PR cell went stale (`marker-dropped-when-pr-cell-empty` - fixed at the time, in
code that would have been deleted within days of landing). `internal/dashboard` now carries none
of this PR's changes: reverted `dashboard.go`, `dashboard_test.go`, `cmd/merge.go`,
`cmd/merge_test.go`, `internal/watcher/watcher.go`, `watcher_test.go` to `main`, and decoupled
`cmd/status.go`'s `mergeSuffix` from `dashboard.DeriveMergeState` so it derives the suffix from
`state.Task` directly.

The design question this raised - whether `Merged`/`PRMergedObserved` round-tripping through
rendered markdown was the right shape at all - was posted to #53 as a question rather than decided
there: [comment](https://github.com/atqamz/secondhand/issues/53#issuecomment-5091646707). #62's
decision to delete the file rather than patch the round trip is the answer.

## Wording

- No PR, or PR unmerged: unchanged, no suffix.
- `MergeExecuted`: ` (merged)`.
- `MergeAnnounced` alone: ` (merged, external)`.
- Both set: renders as ` (merged)`. Once hand performed the merge, a later poll independently
  confirming the same merge is bookkeeping, not a new fact - it doesn't downgrade who did it.

`MergeAnnounced` alone overwhelmingly means the operator merged the PR in the GitHub web UI - a
normal, common path, not an incident. "external" was chosen over anything that could read as an
alarm, since the wording must not imply wrongdoing (per #51). It still reads unambiguously next to
a PR link: the merge happened, and `hand merge` did not do it - which is exactly the fact a
supervising agent needs to decide whether to look closer.

## The rename (#58)

`state.Task` named two related facts inconsistently, and neither name stated the fact it
recorded: `Merged` did not mean the PR is merged, it meant hand itself performed the merge;
`PRMergedObserved` was not that fact's observational counterpart, it meant hand watch already
announced the merge (its own idempotence latch, so a restarted watcher doesn't re-announce). Both
fields record actions hand took, not facts about the PR, so they're renamed to say that:
`MergeExecuted`/`MergeExecutedAt`/`MergeAnnounced`. `DoneVerified` is the existing precedent for
this naming shape.

The same trap the rename fixes had already caught the derived display type on this PR three times
- once on enum value names, once on derivation parameter names, once on a field comment - before
the source fields themselves were touched. Renaming after landing new code against names already
known to be wrong is the worse order, and with the dashboard half gone the rename surface is small
enough (`internal/state/types.go`, `cmd/merge.go`, `internal/watcher/events.go`,
`internal/watcher/watcher.go`, `cmd/status.go`, and their tests - about fifteen identifier sites)
to fold in here rather than ship separately, which is the fold #58 itself now proposes.

JSON tags stay exactly as they were (`merged`, `merged_at`, `pr_merged_observed`): this is a Go
identifier rename only. It requires no migration of existing `state/*.json` - Go field names and
JSON tags are independent, and this PR is the proof: no file on disk needs to change for any of
this to work.

## Before / after

`hand status` overview, same three tasks throughout: `task-hand-merged` (`MergeExecuted=true`),
`task-merged-externally` (`MergeAnnounced=true`, `MergeExecuted=false` - the operator merged it in
the GitHub web UI), `task-awaiting-merge` (neither set).

Before:
```
task-awaiting-merge      nsr  ship  unknown  2h ago
task-hand-merged         nsr  ship  unknown  2h ago
task-merged-externally   nsr  ship  unknown  2h ago
```

After:
```
task-awaiting-merge      nsr  ship  unknown                     2h ago
task-hand-merged         nsr  ship  unknown (merged)            2h ago
task-merged-externally   nsr  ship  unknown (merged, external)  2h ago
```

`hand status <id>` detail carries the same suffix on the `PR:` line.

## Scope

Surfacing only, as scoped by #51. `internal/watcher`'s classification (`ClassifyPRMerged`,
`PersistedPRMerged`, `dashboardRowFor`'s `KindPRMerged` disposition) is untouched.
`internal/dashboard` carries none of this PR's changes - #62 owns that file now. No new `hand`
subcommand.

## Gate

Ran through the `no-mistakes` gate against this reshaped diff (a behaviour change: the rename
touches every reader and writer of the three fields).

Closes #51
Closes #58

## Test plan

- `cmd/status_test.go`: detail view shows the marker for a merged PR and is unchanged for an
  unmerged one; all four `MergeExecuted`/`MergeAnnounced` combinations; fleet overview renders the
  marker; a task with no PR at all is unaffected.
- `internal/state`, `internal/watcher`, `tests/e2e`: assertions updated to the renamed
  identifiers only, no behavior change.
- `make lint`, `go test -race ./...`, and `make e2e` all pass locally, and again inside the
  `no-mistakes` gate run.
