### PR TITLE
docs(contributing): require an issue before contributing and a closing PR reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,13 @@ Without Nix, install those yourself.
 
 ## Making changes
 
-1. Fork and branch from main.
-2. Make changes.
-3. make lint && make test
-4. make e2e if you changed CLI behavior (end-to-end suite, excluded from make test).
-5. nix build .#default if you changed Go dependencies (CI builds the flake, and a stale vendorHash in flake.nix fails it).
-6. Open a PR.
+1. Open an issue describing the intent, design, or proposal, and get agreement there before writing code. This applies to any contribution, no matter the size. See "Reporting issues" below for what to include.
+2. Fork and branch from main.
+3. Make changes.
+4. make lint && make test
+5. make e2e if you changed CLI behavior (end-to-end suite, excluded from make test).
+6. nix build .#default if you changed Go dependencies (CI builds the flake, and a stale vendorHash in flake.nix fails it).
+7. Open a PR whose body carries a closing keyword (Closes, Fixes, or Resolves) directly preceding a fully qualified atqamz/secondhand#N, on its own line. A bare #N links but reads ambiguously outside the repo, and a reference without the keyword links the issue without ever closing it.
 
 Commits use conventional commits: feat:, fix:, chore:, etc.
 release-please handles versioning and changelogs from these.


### PR DESCRIPTION
## Summary

- Add a first step to "Making changes": open an issue and get agreement before writing code, with no size exemption.
- Require the final step's PR body to carry a closing keyword (Closes, Fixes, or Resolves) plus a fully qualified atqamz/secondhand#N on its own line, and explain why: a bare #N is ambiguous outside the repo, a reference without the keyword never closes.
- Renumber the existing six steps to fit around both additions.

Closes atqamz/secondhand#95

## Test plan

- Docs-only change, no code paths affected.
- Reviewed rendered CONTRIBUTING.md for numbering and cross-reference to "Reporting issues".
