### PR TITLE
fix(cmd): reuse a new workspace's root tab instead of orphaning it

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -296,7 +296,7 @@ Behavior:
      way to create an empty workspace - it always creates a root tab and pane alongside it - so
      this reuses that root tab as the task's tab (renamed to the task ID) instead of creating a
      second one, which would leave the root tab behind as an orphan shell in the workspace.
-   - If the workspace already exists, create a new tab in it for the task, as before.
+   - If the workspace already exists, create a new tab in it for the task.
 7. Construct the harness launch command from the template (see harness section).
 8. Send the launch command to the herdr pane.
 9. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and

--- a/SPECS.md
+++ b/SPECS.md
@@ -289,9 +289,14 @@ Behavior:
 3. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
 4. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
 5. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in `state/*.json`. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
-6. Create a herdr tab in the project's workspace.
+6. Acquire the task's herdr tab in the project's workspace.
    - Workspace naming: one workspace per project, named after the project.
    - Tab naming: task ID.
+   - If the project's workspace does not exist yet, create it at the worktree's cwd. herdr has no
+     way to create an empty workspace - it always creates a root tab and pane alongside it - so
+     this reuses that root tab as the task's tab (renamed to the task ID) instead of creating a
+     second one, which would leave the root tab behind as an orphan shell in the workspace.
+   - If the workspace already exists, create a new tab in it for the task, as before.
 7. Construct the harness launch command from the template (see harness section).
 8. Send the launch command to the herdr pane.
 9. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
@@ -302,8 +307,8 @@ Behavior:
 
 Any failure before step 10 leaves nothing behind: the worktree lease returns to treehouse and the
 herdr side is rolled back.
-A workspace this command created is closed whole, because a fresh workspace already holds an
-auto-created root tab and closing only the task's tab would leak it.
+A workspace this command created is closed whole: the task's tab is that workspace's own
+auto-created root tab, so there is nothing else in it to preserve.
 A workspace that already existed is shared with other tasks, so it keeps running and only loses
 the tab this command added.
 Once `state/<id>.json` is written the task owns its worktree and tab, so a later failure such as
@@ -756,7 +761,7 @@ Behavior:
 1. Validate the task exists and is a completed scout (has `data/<id>/report.md`, herdr pane is not busy - `idle` or `done`, which mean the same thing here, see "Agent state" - or unreachable/dead).
 2. Create or update `data/<id>/brief.md` - the agent should update it with implementation instructions before calling promote, referencing the scout report.
 3. Acquire a fresh treehouse worktree (with collision guard).
