### PR TITLE
feat(cmd): resolve the fleet home from HAND_HOME or an ancestor walk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Run `hand --help` for the full command reference.
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
-- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
+- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from `HAND_HOME` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce `data/<id>/report.md`.
 - `data/backlog.md` is your task queue. Edit it directly.
 - For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Talk to one agent. Ship with a crew.
 
 Secondhand is a single Go CLI binary, `hand`, that orchestrates a fleet of coding agents across projects.
-A supervisory agent runs in the secondhand directory, records tasks in a markdown backlog, and calls `hand` to spawn autonomous workers into isolated git worktrees.
+A supervisory agent runs in a fleet home - a standalone directory anywhere on disk, or the secondhand checkout itself - records tasks in a markdown backlog, and calls `hand` to spawn autonomous workers into isolated git worktrees.
 The CLI owns lifecycle correctness, state management, and process supervision.
 It was born from [firstmate](https://github.com/kunchenguid/firstmate), an agent fleet supervisor built as 34K lines of shell, and rebuilds that concept as a clean CLI.
 
@@ -34,8 +34,9 @@ hand project add https://github.com/org/repo
 `hand init` only writes runtime directories and skeleton files under the current directory; it never places a `hand` binary there.
 Install `hand` from one of the options under "Installation" below and make sure it is on `PATH` before running any command.
 
-Every `hand` command resolves its fleet home the same way: the `HAND_HOME` environment variable if set, otherwise the current directory or the nearest ancestor holding both `data/` and `state/`.
-Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a script or a different working directory.
+Every `hand` command resolves its fleet home the same way: the `HAND_HOME` environment variable if set, otherwise the current directory or the nearest ancestor holding both `data/dashboard.md` and `state/`.
+`data/dashboard.md` is the marker because only `hand init` writes it, so a project clone under `projects/` never captures the walk up.
+Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a script or a different working directory; pointed at a directory that is not a fleet home it refuses rather than falling back.
 
 ## Core concepts
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ make build
 
 The worker lifecycle commands are available, including `hand spawn`, `hand status`, `hand send`, and `hand teardown`.
 
+## Set up a fleet home
+
+The quick start above dogfoods a fleet home inside the secondhand repo checkout itself, which is how the maintainers run it.
+Most users instead want a standalone fleet home: a plain directory, anywhere on disk, unrelated to any project's own repo.
+
+```sh
+mkdir ~/fleet
+cd ~/fleet
+hand init --setup
+hand project add https://github.com/org/repo
+```
+
+`hand init` only writes runtime directories and skeleton files under the current directory; it never places a `hand` binary there.
+Install `hand` from one of the options under "Installation" below and make sure it is on `PATH` before running any command.
+
+Every `hand` command resolves its fleet home the same way: the `HAND_HOME` environment variable if set, otherwise the current directory or the nearest ancestor holding both `data/` and `state/`.
+Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a script or a different working directory.
+
 ## Core concepts
 
 - **Projects**: git repositories cloned under `projects/` and registered in `data/projects.md`. Each has a delivery mode: `no-mistakes`, `direct-pr`, or `local-only`.
@@ -106,9 +124,9 @@ From releases: download the binary for your platform from the [releases page](ht
 
 To update an installed binary, run `hand update`.
 It downloads the release asset for the current OS and architecture, verifies its SHA256 checksum, and replaces the running binary in place.
-When run inside a workspace it then refreshes the generated part of that workspace's AGENTS.md, leaving your own additions untouched, and prints the new release's notes.
+When run inside a fleet home it then refreshes the generated part of that home's AGENTS.md, leaving your own additions untouched, and prints the new release's notes.
 `hand update --check` reports whether an update is available without installing it.
-Every other command run in a workspace prints a one-line notice to stderr when a newer release exists, checked at most once a day and cached in `state/.version-check`.
+Every other command run in a fleet home prints a one-line notice to stderr when a newer release exists, checked at most once a day and cached in `state/.version-check`.
 Builds without an embedded version never print the notice.
 
 ## Configuration

--- a/SPECS.md
+++ b/SPECS.md
@@ -59,7 +59,7 @@ Secondhand keeps the concept and rebuilds the execution as a single Go CLI binar
        +-- scout: investigate -> report.md -> teardown
 ```
 
-The supervisory agent is any supported harness (claude, codex, pi, grok, opencode) launched inside the secondhand directory.
+The supervisory agent is any supported harness (claude, codex, pi, grok, opencode) launched inside a fleet home.
 It reads AGENTS.md, understands the `hand` CLI, and manages the fleet.
 
 Workers are autonomous agents launched by `hand spawn` into herdr tabs with treehouse worktrees.
@@ -90,6 +90,8 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
     promote.go
     notify.go
   internal/
+    home/                   # fleet home definition and resolution
+      home.go               # IsHome marker check, HAND_HOME/ancestor-walk Resolve
     herdr/                  # herdr client library
       client.go             # API calls: create tab, get state, send keys
       types.go              # herdr data types

--- a/SPECS.md
+++ b/SPECS.md
@@ -30,7 +30,7 @@ Secondhand keeps the concept and rebuilds the execution as a single Go CLI binar
 3. **herdr-native.** herdr provides semantic agent state (working/idle/blocked/done/unknown) and push events. Use them instead of regex-scraping terminal output. herdr's own agent state carries no task-outcome signal (see "Agent state"); the report channel is what actually tells hand whether a task finished.
 4. **Text editing stays with the agent.** The backlog is a markdown file. The agent reads and edits it directly. No CLI wrapper for text operations.
 5. **No feature without friction.** Every feature in firstmate that doesn't have a proven use case is cut. Features get added when their absence causes real pain.
-6. **A fleet home is any directory with `data/` and `state/`.** `hand init` creates one anywhere on disk; put `hand` on PATH and launch the agent there. Maintainers dogfood a fleet home inside the secondhand repo checkout itself, with runtime state gitignored alongside the tracked code, but the CLI has no opinion about the two: `HAND_HOME`, or an ancestor of the working directory, is all it looks for.
+6. **A fleet home is any directory with `data/dashboard.md` and `state/`.** `hand init` creates one anywhere on disk; put `hand` on PATH and launch the agent there. The marker is the dashboard file rather than the `data/` directory because only `hand init` writes it, so a project clone under `projects/` carrying its own generic top-level `data/` and `state/` cannot capture the walk up. Maintainers dogfood a fleet home inside the secondhand repo checkout itself, with runtime state gitignored alongside the tracked code, but the CLI has no opinion about the two: `HAND_HOME`, or an ancestor of the working directory, is all it looks for.
 7. **The dashboard is the memory.** `data/dashboard.md` is the living document the CLI maintains. The agent reads it for context. The user watches it for visibility. No session digests, no bootstrap scripts, no 187-line status dumps.
 8. **No hooks, no guards, no callbacks.** The CLI fails closed on bad operations. Errors are CLI output, not injected hook messages. The agent reads errors and decides. No magic.
 
@@ -159,6 +159,8 @@ Initialize secondhand runtime directories in the current working directory.
 Creates `state/`, `data/`, `projects/`, `config/` if they don't exist.
 Creates `data/backlog.md`, `data/projects.md`, and `data/dashboard.md` with skeleton content.
 Idempotent: safe to run multiple times.
+This is the one command that does not resolve its home: it creates the one its argument or the working directory names.
+When `HAND_HOME` is set and names some other directory it still initializes the requested target, and warns on stderr that every other command will use `HAND_HOME` instead.
 
 ```
 hand init
@@ -1599,6 +1601,7 @@ On restart (new supervisory agent session):
 - `2`: usage error: wrong argument count, unknown flag, unknown command or subcommand, mutually exclusive or mutually dependent flags (`hand watch --timeout` without `--until-event`), an invalid argument or flag value (malformed project URL, unknown project mode or harness, unparsable `--poll` duration, a non-positive `--timeout`).
   A value the invocation did not supply is not a usage error: the same malformed value read from a `config/` default is a general error (code `1`).
 - `3`: precondition failed, meaning the command refuses because the world is not in the state it requires: unlanded work, red CI, a missing or unmerged PR, a missing brief or report, a task or project that does not exist, a task in the wrong kind or state (already merged, not a completed scout, already claimed by another command), a project name or worktree already taken, a project still referenced by active tasks, a PR that conflicts with one already recorded for a task or doesn't belong to the task's project's repo (`hand pr`), a PR that `gh pr view` can't confirm exists (`hand pr`), a repeat recording with no active dashboard row left to reconcile (`hand pr`), a task branch whose PRs do not resolve to a single usable winner (`hand teardown`), a `no-mistakes`-mode project whose gate is not initialized (`hand spawn`, `hand promote` - see "Gate preflight").
+  Two more apply to every command, since each one resolves a fleet home before it does anything: the working directory has no fleet home at or above it and `HAND_HOME` is unset, or `HAND_HOME` is set to a directory that is not a fleet home. The second refuses rather than falling back to the walk up, because a silent fallback is how an operator dispatches into the wrong fleet.
 - `4`: no event delivered, only from `hand watch --until-event`: its `--timeout` elapsed, or it was signaled, without a transition. This includes the timeout elapsing anywhere in arming, the herdr reachability probe as well as the per-task probe sweep - the window is over either way, and no one task is at fault. Distinct from `0` because there the exit *is* the event delivery, and from `1` because the watcher itself did not fail (see "Delivering an event to a supervisory agent").
 - `5`: arm-time probe failure, only from `hand watch --until-event`: one named task's herdr pane answered its pre-wait probe with a failure, named on stderr. Distinct from `4` because a specific worker is at fault and can be acted on, and from `0` because nothing was delivered (see "Delivering an event to a supervisory agent").
 
@@ -1693,12 +1696,12 @@ go build -o hand .
 # optionally: cp hand ~/.local/bin/
 ```
 
-The source repo is a development repo. End users install the binary and create workspaces anywhere.
+The source repo is a development repo. End users install the binary and create fleet homes anywhere.
 
-### Workspace creation
+### Fleet home creation
 
 ```sh
-# create a workspace anywhere
+# create a fleet home anywhere
 mkdir ~/fleet && cd ~/fleet
 hand init --setup
 
@@ -1724,7 +1727,7 @@ Behavior:
 1. Query GitHub Releases API for the latest version tag.
 2. Compare against the running binary's embedded version.
 3. If newer: download the binary for the current OS/arch, verify checksum, replace the running binary in place.
-4. After update, refresh the generated AGENTS.md template in the current workspace to the latest version, preserving user edits (see "AGENTS.md (target)"). Outside a workspace this is skipped silently; a refresh that fails is a warning on stderr, not a failed update, since the binary is already replaced.
+4. After update, refresh the generated AGENTS.md template in the resolved fleet home to the latest version, preserving user edits (see "AGENTS.md (target)"). Outside any fleet home this is skipped silently; a `HAND_HOME` that names no fleet home is a warning, not a silent skip, since that is a misconfiguration rather than an absence. A refresh that fails is likewise a warning on stderr, not a failed update, since the binary is already replaced.
 5. Print old version, new version, and what changed (from the installed release's notes). The AGENTS.md line appears only when the template actually changed, and the `changed:` block only when the release has notes.
 
 ```
@@ -1856,7 +1859,7 @@ Deliverable: ready for daily use.
 
 ## AGENTS.md (target)
 
-**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new workspace's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh.
+**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh.
 
-This repo's own `AGENTS.md` is not a `hand` workspace (no `data/dashboard.md`), so `agentsmd.Refresh` never touches it: its top section is a hand-kept copy of `generatedBody`, kept in sync manually rather than by the refresh mechanism.
+This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even once a maintainer runs `hand init` in the checkout and makes it a fleet home: its top section is a hand-kept copy of `generatedBody`, kept in sync manually rather than by the refresh mechanism.
 Drift between the two copies is caught by a unit test in `internal/agentsmd` asserting the repo copy's rules open with the generated ones verbatim, not by the mechanism that would remove the duplication.

--- a/SPECS.md
+++ b/SPECS.md
@@ -30,7 +30,7 @@ Secondhand keeps the concept and rebuilds the execution as a single Go CLI binar
 3. **herdr-native.** herdr provides semantic agent state (working/idle/blocked/done/unknown) and push events. Use them instead of regex-scraping terminal output. herdr's own agent state carries no task-outcome signal (see "Agent state"); the report channel is what actually tells hand whether a task finished.
 4. **Text editing stays with the agent.** The backlog is a markdown file. The agent reads and edits it directly. No CLI wrapper for text operations.
 5. **No feature without friction.** Every feature in firstmate that doesn't have a proven use case is cut. Features get added when their absence causes real pain.
-6. **The repo is the working directory.** Clone secondhand, cd in, launch your agent. The repo contains tracked code; runtime state is gitignored.
+6. **A fleet home is any directory with `data/` and `state/`.** `hand init` creates one anywhere on disk; put `hand` on PATH and launch the agent there. Maintainers dogfood a fleet home inside the secondhand repo checkout itself, with runtime state gitignored alongside the tracked code, but the CLI has no opinion about the two: `HAND_HOME`, or an ancestor of the working directory, is all it looks for.
 7. **The dashboard is the memory.** `data/dashboard.md` is the living document the CLI maintains. The agent reads it for context. The user watches it for visibility. No session digests, no bootstrap scripts, no 187-line status dumps.
 8. **No hooks, no guards, no callbacks.** The CLI fails closed on bad operations. Errors are CLI output, not injected hook messages. The agent reads errors and decides. No magic.
 
@@ -67,8 +67,13 @@ They follow the brief, do the work, and report through herdr's agent state.
 
 ## Directory layout
 
+A standalone fleet home has no tracked section: `hand init` lays down only the gitignored
+runtime below, and `hand` runs against it from wherever it lives on disk. The tracked section
+exists because secondhand's own maintainers dogfood a fleet home inside the repo checkout,
+alongside the code that implements it.
+
 ```
-secondhand/                 # repo root = working directory
+secondhand/                 # maintainer's in-repo fleet home = repo checkout
   # tracked (committed)
   main.go                   # entry point
   cmd/                      # cobra command implementations

--- a/cmd/fleethome_test.go
+++ b/cmd/fleethome_test.go
@@ -6,14 +6,27 @@ import (
 	"testing"
 )
 
-// mkFleetDirs creates the data/ and state/ directories home.Resolve requires
-// to recognize dir as a fleet home, for fixtures that chdir into a bare temp
-// directory without going through hand init.
+// mkFleetDirs lays down the state/ directory and data/dashboard.md marker
+// home.Resolve requires to recognize dir as a fleet home, for fixtures that
+// chdir into a bare temp directory without going through hand init. A
+// dashboard the fixture already wrote is left alone, since tests assert
+// against their own skeleton. It also neutralizes an ambient HAND_HOME, which
+// would otherwise outrank the fixture and point the command under test at the
+// developer's real fleet.
 func mkFleetDirs(t *testing.T, dir string) {
 	t.Helper()
+	t.Setenv("HAND_HOME", "")
 	for _, sub := range []string{"data", "state"} {
 		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
 			t.Fatal(err)
 		}
+	}
+	dashboard := filepath.Join(dir, "data", "dashboard.md")
+	if _, err := os.Stat(dashboard); os.IsNotExist(err) {
+		if err := os.WriteFile(dashboard, []byte(dashboardSkeleton), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	} else if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/fleethome_test.go
+++ b/cmd/fleethome_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkFleetDirs creates the data/ and state/ directories home.Resolve requires
+// to recognize dir as a fleet home, for fixtures that chdir into a bare temp
+// directory without going through hand init.
+func mkFleetDirs(t *testing.T, dir string) {
+	t.Helper()
+	for _, sub := range []string{"data", "state"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -60,6 +60,7 @@ func setupSpawnHomeGate(t *testing.T, noMistakesPath string) string {
 	}
 	t.Setenv("PATH", noMistakesPath)
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	return home
 }
 
@@ -104,6 +105,7 @@ func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
 	}
 	t.Setenv("PATH", herdrBin+string(os.PathListSeparator)+noMistakesPath)
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	return home
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -77,6 +77,9 @@ func newInitCmd() *cobra.Command {
 				}
 			}
 
+			if err := warnHandHomeMismatch(cmd.ErrOrStderr(), home); err != nil {
+				return err
+			}
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "initialized secondhand home at %s\n", home); err != nil {
 				return err
 			}
@@ -210,6 +213,22 @@ func resolveInitHome(cwd string, args []string) (string, error) {
 		home = filepath.Join(cwd, home)
 	}
 	return filepath.Clean(home), nil
+}
+
+// warnHandHomeMismatch reports the one asymmetry in home handling: init
+// creates the home its argument or working directory names, while every other
+// command resolves HAND_HOME first, so an operator who exported HAND_HOME and
+// initialized somewhere else would otherwise get a home nothing ever uses.
+func warnHandHomeMismatch(w io.Writer, home string) error {
+	handHome := os.Getenv("HAND_HOME")
+	if handHome == "" {
+		return nil
+	}
+	if abs, err := filepath.Abs(handHome); err == nil && abs == home {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "warning: HAND_HOME is set to %s, so every other hand command will use that home, not %s\n", handHome, home)
+	return err
 }
 
 func readSetupChoice(in io.Reader, choices []string, label string) (string, error) {

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/ghutil"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/spf13/cobra"
@@ -33,9 +33,9 @@ func newMergeCmd() *cobra.Command {
 			}
 
 			id := args[0]
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			release, err := state.Lock(home, "task:"+id)

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -151,6 +151,7 @@ printf '[{"bucket":"pass"},{"bucket":"fail"}]'
 func TestMergeRefusesWhenNoPRRecorded(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := state.Write(home, state.Task{ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
@@ -173,6 +174,7 @@ func TestMergeRefusesWhenNoPRRecorded(t *testing.T) {
 func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeGh(t, `#!/bin/sh
 case "$1 $2" in
 "pr view") printf '{"state":"MERGED"}' ;;
@@ -207,6 +209,7 @@ esac
 func TestMergePRRefusesRedCI(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeGh(t, fakeGhChecksRed)
 
 	if err := state.Write(home, state.Task{ID: "task-1", PR: "https://github.com/org/repo/pull/42"}); err != nil {
@@ -236,6 +239,7 @@ func TestMergePRRefusesRedCI(t *testing.T) {
 func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeGh(t, fakeGhChecksGreenAndMerge)
 
 	if err := state.Write(home, state.Task{ID: "task-1", PR: "https://github.com/org/repo/pull/42"}); err != nil {
@@ -263,6 +267,7 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 func TestMergeLocalRefusesUncommittedChanges(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	worktreePath := filepath.Join(t.TempDir(), "wt")
 	initGitRepo(t, worktreePath)
 	if err := os.WriteFile(filepath.Join(worktreePath, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
@@ -285,6 +290,7 @@ func TestMergeLocalRefusesUncommittedChanges(t *testing.T) {
 func TestMergeLocalFastForwardSucceeds(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	clonePath := filepath.Join(home, "projects", "myproj")
 	initGitRepo(t, clonePath)
@@ -330,6 +336,7 @@ func TestMergeLocalFastForwardSucceeds(t *testing.T) {
 func TestMergeLocalRefusesWhenNotFastForwardable(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	clonePath := filepath.Join(home, "projects", "myproj")
 	initGitRepo(t, clonePath)

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/spf13/cobra"
 )
 
@@ -17,9 +18,9 @@ func newNotifyCmd() *cobra.Command {
 		Args:  usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			message := args[0]
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			template, err := os.ReadFile(filepath.Join(home, "config", "notify"))

--- a/cmd/notify_test.go
+++ b/cmd/notify_test.go
@@ -11,6 +11,7 @@ import (
 func TestNotifyWithoutConfigPrintsToStdoutOnly(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	var out bytes.Buffer
 	cmd := newNotifyCmd()
@@ -27,6 +28,7 @@ func TestNotifyWithoutConfigPrintsToStdoutOnly(t *testing.T) {
 func TestNotifySubstitutesMessageAndExecutesTemplate(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -59,6 +61,7 @@ func TestNotifySubstitutesMessageAndExecutesTemplate(t *testing.T) {
 func TestNotifyFailureWarnsButDoesNotBlock(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/spf13/cobra"
@@ -25,9 +25,9 @@ func newPRCmd() *cobra.Command {
 				return &ExitError{Err: fmt.Errorf("invalid PR URL %q: must match https://github.com/<owner>/<repo>/pull/<number>", url), Code: 2}
 			}
 
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			release, err := state.Lock(home, "task:"+id)

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -52,6 +52,7 @@ func setupPRHome(t *testing.T) (home, clonePath string) {
 	t.Helper()
 	home = t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -20,6 +20,7 @@ var preconditionSentinels = []error{
 	state.ErrTaskActive,
 	project.ErrNotFound,
 	home.ErrNotFound,
+	home.ErrHandHomeInvalid,
 }
 
 func asPrecondition(err error) error {

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -3,21 +3,23 @@ package cmd
 import (
 	"errors"
 
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 )
 
-// preconditionSentinels are errors from internal/state and internal/project that
-// SPECS.md classifies as precondition failures (exit code 3) rather than general
-// errors (exit code 1). Both packages are imported by cmd, so they can't construct
-// ExitError themselves; they signal via these sentinels instead. A new sentinel
-// should hold only the trailing phrase and be wrapped as
+// preconditionSentinels are errors from internal/state, internal/project, and
+// internal/home that SPECS.md classifies as precondition failures (exit code 3)
+// rather than general errors (exit code 1). Those packages are imported by cmd,
+// so they can't construct ExitError themselves; they signal via these sentinels
+// instead. A new sentinel should hold only the trailing phrase and be wrapped as
 // fmt.Errorf("<noun> %q <phrase>", name, sentinel), matching ErrTaskNotFound and
 // ErrNotFound, so each condition renders one consistent string everywhere.
 var preconditionSentinels = []error{
 	state.ErrTaskNotFound,
 	state.ErrTaskActive,
 	project.ErrNotFound,
+	home.ErrNotFound,
 }
 
 func asPrecondition(err error) error {

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/spf13/cobra"
@@ -45,9 +46,9 @@ func newProjectAddCmd() *cobra.Command {
 			if err := validateProjectMode(mode); err != nil {
 				return err
 			}
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			if name == "" {
@@ -230,9 +231,9 @@ func newProjectListCmd() *cobra.Command {
 		Short: "List registered projects",
 		Args:  usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			projects, err := project.List(home)
@@ -299,9 +300,9 @@ func newProjectRemoveCmd() *cobra.Command {
 		Args:  usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			if active, err := hasActiveTasksForProject(home, name); err != nil {
@@ -365,9 +366,9 @@ func newProjectSyncCmd() *cobra.Command {
 		Short: "Fast-forward project clones to their remote default branch",
 		Args:  usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			var targets []project.Project

--- a/cmd/project_sync_test.go
+++ b/cmd/project_sync_test.go
@@ -231,6 +231,7 @@ func TestPruneGoneBranchesDeletesLocalBranchWithGoneUpstream(t *testing.T) {
 func TestProjectSyncCommandUpdatesDashboardWhenAdvanced(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -274,6 +275,7 @@ func TestProjectSyncCommandUpdatesDashboardWhenAdvanced(t *testing.T) {
 func TestProjectSyncCommandRejectsUnknownProjectName(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -72,6 +72,7 @@ func TestProjectAddRemovesIncompleteCloneOnGitFailure(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newProjectAddCmd()
 	cmd.SetArgs([]string{"https://example.com/org/repo.git", "--mode", "local-only"})
@@ -101,6 +102,7 @@ func TestProjectAddRefusesExistingCloneDestination(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newProjectAddCmd()
 	cmd.SetArgs([]string{"https://example.com/org/repo.git", "--mode", "local-only"})
@@ -118,6 +120,7 @@ func TestProjectAddRefusesAlreadyRegistered(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := project.Add(home, project.Project{Name: "repo", URL: "https://example.com/org/repo.git", Mode: project.ModeDirectPR}); err != nil {
 		t.Fatal(err)
 	}
@@ -140,6 +143,7 @@ func TestProjectRemoveRefusesActiveTasks(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := project.Add(home, project.Project{Name: "myproj", URL: "https://example.com/org/myproj.git", Mode: project.ModeDirectPR}); err != nil {
 		t.Fatal(err)
 	}
@@ -165,6 +169,7 @@ func TestProjectRemoveRefusesUnregistered(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newProjectRemoveCmd()
 	cmd.SetArgs([]string{"missing-proj"})
@@ -184,6 +189,7 @@ func TestProjectListColumnsDoNotMergeAtFieldWidth(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	url := "https://github.com/atqamz/secondhand.git"
 	if err := project.Add(home, project.Project{Name: "secondhand", URL: url, Mode: project.ModeNoMistakes}); err != nil {
@@ -218,6 +224,7 @@ func TestProjectListMarksGateNotInitialized(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newProjectListCmd()
 	var out strings.Builder
@@ -243,6 +250,7 @@ func TestProjectListJSONIncludesGateIssue(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newProjectListCmd()
 	cmd.SetArgs([]string{"--json"})
@@ -269,6 +277,7 @@ func TestProjectListOmitsGateMarkerWhenGateReady(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeNoMistakesPath(t, "gate: ready\n\n  no active run"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newProjectListCmd()
 	var out strings.Builder

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -357,6 +357,38 @@ func TestResolveInitHome(t *testing.T) {
 	}
 }
 
+func TestWarnHandHomeMismatch(t *testing.T) {
+	home := t.TempDir()
+
+	t.Setenv("HAND_HOME", "")
+	var quiet strings.Builder
+	if err := warnHandHomeMismatch(&quiet, home); err != nil {
+		t.Fatal(err)
+	}
+	if quiet.String() != "" {
+		t.Fatalf("got %q, want no warning without HAND_HOME", quiet.String())
+	}
+
+	t.Setenv("HAND_HOME", home)
+	quiet.Reset()
+	if err := warnHandHomeMismatch(&quiet, home); err != nil {
+		t.Fatal(err)
+	}
+	if quiet.String() != "" {
+		t.Fatalf("got %q, want no warning when HAND_HOME is the initialized home", quiet.String())
+	}
+
+	elsewhere := t.TempDir()
+	t.Setenv("HAND_HOME", elsewhere)
+	var warned strings.Builder
+	if err := warnHandHomeMismatch(&warned, home); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(warned.String(), elsewhere) || !strings.Contains(warned.String(), home) {
+		t.Fatalf("got %q, want a warning naming both %q and %q", warned.String(), elsewhere, home)
+	}
+}
+
 func TestReadSetupChoice(t *testing.T) {
 	choice, err := readSetupChoice(strings.NewReader("2\n"), []string{"claude", "codex"}, "harness")
 	if err != nil || choice != "codex" {

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/atqamz/secondhand/internal/harness"
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/atqamz/secondhand/internal/worktree"
@@ -26,9 +27,9 @@ func newPromoteCmd() *cobra.Command {
 		Args:  usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := args[0]
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			release, err := state.Lock(home, "task:"+id)

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -106,6 +106,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string
 	writeFakeTreehouseGet(t, bin, newWorktree)
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	return home
 }
 
@@ -195,6 +196,7 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 func TestPromoteRefusesNonScout(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip}); err != nil {
 		t.Fatal(err)
 	}
@@ -211,6 +213,7 @@ func TestPromoteRefusesNonScout(t *testing.T) {
 func TestPromoteRefusesMissingReport(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout}); err != nil {
 		t.Fatal(err)
 	}
@@ -227,6 +230,7 @@ func TestPromoteRefusesMissingReport(t *testing.T) {
 func TestPromoteRefusesMissingBrief(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -249,6 +253,7 @@ func TestPromoteRefusesMissingBrief(t *testing.T) {
 func TestPromoteRefusesUnregisteredProject(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/selfupdate"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,7 @@ func newRootCmd(version string) *cobra.Command {
 			if cmd.Name() == "update" {
 				return nil
 			}
-			if home, err := os.Getwd(); err == nil {
+			if home, err := home.Resolve(); err == nil {
 				if notice := selfupdate.CheckNotice(home, selfupdate.Repo, version); notice != "" {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), notice)
 				}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -21,9 +21,9 @@ func newSendCmd() *cobra.Command {
 			id := args[0]
 			message := args[1]
 
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			t, err := state.Read(home, id)

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -13,6 +13,7 @@ func setupSendHome(t *testing.T, herdrScript string) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	bin := t.TempDir()
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -12,6 +12,7 @@ import (
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/harness"
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/atqamz/secondhand/internal/worktree"
@@ -33,9 +34,9 @@ func newSpawnCmd() *cobra.Command {
 			id := args[0]
 			projectName := args[1]
 
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			proj, exists, err := project.Find(home, projectName)

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -101,6 +101,7 @@ func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 	writeFakeTreehouseGet(t, bin, worktreePath)
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	return home
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"text/tabwriter"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -20,9 +20,9 @@ func newStatusCmd() *cobra.Command {
 		Short: "Show fleet overview or single-task detail",
 		Args:  usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 			client := herdr.NewClient()
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -30,6 +30,7 @@ func writeFakeHerdrPaneStatus(t *testing.T, status string) {
 func TestStatusFleetListsAllTasks(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -52,6 +53,7 @@ func TestStatusFleetListsAllTasks(t *testing.T) {
 func TestStatusFleetColumnsDoNotMergeAtFieldWidth(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
 	id := "task-aaaaaaaaaaa"
@@ -78,6 +80,7 @@ func TestStatusFleetColumnsDoNotMergeAtFieldWidth(t *testing.T) {
 func TestStatusFleetDegradesToUnknownWhenHerdrUnreachable(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	t.Setenv("PATH", t.TempDir())
 
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
@@ -99,6 +102,7 @@ func TestStatusFleetDegradesToUnknownWhenHerdrUnreachable(t *testing.T) {
 func TestStatusFleetJSON(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -124,6 +128,7 @@ func TestStatusFleetJSON(t *testing.T) {
 func TestStatusSingleTaskDetail(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, Harness: "claude",
@@ -160,6 +165,7 @@ func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			home := t.TempDir()
 			t.Chdir(home)
+			mkFleetDirs(t, home)
 			writeFakeHerdrPaneStatus(t, "idle")
 
 			if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -319,6 +325,7 @@ func TestStatusSkipsPRDetectionForScoutTasks(t *testing.T) {
 func TestStatusFleetOverviewRendersMergeMarker(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -342,6 +349,7 @@ func TestStatusFleetOverviewRendersMergeMarker(t *testing.T) {
 func TestStatusFleetOverviewTaskWithNoPRIsUnaffected(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -364,6 +372,7 @@ func TestStatusFleetOverviewTaskWithNoPRIsUnaffected(t *testing.T) {
 func TestStatusSingleTaskJSON(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "blocked")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
@@ -385,6 +394,7 @@ func TestStatusSingleTaskJSON(t *testing.T) {
 func TestStatusSingleTaskMissing(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	cmd := newStatusCmd()
 	cmd.SetArgs([]string{"missing-task"})
@@ -396,6 +406,7 @@ func TestStatusSingleTaskMissing(t *testing.T) {
 func TestStatusFleetFlagsIdleWithoutTerminalReportAsUnreported(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -418,6 +429,7 @@ func TestStatusFleetFlagsIdleWithoutTerminalReportAsUnreported(t *testing.T) {
 func TestStatusFleetFlagsIdleWithTerminalReportInsteadOfUnreported(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -450,6 +462,7 @@ func TestStatusFleetFlagsIdleWithTerminalReportInsteadOfUnreported(t *testing.T)
 func TestStatusFleetKeepsTheReportedFlagAfterATrailingMalformedLine(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -476,6 +489,7 @@ func TestStatusFleetKeepsTheReportedFlagAfterATrailingMalformedLine(t *testing.T
 func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -498,6 +512,7 @@ func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 func TestStatusSingleTaskShowsReportedStateAndHistory(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -536,6 +551,7 @@ func TestStatusSingleTaskShowsReportedStateAndHistory(t *testing.T) {
 func TestStatusSingleTaskDegradesOnAnUnreadableReport(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -604,6 +620,7 @@ func TestTruncateReportLineDoesNotSplitAMultibyteRune(t *testing.T) {
 func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -643,6 +660,7 @@ func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing
 func TestStatusSingleTaskAlignsEveryLabeledValueInOneColumn(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -685,6 +703,7 @@ func TestStatusSingleTaskAlignsEveryLabeledValueInOneColumn(t *testing.T) {
 func TestStatusSingleTaskHistoryDoesNotRepeatTheReportedEntry(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -717,6 +736,7 @@ func TestStatusSingleTaskHistoryDoesNotRepeatTheReportedEntry(t *testing.T) {
 func TestStatusSingleTaskFullFlagRestoresThePreviousBehaviorExactly(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
@@ -748,6 +768,7 @@ func TestStatusSingleTaskFullFlagRestoresThePreviousBehaviorExactly(t *testing.T
 func TestStatusSingleTaskJSONKeepsTheFullReportUntruncated(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
@@ -773,6 +794,7 @@ func TestStatusSingleTaskJSONKeepsTheFullReportUntruncated(t *testing.T) {
 func TestStatusSingleTaskJSONIncludesReportedAndHistory(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -15,6 +15,7 @@ import (
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/ghutil"
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/atqamz/secondhand/internal/worktree"
@@ -30,9 +31,9 @@ func newTeardownCmd() *cobra.Command {
 		Args:  usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := args[0]
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 			release, err := state.Lock(home, "task:"+id)
 			if err != nil {

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -373,6 +373,7 @@ func setupTeardownHome(t *testing.T) (home, worktree string) {
 	t.Helper()
 	home = t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -638,6 +639,7 @@ func TestTeardownRetiresTheTasksPendingQuestion(t *testing.T) {
 func TestTeardownShipLocalOnlyFailsWhenBranchNotMerged(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 	clonePath := filepath.Join(t.TempDir(), "clone")
 	initGitRepo(t, clonePath)
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/atqamz/secondhand/internal/agentsmd"
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/selfupdate"
 	"github.com/spf13/cobra"
 )
@@ -47,9 +48,12 @@ func newUpdateCmd(version string) *cobra.Command {
 			// exiting nonzero here reads as "the update failed" and invites a
 			// pointless re-run.
 			var refreshed bool
-			cwd, refreshErr := os.Getwd()
-			if refreshErr == nil {
-				refreshed, refreshErr = agentsmd.Refresh(cwd)
+			fleetHome, refreshErr := home.Resolve()
+			switch {
+			case refreshErr == nil:
+				refreshed, refreshErr = agentsmd.Refresh(fleetHome)
+			case errors.Is(refreshErr, home.ErrNotFound):
+				refreshErr = nil
 			}
 
 			notes, _ := selfupdate.ReleaseNotes(selfupdate.Repo, latest)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -132,6 +132,7 @@ func TestUpdateRefreshesWorkspaceAndReportsChanges(t *testing.T) {
 	setFakeExecutable(t)
 	home := makeUpdateWorkspace(t)
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	fixture := buildUpdateFixture(t, []byte("new binary contents"))
 	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
@@ -184,7 +185,7 @@ func TestUpdateSkipsAgentsRefreshOutsideWorkspace(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 	if _, err := os.Stat(filepath.Join(home, "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("got AGENTS.md written outside a workspace, err=%v", err)
+		t.Fatalf("got AGENTS.md written outside a fleet home, err=%v", err)
 	}
 }
 
@@ -195,6 +196,7 @@ func TestUpdateDegradesGracefullyWithoutReleaseNotes(t *testing.T) {
 	setFakeExecutable(t)
 	home := makeUpdateWorkspace(t)
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	fixture := buildUpdateFixture(t, []byte("new binary contents"))
 	writeFakeGHUpdate(t, "v0.5.0", "", fixture)
@@ -226,6 +228,7 @@ func TestUpdateReportsVersionsWhenAgentsRefreshFails(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	fixture := buildUpdateFixture(t, []byte("new binary contents"))
 	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -160,6 +160,42 @@ func TestUpdateRefreshesWorkspaceAndReportsChanges(t *testing.T) {
 	}
 }
 
+func TestUpdateRefreshesHandHomeRatherThanWorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("update binary layout targets unix asset names")
+	}
+	setFakeExecutable(t)
+	fleetHome := makeUpdateWorkspace(t)
+	mkFleetDirs(t, fleetHome)
+	t.Setenv("HAND_HOME", fleetHome)
+	t.Chdir(t.TempDir())
+
+	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
+
+	cmd := newUpdateCmd("v0.1.0")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	want := "current: v0.1.0\nlatest:  v0.5.0\nupdated hand to v0.5.0\nupdated AGENTS.md template\nchanged:\nfixed the frobnicator\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+
+	agentsMD, err := os.ReadFile(filepath.Join(fleetHome, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(agentsMD), "## Workflow") {
+		t.Fatalf("got %q, want AGENTS.md written with the workflow template", agentsMD)
+	}
+}
+
 func TestUpdateSkipsAgentsRefreshOutsideWorkspace(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("update binary layout targets unix asset names")

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -196,11 +196,12 @@ func TestUpdateRefreshesHandHomeRatherThanWorkingDirectory(t *testing.T) {
 	}
 }
 
-func TestUpdateSkipsAgentsRefreshOutsideWorkspace(t *testing.T) {
+func TestUpdateSkipsAgentsRefreshOutsideAFleetHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("update binary layout targets unix asset names")
 	}
 	setFakeExecutable(t)
+	t.Setenv("HAND_HOME", "")
 	home := t.TempDir()
 	t.Chdir(home)
 
@@ -222,6 +223,41 @@ func TestUpdateSkipsAgentsRefreshOutsideWorkspace(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(home, "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("got AGENTS.md written outside a fleet home, err=%v", err)
+	}
+}
+
+// "No home here" is the silent skip; "HAND_HOME names something that is not a
+// home" is a misconfiguration, and swallowing it would leave the operator with
+// an unrefreshed AGENTS.md and nothing on stderr saying why.
+func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("update binary layout targets unix asset names")
+	}
+	setFakeExecutable(t)
+	home := t.TempDir()
+	t.Chdir(home)
+	notAHome := t.TempDir()
+	t.Setenv("HAND_HOME", notAHome)
+
+	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
+
+	cmd := newUpdateCmd("v0.1.0")
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want a successful update despite the misconfigured HAND_HOME", err)
+	}
+
+	got := out.String()
+	want := "current: v0.1.0\nlatest:  v0.5.0\nupdated hand to v0.5.0\nchanged:\nfixed the frobnicator\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if !strings.Contains(errOut.String(), "warning: refresh AGENTS.md:") || !strings.Contains(errOut.String(), notAHome) {
+		t.Fatalf("got stderr %q, want a warning naming %q", errOut.String(), notAHome)
 	}
 }
 

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/atqamz/secondhand/internal/home"
 	"github.com/atqamz/secondhand/internal/watcher"
 	"github.com/spf13/cobra"
 )
@@ -26,9 +27,9 @@ func newWatchCmd() *cobra.Command {
 		Short: "Poll herdr agent states and report actionable events",
 		Args:  usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.Getwd()
+			home, err := home.Resolve()
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return asPrecondition(err)
 			}
 
 			if cmd.Flags().Changed("timeout") {

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -28,6 +28,7 @@ func setupWatchHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Chdir(home)
+	mkFleetDirs(t, home)
 
 	bin := t.TempDir()
 	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(fakeHerdrWatchScript), 0o755); err != nil {

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -1,5 +1,5 @@
 // Package agentsmd generates and refreshes the AGENTS.md workflow/rules
-// template that hand init writes into a workspace, described in SPECS.md's
+// template that hand init writes into a fleet home, described in SPECS.md's
 // "AGENTS.md (target)" section.
 package agentsmd
 
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/atqamz/secondhand/internal/atomicfile"
+	"github.com/atqamz/secondhand/internal/home"
 )
 
 const (
@@ -51,33 +52,19 @@ Run ` + "`hand --help`" + ` for the full command reference.
 - ` + "`hand status <id>`" + ` shows a worker's reported state; see SPECS.md's state management section for the report vocabulary (working/paused/blocked/needs-decision/done/failed).
 `
 
-// isWorkspace reports whether dir has been initialized by hand init: the
-// presence of data/dashboard.md is the concrete, unambiguous signal since
-// hand init is the only thing that writes it.
-func isWorkspace(dir string) (bool, error) {
-	_, err := os.Stat(filepath.Join(dir, "data", "dashboard.md"))
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, fmt.Errorf("check workspace: %w", err)
-}
-
 // Refresh writes or refreshes dir/AGENTS.md and its CLAUDE.md symlink,
 // reporting whether the template content actually changed (false, nil when dir
-// is not a workspace, which is not an error). An existing AGENTS.md keeps
+// is not a fleet home, which is not an error). An existing AGENTS.md keeps
 // everything outside the generated markers untouched, so user-added content and
 // extra rules survive; only the span between the markers is replaced, never the
 // whole file. A file whose markers are already current, and a marker-less file
 // mergeGenerated declines to touch, are both left on disk untouched.
 func Refresh(dir string) (bool, error) {
-	workspace, err := isWorkspace(dir)
+	isHome, err := home.IsHome(dir)
 	if err != nil {
 		return false, err
 	}
-	if !workspace {
+	if !isHome {
 		return false, nil
 	}
 

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -44,7 +44,7 @@ Run ` + "`hand --help`" + ` for the full command reference.
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
-- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. ` + "`hand`" + ` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
+- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. ` + "`hand`" + ` resolves the home from ` + "`HAND_HOME`" + ` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce ` + "`data/<id>/report.md`" + `.
 - ` + "`data/backlog.md`" + ` is your task queue. Edit it directly.
 - For no-mistakes projects, workers use ` + "`no-mistakes axi`" + ` directly in the worktree.

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -13,45 +13,23 @@ func makeWorkspace(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "data", "dashboard.md"), []byte("# Dashboard\n"), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return dir
 }
 
-func TestIsWorkspaceTrueWhenDashboardExists(t *testing.T) {
-	dir := makeWorkspace(t)
-	got, err := isWorkspace(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !got {
-		t.Fatal("got false, want true")
-	}
-}
-
-func TestIsWorkspaceFalseWhenNotInitialized(t *testing.T) {
-	dir := t.TempDir()
-	got, err := isWorkspace(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got {
-		t.Fatal("got true, want false")
-	}
-}
-
-func TestRefreshSkipsSilentlyWhenNotWorkspace(t *testing.T) {
+func TestRefreshSkipsSilentlyWhenNotAFleetHome(t *testing.T) {
 	dir := t.TempDir()
 	refreshed, err := Refresh(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if refreshed {
-		t.Fatal("got refreshed=true, want false outside a workspace")
+		t.Fatal("got refreshed=true, want false outside a fleet home")
 	}
 	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); !os.IsNotExist(err) {
-		t.Fatalf("got AGENTS.md written outside a workspace, err=%v", err)
+		t.Fatalf("got AGENTS.md written outside a fleet home, err=%v", err)
 	}
 }
 

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -16,6 +16,9 @@ func makeWorkspace(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, "data", "dashboard.md"), []byte("# Dashboard\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	return dir
 }
 

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -178,7 +178,7 @@ func TestGeneratedRulesMatchThisRepoAgentsMdCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	absolutePathRule := "- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from the current working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.\n"
+	absolutePathRule := "- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from `HAND_HOME` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.\n"
 	if !strings.Contains(generatedBody, absolutePathRule) {
 		t.Fatalf("got generated body %q, want the absolute-path rule verbatim", generatedBody)
 	}

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -10,25 +10,40 @@ import (
 	"path/filepath"
 )
 
-// ErrNotFound is wrapped into the error Resolve returns when no directory
-// from the resolution order qualifies as a fleet home. It renders as the
-// full user-facing sentence on its own, so callers should not add more
-// context around it.
+// ErrNotFound is wrapped into the error Resolve returns when the working
+// directory has no fleet home above it. It renders as the full user-facing
+// sentence on its own, so callers should not add more context around it.
 var ErrNotFound = errors.New("not inside a secondhand home; run `hand init` or set HAND_HOME")
 
-// IsHome reports whether dir holds both data/ and state/ as directories,
-// the one definition of a fleet home every caller (the resolver, hand init,
-// and agentsmd's refresh) shares.
+// ErrHandHomeInvalid is wrapped into the error Resolve returns when HAND_HOME
+// is set but does not name a fleet home. It is separate from ErrNotFound
+// because the remedy differs: an operator who already set HAND_HOME is not
+// helped by being told to set it.
+var ErrHandHomeInvalid = errors.New("is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory")
+
+// IsHome reports whether dir is a fleet home, the one definition every caller
+// (the resolver, hand init, and agentsmd's refresh) shares. The marker is
+// data/dashboard.md, which only hand init writes, rather than the data/
+// directory itself: project clones live at <home>/projects/<name>, so a clone
+// carrying its own generic top-level data/ and state/ directories would
+// otherwise stop the ancestor walk short and be dispatched into as the home.
 func IsHome(dir string) (bool, error) {
-	for _, sub := range []string{"data", "state"} {
-		info, err := os.Stat(filepath.Join(dir, sub))
+	markers := []struct {
+		rel   string
+		isDir bool
+	}{
+		{filepath.Join("data", "dashboard.md"), false},
+		{"state", true},
+	}
+	for _, m := range markers {
+		info, err := os.Stat(filepath.Join(dir, m.rel))
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		if err != nil {
-			return false, fmt.Errorf("check %s: %w", sub, err)
+			return false, fmt.Errorf("check %s: %w", m.rel, err)
 		}
-		if !info.IsDir() {
+		if info.IsDir() != m.isDir {
 			return false, nil
 		}
 	}
@@ -48,7 +63,7 @@ func Resolve() (string, error) {
 			return "", fmt.Errorf("check HAND_HOME %q: %w", handHome, err)
 		}
 		if !ok {
-			return "", fmt.Errorf("HAND_HOME %q: %w", handHome, ErrNotFound)
+			return "", fmt.Errorf("HAND_HOME %q %w", handHome, ErrHandHomeInvalid)
 		}
 		return handHome, nil
 	}

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -55,9 +55,16 @@ func IsHome(dir string) (bool, error) {
 // the working directory itself) that IsHome reports true for. HAND_HOME set
 // to a directory that isn't a home fails loudly instead of silently falling
 // back to the walk-up, since a silent fallback is how an operator ends up
-// dispatching into the wrong fleet.
+// dispatching into the wrong fleet. The returned path is always absolute:
+// commands derive paths they hand to subprocesses running elsewhere from it,
+// and a relative HAND_HOME would otherwise name a different home per
+// working directory.
 func Resolve() (string, error) {
 	if handHome := os.Getenv("HAND_HOME"); handHome != "" {
+		handHome, err := filepath.Abs(handHome)
+		if err != nil {
+			return "", fmt.Errorf("resolve HAND_HOME: %w", err)
+		}
 		ok, err := IsHome(handHome)
 		if err != nil {
 			return "", fmt.Errorf("check HAND_HOME %q: %w", handHome, err)

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -1,0 +1,75 @@
+// Package home resolves the one secondhand fleet home a command runs
+// against, replacing the scattered bare os.Getwd() calls each command used
+// to make on its own.
+package home
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrNotFound is wrapped into the error Resolve returns when no directory
+// from the resolution order qualifies as a fleet home. It renders as the
+// full user-facing sentence on its own, so callers should not add more
+// context around it.
+var ErrNotFound = errors.New("not inside a secondhand home; run `hand init` or set HAND_HOME")
+
+// IsHome reports whether dir holds both data/ and state/ as directories,
+// the one definition of a fleet home every caller (the resolver, hand init,
+// and agentsmd's refresh) shares.
+func IsHome(dir string) (bool, error) {
+	for _, sub := range []string{"data", "state"} {
+		info, err := os.Stat(filepath.Join(dir, sub))
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("check %s: %w", sub, err)
+		}
+		if !info.IsDir() {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// Resolve finds the fleet home a command should run against: HAND_HOME if
+// set, otherwise the nearest ancestor of the working directory (including
+// the working directory itself) that IsHome reports true for. HAND_HOME set
+// to a directory that isn't a home fails loudly instead of silently falling
+// back to the walk-up, since a silent fallback is how an operator ends up
+// dispatching into the wrong fleet.
+func Resolve() (string, error) {
+	if handHome := os.Getenv("HAND_HOME"); handHome != "" {
+		ok, err := IsHome(handHome)
+		if err != nil {
+			return "", fmt.Errorf("check HAND_HOME %q: %w", handHome, err)
+		}
+		if !ok {
+			return "", fmt.Errorf("HAND_HOME %q: %w", handHome, ErrNotFound)
+		}
+		return handHome, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+
+	for dir := cwd; ; {
+		ok, err := IsHome(dir)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", ErrNotFound
+		}
+		dir = parent
+	}
+}

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -1,0 +1,159 @@
+package home
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func makeHome(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsHomeTrueWhenDataAndStateDirsExist(t *testing.T) {
+	dir := t.TempDir()
+	makeHome(t, dir)
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("got false, want true")
+	}
+}
+
+func TestIsHomeFalseWhenEmpty(t *testing.T) {
+	got, err := IsHome(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want false")
+	}
+}
+
+func TestIsHomeFalseWhenOnlyDataDirExists(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want false")
+	}
+}
+
+func TestIsHomeFalseWhenDataIsAFileNotADir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want false")
+	}
+}
+
+func TestResolveReturnsCwdWhenItIsAHome(t *testing.T) {
+	dir := t.TempDir()
+	makeHome(t, dir)
+	t.Chdir(dir)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != dir {
+		t.Fatalf("got %q, want %q", got, dir)
+	}
+}
+
+func TestResolveWalksUpToAnAncestorHome(t *testing.T) {
+	home := t.TempDir()
+	makeHome(t, home)
+	nested := filepath.Join(home, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != home {
+		t.Fatalf("got %q, want %q", got, home)
+	}
+}
+
+func TestResolveFailsLoudlyWithNoHomeAnywhereInTheTree(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	_, err := Resolve()
+	if err == nil {
+		t.Fatal("got nil error, want failure")
+	}
+	want := "not inside a secondhand home; run `hand init` or set HAND_HOME"
+	if err.Error() != want {
+		t.Fatalf("got %q, want %q", err.Error(), want)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("got %v, want it to wrap ErrNotFound", err)
+	}
+}
+
+func TestResolvePrefersHandHomeOverCwd(t *testing.T) {
+	cwdHome := t.TempDir()
+	makeHome(t, cwdHome)
+	t.Chdir(cwdHome)
+
+	envHome := t.TempDir()
+	makeHome(t, envHome)
+	t.Setenv("HAND_HOME", envHome)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != envHome {
+		t.Fatalf("got %q, want %q", got, envHome)
+	}
+}
+
+func TestResolveFailsLoudlyWhenHandHomeIsNotAHome(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	notAHome := t.TempDir()
+	t.Setenv("HAND_HOME", notAHome)
+
+	_, err := Resolve()
+	if err == nil {
+		t.Fatal("got nil error, want failure")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("got %v, want it to wrap ErrNotFound", err)
+	}
+	if !strings.Contains(err.Error(), notAHome) {
+		t.Fatalf("got %q, want it to name HAND_HOME's value %q", err.Error(), notAHome)
+	}
+}

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -10,6 +10,16 @@ import (
 
 func makeHome(t *testing.T, dir string) {
 	t.Helper()
+	makeGenericDataAndState(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "data", "dashboard.md"), []byte("# Dashboard\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// makeGenericDataAndState builds what an unrelated project clone can plausibly
+// have at its top level, which must not be mistaken for a fleet home.
+func makeGenericDataAndState(t *testing.T, dir string) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +28,7 @@ func makeHome(t *testing.T, dir string) {
 	}
 }
 
-func TestIsHomeTrueWhenDataAndStateDirsExist(t *testing.T) {
+func TestIsHomeTrueWhenDashboardFileAndStateDirExist(t *testing.T) {
 	dir := t.TempDir()
 	makeHome(t, dir)
 
@@ -41,9 +51,25 @@ func TestIsHomeFalseWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestIsHomeFalseWhenOnlyDataDirExists(t *testing.T) {
+func TestIsHomeFalseForAProjectCloneWithGenericDataAndStateDirs(t *testing.T) {
+	dir := t.TempDir()
+	makeGenericDataAndState(t, dir)
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want false without data/dashboard.md")
+	}
+}
+
+func TestIsHomeFalseWhenDashboardExistsWithoutStateDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data", "dashboard.md"), []byte("# Dashboard\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,12 +82,29 @@ func TestIsHomeFalseWhenOnlyDataDirExists(t *testing.T) {
 	}
 }
 
-func TestIsHomeFalseWhenDataIsAFileNotADir(t *testing.T) {
+func TestIsHomeFalseWhenStateIsAFileNotADir(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "data"), []byte("x"), 0o644); err != nil {
+	makeHome(t, dir)
+	if err := os.RemoveAll(filepath.Join(dir, "state")); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "state"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want false")
+	}
+}
+
+func TestIsHomeFalseWhenDashboardIsADirNotAFile(t *testing.T) {
+	dir := t.TempDir()
+	makeGenericDataAndState(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "data", "dashboard.md"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,6 +118,7 @@ func TestIsHomeFalseWhenDataIsAFileNotADir(t *testing.T) {
 }
 
 func TestResolveReturnsCwdWhenItIsAHome(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	dir := t.TempDir()
 	makeHome(t, dir)
 	t.Chdir(dir)
@@ -89,6 +133,7 @@ func TestResolveReturnsCwdWhenItIsAHome(t *testing.T) {
 }
 
 func TestResolveWalksUpToAnAncestorHome(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	home := t.TempDir()
 	makeHome(t, home)
 	nested := filepath.Join(home, "a", "b", "c")
@@ -106,7 +151,27 @@ func TestResolveWalksUpToAnAncestorHome(t *testing.T) {
 	}
 }
 
+// The walk-up's primary path runs through projects/<name>, so a clone with its
+// own top-level data/ and state/ must not stop it short of the real home.
+func TestResolveWalksPastAProjectCloneWithGenericDataAndStateDirs(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	home := t.TempDir()
+	makeHome(t, home)
+	clone := filepath.Join(home, "projects", "myapp")
+	makeGenericDataAndState(t, clone)
+	t.Chdir(clone)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != home {
+		t.Fatalf("got %q, want %q", got, home)
+	}
+}
+
 func TestResolveFailsLoudlyWithNoHomeAnywhereInTheTree(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	t.Chdir(t.TempDir())
 
 	_, err := Resolve()
@@ -140,8 +205,13 @@ func TestResolvePrefersHandHomeOverCwd(t *testing.T) {
 	}
 }
 
+// A misconfigured HAND_HOME reports its own sentinel, not ErrNotFound: the two
+// have different remedies, and callers that quietly tolerate "no home here"
+// (hand update's AGENTS.md refresh) must still surface this one.
 func TestResolveFailsLoudlyWhenHandHomeIsNotAHome(t *testing.T) {
-	t.Chdir(t.TempDir())
+	cwdHome := t.TempDir()
+	makeHome(t, cwdHome)
+	t.Chdir(cwdHome)
 
 	notAHome := t.TempDir()
 	t.Setenv("HAND_HOME", notAHome)
@@ -150,10 +220,16 @@ func TestResolveFailsLoudlyWhenHandHomeIsNotAHome(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error, want failure")
 	}
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("got %v, want it to wrap ErrNotFound", err)
+	if !errors.Is(err, ErrHandHomeInvalid) {
+		t.Fatalf("got %v, want it to wrap ErrHandHomeInvalid", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("got %v, want it not to wrap ErrNotFound", err)
 	}
 	if !strings.Contains(err.Error(), notAHome) {
 		t.Fatalf("got %q, want it to name HAND_HOME's value %q", err.Error(), notAHome)
+	}
+	if strings.Contains(err.Error(), ErrNotFound.Error()) {
+		t.Fatalf("got %q, want it not to prescribe setting the variable that is already wrong", err.Error())
 	}
 }

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -205,6 +205,26 @@ func TestResolvePrefersHandHomeOverCwd(t *testing.T) {
 	}
 }
 
+// A relative HAND_HOME names one fleet home, not a different one per working
+// directory: commands join paths onto the resolved home and hand them to
+// subprocesses that run somewhere else entirely (hand spawn's brief path, which
+// the harness reads from inside the worktree).
+func TestResolveAbsolutizesARelativeHandHome(t *testing.T) {
+	parent := t.TempDir()
+	home := filepath.Join(parent, "fleet")
+	makeHome(t, home)
+	t.Chdir(parent)
+	t.Setenv("HAND_HOME", "fleet")
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != home {
+		t.Fatalf("got %q, want %q", got, home)
+	}
+}
+
 // A misconfigured HAND_HOME reports its own sentinel, not ErrNotFound: the two
 // have different remedies, and callers that quietly tolerate "no home here"
 // (hand update's AGENTS.md refresh) must still surface this one.

--- a/tests/e2e/completion_store_test.go
+++ b/tests/e2e/completion_store_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
-// TestTeardownCompletionSurvivesMissingDashboard is atqamz/secondhand#61's
-// done-when condition run literally: data/dashboard.md is gone from disk before
-// teardown runs, so the only way this test can pass is if the completion record
-// lives somewhere else. data/dashboard.md is also the fleet-home marker
-// home.Resolve looks for (atqamz/secondhand#46, not this issue's fix), so the
-// final teardown names the home through HAND_HOME instead of the walk up: an
-// operator whose dashboard is gone runs `hand init` to restore it, which is
-// what the resolver's own refusal tells them to do.
-func TestTeardownCompletionSurvivesMissingDashboard(t *testing.T) {
+// TestTeardownCompletionSurvivesUnwritableDashboard is atqamz/secondhand#61's
+// done-when condition, reached through the fault that can still happen now that
+// data/dashboard.md is also the fleet-home marker (atqamz/secondhand#46):
+// deleting the file would make every command refuse to resolve a home before it
+// ran, so instead data/ is sealed against writes and the file stays on disk and
+// unchanged throughout. Teardown's closing dashboard render fails, and the only
+// way this test can pass is if the completion record lives somewhere else. The
+// home here resolves through the plain ancestor walk, with no HAND_HOME.
+func TestTeardownCompletionSurvivesUnwritableDashboard(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "local-only")
 	writeBrief(t, home, "task-1")

--- a/tests/e2e/completion_store_test.go
+++ b/tests/e2e/completion_store_test.go
@@ -14,10 +14,11 @@ import (
 // TestTeardownCompletionSurvivesMissingDashboard is atqamz/secondhand#61's
 // done-when condition run literally: data/dashboard.md is gone from disk before
 // teardown runs, so the only way this test can pass is if the completion record
-// lives somewhere else. Deleting the file here, rather than after hand init
-// as usual, sidesteps internal/agentsmd's dashboard.md stat for fleet-home
-// detection (atqamz/secondhand#46, not this issue's fix) simply by never calling
-// hand init or hand update again once the file is gone.
+// lives somewhere else. data/dashboard.md is also the fleet-home marker
+// home.Resolve looks for (atqamz/secondhand#46, not this issue's fix), so the
+// final teardown names the home through HAND_HOME instead of the walk up: an
+// operator whose dashboard is gone runs `hand init` to restore it, which is
+// what the resolver's own refusal tells them to do.
 func TestTeardownCompletionSurvivesMissingDashboard(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "local-only")
@@ -44,24 +45,29 @@ func TestTeardownCompletionSurvivesMissingDashboard(t *testing.T) {
 	}
 
 	dashPath := filepath.Join(home, "data", "dashboard.md")
-	if err := os.Remove(dashPath); err != nil {
+	before, err := os.ReadFile(dashPath)
+	if err != nil {
 		t.Fatal(err)
 	}
+	sealDir(t, filepath.Join(home, "data"))
 
 	// teardown still fails here: its last step renders into data/dashboard.md,
-	// and that file's removal belongs to atqamz/secondhand#62, not this issue.
-	// The point this test proves is what happens before that last step: the
-	// completion record and the task state deletion both come earlier in
-	// cmd/teardown.go, so neither is lost when the dashboard step has nothing
-	// left to read.
+	// and surviving that failure belongs to atqamz/secondhand#62, not this
+	// issue. The point this test proves is what happens before that last step:
+	// the completion record and the task state deletion both come earlier in
+	// cmd/teardown.go, so neither is lost when the dashboard step cannot write.
 	done := runHand(t, home, "teardown", "task-1")
 	assertInvocation(t, done, 1, "update dashboard")
 
 	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
 		t.Fatalf("state.Exists after teardown = %v, %v, want task removed", exists, err)
 	}
-	if _, err := os.Stat(dashPath); !os.IsNotExist(err) {
-		t.Fatalf("dashboard.md stat = %v, want it to stay gone: teardown must not have recreated it", err)
+	after, err := os.ReadFile(dashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("dashboard.md = %q, want it unchanged: the step that could not write must not have half-written", after)
 	}
 
 	records, err := completion.List(home)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -79,6 +79,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	// Every hand process this suite drives inherits this environment and
+	// resolves HAND_HOME ahead of its working directory, so a developer who
+	// exported one would otherwise have the suite spawn, merge and tear down
+	// against their real fleet.
+	if err := os.Unsetenv("HAND_HOME"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	code := m.Run()
 	_ = os.RemoveAll(dir)
@@ -93,8 +101,18 @@ type invocation struct {
 
 func runHand(t *testing.T, home string, args ...string) invocation {
 	t.Helper()
+	return runHandEnv(t, home, nil, args...)
+}
+
+// runHandEnv is runHand for the cases that need one extra environment entry,
+// appended to the suite's own (already HAND_HOME-free) environment.
+func runHandEnv(t *testing.T, home string, extraEnv []string, args ...string) invocation {
+	t.Helper()
 	cmd := exec.Command(handBin, args...)
 	cmd.Dir = home
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -281,6 +299,21 @@ func writeBrief(t *testing.T, home, id string) {
 	}
 }
 
+// sealDir makes dir reject new entries for the rest of the test, the portable
+// way to fault a write that creates its temp file next to the target (see
+// internal/atomicfile). Root ignores the mode, so a run as root skips rather
+// than silently proving nothing.
+func sealDir(t *testing.T, dir string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop root")
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+}
+
 func assertInvocation(t *testing.T, got invocation, wantCode int, wantStderr string) {
 	t.Helper()
 	if got.code != wantCode {
@@ -465,6 +498,25 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			assertInvocation(t, runHand(t, home, tc.args...), 3, tc.wantStderr)
 		})
 	}
+}
+
+// Every command routes home.Resolve's failure through asPrecondition, so this
+// covers that wiring for all of them at once: a regression downgrades the
+// refusal to a plain exit 1.
+func TestExitCodeThreeOutsideAnyFleetHome(t *testing.T) {
+	assertInvocation(t, runHand(t, t.TempDir(), "status"), 3,
+		"not inside a secondhand home; run `hand init` or set HAND_HOME")
+}
+
+// A HAND_HOME pointing at a directory that is not a fleet home refuses rather
+// than silently falling back to the working directory, which here is a real
+// home the fallback would have found.
+func TestExitCodeThreeWhenHandHomeIsNotAFleetHome(t *testing.T) {
+	home := newHome(t)
+	notAHome := t.TempDir()
+
+	got := runHandEnv(t, home, []string{"HAND_HOME=" + notAHome}, "status")
+	assertInvocation(t, got, 3, fmt.Sprintf("HAND_HOME %q is not a secondhand home", notAHome))
 }
 
 func TestExitCodeOneOnGeneralError(t *testing.T) {


### PR DESCRIPTION
## Intent

support both an in-repo maintainer home and a standalone fleet home for the hand CLI: replace bare os.Getwd() home derivations across cmd/*.go with a HAND_HOME/ancestor-walk resolver, move the fleet-home definition into internal/home, and document the standalone home as the default in SPECS.md and README.md

Closes atqamz/secondhand#46

## What Changed

- Main had 16 bare `os.Getwd()` calls total (the issue's original count of 11 was stale). 15 were genuine home derivations and are replaced with `home.Resolve()`; the 16th, in `cmd/init.go`, resolves the base for a home that does not exist yet and is left as-is on purpose.
- Adds `internal/home` with the single fleet-home definition (`data/dashboard.md` plus `state/`) and a `Resolve` that returns an absolute path from `HAND_HOME`, or from the nearest fleet-home ancestor of the working directory. A `HAND_HOME` naming a non-home refuses via its own sentinel instead of falling back to the walk.
- Replaces the bare `os.Getwd()` home derivation in every command (`status`, `spawn`, `send`, `watch`, `merge`, `pr`, `promote`, `teardown`, `notify`, `project`, `update`, ...) with `home.Resolve()`, and registers both new sentinels in `preconditionSentinels` so running outside a home exits 3. `hand init` still creates the home its argument or working directory names, and now warns on stderr when `HAND_HOME` points elsewhere. `hand update` refreshes AGENTS.md in the resolved home, skipping silently only when no home exists.
- Reworks the workspace vocabulary in SPECS.md, README.md, AGENTS.md, and `agentsmd`'s generated template around the fleet home: documents the standalone home as the default with the in-repo maintainer home as the dogfooding case, and drops `agentsmd`'s private `isWorkspace` in favor of `home.IsHome`.

## Risk Assessment

Low: Both round-2 findings were fixed exactly as directed and are covered by new unit and e2e tests, the resolver now returns an absolute home on every path, and the only issue left is one operator warning string that prints a relative path where the code already has the absolute one.

## Testing

Ran the home-resolution unit tests, the full cmd package tests, and the targeted e2e cases for the new exit-3 refusals plus the changed project and completion-store paths - all green - then built `hand` from the target commit and drove it by hand through both supported home shapes: a standalone fleet home in a temp directory (init output, ancestor walk from a nested dir and from inside a project clone carrying its own data/+state/, absolute and relative HAND_HOME from unrelated working directories, exit 3 both when HAND_HOME names a non-home and when no home exists above cwd, and init's stderr warning under a mismatched HAND_HOME) and a maintainer home inside this checkout (exit 3 before init, working commands from the root and two subdirectories after, with git confirming no tracked file and neither AGENTS.md nor its CLAUDE.md symlink changed). A config/notify hook stored in the fleet home fired correctly from three different working directories, showing the resolved home drives real side effects rather than just command startup. Evidence is CLI transcripts because this change has no rendered UI surface; the gitignored runtime and build output created during verification were removed and the worktree is clean.

<details>
<summary>Evidence: Standalone fleet home CLI transcript (init, ancestor walk, HAND_HOME, exit-3 refusals, init mismatch warning)</summary>

<code>$ cd /tmp/hand-home-scenario/fleet&#10;$ hand init&#10;initialized secondhand home at /tmp/hand-home-scenario/fleet&#10;[exit 0]&#10;&#10;$ ls -A /tmp/hand-home-scenario/fleet&#10;AGENTS.md CLAUDE.md config data projects state&#10;&#10;$ cd /tmp/hand-home-scenario/fleet/projects/app # clone with its own data/ and state/&#10;$ hand project list&#10;app https://github.com/org/app local-only&#10;[exit 0]&#10;&#10;$ cd /tmp&#10;$ HAND_HOME=/tmp/hand-home-scenario/fleet hand project list&#10;app https://github.com/org/app local-only&#10;[exit 0]&#10;&#10;$ cd /tmp/hand-home-scenario/fleet&#10;$ HAND_HOME=/tmp/hand-home-scenario/elsewhere hand project list&#10;HAND_HOME &#34;/tmp/hand-home-scenario/elsewhere&#34; is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory&#10;[exit 3]&#10;&#10;$ cd /tmp/hand-home-scenario/elsewhere&#10;$ hand status&#10;not inside a secondhand home; run `hand init` or set HAND_HOME&#10;[exit 3]&#10;&#10;$ cd /tmp/hand-home-scenario/second&#10;$ HAND_HOME=/tmp/hand-home-scenario/fleet hand init&#10;warning: HAND_HOME is set to /tmp/hand-home-scenario/fleet, so every other hand command will use that home, not /tmp/hand-home-scenario/second&#10;initialized secondhand home at /tmp/hand-home-scenario/second&#10;[exit 0]</code>

```text

=== 1. create a standalone fleet home in a plain directory anywhere on disk ===

$ cd /tmp/hand-home-scenario.odYsvj/fleet
$ hand init
initialized secondhand home at /tmp/hand-home-scenario.odYsvj/fleet
[exit 0]

$ ls -A /tmp/hand-home-scenario.odYsvj/fleet
AGENTS.md
CLAUDE.md
config
data
projects
state

=== 2. hand runs against that standalone home ===

$ cd /tmp/hand-home-scenario.odYsvj/fleet
$ hand status
[exit 0]

$ cd /tmp/hand-home-scenario.odYsvj/fleet
$ hand project list
[exit 0]

=== 3. seed a project clone that carries its own generic top-level data/ and state/ ===

$ find /tmp/hand-home-scenario.odYsvj/fleet/projects/app -maxdepth 2 | sort
/tmp/hand-home-scenario.odYsvj/fleet/projects/app
/tmp/hand-home-scenario.odYsvj/fleet/projects/app/data
/tmp/hand-home-scenario.odYsvj/fleet/projects/app/data/notes.md
/tmp/hand-home-scenario.odYsvj/fleet/projects/app/state
/tmp/hand-home-scenario.odYsvj/fleet/projects/app/state/sub

=== 4. ancestor walk: from a nested subdirectory of the home ===

$ cd /tmp/hand-home-scenario.odYsvj/fleet/data
$ hand project list
app  https://github.com/org/app  local-only
[exit 0]

=== 5. ancestor walk from inside the project clone skips the clone's own data/+state/ and finds the real home ===

$ cd /tmp/hand-home-scenario.odYsvj/fleet/projects/app
$ hand project list
app  https://github.com/org/app  local-only
[exit 0]

$ cd /tmp/hand-home-scenario.odYsvj/fleet/projects/app/state/sub
$ hand status
[exit 0]

=== 6. HAND_HOME lets hand run from an unrelated working directory ===

$ cd /tmp
$ HAND_HOME=/tmp/hand-home-scenario.odYsvj/fleet hand project list
app  https://github.com/org/app  local-only
[exit 0]

=== 7. a relative HAND_HOME is absolutized, not re-resolved per working directory ===

$ cd /tmp/hand-home-scenario.odYsvj
$ HAND_HOME=fleet hand project list
app  https://github.com/org/app  local-only
[exit 0]

$ cd /tmp/hand-home-scenario.odYsvj/elsewhere
$ HAND_HOME=fleet hand project list
HAND_HOME "/tmp/hand-home-scenario.odYsvj/elsewhere/fleet" is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory
[exit 3]

=== 8. HAND_HOME pointing at a non-home refuses (exit 3) instead of silently falling back to the real home under cwd ===

$ cd /tmp/hand-home-scenario.odYsvj/fleet
$ HAND_HOME=/tmp/hand-home-scenario.odYsvj/elsewhere hand project list
HAND_HOME "/tmp/hand-home-scenario.odYsvj/elsewhere" is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory
[exit 3]

=== 9. no fleet home at or above the working directory: exit 3, actionable message ===

$ cd /tmp/hand-home-scenario.odYsvj/elsewhere
$ hand status
not inside a secondhand home; run `hand init` or set HAND_HOME
[exit 3]

=== 10. hand init warns when HAND_HOME names a different home than the one being created ===

$ cd /tmp/hand-home-scenario.odYsvj/second
$ HAND_HOME=/tmp/hand-home-scenario.odYsvj/fleet hand init
warning: HAND_HOME is set to /tmp/hand-home-scenario.odYsvj/fleet, so every other hand command will use that home, not /tmp/hand-home-scenario.odYsvj/second
initialized secondhand home at /tmp/hand-home-scenario.odYsvj/second
[exit 0]

=== scratch fleet home tree ===
/tmp/hand-home-scenario.odYsvj/fleet
/tmp/hand-home-scenario.odYsvj/fleet/AGENTS.md
/tmp/hand-home-scenario.odYsvj/fleet/CLAUDE.md
/tmp/hand-home-scenario.odYsvj/fleet/config
/tmp/hand-home-scenario.odYsvj/fleet/data
/tmp/hand-home-scenario.odYsvj/fleet/data/backlog.md
/tmp/hand-home-scenario.odYsvj/fleet/data/dashboard.md
/tmp/hand-home-scenario.odYsvj/fleet/data/projects.md
/tmp/hand-home-scenario.odYsvj/fleet/projects
/tmp/hand-home-scenario.odYsvj/fleet/projects/app
/tmp/hand-home-scenario.odYsvj/fleet/state

SCRATCH=/tmp/hand-home-scenario.odYsvj
```
</details>
<details>
<summary>Evidence: In-repo maintainer fleet home CLI transcript (this checkout, tracked files untouched)</summary>

<code>$ cd &lt;checkout&gt;&#10;$ hand status&#10;not inside a secondhand home; run `hand init` or set HAND_HOME&#10;[exit 3]&#10;&#10;$ hand init&#10;initialized secondhand home at &lt;checkout&gt;&#10;[exit 0]&#10;&#10;$ cd &lt;checkout&gt;/cmd&#10;$ hand status&#10;[exit 0]&#10;&#10;$ cd &lt;checkout&gt;/internal/home&#10;$ hand project list&#10;[exit 0]&#10;&#10;$ git status --porcelain&#10;[empty means no tracked file changed]&#10;&#10;$ git diff --stat -- AGENTS.md CLAUDE.md&#10;[empty means the repo AGENTS.md and its CLAUDE.md symlink were left alone]&#10;&#10;(after removing the gitignored runtime)&#10;$ hand status&#10;not inside a secondhand home; run `hand init` or set HAND_HOME&#10;[exit 3]</code>

```text

=== before: the checkout is not a fleet home ===

$ cd <fleet-home>
$ hand status
not inside a secondhand home; run `hand init` or set HAND_HOME
[exit 3]

=== make the repo checkout itself the maintainer's fleet home ===

$ cd <fleet-home>
$ hand init
initialized secondhand home at <fleet-home>
[exit 0]

=== hand works from the checkout root and from any tracked subdirectory of it ===

$ cd <fleet-home>
$ hand project list
[exit 0]

$ cd <fleet-home>/cmd
$ hand status
[exit 0]

$ cd <fleet-home>/internal/home
$ hand project list
[exit 0]

=== tracked files are untouched; only gitignored runtime appeared ===

$ git status --porcelain
[empty means no tracked file changed]

$ git status --porcelain --ignored | grep -E "data|state|projects|config"
!! data/

$ git diff --stat -- AGENTS.md CLAUDE.md
[empty means the repo AGENTS.md and its CLAUDE.md symlink were left alone]

=== a relative HAND_HOME writes into the home it names, not into the working directory ===

$ cd <fleet-home>/cmd
$ HAND_HOME=.. hand notify "fleet home resolved"
notified: fleet home resolved
[exit 0]

$ grep -n "fleet home resolved" <fleet-home>/data/dashboard.md

$ ls <fleet-home>/cmd/data 2>&1
ls: cannot access '<fleet-home>/cmd/data': No such file or directory

=== cleanup: remove the gitignored runtime this check created ===

$ git status --porcelain --ignored
!! codedb.snapshot
[clean, including ignored entries]

$ cd <fleet-home>
$ hand status
not inside a secondhand home; run `hand init` or set HAND_HOME
[exit 3]
```
</details>
<details>
<summary>Evidence: config/notify hook fired from the resolved fleet home across three working directories</summary>

<code>$ cat &lt;fleet&gt;/config/notify&#10;printf &#34;%s | %s\n&#34; &#34;$HAND_MESSAGE&#34; &#34;$(pwd)&#34; &gt;&gt; &lt;fleet&gt;/data/events.log&#10;&#10;$ cd &lt;scratch&gt;/far/away &amp;&amp; HAND_HOME=&lt;fleet&gt; hand notify &#34;absolute HAND_HOME&#34; -&gt; notified&#10;$ cd &lt;scratch&gt; &amp;&amp; HAND_HOME=fleet hand notify &#34;relative HAND_HOME&#34; -&gt; notified&#10;$ cd &lt;fleet&gt;/data &amp;&amp; hand notify &#34;ancestor walk, no HAND_HOME&#34; -&gt; notified&#10;&#10;$ cat &lt;fleet&gt;/data/events.log&#10;absolute HAND_HOME | /tmp/hand-notify/far/away&#10;relative HAND_HOME | /tmp/hand-notify&#10;ancestor walk, no HAND_HOME | /tmp/hand-notify/fleet/data</code>

```text
=== a real side effect keyed to the resolved home: config/notify ===

$ cat /tmp/hand-notify.84PVgX/fleet/config/notify
printf "%s | %s\n" "$HAND_MESSAGE" "$(pwd)" >> /tmp/hand-notify.84PVgX/fleet/data/events.log

$ cd /tmp/hand-notify.84PVgX/far/away
$ HAND_HOME=/tmp/hand-notify.84PVgX/fleet hand notify "absolute HAND_HOME"
notified: absolute HAND_HOME
[exit 0]

$ cd /tmp/hand-notify.84PVgX
$ HAND_HOME=fleet hand notify "relative HAND_HOME"
notified: relative HAND_HOME
[exit 0]

$ cd /tmp/hand-notify.84PVgX/fleet/data
$ hand notify "ancestor walk, no HAND_HOME"
notified: ancestor walk, no HAND_HOME
[exit 0]

$ cat /tmp/hand-notify.84PVgX/fleet/data/events.log
absolute HAND_HOME | /tmp/hand-notify.84PVgX/far/away
relative HAND_HOME | /tmp/hand-notify.84PVgX
ancestor walk, no HAND_HOME | /tmp/hand-notify.84PVgX/fleet/data

[each line was appended by the notify hook stored in the resolved fleet home, from three different working directories]
```
</details>
<details>
<summary>Evidence: Standalone-home scenario script (reproducible)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end check of hand's fleet-home resolution.
set -u

EVID=/tmp/no-mistakes-evidence/01KZ1FBHSHZAQAB4RFP625FEB5
HAND=$EVID/hand
SCRATCH=$(mktemp -d /tmp/hand-home-scenario.XXXXXX)
export HOME_SCRATCH=$SCRATCH
unset HAND_HOME

say() { printf '\n=== %s ===\n' "$*"; }
run() {
  # run <cwd> <label> -- cmd...
  local cwd=$1; shift
  printf '\n$ cd %s\n' "$cwd"
  if [ -n "${HAND_HOME_SHOW:-}" ]; then printf '$ HAND_HOME=%s hand %s\n' "$HAND_HOME_SHOW" "$*"; else printf '$ hand %s\n' "$*"; fi
  ( cd "$cwd" && "$HAND" "$@" 2>&1 )
  printf '[exit %s]\n' "$?"
}

say "1. create a standalone fleet home in a plain directory anywhere on disk"
mkdir -p "$SCRATCH/fleet"
run "$SCRATCH/fleet" init
printf '\n$ ls -A %s\n' "$SCRATCH/fleet"
ls -A "$SCRATCH/fleet"

say "2. hand runs against that standalone home"
run "$SCRATCH/fleet" status
run "$SCRATCH/fleet" project list

say "3. seed a project clone that carries its own generic top-level data/ and state/"
mkdir -p "$SCRATCH/fleet/projects/app/data" "$SCRATCH/fleet/projects/app/state/sub"
printf 'app data\n' > "$SCRATCH/fleet/projects/app/data/notes.md"
printf -- '- app: https://github.com/org/app mode=local-only\n' >> "$SCRATCH/fleet/data/projects.md"
printf '\n$ find %s -maxdepth 2 | sort\n' "$SCRATCH/fleet/projects/app"
find "$SCRATCH/fleet/projects/app" -maxdepth 2 | sort

say "4. ancestor walk: from a nested subdirectory of the home"
run "$SCRATCH/fleet/data" project list

say "5. ancestor walk from inside the project clone skips the clone's own data/+state/ and finds the real home"
run "$SCRATCH/fleet/projects/app" project list
run "$SCRATCH/fleet/projects/app/state/sub" status

say "6. HAND_HOME lets hand run from an unrelated working directory"
export HAND_HOME="$SCRATCH/fleet"
HAND_HOME_SHOW="$SCRATCH/fleet" run /tmp project list
unset HAND_HOME

say "7. a relative HAND_HOME is absolutized, not re-resolved per working directory"
mkdir -p "$SCRATCH/elsewhere"
export HAND_HOME=fleet
HAND_HOME_SHOW=fleet run "$SCRATCH" project list
HAND_HOME_SHOW=fleet run "$SCRATCH/elsewhere" project list
unset HAND_HOME

say "8. HAND_HOME pointing at a non-home refuses (exit 3) instead of silently falling back to the real home under cwd"
export HAND_HOME="$SCRATCH/elsewhere"
HAND_HOME_SHOW="$SCRATCH/elsewhere" run "$SCRATCH/fleet" project list
unset HAND_HOME

say "9. no fleet home at or above the working directory: exit 3, actionable message"
run "$SCRATCH/elsewhere" status

say "10. hand init warns when HAND_HOME names a different home than the one being created"
mkdir -p "$SCRATCH/second"
export HAND_HOME="$SCRATCH/fleet"
HAND_HOME_SHOW="$SCRATCH/fleet" run "$SCRATCH/second" init
unset HAND_HOME

say "scratch fleet home tree"
find "$SCRATCH/fleet" -maxdepth 2 -not -path '*/projects/app/*' | sort

printf '\nSCRATCH=%s\n' "$SCRATCH"
```
</details>
<details>
<summary>Evidence: In-repo-home scenario script (reproducible)</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end check of the second supported shape: a maintainer's fleet
# home inside the secondhand repo checkout itself.
set -u

EVID=/tmp/no-mistakes-evidence/01KZ1FBHSHZAQAB4RFP625FEB5
HAND=$EVID/hand
REPO=<fleet-home>
unset HAND_HOME

say() { printf '\n=== %s ===\n' "$*"; }
run() {
  local cwd=$1; shift
  printf '\n$ cd %s\n$ hand %s\n' "$cwd" "$*"
  ( cd "$cwd" && "$HAND" "$@" 2>&1 )
  printf '[exit %s]\n' "$?"
}

say "before: the checkout is not a fleet home"
run "$REPO" status

say "make the repo checkout itself the maintainer's fleet home"
run "$REPO" init

say "hand works from the checkout root and from any tracked subdirectory of it"
run "$REPO" project list
run "$REPO/cmd" status
run "$REPO/internal/home" project list

say "tracked files are untouched; only gitignored runtime appeared"
printf '\n$ git status --porcelain\n'
( cd "$REPO" && git status --porcelain )
printf '[empty means no tracked file changed]\n'
printf '\n$ git status --porcelain --ignored | grep -E "data|state|projects|config"\n'
( cd "$REPO" && git status --porcelain --ignored | grep -E 'data|state|projects|config' )
printf '\n$ git diff --stat -- AGENTS.md CLAUDE.md\n'
( cd "$REPO" && git diff --stat -- AGENTS.md CLAUDE.md )
printf '[empty means the repo AGENTS.md and its CLAUDE.md symlink were left alone]\n'

say "a relative HAND_HOME writes into the home it names, not into the working directory"
printf '\n$ cd %s/cmd\n$ HAND_HOME=.. hand notify "fleet home resolved"\n' "$REPO"
( cd "$REPO/cmd" && HAND_HOME=.. "$HAND" notify "fleet home resolved" 2>&1 )
printf '[exit %s]\n' "$?"
printf '\n$ grep -n "fleet home resolved" %s/data/dashboard.md\n' "$REPO"
grep -n "fleet home resolved" "$REPO/data/dashboard.md"
printf '\n$ ls %s/cmd/data 2>&1\n' "$REPO"
ls "$REPO/cmd/data" 2>&1

say "cleanup: remove the gitignored runtime this check created"
rm -rf "$REPO/data" "$REPO/state" "$REPO/projects" "$REPO/config"
printf '\n$ git status --porcelain --ignored\n'
( cd "$REPO" && git status --porcelain --ignored )
printf '[clean, including ignored entries]\n'
run "$REPO" status
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>**intent** - passed</summary>

No issues found.

</details>

<details>
<summary>**Rebase** - passed</summary>

No issues found.

</details>

<details>
<summary>**Review** - 1 info</summary>

- `tests/e2e/e2e_test.go:74` - Nothing in the test harness neutralizes the new HAND_HOME variable, so a developer who follows the new README advice (&#34;Set HAND_HOME to run hand from outside the fleet home&#34;) and exports it will have `go test ./...` operate on their live fleet home. tests/e2e/e2e_test.go:74 builds a hermetic PATH and asserts no ambient backends, but runHand (line 94) only sets cmd.Dir = home and inherits the parent environment, so every e2e `hand spawn`/`teardown`/`merge`/`project add` subprocess resolves HAND_HOME instead of the temp home and writes into the real one. Same hole in cmd/fleethome_test.go:12 (mkFleetDirs builds the temp home but HAND_HOME still wins) and internal/home/home_test.go (TestResolveReturnsCwdWhenItIsAHome, TestResolveWalksUpToAnAncestorHome). Fix: os.Unsetenv(&#34;HAND_HOME&#34;) in the e2e TestMain next to the PATH hermeticity, and t.Setenv(&#34;HAND_HOME&#34;, &#34;&#34;) in mkFleetDirs and those two internal/home tests.
- `internal/home/home.go:23` - The fleet-home marker was weakened from data/dashboard.md (which the removed isWorkspace comment called &#34;the concrete, unambiguous signal since hand init is the only thing that writes it&#34;) to the presence of two of the most common top-level directory names. Combined with the ancestor walk this is silently wrong on the resolver&#39;s primary intended path: project clones live at &lt;home&gt;/projects/&lt;name&gt;, so `cd ~/fleet/projects/myapp &amp;&amp; hand status` resolves the clone as the home whenever myapp has top-level data/ and state/ directories. Read commands then report an empty fleet, and write commands (hand pr, hand spawn) create state/*.json and data/dashboard.md inside a tracked project repo. hand init still writes data/dashboard.md before calling agentsmd.Refresh (cmd/init.go:64-70), so requiring that marker in addition to the two directories costs nothing and restores the unambiguous signal. This contradicts the definition now written into SPECS.md:33 and README.md:37, so it is a deliberate-intent question rather than a mechanical fix.
- `SPECS.md:1601` - Every command can now exit 3 for a reason the authoritative exit-code table does not list: home.ErrNotFound is registered in preconditionSentinels (cmd/precondition.go:22) and 14 commands route home.Resolve() failures through asPrecondition, but the exit-3 enumeration in SPECS.md stops at gate preflight and never mentions &#34;not inside a secondhand home&#34;. CLAUDE.md names SPECS.md&#39;s &#34;Exit codes&#34; section as the owner of that table, so the new refusal is undocumented where agents and operators are told to read.
- `cmd/update.go:55` - errors.Is(refreshErr, home.ErrNotFound) matches both Resolve failure modes, because the HAND_HOME branch wraps the same sentinel (internal/home/home.go:51). So `HAND_HOME=/typo hand update` replaces the binary and then silently skips the AGENTS.md refresh with no stderr warning - exactly the silent behavior home.go&#39;s own comment says it refuses (&#34;HAND_HOME set to a directory that isn&#39;t a home fails loudly instead of silently falling back&#34;). Distinguish the two: silence only the bare-sentinel case (check os.Getenv(&#34;HAND_HOME&#34;) == &#34;&#34; first, or give the HAND_HOME branch its own sentinel) so a misconfigured HAND_HOME still warns.
- `internal/home/home.go:51` - ErrNotFound&#39;s doc comment says it &#34;renders as the full user-facing sentence on its own, so callers should not add more context around it&#34;, but Resolve wraps it anyway, producing `HAND_HOME &#34;/typo&#34;: not inside a secondhand home; run hand init or set HAND_HOME` - telling the operator to set a variable they already set. The precondition.go comment this sentinel was just added to states the same convention (&#34;A new sentinel should hold only the trailing phrase&#34;), which ErrNotFound also does not follow. Give the HAND_HOME case its own message naming the real remedy.
- `SPECS.md:1861` - SPECS.md still describes the pre-change gate and location. Line 1861 says this repo&#39;s AGENTS.md is safe because it is &#34;not a hand workspace (no data/dashboard.md)&#34; - the refresh no longer looks at dashboard.md at all, and the same change (SPECS.md:33 and 68-71) explicitly endorses an in-repo maintainer home where data/ and state/ both exist, making the stated reason false. Line 1727 still says hand update refreshes &#34;the current workspace&#34; and skips &#34;outside a workspace&#34;, which is now the HAND_HOME/ancestor-resolved fleet home. Both were missed by the doc pass the intent required.
- `README.md:6` - README&#39;s opening paragraph still states the pre-change model - &#34;A supervisory agent runs in the secondhand directory&#34; - directly above the new section explaining that most users should run a standalone fleet home anywhere on disk. Given the intent requires documenting the standalone home as the default, this is the first line a reader hits and it says the opposite.
- `cmd/init.go:55` - hand init derives its target from os.Getwd() and ignores HAND_HOME entirely, so an operator who exported HAND_HOME=~/fleet (which README.md:38 now recommends) and runs hand init from anywhere else creates a second home in the wrong place while every other command keeps using ~/fleet. init legitimately creates rather than resolves a home, so this may be intended, but the asymmetry is invisible - at minimum init could report the mismatch when HAND_HOME is set and points elsewhere.
- `cmd/precondition.go:22` - The new exit-3 refusal is exercised only at the package level (internal/home/home_test.go:109 asserts Resolve&#39;s error), never through a command. No test in cmd/ or tests/e2e asserts that running a command outside any home exits 3 with the sentinel message, so a regression in the asPrecondition wiring (cmd/precondition.go:22) or in a command&#39;s `return asPrecondition(err)` would silently downgrade it to exit 1. One e2e case running hand status from a bare temp dir and asserting code 3 covers the wiring for all 14 call sites.

Fix: harden fleet home resolution and its test isolation
2 warnings still open:
- `internal/home/home.go:66` - Resolve returns HAND_HOME verbatim without absolutizing it (internal/home/home.go:66,68), so a relative HAND_HOME yields a relative fleet home. Two concrete failures: (1) cmd/spawn.go:62 builds briefAbs := filepath.Join(home, &#34;data&#34;, id, &#34;brief.md&#34;) and passes it on the harness command line (internal/harness/harness.go:185,193,213), but the harness runs with cwd set to the treehouse worktree, so with HAND_HOME=fleet the worker is told to read &#34;fleet/data/task-1/brief.md&#34; relative to the worktree and never finds its brief - the exact absolute-path invariant CLAUDE.md states for anything named in a brief. (2) Each hand invocation re-resolves the relative value against its own working directory, so `HAND_HOME=fleet` exported in a shell makes `cd ~ &amp;&amp; hand spawn` and `cd ~/projects &amp;&amp; hand status` operate on different homes - precisely the &#34;operator ends up dispatching into the wrong fleet&#34; the resolver&#39;s own comment (lines 55-58) says it prevents. The walk-up branch is unaffected since os.Getwd returns an absolute path. cmd/init.go:227 already calls filepath.Abs on HAND_HOME before comparing, so the codebase already treats the value as possibly relative. Fix: absolutize handHome once at the top of the HAND_HOME branch, before IsHome and before returning.
- `tests/e2e/completion_store_test.go:14` - TestTeardownCompletionSurvivesMissingDashboard no longer tests a missing dashboard, and its doc comment now describes both a condition and a mechanism that are not in the body. Lines 14-16 still assert &#34;data/dashboard.md is gone from disk before teardown runs&#34;, but the fix replaced os.Remove(dashPath) with sealDir(data) - line 48 reads the file and line 65 reads it again afterward, so it is present throughout. Lines 17-21 claim &#34;the final teardown names the home through HAND_HOME instead of the walk up&#34;, but line 59 calls plain runHand with no HAND_HOME; that described approach also cannot work, because Resolve validates HAND_HOME through IsHome (internal/home/home.go:61), which now requires data/dashboard.md, so HAND_HOME pointed at a dashboard-less home returns ErrHandHomeInvalid and exit 3. The substitute fault (unwritable data/, proving no half-write) is a reasonable thing to test, but the net effect is that atqamz/secondhand#61&#39;s literal done-when condition - the completion record surviving when data/dashboard.md is actually gone - is no longer covered anywhere, since the new marker makes hand teardown exit 3 before reaching the completion path in that state. Either keep the reduced coverage and rewrite the name and comment to say what the test actually proves, or reconsider whether losing data/dashboard.md should brick every command including the teardown path built to survive it.

Fix: absolutize HAND_HOME and correct teardown test naming
1 info still open:
- `cmd/init.go:230` - warnHandHomeMismatch prints the raw HAND_HOME env value while printing the init target absolutely, so with HAND_HOME=fleet the operator gets `warning: HAND_HOME is set to fleet, so every other hand command will use that home, not /home/x/other` and cannot tell which directory `fleet` names without knowing init&#39;s working directory. The abs value is already computed one line earlier at cmd/init.go:227 and discarded, and now that home.Resolve absolutizes HAND_HOME (internal/home/home.go:64) the relative string is not what any other command will actually use. CLAUDE.md requires operator-facing paths to be full and absolute. Fix: hoist the filepath.Abs result and print it in place of handHome, falling back to the raw value only if Abs errors.

</details>

<details>
<summary>**Test** - passed</summary>

No issues found.
- `nix develop -c go test -race ./internal/home/... ./internal/agentsmd/...`
- <code>`nix develop -c go test -race ./cmd/...` (covers every command&#39;s home resolution, update&#39;s HAND_HOME refresh/warn cases, init&#39;s mismatch warning)</code>
- `nix develop -c go test -tags=e2e -timeout=10m -run 'TestExitCodeThreeOutsideAnyFleetHome|TestExitCodeThreeWhenHandHomeIsNotAFleetHome|TestExitCodeThreeOnPreconditionFailure|TestCompletionRecord' -v ./tests/e2e/...`
- `nix develop -c go test -tags=e2e -timeout=10m -run 'TestProject|TestCompletion' ./tests/e2e/...`
- <code>Manual standalone-home CLI walkthrough with a binary built from the target commit: `bash /tmp/no-mistakes-evidence/01KZ1FBHSHZAQAB4RFP625FEB5/scenario.sh` (init in a plain temp dir, ancestor walk from data/ and from a project clone holding its own data/+state/, absolute and relative HAND_HOME from unrelated cwds, HAND_HOME naming a non-home while cwd is a real home, no-home-anywhere, init under a mismatched HAND_HOME)</code>
- <code>Manual in-repo maintainer-home walkthrough in this checkout: `bash /tmp/no-mistakes-evidence/01KZ1FBHSHZAQAB4RFP625FEB5/scenario-inrepo.sh` (`hand status` exit 3 before init, `hand init` in the checkout, `hand status`/`hand project list` from repo root, `cmd/`, `internal/home/`, `git status --porcelain` and `git diff -- AGENTS.md CLAUDE.md` to confirm tracked files untouched, then runtime removed)</code>
- <code>Manual side-effect check that the resolved home drives real work: a `config/notify` hook in the fleet home fired by `hand notify` from three working directories (absolute HAND_HOME, relative HAND_HOME, ancestor walk), verified via the appended `data/events.log`</code>
- <code>`go build -o /tmp/no-mistakes-evidence/01KZ1FBHSHZAQAB4RFP625FEB5/hand .` to produce the binary used for all manual checks (removed afterwards)</code>

</details>

<details>
<summary>**Document** - 1 issue found -> auto-fixed</summary>

- `AGENTS.md:24` - The absolute-path rule still says &#34;`hand` resolves the home from the current working directory&#34;, which this change made inaccurate: hand now honors HAND_HOME first and otherwise walks ancestors of the working directory. The same sentence lives verbatim in three places - AGENTS.md:24, internal/agentsmd/agentsmd.go&#39;s generatedBody (line 47), and a hardcoded literal in internal/agentsmd/agentsmd_test.go:181 that asserts the two copies match byte-for-byte. Correcting the prose therefore requires editing the test literal, which is outside this pass&#39;s mandate (no test changes). Suggested replacement for all three: &#34;`hand` resolves the home from `HAND_HOME` or the nearest fleet-home ancestor of the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.&#34;

Fix: describe HAND_HOME resolution in absolute-path rule copies
Re-checked - no issues remain.

</details>

<details>
<summary>**Lint** - passed</summary>

No issues found.

</details>

<details>
<summary>**Push** - passed</summary>

No issues found.

</details>

