### PR TITLE
fix(herdr): close the workspace herdr created when workspace create returns an unusable response

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -1038,7 +1038,7 @@ Behavior:
    refuse before acquiring any worktree if it comes back not initialized or unreachable, unless
    `--skip-gate-check` is set.
 4. Acquire a fresh treehouse worktree (with collision guard).
-5. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 7, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
+5. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 8, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
 6. Launch the worker and confirm it started (same as `hand spawn`).
 7. Rewrite the task's row in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree` and the `herdr` coordinates describe the new worker. Every field anchored to the scout's pane is reset: `done_verified` to false, `status_changed_at` restamped to the promotion time with `status_changed_for` cleared, and `last_report_state` / `last_report_note` emptied. Every pane-independent field is carried, including `created_at` and the watcher's `report_offset` - see "Pane-anchored facts across `hand promote`", which classifies each of them and covers the matching in-memory cache a live `hand watch` has to drop.
 8. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -115,37 +115,23 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
 			}
 
-			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
-			createdWorkspace := false
-			var rootTab herdr.Tab
-			var rootPane herdr.Pane
-			if err == nil && !found {
-				ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, proj.Name)
-				createdWorkspace = err == nil
-			}
+			ws, tab, pane, rollback, err := acquireTaskWorkspace(client, wt, id, proj.Name)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("herdr workspace lookup/create failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 
 			// Same rollback contract as hand spawn: until state.Write records the promotion,
 			// this call owns the new workspace or tab and must undo it on any failure; after
 			// that the promoted task owns them and later warnings must not tear them down.
 			promoted := false
-			var tabID string
 			defer func() {
 				if promoted {
 					return
 				}
-				if closeErr := rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, tabID); closeErr != nil {
+				if closeErr := rollback(); closeErr != nil {
 					err = reportSpawnCleanup(err, closeErr)
 				}
 			}()
-
-			tab, pane, err := acquireTaskTab(client, createdWorkspace, ws.WorkspaceID, wt, id, rootTab, rootPane)
-			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
-			}
-			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree:            wt,

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -112,39 +112,23 @@ func newSpawnCmd() *cobra.Command {
 			}
 
 			client := herdr.NewClient()
-			ws, found, err := client.FindWorkspaceByLabel(proj.Name)
-			createdWorkspace := false
-			var rootTab herdr.Tab
-			var rootPane herdr.Pane
-			if err == nil && !found {
-				ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, proj.Name)
-				createdWorkspace = err == nil
-			}
+			ws, tab, pane, rollback, err := acquireTaskWorkspace(client, wt, id, proj.Name)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("herdr workspace lookup/create failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 
 			// spawned disarms the rollback below once state.Write has durably recorded the
 			// task: from that point its workspace and tab are owned by the running task, not
-			// by this call, even if a later step (dashboard update) fails. Before that point,
-			// a single deferred rollback - rather than repeating the createdWorkspace check at
-			// every exit - undoes whatever this call created.
+			// by this call, even if a later step (dashboard update) fails.
 			spawned := false
-			var tabID string
 			defer func() {
 				if spawned {
 					return
 				}
-				if closeErr := rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, tabID); closeErr != nil {
+				if closeErr := rollback(); closeErr != nil {
 					err = reportSpawnCleanup(err, closeErr)
 				}
 			}()
-
-			tab, pane, err := acquireTaskTab(client, createdWorkspace, ws.WorkspaceID, wt, id, rootTab, rootPane)
-			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
-			}
-			tabID = tab.TabID
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree:            wt,
@@ -235,6 +219,36 @@ func gatePreflight(cmd *cobra.Command, proj project.Project, clonePath string, s
 		return &ExitError{Err: fmt.Errorf("no-mistakes gate not initialized for project %q, run: %s", proj.Name, project.GateInitCommand(clonePath)), Code: 3}
 	}
 	return nil
