### PR TITLE
fix(cmd): cap report rendering in hand status

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -373,10 +373,12 @@ Show fleet overview or single-task detail.
 hand status
 hand status fix-login
 hand status --json
+hand status fix-login --full
 ```
 
 Flags:
-- `--json`: output as JSON.
+- `--json`: output as JSON. Always carries the reported line and history untruncated - a machine consumer wants the whole field, and silently truncating a JSON field is a data-loss bug, not a rendering choice.
+- `--full`: in the single-task view, show the reported line and history untruncated and skip the history dedup below, reproducing the output from before atqamz/secondhand#65 exactly.
 
 Behavior (fleet overview):
 1. List all `state/*.json` files.
@@ -415,13 +417,22 @@ Herdr:      default / wA:tB
 Created:    2h ago
 PR:         (none)
 Reported:   needs-decision: two ways to fix the race, ask-user found both risky
+Report file: /home/user/secondhand/state/fix-login.status
 
 Report history (reported by worker, not verified current truth):
   working: added the retry loop
-  needs-decision: two ways to fix the race, ask-user found both risky
 ```
 
 The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the same merge suffix the fleet overview appends: `PR:         https://github.com/org/repo/pull/42 (merged, external)`.
+
+atqamz/secondhand#65: a worker's report prose has run several KB for a single task, and rendering it in full doubled the cost by repeating the latest entry - once as `Reported:`, again as the last line of `Report history`. Without `--full`:
+- The `Reported` line and every history line are capped to 200 runes (a character budget, not a word or line count, since the point is bounding rendered size). The cut lands after the state-vocabulary prefix (`working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, `failed:`) - the prefix is never part of what's cut - and a cut line always carries a trailing `... [+N chars]` marker naming how much was dropped, so a short report is never mistaken for a truncated one. `done: <PR url>` stays intact under this budget in the common case, since the worker convention puts the URL immediately after the prefix and 200 runes covers it comfortably; a URL buried after long prose is the same brief-authoring problem the write side already owns (see "Report channel").
+- `Report history` drops the entry already shown on the `Reported:` line above it, so the same report is never printed twice in one invocation.
+- A `Report file:` line names the absolute path to `state/<id>.status`, so nothing is lost: the full text stays on disk and the path to it is one line away.
+
+`--full` restores the exact pre-#65 shape: both lines untruncated, the latest entry repeated in history, and no `Report file:` line.
+
+`--json` is never truncated or deduped, `--full` or not - see the JSON section below.
 
 The "Report history" label is deliberate: these lines are the worker's own claims about itself, not something `hand` has verified, same caution as the `done`-vs-`reported-done` distinction in `hand watch`.
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -406,24 +406,24 @@ Behavior (single task):
 
 Output (single task):
 ```
-Task:       fix-login
-Project:    nsr
-Kind:       ship
-Harness:    claude
-Model:      sonnet
-State:      working
-Worktree:   /home/user/.treehouse/nsr-abc/1/nsr
-Herdr:      default / wA:tB
-Created:    2h ago
-PR:         (none)
-Reported:   needs-decision: two ways to fix the race, ask-user found both risky
+Task:        fix-login
+Project:     nsr
+Kind:        ship
+Harness:     claude
+Model:       sonnet
+State:       working
+Worktree:    /home/user/.treehouse/nsr-abc/1/nsr
+Herdr:       default / wA:tB
+Created:     2h ago
+PR:          (none)
+Reported:    needs-decision: two ways to fix the race, ask-user found both risky
 Report file: /home/user/secondhand/state/fix-login.status
 
 Report history (reported by worker, not verified current truth):
   working: added the retry loop
 ```
 
-The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the same merge suffix the fleet overview appends: `PR:         https://github.com/org/repo/pull/42 (merged, external)`.
+The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the same merge suffix the fleet overview appends: `PR:          https://github.com/org/repo/pull/42 (merged, external)`.
 
 atqamz/secondhand#65: a worker's report prose has run several KB for a single task, and rendering it in full doubled the cost by repeating the latest entry - once as `Reported:`, again as the last line of `Report history`. Without `--full`:
 - The `Reported` line and every history line are capped to 200 runes (a character budget, not a word or line count, since the point is bounding rendered size). The cut lands after the state-vocabulary prefix (`working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, `failed:`) - the prefix is never part of what's cut - and a cut line always carries a trailing `... [+N chars]` marker naming how much was dropped, so a short report is never mistaken for a truncated one. `done: <PR url>` stays intact under this budget in the common case, since the worker convention puts the URL immediately after the prefix and 200 runes covers it comfortably; a URL buried after long prose is the same brief-authoring problem the write side already owns (see "Report channel").

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,7 +34,7 @@ func newStatusCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
-	cmd.Flags().BoolVar(&full, "full", false, "show the reported line and history untruncated, with no history dedup")
+	cmd.Flags().BoolVar(&full, "full", false, "show the reported line and history untruncated, with no history dedup (single task only)")
 	return cmd
 }
 
@@ -242,29 +242,34 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	} else {
 		pr += mergeSuffix(t)
 	}
+	// One render choice drives both the Reported line and every history entry,
+	// so a change to the budget can never reach one of them and miss the other.
+	render := reportLineText
+	if !full {
+		render = func(line state.ReportLine) string { return truncateReportLine(line, reportSummaryBudget) }
+	}
+
 	reported := "(none)"
 	switch {
 	case readErr != nil:
 		reported = fmt.Sprintf("report %s: %v", reportUnreadable, readErr)
-	case len(tail) > 0 && full:
-		reported = reportLineText(last)
 	case len(tail) > 0:
-		reported = truncateReportLine(last, reportSummaryBudget)
+		reported = render(last)
 	}
 
 	w := cmd.OutOrStdout()
 	lines := []string{
-		fmt.Sprintf("Task:       %s", t.ID),
-		fmt.Sprintf("Project:    %s", t.Project),
-		fmt.Sprintf("Kind:       %s", t.Kind),
-		fmt.Sprintf("Harness:    %s", t.Harness),
-		fmt.Sprintf("Model:      %s", t.Model),
-		fmt.Sprintf("State:      %s", agentState),
-		fmt.Sprintf("Worktree:   %s", t.Worktree),
-		fmt.Sprintf("Herdr:      %s / %s", t.Herdr.Session, t.Herdr.TabID),
-		fmt.Sprintf("Created:    %s", formatAge(t.CreatedAt)),
-		fmt.Sprintf("PR:         %s", pr),
-		fmt.Sprintf("Reported:   %s", reported),
+		fmt.Sprintf("Task:        %s", t.ID),
+		fmt.Sprintf("Project:     %s", t.Project),
+		fmt.Sprintf("Kind:        %s", t.Kind),
+		fmt.Sprintf("Harness:     %s", t.Harness),
+		fmt.Sprintf("Model:       %s", t.Model),
+		fmt.Sprintf("State:       %s", agentState),
+		fmt.Sprintf("Worktree:    %s", t.Worktree),
+		fmt.Sprintf("Herdr:       %s / %s", t.Herdr.Session, t.Herdr.TabID),
+		fmt.Sprintf("Created:     %s", formatAge(t.CreatedAt)),
+		fmt.Sprintf("PR:          %s", pr),
+		fmt.Sprintf("Reported:    %s", reported),
 	}
 	if !full && (len(tail) > 0 || readErr != nil) {
 		lines = append(lines, fmt.Sprintf("Report file: %s", state.ReportPath(home, id)))
@@ -289,11 +294,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 			return err
 		}
 		for _, line := range historyTail {
-			text := reportLineText(line)
-			if !full {
-				text = truncateReportLine(line, reportSummaryBudget)
-			}
-			if _, err := fmt.Fprintf(w, "  %s\n", text); err != nil {
+			if _, err := fmt.Fprintf(w, "  %s\n", render(line)); err != nil {
 				return err
 			}
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newStatusCmd() *cobra.Command {
-	var asJSON bool
+	var asJSON, full bool
 
 	cmd := &cobra.Command{
 		Use:   "status [id]",
@@ -27,14 +27,45 @@ func newStatusCmd() *cobra.Command {
 			client := herdr.NewClient()
 
 			if len(args) == 1 {
-				return runStatusSingle(cmd, home, client, args[0], asJSON)
+				return runStatusSingle(cmd, home, client, args[0], asJSON, full)
 			}
 			return runStatusFleet(cmd, home, client, asJSON)
 		},
 	}
 
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	cmd.Flags().BoolVar(&full, "full", false, "show the reported line and history untruncated, with no history dedup")
 	return cmd
+}
+
+// reportSummaryBudget bounds the rendered length of one report line (state
+// prefix plus note) in the human-readable single-task view, in runes so a
+// multi-byte character never lands half-cut. A worker's status prose has run
+// 2.7-4.3 KB for a single task; this keeps a normal terse report (which is
+// what the vocabulary in CLAUDE.md/AGENTS.md asks for) untouched while
+// bounding the pathological case. --json and --full both bypass it, since a
+// machine consumer needs the whole field and --full is the explicit opt-out.
+const reportSummaryBudget = 200
+
+// truncateReportLine renders line the same way reportLineText does, then caps
+// it to budget runes. The state-vocabulary prefix ("done: ", "blocked: ", ...)
+// is never part of what gets cut - it is the highest-value part of the line -
+// and a cut line always carries a visible marker naming how much was dropped,
+// so a short report can never be mistaken for a truncated one.
+func truncateReportLine(line state.ReportLine, budget int) string {
+	full := reportLineText(line)
+	runes := []rune(full)
+	if len(runes) <= budget {
+		return full
+	}
+	prefixLen := 0
+	if !line.Malformed {
+		prefixLen = len(line.State) + len(": ")
+	}
+	if budget < prefixLen {
+		budget = prefixLen
+	}
+	return fmt.Sprintf("%s... [+%d chars]", string(runes[:budget]), len(runes)-budget)
 }
 
 // paneAgentStatus degrades gracefully to "unknown" when herdr is unreachable or the
@@ -170,7 +201,7 @@ func reportedFrom(last state.ReportLine, ok bool, readErr error) *reportedJSON {
 	return &reportedJSON{State: last.State, Note: last.Note}
 }
 
-func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON bool) error {
+func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON, full bool) error {
 	t, err := state.Read(home, id)
 	if err != nil {
 		return asPrecondition(err)
@@ -215,8 +246,10 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	switch {
 	case readErr != nil:
 		reported = fmt.Sprintf("report %s: %v", reportUnreadable, readErr)
-	case len(tail) > 0:
+	case len(tail) > 0 && full:
 		reported = reportLineText(last)
+	case len(tail) > 0:
+		reported = truncateReportLine(last, reportSummaryBudget)
 	}
 
 	w := cmd.OutOrStdout()
@@ -233,18 +266,34 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		fmt.Sprintf("PR:         %s", pr),
 		fmt.Sprintf("Reported:   %s", reported),
 	}
+	if !full && (len(tail) > 0 || readErr != nil) {
+		lines = append(lines, fmt.Sprintf("Report file: %s", state.ReportPath(home, id)))
+	}
 	for _, line := range lines {
 		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err
 		}
 	}
 
-	if len(tail) > 0 {
+	// In the default view, the entry already shown on the Reported line above
+	// is dropped from the history block below it - repeating it there was the
+	// core of atqamz/secondhand#65, doubling the cost of every terminal report.
+	// --full restores the exact previous shape: the full tail, untruncated,
+	// duplicate entry included.
+	historyTail := tail
+	if !full && len(tail) > 0 {
+		historyTail = tail[:len(tail)-1]
+	}
+	if len(historyTail) > 0 {
 		if _, err := fmt.Fprintln(w, "\nReport history (reported by worker, not verified current truth):"); err != nil {
 			return err
 		}
-		for _, line := range tail {
-			if _, err := fmt.Fprintf(w, "  %s\n", reportLineText(line)); err != nil {
+		for _, line := range historyTail {
+			text := reportLineText(line)
+			if !full {
+				text = truncateReportLine(line, reportSummaryBudget)
+			}
+			if _, err := fmt.Fprintf(w, "  %s\n", text); err != nil {
 				return err
 			}
 		}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/state"
@@ -558,6 +559,169 @@ func TestStatusSingleTaskDegradesOnAnUnreadableReport(t *testing.T) {
 	}
 	if !strings.Contains(got, "Task:       task-1") || !strings.Contains(got, "State:      idle") {
 		t.Fatalf("got %q, want the rest of the detail view still printed", got)
+	}
+}
+
+// atqamz/secondhand#65: a worker's report prose has run 2.7-4.3 KB for a
+// single task, and hand status rendered it in full - the point of this test.
+func TestTruncateReportLineKeepsVocabularyPrefixIntactUnderAnAdversarialBudget(t *testing.T) {
+	line := state.ParseReportLine("done: " + strings.Repeat("x", 500))
+	got := truncateReportLine(line, 3) // smaller than the "done: " prefix itself
+	if !strings.HasPrefix(got, "done: ") {
+		t.Fatalf("got %q, want the done: prefix preserved even when the budget can't fit it", got)
+	}
+}
+
+func TestTruncateReportLineMarksTruncationVisibly(t *testing.T) {
+	line := state.ParseReportLine("working: " + strings.Repeat("x", 500))
+	got := truncateReportLine(line, 50)
+	if strings.Contains(got, strings.Repeat("x", 500)) {
+		t.Fatalf("got %q, want the note cut short", got)
+	}
+	if !strings.Contains(got, "[+") {
+		t.Fatalf("got %q, want a visible marker naming the cut, not a silently shortened line", got)
+	}
+}
+
+func TestTruncateReportLineLeavesShortLinesUntouched(t *testing.T) {
+	line := state.ParseReportLine("done: short")
+	if got := truncateReportLine(line, reportSummaryBudget); got != "done: short" {
+		t.Fatalf("got %q, want a report already under budget left exactly as reported", got)
+	}
+}
+
+func TestTruncateReportLineDoesNotSplitAMultibyteRune(t *testing.T) {
+	line := state.ParseReportLine("done: " + strings.Repeat("héllo", 100))
+	got := truncateReportLine(line, 50)
+	if !utf8.ValidString(got) {
+		t.Fatalf("got %q, want valid utf8 even when the cut lands inside a multi-byte character", got)
+	}
+}
+
+// atqamz/secondhand#65's core complaint: hand status <id> printed the latest
+// report twice, once under Reported: and again as the last entry of Report
+// history. This asserts the fix at the command level, not just the helper.
+func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	longNote := strings.Repeat("x", 500)
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: "+longNote+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Reported:   done: ") {
+		t.Fatalf("got %q, want the done: prefix intact on the Reported line", got)
+	}
+	if strings.Contains(got, longNote) {
+		t.Fatalf("got %q, want the long note truncated rather than printed in full", got)
+	}
+	if !strings.Contains(got, "[+") {
+		t.Fatalf("got %q, want a visible truncation marker", got)
+	}
+	if !strings.Contains(got, "Report file: "+state.ReportPath(home, "task-1")) {
+		t.Fatalf("got %q, want the absolute path to the full report shown", got)
+	}
+}
+
+func TestStatusSingleTaskHistoryDoesNotRepeatTheReportedEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	reportBody := "working: started\nneeds-decision: waiting on review\n"
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(reportBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Count(got, "needs-decision: waiting on review") != 1 {
+		t.Fatalf("got %q, want the latest report shown exactly once, not repeated in history", got)
+	}
+	if !strings.Contains(got, "working: started") {
+		t.Fatalf("got %q, want the earlier report kept in history", got)
+	}
+}
+
+// --full is the literal opt-out: it must reproduce the pre-#65 shape exactly,
+// duplicate entry and all, with no new report-file pointer line.
+func TestStatusSingleTaskFullFlagRestoresThePreviousBehaviorExactly(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	longNote := strings.Repeat("x", 500)
+	reportBody := "working: started\ndone: " + longNote + "\n"
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(reportBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--full"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Count(got, "done: "+longNote) != 2 {
+		t.Fatalf("got %q, want --full to show the full untruncated entry twice, matching prior behavior", got)
+	}
+	if strings.Contains(got, "Report file:") {
+		t.Fatalf("got %q, want --full to skip the new report-file pointer line", got)
+	}
+}
+
+func TestStatusSingleTaskJSONKeepsTheFullReportUntruncated(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	longNote := strings.Repeat("x", 500)
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: "+longNote+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), longNote) {
+		t.Fatalf("got %q, want the JSON report note left fully untruncated - a machine consumer wants the whole field", out.String())
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -138,7 +138,7 @@ func TestStatusSingleTaskDetail(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.String(), "Task:       task-1") || !strings.Contains(out.String(), "State:      idle") {
+	if !strings.Contains(out.String(), "Task:        task-1") || !strings.Contains(out.String(), "State:       idle") {
 		t.Fatalf("got %q", out.String())
 	}
 }
@@ -151,10 +151,10 @@ func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 		want             string
 		wantNot          []string
 	}{
-		{"neither", false, false, "PR:         https://github.com/a/b/pull/1\n", []string{"merged"}},
-		{"handMerged", true, false, "PR:         https://github.com/a/b/pull/1 (merged)\n", []string{"external"}},
-		{"observedOnly", false, true, "PR:         https://github.com/a/b/pull/1 (merged, external)\n", nil},
-		{"both", true, true, "PR:         https://github.com/a/b/pull/1 (merged)\n", []string{"external"}},
+		{"neither", false, false, "PR:          https://github.com/a/b/pull/1\n", []string{"merged"}},
+		{"handMerged", true, false, "PR:          https://github.com/a/b/pull/1 (merged)\n", []string{"external"}},
+		{"observedOnly", false, true, "PR:          https://github.com/a/b/pull/1 (merged, external)\n", nil},
+		{"both", true, true, "PR:          https://github.com/a/b/pull/1 (merged)\n", []string{"external"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -517,7 +517,7 @@ func TestStatusSingleTaskShowsReportedStateAndHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "Reported:   needs-decision: waiting on review") {
+	if !strings.Contains(got, "Reported:    needs-decision: waiting on review") {
 		t.Fatalf("got %q, want the last reported state on its own line", got)
 	}
 	if !strings.Contains(got, "Report history (reported by worker, not verified current truth):") {
@@ -554,10 +554,10 @@ func TestStatusSingleTaskDegradesOnAnUnreadableReport(t *testing.T) {
 		t.Fatalf("got %v, want the read fault degraded rather than failing the command", err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "Reported:   report "+reportUnreadable) {
+	if !strings.Contains(got, "Reported:    report "+reportUnreadable) {
 		t.Fatalf("got %q, want the unreadable report named on the Reported line", got)
 	}
-	if !strings.Contains(got, "Task:       task-1") || !strings.Contains(got, "State:      idle") {
+	if !strings.Contains(got, "Task:        task-1") || !strings.Contains(got, "State:       idle") {
 		t.Fatalf("got %q, want the rest of the detail view still printed", got)
 	}
 }
@@ -623,7 +623,7 @@ func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing
 		t.Fatal(err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "Reported:   done: ") {
+	if !strings.Contains(got, "Reported:    done: ") {
 		t.Fatalf("got %q, want the done: prefix intact on the Reported line", got)
 	}
 	if strings.Contains(got, longNote) {
@@ -634,6 +634,51 @@ func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing
 	}
 	if !strings.Contains(got, "Report file: "+state.ReportPath(home, "task-1")) {
 		t.Fatalf("got %q, want the absolute path to the full report shown", got)
+	}
+}
+
+// The longest label in the block is "Report file:", so every other label pads
+// to its width; a new label that outgrows the column has to widen the whole
+// block, not start its own.
+func TestStatusSingleTaskAlignsEveryLabeledValueInOneColumn(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Harness: "claude", Model: "sonnet", Worktree: filepath.Join(home, "wt"),
+		Herdr:     state.Herdr{Session: "default", TabID: "wA:tB", PaneID: "wA:pB"},
+		CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: landed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	labels := 0
+	for _, line := range strings.Split(out.String(), "\n") {
+		if line == "" {
+			break
+		}
+		label, value, ok := strings.Cut(line, ":")
+		if !ok {
+			t.Fatalf("got %q, want every line of the detail block labeled", line)
+		}
+		labels++
+		if col := len(label) + 1 + (len(value) - len(strings.TrimLeft(value, " "))); col != len("Report file: ") {
+			t.Fatalf("got %q starting its value at column %d, want every value at column %d", line, col+1, len("Report file: ")+1)
+		}
+	}
+	if labels != 12 {
+		t.Fatalf("got %d labeled lines, want all 12 checked for alignment", labels)
 	}
 }
 


### PR DESCRIPTION
## Intent

cap report rendering in hand status <id>: workers write unbounded status prose (2.7-4.3 KB measured for a single task) into state/<id>.status, and hand status printed the latest report twice - once under Reported:, again as the last line of Report history - which is the main cost landing on the orchestrator session that has to survive a whole fleet run. Truncate the Reported line and each history entry to a 200-rune character budget (not word/line count), never cutting into the state-vocabulary prefix (working:/paused:/blocked:/needs-decision:/done:/failed:), with a visible trailing marker naming how much was dropped. Report history drops the entry already shown under Reported: instead of repeating it. A new Report file: line names the absolute path to state/<id>.status so nothing is lost. --full restores the exact previous output (untruncated, duplicate entry, no path line). --json is completely unaffected - a machine consumer wants the whole field and silent truncation there would be data loss, not a rendering choice. Deliberate decision: truncation is left-anchored (keeps the start of the note, cuts the tail) specifically because the done: <PR url> convention puts the URL immediately after the prefix, so the common case preserves the PR URL without needing URL-aware special-casing; verified manually against a realistic 2.9 KB done: line. Write-side caps on report length are explicitly out of scope per the issue and brief - this is a render-only fix. Scope is cmd/status.go, cmd/status_test.go, and the hand status section of SPECS.md only; three other issues (#79, #60) are in flight on other files in this same repo and must not be touched.

Fixes atqamz/secondhand#65

## What Changed

- `hand status <id>` now caps the `Reported:` line and every `Report history` entry to a 200-rune budget, cutting only after the state-vocabulary prefix (`working:`/`paused:`/`blocked:`/`needs-decision:`/`done:`/`failed:`) and appending a `... [+N chars]` marker so a truncated line is never mistaken for a short one. Truncation is left-anchored, which keeps the PR URL of the `done: <url>` convention intact without URL-aware special-casing.
- `Report history` no longer repeats the entry already shown on the `Reported:` line, and a new `Report file:` line names the absolute path to `state/<id>.status` so the full text is one line away. Detail-view labels widened one column to align with the new label.
- Added `--full` to opt out (untruncated lines, duplicate history entry retained, no `Report file:` line); `--json` is untouched and still carries the whole field. Write-side report length is unchanged - this is render-only. `cmd/status_test.go` covers the rune budget, prefix preservation, multibyte and malformed lines, history dedup, and the `--full` and `--json` paths.

## Risk Assessment

Low: Render-only change confined to one command's human-readable single-task block, with the JSON path returning before any of it, a --full escape hatch, all three prior review items applied verbatim, and every affected assertion plus the SPECS example updated in lockstep with no stale references remaining.

## Testing

Ran the targeted cmd-package status tests plus the e2e precondition suite (all green), then proved the intent at the product level: I built `hand` from both the base and target commits and ran them side by side against a temp home holding a realistic 3.2 KB worker report. The capped view shrank from 6704 to 841 bytes while keeping the `done:` prefix and the PR URL, carried a `... [+2894 chars]` marker and a new absolute `Report file:` line, and stopped repeating the latest entry in history; `--full` reproduced the base binary's content and `--json` was byte-identical to base. Edge-case runs confirmed multibyte-safe cuts, capped malformed lines, and an exact 200-rune budget. No failures; one informational note that `--full` differs from base by the deliberate one-space label widening.

<details>
<summary>Evidence: CLI transcript: capped vs --full vs --json on a 3.2 KB report</summary>

<code>$ hand status status-cap&#10;Task: status-cap&#10;Project: secondhand&#10;Kind: ship&#10;Harness: claude&#10;Model: opus&#10;State: unknown&#10;Worktree: /home/atqa/.treehouse/secondhand-abc/1/secondhand&#10;Herdr: default / wA:tB&#10;Created: just now&#10;PR: (none)&#10;Reported: done: https://github.com/atqamz/secondhand/pull/78 Implemented the render cap in cmd/status.go, added the truncation helper with the vocabulary-prefix guard, wired --full as the untruncated opt-out, d... [+2894 chars]&#10;Report file: /tmp/no-mistakes-evidence/01KZ18K2SYE2CZ18TXWW9YY11W/demo-home/state/status-cap.status&#10;&#10;Report history (reported by worker, not verified current truth):&#10;working: read the issue and the brief, mapped the current render path in cmd/status.go&#10;working: wrote the truncation helper plus its tests, measured a real 2.9 KB report against it&#10;&#10;$ hand status status-cap --full | wc -c -&gt; 6715&#10;$ hand status status-cap | wc -c -&gt; 841&#10;$ hand status status-cap --json | wc -c -&gt; 6872 (note field 3088 chars, untruncated)</code>

```text
$ hand status status-cap        # default: capped render
Task:        status-cap
Project:     secondhand
Kind:        ship
Harness:     claude
Model:       opus
State:       unknown
Worktree:    /home/atqa/.treehouse/secondhand-abc/1/secondhand
Herdr:       default / wA:tB
Created:     just now
PR:          (none)
Reported:    done: https://github.com/atqamz/secondhand/pull/78 Implemented the render cap in cmd/status.go, added the truncation helper with the vocabulary-prefix guard, wired --full as the untruncated opt-out, d... [+2894 chars]
Report file: /tmp/no-mistakes-evidence/01KZ18K2SYE2CZ18TXWW9YY11W/demo-home/state/status-cap.status

Report history (reported by worker, not verified current truth):
  working: read the issue and the brief, mapped the current render path in cmd/status.go
  working: wrote the truncation helper plus its tests, measured a real 2.9 KB report against it

$ hand status status-cap --full | wc -c    # pre-#65 shape (untruncated + duplicate entry)
6715
$ hand status status-cap | wc -c           # capped
841

$ hand status status-cap --full | tail -n 6 | cut -c1-160    # duplicate latest entry restored, no Report file: line
Reported:    done: https://github.com/atqamz/secondhand/pull/78 Implemented the render cap in cmd/status.go, added the truncation helper with the vocabulary-pre

Report history (reported by worker, not verified current truth):
  working: read the issue and the brief, mapped the current render path in cmd/status.go
  working: wrote the truncation helper plus its tests, measured a real 2.9 KB report against it
  done: https://github.com/atqamz/secondhand/pull/78 Implemented the render cap in cmd/status.go, added the truncation helper with the vocabulary-prefix guard, 

$ hand status status-cap --full | grep -c "Report file:"
2

$ hand status status-cap --json | jq -r ".reported.note | length"   # json untouched
3088

$ hand status status-cap --json | wc -c
6872
```
</details>
<details>
<summary>Evidence: Before/after against base-commit binary (4149241)</summary>

```text
$ hand-base status status-cap | wc -c -> 6704
$ hand status status-cap | wc -c -> 841
$ diff base-default.txt new-full.txt -> only label-column padding differs (content identical)
$ diff base-json.txt new-json.txt -> JSON IDENTICAL
$ grep -c '^Report file:' new-full.txt -> 0
```
</details>
<details>
<summary>Evidence: Edge cases: multibyte, malformed line, long history entries</summary>

<code>Reported: done: https://github.com/atqamz/secondhand/pull/79 tail prose tail prose ... [+510 chars]&#10;Report file: /tmp/no-mistakes-evidence/01KZ18K2SYE2CZ18TXWW9YY11W/demo-home/state/edge-case.status&#10;&#10;Report history (reported by worker, not verified current truth):&#10;blocked: wäiting on secretswäiting on secrets... [+529 chars]&#10;this line has no vocabulary prefix at all and is therefore malformed, padding padding... [+190 chars]&#10;&#10;# each rendered body: 216 runes (200 budget + marker); output is valid utf-8</code>

```text
$ hand status edge-case     # long multibyte history entry, malformed line, long done: line
Task:        edge-case
Project:     secondhand
Kind:        ship
Harness:     claude
Model:       opus
State:       unknown
Worktree:    /home/atqa/.treehouse/secondhand-abc/1/secondhand
Herdr:       default / wA:tB
Created:     just now
PR:          (none)
Reported:    done: https://github.com/atqamz/secondhand/pull/79 tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail prose tail p... [+510 chars]
Report file: /tmp/no-mistakes-evidence/01KZ18K2SYE2CZ18TXWW9YY11W/demo-home/state/edge-case.status

Report history (reported by worker, not verified current truth):
  blocked: wäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on secretswäiting on ... [+529 chars]
  this line has no vocabulary prefix at all and is therefore malformed, padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding pa... [+190 chars]

# rune count of each rendered report body (budget 200 + marker):
216 runes | ends: tail p... [+510 chars]
216 runes | ends: ng on ... [+529 chars]
216 runes | ends: ing pa... [+190 chars]

# utf8 validity of truncated output:
valid utf-8
```
</details>
<details>
<summary>Evidence: Help text and fleet view unaffected</summary>

<code>Flags:&#10;--full show the reported line and history untruncated, with no history dedup (single task only)&#10;-h, --help help for status&#10;--json output as JSON&#10;&#10;$ hand status&#10;edge-case secondhand ship unknown just now&#10;status-cap secondhand ship unknown just now</code>

```text
$ hand status --help
Show fleet overview or single-task detail

Usage:
  hand status [id] [flags]

Flags:
      --full   show the reported line and history untruncated, with no history dedup (single task only)
  -h, --help   help for status
      --json   output as JSON

$ hand status            # fleet view unchanged
edge-case   secondhand  ship  unknown  just now
status-cap  secondhand  ship  unknown  just now

$ hand status --full     # fleet view ignores --full (no crash, same output)
edge-case   secondhand  ship  unknown  just now
status-cap  secondhand  ship  unknown  just now
```
</details>
- Evidence: Demo home used for the transcripts (state + report files) (local file: <code>/tmp/no-mistakes-evidence/01KZ18K2SYE2CZ18TXWW9YY11W/demo-home</code>)
- Outcome: 1 info across 1 run (4m36s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>**intent** - passed</summary>

No issues found.

</details>

<details>
<summary>**Rebase** - passed</summary>

No issues found.

</details>

<details>
<summary>**Review** - 1 info</summary>

- info: `cmd/status.go:292` - The full-vs-truncated render choice is expressed twice: as a switch arm pair at cmd/status.go:249-253 for the Reported line, and again as an inline `if !full` at cmd/status.go:292-295 for each history entry. A single `render := reportLineText` / `if !full { render = func(l state.ReportLine) string { return truncateReportLine(l, reportSummaryBudget) } }` computed once above both sites would keep the two paths from drifting (e.g. a future budget change applied to one and not the other).
- info: `cmd/status.go:37` - `--full` is registered on the status command but only consulted by runStatusSingle; `hand status --full` with no id is accepted and silently does nothing. SPECS.md already scopes it (&#34;in the single-task view&#34;), but the flag&#39;s own help string does not, so `hand status --help` reads as if it applies to the fleet overview too. Appending &#34;(single task only)&#34; to the usage string closes the gap.
- info: `cmd/status.go:270` - Every other label in the single-task block pads its value to column 13 (&#34;Task:       &#34;, &#34;Reported:   &#34; are each 12 chars plus the value). &#34;Report file: &#34; is 13 chars, so its path starts one column right of every other value, visibly breaking the aligned block. SPECS.md:420 documents this exact rendering, so it reads as deliberate rather than accidental; noting it only because the label cannot fit the existing column and the alternative (widening every label by one) is a decision about the whole block, not this line.

Fix: align status labels, unify report render, scope --full help
1 info still open:
- info: `SPECS.md:381` - SPECS.md:381 says `--full` reproduces &#34;the output from before atqamz/secondhand#65 exactly&#34; and SPECS.md:433 repeats &#34;restores the exact pre-#65 shape&#34;. The same commit widened every label in the single-task block by one column (cmd/status.go:262-272), which applies to the `--full` path too, so `--full` output is no longer byte-identical to pre-#65 - the label column differs on all 11 lines. The three properties that actually define the opt-out (untruncated, duplicate entry retained, no `Report file:` line) do hold, and the widening was explicitly directed, so this is wording drift, not a behavior defect: scope both sentences to the report rendering rather than the whole output. The same overstatement sits in the test comment above cmd/status_test.go&#39;s `TestStatusSingleTaskFullFlagRestoresThePreviousBehaviorExactly` (the assertions themselves check only the three real properties, so no test is wrong).

</details>

<details>
<summary>**Test** - 1 info</summary>

- info: `cmd/status.go:262` - `--full` restores the previous content exactly (untruncated line, duplicate history entry, no `Report file:` line - diff against a binary built at base commit 4149241 is clean once label padding is normalized), but not the previous bytes: commit 306444b widened every detail-view label by one space to align with the new `Report file:` label, and that widening also applies under `--full`. Intentional per the commit message; noting it only because the intent phrases --full as restoring &#34;the exact previous output&#34;.
- `nix develop -c go test -race -run 'TestStatus|TestTruncateReportLine' ./cmd/`
- <code>`nix develop -c go test -race ./cmd/` (changed package, full)</code>
- `nix develop -c go test -tags=e2e -run Precondition ./tests/e2e/`
- <code>Built target-commit `hand` and base-commit (`4149241`) `hand-base`; ran both against a temp home with a 3.2 KB `state/status-cap.status` whose last line is a 3095-byte `done: &lt;PR url&gt; ...` report</code>
- <code>`hand status status-cap` - capped Reported line, PR URL preserved, `... [+2894 chars]` marker, `Report file:` absolute path, history without the duplicate entry</code>
- <code>`diff base-default.txt new-full.txt` - `--full` content matches pre-change output (only label-column padding differs)</code>
- <code>`diff base-json.txt new-json.txt` - JSON output identical to base binary</code>
- <code>`hand status edge-case` - multibyte (`wäiting`) cut stays valid UTF-8 via `iconv -f utf-8 -t utf-8`, malformed prefix-less line rendered raw and capped, each capped body measured at exactly 216 runes (200 budget + marker)</code>
- <code>`hand status --help`, `hand status`, `hand status --full` (fleet view) - flag documented, fleet output unaffected</code>

</details>

<details>
<summary>**Document** - passed</summary>

No issues found.

</details>

<details>
<summary>**Lint** - passed</summary>

No issues found.

</details>

<details>
<summary>**Push** - passed</summary>

No issues found.

</details>


