### PR TITLE
feat(cmd): add hand hold set/clear backed by a sqlite hold table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a sc
 | `hand spawn` | Spawn a worker agent in an isolated worktree | Available |
 | `hand status` | Show fleet overview or single-task detail | Available |
 | `hand send` | Send a message to a running worker | Available |
+| `hand hold set` | Record that an id is waiting on a human or on another id; survives the task's teardown, so `hand spawn` refuses to reuse a held id | Available |
+| `hand hold clear` | Clear the hold on an id | Available |
 | `hand watch` | Blocking watcher that prints actionable fleet events, including a worker gone silent with no herdr transition at all (`parked`); `--until-event` exits on the first one so the exit itself wakes the supervisory agent, and exits `5` naming any worker it can't reach before arming | Available |
 | `hand merge` | Merge a task's completed work | Available |
 | `hand pr` | Record a task's pull request URL | Available |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a sc
 - **treehouse worktrees**: workers operate in isolated git checkouts acquired from a treehouse pool, never in the project clone itself.
 - **Dashboard**: `data/dashboard.md` is the living fleet overview, auto-maintained by `hand`. The agent reads it for context; the user watches it for visibility.
 - **Backlog**: `data/backlog.md` is a plain markdown task queue, read and edited directly by the supervisory agent.
-- **Machine state vs. the prose corpus**: machine state - tasks, PR state, pane ids, the project registry - is authoritative in sqlite at `state/hand.db`. The prose under `data/` stays authoritative in files, with a derived full-text index at `state/index.db` that `hand search` reads and that is safe to delete at any time. When the database and a `state/<id>.status` file disagree about what a worker said, believe the file: it is readable without a working `hand`, which is what recovery has actually needed - see SPECS.md's "Machine state and the prose corpus" section.
+- **Machine state vs. the prose corpus**: machine state - tasks, PR state, pane ids, the project registry, holds - is authoritative in sqlite at `state/hand.db`. The prose under `data/` stays authoritative in files, with a derived full-text index at `state/index.db` that `hand search` reads and that is safe to delete at any time. When the database and a `state/<id>.status` file disagree about what a worker said, believe the file: it is readable without a working `hand`, which is what recovery has actually needed - see SPECS.md's "Machine state and the prose corpus" section.
 
 ## CLI overview
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -138,13 +138,14 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
       client.go             # API calls: create tab, get state, send keys
       types.go              # herdr data types
     store/                  # machine state in sqlite (see "Machine state and the prose corpus")
-      store.go              # schema, task and project rows, meta keys
+      store.go              # schema, task, project and hold rows, meta keys
       lock.go               # named flocks over state/, shared by state and the import
       migrate.go            # one-way import of pre-sqlite state/<id>.json and data/projects.md
       index.go              # derived full-text index over the prose corpus
     state/                  # task state management, a thin facade over store
       task.go               # read/write/list task rows
-      types.go              # Task struct aliases
+      hold.go               # set/clear/read/list hold rows (see "Holds")
+      types.go              # Task and Hold struct aliases
       report.go             # read/classify state/<id>.status (see "Report channel")
       pr.go                 # PR URL validation and extraction
     worktree/               # treehouse integration
@@ -177,7 +178,7 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
 
   # gitignored runtime (created by `hand init`)
   state/                    # machine state, the report channel, and the durable completion store
-    hand.db                 # authoritative machine state: tasks, PR state, pane ids, report offsets, projects
+    hand.db                 # authoritative machine state: tasks, PR state, pane ids, report offsets, projects, holds
     index.db                # derived full-text index over data/, safe to delete at any time
     migrated/               # pre-sqlite state/<id>.json files, moved aside once imported
     <id>.status             # worker-to-supervisor report channel, worker-written, hand-read-only
@@ -674,6 +675,7 @@ Behavior (ship task):
 8. Keep `data/<id>/brief.md` for history (the agent can prune old briefs).
 
 The report channel goes because it is the volatile wake log, not a deliverable: a task respawned under a used ID starts at `report_offset` 0, so a surviving log would be replayed as this run's - re-raising decisions already resolved, absorbing a genuine unexplained stop as one already seen, and auto-recording a PR URL out of the previous run's `done` line onto a task nobody recorded it for. The durable deliverables under `data/<id>/` survive teardown, as before; keeping a torn-down task's wake history would be its own feature with its own reason, not a side effect of cleanup.
+A hold on the id is not removed either, deliberately - it is not task-scoped, so it outlives the row and keeps an unanswered question visible, which is also why `hand spawn` then refuses the id until `hand hold clear` (see "Holds" under "State management").
 
 Behavior (scout task):
 1. Check `data/<id>/report.md` exists (the report is the deliverable).
@@ -1794,9 +1796,9 @@ An existing fleet home has live state on disk, and the import has to meet it wit
 
 - `0`: success.
 - `1`: general error.
-- `2`: usage error: wrong argument count, unknown flag, unknown command or subcommand, mutually exclusive or mutually dependent flags (`hand watch --timeout` without `--until-event`), an invalid argument or flag value (malformed project URL, unknown project mode or harness, unparsable `--poll` duration, a non-positive `--timeout`).
+- `2`: usage error: wrong argument count, unknown flag, unknown command or subcommand, a required flag left out (`hand hold set --reason`), mutually exclusive or mutually dependent flags (`hand watch --timeout` without `--until-event`, `hand hold set --blocked-on` on any kind but `blocked` and its absence on a `blocked` one), an invalid argument or flag value (malformed project URL, unknown project mode, harness or hold kind, unparsable `--poll` duration, a non-positive `--timeout`).
   A value the invocation did not supply is not a usage error: the same malformed value read from a `config/` default is a general error (code `1`).
-- `3`: precondition failed, meaning the command refuses because the world is not in the state it requires: unlanded work, red CI, a missing or unmerged PR, a missing brief or report, a task or project that does not exist, a task in the wrong kind or state (already merged, not a completed scout, already claimed by another command), a project name or worktree already taken, a project still referenced by active tasks, a PR that conflicts with one already recorded for a task or doesn't belong to the task's project's repo (`hand pr`), a PR that `gh pr view` can't confirm exists (`hand pr`), a task branch whose PRs do not resolve to a single usable winner (`hand teardown`), a `no-mistakes`-mode project whose gate is not initialized (`hand spawn`, `hand promote` - see "Gate preflight").
+- `3`: precondition failed, meaning the command refuses because the world is not in the state it requires: unlanded work, red CI, a missing or unmerged PR, a missing brief or report, a task, project or hold that does not exist, an id carrying an open hold (`hand spawn`), a task in the wrong kind or state (already merged, not a completed scout, already claimed by another command), a project name or worktree already taken, a project still referenced by active tasks, a PR that conflicts with one already recorded for a task or doesn't belong to the task's project's repo (`hand pr`), a PR that `gh pr view` can't confirm exists (`hand pr`), a task branch whose PRs do not resolve to a single usable winner (`hand teardown`), a `no-mistakes`-mode project whose gate is not initialized (`hand spawn`, `hand promote` - see "Gate preflight").
   Two more apply to every command, since each one resolves a fleet home before it does anything: the working directory has no fleet home at or above it and `HAND_HOME` is unset, or `HAND_HOME` is set to a directory that is not a fleet home. The second refuses rather than falling back to the walk up, because a silent fallback is how an operator dispatches into the wrong fleet.
 - `4`: no event delivered, only from `hand watch --until-event`: its `--timeout` elapsed, or it was signaled, without a transition. This includes the timeout elapsing anywhere in arming, the herdr reachability probe as well as the per-task probe sweep - the window is over either way, and no one task is at fault. Distinct from `0` because there the exit *is* the event delivery, and from `1` because the watcher itself did not fail (see "Delivering an event to a supervisory agent").
 - `5`: arm-time probe failure, only from `hand watch --until-event`: one named task's herdr pane answered its pre-wait probe with a failure, named on stderr. Distinct from `4` because a specific worker is at fault and can be acted on, and from `0` because nothing was delivered (see "Delivering an event to a supervisory agent").
@@ -1840,6 +1842,7 @@ CI therefore installs no real herdr or treehouse.
 - Migration of a pre-sqlite fleet home the suite builds by hand, run twice.
 - Promote scout-to-ship cycle.
 - Collision guard with concurrent tasks.
+- Hold lifecycle: set, every `hand status` surface, surviving the teardown of the task it was set on, the spawn refusal on the reused id, and clear.
 
 ### No test categories from firstmate
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -359,10 +359,11 @@ Behavior:
    refuse before touching any task or worktree state if it comes back not initialized or
    unreachable, unless `--skip-gate-check` is set.
 3. Validate no active task with this ID exists.
-4. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
-5. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
-6. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in the store. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
-7. Acquire the task's herdr tab in the project's workspace.
+4. Validate no hold is set on this ID (see "Holds" under "State management"). A hold survives the teardown of the task it was set on, so reusing the id for new work would reattach the previous incarnation's open question to an unrelated task; the error names `hand hold clear <id>` as the remedy.
+5. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
+6. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
+7. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in the store. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
+8. Acquire the task's herdr tab in the project's workspace.
    - Workspace naming: one workspace per project, named after the project.
    - Tab naming: task ID.
    - If the project's workspace does not exist yet, create it at the worktree's cwd. herdr has no