+}
+
+// acquireTaskWorkspace runs the shared spawn/promote workspace lifecycle: find or create the
+// project's herdr workspace, then acquire the task's tab within it. The returned rollback func
+// undoes whatever this call created; the caller must invoke it, guarded by its own
+// spawned/promoted flag, until state.Write durably records the task - the same ordering
+// rollbackHerdr and acquireTaskTab already encode, now installed in one place instead of once per
+// caller.
+func acquireTaskWorkspace(client *herdr.Client, wt, id, projName string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
+	ws, found, err := client.FindWorkspaceByLabel(projName)
+	createdWorkspace := false
+	var rootTab herdr.Tab
+	var rootPane herdr.Pane
+	if err == nil && !found {
+		ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, projName)
+		createdWorkspace = err == nil
+	}
+	if err != nil {
+		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, nil, fmt.Errorf("herdr workspace lookup/create failed: %w", err)
+	}
+
+	tab, pane, err := acquireTaskTab(client, createdWorkspace, ws.WorkspaceID, wt, id, rootTab, rootPane)
+	if err != nil {
+		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, nil, err
+	}
+	tabID := tab.TabID
+	rollback := func() error {
+		return rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, tabID)
+	}
+	return ws, tab, pane, rollback, nil
 }
 
 // acquireTaskTab returns the tab and pane a spawn-shaped lifecycle should use for the task. herdr

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -221,12 +221,8 @@ func gatePreflight(cmd *cobra.Command, proj project.Project, clonePath string, s
 	return nil
 }
 
-// acquireTaskWorkspace runs the shared spawn/promote workspace lifecycle: find or create the
-// project's herdr workspace, then acquire the task's tab within it. The returned rollback func
-// undoes whatever this call created; the caller must invoke it, guarded by its own
-// spawned/promoted flag, until state.Write durably records the task - the same ordering
-// rollbackHerdr and acquireTaskTab already encode, now installed in one place instead of once per
-// caller.
+// The caller must invoke the returned rollback, guarded by its own spawned/promoted flag,
+// until state.Write durably records the task.
 func acquireTaskWorkspace(client *herdr.Client, wt, id, projName string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
 	ws, found, err := client.FindWorkspaceByLabel(projName)
 	createdWorkspace := false

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -242,6 +242,9 @@ func acquireTaskWorkspace(client *herdr.Client, wt, id, projName string) (herdr.
 
 	tab, pane, err := acquireTaskTab(client, createdWorkspace, ws.WorkspaceID, wt, id, rootTab, rootPane)
 	if err != nil {
+		// No rollback reaches the caller on this path, so a workspace this call just created has
+		// to be undone here or it stays open with nobody left holding its ID.
+		err = reportSpawnCleanup(err, rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, ""))
 		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, nil, err
 	}
 	tabID := tab.TabID

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -431,6 +431,55 @@ func TestSpawnFailureClosesWorkspaceItCreated(t *testing.T) {
 	}
 }
 
