### PR TITLE
ci: label non-atqamz issues with needs-triage

### DIFF
--- a/.github/workflows/triage-label.yaml
+++ b/.github/workflows/triage-label.yaml
@@ -1,0 +1,24 @@
+name: Triage label
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-non-author-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label needs-triage if not filed by atqamz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          if [ "$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')" = "atqamz" ]; then
+            echo "Filed by atqamz, skipping"
+            exit 0
+          fi
+          gh issue edit "$ISSUE_URL" --add-label needs-triage

--- a/SPECS.md
+++ b/SPECS.md
@@ -2072,9 +2072,9 @@ Automated via [release-please](https://github.com/googleapis/release-please) (sa
 
 **`.github/workflows/release.yaml`:** the tracked file is authoritative - runs on push to main; `workflow_dispatch` exists to re-run release-please after a conflicted release PR is rebased.
 
-**`.github/workflows/triage-label.yaml`:** the tracked file is authoritative - runs on `issues: opened`, labels the issue `needs-triage` unless its author (login, case-insensitive) is `atqamz`. Scoped to `issues: write` only, uses the built-in `GITHUB_TOKEN` via `gh issue edit`, no third-party action. Does not fire on reopen and does not distinguish bot authors from human ones - see the issue that introduced it for the reasoning.
-
 Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (no real ones installed, see "Integration tests"), plus a nix-build job guarding the flake package, then release-please for automated releases.
+
+**`.github/workflows/triage-label.yaml`:** the tracked file is authoritative - runs on `issues: opened`, labels the issue `needs-triage` unless its author (login, case-insensitive) is `atqamz`. Scoped to `issues: write` only, uses the built-in `GITHUB_TOKEN` via `gh issue edit`, no third-party action. Does not fire on reopen and does not distinguish bot authors from human ones (atqamz/secondhand#116).
 
 `.github/dependabot.yaml` - keep Go modules and GitHub Actions up to date:
 ```yaml

--- a/SPECS.md
+++ b/SPECS.md
@@ -2072,6 +2072,8 @@ Automated via [release-please](https://github.com/googleapis/release-please) (sa
 
 **`.github/workflows/release.yaml`:** the tracked file is authoritative - runs on push to main; `workflow_dispatch` exists to re-run release-please after a conflicted release PR is rebased.
 
+**`.github/workflows/triage-label.yaml`:** the tracked file is authoritative - runs on `issues: opened`, labels the issue `needs-triage` unless its author (login, case-insensitive) is `atqamz`. Scoped to `issues: write` only, uses the built-in `GITHUB_TOKEN` via `gh issue edit`, no third-party action. Does not fire on reopen and does not distinguish bot authors from human ones - see the issue that introduced it for the reasoning.
+
 Same CI pattern as no-mistakes and treehouse: format, vet, lint, test across OS matrix, e2e against faked herdr and treehouse (no real ones installed, see "Integration tests"), plus a nix-build job guarding the flake package, then release-please for automated releases.
 
 `.github/dependabot.yaml` - keep Go modules and GitHub Actions up to date:


### PR DESCRIPTION
## Intent

Add a GitHub Actions workflow that labels an issue opened by anyone other than atqamz with the existing needs-triage label, using the built-in GITHUB_TOKEN and no third-party action. Closes atqamz/secondhand#116.

## What Changed

- Add `.github/workflows/triage-label.yaml`: on `issues: opened`, a single inline step adds the existing `needs-triage` label via `gh issue edit`, skipping issues whose author login is `atqamz` (case-insensitive). Scoped to `issues: write` with the built-in `GITHUB_TOKEN` and no third-party action.
- Document the workflow in SPECS.md next to the other `.github` entries, recording the tracked file as authoritative plus the two deliberate gaps: it does not fire on reopen and does not distinguish bot authors from humans, with the reference fully qualified as `atqamz/secondhand#116`.

Verified by running the workflow under `act` against synthesized issue events (stranger, `atqamz`, uppercase `ATQAMZ`, release-please bot) and by confirming the `needs-triage` label already exists on the repo. No Go test covers SPECS.md or workflow files.

## Risk Assessment

ok: Low: Additive, self-contained CI workflow with minimal token permissions, no third-party action, injection-safe env handling, and a verified pre-existing label; it cannot affect the Go binary or any existing workflow, and the only finding is a docs reference nit.

## Testing

I ran the tracked workflow file itself through act (podman backend, ubuntu:24.04 runner image) against four realistic issues.opened webhook payloads, with a stub gh on the container PATH so the job's real command and token were captured without mutating the public repo: a stranger-authored issue produces exactly `gh issue edit https://github.com/atqamz/secondhand/issues/116 --add-label needs-triage` with GH_TOKEN set from the built-in GITHUB_TOKEN, while atqamz and ATQAMZ both short-circuit with "Filed by atqamz, skipping" and zero gh calls, and a bot author is labeled as the spec section says it will be. I confirmed structurally that the workflow triggers only on `issues: [opened]`, requests only `issues: write`, uses no third-party action, and that the `needs-triage` label already exists in atqamz/secondhand; I also confirmed gh resolves the passed html_url with no local checkout. Two inherent limits, neither a defect: act ignores the `types:` activity filter so the reopen case still fired locally and reopen scoping rests on the declared trigger, and a real Actions run is impossible before merge because issues events only run workflows from the default branch. No Go code changed and no test references SPECS.md or the workflow files, so I did not add a Go test (it would need a new YAML dependency to assert config strings); the act transcript is the stronger evidence. Everything passed and the worktree is clean.

<details>
<summary>Evidence: act transcript: workflow run per author case, with captured gh calls</summary>

<code>### case: issue opened by stranger (octocat)&#10;[Triage label/label-non-author-issues] ⭐ Run Main Label needs-triage if not filed by atqamz&#10;[Triage label/label-non-author-issues] | https://github.com/atqamz/secondhand/issues/116&#10;[Triage label/label-non-author-issues] ok: Success - Main Label needs-triage if not filed by atqamz&#10;[Triage label/label-non-author-issues] done: Job succeeded&#10;--- gh CLI calls made by the job ---&#10;gh issue edit https://github.com/atqamz/secondhand/issues/116 --add-label needs-triage&#10;GH_TOKEN=ghs_fakeBuiltInToken&#10;&#10;### case: issue opened by atqamz&#10;[Triage label/label-non-author-issues] | Filed by atqamz, skipping&#10;[Triage label/label-non-author-issues] done: Job succeeded&#10;--- gh CLI calls made by the job ---&#10;(none - no label applied)&#10;&#10;### case: issue opened by ATQAMZ (case variant)&#10;[Triage label/label-non-author-issues] | Filed by atqamz, skipping&#10;[Triage label/label-non-author-issues] done: Job succeeded&#10;--- gh CLI calls made by the job ---&#10;(none - no label applied)&#10;&#10;### case: issue opened by bot account (release-please)&#10;--- gh CLI calls made by the job ---&#10;gh issue edit https://github.com/atqamz/secondhand/issues/116 --add-label needs-triage&#10;GH_TOKEN=ghs_fakeBuiltInToken</code>

```text
### case: issue opened by stranger (octocat)   (event payload: event-stranger.json, author: octocat, action: opened)
[Triage label/label-non-author-issues] ⭐ Run Set up job
[Triage label/label-non-author-issues] ship:  Start image=docker.io/library/ubuntu:24.04
[Triage label/label-non-author-issues]   ok:  Success - Set up job
[Triage label/label-non-author-issues] ⭐ Run Main Label needs-triage if not filed by atqamz
[Triage label/label-non-author-issues]   | https://github.com/atqamz/secondhand/issues/116
[Triage label/label-non-author-issues]   ok:  Success - Main Label needs-triage if not filed by atqamz [162.097121ms]
[Triage label/label-non-author-issues] ⭐ Run Complete job
[Triage label/label-non-author-issues] Cleaning up container for job label-non-author-issues
[Triage label/label-non-author-issues]   ok:  Success - Complete job
[Triage label/label-non-author-issues] done:  Job succeeded
--- gh CLI calls made by the job ---
gh issue edit https://github.com/atqamz/secondhand/issues/116 --add-label needs-triage
GH_TOKEN=ghs_fakeBuiltInToken

### case: issue opened by atqamz   (event payload: event-atqamz.json, author: atqamz, action: opened)
[Triage label/label-non-author-issues] ⭐ Run Set up job
[Triage label/label-non-author-issues] ship:  Start image=docker.io/library/ubuntu:24.04
[Triage label/label-non-author-issues]   ok:  Success - Set up job
[Triage label/label-non-author-issues] ⭐ Run Main Label needs-triage if not filed by atqamz
[Triage label/label-non-author-issues]   | Filed by atqamz, skipping
[Triage label/label-non-author-issues]   ok:  Success - Main Label needs-triage if not filed by atqamz [170.868532ms]
[Triage label/label-non-author-issues] ⭐ Run Complete job
[Triage label/label-non-author-issues] Cleaning up container for job label-non-author-issues
[Triage label/label-non-author-issues]   ok:  Success - Complete job
[Triage label/label-non-author-issues] done:  Job succeeded
--- gh CLI calls made by the job ---
(none - no label applied)

### case: issue opened by ATQAMZ (case variant)   (event payload: event-atqamz-uppercase.json, author: ATQAMZ, action: opened)
[Triage label/label-non-author-issues] ⭐ Run Set up job
[Triage label/label-non-author-issues] ship:  Start image=docker.io/library/ubuntu:24.04
[Triage label/label-non-author-issues]   ok:  Success - Set up job
[Triage label/label-non-author-issues] ⭐ Run Main Label needs-triage if not filed by atqamz
[Triage label/label-non-author-issues]   | Filed by atqamz, skipping
[Triage label/label-non-author-issues]   ok:  Success - Main Label needs-triage if not filed by atqamz [168.650926ms]
[Triage label/label-non-author-issues] ⭐ Run Complete job
[Triage label/label-non-author-issues] Cleaning up container for job label-non-author-issues
[Triage label/label-non-author-issues]   ok:  Success - Complete job
[Triage label/label-non-author-issues] done:  Job succeeded
--- gh CLI calls made by the job ---
(none - no label applied)

### case: issue opened by bot account (release-please)   (event payload: event-bot.json, author: release-please, action: opened)
[Triage label/label-non-author-issues] ⭐ Run Set up job
[Triage label/label-non-author-issues] ship:  Start image=docker.io/library/ubuntu:24.04
[Triage label/label-non-author-issues]   ok:  Success - Set up job
[Triage label/label-non-author-issues] ⭐ Run Main Label needs-triage if not filed by atqamz
[Triage label/label-non-author-issues]   | https://github.com/atqamz/secondhand/issues/116
[Triage label/label-non-author-issues]   ok:  Success - Main Label needs-triage if not filed by atqamz [171.822613ms]
[Triage label/label-non-author-issues] ⭐ Run Complete job
[Triage label/label-non-author-issues] Cleaning up container for job label-non-author-issues
[Triage label/label-non-author-issues]   ok:  Success - Complete job
[Triage label/label-non-author-issues] done:  Job succeeded
--- gh CLI calls made by the job ---
gh issue edit https://github.com/atqamz/secondhand/issues/116 --add-label needs-triage
GH_TOKEN=ghs_fakeBuiltInToken

### case: issue REOPENED by stranger (should not fire)   (event payload: event-stranger-reopened.json, author: octocat, action: reopened)
[Triage label/label-non-author-issues] ⭐ Run Set up job
[Triage label/label-non-author-issues] ship:  Start image=docker.io/library/ubuntu:24.04
[Triage label/label-non-author-issues]   ok:  Success - Set up job
[Triage label/label-non-author-issues] ⭐ Run Main Label needs-triage if not filed by atqamz
[Triage label/label-non-author-issues]   | https://github.com/atqamz/secondhand/issues/116
[Triage label/label-non-author-issues]   ok:  Success - Main Label needs-triage if not filed by atqamz [165.319089ms]
[Triage label/label-non-author-issues] ⭐ Run Complete job
[Triage label/label-non-author-issues] Cleaning up container for job label-non-author-issues
[Triage label/label-non-author-issues]   ok:  Success - Complete job
[Triage label/label-non-author-issues] done:  Job succeeded
--- gh CLI calls made by the job ---
gh issue edit https://github.com/atqamz/secondhand/issues/116 --add-label needs-triage
GH_TOKEN=ghs_fakeBuiltInToken
```
</details>
<details>
<summary>Evidence: workflow scoping, existing needs-triage label, gh URL resolution</summary>

<code>### workflow scoping, as declared in .github/workflows/triage-label.yaml&#10;triggers: {&#34;issues&#34;:{&#34;types&#34;:[&#34;opened&#34;]}}&#10;permissions: {&#34;issues&#34;:&#34;write&#34;}&#10;steps using actions: 0&#10;token source: ${{ secrets.GITHUB_TOKEN }}&#10;&#10;### needs-triage label already exists in atqamz/secondhand (gh label list --search triage)&#10;needs-triage Filed by someone other than atqamz; not yet read, scoped, or milestoned #d876e3&#10;&#10;### gh resolves the issue URL the workflow passes it, without a local checkout (run from /tmp, read-only view)&#10;resolved https://github.com/atqamz/secondhand/issues/116 labels=(none)</code>

```text
### workflow scoping, as declared in .github/workflows/triage-label.yaml
triggers:            {"issues":{"types":["opened"]}}
permissions:         {"issues":"write"}
steps using actions: 0
token source:        ${{ secrets.GITHUB_TOKEN }}

### needs-triage label already exists in atqamz/secondhand (gh label list --search triage)
needs-triage	Filed by someone other than atqamz; not yet read, scoped, or milestoned	#d876e3

### gh resolves the issue URL the workflow passes it, without a local checkout (run from /tmp, read-only view)
resolved https://github.com/atqamz/secondhand/issues/116  labels=(none)
```
</details>
<details>
<summary>Evidence: issues.opened webhook payloads used as act event inputs (stranger, atqamz, ATQAMZ, bot, reopened)</summary>

```text
{
  "action": "opened",
  "issue": {
    "number": 116,
    "html_url": "https://github.com/atqamz/secondhand/issues/116",
    "title": "Label issues from non-atqamz authors with needs-triage",
    "state": "open",
    "labels": [],
    "user": { "login": "octocat", "type": "User" }
  },
  "repository": {
    "full_name": "atqamz/secondhand",
    "name": "secondhand",
    "owner": { "login": "atqamz" },
    "private": false
  },
  "sender": { "login": "octocat" }
}
```
</details>
<details>
<summary>Evidence: gh stub that recorded the job&#39;s argv and token instead of mutating the public repo</summary>

```text
#!/usr/bin/env bash
# stand-in for the gh CLI: records argv + the token the workflow handed it,
# then mimics the success output of a real `gh issue edit --add-label`.
printf 'gh %s\n' "$*" >> "${GH_STUB_LOG:-/evidence/gh-calls.log}"
printf 'GH_TOKEN=%s\n' "${GH_TOKEN:-<unset>}" >> "${GH_STUB_LOG:-/evidence/gh-calls.log}"
for arg in "$@"; do
  case "$arg" in
    http*) url="$arg" ;;
  esac
done
echo "$url"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>warning: **Review** - 1 info</summary>

- info: `SPECS.md:2075` - The new SPECS paragraph defers its rationale to &#34;see the issue that introduced it&#34; without naming it, so a reader has no way to find that reasoning; the project convention is fully qualified references (`atqamz/secondhand#116`). The same paragraph also lands between the release.yaml entry and the &#34;Same CI pattern as no-mistakes and treehouse...&#34; summary at SPECS.md:2077, which recaps ci.yaml/release.yaml only - moving the triage paragraph after 2077 keeps that summary adjacent to what it summarizes.

</details>

<details>
<summary>ok: **Test** - passed</summary>

ok: No issues found.
- <code>`nix shell nixpkgs#act -c act issues -W .github/workflows/triage-label.yaml --eventpath event-stranger.json -P ubuntu-latest=docker.io/library/ubuntu:24.04 -s GITHUB_TOKEN=... --container-options &#39;-v stub/gh:/usr/bin/gh:ro&#39;` (issue opened by octocat: labeled)</code>
- <code>same act run with `event-atqamz.json` (author atqamz: step logs &#34;Filed by atqamz, skipping&#34;, zero gh calls)</code>
- <code>same act run with `event-atqamz-uppercase.json` (author ATQAMZ: skipped, confirms the `tr &#39;[:upper:]&#39; &#39;[:lower:]&#39;` case-insensitive guard)</code>
- <code>same act run with `event-bot.json` (release-please author: labeled, matches the documented &#34;does not distinguish bot authors&#34; behavior)</code>
- <code>same act run with `event-stranger-reopened.json` (act does not enforce the `types:` filter, so reopen scoping was checked from the declared trigger instead)</code>
- <code>`yq &#39;.on&#39; / &#39;.permissions&#39; / &#39;[.jobs[].steps[] | select(has(&#34;uses&#34;))] | length&#39; / &#39;.jobs[].steps[].env.GH_TOKEN&#39; .github/workflows/triage-label.yaml` (trigger, permission scope, no third-party action, built-in token)</code>
- <code>`gh label list --repo atqamz/secondhand --search triage` (needs-triage label exists)</code>
- <code>`gh issue view https://github.com/atqamz/secondhand/issues/116` run from /tmp (gh resolves the html_url the workflow passes it with no local checkout or GH_REPO)</code>
- <code>`grep -rl &#39;SPECS.md|\.github&#39; --include=&#39;*_test.go&#39; .` (no Go test asserts SPECS.md or workflow files, so no Go suite is relevant to this change)</code>
- <code>`git status --porcelain` and `docker ps -a --filter name=act-` (worktree clean, no leftover act containers)</code>

</details>

<details>
<summary>ok: **Document** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>

