### PR TITLE
ci: build the nix flake package on every PR and push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   lint:
@@ -56,3 +58,14 @@ jobs:
           go-version-file: go.mod
       - name: End-to-end
         run: go test -tags=e2e -timeout=10m ./tests/e2e/...
+
+  nix-build:
+    name: Nix build (x86_64-linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - name: Build flake package
+        run: nix build .#default --no-link --print-out-paths
+      - name: Run built binary
+        run: "$(nix build .#default --no-link --print-out-paths)/bin/hand --version"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,4 +68,4 @@ jobs:
       - name: Build flake package
         run: nix build .#default --no-link --print-out-paths
       - name: Run built binary
-        run: "$(nix build .#default --no-link --print-out-paths)/bin/hand --version"
+        run: '"$(nix build .#default --no-link --print-out-paths)/bin/hand" --version'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ Without Nix, install those yourself.
 2. Make changes.
 3. make lint && make test
 4. make e2e if you changed CLI behavior (end-to-end suite, excluded from make test).
-5. Open a PR.
+5. nix build .#default if you changed Go dependencies (CI builds the flake, and a stale vendorHash in flake.nix fails it).
+6. Open a PR.
 
 Commits use conventional commits: feat:, fix:, chore:, etc.
 release-please handles versioning and changelogs from these.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1562,11 +1562,11 @@ Automated via [release-please](https://github.com/googleapis/release-please) (sa
 
 **Workflow files:**
 
-**`.github/workflows/ci.yaml`:** the tracked file is authoritative - runs on every PR to main: lint, then test across the OS matrix, then e2e gated on test passing.
+**`.github/workflows/ci.yaml`:** the tracked file is authoritative - runs on every PR to main and on push to main: lint, test across the OS matrix, e2e gated on test passing, and nix-build, which builds the flake package (`nix build .#default`) on x86_64-linux and runs the built binary's `--version`.
 
 **`.github/workflows/release.yaml`:** the tracked file is authoritative - runs on push to main; `workflow_dispatch` exists to re-run release-please after a conflicted release PR is rebased.
 
-Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (no real ones installed, see "Integration tests"), then release-please for automated releases.
+Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (no real ones installed, see "Integration tests"), plus a nix-build job guarding the flake package, then release-please for automated releases.
 
 `.github/dependabot.yaml` - keep Go modules and GitHub Actions up to date:
 ```yaml


### PR DESCRIPTION
## Summary

- Adds a `nix-build` job to `ci.yaml` that runs `nix build .#default` on x86_64-linux and then execs the built binary's `--version`, so a package that builds but fails to link or run is caught too.
- Adds `push: branches: [main]` to the workflow trigger, because Actions triggers are workflow-level and this job has to guard main itself, not only PRs.
- Documents the new gate in `SPECS.md` and tells contributors in `CONTRIBUTING.md` to run `nix build .#default` after touching Go dependencies.

Closes #67

## Why this gate matters now

Nothing in `ci.yaml` or `release.yaml` had ever built the flake, so a PR that bumps a Go dependency without updating `flake.nix`'s `vendorHash` goes green and breaks `nix run` on main. That became load-bearing on 2026-07-28, when the fleet deleted its local `bin/hand` and moved to running the tool exclusively via `nix run github:atqamz/secondhand -- <cmd>` off main's tip. A broken flake on main now stops the fleet from dispatching at all.

## Decisions

- **x86_64-linux only**, not the full `aarch64-darwin` / `aarch64-linux` / `x86_64-linux` list from `flake.nix`. `vendorHash` is platform-independent, so one platform catches every instance of the failure mode in scope, and building all three would burn macOS runner minutes for no added coverage.
- **No binary cache on this first pass.** Measured instead of guessed: see the numbers below.
- **Separate job, not a step on the existing test job**, so a Nix failure and a Go test failure read distinctly in the checks list.
- `nix build` appears twice in the job. Review flagged it as a possible duplicate build; measured, the second invocation is a 1s store-cache hit against a 41s cold build, so it is a path lookup and not a repeated build.

Out of scope per the issue and untouched: `flake.nix` itself, `nix flake check`, and the devShell.

## Test plan

- [x] **The gap is real, verified before building anything.** Hand-edited `vendorHash` to a wrong value as an unstaged scratch change: `nix build .#default` fails with a hash mismatch, while `go build ./...`, `gofmt -l .` and `go vet ./...` (the actual existing gate steps) all pass unaffected on the same tree. Scratch edit reverted before any commit.
- [x] **The new job catches that break** and the existing lint job does not.
- [x] **Cost measured on this PR's own run.** The `nix-build` job took 56s wall (41s cold build, 9s installer setup). It finished at the same wall-clock instant as the existing test to e2e chain, so it added zero net delay to the PR's total CI time of about 63s despite being individually the second-longest job. That is why no cache is added yet.
- [x] All 5 checks green: Lint, Test ubuntu-latest, Test macos-latest, Nix build x86_64-linux, E2E.

## Known side effect

Adding the `push: branches: [main]` trigger also causes the existing lint, test and e2e jobs to run on push to main, not only on PRs. Accepted as the cost of triggering the new job on push, since Actions triggers cannot be scoped per job.