+// fakeHerdrPartialWorkspaceCreateScript answers "workspace create" the way a herdr whose protocol
+// predates the tab/root_pane fields on workspace_created would: it reports the workspace but
+// omits both, the partial-response shape atqamz/secondhand#74 fixes. herdr has still created the
+// workspace by the time this responds, so a faithful fake must also accept "workspace close" and
+// log it, or a test using this script could pass with the leak fix reverted.
+const fakeHerdrPartialWorkspaceCreateScript = `#!/bin/sh
+echo "$@" >> "$HERDR_CALL_LOG"
+cmd="$1 $2"
+case "$cmd" in
+"workspace list")
+	printf '{"id":"cli:1","result":{"workspaces":[]}}'
+	;;
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
+	;;
+"workspace close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, fakeHerdrPartialWorkspaceCreateScript)
+	callLog := setupSpawnLeakEnv(t, false)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing workspace, tab, or root pane") {
+		t.Fatalf("got err %v, want the partial workspace_created response rejected", err)
+	}
+
+	if exists, existsErr := state.Exists(home, "task-1"); existsErr != nil || exists {
+		t.Fatalf("state written for a partial workspace_created response: exists=%v err=%v", exists, existsErr)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace herdr created to be closed", calls)
+	}
+}
+
 func TestSpawnFailureKeepsPreexistingWorkspace(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	setupSpawnHome(t, wt, fakeHerdrLeakScript)

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -480,6 +480,57 @@ func TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind(t *testing.T) {
 	}
 }
 
+// fakeHerdrTabRenameFailureScript answers "workspace create" in full and then fails the rename of
+// the root tab into the task's - the one failure that lands between herdr creating the workspace
+// and the caller arming its own rollback, so the workspace has to be closed by the acquisition
+// step itself.
+const fakeHerdrTabRenameFailureScript = `#!/bin/sh
+echo "$@" >> "$HERDR_CALL_LOG"
+cmd="$1 $2"
+case "$cmd" in
+"workspace list")
+	printf '{"id":"cli:1","result":{"workspaces":[]}}'
+	;;
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+	;;
+"tab rename")
+	exit 1
+	;;
+"workspace close")
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func TestSpawnTabRenameFailureClosesWorkspaceItCreated(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, fakeHerdrTabRenameFailureScript)
+	callLog := setupSpawnLeakEnv(t, false)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "herdr tab rename failed") {
+		t.Fatalf("got err %v, want the tab rename failure surfaced", err)
+	}
+
+	if exists, existsErr := state.Exists(home, "task-1"); existsErr != nil || exists {
+		t.Fatalf("state written for a failed tab rename: exists=%v err=%v", exists, existsErr)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace hand created to be closed", calls)
+	}
+}
+
 func TestSpawnFailureKeepsPreexistingWorkspace(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	setupSpawnHome(t, wt, fakeHerdrLeakScript)

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -158,21 +158,24 @@ func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, Tab, Pane, error
 		Tab       Tab       `json:"tab"`
 		RootPane  Pane      `json:"root_pane"`
 	}
-	if err := json.Unmarshal(res, &body); err != nil {
-		return Workspace{}, Tab{}, Pane{}, fmt.Errorf("parse workspace create: %w", err)
-	}
-	if body.Workspace.WorkspaceID == "" || body.Tab.TabID == "" || body.RootPane.PaneID == "" {
-		parseErr := fmt.Errorf("parse workspace create: missing workspace, tab, or root pane")
-		// A workspace ID here means herdr already created the workspace before the response
-		// came back incomplete - reachable only against a herdr whose protocol predates the
-		// tab/root_pane fields - so it must be closed here, before the parse error leaves this
-		// function, or nothing else will ever learn the workspace exists to clean it up.
+	// A workspace ID on any failure path below means herdr already created the workspace before
+	// the response came back unusable - reachable only against a herdr whose protocol predates
+	// the tab/root_pane fields - so it must be closed here, before the parse error leaves this
+	// function, or nothing else will ever learn the workspace exists to clean it up. Unmarshal
+	// keeps decoding past its first type error, so a partly-decoded body carries an ID too.
+	failed := func(parseErr error) (Workspace, Tab, Pane, error) {
 		if body.Workspace.WorkspaceID != "" {
 			if closeErr := c.WorkspaceClose(body.Workspace.WorkspaceID); closeErr != nil {
 				return Workspace{}, Tab{}, Pane{}, fmt.Errorf("%w; cleanup failed: %w", parseErr, closeErr)
 			}
 		}
 		return Workspace{}, Tab{}, Pane{}, parseErr
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return failed(fmt.Errorf("parse workspace create: %w", err))
+	}
+	if body.Workspace.WorkspaceID == "" || body.Tab.TabID == "" || body.RootPane.PaneID == "" {
+		return failed(fmt.Errorf("parse workspace create: missing workspace, tab, or root pane"))
 	}
 	return body.Workspace, body.Tab, body.RootPane, nil
 }

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -162,7 +162,17 @@ func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, Tab, Pane, error
 		return Workspace{}, Tab{}, Pane{}, fmt.Errorf("parse workspace create: %w", err)
 	}
 	if body.Workspace.WorkspaceID == "" || body.Tab.TabID == "" || body.RootPane.PaneID == "" {
-		return Workspace{}, Tab{}, Pane{}, fmt.Errorf("parse workspace create: missing workspace, tab, or root pane")
+		parseErr := fmt.Errorf("parse workspace create: missing workspace, tab, or root pane")
+		// A workspace ID here means herdr already created the workspace before the response
+		// came back incomplete - reachable only against a herdr whose protocol predates the
+		// tab/root_pane fields - so it must be closed here, before the parse error leaves this
+		// function, or nothing else will ever learn the workspace exists to clean it up.
+		if body.Workspace.WorkspaceID != "" {
+			if closeErr := c.WorkspaceClose(body.Workspace.WorkspaceID); closeErr != nil {
+				return Workspace{}, Tab{}, Pane{}, fmt.Errorf("%w; cleanup failed: %w", parseErr, closeErr)
+			}
+		}
+		return Workspace{}, Tab{}, Pane{}, parseErr
 	}
 	return body.Workspace, body.Tab, body.RootPane, nil
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -136,6 +136,46 @@ esac
 	}
 }
 
