### PR TITLE
feat(home): mark a fleet home with state/hand.db instead of data/dashboard.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ hand project add https://github.com/org/repo
 `hand init` only writes runtime directories and skeleton files under the current directory; it never places a `hand` binary there.
 Install `hand` from one of the options under "Installation" below and make sure it is on `PATH` before running any command.
 
-Every `hand` command resolves its fleet home the same way: the `HAND_HOME` environment variable if set, otherwise the current directory or the nearest ancestor holding both `data/dashboard.md` and `state/`.
-`data/dashboard.md` is the marker because only `hand init` writes it, so a project clone under `projects/` never captures the walk up.
+Every `hand` command resolves its fleet home the same way: the `HAND_HOME` environment variable if set, otherwise the current directory or the nearest ancestor holding `state/hand.db`.
+`state/hand.db` is the marker because only `hand` ever writes it, so a project clone under `projects/` carrying its own generic top-level `data/` and `state/` never captures the walk up.
+A home initialized before this marker existed falls back to the marker it was initialized with, `data/dashboard.md` plus `state/`, so upgrading in place needs nothing re-run by hand.
 Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a script or a different working directory; pointed at a directory that is not a fleet home it refuses rather than falling back.
 
 ## Core concepts

--- a/SPECS.md
+++ b/SPECS.md
@@ -30,8 +30,7 @@ Secondhand keeps the concept and rebuilds the execution as a single Go CLI binar
 3. **herdr-native.** herdr provides semantic agent state (working/idle/blocked/done/unknown) and push events. Use them instead of regex-scraping terminal output. herdr's own agent state carries no task-outcome signal (see "Agent state"); the report channel is what actually tells hand whether a task finished.
 4. **Text editing stays with the agent.** The backlog is a markdown file. The agent reads and edits it directly. No CLI wrapper for text operations.
 5. **No feature without friction.** Every feature in firstmate that doesn't have a proven use case is cut. Features get added when their absence causes real pain.
