### PR TITLE
feat(cmd): refuse dispatch into an ungated no-mistakes project

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -299,9 +299,9 @@ Behavior:
    unreachable, unless `--skip-gate-check` is set.
 3. Validate no active task with this ID exists.
 4. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
-6. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
-7. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in `state/*.json`. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
-8. Acquire the task's herdr tab in the project's workspace.
+5. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
+6. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in `state/*.json`. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
+7. Acquire the task's herdr tab in the project's workspace.
    - Workspace naming: one workspace per project, named after the project.
    - Tab naming: task ID.
    - If the project's workspace does not exist yet, create it at the worktree's cwd. herdr has no
@@ -309,15 +309,15 @@ Behavior:
      this reuses that root tab as the task's tab (renamed to the task ID) instead of creating a
      second one, which would leave the root tab behind as an orphan shell in the workspace.
    - If the workspace already exists, create a new tab in it for the task.
-9. Construct the harness launch command from the template (see harness section).
-10. Send the launch command to the herdr pane.
-11. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
+8. Construct the harness launch command from the template (see harness section).
+9. Send the launch command to the herdr pane.
+10. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
    no first-run dialog is left, answering any known dialog along the way, or the poll window
    elapses (see Harness launch templates).
-12. Write `state/<id>.json` with all metadata.
-13. Update `data/dashboard.md` with the new task.
+11. Write `state/<id>.json` with all metadata.
+12. Update `data/dashboard.md` with the new task.
 
-Any failure before step 12 leaves nothing behind: the worktree lease returns to treehouse and the
+Any failure before step 11 leaves nothing behind: the worktree lease returns to treehouse and the
 herdr side is rolled back.
 A workspace this command created is closed whole: the task's tab is that workspace's own
 auto-created root tab, so there is nothing else in it to preserve.
@@ -871,7 +871,7 @@ Behavior:
    refuse before acquiring any worktree if it comes back not initialized or unreachable, unless
    `--skip-gate-check` is set.
 4. Acquire a fresh treehouse worktree (with collision guard).
-5. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 8, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
+5. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 7, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
 6. Launch the worker and confirm it started (same as `hand spawn`).
 7. Rewrite `state/<id>.json` in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree` and the `herdr` coordinates describe the new worker. Every field anchored to the scout's pane is reset: `done_verified` to false, `status_changed_at` restamped to the promotion time with `status_changed_for` cleared, and `last_report_state` / `last_report_note` emptied. Every pane-independent field is carried, including `created_at` and the watcher's `report_offset` - see "Pane-anchored facts across `hand promote`", which classifies each of them and covers the matching in-memory cache a live `hand watch` has to drop.
 8. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.

--- a/SPECS.md
+++ b/SPECS.md
@@ -231,16 +231,22 @@ hand project list --json
 Output (human):
 ```
 nsr         https://github.com/yes2games/nsr          direct-pr