@@ -370,15 +371,15 @@ Behavior:
      this reuses that root tab as the task's tab (renamed to the task ID) instead of creating a
      second one, which would leave the root tab behind as an orphan shell in the workspace.
    - If the workspace already exists, create a new tab in it for the task.
-8. Construct the harness launch command from the template (see harness section).
-9. Send the launch command to the herdr pane.
-10. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
+9. Construct the harness launch command from the template (see harness section).
+10. Send the launch command to the herdr pane.
+11. Confirm the worker actually started: poll the pane until herdr reports a live agent on it and
    no first-run dialog is left, answering any known dialog along the way, or the poll window
    elapses (see Harness launch templates).
-11. Write the task's row with all metadata.
-12. Update `data/dashboard.md` with the new task.
+12. Write the task's row with all metadata.
+13. Update `data/dashboard.md` with the new task.
 
-Any failure before step 11 leaves nothing behind: the worktree lease returns to treehouse and the
+Any failure before step 12 leaves nothing behind: the worktree lease returns to treehouse and the
 herdr side is rolled back.
 A workspace this command created is closed whole: the task's tab is that workspace's own
 auto-created root tab, so there is nothing else in it to preserve.
@@ -398,6 +399,7 @@ Errors:
   command; see "Gate preflight"). Skipped entirely with `--skip-gate-check`.
 - `no-mistakes` binary missing or not runnable, distinct from the above (see "Gate preflight").
 - Task ID already active.
+- Task ID has an open hold (names `hand hold clear <id>` as the remedy).
 - Brief not found at `data/<id>/brief.md`.
 - Treehouse worktree acquisition failed (pool exhausted, git error).
 - Worktree collision with another active task (names the conflicting task).
@@ -1194,7 +1196,7 @@ Only the append-only sections have per-command rules, because only they carry an
 
 A mutating command re-renders the whole file, and the derived sections follow from the store and the report channel wherever the write came from.
 It re-renders unconditionally, never after testing whether its own effect reached a section: `hand promote` changes the `kind` the Active Tasks row derives, while `hand project sync` and `hand merge`'s PR path may leave every derived value identical, and a command that had to know which case it was in would be deciding from outside the render what the render already answers.
-Three commands still write nothing at all: `hand send` and `hand notify` reach a worker without touching the store, and `hand merge --local` writes only a merge flag no section reads and runs no project sync.
+Five commands still write nothing at all: `hand send` and `hand notify` reach a worker without touching the store, `hand hold set` and `hand hold clear` mutate only the `hold` table, which no section of this file derives from (see "Holds" under "State management"), and `hand merge --local` writes only a merge flag no section reads and runs no project sync.
 
 Recent Completions is a capped view, not the record of truth: every entry `hand teardown` moves here also lands, uncapped, in `state/completions.jsonl` first (see "Completion store" under `hand teardown`), so the 10-entry cap loses nothing that store still has.
 
@@ -1736,6 +1738,8 @@ Two kinds, no others invented without a new issue:
 
 Set with `hand hold set`, which upserts - a second call on the same id replaces its kind, reason, and blocked-on, so narrowing down a reason is a re-run, not a clear-then-set. Cleared with `hand hold clear`, which deletes the row outright: no residue survives a clear for `hand status` to find later.
 
+**Surviving teardown makes id reuse a hazard, so `hand spawn` refuses a held id.** The same standalone row that keeps a torn-down task's question visible would otherwise reattach it to whatever new work claimed the id next, which is the replay hazard `Delete` already guards against for the report channel by removing `state/<id>.status` (see "Report channel"). The report channel is a volatile wake log and can simply be discarded; a hold is operator-authored, so `hand spawn` refuses with exit 3 and names `hand hold clear <id>` rather than clearing it silently - answering the question is an acknowledgement `hand` has no business making on the operator's behalf. Clearing the hold is therefore the explicit step that says the question is settled, and it is the only escape hatch, since a `--force`-style flag would be the silent clear wearing a different name.
+
 **A hold that cannot be read must never read as nothing waiting.** `ListHolds`/`ReadHold` surface every row exactly as stored, inconsistent ones included - filtering here is what would let an external write's mistake silently disappear from "what is held" - and `hand status` flags an inconsistent row (an unrecognized `kind`, a `blocked` hold with no `blocked_on`, or an `operator` hold carrying one) rather than rendering it as if it were valid. A store-level failure to read holds at all - not a single bad row, the whole read - propagates as a hard error out of `hand status`, fleet or single-task, rather than degrading to an empty list: this is the one place in `hand status` that does not fail open on a read, because an empty `held:` block and "the store couldn't be read" look identical unless the second one is a fatal error instead.
 
 ### Concurrency
@@ -1854,7 +1858,7 @@ These are explicit non-goals. Each lists the firstmate feature it replaces and w
 | AFK daemon | `fm-supervise-daemon.sh`, `fm-afk-launch.sh` (2,150 lines) | `hand watch --until-event` as the agent's own background task covers the awake path; `hand notify` is meant to cover the AFK half but is not wired to anything yet (atqamz/secondhand#80). |
 | Multiple backends | `backends/herdr.sh`, `backends/cmux.sh`, `backends/zellij.sh`, `backends/orca.sh`, `fm-backend.sh` (5,500 lines) | herdr only. Add tmux fallback later if herdr proves insufficient. |
 | Dispatch profiles | `fm-dispatch-select.sh`, `config/crew-dispatch.json` (340 lines + skill) | Pass `--harness`/`--model`/`--effort` explicitly, declare `model`/`effort` in the brief, or set defaults in `config/`. |
-| Decision holds | `fm-decision-hold.sh`, decision-hold-lifecycle skill (500 lines) | Agent tracks decisions in backlog and dashboard. |
+| Decision holds | `fm-decision-hold.sh`, decision-hold-lifecycle skill (500 lines) | No longer cut: `hand hold set`/`hand hold clear` record a hold in the store and `hand status` renders it (see "Holds" under "State management"). Only the lifecycle skill wrapped around it stays out. |
 | Hook-based guards | `fm-continuity-pretool-check.sh`, `fm-continuity-command-policy.mjs`, `fm-subagent-pretool-check.sh` (450 lines) | CLI refuses bad operations internally. No hooks. |
 | PR-check migration | `fm-pr-check-migrate.sh` (1,148 lines) | No legacy to migrate. |
 | Fleet snapshot / bearings | `fm-fleet-snapshot.sh`, `fm-bearings-snapshot.sh` (1,860 lines) | `hand status --json` and `data/dashboard.md` cover it. |

--- a/SPECS.md
+++ b/SPECS.md
@@ -69,7 +69,7 @@ They follow the brief, do the work, and report through herdr's agent state.
 
 A fleet home holds two kinds of state, and they have different owners.
 
-**Machine state is authoritative in sqlite**, at `state/hand.db`: the task registry, PR state, herdr pane and tab ids, `hand watch`'s report offsets, and the project registry.
+**Machine state is authoritative in sqlite**, at `state/hand.db`: the task registry, PR state, herdr pane and tab ids, `hand watch`'s report offsets, the project registry, and holds (see `hand hold set` and "Holds" under "State management").
 It is what `hand` writes and what `hand` reads back.
 Nothing derives it from a file, and no view is assembled by re-reading a rendering of it.
 
@@ -460,6 +460,7 @@ Behavior (fleet overview):
 3. Append the worker's own last classified report to the same column as ` (reported: <state>)`, whatever the pane is doing. A pane state and a report answer different questions, so both print: a worker that appends `paused:` while its harness keeps running used to render as a bare `working`, showing the pane and hiding the only party that had said why. `working` is the one report that stays unadorned, because it is what the column already says. ` (unreported)` still requires a not-busy pane (herdr's `idle` or `done` - see "Agent state" below), since a busy pane that has not reported yet is not a stop anyone has to explain. A report file that exists but can't be read appends ` (report unreadable)`, never ` (unreported)` - an I/O fault is not evidence the worker never reported.
 4. If the task has a recorded PR, append its merge state to the same column: ` (merged)` when `hand` performed the merge, ` (merged, external)` when `hand` only observed it - `hand watch`'s own `gh` poll saw it merged, or gate-opened-PR detection recorded a PR that was already merged. It is appended whatever the agent state is, since a merged PR is a fact about the PR rather than about the pane.
 5. Print one line per task, with a header row.
+6. List every hold in the store (see "Holds" under "State management") and print a `held:` block below the task table, one line per hold, skipped entirely when nothing is held. A hold names any id, not only a live task's, so a torn-down task's still-open hold keeps appearing here after its task row is gone. A failure to read the holds fails the whole command rather than degrading to an empty list - reading no holds back must never be mistaken for nothing being held.
 
 The `last report` column is the mtime of `state/<id>.status`, and `(none)` when the worker has never written one.
 It is deliberately not the task's age: the two used to be conflated, so a task spawned hours ago read as hours stale next to a status file its worker had touched minutes earlier - a reporting worker that looked abandoned.
