### PR TITLE
feat(cmd): honor a brief's declared model and effort on spawn and promote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Run `hand --help` for the full command reference.
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
+- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce `data/<id>/report.md`.
 - `data/backlog.md` is your task queue. Edit it directly.
 - For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Run `hand --help` for the full command reference.
 1. Read `data/dashboard.md` for current fleet state.
 2. Match the request to a project in `data/projects.md`.
 3. Edit `data/backlog.md` to record the task with a unique ID.
-4. Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.
+4. Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it. The brief may open with a `---` fenced block declaring `model` and `effort` for the task, which spawn and promote apply unless a flag overrides them.
 5. `hand spawn <id> <project>` to start a worker.
 6. `hand watch` as a background task to monitor the fleet.
 7. Act on watch output: steer blocked workers with `hand send`, relay results.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Builds without an embedded version never print the notice.
 
 Currently supported preferences live as plain files under `config/`: default worker harness, model, and effort.
 Run `hand init --setup` to discover installed harnesses and tools and write the defaults interactively.
+A brief can declare its own `model` and `effort` for one task, which win over these defaults and lose only to a `hand spawn`/`hand promote` flag - see SPECS.md's "Brief format" section.
 
 Workers run their harness interactively so they can be steered and watched.
 For Claude Code that means first-run dialogs, and `hand spawn` and `hand promote` answer the workspace-trust and bypass-permissions ones for you, then confirm the worker is actually running before reporting success.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1242,7 +1242,9 @@ Model names are not validated against a list, which would rot the first time a m
 
 The declaration is dispatch metadata, not task content. The worker opens the brief itself, so the
 launch prompt gains one sentence telling it to skip past the front matter when a block is present;
-the brief on disk is never rewritten or stripped.
+the brief on disk is never rewritten or stripped. Only the prompt-bearing harnesses carry that
+sentence: `codex`, `grok` and `pi` are handed the brief as a file with no prompt at all, so a
+declaring brief reaches them undisclaimed.
 
 A declared effort under a harness that cannot apply one warns on stderr (see `hand spawn`).
 
@@ -1435,7 +1437,7 @@ These are explicit non-goals. Each lists the firstmate feature it replaces and w
 | X-mode / Twitter | `fm-x-*.sh`, `fmx-respond` skill (3,250 lines) | Separate product concern. Build as a separate tool if ever needed. |
 | AFK daemon | `fm-supervise-daemon.sh`, `fm-afk-launch.sh` (2,150 lines) | `hand watch` + `hand notify` + the agent's own background task is sufficient. |
 | Multiple backends | `backends/herdr.sh`, `backends/cmux.sh`, `backends/zellij.sh`, `backends/orca.sh`, `fm-backend.sh` (5,500 lines) | herdr only. Add tmux fallback later if herdr proves insufficient. |
-| Dispatch profiles | `fm-dispatch-select.sh`, `config/crew-dispatch.json` (340 lines + skill) | Pass `--harness`/`--model`/`--effort` explicitly, or set defaults in `config/`. |
+| Dispatch profiles | `fm-dispatch-select.sh`, `config/crew-dispatch.json` (340 lines + skill) | Pass `--harness`/`--model`/`--effort` explicitly, declare `model`/`effort` in the brief, or set defaults in `config/`. |
 | Decision holds | `fm-decision-hold.sh`, decision-hold-lifecycle skill (500 lines) | Agent tracks decisions in backlog and dashboard. |
 | Hook-based guards | `fm-continuity-pretool-check.sh`, `fm-continuity-command-policy.mjs`, `fm-subagent-pretool-check.sh` (450 lines) | CLI refuses bad operations internally. No hooks. |
 | PR-check migration | `fm-pr-check-migrate.sh` (1,148 lines) | No legacy to migrate. |

--- a/SPECS.md
+++ b/SPECS.md
@@ -95,8 +95,8 @@ secondhand/                 # repo root = working directory
       pr.go                 # PR URL validation and extraction
     worktree/               # treehouse integration
       worktree.go           # get, return, status, collision check
-    brief/                  # brief template and generation
-      brief.go              # scaffold a brief from a template
+    brief/                  # brief parsing
+      brief.go              # read the brief's declared model/effort (see "Brief format")
     watcher/                # fleet supervision
       watcher.go            # poll/push event loop
       events.go             # event classification