-6. **A fleet home is any directory with `data/dashboard.md` and `state/`.** `hand init` creates one anywhere on disk; put `hand` on PATH and launch the agent there. The marker is the dashboard file rather than the `data/` directory because only `hand init` writes it, so a project clone under `projects/` carrying its own generic top-level `data/` and `state/` cannot capture the walk up. Maintainers dogfood a fleet home inside the secondhand repo checkout itself, with runtime state gitignored alongside the tracked code, but the CLI has no opinion about the two: `HAND_HOME`, or an ancestor of the working directory, is all it looks for.
-`state/hand.db` would be the better marker on both counts - only `hand` creates it, and unlike the dashboard it is not scheduled for deletion (atqamz/secondhand#62) - but the marker is deliberately left alone here, since changing what identifies a fleet home is its own change with its own migration.
+6. **A fleet home is any directory `state/hand.db` marks as one.** `hand init` creates the file up front; put `hand` on PATH and launch the agent there. Only `hand` ever writes it, so a project clone under `projects/` carrying its own generic top-level `data/` and `state/` cannot capture the walk up. A home initialized before this marker existed falls back to the marker it was initialized with, `data/dashboard.md` plus `state/`, so an operator upgrading in place never has to re-run anything by hand; new homes do not depend on the dashboard file at all, so deleting it (atqamz/secondhand#62) is safe. Maintainers dogfood a fleet home inside the secondhand repo checkout itself, with runtime state gitignored alongside the tracked code, but the CLI has no opinion about the two: `HAND_HOME`, or an ancestor of the working directory, is all it looks for.
 7. **The dashboard is the memory.** `data/dashboard.md` is the living document the CLI maintains. The agent reads it for context. The user watches it for visibility. No session digests, no bootstrap scripts, no 187-line status dumps.
 8. **No hooks, no guards, no callbacks.** The CLI fails closed on bad operations. Errors are CLI output, not injected hook messages. The agent reads errors and decides. No magic.
 
@@ -209,7 +208,7 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
 
 Initialize secondhand runtime directories in the current working directory.
 Creates `state/`, `data/`, `projects/`, `config/` if they don't exist.
-Creates `data/backlog.md`, `data/projects.md`, and `data/dashboard.md` with skeleton content. The machine-state database is created on first use, not here.
+Creates `data/backlog.md`, `data/projects.md`, and `data/dashboard.md` with skeleton content, and creates `state/hand.db` if it does not already exist - the fleet-home marker `IsHome` checks for (see "Core principles").
 Idempotent: safe to run multiple times.
 This is the one command that does not resolve its home: it creates the one its argument or the working directory names.
 When `HAND_HOME` is set and names some other directory it still initializes the requested target, and warns on stderr that every other command will use `HAND_HOME` instead.
@@ -1812,7 +1811,7 @@ hand init --setup
 hand init ~/fleet --setup
 ```
 
-`hand init` writes the runtime dirs (`data/`, `state/`, `config/`, `projects/`) and creates missing `data/backlog.md`, `data/projects.md`, and `data/dashboard.md` skeletons.
+`hand init` writes the runtime dirs (`data/`, `state/`, `config/`, `projects/`), creates missing `data/backlog.md`, `data/projects.md`, and `data/dashboard.md` skeletons, and creates `state/hand.db` if it is not already there.
 It also writes the generated AGENTS.md template and its CLAUDE.md symlink (see "AGENTS.md (target)").
 Other existing files are left unchanged, and an optional target path is accepted.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/atqamz/secondhand/internal/agentsmd"
+	"github.com/atqamz/secondhand/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -67,6 +68,9 @@ func newInitCmd() *cobra.Command {
 			if err := initSkeletonFiles(home); err != nil {
 				return err
 			}
+			if err := initMarker(home); err != nil {
+				return err
+			}
 			if _, err := agentsmd.Refresh(home); err != nil {
 				return err
 			}
@@ -119,6 +123,17 @@ func initSkeletonFiles(home string) error {
 		}
 	}
 	return nil
+}
+
+// initMarker creates state/hand.db up front so home.IsHome's marker exists as
+// soon as init returns, rather than waiting for the first command that
+// happens to touch machine state. store.Open is safe to call repeatedly.
+func initMarker(home string) error {
+	db, err := store.Open(home)
+	if err != nil {
+		return fmt.Errorf("create state/hand.db: %w", err)
+	}
+	return db.Close()
 }
 
 func runInteractiveSetup(cmd *cobra.Command, home string) error {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -14,6 +14,7 @@ func TestInitCreatesTheHandDbMarker(t *testing.T) {
 	t.Chdir(dir)
 
 	cmd := newInitCmd()
+	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
@@ -37,6 +38,7 @@ func TestInitIsIdempotentAboutTheHandDbMarker(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		cmd := newInitCmd()
+		cmd.SetArgs([]string{})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("run %d: %v", i+1, err)
 		}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/home"
+)
+
+func TestInitCreatesTheHandDbMarker(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newInitCmd()
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "state", "hand.db")); err != nil {
+		t.Fatalf("state/hand.db missing after init: %v", err)
+	}
+	ok, err := home.IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("got IsHome false right after init, want true")
+	}
+}
+
+func TestInitIsIdempotentAboutTheHandDbMarker(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	for i := 0; i < 2; i++ {
+		cmd := newInitCmd()
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("run %d: %v", i+1, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "state", "hand.db")); err != nil {
+		t.Fatalf("state/hand.db missing after repeat init: %v", err)
+	}
+}

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -53,15 +53,16 @@ var markerSets = [][]homeMarker{
 		{filepath.Join("state", "hand.db"), false},
 	},
 	{
+		{"data", true},
 		{filepath.Join("data", "dashboard.md"), false},
 		{"state", true},
 	},
 }
 
-// matchesMarkers checks state before state/hand.db so a state/ that turned
-// out to be a plain file, not a directory, is rejected before the nested
-// stat, which would otherwise fail with "not a directory" instead of the
-// not-exist the caller treats as a clean no-match.
+// matchesMarkers relies on every marker set listing a directory ahead of the
+// markers nested under it, so a parent that turned out to be a plain file is
+// rejected before the nested stat, which would otherwise fail with "not a
+// directory" instead of the not-exist the caller treats as a clean no-match.
 func matchesMarkers(dir string, markers []homeMarker) (bool, error) {
 	for _, m := range markers {
 		info, err := os.Stat(filepath.Join(dir, m.rel))

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -23,18 +23,46 @@ var ErrHandHomeInvalid = errors.New("is not a secondhand home; check the path or
 
 // IsHome reports whether dir is a fleet home, the one definition every caller
 // (the resolver, hand init, and agentsmd's refresh) shares. The marker is
-// data/dashboard.md, which only hand init writes, rather than the data/
-// directory itself: project clones live at <home>/projects/<name>, so a clone
-// carrying its own generic top-level data/ and state/ directories would
-// otherwise stop the ancestor walk short and be dispatched into as the home.
+// state/hand.db, which only hand ever creates (hand init writes it up front;
+// every command that touches machine state recreates it if missing), rather
+// than the state/ directory itself: project clones live at
+// <home>/projects/<name>, so a clone carrying its own generic top-level
+// data/ and state/ directories would otherwise stop the ancestor walk short
+// and be dispatched into as the home. A home initialized before this marker
+// existed falls back to the marker it was initialized with, data/dashboard.md
+// plus state/, so an operator upgrading in place never has to re-run
+// anything by hand.
 func IsHome(dir string) (bool, error) {
-	markers := []struct {
-		rel   string
-		isDir bool
-	}{
+	for _, markers := range markerSets {
+		ok, err := matchesMarkers(dir, markers)
+		if err != nil || ok {
+			return ok, err
+		}
+	}
+	return false, nil
+}
+
+type homeMarker struct {
+	rel   string
+	isDir bool
+}
+
+var markerSets = [][]homeMarker{
+	{
+		{"state", true},
+		{filepath.Join("state", "hand.db"), false},
+	},
+	{
 		{filepath.Join("data", "dashboard.md"), false},
 		{"state", true},
-	}
+	},
+}
+
+// matchesMarkers checks state before state/hand.db so a state/ that turned
+// out to be a plain file, not a directory, is rejected before the nested
+// stat, which would otherwise fail with "not a directory" instead of the
+// not-exist the caller treats as a clean no-match.
+func matchesMarkers(dir string, markers []homeMarker) (bool, error) {
 	for _, m := range markers {
 		info, err := os.Stat(filepath.Join(dir, m.rel))
 		if os.IsNotExist(err) {

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -142,6 +142,26 @@ func TestIsHomeFalseWhenDashboardIsADirNotAFile(t *testing.T) {
 	}
 }
 
+// A plain file named data must read as a clean no-match, not a stat error that
+// aborts the whole ancestor walk and fails every command.
+func TestIsHomeFalseWhenDataIsAFileNotADir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want false")
+	}
+}
+
 func TestResolveReturnsCwdWhenItIsAHome(t *testing.T) {
 	t.Setenv("HAND_HOME", "")
 	dir := t.TempDir()

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -28,9 +28,34 @@ func makeGenericDataAndState(t *testing.T, dir string) {
 	}
 }
 
+// makeHandDBHome builds a home carrying only the current marker, state/hand.db,
+// without the legacy data/dashboard.md marker a pre-upgrade home would also have.
+func makeHandDBHome(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state", "hand.db"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestIsHomeTrueWhenDashboardFileAndStateDirExist(t *testing.T) {
 	dir := t.TempDir()
 	makeHome(t, dir)
+
+	got, err := IsHome(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("got false, want true")
+	}
+}
+
+func TestIsHomeTrueWhenHandDbExistsWithoutDashboard(t *testing.T) {
+	dir := t.TempDir()
+	makeHandDBHome(t, dir)
 
 	got, err := IsHome(dir)
 	if err != nil {
@@ -157,6 +182,25 @@ func TestResolveWalksPastAProjectCloneWithGenericDataAndStateDirs(t *testing.T) 
 	t.Setenv("HAND_HOME", "")
 	home := t.TempDir()
 	makeHome(t, home)
+	clone := filepath.Join(home, "projects", "myapp")
+	makeGenericDataAndState(t, clone)
+	t.Chdir(clone)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != home {
+		t.Fatalf("got %q, want %q", got, home)
+	}
+}
+
+// A home that only carries the current marker must still survive the same
+// clone-shaped directory below it that the legacy marker had to survive.
+func TestResolveWalksPastAProjectCloneWhenAncestorHomeHasOnlyTheHandDbMarker(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	home := t.TempDir()
+	makeHandDBHome(t, home)
 	clone := filepath.Join(home, "projects", "myapp")
 	makeGenericDataAndState(t, clone)
 	t.Chdir(clone)


### PR DESCRIPTION
## Intent

make deleting data/dashboard.md safe by giving IsHome a marker no project clone can carry by accident (state/hand.db), with a legacy fallback for homes initialized before this change

Closes atqamz/secondhand#105

## What Changed

- `home.IsHome` now identifies a fleet home by `state/hand.db` (a file only `hand` ever creates) instead of `data/dashboard.md` + `state/`, so deleting the dashboard no longer breaks home resolution; the old dashboard pair stays as a fallback marker set for homes initialized before this change.
- Marker matching moved into ordered marker sets checked by `matchesMarkers`, with each set listing its parent directory first so an ancestor holding a plain file named `data` or `state` is a clean no-match rather than a "not a directory" error that aborts the ancestor walk.
- `hand init` now creates `state/hand.db` up front via `store.Open` (idempotent), so the marker exists as soon as init returns instead of on the first command that touches machine state; README and SPECS describe the new marker and the legacy fallback.
- Tests cover the new marker, the legacy fallback, the non-directory `data`/`state` cases, and init creating the database idempotently.

## Risk Assessment

Low: The change is narrowly scoped to the fleet-home marker check, matches the stated intent exactly (state/hand.db marker created up front by init, legacy data/dashboard.md + state/ fallback retained), is covered by tests for the new marker, the legacy fallback, the clone walk-past case and the non-directory edge, and all three round-1 findings were fixed correctly with docs now consistent across README.md and SPECS.md.

## Testing

Ran the targeted unit tests for the changed packages (internal/home plus the two new cmd init tests) and then drove the real `hand` binary through six operator-level scenarios: a fresh `hand init` creates `state/hand.db`; deleting `data/dashboard.md` from that home leaves `hand project list` and `hand status` fully working; running from inside a clone-shaped `projects/myapp` with its own competing registry still resolves to the fleet home above it; a legacy home with only `data/dashboard.md` + `state/` resolves through the fallback; a bare clone-shaped directory and a directory whose `data` is a plain file are both refused cleanly with exit 3 rather than a stat error, and the latter shape below a real home does not abort the ancestor walk. Each home was given a registry entry naming itself so the CLI output proves which home the resolver picked rather than merely that the command succeeded. I also verified the review commit's non-directory guard is load-bearing by temporarily removing it and watching the corresponding test fail, then restoring the file (worktree clean). No visual surface is involved - this is a CLI-only change, so the evidence is a command transcript. All checks passed; the broad regression suite was deliberately left to CI.

<details>
<summary>Evidence: End-to-end CLI transcript: hand.db marker, dashboard deletion, clone walk-past, legacy fallback</summary>

<code>=== 1. fresh home: hand init creates the state/hand.db marker ===&#10;$ hand init&#10;initialized secondhand home at /tmp/hand-e2e/fleet&#10;[exit=0]&#10;&#10;$ ls -1 /tmp/hand-e2e/fleet/state&#10;hand.db&#10;[exit=0]&#10;&#10;=== 2. delete data/dashboard.md - the home must still resolve and work ===&#10;$ rm /tmp/hand-e2e/fleet/data/dashboard.md&#10;[exit=0]&#10;&#10;$ ls -1 /tmp/hand-e2e/fleet/data&#10;backlog.md&#10;projects.md&#10;[exit=0]&#10;&#10;$ hand project list&#10;fleetapp https://github.com/org/fleetapp direct-pr&#10;[exit=0]&#10;&#10;$ hand status&#10;id project kind state age last report&#10;[exit=0]&#10;&#10;=== 3. from inside a clone-shaped projects/myapp holding its own data/ + state/ ===&#10;cwd=/tmp/hand-e2e/fleet/projects/myapp (its own registry lists cloneapp; the fleet home above lists fleetapp)&#10;$ hand project list&#10;fleetapp https://github.com/org/fleetapp direct-pr&#10;[exit=0]&#10;&#10;=== 4. legacy home: data/dashboard.md + state/ only, no state/hand.db ===&#10;$ find /tmp/hand-e2e/legacy -maxdepth 2&#10;/tmp/hand-e2e/legacy&#10;/tmp/hand-e2e/legacy/data&#10;/tmp/hand-e2e/legacy/data/dashboard.md&#10;/tmp/hand-e2e/legacy/data/projects.md&#10;/tmp/hand-e2e/legacy/state&#10;[exit=0]&#10;&#10;$ hand project list&#10;legacyapp https://github.com/org/legacyapp direct-pr&#10;[exit=0]&#10;&#10;=== 5. a bare clone-shaped directory is still not a home ===&#10;$ env HAND_HOME=/tmp/hand-e2e/notahome hand project list&#10;HAND_HOME &#34;/tmp/hand-e2e/notahome&#34; is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory&#10;[exit=3]&#10;&#10;=== 6. a plain FILE named data next to state/ - clean refusal, not a stat error ===&#10;$ env HAND_HOME=/tmp/hand-e2e/datafile hand project list&#10;HAND_HOME &#34;/tmp/hand-e2e/datafile&#34; is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory&#10;[exit=3]&#10;&#10;=== 6b. the same shape below a real home must not abort the ancestor walk ===&#10;cwd=/tmp/hand-e2e/fleet/projects/weird&#10;$ hand project list&#10;fleetapp https://github.com/org/fleetapp direct-pr&#10;[exit=0]&#10;&#10;=== state/hand.db is a real sqlite database, not a file a clone carries by accident ===&#10;$ head -c 16 /tmp/hand-e2e/fleet/state/hand.db | od -c&#10;0000000 S Q L i t e f o r m a t 3 \0</code>

```text
=== 1. fresh home: hand init creates the state/hand.db marker ===
$ /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand init
initialized secondhand home at /tmp/hand-e2e/fleet
[exit=0]

$ ls -1 /tmp/hand-e2e/fleet/state
hand.db
[exit=0]

=== 2. delete data/dashboard.md - the home must still resolve and work ===
$ rm /tmp/hand-e2e/fleet/data/dashboard.md
[exit=0]

$ ls -1 /tmp/hand-e2e/fleet/data
backlog.md
projects.md
[exit=0]

$ /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand project list
fleetapp  https://github.com/org/fleetapp  direct-pr
[exit=0]

$ /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand status
id  project  kind  state  age  last report
[exit=0]

=== 3. from inside a clone-shaped projects/myapp holding its own data/ + state/ ===
cwd=/tmp/hand-e2e/fleet/projects/myapp  (its own registry lists cloneapp; the fleet home above lists fleetapp)
$ /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand project list
fleetapp  https://github.com/org/fleetapp  direct-pr
[exit=0]


=== 4. legacy home: data/dashboard.md + state/ only, no state/hand.db ===
$ find /tmp/hand-e2e/legacy -maxdepth 2
/tmp/hand-e2e/legacy
/tmp/hand-e2e/legacy/data
/tmp/hand-e2e/legacy/data/dashboard.md
/tmp/hand-e2e/legacy/data/projects.md
/tmp/hand-e2e/legacy/state
[exit=0]

$ /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand project list
legacyapp  https://github.com/org/legacyapp  direct-pr
[exit=0]

=== 5. a bare clone-shaped directory is still not a home ===
$ env HAND_HOME=/tmp/hand-e2e/notahome /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand project list
HAND_HOME "/tmp/hand-e2e/notahome" is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory
[exit=3]

=== 6. a plain FILE named data next to state/ - clean refusal, not a stat error ===
$ env HAND_HOME=/tmp/hand-e2e/datafile /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand project list
HAND_HOME "/tmp/hand-e2e/datafile" is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory
[exit=3]

=== 6b. the same shape below a real home must not abort the ancestor walk ===
cwd=/tmp/hand-e2e/fleet/projects/weird
$ /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand project list
fleetapp  https://github.com/org/fleetapp  direct-pr
[exit=0]

=== state/hand.db is a real sqlite database, not a file a clone carries by accident ===
$ head -c 16 /tmp/hand-e2e/fleet/state/hand.db | od -c
0000000   S   Q   L   i   t   e       f   o   r   m   a   t       3  \0
0000020
```
</details>
<details>
<summary>Evidence: Reproducer script for the six-scenario CLI check</summary>

```text
#!/usr/bin/env bash
# End-to-end check of the state/hand.db fleet-home marker.
#
# Build the binary under test first, from the repo checkout:
#   nix develop --command go build -o /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand .
#
# Each home gets a registry entry naming itself, so `hand project list` output
# names which home the resolver actually picked - not just that it succeeded.
#
#   1. `hand init` creates state/hand.db up front
#   2. deleting data/dashboard.md leaves the home fully usable
#   3. the ancestor walk still skips a clone-shaped projects/<name>/{data,state}
#      even when the home above it has only the new marker
#   4. a legacy home (data/dashboard.md + state/, no hand.db) still resolves
#   5. a bare clone-shaped directory is still rejected as a home
set -u
HAND=/tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand
ROOT=/tmp/hand-e2e
unset HAND_HOME
rm -rf "$ROOT"

run() { echo "\$ $*"; "$@" 2>&1; echo "[exit=$?]"; echo; }

echo "=== 1. fresh home: hand init creates the state/hand.db marker ==="
mkdir -p "$ROOT/fleet"
cd "$ROOT/fleet" || exit 1
run "$HAND" init
run ls -1 "$ROOT/fleet/state"
printf -- '- fleetapp: https://github.com/org/fleetapp mode=direct-pr\n' >> "$ROOT/fleet/data/projects.md"

echo "=== 2. delete data/dashboard.md - the home must still resolve and work ==="
run rm "$ROOT/fleet/data/dashboard.md"
run ls -1 "$ROOT/fleet/data"
run "$HAND" project list
run "$HAND" status

echo "=== 3. from inside a clone-shaped projects/myapp holding its own data/ + state/ ==="
mkdir -p "$ROOT/fleet/projects/myapp/data" "$ROOT/fleet/projects/myapp/state"
printf '# Projects\n\n- cloneapp: https://github.com/org/cloneapp mode=direct-pr\n' \
  > "$ROOT/fleet/projects/myapp/data/projects.md"
cd "$ROOT/fleet/projects/myapp" || exit 1
echo "cwd=$(pwd)  (its own registry lists cloneapp; the fleet home above lists fleetapp)"
run "$HAND" project list
echo

echo "=== 4. legacy home: data/dashboard.md + state/ only, no state/hand.db ==="
mkdir -p "$ROOT/legacy/data" "$ROOT/legacy/state"
printf '# Dashboard\n\n## Active Tasks\n| id | project | kind | state | age | pr |\n|---|---|---|---|---|---|\n' \
  > "$ROOT/legacy/data/dashboard.md"
printf '# Projects\n\n- legacyapp: https://github.com/org/legacyapp mode=direct-pr\n' \
  > "$ROOT/legacy/data/projects.md"
cd "$ROOT/legacy" || exit 1
run find "$ROOT/legacy" -maxdepth 2
run "$HAND" project list

echo "=== 5. a bare clone-shaped directory is still not a home ==="
mkdir -p "$ROOT/notahome/data" "$ROOT/notahome/state"
cd "$ROOT/notahome" || exit 1
run env HAND_HOME="$ROOT/notahome" "$HAND" project list

echo "=== 6. a plain FILE named data next to state/ - clean refusal, not a stat error ==="
mkdir -p "$ROOT/datafile/state"
printf 'x\n' > "$ROOT/datafile/data"
run env HAND_HOME="$ROOT/datafile" "$HAND" project list
echo "=== 6b. the same shape below a real home must not abort the ancestor walk ==="
mkdir -p "$ROOT/fleet/projects/weird/state"
printf 'x\n' > "$ROOT/fleet/projects/weird/data"
cd "$ROOT/fleet/projects/weird" || exit 1
echo "cwd=$(pwd)"
run "$HAND" project list
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>**intent** - passed</summary>

No issues found.

</details>

<details>
<summary>**Rebase** - passed</summary>

No issues found.

</details>

<details>
<summary>**Review** - 3 issues found, auto-fixed</summary>

- `cmd/init_test.go:17` - Both new tests call cmd.Execute() without cmd.SetArgs(...). Cobra v1.10.2 (command.go:1105) falls back to os.Args[1:] when c.args is nil and filepath.Base(os.Args[0]) != &#34;cobra.test&#34;; the binary here is cmd.test, so the go test harness flags (-test.paniconexit0, -test.timeout=..., -test.run=...) are handed to pflag, which parses -test.paniconexit0 as shorthand flags and returns &#34;unknown shorthand flag: &#39;t&#39;&#34;. Execute() returns that error and both tests t.Fatal immediately, so TestInitCreatesTheHandDbMarker and TestInitIsIdempotentAboutTheHandDbMarker (line 40) never exercise the marker at all. Every other test in cmd/ sets args first (cmd/send_test.go:54, cmd/notify_test.go:19, cmd/gatepreflight_test.go:121). Fix: add cmd.SetArgs([]string{}) before Execute in both tests.
- `README.md:37` - README still documents the pre-change marker: line 37 says the home is &#34;the current directory or the nearest ancestor holding both `data/dashboard.md` and `state/`&#34;, and line 38 says &#34;`data/dashboard.md` is the marker because only `hand init` writes it&#34;. After this change IsHome matches state/hand.db first and only falls back to the dashboard pair for pre-upgrade homes. SPECS.md:33 was updated in the same commit; README was not, so the two docs now contradict each other and README&#39;s stated reason for the marker is the one the commit removed. Update lines 37-38 to name state/hand.db as the marker with data/dashboard.md + state/ as the legacy fallback.
- `internal/home/home.go:55` - The legacy marker set stats data/dashboard.md before anything confirms `data` is a directory - the exact hazard matchesMarkers&#39; new comment guards against for the state/hand.db set by ordering {&#34;state&#34;, true} first. If an ancestor of the working directory holds a plain file named `data`, os.Stat(&#34;&lt;dir&gt;/data/dashboard.md&#34;) returns ENOTDIR, which os.IsNotExist does not match, so matchesMarkers returns an error, IsHome propagates it, and Resolve aborts the ancestor walk with &#34;check data/dashboard.md: ... not a directory&#34; instead of treating the directory as a clean no-match - failing every hand command for that operator. Pre-existing (the old marker list had the same order) and unchanged in behavior by this diff, but now asymmetric with the guarded new set. One-line fix mirroring the new set: prepend {&#34;data&#34;, true} to the legacy marker set.

Fix: guard legacy home marker against a non-directory data path
Re-checked - no issues remain.

</details>

<details>
<summary>**Test** - passed</summary>

No issues found.
- `nix develop --command go test -race ./internal/home/...`
- <code>`nix develop --command go test -race ./cmd/ -run &#34;TestInit&#34; -v` (TestInitCreatesTheHandDbMarker, TestInitIsIdempotentAboutTheHandDbMarker)</code>
- <code>`nix develop --command go build -o /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/hand .` then ran `bash /tmp/no-mistakes-evidence/01KZ225PNGY8JKP28R7VZG29ZD/e2e-home-marker.sh` covering 6 CLI scenarios</code>
- <code>Manual: `hand init` in a fresh dir, confirmed `state/hand.db` exists and is a real SQLite file (`head -c 16 ... | od -c` -&gt; `SQLite format 3`)</code>
- <code>Manual: `rm &lt;home&gt;/data/dashboard.md` then `hand project list` and `hand status` from that home - both still resolve and work</code>
- <code>Manual: `hand project list` from inside `&lt;home&gt;/projects/myapp` holding its own `data/`+`state/` and a competing registry - resolver returned the fleet home&#39;s project (fleetapp), not the clone&#39;s (cloneapp)</code>
- <code>Manual: legacy home (`data/dashboard.md` + `state/`, no `hand.db`) - `hand project list` resolved and printed legacyapp</code>
- <code>Manual: `HAND_HOME=&lt;bare data/+state/ dir&gt; hand project list` - refused with exit 3</code>
- <code>Manual: plain FILE named `data` beside `state/` - clean refusal via HAND_HOME (exit 3), and same shape under a real home did not abort the ancestor walk</code>
- <code>Negative control: deleted the `{&#34;data&#34;, true}` guard from internal/home/home.go, `go test -count=1 ./internal/home/ -run TestIsHomeFalseWhenDataIsAFileNotADir` failed with `check data/dashboard.md: ... not a directory`; source restored, `git status --porcelain` clean</code>

</details>

<details>
<summary>**Document** - passed</summary>

No issues found.

</details>

<details>
<summary>**Lint** - passed</summary>

No issues found.

</details>

<details>
<summary>**Push** - passed</summary>

No issues found.

</details>