+// TestWorkspaceCreateClosesWorkspaceOnMalformedResponse covers the sibling of the partial-response
+// path: encoding/json keeps decoding past its first type error, so a response that types a field
+// wrongly still yields a workspace ID herdr has already created and this call must still close.
+func TestWorkspaceCreateClosesWorkspaceOnMalformedResponse(t *testing.T) {
+	writeFakeHerdr(t, `
+echo "$@" >> "$HERDR_CALL_LOG"
+case "$1 $2" in
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"},"tab":"none"}}'
+	;;
+"workspace close")
+	if [ "$3" != "wA" ]; then
+		echo "unexpected close target: $@" >&2
+		exit 1
+	fi
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	c := NewClient()
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
+		t.Fatal("expected an error when the response mistypes the tab field")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace herdr created to be closed", calls)
+	}
+}
+
 func TestTabRenameSendsCorrectArgs(t *testing.T) {
 	writeFakeHerdr(t, `
 if [ "$1 $2 $3 $4" != "tab rename wA:tB task-1" ]; then

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -94,6 +94,48 @@ func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
 	}
 }
 
+// TestWorkspaceCreateClosesWorkspaceOnPartialResponse pins the fix for atqamz/secondhand#74: a
+// workspace_created result missing tab or root_pane still means herdr already created the
+// workspace (reachable against a herdr whose protocol predates those fields), so WorkspaceCreate
+// must close it itself before the parse error reaches the caller - nothing downstream ever learns
+// the workspace ID otherwise.
+func TestWorkspaceCreateClosesWorkspaceOnPartialResponse(t *testing.T) {
+	writeFakeHerdr(t, `
+echo "$@" >> "$HERDR_CALL_LOG"
+case "$1 $2" in
+"workspace create")
+	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"}}}'
+	;;
+"workspace close")
+	if [ "$3" != "wA" ]; then
+		echo "unexpected close target: $@" >&2
+		exit 1
+	fi
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	c := NewClient()
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
+		t.Fatal("expected an error when the response omits the root tab and pane")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "workspace close wA") {
+		t.Fatalf("calls = %q, want the workspace herdr created to be closed", calls)
+	}
+}
+
 func TestTabRenameSendsCorrectArgs(t *testing.T) {
 	writeFakeHerdr(t, `
 if [ "$1 $2 $3 $4" != "tab rename wA:tB task-1" ]; then


### PR DESCRIPTION
Closes atqamz/secondhand#74

## Intent

Fix atqamz/secondhand#74: a workspace_created response missing tab or root_pane leaks the herdr workspace because WorkspaceCreate returns its parse error before the caller installs any rollback, and cmd/spawn.go and cmd/promote.go duplicate the entire workspace lookup/create/rollback/tab-acquisition block around the shared acquireTaskTab helper. Chose to fix the leak inside WorkspaceCreate itself (internal/herdr/client.go): on a partial response it now calls WorkspaceClose on the workspace herdr already created before returning the parse error, keeping the invariant inside the function that broke it rather than pushing a pre-parse rollback into every caller. Extracted the duplicated spawn/promote block into a new shared acquireTaskWorkspace helper in cmd/spawn.go that both commands call; the per-caller defer (spawned/promoted flag) that decides when to disarm the rollback stays in each caller since it must span later steps (harness build, pane run, confirm launch, state.Write) that are not part of the shared block. This is deliberately scoped to internal/herdr/, cmd/spawn.go, cmd/promote.go, and their tests only, per the task brief - explicitly not touching internal/store, cmd/status.go, internal/home, internal/watcher, or internal/agentsmd, which other workers are active on concurrently. Added a herdr-client-level test (TestWorkspaceCreateClosesWorkspaceOnPartialResponse) and a full spawn-path test against a herdr fake shaped like a pre-upgrade protocol (TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind); confirmed the latter fails when the client.go fix is reverted, so the fake genuinely exercises the fix rather than passing regardless (this repo has a standing fake-fidelity concern tracked in atqamz/secondhand#40). This bug is only reachable against a herdr whose protocol predates the tab/root_pane fields, so it is not an active leak against today's herdr - the PR body says this explicitly so it isn't oversold. Already rebased onto main after atqamz/secondhand#113 merged and touched the same region of cmd/spawn.go (a new hold check inserted earlier in the function); rebase was clean with no conflicts, and the full test suite, e2e suite, and lint were re-run after rebasing and pass.

## What Changed

- `WorkspaceCreate` in `internal/herdr/client.go` now routes both parse-failure returns (unmarshal error and missing `workspace`/`tab`/`root_pane`) through a `failed` helper that calls `WorkspaceClose` when the response still carried a workspace ID, so a workspace herdr already created is not left open with no caller holding its ID. This path is only reachable against a herdr whose protocol predates the `tab`/`root_pane` fields, so it is not an active leak against today's herdr.
- Extracted the workspace lookup/create plus tab acquisition block duplicated by `hand spawn` and `hand promote` into a shared `acquireTaskWorkspace` helper in `cmd/spawn.go`, which returns a rollback closure; a tab-acquisition failure inside the helper rolls back the workspace it just created, since no rollback reaches the caller on that path. Each command keeps its own `spawned`/`promoted`-guarded defer, which must span later steps outside the shared block.
- Added `TestWorkspaceCreateClosesWorkspaceOnPartialResponse` and `TestWorkspaceCreateClosesWorkspaceOnMalformedResponse` at the client level, plus `TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind` and `TestSpawnTabRenameFailureClosesWorkspaceItCreated` driving the full spawn path against a pre-upgrade-shaped herdr fake; each was confirmed to fail with its fix reverted. Corrected a stale `hand spawn` step cross-reference in the promote section of `SPECS.md`.

## Risk Assessment

Low: Both round-1 findings are correctly fixed with targeted tests that exercise the exact failure windows, the change stays inside the intent's declared scope, and the one remaining item is a not-currently-reachable sibling leak in unchanged code that is safe to handle as a follow-up.

## Testing

Ran the targeted herdr-client and spawn/promote unit tests plus the spawn/promote e2e subset (all pass), then proved the intent at the product level by driving the real `hand` CLI in a throwaway fleet home against a fake herdr that answers `workspace create` without `tab`/`root_pane`: with the target commit's binary, `hand spawn` and `hand promote` both close workspace wA/wB before surfacing the parse error, while a binary built with the `internal/herdr/client.go` fix reverted leaves the workspace open - the same contrast the new tests encode, confirmed by reverting each half of the change and watching the corresponding test fail. `hand status` shows no task state written on the failed spawn and the scout unchanged after the failed promote. This is a CLI-only change, so the reviewer-visible surface is command transcripts and backend call logs rather than screenshots. Build artifacts and scratch fleet homes were deleted; the worktree is clean.

<details>
<summary>Evidence: hand spawn against a pre-upgrade herdr - fixed binary (no leak)</summary>

<code>=== $ hand spawn task-1 myproj (herdr = pre-upgrade protocol, binary: hand-fixed) ===&#10;herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane&#10;exit status: 1&#10;&#10;=== herdr/treehouse calls hand actually made ===&#10;treehouse get --lease --json --lease-holder hand:task-1&#10;herdr workspace list&#10;herdr workspace create --no-focus --cwd .../fleet-fixed/wt --label myproj&#10;herdr workspace close wA&#10;treehouse return .../fleet-fixed/wt --force&#10;&#10;RESULT: workspace wA was closed -&gt; no leak&#10;=== task state recorded? ===&#10;id project kind state age last report</code>

```text
=== $ hand spawn task-1 myproj   (herdr = pre-upgrade protocol, binary: hand-fixed) ===
herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane
exit status: 1

=== herdr/treehouse calls hand actually made ===
treehouse get --lease --json --lease-holder hand:task-1
herdr workspace list
herdr workspace create --no-focus --cwd /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/fleet-fixed/wt --label myproj
herdr workspace close wA
treehouse return /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/fleet-fixed/wt --force

RESULT: workspace wA was closed -> no leak
=== task state recorded? ===
id  project  kind  state  age  last report
```
</details>
<details>
<summary>Evidence: hand spawn against a pre-upgrade herdr - pre-fix binary (leaks)</summary>

<code>=== $ hand spawn task-1 myproj (herdr = pre-upgrade protocol, binary: hand-leaky) ===&#10;herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane&#10;exit status: 1&#10;&#10;=== herdr/treehouse calls hand actually made ===&#10;treehouse get --lease --json --lease-holder hand:task-1&#10;herdr workspace list&#10;herdr workspace create --no-focus --cwd .../fleet-leaky/wt --label myproj&#10;treehouse return .../fleet-leaky/wt --force&#10;&#10;RESULT: workspace wA still open on the herdr server -&gt; LEAKED</code>

```text
=== $ hand spawn task-1 myproj   (herdr = pre-upgrade protocol, binary: hand-leaky) ===
herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane
exit status: 1

=== herdr/treehouse calls hand actually made ===
treehouse get --lease --json --lease-holder hand:task-1
herdr workspace list
herdr workspace create --no-focus --cwd /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/fleet-leaky/wt --label myproj
treehouse return /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/fleet-leaky/wt --force

RESULT: workspace wA still open on the herdr server -> LEAKED
=== task state recorded? ===
id  project  kind  state  age  last report
```
</details>
<details>
<summary>Evidence: hand promote through the shared acquireTaskWorkspace helper - fixed binary</summary>

<code>=== $ hand spawn task-1 myproj --scout (healthy herdr) ===&#10;spawned task-1 project=myproj kind=scout harness=claude worktree=.../promote-fixed/wt&#10;id project kind state age last report&#10;task-1 myproj scout idle (unreported) just now (none)&#10;&#10;=== herdr now answers workspace create without tab/root_pane (pre-upgrade protocol) ===&#10;=== $ hand promote task-1 (binary: hand-fixed) ===&#10;herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane&#10;exit status: 1&#10;&#10;herdr pane get wA:pC&#10;treehouse get --lease --json --lease-holder hand:task-1&#10;herdr workspace list&#10;herdr workspace create --no-focus --cwd .../promote-fixed/wt --label myproj&#10;herdr workspace close wB&#10;treehouse return .../promote-fixed/wt --force&#10;&#10;RESULT: workspace wB was closed -&gt; no leak&#10;=== task still a scout, untouched by the failed promote ===&#10;task-1 myproj scout idle (unreported) just now (none)</code>

```text
=== $ hand spawn task-1 myproj --scout   (healthy herdr) ===
spawned task-1 project=myproj kind=scout harness=claude worktree=/tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/promote-fixed/wt
exit status: 0
id      project  kind   state              age       last report
task-1  myproj   scout  idle (unreported)  just now  (none)

=== herdr now answers workspace create without tab/root_pane (pre-upgrade protocol) ===
=== $ hand promote task-1   (binary: hand-fixed) ===
herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane
exit status: 1

=== herdr/treehouse calls hand promote made ===
herdr pane get wA:pC
treehouse get --lease --json --lease-holder hand:task-1
herdr workspace list
herdr workspace create --no-focus --cwd /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/promote-fixed/wt --label myproj
herdr workspace close wB
treehouse return /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/promote-fixed/wt --force

RESULT: workspace wB was closed -> no leak
=== task still a scout, untouched by the failed promote ===
id      project  kind   state              age       last report
task-1  myproj   scout  idle (unreported)  just now  (none)
```
</details>
<details>
<summary>Evidence: hand promote - pre-fix binary (leaks wB)</summary>

<code>=== $ hand promote task-1 (binary: hand-leaky) ===&#10;herdr pane get wA:pC&#10;treehouse get --lease --json --lease-holder hand:task-1&#10;herdr workspace list&#10;herdr workspace create --no-focus --cwd .../promote-leaky/wt --label myproj&#10;treehouse return .../promote-leaky/wt --force&#10;&#10;RESULT: workspace wB still open on the herdr server -&gt; LEAKED</code>

```text
task-1  myproj   scout  idle (unreported)  just now  (none)

=== herdr now answers workspace create without tab/root_pane (pre-upgrade protocol) ===
=== $ hand promote task-1   (binary: hand-leaky) ===
herdr workspace lookup/create failed: parse workspace create: missing workspace, tab, or root pane
exit status: 1

=== herdr/treehouse calls hand promote made ===
herdr pane get wA:pC
treehouse get --lease --json --lease-holder hand:task-1
herdr workspace list
herdr workspace create --no-focus --cwd /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/promote-leaky/wt --label myproj
treehouse return /tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/promote-leaky/wt --force

RESULT: workspace wB still open on the herdr server -> LEAKED
=== task still a scout, untouched by the failed promote ===
id      project  kind   state              age       last report
task-1  myproj   scout  idle (unreported)  just now  (none)
```
</details>
<details>
<summary>Evidence: Reproduction scripts and instructions</summary>

`demo.sh and demo-promote.sh build a throwaway fleet home with fake herdr/treehouse on PATH, log every backend invocation, and report whether the workspace herdr created was closed. README.md records the two build commands (target commit vs. client.go reverted to 0680cc1).`

```text
# atqamz/secondhand#74 evidence

Reproduction of the herdr workspace leak against a herdr whose `workspace_created`
response predates the `tab`/`root_pane` fields, driven through the real `hand` CLI.

Build the two binaries (from the repo worktree):

    nix develop -c go build -o hand-fixed .                       # target commit b2f584f
    git show 0680cc1:internal/herdr/client.go > internal/herdr/client.go
    nix develop -c go build -o hand-leaky .                       # fix reverted
    git checkout -- internal/herdr/client.go

Then:

    ./demo.sh fixed          # -> fixed-run.txt
    ./demo.sh leaky          # -> leaky-run.txt
    ./demo-promote.sh fixed  # -> promote-fixed-run.txt
    ./demo-promote.sh leaky  # -> promote-leaky-run.txt

Each script builds a throwaway fleet home with a fake herdr and treehouse on PATH,
logs every backend invocation, and reports whether the workspace herdr created was
closed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>**intent** - passed</summary>

No issues found.

</details>

<details>
<summary>**Rebase** - passed</summary>

No issues found.

</details>

<details>
<summary>**Review** - 1 info</summary>

- `cmd/spawn.go:245` - acquireTaskWorkspace performs tab acquisition and returns a nil rollback on failure, but each caller&#39;s deferred rollback is only installed after the helper returns - so a tab-acquisition failure following a successful WorkspaceCreate now leaks the created workspace. In the base commit both callers installed `defer rollbackHerdr(...)` BEFORE calling acquireTaskTab, precisely so this path was covered; the extraction moved acquireTaskTab inside the helper without carrying that ordering. Concrete path: no workspace labeled myproj exists -&gt; WorkspaceCreate creates wA -&gt; client.TabRename errors -&gt; cmd/spawn.go:117 returns with only worktree.Return, wA plus its root shell stay open. Fix inside the helper (same principle as the client.go fix): on the acquireTaskTab error call rollbackHerdr(client, createdWorkspace, ws.WorkspaceID, &#34;&#34;) and join its error via reportSpawnCleanup before returning. Covers cmd/promote.go:118 through the same shared site.
- `internal/herdr/client.go:162` - The new close-on-partial-response covers only the missing-field branch; the sibling json.Unmarshal error return above it still drops a workspace herdr already created. encoding/json records the first UnmarshalTypeError and keeps decoding the remaining fields, so a response like {&#34;workspace&#34;:{&#34;workspace_id&#34;:&#34;wA&#34;,...},&#34;tab&#34;:&#34;none&#34;} populates body.Workspace, returns at line 162, and leaves wA open with nothing downstream knowing its ID - the same invariant this change moves into WorkspaceCreate. Hoist the `if body.Workspace.WorkspaceID != &#34;&#34; { WorkspaceClose(...) }` step so both error returns pass through it.

Fix: close workspace on tab-acquire and unmarshal failures
1 info still open:
- `internal/herdr/client.go:224` - Sibling of the invariant this change just moved into WorkspaceCreate, still open in TabCreate (unchanged code, but inside the intent&#39;s declared internal/herdr scope). Reachable path: workspace labeled myproj already exists -&gt; acquireTaskTab takes the TabCreate branch -&gt; a pre-upgrade herdr answers {&#34;tab&#34;:{&#34;tab_id&#34;:&#34;wA:tB&#34;},&#34;root_pane&#34;:{}} -&gt; line 225 returns a parse error with no tab ID, and acquireTaskWorkspace&#39;s new cleanup calls rollbackHerdr with createdWorkspace=false and tabID=&#34;&#34;, which is a deliberate no-op, so tab wA:tB stays open as an orphan shell in a shared workspace nobody can clean up by ID. Same reachability caveat as atqamz/secondhand#74 (only against a herdr protocol predating those fields), and the same one-place fix: give TabCreate the WorkspaceCreate treatment - a failed() helper that closes body.Tab.TabID when it is non-empty before returning the parse error, covering both the Unmarshal and missing-field returns.

</details>

<details>
<summary>**Test** - passed</summary>

No issues found.
- `nix develop -c go test -race ./internal/herdr/...`
- `nix develop -c go test -race -v -run 'TestWorkspaceCreate' ./internal/herdr/`
- `nix develop -c go test -race -v -run 'TestSpawn|TestPromote' ./cmd/`
- `nix develop -c go test -tags=e2e -timeout=10m -run 'Spawn|Promote' ./tests/e2e/...`
- <code>Revert check: restored `internal/herdr/client.go` from 0680cc1, confirmed `TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind`, `TestWorkspaceCreateClosesWorkspaceOnPartialResponse`, and `TestWorkspaceCreateClosesWorkspaceOnMalformedResponse` all FAIL, then restored the file (`git status` clean)</code>
- <code>Revert check: restored `cmd/spawn.go` from HEAD~1, confirmed `TestSpawnTabRenameFailureClosesWorkspaceItCreated` FAILs, then restored the file</code>
- <code>Manual CLI repro: `/tmp/no-mistakes-evidence/01KZ2630TA35RFX15V88XPKAS2/demo.sh fixed` and `demo.sh leaky` - real `hand spawn task-1 myproj --skip-gate-check` in a throwaway fleet home with a fake herdr whose `workspace create` omits `tab`/`root_pane`, asserting on the logged backend calls</code>
- <code>Manual CLI repro: `demo-promote.sh fixed` and `demo-promote.sh leaky` - `hand spawn --scout` against a healthy herdr, then `hand promote task-1` after flipping herdr to the pre-upgrade response shape, plus `hand status` before/after</code>

</details>

<details>
<summary>**Document** - passed</summary>

No issues found.

</details>

<details>
<summary>**Lint** - passed</summary>

No issues found.

</details>

<details>
<summary>**Push** - passed</summary>

No issues found.

</details>