-yes2infra   https://github.com/yes2games/yes2infra    no-mistakes
+yes2infra   https://github.com/yes2games/yes2infra    no-mistakes  (gate: not initialized)
 ```
 
 Output (JSON):
 ```json
 [
   {"name": "nsr", "url": "https://github.com/yes2games/nsr", "mode": "direct-pr"},
-  {"name": "yes2infra", "url": "https://github.com/yes2games/yes2infra", "mode": "no-mistakes"}
+  {"name": "yes2infra", "url": "https://github.com/yes2games/yes2infra", "mode": "no-mistakes", "gate_issue": "not initialized"}
 ]
 ```
+
+A `no-mistakes`-mode project whose gate cannot currently be honoured (not initialized, or the
+`no-mistakes` binary itself unreachable) gets a `(gate: <issue>)` suffix in human output and a
+`gate_issue` field in JSON output (omitted when there is no issue). See "Gate preflight" for what
+this checks and why. Every `no-mistakes`-mode project pays one `no-mistakes status` call per
+`hand project list` invocation; other modes pay nothing.
 
 ---
 
@@ -279,6 +285,7 @@ Flags:
 - `--harness <name>`: agent harness to launch. Default: value from `config/harness`, or `claude`.
 - `--model <name>`: model override for harnesses that support it. Default: the brief's declared `model`, else `config/model`.
 - `--effort <level>`: effort level for harnesses that support it. Default: the brief's declared `effort`, else `config/effort`.
+- `--skip-gate-check`: dispatch into a `no-mistakes` project even if its gate is not initialized (see "Gate preflight").
 
 Model and effort resolve most-specific-first: the flag, then the brief's `---` declaration (see
 "Brief format"), then the config default, then unset. A resolved effort under a harness with no
@@ -287,11 +294,14 @@ the effort recorded in state and ignored by the launch command.
 
 Behavior:
 1. Validate project exists in registry.
-2. Validate no active task with this ID exists.
-3. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
-4. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
-5. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in `state/*.json`. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
-6. Acquire the task's herdr tab in the project's workspace.
+2. If the project's mode is `no-mistakes`, run the gate preflight check (see "Gate preflight");
+   refuse before touching any task or worktree state if it comes back not initialized or
+   unreachable, unless `--skip-gate-check` is set.
+3. Validate no active task with this ID exists.
+4. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
+6. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
+7. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in `state/*.json`. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
+8. Acquire the task's herdr tab in the project's workspace.
    - Workspace naming: one workspace per project, named after the project.
    - Tab naming: task ID.
    - If the project's workspace does not exist yet, create it at the worktree's cwd. herdr has no
@@ -299,15 +309,15 @@ Behavior:
      this reuses that root tab as the task's tab (renamed to the task ID) instead of creating a
      second one, which would leave the root tab behind as an orphan shell in the workspace.
    - If the workspace already exists, create a new tab in it for the task.
-7. Construct the harness launch command from the template (see harness section).
-8. Send the launch command to the herdr pane.
-9. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
+9. Construct the harness launch command from the template (see harness section).
+10. Send the launch command to the herdr pane.
+11. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
    no first-run dialog is left, answering any known dialog along the way, or the poll window
    elapses (see Harness launch templates).
-10. Write `state/<id>.json` with all metadata.
-11. Update `data/dashboard.md` with the new task.
+12. Write `state/<id>.json` with all metadata.
+13. Update `data/dashboard.md` with the new task.
 
-Any failure before step 10 leaves nothing behind: the worktree lease returns to treehouse and the
+Any failure before step 12 leaves nothing behind: the worktree lease returns to treehouse and the
 herdr side is rolled back.
 A workspace this command created is closed whole: the task's tab is that workspace's own
 auto-created root tab, so there is nothing else in it to preserve.
@@ -323,6 +333,9 @@ spawned fix-login project=nsr kind=ship harness=claude worktree=/home/user/.tree
 
 Errors:
 - Project not registered.
+- `no-mistakes` gate not initialized for a `no-mistakes`-mode project (names the exact remedy
+  command; see "Gate preflight"). Skipped entirely with `--skip-gate-check`.
+- `no-mistakes` binary missing or not runnable, distinct from the above (see "Gate preflight").
 - Task ID already active.
 - Brief not found at `data/<id>/brief.md`.
 - Treehouse worktree acquisition failed (pool exhausted, git error).
@@ -845,6 +858,7 @@ Flags:
 - `--harness <name>`: harness for the new ship worker. Default: value from `config/harness`.
 - `--model <name>`: model override. Default: the brief's declared `model`, else `config/model`.
 - `--effort <level>`: effort override. Default: the brief's declared `effort`, else `config/effort`.
+- `--skip-gate-check`: dispatch into a `no-mistakes` project even if its gate is not initialized (see "Gate preflight").
 
 Promote resolves model and effort exactly as `hand spawn` does, against the brief the agent
 updated for the ship phase, so a scout brief that declared a tier keeps it through promotion
@@ -853,14 +867,17 @@ unless the brief or a flag says otherwise.
 Behavior:
 1. Validate the task exists and is a completed scout (has `data/<id>/report.md`, herdr pane is not busy - `idle` or `done`, which mean the same thing here, see "Agent state" - or unreachable/dead).
 2. Create or update `data/<id>/brief.md` - the agent should update it with implementation instructions before calling promote, referencing the scout report.
-3. Acquire a fresh treehouse worktree (with collision guard).
-4. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 6, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
-5. Launch the worker and confirm it started (same as `hand spawn`).
-6. Rewrite `state/<id>.json` in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree` and the `herdr` coordinates describe the new worker. Every field anchored to the scout's pane is reset: `done_verified` to false, `status_changed_at` restamped to the promotion time with `status_changed_for` cleared, and `last_report_state` / `last_report_note` emptied. Every pane-independent field is carried, including `created_at` and the watcher's `report_offset` - see "Pane-anchored facts across `hand promote`", which classifies each of them and covers the matching in-memory cache a live `hand watch` has to drop.
-7. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.
+3. If the project's mode is `no-mistakes`, run the gate preflight check (see "Gate preflight");
+   refuse before acquiring any worktree if it comes back not initialized or unreachable, unless
+   `--skip-gate-check` is set.
+4. Acquire a fresh treehouse worktree (with collision guard).
+5. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 8, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
+6. Launch the worker and confirm it started (same as `hand spawn`).
+7. Rewrite `state/<id>.json` in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree` and the `herdr` coordinates describe the new worker. Every field anchored to the scout's pane is reset: `done_verified` to false, `status_changed_at` restamped to the promotion time with `status_changed_for` cleared, and `last_report_state` / `last_report_note` emptied. Every pane-independent field is carried, including `created_at` and the watcher's `report_offset` - see "Pane-anchored facts across `hand promote`", which classifies each of them and covers the matching in-memory cache a live `hand watch` has to drop.
+8. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.
 
 The scout side is torn down last on purpose: the same rollback contract as `hand spawn` applies up
-to step 6, so a promotion that fails partway still leaves the scout's pane and worktree intact
+to step 7, so a promotion that fails partway still leaves the scout's pane and worktree intact
 instead of stranding the task with nothing to look at.
 `data/dashboard.md` is deliberately left untouched, so the task's row keeps reading `scout` until
 something else rewrites it.
@@ -874,6 +891,9 @@ Errors:
 - Task not found.
 - Task is not a completed scout.
 - Scout report not found.
+- `no-mistakes` gate not initialized, or the binary missing/not runnable, for a `no-mistakes`-mode
+  project (same two distinct errors as `hand spawn`; see "Gate preflight"). Skipped entirely with
+  `--skip-gate-check`.
 - Worktree or herdr errors (same as `hand spawn`).
 
 ---
@@ -1302,7 +1322,45 @@ The worker uses `no-mistakes` directly in the worktree:
 Secondhand's only no-mistakes awareness:
 - `hand project add` initializes it when `--mode no-mistakes`.
 - The ship brief template mentions the no-mistakes workflow when the project mode is `no-mistakes`.
-- `hand` itself never calls `no-mistakes`. The worker does.
+- `hand spawn` and `hand promote` ask `no-mistakes status` before dispatching into a `no-mistakes`
+  project, refusing if the gate is not initialized for that repo (see "Gate preflight" below). This
+  is a read-only status check, not driving the pipeline: `hand` still never calls `axi run`,
+  `axi respond`, or `axi abort`. The worker does.
+
+### Gate preflight
+
+`no-mistakes`'s own state is keyed on the absolute `working_path` of the repo it was initialized
+against. Two real histories orphan that row without either `hand` or `no-mistakes` reporting it
+anywhere: the fleet home gets renamed (moving every project's clone path at once), or a project is
+registered with `--mode no-mistakes` but `no-mistakes init` is never run against it. Both leave a
+`no-mistakes`-mode project silently ungated - a worker's `axi run` either fails deep into the task
+or, worse, is never invoked at all - with nothing obliging anyone to notice.
+
+`hand spawn` and `hand promote` each run a preflight check before dispatching into a `no-mistakes`
+project: `no-mistakes status`, run inside the project's clone. `no-mistakes status` always exits 0,
+whether or not the repo is initialized, and reports both of the histories above with the identical
+text `repo not initialized (run 'no-mistakes init' first)` - there is no way to distinguish a
+never-initialized repo from a stale renamed one from the outside, so the preflight does not try.
+The outcome is read from that text, never from `/home/atqa/.no-mistakes/state.sqlite` directly,
+which is another tool's private schema.
+
+Three outcomes:
+- **Initialized:** proceed.
+- **Not initialized** (either history): refuse with exit code 3, naming the exact remedy verbatim -
+  `no-mistakes init` is idempotent and repairs a stale `working_path` in place, so the message reads
+  `no-mistakes gate not initialized for project "<name>", run: cd <clone-path> && no-mistakes init`.
+- **Binary missing or not runnable:** refuse with a distinctly different message (`no-mistakes
+  binary not found or not runnable: <error>`), never collapsed into "not initialized" - the remedy
+  for a missing binary is not `no-mistakes init`.
+
+Escape hatch: `--skip-gate-check` on both `hand spawn` and `hand promote` bypasses the preflight
+and prints a warning to stderr naming the project, so bypassing it is visible in the transcript
+rather than a silent env var.
+
+`hand project list` runs the same check for every `no-mistakes`-mode project and appends `(gate:
+not initialized)` or `(gate: unreachable)` to its output line (and `"gate_issue"` in `--json`
+output) when the check doesn't come back clean, so a stale or never-initialized gate is visible
+without waiting for a spawn or promote to refuse.
 
 ## Brief format
 
@@ -1418,7 +1476,9 @@ Fields:
 - `mode=<mode>`: delivery mode.
 
 Delivery modes:
-- `no-mistakes`: worker runs no-mistakes pipeline, ships via PR with validation evidence.
+- `no-mistakes`: worker runs no-mistakes pipeline, ships via PR with validation evidence. `hand
+  spawn` and `hand promote` refuse to dispatch into a `no-mistakes` project whose gate is not
+  initialized (see "Gate preflight").
 - `direct-pr`: worker pushes branch and opens PR directly.
 - `local-only`: worker commits to a local branch. Merging into default branch via `hand merge --local`.
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -1341,7 +1341,7 @@ project: `no-mistakes status`, run inside the project's clone. `no-mistakes stat
 whether or not the repo is initialized, and reports both of the histories above with the identical
 text `repo not initialized (run 'no-mistakes init' first)` - there is no way to distinguish a
 never-initialized repo from a stale renamed one from the outside, so the preflight does not try.
-The outcome is read from that text, never from `/home/atqa/.no-mistakes/state.sqlite` directly,
+The outcome is read from that text, never from `~/.no-mistakes/state.sqlite` directly,
 which is another tool's private schema.
 
 Three outcomes:
@@ -1351,7 +1351,8 @@ Three outcomes:
   `no-mistakes gate not initialized for project "<name>", run: cd <clone-path> && no-mistakes init`.
 - **Binary missing or not runnable:** refuse with a distinctly different message (`no-mistakes
   binary not found or not runnable: <error>`), never collapsed into "not initialized" - the remedy
-  for a missing binary is not `no-mistakes init`.
+  for a missing binary is not `no-mistakes init`. This is a general error (exit code `1`), not a
+  precondition: the world is not in a state the operator can fix by initializing anything.
 
 Escape hatch: `--skip-gate-check` on both `hand spawn` and `hand promote` bypasses the preflight
 and prints a warning to stderr naming the project, so bypassing it is visible in the transcript
@@ -1561,7 +1562,7 @@ On restart (new supervisory agent session):
 - `1`: general error.
 - `2`: usage error: wrong argument count, unknown flag, unknown command or subcommand, mutually exclusive or mutually dependent flags (`hand watch --timeout` without `--until-event`), an invalid argument or flag value (malformed project URL, unknown project mode or harness, unparsable `--poll` duration, a non-positive `--timeout`).
   A value the invocation did not supply is not a usage error: the same malformed value read from a `config/` default is a general error (code `1`).
-- `3`: precondition failed, meaning the command refuses because the world is not in the state it requires: unlanded work, red CI, a missing or unmerged PR, a missing brief or report, a task or project that does not exist, a task in the wrong kind or state (already merged, not a completed scout, already claimed by another command), a project name or worktree already taken, a project still referenced by active tasks, a PR that conflicts with one already recorded for a task or doesn't belong to the task's project's repo (`hand pr`), a PR that `gh pr view` can't confirm exists (`hand pr`), a repeat recording with no active dashboard row left to reconcile (`hand pr`), a task branch whose PRs do not resolve to a single usable winner (`hand teardown`).
+- `3`: precondition failed, meaning the command refuses because the world is not in the state it requires: unlanded work, red CI, a missing or unmerged PR, a missing brief or report, a task or project that does not exist, a task in the wrong kind or state (already merged, not a completed scout, already claimed by another command), a project name or worktree already taken, a project still referenced by active tasks, a PR that conflicts with one already recorded for a task or doesn't belong to the task's project's repo (`hand pr`), a PR that `gh pr view` can't confirm exists (`hand pr`), a repeat recording with no active dashboard row left to reconcile (`hand pr`), a task branch whose PRs do not resolve to a single usable winner (`hand teardown`), a `no-mistakes`-mode project whose gate is not initialized (`hand spawn`, `hand promote` - see "Gate preflight").
 - `4`: no event delivered, only from `hand watch --until-event`: its `--timeout` elapsed, or it was signaled, without a transition. This includes the timeout elapsing anywhere in arming, the herdr reachability probe as well as the per-task probe sweep - the window is over either way, and no one task is at fault. Distinct from `0` because there the exit *is* the event delivery, and from `1` because the watcher itself did not fail (see "Delivering an event to a supervisory agent").
 - `5`: arm-time probe failure, only from `hand watch --until-event`: one named task's herdr pane answered its pre-wait probe with a failure, named on stderr. Distinct from `4` because a specific worker is at fault and can be acted on, and from `0` because nothing was delivered (see "Delivering an event to a supervisory agent").
 

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+// fakeNoMistakesPath writes a fake no-mistakes binary that only answers `status`, mirroring the
+// real binary's observed behavior documented in internal/project.GateStatus: it always exits 0,
+// so the outcome is read from stdout text rather than the exit code. Returns a PATH with the fake
+// binary's directory prepended ahead of the real PATH: the script's own "cat" still needs to
+// resolve, and the fake must win the lookup over any real no-mistakes already on this machine.
+func fakeNoMistakesPath(t *testing.T, stdout string) string {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\ncat <<'EOF'\n" + stdout + "\nEOF\n"
+	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin + string(os.PathListSeparator) + os.Getenv("PATH")
+}
+
+// fakeHerdrPaneDone fakes only "pane get", answering the pane as done (not busy), enough for
+// promote's precondition check to pass through to gatePreflight without needing the rest of a
+// clean promote's herdr calls, which gatePreflight's refusal preempts.
+const fakeHerdrPaneDone = `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tOld","workspace_id":"wA","agent_status":"done"}}}' "$3"
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+// setupSpawnHomeGate registers a no-mistakes-mode project and nothing else: gatePreflight fires
+// in spawn before state.Claim, the brief check, or any herdr/treehouse call, so none of those need
+// to exist for these tests. noMistakesPath becomes PATH verbatim, letting each test control
+// exactly whether a fake no-mistakes binary is reachable.
+func setupSpawnHomeGate(t *testing.T, noMistakesPath string) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", noMistakesPath)
+	t.Chdir(home)
+	return home
+}
+
+// setupPromoteHomeGate mirrors setupPromoteHome but registers a no-mistakes-mode project and
+// skips the worktree/treehouse setup: gatePreflight fires in promote after the report, pane-busy,
+// and brief checks but before worktree.Get, so those three preconditions must be satisfied while
+// nothing past gatePreflight needs to exist. noMistakesPath becomes PATH verbatim except for the
+// fake herdr binary this helper always adds, letting each test control whether no-mistakes is
+// reachable.
+func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
+	t.Helper()
+	useFastLaunchPolling(t)
+	home := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("scout findings"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "brief.md"), []byte("implement the fix"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{
+		ID:      "task-1",
+		Project: "gated",
+		Kind:    state.KindScout,
+		Herdr:   state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	herdrBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(herdrBin, "herdr"), []byte(fakeHerdrPaneDone), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", herdrBin+string(os.PathListSeparator)+noMistakesPath)
+	t.Chdir(home)
+	return home
+}
+
+// TestSpawnRefusesWhenNoMistakesGateNotInitialized stands in for both real histories from
+// atqamz/secondhand#60 (never-initialized project, and a project whose working_path went stale
+// after the fleet home was renamed): internal/project.TestGateStatusNotInitialized_* already prove
+// those two histories produce byte-identical no-mistakes status output, so one refusal test here
+// covers both.
+func TestSpawnRefusesWhenNoMistakesGateNotInitialized(t *testing.T) {
+	path := fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)")
+	home := setupSpawnHomeGate(t, path)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "gated"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+
+	clonePath := filepath.Join(home, "projects", "gated")
+	wantRemedy := "no-mistakes init"
+	if !strings.Contains(err.Error(), wantRemedy) || !strings.Contains(err.Error(), clonePath) {
+		t.Fatalf("err = %v, want it to name %q and the remedy %q", err, clonePath, wantRemedy)
+	}
+}
+
+func TestSpawnRefusesDistinctlyWhenNoMistakesBinaryMissing(t *testing.T) {
+	setupSpawnHomeGate(t, t.TempDir())
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "gated"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when no-mistakes is not runnable")
+	}
+	if exitCodeFor(t, err) == 3 && strings.Contains(err.Error(), "not initialized") {
+		t.Fatalf("err = %v, must not read as the gate-not-initialized case", err)
+	}
+}
+
+func TestSpawnProceedsWhenNoMistakesGateReady(t *testing.T) {
+	path := fakeNoMistakesPath(t, "gate: ready\n\n  no active run")
+	setupSpawnHomeGate(t, path)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "gated"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected spawn to still fail past the gate check (no brief, no herdr fake)")
+	}
+	if exitCodeFor(t, err) == 3 && strings.Contains(err.Error(), "gate") {
+		t.Fatalf("err = %v, gate check should have passed and failed later for an unrelated reason", err)
+	}
+}
+
+func TestPromoteRefusesWhenNoMistakesGateNotInitialized(t *testing.T) {
+	path := fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)")
+	home := setupPromoteHomeGate(t, path)
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+
+	clonePath := filepath.Join(home, "projects", "gated")
+	wantRemedy := "no-mistakes init"
+	if !strings.Contains(err.Error(), wantRemedy) || !strings.Contains(err.Error(), clonePath) {
+		t.Fatalf("err = %v, want it to name %q and the remedy %q", err, clonePath, wantRemedy)
+	}
+}
+
+func TestPromoteRefusesDistinctlyWhenNoMistakesBinaryMissing(t *testing.T) {
+	setupPromoteHomeGate(t, t.TempDir())
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when no-mistakes is not runnable")
+	}
+	if exitCodeFor(t, err) == 3 && strings.Contains(err.Error(), "not initialized") {
+		t.Fatalf("err = %v, must not read as the gate-not-initialized case", err)
+	}
+}

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,9 +109,8 @@ func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
 
 // TestSpawnRefusesWhenNoMistakesGateNotInitialized stands in for both real histories from
 // atqamz/secondhand#60 (never-initialized project, and a project whose working_path went stale
-// after the fleet home was renamed): internal/project.TestGateStatusNotInitialized_* already prove
-// those two histories produce byte-identical no-mistakes status output, so one refusal test here
-// covers both.
+// after the fleet home was renamed): both were checked against the real binary and emit the same
+// status text, so one refusal test here covers both.
 func TestSpawnRefusesWhenNoMistakesGateNotInitialized(t *testing.T) {
 	path := fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)")
 	home := setupSpawnHomeGate(t, path)
@@ -153,6 +153,29 @@ func TestSpawnProceedsWhenNoMistakesGateReady(t *testing.T) {
 	}
 	if exitCodeFor(t, err) == 3 && strings.Contains(err.Error(), "gate") {
 		t.Fatalf("err = %v, gate check should have passed and failed later for an unrelated reason", err)
+	}
+}
+
+// TestSpawnSkipGateCheckBypassesRefusalAndWarns pairs the two halves of the escape hatch: the
+// not-initialized gate no longer refuses, and the bypass still announces itself on stderr, which
+// is the only thing that keeps it visible in a transcript.
+func TestSpawnSkipGateCheckBypassesRefusalAndWarns(t *testing.T) {
+	path := fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)")
+	setupSpawnHomeGate(t, path)
+
+	var errOut bytes.Buffer
+	cmd := newSpawnCmd()
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"task-1", "gated", "--skip-gate-check"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected spawn to still fail past the gate check (no brief, no herdr fake)")
+	}
+	if exitCodeFor(t, err) == 3 && strings.Contains(err.Error(), "gate") {
+		t.Fatalf("err = %v, --skip-gate-check should have bypassed the gate refusal", err)
+	}
+	if !strings.Contains(errOut.String(), "--skip-gate-check") || !strings.Contains(errOut.String(), "gated") {
+		t.Fatalf("stderr = %q, want a warning naming the flag and the project", errOut.String())
 	}
 }
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -242,13 +242,14 @@ func newProjectListCmd() *cobra.Command {
 
 			if asJSON {
 				type projectJSON struct {
-					Name string `json:"name"`
-					URL  string `json:"url"`
-					Mode string `json:"mode"`
+					Name      string `json:"name"`
+					URL       string `json:"url"`
+					Mode      string `json:"mode"`
+					GateIssue string `json:"gate_issue,omitempty"`
 				}
 				out := make([]projectJSON, 0, len(projects))
 				for _, p := range projects {
-					out = append(out, projectJSON{Name: p.Name, URL: p.URL, Mode: p.Mode})
+					out = append(out, projectJSON{Name: p.Name, URL: p.URL, Mode: p.Mode, GateIssue: gateIssue(home, p)})
 				}
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
@@ -257,7 +258,11 @@ func newProjectListCmd() *cobra.Command {
 
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			for _, p := range projects {
-				if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", p.Name, p.URL, p.Mode); err != nil {
+				line := fmt.Sprintf("%s\t%s\t%s", p.Name, p.URL, p.Mode)
+				if issue := gateIssue(home, p); issue != "" {
+					line += "\t(gate: " + issue + ")"
+				}
+				if _, err := fmt.Fprintln(w, line); err != nil {
 					return err
 				}
 			}
@@ -267,6 +272,24 @@ func newProjectListCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
 	return cmd
+}
+
+// gateIssue reports why a no-mistakes project's recorded mode cannot currently be honoured, so
+// hand project list is the surface an operator catches a stale or missing gate registration on,
+// instead of a worker discovering it mid-dispatch with nothing obliging it to say so.
+func gateIssue(home string, p project.Project) string {
+	if p.Mode != project.ModeNoMistakes {
+		return ""
+	}
+	clonePath := filepath.Join(home, "projects", p.Name)
+	gateState, err := project.GateStatus(clonePath)
+	if err != nil {
+		return "unreachable"
+	}
+	if gateState == project.GateNotInitialized {
+		return "not initialized"
+	}
+	return ""
 }
 
 func newProjectRemoveCmd() *cobra.Command {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -205,6 +205,82 @@ func TestProjectListColumnsDoNotMergeAtFieldWidth(t *testing.T) {
 	}
 }
 
+func TestProjectListMarksGateNotInitialized(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)"))
+	t.Chdir(home)
+
+	cmd := newProjectListCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "(gate: not initialized)") {
+		t.Fatalf("project list output = %q, want a not-initialized gate marker", out.String())
+	}
+}
+
+func TestProjectListJSONIncludesGateIssue(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)"))
+	t.Chdir(home)
+
+	cmd := newProjectListCmd()
+	cmd.SetArgs([]string{"--json"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"gate_issue": "not initialized"`) {
+		t.Fatalf("project list --json output = %q, want gate_issue: not initialized", out.String())
+	}
+}
+
+func TestProjectListOmitsGateMarkerWhenGateReady(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeNoMistakesPath(t, "gate: ready\n\n  no active run"))
+	t.Chdir(home)
+
+	cmd := newProjectListCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "(gate:") {
+		t.Fatalf("project list output = %q, want no gate marker for a ready gate", out.String())
+	}
+}
+
 func TestReserveCloneDestinationIsAtomic(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "projects", "repo")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -18,6 +18,7 @@ func newPromoteCmd() *cobra.Command {
 	var harnessName string
 	var model string
 	var effort string
+	var skipGateCheck bool
 
 	cmd := &cobra.Command{
 		Use:   "promote <id>",
@@ -81,6 +82,11 @@ func newPromoteCmd() *cobra.Command {
 				return &ExitError{Err: fmt.Errorf("project %q not registered", t.Project), Code: 3}
 			}
 
+			clonePath := filepath.Join(home, "projects", proj.Name)
+			if err := gatePreflight(cmd, proj, clonePath, skipGateCheck); err != nil {
+				return err
+			}
+
 			releaseProject, err := state.Lock(home, "project:"+proj.Name)
 			if err != nil {
 				return fmt.Errorf("lock project %q: %w", proj.Name, err)
@@ -91,7 +97,6 @@ func newPromoteCmd() *cobra.Command {
 			oldWorkspaceID := t.Herdr.WorkspaceID
 			oldTabID := t.Herdr.TabID
 
-			clonePath := filepath.Join(home, "projects", proj.Name)
 			wt, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
@@ -207,5 +212,6 @@ func newPromoteCmd() *cobra.Command {
 	cmd.Flags().StringVar(&harnessName, "harness", "", "harness for the new ship worker (default: config/harness, or claude)")
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort override for harnesses that support it")
+	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized for this project")
 	return cmd
 }

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -23,6 +23,7 @@ func newSpawnCmd() *cobra.Command {
 	var harnessName string
 	var model string
 	var effort string
+	var skipGateCheck bool
 
 	cmd := &cobra.Command{
 		Use:   "spawn <id> <project>",
@@ -43,6 +44,11 @@ func newSpawnCmd() *cobra.Command {
 			}
 			if !exists {
 				return &ExitError{Err: fmt.Errorf("project %q not registered", projectName), Code: 3}
+			}
+
+			clonePath := filepath.Join(home, "projects", proj.Name)
+			if err := gatePreflight(cmd, proj, clonePath, skipGateCheck); err != nil {
+				return err
 			}
 
 			releaseClaim, err := state.Claim(home, id)
@@ -75,7 +81,6 @@ func newSpawnCmd() *cobra.Command {
 			}
 			defer releaseProject()
 
-			clonePath := filepath.Join(home, "projects", proj.Name)
 			wt, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
@@ -191,7 +196,34 @@ func newSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&harnessName, "harness", "", "agent harness to launch (default: config/harness, or claude)")
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
+	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized for this project")
 	return cmd
+}
+
+// gatePreflight refuses to dispatch into a no-mistakes project whose gate is not initialized,
+// rather than letting the worker discover it mid-run with nothing obliged to report it. It asks
+// the no-mistakes binary rather than reading its private state.sqlite, so a stale or missing gate
+// registration (renamed working_path, never-initialized repo) is caught here instead of silently
+// producing an ungated "done". skipGateCheck is the escape hatch for a project mid-migration; it
+// still prints so bypassing it is visible, not silent.
+func gatePreflight(cmd *cobra.Command, proj project.Project, clonePath string, skipGateCheck bool) error {
+	if proj.Mode != project.ModeNoMistakes {
+		return nil
+	}
+	if skipGateCheck {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: --skip-gate-check bypassing the no-mistakes gate check for project %q\n", proj.Name); err != nil {
+			return err
+		}
+		return nil
+	}
+	gateState, err := project.GateStatus(clonePath)
+	if err != nil {
+		return fmt.Errorf("check no-mistakes gate for project %q: %w", proj.Name, err)
+	}
+	if gateState == project.GateNotInitialized {
+		return &ExitError{Err: fmt.Errorf("no-mistakes gate not initialized for project %q, run: %s", proj.Name, project.GateInitCommand(clonePath)), Code: 3}
+	}
+	return nil
 }
 
 // acquireTaskTab returns the tab and pane a spawn-shaped lifecycle should use for the task. herdr

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"syscall"
 
@@ -121,6 +122,41 @@ func Find(homeDir, name string) (Project, bool, error) {
 		}
 	}
 	return Project{}, false, nil
+}
+
+// GateState is the result of asking the no-mistakes binary whether a repo's gate is initialized.
+type GateState int
+
+const (
+	GateReady GateState = iota
+	GateNotInitialized
+)
+
+const gateNotInitializedMarker = "repo not initialized"
+
+// GateInitCommand is the exact remedy for GateNotInitialized. no-mistakes init is idempotent and
+// repairs a stale working_path in place, so callers should print this verbatim rather than describe it.
+func GateInitCommand(clonePath string) string {
+	return fmt.Sprintf("cd %s && no-mistakes init", clonePath)
+}
+
+// GateStatus asks the no-mistakes binary whether clonePath's gate is initialized, rather than
+// reading /home/atqa/.no-mistakes/state.sqlite directly, which is another tool's private schema.
+// no-mistakes status exits 0 whether or not the repo is initialized, so the outcome is read from
+// its output text, not its exit code. Any failure to run the binary at all (missing, unexecutable,
+// unexpected nonzero exit) is returned as an error distinct from GateNotInitialized: the remedy for
+// a missing binary is not `no-mistakes init`.
+func GateStatus(clonePath string) (GateState, error) {
+	cmd := exec.Command("no-mistakes", "status")
+	cmd.Dir = clonePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return GateReady, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
+	}
+	if strings.Contains(string(out), gateNotInitializedMarker) {
+		return GateNotInitialized, nil
+	}
+	return GateReady, nil
 }
 
 // Add appends a project line to the registry. Returns an error if the name is already registered.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -141,7 +141,7 @@ func GateInitCommand(clonePath string) string {
 }
 
 // GateStatus asks the no-mistakes binary whether clonePath's gate is initialized, rather than
-// reading /home/atqa/.no-mistakes/state.sqlite directly, which is another tool's private schema.
+// reading ~/.no-mistakes/state.sqlite directly, which is another tool's private schema.
 // no-mistakes status exits 0 whether or not the repo is initialized, so the outcome is read from
 // its output text, not its exit code. Any failure to run the binary at all (missing, unexecutable,
 // unexpected nonzero exit) is returned as an error distinct from GateNotInitialized: the remedy for

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -243,27 +243,12 @@ func TestGateStatusReady(t *testing.T) {
 	}
 }
 
-// TestGateStatusNotInitialized_NeverInitialized covers the first real history from
-// atqamz/secondhand#60: a project that was registered but never had no-mistakes init run
-// against it. Output text mirrors a real never-initialized repo verbatim.
-func TestGateStatusNotInitialized_NeverInitialized(t *testing.T) {
-	fakeNoMistakes(t, "repo not initialized (run 'no-mistakes init' first)")
-
-	got, err := GateStatus(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != GateNotInitialized {
-		t.Fatalf("got %v, want GateNotInitialized", got)
-	}
-}
-
-// TestGateStatusNotInitialized_StaleRenamedPath covers the second real history: the fleet home
-// was renamed (/home/atqa/fleet to /home/atqa/secondhand), orphaning no-mistakes's own
-// working_path row. Verified empirically against the real binary: init, then move the repo, then
-// status from the new path prints this exact text, byte-for-byte identical to the
-// never-initialized case, and exits 0 either way.
-func TestGateStatusNotInitialized_StaleRenamedPath(t *testing.T) {
+// TestGateStatusNotInitialized covers both real histories from atqamz/secondhand#60 at once: a
+// project registered but never given a no-mistakes init, and a project whose working_path went
+// stale when the fleet home was renamed (/home/atqa/fleet to /home/atqa/secondhand). Both were
+// checked against the real binary and print this one text byte-for-byte, exiting 0 either way, so
+// a second test replaying the same literal would assert nothing new.
+func TestGateStatusNotInitialized(t *testing.T) {
 	fakeNoMistakes(t, "repo not initialized (run 'no-mistakes init' first)")
 
 	got, err := GateStatus(t.TempDir())

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -213,6 +214,87 @@ func TestRemoveNotFound(t *testing.T) {
 
 	if err := Remove(dir, "missing"); err == nil {
 		t.Fatal("expected error for missing project")
+	}
+}
+
+// fakeNoMistakes puts a fake no-mistakes binary at the front of PATH. It only ever needs to
+// answer `status`, so it ignores its arguments and always exits 0, matching the real binary's
+// observed behavior: no-mistakes status exits 0 whether the repo is initialized or not, so
+// GateStatus reads the outcome from stdout text rather than the exit code.
+func fakeNoMistakes(t *testing.T, stdout string) {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\ncat <<'EOF'\n" + stdout + "\nEOF\n"
+	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestGateStatusReady(t *testing.T) {
+	fakeNoMistakes(t, "    repo:  /home/atqa/secondhand/projects/secondhand\n  remote:  git@github.com:atqamz/secondhand.git\n    gate:  /home/atqa/.no-mistakes/repos/0b474f2021dd.git\n  daemon:  running\n\n  no active run")
+
+	got, err := GateStatus(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != GateReady {
+		t.Fatalf("got %v, want GateReady", got)
+	}
+}
+
+// TestGateStatusNotInitialized_NeverInitialized covers the first real history from
+// atqamz/secondhand#60: a project that was registered but never had no-mistakes init run
+// against it. Output text mirrors a real never-initialized repo verbatim.
+func TestGateStatusNotInitialized_NeverInitialized(t *testing.T) {
+	fakeNoMistakes(t, "repo not initialized (run 'no-mistakes init' first)")
+
+	got, err := GateStatus(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != GateNotInitialized {
+		t.Fatalf("got %v, want GateNotInitialized", got)
+	}
+}
+
+// TestGateStatusNotInitialized_StaleRenamedPath covers the second real history: the fleet home
+// was renamed (/home/atqa/fleet to /home/atqa/secondhand), orphaning no-mistakes's own
+// working_path row. Verified empirically against the real binary: init, then move the repo, then
+// status from the new path prints this exact text, byte-for-byte identical to the
+// never-initialized case, and exits 0 either way.
+func TestGateStatusNotInitialized_StaleRenamedPath(t *testing.T) {
+	fakeNoMistakes(t, "repo not initialized (run 'no-mistakes init' first)")
+
+	got, err := GateStatus(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != GateNotInitialized {
+		t.Fatalf("got %v, want GateNotInitialized", got)
+	}
+}
+
+func TestGateStatusMissingBinaryIsDistinctFromNotInitialized(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	gotState, err := GateStatus(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when no-mistakes binary is not on PATH")
+	}
+	if gotState == GateNotInitialized {
+		t.Fatal("missing binary must not report GateNotInitialized, it has a different remedy")
+	}
+	if strings.Contains(err.Error(), gateNotInitializedMarker) {
+		t.Fatalf("err = %v, must not read as the not-initialized case", err)
+	}
+}
+
+func TestGateInitCommand(t *testing.T) {
+	got := GateInitCommand("/home/atqa/secondhand/projects/secondhand")
+	want := "cd /home/atqa/secondhand/projects/secondhand && no-mistakes init"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Intent

Refuse hand spawn/promote dispatch into a no-mistakes project whose gate is not initialized, print exact remedy, distinguish missing-binary from not-initialized, and surface it in hand project list.

Closes atqamz/secondhand#60

## What Changed

- `hand spawn` and `hand promote` now run a gate preflight before claiming state or acquiring a worktree: for `mode=no-mistakes` projects they ask the `no-mistakes` binary about the clone's gate and exit 3 with the verbatim remedy (`cd <clone-path> && no-mistakes init`) when it is not initialized. A missing or unrunnable binary is reported as a distinct error, not as an init remedy. `--skip-gate-check` bypasses the refusal on both commands and prints a warning to stderr so the bypass stays visible.
- Added `project.GateStatus` and `project.GateInitCommand` in `internal/project`, reading the gate answer from `no-mistakes status` output text (it exits 0 either way) instead of touching that tool's private state store.
- `hand project list` surfaces the same signal per project: a `(gate: not initialized)` / `(gate: unreachable)` marker in the table and a `gate_issue` field in `--json`. SPECS.md documents the new preflight step, flag, and exit codes; new tests cover gate detection, the preflight refusals, the `--skip-gate-check` path, and the list output.

## Risk Assessment

Low: The follow-up commit only renumbers a SPECS list, folds a duplicate test, and adds coverage for the --skip-gate-check bypass; the underlying additive, fail-closed preflight is unchanged from the round-1 review and every intent criterion is satisfied and tested.

## Testing

Ran the targeted unit tests for the new gate-status helper and the spawn/promote/project-list preflight paths under -race (all pass), then verified the fake's fidelity against the real no-mistakes binary (uninitialized repo prints "repo not initialized" and exits 0, as the code assumes). For product-level evidence I built the hand CLI and drove it against a temp fleet home containing a real, never-initialized clone: spawn and promote both refuse with exit 3 and the exact remedy command, a missing no-mistakes binary yields a clearly different error, --skip-gate-check bypasses the refusal while announcing itself on stderr, project list marks the project in both human and JSON output, an initialized gate is unmarked and dispatch proceeds, refusals leave no state or dashboard residue, and direct-pr projects are untouched by the check. Captured the whole run as a CLI transcript artifact; all transient test dirs and a stray treehouse pool were removed and the worktree is clean.

<details>
<summary>Evidence: hand gate preflight - end-to-end CLI transcript</summary>

<code>== ground truth ==&#10;$ cd &lt;fleet&gt;/projects/gated &amp;&amp; no-mistakes status&#10;repo not initialized (run &#39;no-mistakes init&#39; first)&#10;exit=0&#10;&#10;== 1. hand project list surfaces the ungated project ==&#10;$ hand project list&#10;gated https://github.com/atqamz/gated no-mistakes (gate: not initialized)&#10;plain https://github.com/atqamz/plain direct-pr&#10;&#10;$ hand project list --json&#10;[&#10;{&#34;name&#34;: &#34;gated&#34;, &#34;url&#34;: &#34;https://github.com/atqamz/gated&#34;, &#34;mode&#34;: &#34;no-mistakes&#34;, &#34;gate_issue&#34;: &#34;not initialized&#34;},&#10;{&#34;name&#34;: &#34;plain&#34;, &#34;url&#34;: &#34;https://github.com/atqamz/plain&#34;, &#34;mode&#34;: &#34;direct-pr&#34;}&#10;]&#10;&#10;== 2. spawn refuses to dispatch, prints the exact remedy ==&#10;$ hand spawn task-2 gated&#10;no-mistakes gate not initialized for project &#34;gated&#34;, run: cd &lt;fleet&gt;/projects/gated &amp;&amp; no-mistakes init&#10;exit=3&#10;&#10;== 3. promote refuses the same way ==&#10;$ hand promote task-1&#10;no-mistakes gate not initialized for project &#34;gated&#34;, run: cd &lt;fleet&gt;/projects/gated &amp;&amp; no-mistakes init&#10;exit=3&#10;&#10;== 4. missing no-mistakes binary is a distinct failure ==&#10;$ PATH=&lt;no no-mistakes&gt; hand spawn task-2 gated&#10;check no-mistakes gate for project &#34;gated&#34;: no-mistakes binary not found or not runnable: exec: &#34;no-mistakes&#34;: executable file not found in $PATH&#10;$ PATH=&lt;no no-mistakes&gt; hand project list&#10;gated https://github.com/atqamz/gated no-mistakes (gate: unreachable)&#10;&#10;== 5. --skip-gate-check bypasses and warns ==&#10;$ hand spawn task-2 gated --skip-gate-check&#10;warning: --skip-gate-check bypassing the no-mistakes gate check for project &#34;gated&#34;&#10;(dispatch continued past the gate check into treehouse)&#10;&#10;== 6. initialized gate is unmarked and dispatch proceeds ==&#10;$ hand project list&#10;gated https://github.com/atqamz/gated no-mistakes&#10;&#10;== 7. refusal leaves nothing behind; direct-pr never gate-checked ==&#10;$ ls state/ -&gt; task-1.json (no task-3.json written)&#10;$ cat data/dashboard.md -&gt; (file never created)&#10;$ PATH=&lt;no no-mistakes&gt; hand spawn task-3 plain&#10;brief not found at data/task-3/brief.md</code>

```text
# hand gate preflight - end-to-end CLI transcript
# fleet home:      /tmp/tmp.b0prerSvf2/fleet
# projects/gated:  real git repo registered mode=no-mistakes, never given 'no-mistakes init'
# projects/plain:  registered mode=direct-pr (gate check must not apply)
# herdr is faked (pane get -> done) so promote reaches the gate check; no-mistakes is the real binary except where noted

== ground truth ==
$ cd /tmp/tmp.b0prerSvf2/fleet/projects/gated && no-mistakes status
repo not initialized (run 'no-mistakes init' first)
exit=0

== 1. hand project list surfaces the ungated project ==
$ hand project list
gated  https://github.com/atqamz/gated  no-mistakes  (gate: not initialized)
plain  https://github.com/atqamz/plain  direct-pr
exit=0

$ hand project list --json
[
  {
    "name": "gated",
    "url": "https://github.com/atqamz/gated",
    "mode": "no-mistakes",
    "gate_issue": "not initialized"
  },
  {
    "name": "plain",
    "url": "https://github.com/atqamz/plain",
    "mode": "direct-pr"
  }
]
exit=0

== 2. spawn refuses to dispatch, prints the exact remedy ==
$ hand spawn task-2 gated
no-mistakes gate not initialized for project "gated", run: cd /tmp/tmp.b0prerSvf2/fleet/projects/gated && no-mistakes init
exit=3

== 3. promote refuses the same way ==
$ hand promote task-1
no-mistakes gate not initialized for project "gated", run: cd /tmp/tmp.b0prerSvf2/fleet/projects/gated && no-mistakes init
exit=3

== 4. missing no-mistakes binary is a distinct failure, not 'not initialized' ==
$ PATH=<no no-mistakes> hand spawn task-2 gated
check no-mistakes gate for project "gated": no-mistakes binary not found or not runnable: exec: "no-mistakes": executable file not found in $PATH
exit=1

$ PATH=<no no-mistakes> hand project list
gated  https://github.com/atqamz/gated  no-mistakes  (gate: unreachable)
plain  https://github.com/atqamz/plain  direct-pr
exit=0

== 5. --skip-gate-check bypasses the refusal and announces itself on stderr ==
$ hand spawn task-2 gated --skip-gate-check
warning: --skip-gate-check bypassing the no-mistakes gate check for project "gated"
acquire treehouse worktree: treehouse get failed: exit status 1: A new version of treehouse is available: v2.1.0 to v2.1.1
Run "treehouse update" to update
(dispatch continued past the gate check into treehouse, which fails for this stub clone)

== 6. an initialized gate is unmarked and dispatch proceeds (no-mistakes faked as initialized) ==
$ hand project list
gated  https://github.com/atqamz/gated  no-mistakes
plain  https://github.com/atqamz/plain  direct-pr
exit=0
$ hand spawn task-2 gated
acquire treehouse worktree: treehouse get failed: exit status 1: A new version of treehouse is available: v2.1.0 to v2.1.1
Run "treehouse update" to update
(no gate refusal; dispatch continued into treehouse)

== 7. a refusal leaves nothing behind, and non-no-mistakes projects are never gate-checked ==
$ hand spawn task-3 gated   # ungated no-mistakes project
no-mistakes gate not initialized for project "gated", run: cd /tmp/tmp.b0prerSvf2/fleet/projects/gated && no-mistakes init
exit=3
$ ls state/            -> task-1.json (no task-3.json written)
$ cat data/dashboard.md -> (file never created)

$ PATH=<no no-mistakes> hand spawn task-3 plain   # direct-pr project, gate check must not apply
brief not found at data/task-3/brief.md
exit=3
(fails on the ordinary missing-brief check, never on the gate)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>**intent** - passed</summary>

No issues found.

</details>

<details>
<summary>**Rebase** - passed</summary>

No issues found.

</details>

<details>
<summary>**Review** - 4 issues found - auto-fixed</summary>

- info: `internal/project/project.go:156` - GateStatus classifies only output containing &#34;repo not initialized&#34; as ungated, so two clone-path failure modes land wrong. Verified against the real binary: `no-mistakes status` in an existing non-git directory prints &#34;not in a git repository&#34; and exits 0, which GateStatus reports as GateReady - hand spawn then dispatches into a project the gate cannot cover, the exact silence this change exists to remove. And when projects/&lt;name&gt; does not exist at all, cmd.Dir fails at chdir, so the refusal reads &#34;no-mistakes binary not found or not runnable: chdir /home/.../projects/foo: no such file or directory&#34; even though the binary is fine. Both are reachable only through a damaged or hand-deleted clone, hence info, but the fix is one boundary: have GateStatus stat/handle the clone path and treat a non-repo answer as a distinct not-usable outcome rather than ready.
- info: `SPECS.md:302` - The spawn behavior list renumbered for the new preflight step skips 5: it runs 1, 2, 3, 4, 6, 7, ... 13. No step was dropped (the old 11-item list plus preflight should end at 12), and every cross-reference in the file was updated consistently with the skip (&#34;hand spawn step 8&#34;, &#34;before step 12&#34;), so this is a stale label, not a lost step. Renumber 6-13 down to 5-12 and update the three references.
- info: `internal/project/project_test.go:266` - TestGateStatusNotInitialized_StaleRenamedPath and TestGateStatusNotInitialized_NeverInitialized have identical bodies - same fake stdout literal, same assertion - so the second adds no coverage. cmd/gatepreflight_test.go:111 then leans on them: &#34;internal/project.TestGateStatusNotInitialized_* already prove those two histories produce byte-identical no-mistakes status output&#34;. They prove nothing about the real binary; they replay one hardcoded string twice. Fold into one test whose comment records that both histories were verified empirically to emit that text, and fix the cmd-level comment&#39;s claim.
- info: `cmd/spawn.go:199` - --skip-gate-check is new user-facing surface on both spawn and promote and has no test: nothing asserts that with the flag set and a fake no-mistakes reporting &#34;repo not initialized&#34;, the command gets past gatePreflight and writes the warning to stderr. A regression that inverted the flag or dropped the warning would pass the suite, and the warning is the only thing that keeps a bypass visible in the transcript. A spawn test mirroring TestSpawnProceedsWhenNoMistakesGateReady but with the not-initialized fake plus --skip-gate-check covers it.

Fix: fix SPECS step numbering, fold duplicate test, cover --skip-gate-check
Re-checked - no issues remain.

</details>

<details>
<summary>**Test** - passed</summary>

No issues found.
- <code>`nix develop -c go test ./internal/project/ -run &#39;TestGateStatus|TestGateInitCommand&#39; -race -v` (4 tests pass)</code>
- <code>`nix develop -c go test ./cmd/ -run &#39;Gate|ProjectList&#39; -race -v` (gate preflight + project list tests pass)</code>
- <code>Fake-fidelity check against the real binary: `cd &lt;uninitialized git repo&gt; &amp;&amp; no-mistakes status` -&gt; `repo not initialized (run &#39;no-mistakes init&#39; first)`, exit 0, matching what `internal/project.GateStatus` and the test fakes assume</code>
- <code>Manual end-to-end: built `hand` with `nix develop -c go build`, created a temp fleet home with `projects/gated` (real git repo, mode=no-mistakes, never initialized) and `projects/plain` (mode=direct-pr)</code>
- <code>`hand project list` and `hand project list --json` against the real `no-mistakes` binary -&gt; `(gate: not initialized)` and `&#34;gate_issue&#34;: &#34;not initialized&#34;`</code>
- <code>`hand spawn task-2 gated` -&gt; exit 3 with the exact `cd &lt;clone-path&gt; &amp;&amp; no-mistakes init` remedy</code>
- <code>`hand promote task-1` (scout state seeded, herdr `pane get` faked as done) -&gt; same exit-3 refusal, before any worktree acquisition</code>
- <code>`PATH=&lt;no no-mistakes&gt; hand spawn task-2 gated` -&gt; `no-mistakes binary not found or not runnable: ...`, distinct from the not-initialized case; `hand project list` shows `(gate: unreachable)`</code>
- <code>`hand spawn task-2 gated --skip-gate-check` -&gt; stderr warning naming the flag and project, dispatch continues past the gate into treehouse</code>
- <code>`hand spawn task-2 gated` with a no-mistakes stub reporting an initialized gate -&gt; no refusal, no `(gate: ...)` marker in `hand project list`</code>
- <code>Rollback check: after a gate refusal, `state/` has no new task json and `data/dashboard.md` is never created</code>
- <code>`PATH=&lt;no no-mistakes&gt; hand spawn task-3 plain` (direct-pr mode) -&gt; fails on the ordinary missing-brief check, proving the gate check does not apply to other modes</code>

</details>

<details>
<summary>**Document** - passed</summary>

No issues found.

</details>

<details>
<summary>**Lint** - passed</summary>

No issues found.

</details>

<details>
<summary>**Push** - passed</summary>

No issues found.

</details>