-4. Create a new herdr tab.
+4. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 6, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
 5. Launch the worker and confirm it started (same as `hand spawn`).
 6. Rewrite `state/<id>.json` in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree` and the `herdr` coordinates describe the new worker. `done_verified` is reset to false - the scout's verified `done` does not carry to the ship. Every other field is carried, including `created_at` and the watcher's other bookkeeping (`report_offset`) - see "What survives a `hand watch` restart", which classifies each of them.
 7. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.
@@ -1118,7 +1123,7 @@ either one alone.
 
 | hand command | herdr operation |
 |---|---|
-| `hand spawn` | create workspace (if needed) + create tab + send launch command + poll pane state and read pane text until the worker is confirmed started, sending keys to answer first-run dialogs |
+| `hand spawn` | create workspace (if needed, at the worktree's cwd, reusing its own root tab as the task tab) or create tab in an existing workspace + send launch command + poll pane state and read pane text until the worker is confirmed started, sending keys to answer first-run dialogs |
 | `hand status` | get agent state for pane |
 | `hand send` | check composer empty + send keys to pane |
 | `hand teardown` | close tab (+ close workspace if empty) |
@@ -1130,11 +1135,17 @@ either one alone.
 # list workspaces
 herdr workspace list
 
-# create workspace without focusing it
-herdr workspace create --no-focus --cwd <project-clone-path> --label <project-name>
+# create workspace without focusing it - herdr cannot create an empty workspace, so this always
+# creates a root tab and pane too, at --cwd; hand points --cwd at the worktree (not the clone) and
+# reuses that root tab as the first task's tab (see "herdr tab rename" below) rather than
+# discarding it and creating a second tab, which would leave it behind as an orphan shell
+herdr workspace create --no-focus --cwd <worktree> --label <project-name>
 
-# create tab in workspace
+# create tab in an already-existing workspace
 herdr tab create --workspace <ws-id> --no-focus --cwd <worktree> --label <task-id>
+
+# rename a tab - used to turn workspace create's own root tab into the first task's tab
+herdr tab rename <tab-id> <task-id>
 
 # list tabs in workspace
 herdr tab list --workspace <ws-id>

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -109,8 +109,10 @@ func newPromoteCmd() *cobra.Command {
 
 			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
 			createdWorkspace := false
+			var rootTab herdr.Tab
+			var rootPane herdr.Pane
 			if err == nil && !found {
-				ws, err = client.WorkspaceCreate(clonePath, proj.Name)
+				ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, proj.Name)
 				createdWorkspace = err == nil
 			}
 			if err != nil {
@@ -131,9 +133,9 @@ func newPromoteCmd() *cobra.Command {
 				}
 			}()
 
-			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
+			tab, pane, err := acquireTaskTab(client, createdWorkspace, ws.WorkspaceID, wt, id, rootTab, rootPane)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 			tabID = tab.TabID
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -275,10 +275,13 @@ case "$cmd" in
 	fi
 	;;
 "workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
 	;;
 "tab create")
 	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
+	;;
+"tab rename")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"}}}'
 	;;
 "pane run")
 	exit 1

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -212,9 +212,9 @@ func acquireTaskTab(client *herdr.Client, createdWorkspace bool, workspaceID, wt
 	return tab, pane, nil
 }
 
-// rollbackHerdr undoes the herdr side of a failed spawn-shaped lifecycle: a workspace this
-// call created goes away whole (WorkspaceCreate auto-creates a root tab, so closeTaskTab's
-// sole-tab shortcut would never fire and the workspace would leak), while a pre-existing
+// rollbackHerdr undoes the herdr side of a failed spawn-shaped lifecycle: a workspace this call
+// created goes away whole, because its only tab is the root tab acquireTaskTab renames into the
+// task's, and a failure before that rename leaves no tabID to close it by. A pre-existing
 // workspace is shared with other tasks and only loses the tab this call added to it.
 func rollbackHerdr(client *herdr.Client, createdWorkspace bool, workspaceID, tabID string) error {
 	if createdWorkspace {

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -94,8 +94,10 @@ func newSpawnCmd() *cobra.Command {
 			client := herdr.NewClient()
 			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
 			createdWorkspace := false
+			var rootTab herdr.Tab
+			var rootPane herdr.Pane
 			if err == nil && !found {
-				ws, err = client.WorkspaceCreate(clonePath, proj.Name)
+				ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, proj.Name)
 				createdWorkspace = err == nil
 			}
 			if err != nil {
@@ -118,9 +120,9 @@ func newSpawnCmd() *cobra.Command {
 				}
 			}()
 
-			tab, pane, err := client.TabCreate(ws.WorkspaceID, wt, id)
+			tab, pane, err := acquireTaskTab(client, createdWorkspace, ws.WorkspaceID, wt, id, rootTab, rootPane)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("herdr tab create failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 			tabID = tab.TabID
 
@@ -189,6 +191,25 @@ func newSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
 	return cmd
+}
+
+// acquireTaskTab returns the tab and pane a spawn-shaped lifecycle should use for the task. herdr
+// has no way to create an empty workspace: workspace create always creates a root tab and pane at
+// its cwd too, so a task that just created the workspace reuses that root tab (renamed to id)
+// instead of creating a second one, which would leave the root tab behind as an orphan shell. A
+// task landing in an already-existing workspace still creates its own tab.
+func acquireTaskTab(client *herdr.Client, createdWorkspace bool, workspaceID, wt, id string, rootTab herdr.Tab, rootPane herdr.Pane) (herdr.Tab, herdr.Pane, error) {
+	if createdWorkspace {
+		if err := client.TabRename(rootTab.TabID, id); err != nil {
+			return herdr.Tab{}, herdr.Pane{}, fmt.Errorf("herdr tab rename failed: %w", err)
+		}
+		return rootTab, rootPane, nil
+	}
+	tab, pane, err := client.TabCreate(workspaceID, wt, id)
+	if err != nil {
+		return herdr.Tab{}, herdr.Pane{}, fmt.Errorf("herdr tab create failed: %w", err)
+	}
+	return tab, pane, nil
 }
 
 // rollbackHerdr undoes the herdr side of a failed spawn-shaped lifecycle: a workspace this

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -269,10 +269,13 @@ case "$cmd" in
 	fi
 	;;
 "workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
 	;;
 "tab create")
 	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+	;;
+"tab rename")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}}}'
 	;;
 "pane run")
 	exit 1
@@ -318,10 +321,10 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{"workspaces":[]}}'
 	;;
 "workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
 	;;
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+"tab rename")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}}}'
 	;;
 "pane run")
 	printf '{"id":"cli:1","result":{}}'

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -138,7 +138,10 @@ func (c *Client) FindWorkspaceByLabel(label string) (Workspace, bool, error) {
 	return Workspace{}, false, nil
 }
 
-func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, error) {
+// WorkspaceCreate also returns the root tab and pane herdr creates at cwd as a side effect of
+// creating the workspace - herdr has no way to create an empty workspace - so a caller that
+// discards them leaves a live, unowned shell behind in the workspace.
+func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, Tab, Pane, error) {
 	args := []string{"workspace", "create", "--no-focus"}
 	if cwd != "" {
 		args = append(args, "--cwd", cwd)
@@ -148,18 +151,20 @@ func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, error) {
 	}
 	res, err := c.call(args...)
 	if err != nil {
-		return Workspace{}, err
+		return Workspace{}, Tab{}, Pane{}, err
 	}
 	var body struct {
 		Workspace Workspace `json:"workspace"`
+		Tab       Tab       `json:"tab"`
+		RootPane  Pane      `json:"root_pane"`
 	}
 	if err := json.Unmarshal(res, &body); err != nil {
-		return Workspace{}, fmt.Errorf("parse workspace create: %w", err)
+		return Workspace{}, Tab{}, Pane{}, fmt.Errorf("parse workspace create: %w", err)
 	}
-	if body.Workspace.WorkspaceID == "" {
-		return Workspace{}, fmt.Errorf("parse workspace create: missing workspace")
+	if body.Workspace.WorkspaceID == "" || body.Tab.TabID == "" || body.RootPane.PaneID == "" {
+		return Workspace{}, Tab{}, Pane{}, fmt.Errorf("parse workspace create: missing workspace, tab, or root pane")
 	}
-	return body.Workspace, nil
+	return body.Workspace, body.Tab, body.RootPane, nil
 }
 
 func (c *Client) WorkspaceClose(workspaceID string) error {
@@ -207,6 +212,11 @@ func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
 		return Tab{}, Pane{}, fmt.Errorf("parse tab create: missing tab or root pane")
 	}
 	return body.Tab, body.RootPane, nil
+}
+
+func (c *Client) TabRename(tabID, label string) error {
+	_, err := c.call("tab", "rename", tabID, label)
+	return err
 }
 
 func (c *Client) TabClose(tabID string) error {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -64,6 +64,50 @@ func TestFindWorkspaceByLabelNotFound(t *testing.T) {
 	}
 }
 
+// TestWorkspaceCreateParsesRootTabAndPane pins the fix for the orphan-tab bug: herdr always
+// creates a root tab and pane at cwd as a side effect of creating a workspace, so
+// WorkspaceCreate must parse and return them rather than discarding them - a caller that then
+// creates a second tab for its task leaves the root tab behind as an unowned live shell.
+func TestWorkspaceCreateParsesRootTabAndPane(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj","tab_count":1},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'`)
+	c := NewClient()
+	ws, tab, pane, err := c.WorkspaceCreate("/tmp/clone", "proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.WorkspaceID != "wA" {
+		t.Fatalf("got workspace %+v", ws)
+	}
+	if tab.TabID != "wA:tB" {
+		t.Fatalf("got tab %+v", tab)
+	}
+	if pane.PaneID != "wA:pC" || pane.AgentStatus != StatusIdle {
+		t.Fatalf("got pane %+v", pane)
+	}
+}
+
+func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
+	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"}}}'`)
+	c := NewClient()
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
+		t.Fatal("expected an error when the response omits the root tab and pane")
+	}
+}
+
+func TestTabRenameSendsCorrectArgs(t *testing.T) {
+	writeFakeHerdr(t, `
+if [ "$1 $2 $3 $4" != "tab rename wA:tB task-1" ]; then
+	echo "unexpected args: $@" >&2
+	exit 1
+fi
+printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}}}'
+`)
+	c := NewClient()
+	if err := c.TabRename("wA:tB", "task-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCallReturnsErrorOnEnvelopeError(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"not_found","message":"pane missing"}}'; exit 1`)
 	c := NewClient()

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -30,11 +30,12 @@ func writeBriefWith(t *testing.T, home, id, body string) {
 func writeFakeHerdrLaunchLog(t *testing.T, dir, launchLog string, ids herdrIDs) {
 	t.Helper()
 	workspaceList := herdrOK(t, map[string]any{"workspaces": []any{}})
-	workspaceCreate := herdrOK(t, map[string]any{"workspace": map[string]any{"workspace_id": ids.WorkspaceID, "label": ids.Label, "tab_count": 1}})
-	tabCreate := herdrOK(t, map[string]any{
-		"tab":       map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label},
+	workspaceCreate := herdrOK(t, map[string]any{
+		"workspace": map[string]any{"workspace_id": ids.WorkspaceID, "label": ids.Label, "tab_count": 1},
+		"tab":       map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": "1"},
 		"root_pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": "working"},
 	})
+	tabRename := herdrOK(t, map[string]any{"tab": map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label}})
 	status := ids.PaneStatus
 	if status == "" {
 		status = "working"
@@ -48,7 +49,7 @@ func writeFakeHerdrLaunchLog(t *testing.T, dir, launchLog string, ids herdrIDs) 
 	body := strings.Join([]string{
 		`  "workspace list") echo ` + shellSingleQuote(workspaceList) + ` ;;`,
 		`  "workspace create") echo ` + shellSingleQuote(workspaceCreate) + ` ;;`,
-		`  "tab create") echo ` + shellSingleQuote(tabCreate) + ` ;;`,
+		`  "tab rename") echo ` + shellSingleQuote(tabRename) + ` ;;`,
 		`  "tab list") echo ` + shellSingleQuote(tabList) + ` ;;`,
 		`  "tab close") echo ` + shellSingleQuote(herdrOK(t, map[string]any{"type": "ok"})) + ` ;;`,
 		`  "pane run") printf '%s\n' "$4" >> ` + shellSingleQuote(launchLog) + ` ;;`,

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -106,9 +106,20 @@ type herdrIDs struct {
 // writeFakeHerdrStatic writes a herdr fake that always reports the same
 // workspace/tab/pane identifiers, suitable for a spawn (or promote) followed
 // by a teardown within one test: workspace list reports none so a fresh
-// workspace is created, tab list reports exactly the one tab so teardown
-// closes the whole workspace (mirroring closeTaskTab's sole-tab behavior).
+// workspace is created, and workspace create's own response carries the root
+// tab/pane herdr always creates alongside it - the ones the task then renames
+// (via "tab rename") and reuses instead of creating a second tab. tab list
+// reports exactly the one tab so teardown closes the whole workspace
+// (mirroring closeTaskTab's sole-tab behavior).
 func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
+	t.Helper()
+	writeFakeHerdrStaticLogged(t, dir, "", ids)
+}
+
+// writeFakeHerdrStaticLogged is writeFakeHerdrStatic plus an invocation log, for tests that need
+// to assert which herdr calls were actually made (e.g. that spawn reuses the workspace's own root
+// tab instead of creating a second one, and that teardown of that sole tab closes the workspace).
+func writeFakeHerdrStaticLogged(t *testing.T, dir, logPath string, ids herdrIDs) {
 	t.Helper()
 	status := ids.PaneStatus
 	if status == "" {
@@ -116,11 +127,12 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 	}
 
 	workspaceList := herdrOK(t, map[string]any{"workspaces": []any{}})
-	workspaceCreate := herdrOK(t, map[string]any{"workspace": map[string]any{"workspace_id": ids.WorkspaceID, "label": ids.Label, "tab_count": 1}})
-	tabCreate := herdrOK(t, map[string]any{
-		"tab":       map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label},
+	workspaceCreate := herdrOK(t, map[string]any{
+		"workspace": map[string]any{"workspace_id": ids.WorkspaceID, "label": ids.Label, "tab_count": 1},
+		"tab":       map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": "1"},
 		"root_pane": map[string]any{"pane_id": ids.PaneID, "tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "agent_status": status},
 	})
+	tabRename := herdrOK(t, map[string]any{"tab": map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label}})
 	tabList := herdrOK(t, map[string]any{"tabs": []any{map[string]any{"tab_id": ids.TabID, "workspace_id": ids.WorkspaceID, "label": ids.Label}}})
 	tabClose := herdrOK(t, map[string]any{"type": "ok"})
 	workspaceClose := herdrOK(t, map[string]any{"type": "ok"})
@@ -132,7 +144,7 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
 	// is what confirmLaunch's poll loop needs to confirm the launch.
 	body := fmt.Sprintf(`  "workspace list") echo %s ;;
   "workspace create") echo %s ;;
-  "tab create") echo %s ;;
+  "tab rename") echo %s ;;
   "pane run") ;;
   "pane send-text") ;;
   "pane send-keys") ;;
@@ -141,10 +153,10 @@ func writeFakeHerdrStatic(t *testing.T, dir string, ids herdrIDs) {
   "tab close") echo %s ;;
   "workspace close") echo %s ;;
   "pane get") echo %s ;;`,
-		shellSingleQuote(workspaceList), shellSingleQuote(workspaceCreate), shellSingleQuote(tabCreate),
+		shellSingleQuote(workspaceList), shellSingleQuote(workspaceCreate), shellSingleQuote(tabRename),
 		shellSingleQuote(tabList), shellSingleQuote(tabClose),
 		shellSingleQuote(workspaceClose), shellSingleQuote(paneGet))
-	writeFakeDispatch(t, dir, "herdr", "", "$1 $2", body)
+	writeFakeDispatch(t, dir, "herdr", logPath, "$1 $2", body)
 }
 
 // writeFakeHerdrWatch writes a herdr fake for the watch scenario: workspace

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -57,8 +57,8 @@ func TestPromoteScoutToShip(t *testing.T) {
 	// The scout's old workspace holds a second tab, so releasing the scout is a
 	// tab close rather than closeTaskTab's sole-tab workspace-close shortcut.
 	writeFakeDispatch(t, dir, "herdr", invocationLog, "$1 $2", `  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
-  "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-new","label":"demo","tab_count":1}}}' ;;
-  "tab create") echo '{"result":{"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"demo"},"root_pane":{"pane_id":"pane-new","tab_id":"tab-new","workspace_id":"ws-new","agent_status":"working"}}}' ;;
+  "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-new","label":"demo","tab_count":1},"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"1"},"root_pane":{"pane_id":"pane-new","tab_id":"tab-new","workspace_id":"ws-new","agent_status":"working"}}}' ;;
+  "tab rename") echo '{"result":{"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"task-1"}}}' ;;
   "pane run") echo '{"result":{}}' ;;
   "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
   "tab list")
@@ -121,6 +121,12 @@ func TestPromoteScoutToShip(t *testing.T) {
 	}
 	if strings.Contains(log, "herdr tab close tab-new") || strings.Contains(log, "herdr workspace close ws-new") {
 		t.Fatalf("invocation log = %q, want promote to leave the NEW ship tab open", log)
+	}
+	if !strings.Contains(log, "herdr tab rename tab-new task-1") {
+		t.Fatalf("invocation log = %q, want promote to rename the new workspace's own root tab to the task id", log)
+	}
+	if strings.Contains(log, "herdr tab create --workspace ws-new") {
+		t.Fatalf("invocation log = %q, want promote to reuse the new workspace's root tab instead of creating a second one", log)
 	}
 	if !strings.Contains(log, "treehouse return "+oldWorktree) {
 		t.Fatalf("invocation log = %q, want promote to have returned the OLD worktree %s", log, oldWorktree)

--- a/tests/e2e/spawn_teardown_test.go
+++ b/tests/e2e/spawn_teardown_test.go
@@ -3,7 +3,9 @@
 package e2e
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/atqamz/secondhand/internal/state"
@@ -26,8 +28,9 @@ func TestSpawnTeardownCycle(t *testing.T) {
 	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
 
 	dir := binDir(t)
+	invocationLog := filepath.Join(t.TempDir(), "invocations.log")
 	writeFakeTreehouse(t, dir, worktree)
-	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+	writeFakeHerdrStaticLogged(t, dir, invocationLog, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
 
 	spawned := runHand(t, home, "spawn", "task-1", "demo")
 	if spawned.code != 0 {
@@ -41,6 +44,20 @@ func TestSpawnTeardownCycle(t *testing.T) {
 	if task.Project != "demo" || task.Kind != state.KindShip || task.Worktree != worktree ||
 		task.Harness == "" || task.Herdr.WorkspaceID != "ws-1" || task.Herdr.TabID != "tab-1" || task.Herdr.PaneID != "pane-1" {
 		t.Fatalf("spawned task state = %+v, want project=demo kind=ship worktree=%s herdr ids populated", task, worktree)
+	}
+
+	// The regression this cycle exists to catch: a first spawn into a fresh workspace must reuse
+	// the workspace's own root tab (renamed to the task id) rather than creating a second one,
+	// which is what used to leave an orphan shell parked in the workspace at the clone's cwd.
+	spawnLog, err := os.ReadFile(invocationLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(spawnLog), "herdr tab rename tab-1 task-1") {
+		t.Fatalf("invocation log = %q, want spawn to rename the fresh workspace's root tab to the task id", spawnLog)
+	}
+	if strings.Contains(string(spawnLog), "herdr tab create") {
+		t.Fatalf("invocation log = %q, want spawn to reuse the root tab instead of creating a second one", spawnLog)
 	}
 
 	dash := readDashboard(t, home)
@@ -78,5 +95,19 @@ func TestSpawnTeardownCycle(t *testing.T) {
 	}
 	if len(finalDash.RecentCompletions) == 0 {
 		t.Fatal("teardown did not record a recent completion")
+	}
+
+	// The task's tab was the workspace's only tab, so teardown must close the whole workspace
+	// (closeTaskTab's sole-tab shortcut) rather than leaving it behind with nothing pointing at it -
+	// the second half of the orphan-tab regression: an unreachable last-tab check never fires.
+	finalLog, err := os.ReadFile(invocationLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(finalLog), "herdr workspace close ws-1") {
+		t.Fatalf("invocation log = %q, want teardown to close the now-empty workspace", finalLog)
+	}
+	if strings.Contains(string(finalLog), "herdr tab close tab-1") {
+		t.Fatalf("invocation log = %q, want teardown to close the workspace, not just the sole tab in it", finalLog)
 	}
 }


### PR DESCRIPTION
## Summary

- `herdr workspace create` cannot create an empty workspace; it always creates a root tab and pane at its cwd, but `Client.WorkspaceCreate` discarded both, so `hand spawn`/`hand promote` created a second tab for the task and left the root tab behind as an orphan shell parked in the project clone.
- `WorkspaceCreate` now returns the root tab and pane; a new workspace is created at the worktree's cwd, and a shared `acquireTaskTab` helper (used by both `spawn` and `promote`) renames that root tab (via a new `TabRename`) into the task's own tab instead of creating a second one. A task landing in an already-existing workspace is unaffected and still gets its own tab.
- This also fixes `teardown`'s sole-tab-closes-whole-workspace check, which the orphan tab previously kept from ever firing on a project's last task, leaking the workspace.

Closes #71

## Test plan

Ran directly in the worktree (all passed):
- `go build ./...`
- `go test -race ./...`
- `go test -tags e2e ./tests/e2e/...`
- `make lint`

Added regression coverage:
- `internal/herdr/client_test.go`: `TestWorkspaceCreateParsesRootTabAndPane`, `TestWorkspaceCreateRejectsMissingRootTabOrPane`, `TestTabRenameSendsCorrectArgs`.
- `tests/e2e/spawn_teardown_test.go` (`TestSpawnTeardownCycle`) and `tests/e2e/promote_test.go` (`TestPromoteScoutToShip`): assert a fresh workspace's root tab gets renamed instead of a second tab being created, and that a sole-tab teardown closes the whole workspace.
- `cmd/spawn_test.go` / `cmd/promote_test.go`: updated fakes for the new workspace-create response shape; the pre-existing-workspace fixtures are untouched and still exercise `tab create`.

Also exercised end to end against the real, live herdr server (not only fakes), via a build-tagged manual probe (`internal/herdr` package, `-tags manualprobe`, deleted after use) that called the modified client methods directly: created a throwaway workspace, confirmed the response carried `tab`/`root_pane`, renamed the tab, and closed the workspace. Verified via `herdr workspace list` before and after that only the live fleet's `secondhand` and `nsr` workspaces remained; no probe workspace was left behind and the live fleet was not otherwise touched.