@@ -1643,3 +1643,4 @@ Deliverable: ready for daily use.
 **`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new workspace's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh.
 
 This repo's own `AGENTS.md` is not a `hand` workspace (no `data/dashboard.md`), so `agentsmd.Refresh` never touches it: its top section is a hand-kept copy of `generatedBody`, kept in sync manually rather than by the refresh mechanism.
+Drift between the two copies is caught by a unit test in `internal/agentsmd` asserting the repo copy's rules open with the generated ones verbatim, not by the mechanism that would remove the duplication.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1235,14 +1235,16 @@ scope, so a respawn or a promote picks the declaration up again instead of falli
 `config/model`.
 
 The parser is deliberately forgiving, unlike `data/projects.md`'s registry parser: unknown keys
-inside the block are ignored, and a brief it cannot scan (an unterminated fence, an enormous
-pasted line) is read as having no declaration rather than failing the spawn. A brief is prose
-that happens to carry two optional settings, not a config file that happens to contain prose.
+inside the block are ignored, a value written as a YAML quoted scalar (`model: "claude-opus-5"`)
+declares the same tier as the bare form, and a brief it cannot scan (an unterminated fence, an
+enormous pasted line) is read as having no declaration rather than failing the spawn. A brief is
+prose that happens to carry two optional settings, not a config file that happens to contain prose.
 Model names are not validated against a list, which would rot the first time a model ships.
 
 The declaration is dispatch metadata, not task content. The worker opens the brief itself, so the
-launch prompt gains one sentence telling it to skip past the front matter when a block is present;
-the brief on disk is never rewritten or stripped. Only the prompt-bearing harnesses carry that
+launch prompt gains one sentence marking the block's `model` and `effort` keys as dispatch metadata
+when a block is present; anything else the block carries is left to the worker to read, and the
+brief on disk is never rewritten or stripped. Only the prompt-bearing harnesses carry that
 sentence: `codex`, `grok` and `pi` are handed the brief as a file with no prompt at all, so a
 declaring brief reaches them undisclaimed.
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -275,8 +275,13 @@ hand spawn investigate-crash nsr --scout
 Flags:
 - `--scout`: mark as scout task (deliverable is a report, not a PR).
 - `--harness <name>`: agent harness to launch. Default: value from `config/harness`, or `claude`.
-- `--model <name>`: model override for harnesses that support it. Default: value from `config/model`.
-- `--effort <level>`: effort level for harnesses that support it. Default: value from `config/effort`.
+- `--model <name>`: model override for harnesses that support it. Default: the brief's declared `model`, else `config/model`.
+- `--effort <level>`: effort level for harnesses that support it. Default: the brief's declared `effort`, else `config/effort`.
+
+Model and effort resolve most-specific-first: the flag, then the brief's `---` declaration (see
+"Brief format"), then the config default, then unset. A resolved effort under a harness with no
+effort flag (anything but claude) is a warning on stderr, not a failure: the spawn proceeds with
+the effort recorded in state and ignored by the launch command.
 
 Behavior:
 1. Validate project exists in registry.
@@ -733,8 +738,12 @@ hand promote investigate-crash --harness codex
 
 Flags:
 - `--harness <name>`: harness for the new ship worker. Default: value from `config/harness`.
-- `--model <name>`: model override. Default: value from `config/model`.
-- `--effort <level>`: effort override. Default: value from `config/effort`.
+- `--model <name>`: model override. Default: the brief's declared `model`, else `config/model`.
+- `--effort <level>`: effort override. Default: the brief's declared `effort`, else `config/effort`.
+
+Promote resolves model and effort exactly as `hand spawn` does, against the brief the agent
+updated for the ship phase, so a scout brief that declared a tier keeps it through promotion
+unless the brief or a flag says otherwise.
 
 Behavior:
 1. Validate the task exists and is a completed scout (has `data/<id>/report.md`, herdr pane is not busy - `idle` or `done`, which mean the same thing here, see "Agent state" - or unreachable/dead).
@@ -944,6 +953,10 @@ cd <worktree> && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously
 
 The brief path is included in the prompt because Claude Code takes prompt text, not a file path.
 When configured, `--model <name>` and `--effort <level>` are inserted before the prompt.
+Claude is the only harness with an effort flag: `opencode` takes `--model` but no effort, and
+`codex`, `grok` and `pi` take neither (`harness.SupportsEffort`).
+When the brief carries a `---` declaration, the prompt gains a sentence disclaiming it as dispatch
+metadata (see "Brief format").
 `--dangerously-skip-permissions` is required so the unattended worker does not stall on a
 permission dialog.
 `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false` suppresses the dim predicted-next-prompt ghost text
@@ -1201,6 +1214,37 @@ Recommended structure:
 There is no template engine, no placeholder substitution, no generated sections.
 The supervisory agent is an LLM - it writes good briefs naturally.
 Removing template machinery removes a maintenance burden and failure mode.
+
+### Declared model and effort
+
+A brief may open with a `---` fenced block declaring the tier the task should run at:
+
+```markdown
+---
+model: claude-opus-5
+effort: high
+---
+
+# Task: <short description>
+```
+
+Both keys are optional, and the block is only recognized when `---` is the brief's very first
+line. `hand spawn` and `hand promote` read it (`internal/brief`) and resolve model and effort as
+flag, then declaration, then config default, then unset. The brief is the durable statement of
+scope, so a respawn or a promote picks the declaration up again instead of falling back to
+`config/model`.
+
+The parser is deliberately forgiving, unlike `data/projects.md`'s registry parser: unknown keys
+inside the block are ignored, and a brief it cannot scan (an unterminated fence, an enormous
+pasted line) is read as having no declaration rather than failing the spawn. A brief is prose
+that happens to carry two optional settings, not a config file that happens to contain prose.
+Model names are not validated against a list, which would rot the first time a model ships.
+
+The declaration is dispatch metadata, not task content. The worker opens the brief itself, so the
+launch prompt gains one sentence telling it to skip past the front matter when a block is present;
+the brief on disk is never rewritten or stripped.
+
+A declared effort under a harness that cannot apply one warns on stderr (see `hand spawn`).
 
 ## Backlog format
 

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -12,18 +12,28 @@ import (
 )
 
 // useFastLaunchPolling shrinks confirmLaunch's poll window for the rest of the test, so a
-// command test costs milliseconds instead of sleeping through the real settle window.
+// command test costs milliseconds instead of sleeping through the real settle window. The
+// deadline stays generous because a pane that confirms returns on its own poll and never reaches
+// it: every poll here is two real subprocess round-trips into the herdr fake, so a deadline sized
+// to a few of them is a race against machine speed rather than a test. Tests that assert the
+// deadline itself call expectLaunchTimeout to narrow it back down.
 func useFastLaunchPolling(t *testing.T) {
 	t.Helper()
 	previous := launchPolling
 	launchPolling = launchPoll{
 		Interval:   time.Millisecond,
 		QuietReads: 3,
-		Timeout:    150 * time.Millisecond,
+		Timeout:    10 * time.Second,
 		KeySettle:  time.Millisecond,
 		ReadLines:  60,
 	}
 	t.Cleanup(func() { launchPolling = previous })
+}
+
+// expectLaunchTimeout narrows the deadline set by an earlier useFastLaunchPolling, whose cleanup
+// restores it, for a pane that never confirms and so has to run its deadline out.
+func expectLaunchTimeout() {
+	launchPolling.Timeout = 150 * time.Millisecond
 }
 
 // launchFrame is one poll's worth of pane state: what "pane read" shows and what agent, if any,
@@ -226,6 +236,9 @@ func TestConfirmLaunch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			useFastLaunchPolling(t)
+			if tt.wantErr != "" {
+				expectLaunchTimeout()
+			}
 			keyLog := fakeLaunchPane(t, tt.frames...)
 
 			err := confirmLaunch(herdr.NewClient(), "wA:pC", tt.harness)

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -66,11 +66,10 @@ func newPromoteCmd() *cobra.Command {
 			if !harness.IsSupported(harnessName) {
 				return usageValue(harnessFromFlag, fmt.Errorf("harness %q not recognized", harnessName))
 			}
-			if model == "" {
-				model = configDefault(home, "model", "")
-			}
-			if effort == "" {
-				effort = configDefault(home, "effort", "")
+			var frontMatter bool
+			model, effort, frontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
+			if err != nil {
+				return err
 			}
 
 			proj, exists, err := project.Find(home, t.Project)
@@ -139,10 +138,11 @@ func newPromoteCmd() *cobra.Command {
 			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
-				Worktree: wt,
-				Brief:    briefAbs,
-				Model:    model,
-				Effort:   effort,
+				Worktree:    wt,
+				Brief:       briefAbs,
+				Model:       model,
+				Effort:      effort,
+				FrontMatter: frontMatter,
 			})
 			if err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -66,8 +66,8 @@ func newPromoteCmd() *cobra.Command {
 			if !harness.IsSupported(harnessName) {
 				return usageValue(harnessFromFlag, fmt.Errorf("harness %q not recognized", harnessName))
 			}
-			var frontMatter bool
-			model, effort, frontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
+			var briefHasFrontMatter bool
+			model, effort, briefHasFrontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
 			if err != nil {
 				return err
 			}
@@ -138,11 +138,11 @@ func newPromoteCmd() *cobra.Command {
 			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
-				Worktree:    wt,
-				Brief:       briefAbs,
-				Model:       model,
-				Effort:      effort,
-				FrontMatter: frontMatter,
+				Worktree:            wt,
+				Brief:               briefAbs,
+				Model:               model,
+				Effort:              effort,
+				BriefHasFrontMatter: briefHasFrontMatter,
 			})
 			if err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -63,8 +63,8 @@ func newSpawnCmd() *cobra.Command {
 			if !harness.IsSupported(harnessName) {
 				return usageValue(harnessFromFlag, fmt.Errorf("harness %q not recognized", harnessName))
 			}
-			var frontMatter bool
-			model, effort, frontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
+			var briefHasFrontMatter bool
+			model, effort, briefHasFrontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
 			if err != nil {
 				return err
 			}
@@ -125,11 +125,11 @@ func newSpawnCmd() *cobra.Command {
 			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
-				Worktree:    wt,
-				Brief:       briefAbs,
-				Model:       model,
-				Effort:      effort,
-				FrontMatter: frontMatter,
+				Worktree:            wt,
+				Brief:               briefAbs,
+				Model:               model,
+				Effort:              effort,
+				BriefHasFrontMatter: briefHasFrontMatter,
 			})
 			if err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -63,11 +63,10 @@ func newSpawnCmd() *cobra.Command {
 			if !harness.IsSupported(harnessName) {
 				return usageValue(harnessFromFlag, fmt.Errorf("harness %q not recognized", harnessName))
 			}
-			if model == "" {
-				model = configDefault(home, "model", "")
-			}
-			if effort == "" {
-				effort = configDefault(home, "effort", "")
+			var frontMatter bool
+			model, effort, frontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
+			if err != nil {
+				return err
 			}
 			releaseProject, err := state.Lock(home, "project:"+proj.Name)
 			if err != nil {
@@ -126,10 +125,11 @@ func newSpawnCmd() *cobra.Command {
 			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
-				Worktree: wt,
-				Brief:    briefAbs,
-				Model:    model,
-				Effort:   effort,
+				Worktree:    wt,
+				Brief:       briefAbs,
+				Model:       model,
+				Effort:      effort,
+				FrontMatter: frontMatter,
 			})
 			if err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -129,6 +129,32 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 }
 
+func TestSpawnPersistsResolvedNotDeclaredTierValues(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	briefPath := filepath.Join(home, "data", "task-1", "brief.md")
+	if err := os.WriteFile(briefPath, []byte("---\nmodel: brief-model\neffort: brief-effort\n---\n# Title\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj", "--model", "flag-model"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "flag-model" {
+		t.Fatalf("got model %q, want the flag to win over the brief's declared %q", got.Model, "brief-model")
+	}
+	if got.Effort != "brief-effort" {
+		t.Fatalf("got effort %q, want the brief's declared value since no flag or config overrides it", got.Effort)
+	}
+}
+
 func TestSpawnScoutFlag(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -345,6 +345,7 @@ esac
 func TestSpawnRollsBackWhenWorkerNeverStarts(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	home := setupSpawnHome(t, wt, fakeHerdrStuckPaneScript)
+	expectLaunchTimeout()
 	callLog := setupSpawnLeakEnv(t, false)
 
 	cmd := newSpawnCmd()

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	"fmt"
 
 	"github.com/atqamz/secondhand/internal/brief"
@@ -14,21 +15,8 @@ func resolveTier(cmd *cobra.Command, home, briefAbs, harnessName, model, effort 
 		return "", "", false, fmt.Errorf("parse brief %s: %w", briefAbs, err)
 	}
 
-	resolvedModel = model
-	if resolvedModel == "" {
-		resolvedModel = decl.Model
-	}
-	if resolvedModel == "" {
-		resolvedModel = configDefault(home, "model", "")
-	}
-
-	resolvedEffort = effort
-	if resolvedEffort == "" {
-		resolvedEffort = decl.Effort
-	}
-	if resolvedEffort == "" {
-		resolvedEffort = configDefault(home, "effort", "")
-	}
+	resolvedModel = cmp.Or(model, decl.Model, configDefault(home, "model", ""))
+	resolvedEffort = cmp.Or(effort, decl.Effort, configDefault(home, "effort", ""))
 
 	if resolvedEffort != "" && !harness.SupportsEffort(harnessName) {
 		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q has no effort flag, ignoring effort %q\n", harnessName, resolvedEffort); err != nil {

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -8,13 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// resolveTier applies the model/effort precedence spawn and promote share: an explicit flag
-// wins, then the brief's own "---" front matter declaration, then config/model and
-// config/effort, then the harness default. It is the one place that chain lives, since spawn
-// and promote are already near-identical here. frontMatter reports whether briefAbs carries a
-// declaration block at all, so the caller can pass it to harness.Build and keep it out of the
-// worker's prompt as an instruction. A resolved effort the chosen harness cannot apply is
-// reported to stderr, not dropped silently.
 func resolveTier(cmd *cobra.Command, home, briefAbs, harnessName, model, effort string) (resolvedModel, resolvedEffort string, frontMatter bool, err error) {
 	decl, frontMatter, err := brief.Parse(briefAbs)
 	if err != nil {

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/atqamz/secondhand/internal/brief"
+	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/spf13/cobra"
+)
+
+// resolveTier applies the model/effort precedence spawn and promote share: an explicit flag
+// wins, then the brief's own "---" front matter declaration, then config/model and
+// config/effort, then the harness default. It is the one place that chain lives, since spawn
+// and promote are already near-identical here. frontMatter reports whether briefAbs carries a
+// declaration block at all, so the caller can pass it to harness.Build and keep it out of the
+// worker's prompt as an instruction. A resolved effort the chosen harness cannot apply is
+// reported to stderr, not dropped silently.
+func resolveTier(cmd *cobra.Command, home, briefAbs, harnessName, model, effort string) (resolvedModel, resolvedEffort string, frontMatter bool, err error) {
+	decl, frontMatter, err := brief.Parse(briefAbs)
+	if err != nil {
+		return "", "", false, fmt.Errorf("parse brief %s: %w", briefAbs, err)
+	}
+
+	resolvedModel = model
+	if resolvedModel == "" {
+		resolvedModel = decl.Model
+	}
+	if resolvedModel == "" {
+		resolvedModel = configDefault(home, "model", "")
+	}
+
+	resolvedEffort = effort
+	if resolvedEffort == "" {
+		resolvedEffort = decl.Effort
+	}
+	if resolvedEffort == "" {
+		resolvedEffort = configDefault(home, "effort", "")
+	}
+
+	if resolvedEffort != "" && !harness.SupportsEffort(harnessName) {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q has no effort flag, ignoring effort %q\n", harnessName, resolvedEffort); err != nil {
+			return "", "", false, err
+		}
+	}
+
+	return resolvedModel, resolvedEffort, frontMatter, nil
+}

--- a/cmd/tier_test.go
+++ b/cmd/tier_test.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/spf13/cobra"
+)
+
+func writeTierBrief(t *testing.T, home, content string) string {
+	t.Helper()
+	path := filepath.Join(home, "brief.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func newTierTestCmd() (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	stderr := &bytes.Buffer{}
+	cmd.SetErr(stderr)
+	return cmd, stderr
+}
+
+const declaredBrief = "---\nmodel: brief-model\neffort: brief-effort\n---\n# Title\n"
+
+func TestResolveTierFlagOverridesEverything(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, declaredBrief)
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "model"), []byte("config-model\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "effort"), []byte("config-effort\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, _ := newTierTestCmd()
+	model, effort, frontMatter, err := resolveTier(cmd, home, briefAbs, harness.Claude, "flag-model", "flag-effort")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "flag-model" || effort != "flag-effort" {
+		t.Fatalf("got model=%q effort=%q, want the flags to win", model, effort)
+	}
+	if !frontMatter {
+		t.Fatal("frontMatter = false, want true since the brief declares one")
+	}
+}
+
+func TestResolveTierBriefOverridesConfig(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, declaredBrief)
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "model"), []byte("config-model\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "effort"), []byte("config-effort\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, _ := newTierTestCmd()
+	model, effort, frontMatter, err := resolveTier(cmd, home, briefAbs, harness.Claude, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "brief-model" || effort != "brief-effort" {
+		t.Fatalf("got model=%q effort=%q, want the brief to win over config", model, effort)
+	}
+	if !frontMatter {
+		t.Fatal("frontMatter = false, want true")
+	}
+}
+
+func TestResolveTierConfigAlone(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, "# Title\n\nno declaration here\n")
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "model"), []byte("config-model\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "effort"), []byte("config-effort\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, _ := newTierTestCmd()
+	model, effort, frontMatter, err := resolveTier(cmd, home, briefAbs, harness.Claude, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "config-model" || effort != "config-effort" {
+		t.Fatalf("got model=%q effort=%q, want config values", model, effort)
+	}
+	if frontMatter {
+		t.Fatal("frontMatter = true, want false for a brief with no declaration")
+	}
+}
+
+func TestResolveTierAllAbsent(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, "# Title\n\nno declaration here\n")
+
+	cmd, _ := newTierTestCmd()
+	model, effort, frontMatter, err := resolveTier(cmd, home, briefAbs, harness.Claude, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "" || effort != "" || frontMatter {
+		t.Fatalf("got model=%q effort=%q frontMatter=%v, want everything absent", model, effort, frontMatter)
+	}
+}
+
+func TestResolveTierUnknownBriefKeyIsNotAnError(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, "---\nmodel: brief-model\nreviewer: someone\n---\n# Title\n")
+
+	cmd, _ := newTierTestCmd()
+	model, _, _, err := resolveTier(cmd, home, briefAbs, harness.Claude, "", "")
+	if err != nil {
+		t.Fatalf("unknown brief key produced an error: %v", err)
+	}
+	if model != "brief-model" {
+		t.Fatalf("got model=%q", model)
+	}
+}
+
+func TestResolveTierWarnsWhenHarnessCannotApplyEffort(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, declaredBrief)
+
+	cmd, stderr := newTierTestCmd()
+	_, effort, _, err := resolveTier(cmd, home, briefAbs, harness.OpenCode, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effort != "brief-effort" {
+		t.Fatalf("got effort=%q, want it still resolved even though opencode cannot apply it", effort)
+	}
+	if !strings.Contains(stderr.String(), "opencode") || !strings.Contains(stderr.String(), "effort") {
+		t.Fatalf("stderr = %q, want a warning naming the harness and effort", stderr.String())
+	}
+}
+
+func TestResolveTierNoWarningWhenNoEffortResolved(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, "# Title\n\nno declaration here\n")
+
+	cmd, stderr := newTierTestCmd()
+	if _, _, _, err := resolveTier(cmd, home, briefAbs, harness.OpenCode, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no warning when no effort was resolved at all", stderr.String())
+	}
+}
+
+func TestResolveTierNoWarningUnderClaude(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, declaredBrief)
+
+	cmd, stderr := newTierTestCmd()
+	if _, _, _, err := resolveTier(cmd, home, briefAbs, harness.Claude, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no warning under a harness that supports effort", stderr.String())
+	}
+}

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -30,7 +30,7 @@ Run ` + "`hand --help`" + ` for the full command reference.
 1. Read ` + "`data/dashboard.md`" + ` for current fleet state.
 2. Match the request to a project in ` + "`data/projects.md`" + `.
 3. Edit ` + "`data/backlog.md`" + ` to record the task with a unique ID.
-4. Write a brief at ` + "`data/<id>/brief.md`" + `, including the absolute path to ` + "`state/<id>.status`" + ` and the report vocabulary the worker should append to it.
+4. Write a brief at ` + "`data/<id>/brief.md`" + `, including the absolute path to ` + "`state/<id>.status`" + ` and the report vocabulary the worker should append to it. The brief may open with a ` + "`---`" + ` fenced block declaring ` + "`model`" + ` and ` + "`effort`" + ` for the task, which spawn and promote apply unless a flag overrides them.
 5. ` + "`hand spawn <id> <project>`" + ` to start a worker.
 6. ` + "`hand watch`" + ` as a background task to monitor the fleet.
 7. Act on watch output: steer blocked workers with ` + "`hand send`" + `, relay results.

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -43,6 +43,7 @@ Run ` + "`hand --help`" + ` for the full command reference.
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
+- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. ` + "`hand`" + ` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce ` + "`data/<id>/report.md`" + `.
 - ` + "`data/backlog.md`" + ` is your task queue. Edit it directly.
 - For no-mistakes projects, workers use ` + "`no-mistakes axi`" + ` directly in the worktree.

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -188,6 +188,36 @@ func TestRefreshLeavesUpToDateFileOnDiskUntouched(t *testing.T) {
 	}
 }
 
+// This repo keeps a hand-maintained copy of the generated block in its own
+// AGENTS.md instead of deriving it, so a rule edited in one copy and not the
+// other drifts silently until the duplication itself is removed.
+func TestGeneratedRulesMatchThisRepoAgentsMdCopy(t *testing.T) {
+	repoCopy, err := os.ReadFile(filepath.Join("..", "..", "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	absolutePathRule := "- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.\n"
+	if !strings.Contains(generatedBody, absolutePathRule) {
+		t.Fatalf("got generated body %q, want the absolute-path rule verbatim", generatedBody)
+	}
+	if !strings.Contains(string(repoCopy), absolutePathRule) {
+		t.Fatalf("got repo AGENTS.md %q, want the same absolute-path rule byte-for-byte", repoCopy)
+	}
+
+	_, generatedRules, ok := strings.Cut(generatedBody, "## Rules\n")
+	if !ok {
+		t.Fatalf("got generated body %q, want a Rules section", generatedBody)
+	}
+	_, repoRules, ok := strings.Cut(string(repoCopy), "## Rules\n")
+	if !ok {
+		t.Fatalf("got repo AGENTS.md %q, want a Rules section", repoCopy)
+	}
+	if !strings.HasPrefix(repoRules, generatedRules) {
+		t.Fatalf("got repo rules %q, want them to open with the generated rules %q", repoRules, generatedRules)
+	}
+}
+
 func TestRefreshDoesNotOverwriteExistingClaudeSymlink(t *testing.T) {
 	dir := makeWorkspace(t)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("placeholder\n"), 0o644); err != nil {

--- a/internal/brief/brief.go
+++ b/internal/brief/brief.go
@@ -41,10 +41,18 @@ func Parse(path string) (Declaration, bool, error) {
 		}
 		switch strings.TrimSpace(key) {
 		case "model":
-			d.Model = strings.TrimSpace(value)
+			d.Model = unquote(value)
 		case "effort":
-			d.Effort = strings.TrimSpace(value)
+			d.Effort = unquote(value)
 		}
 	}
 	return Declaration{}, false, nil
+}
+
+func unquote(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') && value[len(value)-1] == value[0] {
+		return value[1 : len(value)-1]
+	}
+	return value
 }

--- a/internal/brief/brief.go
+++ b/internal/brief/brief.go
@@ -13,15 +13,8 @@ type Declaration struct {
 	Effort string
 }
 
-// Parse reads path for a leading "---"-delimited front matter block declaring model and/or
-// effort. present reports whether such a block was found at all, independent of whether it
-// declared any recognized key - the harness prompt uses it to warn a worker away from reading
-// the block as task content. A brief whose first line is not exactly "---", or whose opening
-// "---" is never closed, is unmodified prose: Parse returns a zero Declaration and
-// present=false rather than guess. Every existing brief in this fleet starts with a "#" heading
-// or plain prose, never "---", so all of them parse exactly as they did before this existed.
-// Unknown keys inside the block are ignored, not an error: a brief is prose that happens to
-// carry two optional settings, not a config file that happens to contain prose.
+// Parse ignores unknown keys inside the block by choice, not oversight: a brief is prose
+// carrying two optional settings, not a config file.
 func Parse(path string) (Declaration, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -54,7 +47,5 @@ func Parse(path string) (Declaration, bool, error) {
 	if err := scanner.Err(); err != nil {
 		return Declaration{}, false, err
 	}
-	// Opening "---" never closed: not a real front matter block, just a line that looked
-	// like one. Treat the whole file as prose rather than swallowing it as a declaration.
 	return Declaration{}, false, nil
 }

--- a/internal/brief/brief.go
+++ b/internal/brief/brief.go
@@ -1,0 +1,60 @@
+// Package brief reads the optional model/effort tier a brief.md declares for itself.
+package brief
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Declaration struct {
+	Model  string
+	Effort string
+}
+
+// Parse reads path for a leading "---"-delimited front matter block declaring model and/or
+// effort. present reports whether such a block was found at all, independent of whether it
+// declared any recognized key - the harness prompt uses it to warn a worker away from reading
+// the block as task content. A brief whose first line is not exactly "---", or whose opening
+// "---" is never closed, is unmodified prose: Parse returns a zero Declaration and
+// present=false rather than guess. Every existing brief in this fleet starts with a "#" heading
+// or plain prose, never "---", so all of them parse exactly as they did before this existed.
+// Unknown keys inside the block are ignored, not an error: a brief is prose that happens to
+// carry two optional settings, not a config file that happens to contain prose.
+func Parse(path string) (Declaration, bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Declaration{}, false, fmt.Errorf("open brief %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() || strings.TrimSpace(scanner.Text()) != "---" {
+		return Declaration{}, false, scanner.Err()
+	}
+
+	var d Declaration
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "---" {
+			return d, true, scanner.Err()
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "model":
+			d.Model = strings.TrimSpace(value)
+		case "effort":
+			d.Effort = strings.TrimSpace(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Declaration{}, false, err
+	}
+	// Opening "---" never closed: not a real front matter block, just a line that looked
+	// like one. Treat the whole file as prose rather than swallowing it as a declaration.
+	return Declaration{}, false, nil
+}

--- a/internal/brief/brief.go
+++ b/internal/brief/brief.go
@@ -13,8 +13,10 @@ type Declaration struct {
 	Effort string
 }
 
-// Parse ignores unknown keys inside the block by choice, not oversight: a brief is prose
-// carrying two optional settings, not a config file.
+// Parse ignores unknown keys inside the block, and reports "no declaration" for a brief it
+// cannot scan (an unterminated fence, a line past bufio's token cap), by choice rather than
+// oversight: a brief is prose carrying two optional settings, not a config file, so nothing
+// about its shape may fail a spawn.
 func Parse(path string) (Declaration, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -24,14 +26,14 @@ func Parse(path string) (Declaration, bool, error) {
 
 	scanner := bufio.NewScanner(f)
 	if !scanner.Scan() || strings.TrimSpace(scanner.Text()) != "---" {
-		return Declaration{}, false, scanner.Err()
+		return Declaration{}, false, nil
 	}
 
 	var d Declaration
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "---" {
-			return d, true, scanner.Err()
+			return d, true, nil
 		}
 		key, value, ok := strings.Cut(line, ":")
 		if !ok {
@@ -43,9 +45,6 @@ func Parse(path string) (Declaration, bool, error) {
 		case "effort":
 			d.Effort = strings.TrimSpace(value)
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return Declaration{}, false, err
 	}
 	return Declaration{}, false, nil
 }

--- a/internal/brief/brief_test.go
+++ b/internal/brief/brief_test.go
@@ -126,6 +126,35 @@ func TestParseOnlyModelDeclared(t *testing.T) {
 	}
 }
 
+func TestParseStripsQuotedScalars(t *testing.T) {
+	for name, content := range map[string]string{
+		"double": "---\nmodel: \"claude-opus-5\"\neffort: \"high\"\n---\n# Title\n",
+		"single": "---\nmodel: 'claude-opus-5'\neffort: 'high'\n---\n# Title\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			d, present, err := Parse(writeBrief(t, content))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !present || d.Model != "claude-opus-5" || d.Effort != "high" {
+				t.Fatalf("got present=%v d=%+v, want surrounding quotes stripped", present, d)
+			}
+		})
+	}
+}
+
+func TestParseKeepsUnpairedQuote(t *testing.T) {
+	path := writeBrief(t, "---\nmodel: \"claude-opus-5\n---\n# Title\n")
+
+	d, _, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Model != "\"claude-opus-5" {
+		t.Fatalf("got %q, want an unpaired quote left alone", d.Model)
+	}
+}
+
 func TestParseUnclosedFrontMatterTreatedAsProse(t *testing.T) {
 	path := writeBrief(t, "---\nmodel: claude-opus-5\n\n# Title\n\nno closing fence above\n")
 

--- a/internal/brief/brief_test.go
+++ b/internal/brief/brief_test.go
@@ -1,8 +1,10 @@
 package brief
 
 import (
+	"bufio"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -145,6 +147,24 @@ func TestParseEmptyBrief(t *testing.T) {
 	}
 	if present || d != (Declaration{}) {
 		t.Fatalf("got present=%v d=%+v, want no declaration", present, d)
+	}
+}
+
+func TestParseOversizedLineTreatedAsProse(t *testing.T) {
+	huge := strings.Repeat("x", bufio.MaxScanTokenSize+1)
+	for name, content := range map[string]string{
+		"first line":  huge + "\n# Title\n",
+		"inside body": "---\nmodel: claude-opus-5\n" + huge + "\n---\n# Title\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			d, present, err := Parse(writeBrief(t, content))
+			if err != nil {
+				t.Fatalf("oversized line must not fail a spawn: %v", err)
+			}
+			if present || d != (Declaration{}) {
+				t.Fatalf("got present=%v d=%+v, want no declaration", present, d)
+			}
+		})
 	}
 }
 

--- a/internal/brief/brief_test.go
+++ b/internal/brief/brief_test.go
@@ -1,0 +1,156 @@
+package brief
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// realBriefFixture is a verbatim copy of data/secondhand-th-floor/brief.md from the fleet
+// this repo runs, chosen because it opens with plain prose ("You are a crewmate...") rather
+// than a "#" heading - the shape most likely to trip up a header parser that scans for
+// "key: value" lines before the first heading instead of requiring an explicit "---" fence.
+const realBriefFixture = `You are a crewmate: an autonomous worker agent managed by the first mate. Work on your own; do not wait for a human.
+
+# Task
+
+Record a minimum supported treehouse version in the README. This is a one-line documentation change. Do not expand it.
+
+Issue: https://github.com/atqamz/secondhand/issues/41. Read it, including the most recent comment, which narrows the issue to exactly this.
+
+## Background (verified by the first mate)
+
+treehouse v2.0.0 dropped ` + "`--json`" + ` from ` + "`get --lease`" + `, which broke every ` + "`hand spawn`" + `, because ` + "`internal/worktree/worktree.go`" + ` ` + "`Get()`" + ` passes ` + "`--json`" + ` and unmarshals ` + "`{\"path\": ...}`" + `. treehouse v2.1.0 reintroduced ` + "`--json`" + ` as the surface of an unrelated feature, stable lease identities. Verified on the first mate's host: treehouse v2.1.0, ` + "`--json`" + ` present in ` + "`treehouse get --help`" + `, and a real ` + "`hand spawn`" + ` succeeding end to end with the Go code unmodified.
+
+So there is no code bug left. What is left is that nothing in this repo records the version floor, so a fresh install on v2.0.0 or v2.0.1 fails with ` + "`unknown flag: --json`" + ` and no hint as to why.
+
+## What to do
+
+In ` + "`README.md`" + `, the Requirements list already pins Go ("Go 1.26.5 or newer") but pins neither herdr nor treehouse. Change only the treehouse line:
+
+` + "```" + `
+- [treehouse](https://github.com/kunchenguid/treehouse) - git worktree pool manager
+` + "```" + `
+
+to name the floor, matching the phrasing the Go line already uses:
+
+` + "```" + `
+- [treehouse](https://github.com/kunchenguid/treehouse) v2.1.0 or newer - git worktree pool manager
+` + "```" + `
+
+## Constraints / acceptance
+
+- That single line is the whole change. Do not add a version floor to herdr, gh, or anything else: there is no evidence for those, and inventing one is worse than leaving it unpinned.
+- Do not touch ` + "`internal/worktree/worktree.go`" + ` or any Go file. There is no code change in this task.
+- Do not add a changelog entry by hand. ` + "`CHANGELOG.md`" + ` is generated.
+- No em dash anywhere. Plain hyphen.
+`
+
+func writeBrief(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "brief.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseRealBriefWithoutDeclarationUnchanged(t *testing.T) {
+	path := writeBrief(t, realBriefFixture)
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present {
+		t.Fatalf("present = true, want false: %+v", d)
+	}
+	if d != (Declaration{}) {
+		t.Fatalf("got %+v, want zero Declaration", d)
+	}
+}
+
+func TestParseHeadingFirstBriefUnchanged(t *testing.T) {
+	path := writeBrief(t, "# fix-login - repair the broken login flow\n\nRepo: `example/app`.\n")
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present || d != (Declaration{}) {
+		t.Fatalf("got present=%v d=%+v, want no declaration", present, d)
+	}
+}
+
+func TestParseDeclaresModelAndEffort(t *testing.T) {
+	path := writeBrief(t, "---\nmodel: claude-opus-5\neffort: high\n---\n# Title\n\nBody.\n")
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present {
+		t.Fatal("present = false, want true")
+	}
+	if d.Model != "claude-opus-5" || d.Effort != "high" {
+		t.Fatalf("got %+v", d)
+	}
+}
+
+func TestParseIgnoresUnknownKeys(t *testing.T) {
+	path := writeBrief(t, "---\nmodel: claude-opus-5\nnote: whatever this is\nreviewer: someone\n---\n# Title\n")
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present {
+		t.Fatal("present = false, want true")
+	}
+	if d.Model != "claude-opus-5" || d.Effort != "" {
+		t.Fatalf("got %+v, want unknown keys ignored", d)
+	}
+}
+
+func TestParseOnlyModelDeclared(t *testing.T) {
+	path := writeBrief(t, "---\nmodel: claude-haiku-4-5\n---\n# Title\n")
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present || d.Model != "claude-haiku-4-5" || d.Effort != "" {
+		t.Fatalf("got present=%v d=%+v", present, d)
+	}
+}
+
+func TestParseUnclosedFrontMatterTreatedAsProse(t *testing.T) {
+	path := writeBrief(t, "---\nmodel: claude-opus-5\n\n# Title\n\nno closing fence above\n")
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present || d != (Declaration{}) {
+		t.Fatalf("got present=%v d=%+v, want unclosed front matter treated as prose", present, d)
+	}
+}
+
+func TestParseEmptyBrief(t *testing.T) {
+	path := writeBrief(t, "")
+
+	d, present, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present || d != (Declaration{}) {
+		t.Fatalf("got present=%v d=%+v, want no declaration", present, d)
+	}
+}
+
+func TestParseMissingBrief(t *testing.T) {
+	_, _, err := Parse(filepath.Join(t.TempDir(), "missing.md"))
+	if err == nil {
+		t.Fatal("expected error for missing brief")
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -213,7 +213,7 @@ func buildOpenCode(o Options) string {
 func briefPrompt(o Options) string {
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
 	if o.FrontMatter {
-		prompt += " Its leading '---' front matter is dispatch metadata (model/effort selection), not task content; skip past it."
+		prompt += " Any model or effort keys in its leading '---' block are dispatch metadata, not task content."
 	}
 	return prompt
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -114,12 +114,11 @@ func AgentDetectionVerified(name string) bool {
 }
 
 type Options struct {
-	Worktree string
-	Brief    string
-	Model    string
-	Effort   string
-	// FrontMatter: the worker reads Brief itself, so the prompt has to disclaim this block.
-	FrontMatter bool
+	Worktree            string
+	Brief               string
+	Model               string
+	Effort              string
+	BriefHasFrontMatter bool
 }
 
 var effortCapable = map[string]bool{
@@ -212,7 +211,7 @@ func buildOpenCode(o Options) string {
 // briefPrompt is shared so the wording cannot drift between harnesses.
 func briefPrompt(o Options) string {
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
-	if o.FrontMatter {
+	if o.BriefHasFrontMatter {
 		prompt += " Any model or effort keys in its leading '---' block are dispatch metadata, not task content."
 	}
 	return prompt

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -118,6 +118,24 @@ type Options struct {
 	Brief    string
 	Model    string
 	Effort   string
+	// FrontMatter reports whether Brief's file has a leading "---"-delimited front matter
+	// block (see internal/brief). The worker reads Brief itself, so a harness whose prompt
+	// points at it must disclaim that block as dispatch metadata rather than let it read as
+	// part of the task.
+	FrontMatter bool
+}
+
+// effortCapable lists the harnesses whose launch command has an effort flag at all. Only
+// claude does; buildOpenCode has no effort flag and buildCodex/buildGrok/buildPi have neither
+// model nor effort.
+var effortCapable = map[string]bool{
+	Claude: true,
+}
+
+// SupportsEffort reports whether name's launch command can apply an effort level. A resolved
+// effort under a harness this returns false for is not silently dropped - the caller must warn.
+func SupportsEffort(name string) bool {
+	return effortCapable[name]
 }
 
 // Build constructs the shell command that cds into the worktree and launches the harness
@@ -167,8 +185,7 @@ func buildClaude(o Options) string {
 	if o.Effort != "" {
 		args = append(args, "--effort", shellQuote(o.Effort))
 	}
-	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
-	args = append(args, shellQuote(prompt))
+	args = append(args, shellQuote(briefPrompt(o)))
 	return strings.Join(args, " ")
 }
 
@@ -195,9 +212,20 @@ func buildOpenCode(o Options) string {
 	if o.Model != "" {
 		args = append(args, "--model", shellQuote(o.Model))
 	}
-	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
-	args = append(args, "--prompt", shellQuote(prompt))
+	args = append(args, "--prompt", shellQuote(briefPrompt(o)))
 	return strings.Join(args, " ")
+}
+
+// briefPrompt is the initial message every interactive harness sends: a pointer at the brief
+// path rather than the scope inline, shared so the wording never drifts between harnesses. The
+// worker reads Brief itself, so when it carries a front matter block (see Options.FrontMatter),
+// the prompt disclaims it up front instead of leaving the worker to read it as task content.
+func briefPrompt(o Options) string {
+	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
+	if o.FrontMatter {
+		prompt += " Its leading '---' front matter is dispatch metadata (model/effort selection), not task content; skip past it."
+	}
+	return prompt
 }
 
 func shellQuote(s string) string {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -118,22 +118,15 @@ type Options struct {
 	Brief    string
 	Model    string
 	Effort   string
-	// FrontMatter reports whether Brief's file has a leading "---"-delimited front matter
-	// block (see internal/brief). The worker reads Brief itself, so a harness whose prompt
-	// points at it must disclaim that block as dispatch metadata rather than let it read as
-	// part of the task.
+	// FrontMatter: the worker reads Brief itself, so the prompt has to disclaim this block.
 	FrontMatter bool
 }
 
-// effortCapable lists the harnesses whose launch command has an effort flag at all. Only
-// claude does; buildOpenCode has no effort flag and buildCodex/buildGrok/buildPi have neither
-// model nor effort.
 var effortCapable = map[string]bool{
 	Claude: true,
 }
 
-// SupportsEffort reports whether name's launch command can apply an effort level. A resolved
-// effort under a harness this returns false for is not silently dropped - the caller must warn.
+// SupportsEffort: false means the caller must warn instead of silently dropping the effort.
 func SupportsEffort(name string) bool {
 	return effortCapable[name]
 }
@@ -216,10 +209,7 @@ func buildOpenCode(o Options) string {
 	return strings.Join(args, " ")
 }
 
-// briefPrompt is the initial message every interactive harness sends: a pointer at the brief
-// path rather than the scope inline, shared so the wording never drifts between harnesses. The
-// worker reads Brief itself, so when it carries a front matter block (see Options.FrontMatter),
-// the prompt disclaims it up front instead of leaving the worker to read it as task content.
+// briefPrompt is shared so the wording cannot drift between harnesses.
 func briefPrompt(o Options) string {
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
 	if o.FrontMatter {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -115,6 +115,26 @@ func TestBuildOpenCode(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeFrontMatterDisclaimer(t *testing.T) {
+	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", FrontMatter: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "dispatch metadata") {
+		t.Fatalf("got %q, want the front matter disclaimed", got)
+	}
+}
+
+func TestBuildClaudeNoFrontMatterUnchanged(t *testing.T) {
+	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "dispatch metadata") {
+		t.Fatalf("got %q, want no disclaimer for a brief with no front matter", got)
+	}
+}
+
 func TestBuildOpenCodeWithModel(t *testing.T) {
 	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "opus"})
 	if err != nil {
@@ -137,6 +157,27 @@ func TestBuildOpenCodeNeverHeadless(t *testing.T) {
 	}
 	if !strings.Contains(got, `OPENCODE_CONFIG_CONTENT`) {
 		t.Fatalf("got %q, want OPENCODE_CONFIG_CONTENT so an unattended worker never stalls on a permission prompt", got)
+	}
+}
+
+func TestBuildOpenCodeFrontMatterDisclaimer(t *testing.T) {
+	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", FrontMatter: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "dispatch metadata") {
+		t.Fatalf("got %q, want the front matter disclaimed", got)
+	}
+}
+
+func TestSupportsEffort(t *testing.T) {
+	if !SupportsEffort(Claude) {
+		t.Error("SupportsEffort(claude) = false, want true")
+	}
+	for _, name := range []string{Codex, Grok, Pi, OpenCode, "nonexistent"} {
+		if SupportsEffort(name) {
+			t.Errorf("SupportsEffort(%q) = true, want false", name)
+		}
 	}
 }
 

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -116,7 +116,7 @@ func TestBuildOpenCode(t *testing.T) {
 }
 
 func TestBuildClaudeFrontMatterDisclaimer(t *testing.T) {
-	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", FrontMatter: true})
+	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestBuildOpenCodeNeverHeadless(t *testing.T) {
 }
 
 func TestBuildOpenCodeFrontMatterDisclaimer(t *testing.T) {
-	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", FrontMatter: true})
+	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -1,0 +1,260 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+// writeBriefWith writes a brief whose body the test controls, so a declaration
+// block can be put in front of real prose.
+func writeBriefWith(t *testing.T, home, id, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(home, "data", id), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", id, "brief.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeFakeHerdrLaunchLog is writeFakeHerdrStatic plus a record of the launch
+// command every "pane run" carried, which is the only place a resolved
+// model/effort becomes observable to an operator.
+func writeFakeHerdrLaunchLog(t *testing.T, dir, launchLog string, ids herdrIDs) {
+	t.Helper()
+	workspaceList := herdrOK(t, map[string]any{"workspaces": []any{}})
+	workspaceCreate := herdrOK(t, map[string]any{"workspace": map[string]any{"workspace_id": ids.WorkspaceID, "label": ids.Label, "tab_count": 1}})
+	tabCreate := herdrOK(t, map[string]any{
+		"tab":       map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label},
+		"root_pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": "working"},
+	})
+	status := ids.PaneStatus
+	if status == "" {
+		status = "working"
+	}
+	paneGet := herdrOK(t, map[string]any{"pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent": "claude", "agent_status": status}})
+	// Two tabs so releasing a promoted scout's old pane is a tab close rather
+	// than closeTaskTab's sole-tab workspace-close shortcut.
+	tabList := herdrOK(t, map[string]any{"tabs": []any{
+		map[string]any{"tab_id": "tab-old", "workspace_id": "ws-old", "label": ids.Label},
+		map[string]any{"tab_id": "tab-other", "workspace_id": "ws-old", "label": "other"},
+	}})
+
+	body := strings.Join([]string{
+		`  "workspace list") echo ` + shellSingleQuote(workspaceList) + ` ;;`,
+		`  "workspace create") echo ` + shellSingleQuote(workspaceCreate) + ` ;;`,
+		`  "tab create") echo ` + shellSingleQuote(tabCreate) + ` ;;`,
+		`  "tab list") echo ` + shellSingleQuote(tabList) + ` ;;`,
+		`  "tab close") echo ` + shellSingleQuote(herdrOK(t, map[string]any{"type": "ok"})) + ` ;;`,
+		`  "pane run") printf '%s\n' "$4" >> ` + shellSingleQuote(launchLog) + ` ;;`,
+		`  "pane send-keys") ;;`,
+		`  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;`,
+		`  "pane get") echo ` + shellSingleQuote(paneGet) + ` ;;`,
+	}, "\n")
+	writeFakeDispatch(t, dir, "herdr", "", "$1 $2", body)
+}
+
+func readLaunchLog(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read launch log: %v", err)
+	}
+	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+}
+
+// TestSpawnHonorsBriefDeclaredTier drives the whole point of the feature
+// through the built binary: a brief that declares its own tier launches the
+// worker at that tier, a flag still outranks the brief, a brief with no
+// declaration still falls back to config, and the declaration is disclaimed to
+// the worker rather than left to read as task content.
+func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	writeConfig(t, home, "model", "claude-sonnet-5\n")
+
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+
+	launchLog := filepath.Join(t.TempDir(), "launch.log")
+	dir := binDir(t)
+	writeFakeHerdrLaunchLog(t, dir, launchLog, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+
+	// A declaring brief: unknown keys are ignored by design, and the prose
+	// under the fence carries ordinary colons the parser must not reach.
+	declaring := "---\nmodel: claude-opus-5\neffort: high\npriority: urgent\n---\n\n# deep refactor\n\nNote: this one is hard.\n"
+	// A plain brief: no fence, and a first prose line with a colon in it.
+	plain := "# small fix\n\nGoal: rename one field.\n"
+
+	cases := []struct {
+		id         string
+		brief      string
+		args       []string
+		wantModel  string
+		wantEffort string
+		wantFlags  []string
+		denyFlags  []string
+	}{
+		{
+			id:         "task-declared",
+			brief:      declaring,
+			wantModel:  "claude-opus-5",
+			wantEffort: "high",
+			wantFlags: []string{
+				"--model 'claude-opus-5'",
+				"--effort 'high'",
+				"front matter is dispatch metadata",
+			},
+			denyFlags: []string{"claude-sonnet-5"},
+		},
+		{
+			id:         "task-flag-wins",
+			brief:      declaring,
+			args:       []string{"--model", "claude-fable-5"},
+			wantModel:  "claude-fable-5",
+			wantEffort: "high",
+			wantFlags:  []string{"--model 'claude-fable-5'", "--effort 'high'"},
+			denyFlags:  []string{"claude-opus-5"},
+		},
+		{
+			id:        "task-plain",
+			brief:     plain,
+			wantModel: "claude-sonnet-5",
+			wantFlags: []string{"--model 'claude-sonnet-5'"},
+			denyFlags: []string{"--effort", "front matter is dispatch metadata"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			writeBriefWith(t, home, tc.id, tc.brief)
+			worktree := filepath.Join(home, "wt-"+tc.id)
+			runGitIn(t, clonePath, "worktree", "add", "-q", "-b", tc.id+"-branch", worktree)
+			writeFakeTreehouse(t, dir, worktree)
+
+			args := append([]string{"spawn", tc.id, "demo"}, tc.args...)
+			spawned := runHand(t, home, args...)
+			if spawned.code != 0 {
+				t.Fatalf("spawn: exit %d, stderr %q", spawned.code, spawned.stderr)
+			}
+			if strings.Contains(spawned.stderr, "warning:") {
+				t.Fatalf("spawn under claude warned about effort: %q", spawned.stderr)
+			}
+
+			task, err := state.Read(home, tc.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("persisted tier: model=%q effort=%q", task.Model, task.Effort)
+			if task.Model != tc.wantModel || task.Effort != tc.wantEffort {
+				t.Fatalf("persisted tier = model %q effort %q, want model %q effort %q",
+					task.Model, task.Effort, tc.wantModel, tc.wantEffort)
+			}
+
+			lines := readLaunchLog(t, launchLog)
+			launch := lines[len(lines)-1]
+			t.Logf("launch command: %s", launch)
+			for _, want := range tc.wantFlags {
+				if !strings.Contains(launch, want) {
+					t.Fatalf("launch command %q missing %q", launch, want)
+				}
+			}
+			for _, deny := range tc.denyFlags {
+				if strings.Contains(launch, deny) {
+					t.Fatalf("launch command %q unexpectedly contains %q", launch, deny)
+				}
+			}
+		})
+	}
+}
+
+// TestPromoteHonorsBriefDeclaredTier is the same resolution seen through the
+// other command that launches a worker, so a scout promoted to ship comes back
+// up at the tier its brief now declares rather than at config's default.
+func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "direct-pr")
+	writeConfig(t, home, "model", "claude-sonnet-5\n")
+	writeBriefWith(t, home, "task-1", "---\nmodel: claude-opus-5\neffort: max\n---\n\n# promoted scout\n")
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("# report\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{
+		ID: "task-1", Project: "demo", Kind: state.KindScout,
+		Worktree:  filepath.Join(home, "wt-scout-old"),
+		Herdr:     state.Herdr{WorkspaceID: "ws-old", TabID: "tab-old", PaneID: "pane-old"},
+		Model:     "claude-sonnet-5",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	launchLog := filepath.Join(t.TempDir(), "launch.log")
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, filepath.Join(home, "wt-ship-new"))
+	writeFakeHerdrLaunchLog(t, dir, launchLog, herdrIDs{WorkspaceID: "ws-new", TabID: "tab-new", PaneID: "pane-new", Label: "demo", PaneStatus: "done"})
+
+	promoted := runHand(t, home, "promote", "task-1")
+	if promoted.code != 0 {
+		t.Fatalf("promote: exit %d, stderr %q", promoted.code, promoted.stderr)
+	}
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("persisted tier: model=%q effort=%q", task.Model, task.Effort)
+	if task.Model != "claude-opus-5" || task.Effort != "max" {
+		t.Fatalf("persisted tier = model %q effort %q, want claude-opus-5/max from the brief", task.Model, task.Effort)
+	}
+
+	launch := readLaunchLog(t, launchLog)[0]
+	t.Logf("launch command: %s", launch)
+	if !strings.Contains(launch, "--model 'claude-opus-5' --effort 'max'") {
+		t.Fatalf("launch command %q, want the brief's declared tier applied", launch)
+	}
+}
+
+// TestSpawnWarnsOnEffortIncapableHarness covers the deliberate middle path for
+// a declared effort no harness flag can carry: the spawn proceeds, the model
+// still applies, and the dropped effort is said out loud on stderr.
+func TestSpawnWarnsOnEffortIncapableHarness(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	writeConfig(t, home, "harness", "opencode\n")
+	writeBriefWith(t, home, "task-1", "---\nmodel: grok-code\neffort: high\n---\n\n# opencode task\n")
+
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	worktree := filepath.Join(home, "wt-task-1")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
+
+	launchLog := filepath.Join(t.TempDir(), "launch.log")
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, worktree)
+	writeFakeHerdrLaunchLog(t, dir, launchLog, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+
+	spawned := runHand(t, home, "spawn", "task-1", "demo")
+	if spawned.code != 0 {
+		t.Fatalf("spawn: exit %d, stderr %q", spawned.code, spawned.stderr)
+	}
+	if !strings.Contains(spawned.stderr, `warning: harness "opencode" has no effort flag, ignoring effort "high"`) {
+		t.Fatalf("stderr = %q, want the effort-incapable warning", spawned.stderr)
+	}
+
+	launch := readLaunchLog(t, launchLog)[0]
+	t.Logf("launch command: %s", launch)
+	if !strings.Contains(launch, "--model 'grok-code'") || strings.Contains(launch, "--effort") {
+		t.Fatalf("launch command %q, want the declared model applied and no effort flag", launch)
+	}
+}

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -40,8 +40,6 @@ func writeFakeHerdrLaunchLog(t *testing.T, dir, launchLog string, ids herdrIDs) 
 		status = "working"
 	}
 	paneGet := herdrOK(t, map[string]any{"pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent": "claude", "agent_status": status}})
-	// Two tabs so releasing a promoted scout's old pane is a tab close rather
-	// than closeTaskTab's sole-tab workspace-close shortcut.
 	tabList := herdrOK(t, map[string]any{"tabs": []any{
 		map[string]any{"tab_id": "tab-old", "workspace_id": "ws-old", "label": ids.Label},
 		map[string]any{"tab_id": "tab-other", "workspace_id": "ws-old", "label": "other"},
@@ -70,11 +68,6 @@ func readLaunchLog(t *testing.T, path string) []string {
 	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 }
 
-// TestSpawnHonorsBriefDeclaredTier drives the whole point of the feature
-// through the built binary: a brief that declares its own tier launches the
-// worker at that tier, a flag still outranks the brief, a brief with no
-// declaration still falls back to config, and the declaration is disclaimed to
-// the worker rather than left to read as task content.
 func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "local-only")
@@ -175,9 +168,6 @@ func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 	}
 }
 
-// TestPromoteHonorsBriefDeclaredTier is the same resolution seen through the
-// other command that launches a worker, so a scout promoted to ship comes back
-// up at the tier its brief now declares rather than at config's default.
 func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -110,7 +110,7 @@ func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 			wantFlags: []string{
 				"--model 'claude-opus-5'",
 				"--effort 'high'",
-				"front matter is dispatch metadata",
+				"are dispatch metadata, not task content",
 			},
 			denyFlags: []string{"claude-sonnet-5"},
 		},
@@ -128,7 +128,7 @@ func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 			brief:     plain,
 			wantModel: "claude-sonnet-5",
 			wantFlags: []string{"--model 'claude-sonnet-5'"},
-			denyFlags: []string{"--effort", "front matter is dispatch metadata"},
+			denyFlags: []string{"--effort", "are dispatch metadata, not task content"},
 		},
 	}
 


### PR DESCRIPTION
## Intent

Fold atqamz/secondhand#55 into PR #59 (atqamz/secondhand#57): add one line to the generated AGENTS.md block (internal/agentsmd/agentsmd.go's generatedBody, and this repo's hand-maintained AGENTS.md copy identically) requiring full absolute paths whenever agent-facing prose names one - in a brief, a status report, or an operator message. Reason stated inline, since a rule without one is dropped as noise: a secondhand home contains projects/<name>/, so when a home is used to develop secondhand itself, the home and one of its clones share a name (concretely: /home/atqa/secondhand the home, /home/atqa/secondhand/projects/secondhand the clone workers branch from, /home/atqa/.treehouse/secondhand-fcde6a/1/secondhand a worker's own worktree - three directories a bare 'secondhand/' cannot pick between), and hand resolves the home from the current working directory, so a relative path in agent-facing prose resolves against whatever directory happens to be current. Workflow step 4 already states exactly this rule for one file (the absolute path to state/<id>.status); this generalizes it and leaves step 4's wording untouched. #55 said it depended on #50, but that dependency is dead: #50's data/inbox.md half is obsolete now that atqamz/secondhand#64 deletes data/inbox.md, so #55 lands alone, no other issue blocks it. Folded into #59 rather than shipped separately because #59 already edits generatedBody, and the block is rewritten between its hand:generated markers on every hand update, so every existing home reconciles the file once per change to it - two separate PRs would mean two reconciliations for no reason. Noted but explicitly NOT fixed here: this edit has to be made twice, once in internal/agentsmd/agentsmd.go's generatedBody and once in this repo's own AGENTS.md, because the repo keeps a hand-maintained copy of the generated block instead of deriving it - that duplication is atqamz/secondhand#44's problem and gets its own change; both copies must stay byte-identical for this line, and the duplication is called out in the PR body as evidence for #44. PR body must carry 'Closes #57' and 'Closes #55' each on its own line - both already added. Zero comments by default is a hard house rule already enforced once on this branch by a dedicated comment-cut commit; the diff for this addition must not add any comment lines, only the one generated-prose bullet line duplicated across the two files. No merge, no auto-merge, no branch deletion under any circumstance - merge authority is Atqa's alone.

## What Changed

- New `internal/brief` package parses an optional leading `---` block in `brief.md` for `model`/`effort` (unknown keys, unterminated fences, and quoted values tolerated rather than failing a spawn). `cmd/tier.go`'s `resolveTier` resolves the tier as flag > brief declaration > home config default for both `hand spawn` and `hand promote`, and warns on stderr when the resolved effort targets a harness with no effort flag (`harness.SupportsEffort`).
- `internal/harness` gains `Options.FrontMatter`, and the claude/opencode brief prompts are folded into one `briefPrompt` helper that appends a disclaimer telling the worker any `model`/`effort` keys in the leading block are dispatch metadata, not task content.
- Generated operator rules (`internal/agentsmd`) and this repo's hand-maintained `AGENTS.md` copy both document the brief tier declaration and add a rule requiring full absolute paths in briefs, status reports, and operator messages; README/SPECS document the precedence. Tests cover the parser, `resolveTier`, harness build output, an e2e spawn/promote path, and a new drift test asserting the generated block stays byte-identical to the repo copy - that duplication is tracked in #44.

Closes #57
Closes #55

## Risk Assessment

Low: The round-2 changes are two narrow, well-tested corrections (quote stripping in the brief parser and a reworded launch-prompt sentence) with matching SPECS and e2e updates, on top of a branch whose remaining known gap is explicitly parked by the operator.

## Testing

Targeted validation drove the actual end-user surface rather than just unit assertions: I built the `hand` binary at both the base and target commits, ran `hand init` on a fresh home to show the new absolute-path rule rendered into the generated AGENTS.md block (and reachable via the CLAUDE.md symlink an operator agent loads), then reproduced the once-per-change reconciliation by upgrading a base-created home and diffing its AGENTS.md - the diff adds exactly the one Rules bullet, leaves step 4's original wording alone (its only change is #59's own brief-tier sentence), and keeps operator-written content outside the markers intact. Byte-identity of the two copies was verified by hashing the line from the rendered block and from the repo's hand-maintained AGENTS.md, and `git show` of the fold commit confirms zero comment lines added. The existing agentsmd/update tests pass, and I added one focused test that fails if the two copies drift (mutation-checked, with AGENTS.md restored). No screenshot applies: the surface is a plain-markdown rules file consumed as agent prose, so CLI transcripts are the end-user artifact. Overall result: pass, no findings.

<details>
<summary>Evidence: Fresh home: generated rules an operator agent loads via CLAUDE.md</summary>

<code>$ cd /tmp/hand-home-fresh/secondhand &amp;&amp; hand init&#10;initialized secondhand home at /tmp/hand-home-fresh/secondhand&#10;&#10;$ readlink CLAUDE.md # the file an operator agent actually loads&#10;AGENTS.md&#10;&#10;$ sed -n &#34;/## Rules/,/qmd search/p&#34; CLAUDE.md&#10;## Rules&#10;&#10;- Never edit files under `projects/`. Workers do that in worktrees.&#10;- Never merge without explicit authorization.&#10;- Never force-teardown without explicit authorization.&#10;- Report outcomes plainly. If work failed, say so with evidence.&#10;- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.&#10;- Ship tasks produce PRs or local branches. Scout tasks produce `data/&lt;id&gt;/report.md`.&#10;- `data/backlog.md` is your task queue. Edit it directly.&#10;- For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.&#10;- Use `qmd search` to find historical context in data/ when available. Fall back to reading files directly.</code>

```text
$ cd /tmp/hand-home-fresh/secondhand && hand init
initialized secondhand home at /tmp/hand-home-fresh/secondhand

$ readlink CLAUDE.md   # the file an operator agent actually loads
AGENTS.md

$ sed -n "/## Rules/,/qmd search/p" CLAUDE.md
## Rules

- Never edit files under `projects/`. Workers do that in worktrees.
- Never merge without explicit authorization.
- Never force-teardown without explicit authorization.
- Report outcomes plainly. If work failed, say so with evidence.
- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
- Ship tasks produce PRs or local branches. Scout tasks produce `data/<id>/report.md`.
- `data/backlog.md` is your task queue. Edit it directly.
- For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.
- Use `qmd search` to find historical context in data/ when available. Fall back to reading files directly.
```
</details>
<details>
<summary>Evidence: Existing home reconciling once on the hand upgrade (base -&gt; target)</summary>

<code>@@ -22,6 +22,7 @@&#10;- Never merge without explicit authorization.&#10;- Never force-teardown without explicit authorization.&#10;- Report outcomes plainly. If work failed, say so with evidence.&#10;+- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.&#10;- Ship tasks produce PRs or local branches. Scout tasks produce `data/&lt;id&gt;/report.md`.&#10;&#10;$ tail -5 AGENTS.md # operator-written content outside the markers survives&#10;&lt;!-- hand:generated:end --&gt;&#10;&#10;## House rules&#10;&#10;- a rule the operator wrote by hand</code>

```text
# Existing home reconciling its generated block once, on the hand upgrade

$ hand init            # home created by the pre-change hand (base ba28582)
$ printf "\n## House rules\n\n- a rule the operator wrote by hand\n" >> AGENTS.md
$ hand init            # same home, post-change hand (target 00be6a7)
$ diff -u AGENTS.md.before AGENTS.md
--- AGENTS.md (before)
+++ AGENTS.md (after)
@@ -9,7 +9,7 @@
 1. Read `data/dashboard.md` for current fleet state.
 2. Match the request to a project in `data/projects.md`.
 3. Edit `data/backlog.md` to record the task with a unique ID.
-4. Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.
+4. Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it. The brief may open with a `---` fenced block declaring `model` and `effort` for the task, which spawn and promote apply unless a flag overrides them.
 5. `hand spawn <id> <project>` to start a worker.
 6. `hand watch` as a background task to monitor the fleet.
 7. Act on watch output: steer blocked workers with `hand send`, relay results.
@@ -22,6 +22,7 @@
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
+- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce `data/<id>/report.md`.
 - `data/backlog.md` is your task queue. Edit it directly.
 - For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.

$ tail -5 AGENTS.md    # operator-written content outside the markers survives
<!-- hand:generated:end -->

## House rules

- a rule the operator wrote by hand
```
</details>
<details>
<summary>Evidence: Both copies of the rule are byte-identical (duplication tracked as #44)</summary>

<code>$ sha256sum of each copy of the line&#10;74e0a8ad89ed5cae71c2d57f661fa1ce07659b31676289a843b474e7b9d4e5dd generated (hand init)&#10;74e0a8ad89ed5cae71c2d57f661fa1ce07659b31676289a843b474e7b9d4e5dd repo AGENTS.md</code>

```text
# Both copies of the rule are byte-identical (duplication tracked as #44)

$ grep -n "Name a path in a brief" <generated block from hand init>
24:- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.

$ grep -n "Name a path in a brief" AGENTS.md   # repo hand-maintained copy
24:- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.

$ sha256sum of each copy of the line
74e0a8ad89ed5cae71c2d57f661fa1ce07659b31676289a843b474e7b9d4e5dd  generated (hand init)
74e0a8ad89ed5cae71c2d57f661fa1ce07659b31676289a843b474e7b9d4e5dd  repo AGENTS.md
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `cmd/tier.go:21` - resolveTier warns when a resolved effort cannot be applied, but a resolved model has no equivalent check: buildCodex/buildGrok/buildPi (internal/harness/harness.go:185-195) ignore Options.Model entirely. A brief declaring `model: claude-opus-5` spawned under codex/grok/pi runs at the harness default, yet spawn writes Model=&#34;claude-opus-5&#34; into state (cmd/spawn.go:156) and promote into t.Model (cmd/promote.go:163), so `hand status`/dashboard report a tier that was never applied, with no stderr signal. The brief declaration makes this durable and implicit where previously it needed an explicit --model flag. Suggest a symmetric harness.SupportsModel check feeding the same warning path.
- ℹ️ `internal/brief/brief.go:44` - The block is a `---` fence with `key: value` lines, i.e. it reads as YAML front matter, but the parser only TrimSpaces the value. `model: &#34;claude-opus-5&#34;` yields the literal `&#34;claude-opus-5&#34;`, which shellQuote emits as `--model &#39;&#34;claude-opus-5&#34;&#39;`; claude rejects the model, the pane never confirms, and the operator gets a rollback with `confirm worker started` rather than anything pointing at the brief. Stripping one matching pair of surrounding single/double quotes would match the documented &#34;deliberately forgiving&#34; contract (SPECS.md:1231).
- ℹ️ `internal/harness/harness.go:216` - The appended sentence asserts the leading block is &#34;dispatch metadata (model/effort selection)&#34; and tells the worker to skip past it, but Parse deliberately tolerates unknown keys (internal/brief/brief.go:42-47, SPECS.md:1231) and frontMatter is true for any terminated fence, including one that declares neither model nor effort. A brief opening with a fence carrying task-relevant keys gets its worker instructed to ignore them. Narrowing the sentence to &#34;any model/effort keys in it are dispatch metadata&#34; would keep the disclaimer without over-scoping the skip.

🔧 Fix: unquote brief tier values, narrow front-matter disclaimer
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --command go test ./internal/agentsmd/... ./cmd/... -run 'TestRefresh|TestIsWorkspace|TestUpdate' -count=1`
- <code>`nix develop --command go test ./internal/agentsmd/ -count=1` (includes new `TestGeneratedRulesMatchThisRepoAgentsMdCopy`)</code>
- <code>Mutation check: perturbed the rule wording in `AGENTS.md`, confirmed `TestGeneratedRulesMatchThisRepoAgentsMdCopy` FAILs, then `git checkout -- AGENTS.md`</code>
- <code>Built target and base binaries (`go build -o /tmp/hand-bin/hand .` at 00be6a7 and at base ba28582 via `git archive`)</code>
- <code>Manual: `hand init` in a fresh home, then `readlink CLAUDE.md` and read the generated `## Rules` section an operator agent loads</code>
- <code>Manual upgrade path: base-binary `hand init` + operator-written tail, then target-binary `hand init`, `diff -u` of the home&#39;s AGENTS.md before/after, `tail -5 AGENTS.md`</code>
- <code>Manual byte-identity check: `sha256sum` of the rule line from the rendered generated block vs the repo&#39;s hand-maintained `AGENTS.md`</code>
- <code>`git show 74114bb --unified=0` to confirm the fold adds only the two prose lines and no comment lines</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `SPECS.md:68` - Out-of-scope follow-up: SPECS.md&#39;s &#34;Directory layout&#34; block has drifted from the tree independently of this change. It omits cmd/launch.go, cmd/precondition.go, cmd/update.go, internal/ghutil/ and internal/selfupdate/, all of which predate the base commit. I corrected only the internal/brief/ entry, which this change made wrong by creating that package with a different purpose than the listed one. Refreshing the whole block (or replacing the hand-maintained tree with a short pointer to the packages&#39; own doc comments, since a hand-copied tree drifts by default) is a separate consolidation worth its own change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