@@ -475,14 +476,21 @@ stuck-task   nsr      ship   idle (unreported)                         1h ago  (
 paused-task  nsr      ship   idle (reported: needs-decision)           30m ago 12m ago
 investigate  nsr      scout  done (reported: done)                     10m ago 9m ago
 shipped-fix  nsr      ship   done (reported: done) (merged, external)  5m ago  4m ago
+
+held:
+  fix-login         operator  two ways to fix this, needs a call          2h ago
+  torn-down-task    operator  question never answered                    1d ago
 ```
+
+A hold row that can't be trusted at face value - an unrecognized kind, a `blocked` hold with no `blocked_on`, or an `operator` hold carrying one - is still printed, never dropped, with `inconsistent: <why>` in place of its detail: an external write to `state/hand.db` is the only way such a row exists, since `hand hold set` validates before writing, and filtering it out here would silently drop the row most worth seeing.
 
 Behavior (single task):
 1. Read the task from the store.
 2. If the task is a `ship` task with no PR recorded and its project is registered and not `local-only`: look for a PR on the project's repo whose head ref is the task's current branch (never matched on title, issue number, or task id), and record it under the task and in the Active Tasks PR column if found - a no-mistakes gate's own `pr` step opens a PR directly, bypassing `hand pr`, so `pr` can go unrecorded for genuinely landed work. A branch carrying several PRs resolves by preference tier - merged, then open, then closed-unmerged - and only when the winning tier holds exactly one PR: a tier with more than one match is ambiguous, and so is a merged PR coexisting with an open one on the same head ref - an open PR is live evidence the branch may carry unlanded work, so that mix refuses rather than resolving to the merged PR. A `scout` task is skipped: its deliverable is `data/<id>/report.md`, never a PR. This is a best-effort, non-blocking lookup (a held task lock, an unreachable `gh`, an ambiguous branch, or a task with no branch all just leave the command reporting what it read) so a fleet-wide `hand status` never pays this cost.
 3. Query herdr for current agent state and recent output.
 4. Read the last 5 lines of the task's report channel (see "Report channel"). A report file that exists but can't be read degrades exactly as it does in the fleet overview: the `Reported` line reads `report unreadable: <error>` and the rest of the detail view still prints, rather than the command failing and showing nothing.
-5. Print detailed view, including the most recent reported line and a labeled history block.
+5. Read the hold on this id, if any (see "Holds" under "State management"). Unlike the report channel, a failure to read it fails the command - the same reasoning as the fleet overview's `held:` block.
+6. Print detailed view, including the most recent reported line and a labeled history block.
 
 Output (single task):
 ```
@@ -499,12 +507,15 @@ Last report: 3m ago
 PR:          (none)
 Reported:    needs-decision: two ways to fix the race, ask-user found both risky
 Report file: /home/user/secondhand/state/fix-login.status
+Held:        waiting on migrate-schema: needs the new column before this can proceed
 
 Report history (reported by worker, not verified current truth):
   working: added the retry loop
 ```
 
 The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the same merge suffix the fleet overview appends: `PR:          https://github.com/org/repo/pull/42 (merged, external)`.
+
+The `Held:` line is present only when this id has a hold, and reads the reason alone for an `operator` hold or `waiting on <blocked_on>: <reason>` for a `blocked` one; an inconsistent row (see the fleet overview above) prints `inconsistent: <why>` instead.
 
 atqamz/secondhand#65: a worker's report prose has run several KB for a single task, and rendering it in full doubled the cost by repeating the latest entry - once as `Reported:`, again as the last line of `Report history`. Without `--full`:
 - The `Reported` line and every history line are capped to 200 runes (a character budget, not a word or line count, since the point is bounding rendered size). The cut lands after the state-vocabulary prefix (`working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, `failed:`) - the prefix is never part of what's cut - and a cut line always carries a trailing `... [+N chars]` marker naming how much was dropped, so a short report is never mistaken for a truncated one. `done: <PR url>` stays intact under this budget in the common case, since the worker convention puts the URL immediately after the prefix and 200 runes covers it comfortably; a URL buried after long prose is the same brief-authoring problem the write side already owns (see "Report channel").
@@ -533,15 +544,26 @@ Output (JSON, single task):
   "created_at": "2026-07-24T08:00:00Z",
   "last_report_at": "2026-07-24T09:57:00Z",
   "reported": {"state": "needs-decision", "note": "two ways to fix the race, ask-user found both risky"},
-  "report_history": ["working: added the retry loop", "needs-decision: two ways to fix the race, ask-user found both risky"]
+  "report_history": ["working: added the retry loop", "needs-decision: two ways to fix the race, ask-user found both risky"],
+  "held": {"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"}
 }
 ```
 
-`reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. In fleet-overview JSON, only `reported` is included (no history) per row.
+`reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. `held` is omitted when this id has no hold; an inconsistent hold (see the fleet overview above) adds an `inconsistent` field naming why instead of being omitted.
+
+Fleet-overview JSON wraps the per-task rows rather than returning a bare array, so holds - which can outlive the task that had them - have somewhere to sit alongside it:
+
+```json
+{
+  "tasks": [{"id": "fix-login", "...": "one row per task, reported only, no history"}],
+  "holds": [{"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"}]
+}
+```
 
 Errors:
 - Task ID not found.
 - Herdr unreachable (graceful degradation: show state as "unknown").
+- The hold store can't be read (fails the command; never degrades to an empty `holds`/no `held` - see "Holds" under "State management").
 
 ---
 
@@ -568,6 +590,59 @@ Errors:
 - Task not found.
 - Herdr pane doesn't exist (agent died, tab closed).
 - Composer not empty after timeout (agent busy, message queued or refused).
+
+---
+
+### `hand hold set <id> --kind <kind> --reason <reason> [--blocked-on <id>]`
+
+Record that an id is waiting on something (atqamz/secondhand#63). See "Holds" under "State management" for the design this command exposes.
+
+```
+hand hold set fix-login --kind operator --reason "two ways to fix this, needs a call"
+hand hold set fix-login --kind blocked --reason "waiting on the migration task" --blocked-on migrate-schema
+```
+
+`<id>` is any id, not only a live task's - see "Holds" for why. It is validated with the same charset as a task id (`state.ValidateID`), never read back against the task table.
+
+Flags:
+- `--kind`: `operator` (waiting on a human) or `blocked` (waiting on another id). Required.
+- `--reason`: why the id is waiting. Required.
+- `--blocked-on`: the id being waited on. Required for `--kind blocked`, refused for `--kind operator`.
+
+Behavior:
+1. Validate `--kind`, `--reason`, and the `--blocked-on` pairing.
+2. Upsert the hold row - a second `hand hold set` on the same id replaces the previous kind, reason, and blocked-on rather than requiring a clear first, and refreshes `set_at` to when it was last set.
+
+Output:
+```
+hold set on fix-login (kind=operator)
+```
+
+Errors:
+- Invalid `--kind` (exit 2).
+- Missing `--reason` (exit 2).
+- `--blocked-on` missing for a `blocked` hold, or given for an `operator` hold (exit 2).
+
+---
+
+### `hand hold clear <id>`
+
+Clear the hold on an id.
+
+```
+hand hold clear fix-login
+```
+
+Behavior:
+1. Delete the hold row. Leaves no residue - a subsequent `hand status` shows nothing held for this id.
+
+Output:
+```
+hold cleared on fix-login
+```
+
+Errors:
+- No hold set on `<id>` (exit 3).
 
 ---
 
@@ -1613,6 +1688,7 @@ Delivery modes:
   The one exception is `state/<id>.status`, the worker-to-supervisor report channel (see "Report channel" below): herdr's agent state answers "is the pane busy," not "why did it stop" or "what actually happened," and that gap is exactly what caused done/blocked/needs-decision to go unreported in production. This file is not a second copy of herdr's state - it's a channel for information herdr has no way to carry, and it exists only because that specific gap caused a real incident, per principle 5 (no feature without friction).
   This is the strongest argument for the whole design: herdr's `idle`/`done` split (see "Agent state") carries no task-outcome information at all for `hand`'s headless deployment, only whether a human happened to be looking at the time. The report channel isn't a supplement to herdr's status for learning how a task ended - it's the only source of that information there is.
 - **Event log for crash recovery.** `state/events.log` is a bounded rotating log (last 200 lines) of actionable watcher events. Not for real-time consumption - the watcher prints to stdout for that. The log exists so a restarted agent can read recent history that happened while its context was down.
+- **Holds are their own table, not a task column.** See "Holds" below for the full reasoning: a task-scoped hold would be destroyed by `hand teardown` exactly when it matters most.
 
 ### Report channel
 
@@ -1645,6 +1721,22 @@ Read/classify semantics:
 - Each classified line becomes a `report-*` event (see `hand watch`) and updates the task's last-known report state, which `hand watch`'s idle classifier and `hand status`'s report suffix both consult. Both answer from the last line that *classified*, never simply the last line - `hand watch` by only advancing its carried state on one, `hand status` by skipping trailing malformed lines when it re-reads the file - so free text appended after a real report cannot erase it or make the two commands answer differently about the same quiet pane. The Active Tasks `state` column is this same last classified line, derived on every render rather than written by an event, so the row cannot disagree with `hand status` about it (see "Derived sections").
 - **A `done` report is never trusted alone.** A worker's belief that it's finished is a claim, not a fact; it's cross-checked against completion evidence the worker didn't produce before it's allowed to change agent state or clear a pending decision, and until then it surfaces as "reported-done", not "done" (see `classifyReportDone` in `internal/watcher/events.go`). Each task kind has its own evidence: a ship task's merge (`merged` written by `hand merge`, whichever route it took - a PR merge or a `--local` fast-forward that leaves no PR at all - or a recorded PR the watcher's own `gh pr view` poll saw merged), and a scout task's `data/<id>/report.md` - the deliverable `hand promote` itself requires. The ship check never asks which mode the project uses. Evidence usually arrives *after* the `done` line is consumed, so the watcher re-checks every tick and fires the verified `done` event once, when the evidence lands (`ClassifyDeferredDone`) - including when it landed while the watcher was stopped, since the announcement is tracked by the durable `done_verified` marker rather than re-derived from whatever evidence is on disk at startup (see "What survives a `hand watch` restart").
 - A line carrying exactly one PR URL auto-records it on a task that doesn't have one yet, exactly as if `hand pr` had been called - including `hand pr`'s full validation (repo-slug match against the project clone's origin remote, plus the `gh pr view` existence check), since a recorded PR is what `hand merge` later merges for real. Both paths call the one shared `project.ValidatePR`. Neither kind of miss aborts the watcher: an attempted recording that did not complete raises `pr-not-recorded` with the underlying error appended, flattened onto the event's single line, and its remedy is a human running `hand pr`, which reconciles whatever half is missing; one the task lock kept the watcher from even attempting raises `pr-record-unknown`, which claims nothing about the outcome and points at `hand status`. The report line is consumed either way, so both go to the event stream and `state/events.log` rather than only to stderr. The one exception is silent by design: losing the lock race to the `hand pr` recording that very URL is not a failure, so the watcher re-reads the task and says nothing when the URL is already on record. A line with more than one URL, or a task that already has a PR recorded, is left alone so `hand pr`'s own explicit-mismatch refusal stays the single path for correcting a wrong record.
+
+### Holds
+
+A hold (atqamz/secondhand#63) records that an id is waiting on something, so "what needs the operator" is derived from the store rather than authored by hand in `data/backlog.md` - that file stays out of scope for holds entirely; a design that finds itself parsing it has gone wrong.
+
+**A hold is its own row, keyed by an arbitrary id, not a foreign key into the task table.** The alternative - a column or side table hanging off a task row - was rejected: it would fit the common case, but `hand teardown` deletes the task row, so a hold set on a task torn down while its question stayed open would vanish exactly when it matters most. A standalone row survives that teardown, which is the motivating case the issue names - work with no task row behind it, either never dispatched or torn down mid-question.
+
+A second, independent reason favors the same answer: atqamz/secondhand#111 found that `Open` has no schema-version mechanism - it applies `schema` with `CREATE TABLE IF NOT EXISTS`, which is a correct create against a table that does not exist yet but a silent no-op against one that exists and is merely missing a new column, with no error and no column added. Adding a `blocked_on`-style column to the existing `task` table would pass every test (which build fresh databases) and silently fail to apply to any already-migrated `state/hand.db` on disk. A brand-new `hold` table sidesteps the gap entirely: every existing database is missing the whole table, so `CREATE TABLE IF NOT EXISTS` takes the create branch, not the no-op one, on both a fresh database and a migrated one. atqamz/secondhand#111 itself is not fixed here - it remains open for whatever change first needs to alter an existing table.
+
+Two kinds, no others invented without a new issue:
+- `operator`: waiting on a human. `reason` says what for.
+- `blocked`: waiting on another id. `reason` says what for, `blocked_on` names the id.
+
+Set with `hand hold set`, which upserts - a second call on the same id replaces its kind, reason, and blocked-on, so narrowing down a reason is a re-run, not a clear-then-set. Cleared with `hand hold clear`, which deletes the row outright: no residue survives a clear for `hand status` to find later.
+
+**A hold that cannot be read must never read as nothing waiting.** `ListHolds`/`ReadHold` surface every row exactly as stored, inconsistent ones included - filtering here is what would let an external write's mistake silently disappear from "what is held" - and `hand status` flags an inconsistent row (an unrecognized `kind`, a `blocked` hold with no `blocked_on`, or an `operator` hold carrying one) rather than rendering it as if it were valid. A store-level failure to read holds at all - not a single bad row, the whole read - propagates as a hard error out of `hand status`, fleet or single-task, rather than degrading to an empty list: this is the one place in `hand status` that does not fail open on a read, because an empty `held:` block and "the store couldn't be read" look identical unless the second one is a fatal error instead.
 
 ### Concurrency
 
@@ -1682,6 +1774,7 @@ An existing fleet home has live state on disk, and the import has to meet it wit
 - **The whole import runs under one named lock**, the same primitive that guards a command sequence elsewhere, because it spans files sqlite cannot see. Without it two `hand` processes opening a not-yet-migrated home interleave: one parses a file, the other imports it, archives it and then deletes the row under `hand teardown`, and the first lands its insert afterwards and resurrects a torn-down task. It is a lock of its own, not the project registry's, since `hand project add` and `remove` already hold that one when they trigger the registry import.
 - **A legacy file that will not parse stops the import and names the file**, rather than importing the rest and leaving an operator to notice a task went missing. Moving the named file aside is the way forward.
 - There is no reverse migration. The `state/migrated/` copies are what a rollback would read.
+- **A new table needs no migration step of its own, and a new column would need one this codebase does not have.** `Open` runs the whole `schema` string, `CREATE TABLE IF NOT EXISTS` and all, on every open - not only the first. That statement is correct for a table an existing database is missing outright, which is why adding the `hold` table was sufficient on its own for an existing `state/hand.db` to gain it on its next open. It is a silent no-op for a column an existing table is missing, since sqlite has already satisfied "if not exists" at the table level and never looks at the column list again - there is no schema-version check anywhere in this package to catch that gap (atqamz/secondhand#111, filed and left open, not fixed by this change). Holds are a new table for exactly this reason among others; see "Holds" above.
 
 ## Error handling
 

--- a/cmd/hold.go
+++ b/cmd/hold.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/home"
+	"github.com/atqamz/secondhand/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newHoldCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hold",
+		Short: "Set or clear a hold recording what an id is waiting on",
+	}
+	cmd.AddCommand(newHoldSetCmd())
+	cmd.AddCommand(newHoldClearCmd())
+	return cmd
+}
+
+func newHoldSetCmd() *cobra.Command {
+	var kind, reason, blockedOn string
+
+	cmd := &cobra.Command{
+		Use:   "set <id>",
+		Short: "Set a hold on an id, live task or not",
+		Args:  usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			if err := validateHoldKind(kind); err != nil {
+				return err
+			}
+			if reason == "" {
+				return &ExitError{Err: fmt.Errorf("--reason is required"), Code: 2}
+			}
+			if kind == state.HoldKindBlocked && blockedOn == "" {
+				return &ExitError{Err: fmt.Errorf("--blocked-on is required for a %s hold", state.HoldKindBlocked), Code: 2}
+			}
+			if kind != state.HoldKindBlocked && blockedOn != "" {
+				return &ExitError{Err: fmt.Errorf("--blocked-on only applies to a %s hold", state.HoldKindBlocked), Code: 2}
+			}
+
+			home, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+
+			h := state.Hold{
+				ID: id, Kind: kind, Reason: reason, BlockedOn: blockedOn,
+				SetAt: time.Now().UTC().Format(time.RFC3339),
+			}
+			if err := state.SetHold(home, h); err != nil {
+				return asPrecondition(err)
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "hold set on %s (kind=%s)\n", id, kind); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&kind, "kind", "", "hold kind: operator or blocked")
+	cmd.Flags().StringVar(&reason, "reason", "", "why the id is waiting")
+	cmd.Flags().StringVar(&blockedOn, "blocked-on", "", "id being waited on (blocked holds only)")
+	return cmd
+}
+
+func validateHoldKind(kind string) error {
+	switch kind {
+	case state.HoldKindOperator, state.HoldKindBlocked:
+		return nil
+	default:
+		return &ExitError{Err: fmt.Errorf("invalid hold kind %q: must be %s or %s", kind, state.HoldKindOperator, state.HoldKindBlocked), Code: 2}
+	}
+}
+
+func newHoldClearCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear <id>",
+		Short: "Clear the hold on an id",
+		Args:  usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+
+			home, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+
+			if err := state.ClearHold(home, id); err != nil {
+				return asPrecondition(err)
+			}
+
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "hold cleared on %s\n", id); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/hold_test.go
+++ b/cmd/hold_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+func setupHoldHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	return home
+}
+
+func TestHoldSetOperator(t *testing.T) {
+	home := setupHoldHome(t)
+
+	cmd := newHoldSetCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"fix-login", "--kind", "operator", "--reason", "needs a call"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "fix-login") {
+		t.Fatalf("out = %q, want it to name the id", out.String())
+	}
+
+	got, found, err := state.ReadHold(home, "fix-login")
+	if err != nil || !found {
+		t.Fatalf("ReadHold = %v, %v", found, err)
+	}
+	if got.Kind != state.HoldKindOperator || got.Reason != "needs a call" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestHoldSetBlocked(t *testing.T) {
+	home := setupHoldHome(t)
+
+	cmd := newHoldSetCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"fix-login", "--kind", "blocked", "--reason", "waiting on migration", "--blocked-on", "other-task"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, found, err := state.ReadHold(home, "fix-login")
+	if err != nil || !found {
+		t.Fatalf("ReadHold = %v, %v", found, err)
+	}
+	if got.Kind != state.HoldKindBlocked || got.BlockedOn != "other-task" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestHoldSetUpsertsReason(t *testing.T) {
+	home := setupHoldHome(t)
+
+	run := func(reason string) {
+		cmd := newHoldSetCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetArgs([]string{"fix-login", "--kind", "operator", "--reason", reason})
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run("first reason")
+	run("narrowed down reason")
+
+	got, _, err := state.ReadHold(home, "fix-login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Reason != "narrowed down reason" {
+		t.Fatalf("got %+v, want the second set to win", got)
+	}
+
+	holds, err := state.ListHolds(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(holds) != 1 {
+		t.Fatalf("ListHolds = %+v, want the upsert to leave a single row", holds)
+	}
+}
+
+func TestHoldSetRejectsInvalidKind(t *testing.T) {
+	setupHoldHome(t)
+
+	cmd := newHoldSetCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"fix-login", "--kind", "waiting-room", "--reason", "needs a call"})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestHoldSetRequiresReason(t *testing.T) {
+	setupHoldHome(t)
+
+	cmd := newHoldSetCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"fix-login", "--kind", "operator"})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestHoldSetRequiresBlockedOnForBlockedKind(t *testing.T) {
+	setupHoldHome(t)
+
+	cmd := newHoldSetCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"fix-login", "--kind", "blocked", "--reason", "needs a call"})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestHoldSetRejectsBlockedOnForOperatorKind(t *testing.T) {
+	setupHoldHome(t)
+
+	cmd := newHoldSetCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"fix-login", "--kind", "operator", "--reason", "needs a call", "--blocked-on", "other-task"})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestHoldClear(t *testing.T) {
+	home := setupHoldHome(t)
+	if err := state.SetHold(home, state.Hold{ID: "fix-login", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newHoldClearCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"fix-login"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "fix-login") {
+		t.Fatalf("out = %q, want it to name the id", out.String())
+	}
+
+	_, found, err := state.ReadHold(home, "fix-login")
+	if err != nil || found {
+		t.Fatalf("ReadHold after clear = %v, %v, want gone", found, err)
+	}
+}
+
+func TestHoldClearMissing(t *testing.T) {
+	setupHoldHome(t)
+
+	cmd := newHoldClearCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"nope"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !errors.Is(err, state.ErrHoldNotFound) {
+		t.Fatalf("err = %v, want ErrHoldNotFound", err)
+	}
+}

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -18,6 +18,7 @@ import (
 var preconditionSentinels = []error{
 	state.ErrTaskNotFound,
 	state.ErrTaskActive,
+	state.ErrHoldNotFound,
 	project.ErrNotFound,
 	home.ErrNotFound,
 	home.ErrHandHomeInvalid,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func newRootCmd(version string) *cobra.Command {
 	root.AddCommand(newSpawnCmd())
 	root.AddCommand(newStatusCmd())
 	root.AddCommand(newSendCmd())
+	root.AddCommand(newHoldCmd())
 	root.AddCommand(newTeardownCmd())
 	root.AddCommand(newWatchCmd())
 	root.AddCommand(newMergeCmd())

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -58,6 +58,19 @@ func newSpawnCmd() *cobra.Command {
 			}
 			defer releaseClaim()
 
+			// A hold outlives the task row it was set on, by design, so a torn-down
+			// task's open question stays visible. Reusing the id for new work would
+			// silently reattach that question to an unrelated task, so refuse here
+			// rather than clearing it: the hold is operator-authored, and answering it
+			// is an acknowledgement hand has no business making on the operator's behalf.
+			held, hasHold, err := state.ReadHold(home, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			if hasHold {
+				return &ExitError{Err: fmt.Errorf("id %q has an open hold (%s: %s); clear it first: hand hold clear %s", id, held.Kind, held.Reason, id), Code: 3}
+			}
+
 			briefRel := filepath.Join("data", id, "brief.md")
 			briefAbs := filepath.Join(home, briefRel)
 			if _, err := os.Stat(briefAbs); err != nil {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -202,6 +202,46 @@ func TestSpawnRejectsAlreadyActiveTask(t *testing.T) {
 	}
 }
 
+// A hold survives the teardown of the task it was set on, so the id it names can
+// be free while its question is still open. Reusing that id has to refuse rather
+// than reattach the old question to unrelated work.
+func TestSpawnRejectsHeldIDWithNoTaskRow(t *testing.T) {
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), "open hold") || !strings.Contains(err.Error(), "hand hold clear task-1") {
+		t.Fatalf("got err %v, want an open-hold refusal naming the remedy", err)
+	}
+	if _, readErr := state.Read(home, "task-1"); !errors.Is(readErr, state.ErrTaskNotFound) {
+		t.Fatalf("got %v, want no task row written for a refused spawn", readErr)
+	}
+}
+
+func TestSpawnAcceptsIDWhoseHoldWasCleared(t *testing.T) {
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.ClearHold(home, "task-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.Read(home, "task-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSpawnRejectsMissingBrief(t *testing.T) {
 	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
 	if err := os.Remove(filepath.Join(home, "data", "task-1", "brief.md")); err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -106,6 +106,71 @@ type statusJSON struct {
 	LastReportAt   string        `json:"last_report_at,omitempty"`
 	Reported       *reportedJSON `json:"reported,omitempty"`
 	ReportHistory  []string      `json:"report_history,omitempty"`
+	Held           *holdJSON     `json:"held,omitempty"`
+}
+
+// fleetJSON wraps the task rows with the fleet's holds, which name any id -
+// not only a live task - so a torn-down task's still-open hold keeps
+// surfacing here after its task row is gone.
+type fleetJSON struct {
+	Tasks []statusJSON `json:"tasks"`
+	Holds []holdJSON   `json:"holds"`
+}
+
+// holdJSON mirrors state.Hold, plus Inconsistent, which is set instead of the
+// row being dropped when a value can't be trusted at face value - see
+// holdInconsistency.
+type holdJSON struct {
+	ID           string `json:"id"`
+	Kind         string `json:"kind"`
+	Reason       string `json:"reason"`
+	BlockedOn    string `json:"blocked_on,omitempty"`
+	SetAt        string `json:"set_at"`
+	Inconsistent string `json:"inconsistent,omitempty"`
+}
+
+// holdInconsistency names why a hold row can't be trusted at face value, so
+// that ListHolds surfacing every row (rather than filtering) turns into a
+// visible flag instead of a silently wrong render: an unrecognized kind, a
+// blocked hold with nothing to point at, or an operator hold carrying a
+// blocked_on nothing set. Nothing in this codebase writes such a row today -
+// only hand hold set, which validates first - so seeing one here means
+// something outside hand touched state/hand.db directly.
+func holdInconsistency(h state.Hold) string {
+	switch h.Kind {
+	case state.HoldKindOperator:
+		if h.BlockedOn != "" {
+			return fmt.Sprintf("operator hold carries a blocked_on %q", h.BlockedOn)
+		}
+		return ""
+	case state.HoldKindBlocked:
+		if h.BlockedOn == "" {
+			return "blocked hold has no blocked_on"
+		}
+		return ""
+	default:
+		return fmt.Sprintf("unrecognized kind %q", h.Kind)
+	}
+}
+
+func holdToJSON(h state.Hold) holdJSON {
+	return holdJSON{
+		ID: h.ID, Kind: h.Kind, Reason: h.Reason, BlockedOn: h.BlockedOn, SetAt: h.SetAt,
+		Inconsistent: holdInconsistency(h),
+	}
+}
+
+// holdDetail renders a hold's non-identifying fields for the plain-text held
+// block. An inconsistency takes over the whole line: a garbled blocked-on or
+// reason next to it would read as a valid detail rather than as the flag it is.
+func holdDetail(h state.Hold) string {
+	if inc := holdInconsistency(h); inc != "" {
+		return "inconsistent: " + inc
+	}
+	if h.Kind == state.HoldKindBlocked {
+		return fmt.Sprintf("waiting on %s: %s", h.BlockedOn, h.Reason)
+	}
+	return h.Reason
 }
 
 func mergeSuffix(t state.Task) string {
@@ -123,6 +188,12 @@ func mergeSuffix(t state.Task) string {
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool) error {
 	tasks, err := state.List(home)
+	if err != nil {
+		return err
+	}
+	// Propagated rather than degraded to an empty list: a store fault reading
+	// as no holds is exactly the false all-clear this feature exists to avoid.
+	holds, err := state.ListHolds(home)
 	if err != nil {
 		return err
 	}
@@ -149,9 +220,13 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 	}
 
 	if asJSON {
+		holdRows := make([]holdJSON, 0, len(holds))
+		for _, h := range holds {
+			holdRows = append(holdRows, holdToJSON(h))
+		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(rows)
+		return enc.Encode(fleetJSON{Tasks: rows, Holds: holdRows})
 	}
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
@@ -163,7 +238,28 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 			return err
 		}
 	}
-	return w.Flush()
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	return printHeldBlock(cmd, holds)
+}
+
+// printHeldBlock is skipped entirely when holds is empty, so a fleet with
+// nothing waiting prints exactly what it did before this feature existed.
+func printHeldBlock(cmd *cobra.Command, holds []state.Hold) error {
+	if len(holds) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "\nheld:"); err != nil {
+		return err
+	}
+	hw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	for _, h := range holds {
+		if _, err := fmt.Fprintf(hw, "  %s\t%s\t%s\t%s\n", h.ID, h.Kind, holdDetail(h), formatAge(h.SetAt)); err != nil {
+			return err
+		}
+	}
+	return hw.Flush()
 }
 
 // A stat fault reads the same as no report at all: the column is a staleness
@@ -220,6 +316,12 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	t = detectPRForStatus(cmd.Context(), home, t)
 	agentState := paneAgentStatus(client, t.Herdr.PaneID)
 
+	// Propagated, not degraded: see the same comment in runStatusFleet.
+	hold, held, err := state.ReadHold(home, id)
+	if err != nil {
+		return err
+	}
+
 	// An unreadable report degrades exactly as it does in the fleet view: the
 	// fault is named on the Reported line and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
@@ -235,6 +337,12 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		last = tail[len(tail)-1]
 	}
 
+	var heldJSON *holdJSON
+	if held {
+		j := holdToJSON(hold)
+		heldJSON = &j
+	}
+
 	if asJSON {
 		out := statusJSON{
 			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
@@ -242,6 +350,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 			MergeExecuted: t.MergeExecuted, MergeAnnounced: t.MergeAnnounced, CreatedAt: t.CreatedAt,
 			LastReportAt: lastReportAt(home, id),
 			Reported:     reportedFrom(last, len(tail) > 0, readErr), ReportHistory: history,
+			Held: heldJSON,
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -283,6 +392,9 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		fmt.Sprintf("Last report: %s", formatReportAge(lastReportAt(home, id))),
 		fmt.Sprintf("PR:          %s", pr),
 		fmt.Sprintf("Reported:    %s", reported),
+	}
+	if held {
+		lines = append(lines, fmt.Sprintf("Held:        %s", holdDetail(hold)))
 	}
 	if !full && (len(tail) > 0 || readErr != nil) {
 		lines = append(lines, fmt.Sprintf("Report file: %s", state.ReportPath(home, id)))

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/secondhand/internal/store"
 )
 
 // writeFakeHerdrPaneStatus fakes "pane get" as a query command per
@@ -118,10 +119,13 @@ func TestStatusFleetJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), `"id": "task-1"`) || !strings.Contains(out.String(), `"agent_state": "working"`) {
-		t.Fatalf("got %q, want JSON array with task-1 and agent_state working", out.String())
+		t.Fatalf("got %q, want tasks array with task-1 and agent_state working", out.String())
 	}
-	if !strings.HasPrefix(strings.TrimSpace(out.String()), "[") {
-		t.Fatalf("got %q, want JSON array", out.String())
+	if !strings.Contains(out.String(), `"holds": []`) {
+		t.Fatalf("got %q, want an empty holds array", out.String())
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out.String()), "{") {
+		t.Fatalf("got %q, want a JSON object wrapping tasks and holds", out.String())
 	}
 }
 
@@ -948,5 +952,254 @@ func TestStatusSingleTaskJSONIncludesReportedAndHistory(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"report_history"`) {
 		t.Fatalf("got %q, want report_history in JSON", out.String())
+	}
+}
+
+func TestStatusFleetShowsHeldBlock(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	if err := state.SetHold(home, state.Hold{ID: "fix-login", Kind: state.HoldKindOperator,
+		Reason: "needs a call", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "held:") {
+		t.Fatalf("got %q, want a held block", got)
+	}
+	if !strings.Contains(got, "fix-login") || !strings.Contains(got, "operator") || !strings.Contains(got, "needs a call") {
+		t.Fatalf("got %q, want the hold's id, kind, and reason", got)
+	}
+}
+
+// A hold outliving its task is the case the standalone hold table exists for;
+// this pins that hand status still surfaces it once the task row is gone.
+func TestStatusFleetShowsHeldBlockWithNoTaskRowBehindIt(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	if err := state.SetHold(home, state.Hold{ID: "torn-down-task", Kind: state.HoldKindOperator,
+		Reason: "question never answered", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "torn-down-task") {
+		t.Fatalf("got %q, want the hold shown despite no task row", out.String())
+	}
+}
+
+func TestStatusFleetOmitsHeldBlockWithoutHolds(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "working")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "held:") {
+		t.Fatalf("got %q, want no held block when nothing is held", out.String())
+	}
+}
+
+func TestStatusFleetFlagsInconsistentHold(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetHold(store.Hold{ID: "weird", Kind: "not-a-real-kind", Reason: "who knows"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `inconsistent: unrecognized kind "not-a-real-kind"`) {
+		t.Fatalf("got %q, want the inconsistent hold flagged rather than silently rendered", out.String())
+	}
+}
+
+func TestStatusFleetJSONFlagsInconsistentHold(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetHold(store.Hold{ID: "weird", Kind: state.HoldKindBlocked, Reason: "who knows"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"inconsistent": "blocked hold has no blocked_on"`) {
+		t.Fatalf("got %q, want the inconsistency named in JSON", out.String())
+	}
+}
+
+// A store fault reading holds must fail the whole command rather than degrade
+// to an empty holds list, which would read as "nothing is waiting" - exactly
+// the false all-clear this feature exists to avoid.
+func TestStatusFleetPropagatesAnUnreadableHoldStore(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := os.MkdirAll(store.Path(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("got nil error, want the unreadable hold store to fail the command")
+	}
+}
+
+func TestStatusSingleTaskShowsHeldLine(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindBlocked,
+		Reason: "waiting on migration", BlockedOn: "task-2", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Held:        waiting on task-2: waiting on migration") {
+		t.Fatalf("got %q, want a Held line naming what it waits on", out.String())
+	}
+}
+
+func TestStatusSingleTaskOmitsHeldLineWithoutAHold(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "Held:") {
+		t.Fatalf("got %q, want no Held line without a hold", out.String())
+	}
+}
+
+func TestStatusSingleTaskJSONIncludesHeld(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator,
+		Reason: "needs a call", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"held"`) || !strings.Contains(out.String(), `"needs a call"`) {
+		t.Fatalf("got %q, want the held hold in JSON", out.String())
+	}
+}
+
+// The same false-all-clear risk as the fleet view, one task at a time.
+func TestStatusSingleTaskPropagatesAnUnreadableHoldStore(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(store.Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Path(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("got nil error, want the unreadable hold store to fail the command")
 	}
 }

--- a/internal/state/hold.go
+++ b/internal/state/hold.go
@@ -1,0 +1,57 @@
+package state
+
+import "github.com/atqamz/secondhand/internal/store"
+
+// ErrHoldNotFound is wrapped into errors returned by ClearHold when no hold
+// row exists for the given ID, rendering as `hold "<id>" not found`.
+var ErrHoldNotFound = store.ErrHoldNotFound
+
+func SetHold(homeDir string, h Hold) error {
+	if err := ValidateID(h.ID); err != nil {
+		return err
+	}
+	if h.Kind == HoldKindBlocked {
+		if err := ValidateID(h.BlockedOn); err != nil {
+			return err
+		}
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetHold(h)
+}
+
+func ClearHold(homeDir, id string) error {
+	if err := ValidateID(id); err != nil {
+		return err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ClearHold(id)
+}
+
+func ReadHold(homeDir, id string) (Hold, bool, error) {
+	if err := ValidateID(id); err != nil {
+		return Hold{}, false, err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Hold{}, false, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ReadHold(id)
+}
+
+func ListHolds(homeDir string) ([]Hold, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ListHolds()
+}

--- a/internal/state/hold_test.go
+++ b/internal/state/hold_test.go
@@ -1,0 +1,70 @@
+package state
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSetReadClearHoldRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	hold := Hold{ID: "fix-login", Kind: HoldKindOperator, Reason: "needs a call", SetAt: "2026-07-24T10:00:00Z"}
+
+	if err := SetHold(dir, hold); err != nil {
+		t.Fatal(err)
+	}
+	got, found, err := ReadHold(dir, "fix-login")
+	if err != nil || !found {
+		t.Fatalf("ReadHold = %v, %v", found, err)
+	}
+	if got != hold {
+		t.Fatalf("got %+v, want %+v", got, hold)
+	}
+
+	if err := ClearHold(dir, "fix-login"); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := ReadHold(dir, "fix-login"); err != nil || found {
+		t.Fatalf("ReadHold after clear = %v, %v, want gone", found, err)
+	}
+}
+
+func TestClearHoldMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := ClearHold(dir, "nope"); !errors.Is(err, ErrHoldNotFound) {
+		t.Fatalf("ClearHold error = %v, want ErrHoldNotFound", err)
+	}
+}
+
+func TestListHoldsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	holds, err := ListHolds(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(holds) != 0 {
+		t.Fatalf("got %+v, want empty", holds)
+	}
+}
+
+func TestHoldRejectsUnsafeIDs(t *testing.T) {
+	dir := t.TempDir()
+	for _, id := range []string{"../escape", "nested/task", "", "."} {
+		if err := SetHold(dir, Hold{ID: id, Kind: HoldKindOperator}); err == nil {
+			t.Errorf("SetHold accepted unsafe ID %q", id)
+		}
+		if _, _, err := ReadHold(dir, id); err == nil {
+			t.Errorf("ReadHold accepted unsafe ID %q", id)
+		}
+		if err := ClearHold(dir, id); err == nil {
+			t.Errorf("ClearHold accepted unsafe ID %q", id)
+		}
+	}
+}
+
+func TestSetHoldRejectsUnsafeBlockedOn(t *testing.T) {
+	dir := t.TempDir()
+	err := SetHold(dir, Hold{ID: "fix-login", Kind: HoldKindBlocked, BlockedOn: "../escape"})
+	if err == nil {
+		t.Fatal("SetHold accepted unsafe blocked-on id")
+	}
+}

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -10,9 +10,15 @@ const (
 	KindScout = store.KindScout
 )
 
+const (
+	HoldKindOperator = store.HoldKindOperator
+	HoldKindBlocked  = store.HoldKindBlocked
+)
+
 // Aliases rather than separate structs: the store owns the columns these map
 // to, and a second definition would be one more place to forget a field.
 type (
 	Herdr = store.Herdr
 	Task  = store.Task
+	Hold  = store.Hold
 )

--- a/internal/store/hold_test.go
+++ b/internal/store/hold_test.go
@@ -1,0 +1,157 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func sampleHold() Hold {
+	return Hold{
+		ID: "fix-login", Kind: HoldKindOperator, Reason: "race condition needs a call",
+		SetAt: "2026-07-24T10:00:00Z",
+	}
+}
+
+func TestSetReadHoldPreservesEveryField(t *testing.T) {
+	db, _ := openTemp(t)
+	want := sampleHold()
+	if err := db.SetHold(want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, found, err := db.ReadHold(want.ID)
+	if err != nil || !found {
+		t.Fatalf("ReadHold = %v, %v", found, err)
+	}
+	if got != want {
+		t.Fatalf("round trip lost a field:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func TestSetHoldUpsertsInPlace(t *testing.T) {
+	db, _ := openTemp(t)
+	hold := sampleHold()
+	if err := db.SetHold(hold); err != nil {
+		t.Fatal(err)
+	}
+	hold.Reason = "actually two ways to fix this, need a call"
+	if err := db.SetHold(hold); err != nil {
+		t.Fatal(err)
+	}
+
+	holds, err := db.ListHolds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(holds) != 1 || holds[0].Reason != hold.Reason {
+		t.Fatalf("ListHolds = %+v", holds)
+	}
+}
+
+func TestReadHoldReportsAMissingHoldWithoutAnError(t *testing.T) {
+	db, _ := openTemp(t)
+	_, found, err := db.ReadHold("nope")
+	if err != nil || found {
+		t.Fatalf("ReadHold = %v, %v", found, err)
+	}
+}
+
+// TestHoldSurvivesWithNoTaskRowBehindIt pins the design decision that makes a
+// hold cover the motivating case: it is its own row keyed by an arbitrary id,
+// not a foreign key into task, so a hold set on a task torn down while its
+// question stayed open still answers "what needs the operator" after
+// DeleteTask removes the task row that used to carry it.
+func TestHoldSurvivesWithNoTaskRowBehindIt(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.WriteTask(Task{ID: "fix-login"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetHold(sampleHold()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DeleteTask("fix-login"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, found, err := db.ReadHold("fix-login")
+	if err != nil || !found {
+		t.Fatalf("ReadHold after task teardown = %v, %v, want found", found, err)
+	}
+}
+
+func TestClearHoldLeavesNoResidue(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.SetHold(sampleHold()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ClearHold("fix-login"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, found, err := db.ReadHold("fix-login")
+	if err != nil || found {
+		t.Fatalf("ReadHold after clear = %v, %v, want gone", found, err)
+	}
+	holds, err := db.ListHolds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(holds) != 0 {
+		t.Fatalf("ListHolds after clear = %+v, want empty", holds)
+	}
+}
+
+func TestClearHoldMissing(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.ClearHold("nope"); !errors.Is(err, ErrHoldNotFound) {
+		t.Fatalf("ClearHold error = %v, want ErrHoldNotFound", err)
+	}
+}
+
+func TestListHoldsSortedAndEmpty(t *testing.T) {
+	db, _ := openTemp(t)
+	holds, err := db.ListHolds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(holds) != 0 {
+		t.Fatalf("got %+v, want empty", holds)
+	}
+
+	for _, id := range []string{"zebra", "apple", "mango"} {
+		if err := db.SetHold(Hold{ID: id, Kind: HoldKindOperator}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	holds, err = db.ListHolds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"apple", "mango", "zebra"}
+	for i, id := range want {
+		if holds[i].ID != id {
+			t.Errorf("holds[%d].ID = %q, want %q", i, holds[i].ID, id)
+		}
+	}
+}
+
+// TestListHoldsSurfacesEveryRowRegardlessOfKind pins the read side of the
+// design decision in SPECS.md: a row an external write left inconsistent
+// (here, an unrecognized kind) must still come back from ListHolds, not be
+// filtered out, or "what is held" silently drops exactly the row most worth
+// seeing.
+func TestListHoldsSurfacesEveryRowRegardlessOfKind(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.SetHold(Hold{ID: "weird", Kind: "not-a-real-kind", Reason: "who knows"}); err != nil {
+		t.Fatal(err)
+	}
+
+	holds, err := db.ListHolds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(holds) != 1 || holds[0].Kind != "not-a-real-kind" {
+		t.Fatalf("ListHolds = %+v, want the inconsistent row untouched", holds)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,8 +20,16 @@ const (
 	KindScout = "scout"
 )
 
+const (
+	HoldKindOperator = "operator"
+	HoldKindBlocked  = "blocked"
+)
+
 // Wrapped by DeleteTask, rendered by callers as `task "<id>" not found`.
 var ErrTaskNotFound = errors.New("not found")
+
+// Wrapped by ClearHold, rendered by callers as `hold "<id>" not found`.
+var ErrHoldNotFound = errors.New("not found")
 
 // Wrapped by AddProject so a caller importing a registry that already lists a
 // name can tell a duplicate from a real write fault.
@@ -78,6 +86,18 @@ type Project struct {
 	Mode string
 }
 
+// Hold is its own row keyed by an arbitrary id, not a foreign key into task:
+// the case it exists for is a question left open by work that has no task row
+// behind it any more, because hand teardown already removed it. BlockedOn
+// carries the id a HoldKindBlocked hold waits on; empty for HoldKindOperator.
+type Hold struct {
+	ID        string `json:"id"`
+	Kind      string `json:"kind"`
+	Reason    string `json:"reason"`
+	BlockedOn string `json:"blocked_on"`
+	SetAt     string `json:"set_at"`
+}
+
 // Every machine-state file lives here, database included, so a human looking
 // for fleet state has one directory to look in.
 func Dir(homeDir string) string {
@@ -128,6 +148,13 @@ CREATE TABLE IF NOT EXISTS project (
 CREATE TABLE IF NOT EXISTS meta (
 	key   TEXT PRIMARY KEY,
 	value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS hold (
+	id         TEXT PRIMARY KEY,
+	kind       TEXT NOT NULL DEFAULT '',
+	reason     TEXT NOT NULL DEFAULT '',
+	blocked_on TEXT NOT NULL DEFAULT '',
+	set_at     TEXT NOT NULL DEFAULT ''
 );
 `
 
@@ -338,4 +365,80 @@ func (db *DB) RemoveProject(name string) (bool, error) {
 		return false, fmt.Errorf("remove project %q: %w", name, err)
 	}
 	return affected > 0, nil
+}
+
+const holdColumns = `id, kind, reason, blocked_on, set_at`
+
+func scanHold(row interface{ Scan(...any) error }) (Hold, error) {
+	var h Hold
+	err := row.Scan(&h.ID, &h.Kind, &h.Reason, &h.BlockedOn, &h.SetAt)
+	return h, err
+}
+
+// SetHold upserts, so an operator narrowing down a reason re-runs the same
+// command rather than needing a clear first - SetAt then reads as when the
+// hold was last set, not when it was first raised.
+func (db *DB) SetHold(h Hold) error {
+	_, err := db.sql.Exec(`INSERT INTO hold (`+holdColumns+`)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			kind = excluded.kind, reason = excluded.reason,
+			blocked_on = excluded.blocked_on, set_at = excluded.set_at`,
+		h.ID, h.Kind, h.Reason, h.BlockedOn, h.SetAt)
+	if err != nil {
+		return fmt.Errorf("write hold %q: %w", h.ID, err)
+	}
+	return nil
+}
+
+func (db *DB) ReadHold(id string) (Hold, bool, error) {
+	row := db.sql.QueryRow(`SELECT `+holdColumns+` FROM hold WHERE id = ?`, id)
+	h, err := scanHold(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Hold{}, false, nil
+	}
+	if err != nil {
+		return Hold{}, false, fmt.Errorf("read hold %q: %w", id, err)
+	}
+	return h, true, nil
+}
+
+// ListHolds surfaces every row, whatever it holds: a caller that filtered
+// here on kind or on BlockedOn being consistent with kind would let a row an
+// external write left inconsistent silently disappear from "what is held"
+// instead of being reported as a hold that needs attention.
+func (db *DB) ListHolds() ([]Hold, error) {
+	rows, err := db.sql.Query(`SELECT ` + holdColumns + ` FROM hold ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list holds: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var holds []Hold
+	for rows.Next() {
+		h, err := scanHold(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list holds: %w", err)
+		}
+		holds = append(holds, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list holds: %w", err)
+	}
+	return holds, nil
+}
+
+func (db *DB) ClearHold(id string) error {
+	res, err := db.sql.Exec(`DELETE FROM hold WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("clear hold %q: %w", id, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("clear hold %q: %w", id, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("hold %q %w", id, ErrHoldNotFound)
+	}
+	return nil
 }

--- a/tests/e2e/hold_test.go
+++ b/tests/e2e/hold_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+type fleetStatus struct {
+	Tasks []struct {
+		ID string `json:"id"`
+	} `json:"tasks"`
+	Holds []holdView `json:"holds"`
+}
+
+type singleStatus struct {
+	ID   string    `json:"id"`
+	Held *holdView `json:"held"`
+}
+
+type holdView struct {
+	ID           string `json:"id"`
+	Kind         string `json:"kind"`
+	Reason       string `json:"reason"`
+	BlockedOn    string `json:"blocked_on"`
+	SetAt        string `json:"set_at"`
+	Inconsistent string `json:"inconsistent"`
+}
+
+func decodeJSON(t *testing.T, got invocation, into any) {
+	t.Helper()
+	if got.code != 0 {
+		t.Fatalf("exit %d, stderr %q", got.code, got.stderr)
+	}
+	if err := json.Unmarshal([]byte(got.stdout), into); err != nil {
+		t.Fatalf("decode %q: %v", got.stdout, err)
+	}
+}
+
+// TestHoldLifecycle drives holds end to end through the built binary: set on a
+// live task and on an id with no task row at all, rendered by every hand status
+// surface, surviving the teardown of the task it was set on (the case a
+// task-scoped hold could not cover), refusing the spawn that would reuse the
+// id, and leaving nothing behind once cleared.
+func TestHoldLifecycle(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	writeBrief(t, home, "fix-login")
+
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	worktree := filepath.Join(home, "wt-fix-login")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "fix-login-branch", worktree)
+
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, worktree)
+	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+
+	if got := runHand(t, home, "spawn", "fix-login", "demo"); got.code != 0 {
+		t.Fatalf("spawn: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	// A fleet with nothing held prints exactly what it did before holds existed.
+	if got := runHand(t, home, "status"); got.code != 0 || strings.Contains(got.stdout, "held:") {
+		t.Fatalf("status with no holds = %q (exit %d), want no held block", got.stdout, got.code)
+	}
+
+	set := runHand(t, home, "hold", "set", "fix-login",
+		"--kind", "blocked", "--reason", "needs the new column before this can proceed",
+		"--blocked-on", "migrate-schema")
+	if set.code != 0 || !strings.Contains(set.stdout, "hold set on fix-login (kind=blocked)") {
+		t.Fatalf("hold set = %q (exit %d), stderr %q", set.stdout, set.code, set.stderr)
+	}
+
+	single := runHand(t, home, "status", "fix-login")
+	if single.code != 0 || !strings.Contains(single.stdout, "Held:        waiting on migrate-schema: needs the new column before this can proceed") {
+		t.Fatalf("status fix-login = %q (exit %d), want the Held line", single.stdout, single.code)
+	}
+
+	var one singleStatus
+	decodeJSON(t, runHand(t, home, "status", "fix-login", "--json"), &one)
+	if one.Held == nil || one.Held.Kind != state.HoldKindBlocked || one.Held.BlockedOn != "migrate-schema" ||
+		one.Held.Reason != "needs the new column before this can proceed" || one.Held.SetAt == "" {
+		t.Fatalf("single-task JSON held = %+v", one.Held)
+	}
+
+	// An id with no task row behind it: never dispatched, so nothing but the
+	// hold table could carry it.
+	if got := runHand(t, home, "hold", "set", "unqueued-work",
+		"--kind", "operator", "--reason", "two ways to do this, needs a call"); got.code != 0 {
+		t.Fatalf("hold set unqueued-work: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	fleet := runHand(t, home, "status")
+	if fleet.code != 0 {
+		t.Fatalf("status: exit %d, stderr %q", fleet.code, fleet.stderr)
+	}
+	for _, want := range []string{
+		"held:",
+		"fix-login      blocked   waiting on migrate-schema: needs the new column before this can proceed",
+		"unqueued-work  operator  two ways to do this, needs a call",
+	} {
+		if !strings.Contains(fleet.stdout, want) {
+			t.Fatalf("status = %q, want it to contain %q", fleet.stdout, want)
+		}
+	}
+
+	var all fleetStatus
+	decodeJSON(t, runHand(t, home, "status", "--json"), &all)
+	if len(all.Tasks) != 1 || all.Tasks[0].ID != "fix-login" {
+		t.Fatalf("fleet JSON tasks = %+v, want the one spawned task", all.Tasks)
+	}
+	if len(all.Holds) != 2 || all.Holds[0].ID != "fix-login" || all.Holds[1].ID != "unqueued-work" {
+		t.Fatalf("fleet JSON holds = %+v, want both holds", all.Holds)
+	}
+
+	// The motivating case: teardown deletes the task row, and the hold set on
+	// that id has to outlive it.
+	runGitIn(t, worktree, "commit", "--allow-empty", "-q", "-m", "wip")
+	if got := runHand(t, home, "merge", "fix-login", "--local"); got.code != 0 {
+		t.Fatalf("merge --local: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if got := runHand(t, home, "teardown", "fix-login"); got.code != 0 {
+		t.Fatalf("teardown: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if exists, err := state.Exists(home, "fix-login"); err != nil || exists {
+		t.Fatalf("state.Exists after teardown = %v, %v, want the task row gone", exists, err)
+	}
+
+	survived := runHand(t, home, "status")
+	if survived.code != 0 || !strings.Contains(survived.stdout, "fix-login      blocked   waiting on migrate-schema") {
+		t.Fatalf("status after teardown = %q, want the torn-down task's hold still listed", survived.stdout)
+	}
+
+	// Reusing the id would reattach that still-open question to unrelated work.
+	writeBrief(t, home, "fix-login")
+	respawn := runHand(t, home, "spawn", "fix-login", "demo")
+	assertInvocation(t, respawn, 3, `id "fix-login" has an open hold`)
+	if !strings.Contains(respawn.stderr, "hand hold clear fix-login") {
+		t.Fatalf("spawn stderr = %q, want it to name the remedy", respawn.stderr)
+	}
+
+	cleared := runHand(t, home, "hold", "clear", "fix-login")
+	if cleared.code != 0 || !strings.Contains(cleared.stdout, "hold cleared on fix-login") {
+		t.Fatalf("hold clear = %q (exit %d), stderr %q", cleared.stdout, cleared.code, cleared.stderr)
+	}
+	assertInvocation(t, runHand(t, home, "hold", "clear", "fix-login"), 3, `hold "fix-login" not found`)
+
+	if got := runHand(t, home, "hold", "clear", "unqueued-work"); got.code != 0 {
+		t.Fatalf("hold clear unqueued-work: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if got := runHand(t, home, "status"); got.code != 0 || strings.Contains(got.stdout, "held:") {
+		t.Fatalf("status after clearing every hold = %q, want no held block left", got.stdout)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a standalone `hold` table in `state/hand.db` (`internal/store`) recording that an id is waiting on an operator or another id, plus `hand hold set`/`hand hold clear` and `hand status` rendering (fleet `held:` block, single-task `Held:` line, JSON `held`/`holds`).
- `data/backlog.md` is untouched: holds are derived from the store, never authored there, per the 2026-07-29 rescope of this issue.
- `hand spawn` refuses an id carrying an open hold (exit 3), added during review below.

## Design decision

The brief left one call open: task-scoped hold vs a standalone row keyed by an arbitrary id. Standalone row, for two independent reasons:

1. A hold set on a task torn down while its question stayed open needs to survive the teardown. `hand teardown` deletes the task row outright, so a task-scoped hold (a column, or a side table keyed on task id) would vanish exactly when it matters most - the motivating case the issue names is work with no task row behind it, either never dispatched or torn down mid-question.
2. atqamz/secondhand#111 found that `Open` has no schema-version mechanism: `CREATE TABLE IF NOT EXISTS` is a silent no-op against an existing table merely missing a new column, with no error and no column added. That gap only bites an existing table gaining a column; a wholly new table is unaffected, since `CREATE TABLE IF NOT EXISTS` takes the create branch against any database that is missing the table outright, migrated or fresh. atqamz/secondhand#111 itself is not fixed here.

Two kinds only, `operator` and `blocked`, both carrying a reason; `blocked` also carries the id it waits on. Both are validated before write and upserted, so narrowing a reason is a re-run of `hand hold set`, not a clear-then-set.

An unreadable or inconsistent hold must never read as nothing waiting: `ListHolds`/`ReadHold` surface every row exactly as stored rather than filtering, `hand status` flags an inconsistent row (bad kind, or a blocked/operator mismatch with `blocked_on`) instead of rendering it as valid, and a store-level read failure fails `hand status` outright rather than degrading to an empty holds list.

Full reasoning is in SPECS.md under "Holds" (State management) and the updated `hand status`/`hand hold set`/`hand hold clear` CLI sections.

## Fixed during review

The no-mistakes review gate found a real gap the original change missed: a hold outlives `hand teardown` by design, but nothing stopped a stale hold from reattaching to a new task spawned under the same reused id. Fixed by having `hand spawn` refuse an id with an open hold (exit 3, `hand hold clear` first), with a test pinning both the refusal and the post-clear respawn path. Also fixed: the README command table (missing the two new commands), two stale SPECS.md statements (a "three commands write nothing" enumeration and a dropped-feature table still describing holds as a backlog/dashboard mechanism), and the exit-code tables (2 and 3) gaining the new hold-related cases.

One gap found by the review gate was filed as a follow-up rather than fixed here, since it touches a Go constant and its drift test in lockstep: the fleet-home AGENTS.md template never mentions `hand hold`. Filed as atqamz/secondhand#114.

Fixes atqamz/secondhand#63

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `make lint`
- [x] `tests/e2e/hold_test.go`: spawn, hold set, both status renderings, merge --local, teardown, hold survives, respawn refused (exit 3), hold clear, nothing left
