### PR TITLE
feat(cmd): flag ungated shipped PRs and state an explicit empty-fleet count in hand status

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -466,7 +466,7 @@ Behavior (fleet overview):
 4. If the task has a recorded PR, append its merge state to the same column: ` (merged)` when `hand` performed the merge, ` (merged, external)` when `hand` only observed it - `hand watch`'s own `gh` poll saw it merged, or gate-opened-PR detection recorded a PR that was already merged. It is appended whatever the agent state is, since a merged PR is a fact about the PR rather than about the pane.
 5. Print one line per task, with a header row - or, if there are no tasks at all, `no tasks (0)` in place of the table, so an empty fleet reads as a positive statement with a count rather than the same bare output a broken command could also produce.
 6. List every hold in the store (see "Holds" under "State management") and print a `held:` block below the task table, one line per hold, skipped entirely when nothing is held - printed even when there are no tasks, so a torn-down task's still-open hold is never hidden behind the `no tasks (0)` line above it. A hold names any id, not only a live task's, so a torn-down task's still-open hold keeps appearing here after its task row is gone. A failure to read the holds fails the whole command rather than degrading to an empty list - reading no holds back must never be mistaken for nothing being held.
-7. For a `ship` task reported `done` with a recorded PR, on a registered `no-mistakes` project: check whether that PR ever went through a gate run (see "Gate-run visibility" below), and append ` (gate: <issue>)` to the same column when it did not. The project registry read this step needs is best-effort - a registry fault leaves the check silent for every task rather than failing the whole overview over it.
+7. For a `ship` task reported `done` with a recorded PR, on a registered `no-mistakes` project: check whether that PR ever went through a gate run (see "Gate-run visibility" below), and append ` (gate: <issue>)` to the same column when it did not. The project registry read this step needs is best-effort - a registry fault leaves the check silent for every task rather than failing the whole overview over it, but prints a one-line `warning:` to stderr naming the read failure, so dropping every `(gate: ...)` marker fleet-wide is never silent.
 
 The `last report` column is the mtime of `state/<id>.status`, and `(none)` when the worker has never written one.
 It is deliberately not the task's age: the two used to be conflated, so a task spawned hours ago read as hours stale next to a status file its worker had touched minutes earlier - a reporting worker that looked abandoned.
@@ -1601,10 +1601,12 @@ registered after the fact, the PR was opened by hand outside the `pr` step, or t
 bypassed with `--skip-gate-check`. atqamz/secondhand#92 is that gap: `hand status` had no way to
 surface a `done` `ship` task with a recorded PR that never went through a gate run at all.
 
-`hand status` answers this with `project.GateRanForPR(clonePath, prURL)`: run `no-mistakes runs
---limit 10000` in the project's clone and look for a `completed` row whose own recorded PR is
-exactly `prURL`, the same read-only, text-scraping approach `GateStatus` already uses for gate
-preflight, never `~/.no-mistakes/state.sqlite` directly.
+`hand status` answers this with `project.GateRunPRs(clonePath)`: run `no-mistakes runs --limit
+10000` in the project's clone and collect the PR URL each `completed` row recorded for itself, the
+same read-only, text-scraping approach `GateStatus` already uses for gate preflight, never
+`~/.no-mistakes/state.sqlite` directly. A PR is gated when it is exactly one of those URLs. The
+answer is per clone, not per PR, and cached for the length of one render, so a fleet with several
+`done` `ship` tasks on one project pays one `no-mistakes` process rather than one per task.
 
 This establishes only that the no-mistakes `pr` step opened this exact PR from a run that reached
 `completed` - nothing more, and the wording is deliberately no stronger than that:
@@ -1615,9 +1617,14 @@ This establishes only that the no-mistakes `pr` step opened this exact PR from a
 - A PR opened by hand outside the no-mistakes `pr` step reads as `no run found` even sitting behind
   a run that did complete: nothing ties that URL to that run's own bookkeeping.
 - A PR with no completed run recording that exact URL reads as `no run found`. A failure to ask
-  no-mistakes at all - a missing clone, an unrunnable binary - reads as `unreachable`, the same
-  bucket `gateIssue` uses for the identical failure in `hand project list`, so a question the check
-  could not answer never renders as the stronger claim `no run found`.
+  no-mistakes at all reads as `unreachable`, the same bucket `gateIssue` uses for the identical
+  failure in `hand project list`, so a question the check could not answer never renders as the
+  stronger claim `no run found`. That bucket covers a missing clone, an unrunnable binary, and -
+  read from `no-mistakes runs`'s own output text rather than its exit code, exactly as gate
+  preflight reads them - a gate that was never initialized or whose `working_path` went stale, and
+  a clone path that is not a git repository. The uninitialized case matters most: no-mistakes still
+  holds that repo's completed runs, so reading its refusal as an empty run list would report a
+  genuinely gated PR as never gated.
 
 A marker that claims more certainty than this data supports would be worse than no marker at all,
 so `hand status` only ever says what the two outcomes above actually establish - never "this PR is

--- a/SPECS.md
+++ b/SPECS.md
@@ -474,15 +474,15 @@ It is deliberately not the task's age: the two used to be conflated, so a task s
 
 Output (fleet overview):
 ```
-id           project  kind   state                                     age     last report
-fix-login    nsr      ship   working                                   2h ago  3m ago
-dark-mode    nsr      ship   blocked                                   45m ago 40m ago
-build-wait   nsr      ship   working (reported: paused)                20m ago 5m ago
-stuck-task   nsr      ship   idle (unreported)                         1h ago  (none)
-paused-task  nsr      ship   idle (reported: needs-decision)           30m ago 12m ago
-investigate  nsr      scout  done (reported: done)                     10m ago 9m ago
-shipped-fix  nsr      ship   done (reported: done) (merged, external)  5m ago  4m ago
-no-gate-fix  nsr      ship   done (reported: done) (gate: no run found) 3m ago 2m ago
+id           project  kind   state                                       age     last report
+fix-login    nsr      ship   working                                     2h ago  3m ago
+dark-mode    nsr      ship   blocked                                     45m ago 40m ago
+build-wait   nsr      ship   working (reported: paused)                  20m ago 5m ago
+stuck-task   nsr      ship   idle (unreported)                           1h ago  (none)
+paused-task  nsr      ship   idle (reported: needs-decision)             30m ago 12m ago
+investigate  nsr      scout  done (reported: done)                       10m ago 9m ago
+shipped-fix  nsr      ship   done (reported: done) (merged, external)    5m ago  4m ago
+no-gate-fix  nsr      ship   done (reported: done) (gate: no run found)  3m ago  2m ago
 
 held:
   fix-login         operator  two ways to fix this, needs a call          2h ago
@@ -522,7 +522,6 @@ PR:          (none)
 Reported:    needs-decision: two ways to fix the race, ask-user found both risky
 Report file: /home/user/secondhand/state/fix-login.status
 Held:        waiting on migrate-schema: needs the new column before this can proceed
-Gate run:    no run found
 
 Report history (reported by worker, not verified current truth):
   working: added the retry loop
@@ -532,7 +531,7 @@ The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the sam
 
 The `Held:` line is present only when this id has a hold, and reads the reason alone for an `operator` hold or `waiting on <blocked_on>: <reason>` for a `blocked` one; an inconsistent row (see the fleet overview above) prints `inconsistent: <why>` instead.
 
-The `Gate run:` line is present only for a `done` `ship` task with a recorded PR on a registered `no-mistakes` project whose gate-run check (see "Gate-run visibility" below) did not come back clean - `no run found` or `unreachable`. It is absent for every other task, including one where the check came back clean.
+A `Gate run:` line (`Gate run:    no run found`, printed below the `Held:` line) is present only for a `done` `ship` task with a recorded PR on a registered `no-mistakes` project whose gate-run check (see "Gate-run visibility" below) did not come back clean - `no run found` or `unreachable`. It is absent for every other task, including one where the check came back clean, so the example above - which has no PR recorded - never carries it.
 
 atqamz/secondhand#65: a worker's report prose has run several KB for a single task, and rendering it in full doubled the cost by repeating the latest entry - once as `Reported:`, again as the last line of `Report history`. Without `--full`:
 - The `Reported` line and every history line are capped to 200 runes (a character budget, not a word or line count, since the point is bounding rendered size). The cut lands after the state-vocabulary prefix (`working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, `failed:`) - the prefix is never part of what's cut - and a cut line always carries a trailing `... [+N chars]` marker naming how much was dropped, so a short report is never mistaken for a truncated one. `done: <PR url>` stays intact under this budget in the common case, since the worker convention puts the URL immediately after the prefix and 200 runes covers it comfortably; a URL buried after long prose is the same brief-authoring problem the write side already owns (see "Report channel").
@@ -562,12 +561,11 @@ Output (JSON, single task):
   "last_report_at": "2026-07-24T09:57:00Z",
   "reported": {"state": "needs-decision", "note": "two ways to fix the race, ask-user found both risky"},
   "report_history": ["working: added the retry loop", "needs-decision: two ways to fix the race, ask-user found both risky"],
-  "held": {"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"},
-  "gate_run_issue": "no run found"
+  "held": {"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"}
 }
 ```
 
-`reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. `held` is omitted when this id has no hold; an inconsistent hold (see the fleet overview above) adds an `inconsistent` field naming why instead of being omitted. `gate_run_issue` is omitted whenever the `Gate run:` line above would be - not a `done` `ship` task with a recorded PR on a registered `no-mistakes` project, or the check came back clean.
+`reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. `held` is omitted when this id has no hold; an inconsistent hold (see the fleet overview above) adds an `inconsistent` field naming why instead of being omitted. `gate_run_issue` carries the same `no run found` / `unreachable` text as the `Gate run:` line above and is omitted whenever that line would be - not a `done` `ship` task with a recorded PR on a registered `no-mistakes` project, or the check came back clean - which is why the example above, with no PR recorded, does not carry it.
 
 Fleet-overview JSON wraps the per-task rows rather than returning a bare array, so holds - which can outlive the task that had them - have somewhere to sit alongside it, and `task_count` alongside that, always present (never omitted, zero included) so an empty fleet is a positive statement rather than the same absence of output a broken command could also produce:
 
@@ -1579,9 +1577,10 @@ Five outcomes:
   error (exit code `1`), never `GateReady`: a caller must never be told to dispatch into a project
   the gate cannot cover.
 
-The last two are atqamz/secondhand#97: both are read the same way as every other outcome here,
-from `no-mistakes status`'s own text (a missing clone path fails the chdir before the binary ever
-runs), never from `~/.no-mistakes/state.sqlite`.
+The last two are atqamz/secondhand#97, and neither reads `~/.no-mistakes/state.sqlite` either. The
+non-git one is read from `no-mistakes status`'s own text, the same way every other outcome here is.
+The missing clone path is caught by stat-ing that path before the binary is run at all, because
+otherwise the failed chdir is what surfaces, as the misleading "binary not found or not runnable".
 
 Escape hatch: `--skip-gate-check` on both `hand spawn` and `hand promote` bypasses the preflight
 and prints a warning to stderr naming the project, so bypassing it is visible in the transcript

--- a/SPECS.md
+++ b/SPECS.md
@@ -464,8 +464,8 @@ Behavior (fleet overview):
 2. For each, query herdr for current agent state.
 3. Append the worker's own last classified report to the same column as ` (reported: <state>)`, whatever the pane is doing. A pane state and a report answer different questions, so both print: a worker that appends `paused:` while its harness keeps running used to render as a bare `working`, showing the pane and hiding the only party that had said why. `working` is the one report that stays unadorned, because it is what the column already says. ` (unreported)` still requires a not-busy pane (herdr's `idle` or `done` - see "Agent state" below), since a busy pane that has not reported yet is not a stop anyone has to explain. A report file that exists but can't be read appends ` (report unreadable)`, never ` (unreported)` - an I/O fault is not evidence the worker never reported.
 4. If the task has a recorded PR, append its merge state to the same column: ` (merged)` when `hand` performed the merge, ` (merged, external)` when `hand` only observed it - `hand watch`'s own `gh` poll saw it merged, or gate-opened-PR detection recorded a PR that was already merged. It is appended whatever the agent state is, since a merged PR is a fact about the PR rather than about the pane.
-5. Print one line per task, with a header row.
-6. List every hold in the store (see "Holds" under "State management") and print a `held:` block below the task table, one line per hold, skipped entirely when nothing is held. A hold names any id, not only a live task's, so a torn-down task's still-open hold keeps appearing here after its task row is gone. A failure to read the holds fails the whole command rather than degrading to an empty list - reading no holds back must never be mistaken for nothing being held.
+5. Print one line per task, with a header row - or, if there are no tasks at all, `no tasks (0)` in place of the table, so an empty fleet reads as a positive statement with a count rather than the same bare output a broken command could also produce.
+6. List every hold in the store (see "Holds" under "State management") and print a `held:` block below the task table, one line per hold, skipped entirely when nothing is held - printed even when there are no tasks, so a torn-down task's still-open hold is never hidden behind the `no tasks (0)` line above it. A hold names any id, not only a live task's, so a torn-down task's still-open hold keeps appearing here after its task row is gone. A failure to read the holds fails the whole command rather than degrading to an empty list - reading no holds back must never be mistaken for nothing being held.
 
 The `last report` column is the mtime of `state/<id>.status`, and `(none)` when the worker has never written one.
 It is deliberately not the task's age: the two used to be conflated, so a task spawned hours ago read as hours stale next to a status file its worker had touched minutes earlier - a reporting worker that looked abandoned.
@@ -488,6 +488,12 @@ held:
 ```
 
 A hold row that can't be trusted at face value - an unrecognized kind, a `blocked` hold with no `blocked_on`, or an `operator` hold carrying one - is still printed, never dropped, with `inconsistent: <why>` in place of its detail: an external write to `state/hand.db` is the only way such a row exists, since `hand hold set` validates before writing, and filtering it out here would silently drop the row most worth seeing.
+
+Output (fleet overview, empty):
+```
+no tasks (0)
+```
+Still followed by a `held:` block if any hold is open (step 6 above).
 
 Behavior (single task):
 1. Read the task from the store.
@@ -556,14 +562,18 @@ Output (JSON, single task):
 
 `reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. `held` is omitted when this id has no hold; an inconsistent hold (see the fleet overview above) adds an `inconsistent` field naming why instead of being omitted.
 
-Fleet-overview JSON wraps the per-task rows rather than returning a bare array, so holds - which can outlive the task that had them - have somewhere to sit alongside it:
+Fleet-overview JSON wraps the per-task rows rather than returning a bare array, so holds - which can outlive the task that had them - have somewhere to sit alongside it, and `task_count` alongside that, always present (never omitted, zero included) so an empty fleet is a positive statement rather than the same absence of output a broken command could also produce:
 
 ```json
 {
+  "task_count": 1,
   "tasks": [{"id": "fix-login", "...": "one row per task, reported only, no history"}],
   "holds": [{"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"}]
 }
 ```
+
+An empty fleet returns `{"task_count": 0, "tasks": [], "holds": [...]}` - `holds` still carries any
+open hold, never suppressed by there being no tasks.
 
 Errors:
 - Task ID not found.

--- a/SPECS.md
+++ b/SPECS.md
@@ -349,7 +349,8 @@ Flags:
 - `--harness <name>`: agent harness to launch. Default: value from `config/harness`, or `claude`.
 - `--model <name>`: model override for harnesses that support it. Default: the brief's declared `model`, else `config/model`.
 - `--effort <level>`: effort level for harnesses that support it. Default: the brief's declared `effort`, else `config/effort`.
-- `--skip-gate-check`: dispatch into a `no-mistakes` project even if its gate is not initialized (see "Gate preflight").
+- `--skip-gate-check`: dispatch into a `no-mistakes` project even if its gate is not initialized, its
+  clone path is missing from disk, or that path is not a git repository (see "Gate preflight").
 
 Model and effort resolve most-specific-first: the flag, then the brief's `---` declaration (see
 "Brief format"), then the config default, then unset. A resolved effort under a harness with no
@@ -1045,7 +1046,8 @@ Flags:
 - `--harness <name>`: harness for the new ship worker. Default: value from `config/harness`.
 - `--model <name>`: model override. Default: the brief's declared `model`, else `config/model`.
 - `--effort <level>`: effort override. Default: the brief's declared `effort`, else `config/effort`.
-- `--skip-gate-check`: dispatch into a `no-mistakes` project even if its gate is not initialized (see "Gate preflight").
+- `--skip-gate-check`: dispatch into a `no-mistakes` project even if its gate is not initialized, its
+  clone path is missing from disk, or that path is not a git repository (see "Gate preflight").
 
 Promote resolves model and effort exactly as `hand spawn` does, against the brief the agent
 updated for the ship phase, so a scout brief that declared a tier keeps it through promotion

--- a/SPECS.md
+++ b/SPECS.md
@@ -466,6 +466,7 @@ Behavior (fleet overview):
 4. If the task has a recorded PR, append its merge state to the same column: ` (merged)` when `hand` performed the merge, ` (merged, external)` when `hand` only observed it - `hand watch`'s own `gh` poll saw it merged, or gate-opened-PR detection recorded a PR that was already merged. It is appended whatever the agent state is, since a merged PR is a fact about the PR rather than about the pane.
 5. Print one line per task, with a header row - or, if there are no tasks at all, `no tasks (0)` in place of the table, so an empty fleet reads as a positive statement with a count rather than the same bare output a broken command could also produce.
 6. List every hold in the store (see "Holds" under "State management") and print a `held:` block below the task table, one line per hold, skipped entirely when nothing is held - printed even when there are no tasks, so a torn-down task's still-open hold is never hidden behind the `no tasks (0)` line above it. A hold names any id, not only a live task's, so a torn-down task's still-open hold keeps appearing here after its task row is gone. A failure to read the holds fails the whole command rather than degrading to an empty list - reading no holds back must never be mistaken for nothing being held.
+7. For a `ship` task reported `done` with a recorded PR, on a registered `no-mistakes` project: check whether that PR ever went through a gate run (see "Gate-run visibility" below), and append ` (gate: <issue>)` to the same column when it did not. The project registry read this step needs is best-effort - a registry fault leaves the check silent for every task rather than failing the whole overview over it.
 
 The `last report` column is the mtime of `state/<id>.status`, and `(none)` when the worker has never written one.
 It is deliberately not the task's age: the two used to be conflated, so a task spawned hours ago read as hours stale next to a status file its worker had touched minutes earlier - a reporting worker that looked abandoned.
@@ -481,6 +482,7 @@ stuck-task   nsr      ship   idle (unreported)                         1h ago  (
 paused-task  nsr      ship   idle (reported: needs-decision)           30m ago 12m ago
 investigate  nsr      scout  done (reported: done)                     10m ago 9m ago
 shipped-fix  nsr      ship   done (reported: done) (merged, external)  5m ago  4m ago
+no-gate-fix  nsr      ship   done (reported: done) (gate: no run found) 3m ago 2m ago
 
 held:
   fix-login         operator  two ways to fix this, needs a call          2h ago
@@ -501,7 +503,8 @@ Behavior (single task):
 3. Query herdr for current agent state and recent output.
 4. Read the last 5 lines of the task's report channel (see "Report channel"). A report file that exists but can't be read degrades exactly as it does in the fleet overview: the `Reported` line reads `report unreadable: <error>` and the rest of the detail view still prints, rather than the command failing and showing nothing.
 5. Read the hold on this id, if any (see "Holds" under "State management"). Unlike the report channel, a failure to read it fails the command - the same reasoning as the fleet overview's `held:` block.
-6. Print detailed view, including the most recent reported line and a labeled history block.
+6. If the task is a `ship` task reported `done` with a recorded PR: look up its project (unlike the fleet overview's best-effort registry read, a failure here fails the command - this id's own project is the one fact the check is about) and, if it is a registered `no-mistakes` project, check whether that PR ever went through a gate run (see "Gate-run visibility" below).
+7. Print detailed view, including the most recent reported line and a labeled history block.
 
 Output (single task):
 ```
@@ -519,6 +522,7 @@ PR:          (none)
 Reported:    needs-decision: two ways to fix the race, ask-user found both risky
 Report file: /home/user/secondhand/state/fix-login.status
 Held:        waiting on migrate-schema: needs the new column before this can proceed
+Gate run:    no run found
 
 Report history (reported by worker, not verified current truth):
   working: added the retry loop
@@ -527,6 +531,8 @@ Report history (reported by worker, not verified current truth):
 The `PR:` line reads `(none)` with no PR recorded, and otherwise carries the same merge suffix the fleet overview appends: `PR:          https://github.com/org/repo/pull/42 (merged, external)`.
 
 The `Held:` line is present only when this id has a hold, and reads the reason alone for an `operator` hold or `waiting on <blocked_on>: <reason>` for a `blocked` one; an inconsistent row (see the fleet overview above) prints `inconsistent: <why>` instead.
+
+The `Gate run:` line is present only for a `done` `ship` task with a recorded PR on a registered `no-mistakes` project whose gate-run check (see "Gate-run visibility" below) did not come back clean - `no run found` or `unreachable`. It is absent for every other task, including one where the check came back clean.
 
 atqamz/secondhand#65: a worker's report prose has run several KB for a single task, and rendering it in full doubled the cost by repeating the latest entry - once as `Reported:`, again as the last line of `Report history`. Without `--full`:
 - The `Reported` line and every history line are capped to 200 runes (a character budget, not a word or line count, since the point is bounding rendered size). The cut lands after the state-vocabulary prefix (`working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, `failed:`) - the prefix is never part of what's cut - and a cut line always carries a trailing `... [+N chars]` marker naming how much was dropped, so a short report is never mistaken for a truncated one. `done: <PR url>` stays intact under this budget in the common case, since the worker convention puts the URL immediately after the prefix and 200 runes covers it comfortably; a URL buried after long prose is the same brief-authoring problem the write side already owns (see "Report channel").
@@ -556,11 +562,12 @@ Output (JSON, single task):
   "last_report_at": "2026-07-24T09:57:00Z",
   "reported": {"state": "needs-decision", "note": "two ways to fix the race, ask-user found both risky"},
   "report_history": ["working: added the retry loop", "needs-decision: two ways to fix the race, ask-user found both risky"],
-  "held": {"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"}
+  "held": {"id": "fix-login", "kind": "blocked", "reason": "needs the new column before this can proceed", "blocked_on": "migrate-schema", "set_at": "2026-07-24T09:00:00Z"},
+  "gate_run_issue": "no run found"
 }
 ```
 
-`reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. `held` is omitted when this id has no hold; an inconsistent hold (see the fleet overview above) adds an `inconsistent` field naming why instead of being omitted.
+`reported` and `report_history` are omitted when the task has no report file yet, and so is `last_report_at`. `held` is omitted when this id has no hold; an inconsistent hold (see the fleet overview above) adds an `inconsistent` field naming why instead of being omitted. `gate_run_issue` is omitted whenever the `Gate run:` line above would be - not a `done` `ship` task with a recorded PR on a registered `no-mistakes` project, or the check came back clean.
 
 Fleet-overview JSON wraps the per-task rows rather than returning a bare array, so holds - which can outlive the task that had them - have somewhere to sit alongside it, and `task_count` alongside that, always present (never omitted, zero included) so an empty fleet is a positive statement rather than the same absence of output a broken command could also produce:
 
@@ -575,10 +582,13 @@ Fleet-overview JSON wraps the per-task rows rather than returning a bare array, 
 An empty fleet returns `{"task_count": 0, "tasks": [], "holds": [...]}` - `holds` still carries any
 open hold, never suppressed by there being no tasks.
 
+Each row in `tasks` carries `gate_run_issue` under the same omission rule as the single-task JSON above.
+
 Errors:
 - Task ID not found.
 - Herdr unreachable (graceful degradation: show state as "unknown").
 - The hold store can't be read (fails the command; never degrades to an empty `holds`/no `held` - see "Holds" under "State management").
+- The single-task view's own project can't be read while checking gate-run visibility (fails the command; the fleet overview's equivalent lookup is best-effort instead - see behavior step 7 above).
 
 ---
 
@@ -1581,6 +1591,41 @@ rather than a silent env var.
 not initialized)` or `(gate: unreachable)` to its output line (and `"gate_issue"` in `--json`
 output) when the check doesn't come back clean, so a stale or never-initialized gate is visible
 without waiting for a spawn or promote to refuse.
+
+### Gate-run visibility
+
+Gate preflight answers whether a project's gate is initialized. It says nothing about whether any
+given shipped PR actually went through it: a `no-mistakes`-mode project's gate can be ready and
+still never have run against the branch a particular task's PR came from - the project was
+registered after the fact, the PR was opened by hand outside the `pr` step, or the gate was
+bypassed with `--skip-gate-check`. atqamz/secondhand#92 is that gap: `hand status` had no way to
+surface a `done` `ship` task with a recorded PR that never went through a gate run at all.
+
+`hand status` answers this with `project.GateRanForPR(clonePath, prURL)`: run `no-mistakes runs
+--limit 10000` in the project's clone and look for a `completed` row whose own recorded PR is
+exactly `prURL`, the same read-only, text-scraping approach `GateStatus` already uses for gate
+preflight, never `~/.no-mistakes/state.sqlite` directly.
+
+This establishes only that the no-mistakes `pr` step opened this exact PR from a run that reached
+`completed` - nothing more, and the wording is deliberately no stronger than that:
+- It is not a per-commit answer. `no-mistakes`'s own state is keyed on `working_path`, not per-PR
+  (see "Gate preflight" above), and `hand` records no head commit for a task's PR to compare
+  against. A push to the same branch after the matched run completed - amending the PR without a
+  new run - still reads as gated, exactly as it did before that push.
+- A PR opened by hand outside the no-mistakes `pr` step reads as `no run found` even sitting behind
+  a run that did complete: nothing ties that URL to that run's own bookkeeping.
+- A PR with no completed run recording that exact URL reads as `no run found`. A failure to ask
+  no-mistakes at all - a missing clone, an unrunnable binary - reads as `unreachable`, the same
+  bucket `gateIssue` uses for the identical failure in `hand project list`, so a question the check
+  could not answer never renders as the stronger claim `no run found`.
+
+A marker that claims more certainty than this data supports would be worse than no marker at all,
+so `hand status` only ever says what the two outcomes above actually establish - never "this PR is
+safe" or "this PR is gated", only whether a matching completed run was found.
+
+The check applies to a `done` `ship` task with a recorded PR on a registered `no-mistakes`
+project only; every other task - in progress, `scout`, no PR yet, project not registered or not
+`no-mistakes` - has nothing this check can say, so it stays silent.
 
 ## Brief format
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -305,11 +305,12 @@ Output (JSON):
 ]
 ```
 
-A `no-mistakes`-mode project whose gate cannot currently be honoured (not initialized, or the
-`no-mistakes` binary itself unreachable) gets a `(gate: <issue>)` suffix in human output and a
-`gate_issue` field in JSON output (omitted when there is no issue). See "Gate preflight" for what
-this checks and why. Every `no-mistakes`-mode project pays one `no-mistakes status` call per
-`hand project list` invocation; other modes pay nothing.
+A `no-mistakes`-mode project whose gate cannot currently be honoured (not initialized, or
+`unreachable` - the binary itself missing, the clone path missing on disk, or the clone path
+existing but not a git repository; see "Gate preflight") gets a `(gate: <issue>)` suffix in human
+output and a `gate_issue` field in JSON output (omitted when there is no issue). Every
+`no-mistakes`-mode project pays one `no-mistakes status` call per `hand project list` invocation;
+other modes pay nothing.
 
 ---
 
@@ -1540,7 +1541,7 @@ never-initialized repo from a stale renamed one from the outside, so the preflig
 The outcome is read from that text, never from `~/.no-mistakes/state.sqlite` directly,
 which is another tool's private schema.
 
-Three outcomes:
+Five outcomes:
 - **Initialized:** proceed.
 - **Not initialized** (either history): refuse with exit code 3, naming the exact remedy verbatim -
   `no-mistakes init` is idempotent and repairs a stale `working_path` in place, so the message reads
@@ -1549,6 +1550,18 @@ Three outcomes:
   binary not found or not runnable: <error>`), never collapsed into "not initialized" - the remedy
   for a missing binary is not `no-mistakes init`. This is a general error (exit code `1`), not a
   precondition: the world is not in a state the operator can fix by initializing anything.
+- **Clone path does not exist on disk:** refuse with `no-mistakes clone path: <stat error>`, naming
+  the real cause instead of the misleading "binary not found or not runnable" a chdir failure used
+  to produce. Also a general error (exit code `1`).
+- **Clone path exists but is not a git repository:** `no-mistakes status` itself exits 0 and prints
+  `not in a git repository` in this case - a plain-looking success that used to read as a ready
+  gate. Refuse instead with `no-mistakes clone path is not a git repository: <path>`, also a general
+  error (exit code `1`), never `GateReady`: a caller must never be told to dispatch into a project
+  the gate cannot cover.
+
+The last two are atqamz/secondhand#97: both are read the same way as every other outcome here,
+from `no-mistakes status`'s own text (a missing clone path fails the chdir before the binary ever
+runs), never from `~/.no-mistakes/state.sqlite`.
 
 Escape hatch: `--skip-gate-check` on both `hand spawn` and `hand promote` bypasses the preflight
 and prints a warning to stderr naming the project, so bypassing it is visible in the transcript

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,15 +12,25 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
-// fakeNoMistakesPath writes a fake no-mistakes binary that only answers `status`, mirroring the
-// real binary's observed behavior documented in internal/project.GateStatus: it always exits 0,
-// so the outcome is read from stdout text rather than the exit code. Returns a PATH with the fake
-// binary's directory prepended ahead of the real PATH: the script's own "cat" still needs to
-// resolve, and the fake must win the lookup over any real no-mistakes already on this machine.
+// fakeNoMistakesPath writes a fake no-mistakes binary that answers every subcommand with the same
+// text, mirroring the real binary's observed behavior documented in internal/project.GateStatus:
+// `no-mistakes status` exits 0 whether or not the repo is initialized, so the outcome is read from
+// stdout text rather than the exit code. Returns a PATH with the fake binary's directory prepended
+// ahead of the real PATH: the script's own "cat" still needs to resolve, and the fake must win the
+// lookup over any real no-mistakes already on this machine.
 func fakeNoMistakesPath(t *testing.T, stdout string) string {
+	return fakeNoMistakesPathExit(t, stdout, 0)
+}
+
+// fakeNoMistakesPathExit is fakeNoMistakesPath with an explicit exit code, for the invocations the
+// real binary refuses non-zero: `no-mistakes runs` exits 1 on both "repo not initialized" and "not
+// in a git repository", where `no-mistakes status` exits 0 printing the same text. GateRunPRs reads
+// the refusal from the text either way, so the fake reproduces the exit code rather than flattening
+// every refusal to 0.
+func fakeNoMistakesPathExit(t *testing.T, stdout string, code int) string {
 	t.Helper()
 	bin := t.TempDir()
-	script := "#!/bin/sh\ncat <<'EOF'\n" + stdout + "\nEOF\n"
+	script := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\nexit %d\n", stdout, code)
 	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -202,6 +202,6 @@ func newPromoteCmd() *cobra.Command {
 	cmd.Flags().StringVar(&harnessName, "harness", "", "harness for the new ship worker (default: config/harness, or claude)")
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort override for harnesses that support it")
-	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized for this project")
+	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized, the clone path is missing from disk, or that path is not a git repository")
 	return cmd
 }

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -191,7 +191,7 @@ func newSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&harnessName, "harness", "", "agent harness to launch (default: config/harness, or claude)")
 	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
 	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
-	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized for this project")
+	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized, the clone path is missing from disk, or that path is not a git repository")
 	return cmd
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -111,10 +111,13 @@ type statusJSON struct {
 
 // fleetJSON wraps the task rows with the fleet's holds, which name any id -
 // not only a live task - so a torn-down task's still-open hold keeps
-// surfacing here after its task row is gone.
+// surfacing here after its task row is gone. TaskCount is always present,
+// zero included, so an empty fleet is a positive statement ("no tasks") and
+// not the same absence of output a broken command would also produce.
 type fleetJSON struct {
-	Tasks []statusJSON `json:"tasks"`
-	Holds []holdJSON   `json:"holds"`
+	TaskCount int          `json:"task_count"`
+	Tasks     []statusJSON `json:"tasks"`
+	Holds     []holdJSON   `json:"holds"`
 }
 
 // holdJSON mirrors state.Hold, plus Inconsistent, which is set instead of the
@@ -226,7 +229,14 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(fleetJSON{Tasks: rows, Holds: holdRows})
+		return enc.Encode(fleetJSON{TaskCount: len(rows), Tasks: rows, Holds: holdRows})
+	}
+
+	if len(rows) == 0 {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "no tasks (0)"); err != nil {
+			return err
+		}
+		return printHeldBlock(cmd, holds)
 	}
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"text/tabwriter"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/dashboard"
 	"github.com/atqamz/secondhand/internal/herdr"
 	"github.com/atqamz/secondhand/internal/home"
+	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -107,6 +109,7 @@ type statusJSON struct {
 	Reported       *reportedJSON `json:"reported,omitempty"`
 	ReportHistory  []string      `json:"report_history,omitempty"`
 	Held           *holdJSON     `json:"held,omitempty"`
+	GateRunIssue   string        `json:"gate_run_issue,omitempty"`
 }
 
 // fleetJSON wraps the task rows with the fleet's holds, which name any id -
@@ -189,6 +192,39 @@ func mergeSuffix(t state.Task) string {
 	}
 }
 
+// gateRunIssue reports why a done ship task's recorded PR cannot be confirmed to have gone through a
+// no-mistakes gate run, using the same "unreachable" bucket gateIssue (cmd/project.go) uses for any
+// failure to ask no-mistakes at all - a missing clone, an unrunnable binary - so a question this check
+// cannot answer never renders as the stronger claim "no run found".
+//
+// Only a done ship task with a recorded PR on a registered no-mistakes project has anything for this
+// check to say; an in-progress or scout task, a PR-less task, or a project not registered or not run
+// through no-mistakes stays silent, since the check does not apply to it.
+func gateRunIssue(home string, t state.Task, reportedDone bool, p project.Project, registered bool) string {
+	if t.Kind != state.KindShip || t.PR == "" || !reportedDone {
+		return ""
+	}
+	if !registered || p.Mode != project.ModeNoMistakes {
+		return ""
+	}
+	clonePath := filepath.Join(home, "projects", p.Name)
+	ran, err := project.GateRanForPR(clonePath, t.PR)
+	if err != nil {
+		return "unreachable"
+	}
+	if !ran {
+		return "no run found"
+	}
+	return ""
+}
+
+func gateRunSuffix(issue string) string {
+	if issue == "" {
+		return ""
+	}
+	return " (gate: " + issue + ")"
+}
+
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool) error {
 	tasks, err := state.List(home)
 	if err != nil {
@@ -201,6 +237,15 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		return err
 	}
 
+	// Best-effort, like project.List elsewhere in this fleet view: a registry
+	// read fault degrades every task's gate-run check to silent rather than
+	// failing the whole fleet overview over it.
+	projects, _ := project.List(home)
+	projectByName := make(map[string]project.Project, len(projects))
+	for _, p := range projects {
+		projectByName[p.Name] = p
+	}
+
 	rows := make([]statusJSON, 0, len(tasks))
 	suffixes := make([]string, 0, len(tasks))
 	for _, t := range tasks {
@@ -211,6 +256,8 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 			last = lines[len(lines)-1]
 		}
 		reported, reportedOK := state.LastReportedState(lines)
+		p, registered := projectByName[t.Project]
+		runIssue := gateRunIssue(home, t, reportedOK && reported.State == state.ReportDone, p, registered)
 		rows = append(rows, statusJSON{
 			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
 			AgentState: agentState,
@@ -218,8 +265,9 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 			MergeExecuted: t.MergeExecuted, MergeAnnounced: t.MergeAnnounced, CreatedAt: t.CreatedAt,
 			LastReportAt: lastReportAt(home, t.ID),
 			Reported:     reportedFrom(last, len(lines) > 0, readErr),
+			GateRunIssue: runIssue,
 		})
-		suffixes = append(suffixes, reportSuffix(agentState, reported, reportedOK, readErr)+mergeSuffix(t))
+		suffixes = append(suffixes, reportSuffix(agentState, reported, reportedOK, readErr)+mergeSuffix(t)+gateRunSuffix(runIssue))
 	}
 
 	if asJSON {
@@ -346,12 +394,22 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	if len(tail) > 0 {
 		last = tail[len(tail)-1]
 	}
+	lastReported, lastReportedOK := state.LastReportedState(tail)
 
 	var heldJSON *holdJSON
 	if held {
 		j := holdToJSON(hold)
 		heldJSON = &j
 	}
+
+	// Propagated, not degraded: a single task's own project is the one fact
+	// this check is about, unlike the fleet view's best-effort lookup across
+	// every task's project at once.
+	p, registered, err := project.Find(home, t.Project)
+	if err != nil {
+		return err
+	}
+	runIssue := gateRunIssue(home, t, lastReportedOK && lastReported.State == state.ReportDone, p, registered)
 
 	if asJSON {
 		out := statusJSON{
@@ -360,7 +418,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 			MergeExecuted: t.MergeExecuted, MergeAnnounced: t.MergeAnnounced, CreatedAt: t.CreatedAt,
 			LastReportAt: lastReportAt(home, id),
 			Reported:     reportedFrom(last, len(tail) > 0, readErr), ReportHistory: history,
-			Held: heldJSON,
+			Held: heldJSON, GateRunIssue: runIssue,
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -405,6 +463,9 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	}
 	if held {
 		lines = append(lines, fmt.Sprintf("Held:        %s", holdDetail(hold)))
+	}
+	if runIssue != "" {
+		lines = append(lines, fmt.Sprintf("Gate run:    %s", runIssue))
 	}
 	if !full && (len(tail) > 0 || readErr != nil) {
 		lines = append(lines, fmt.Sprintf("Report file: %s", state.ReportPath(home, id)))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -192,27 +192,57 @@ func mergeSuffix(t state.Task) string {
 	}
 }
 
+// gateRunApplies is the single predicate for whether the gate-run check has anything to say about a
+// task: only a done ship task with a recorded PR does. Everything the check needs - the project
+// lookup above all, whose failure the single-task view propagates - hangs off this, so a task the
+// check would stay silent on never pays that cost nor fails over it.
+func gateRunApplies(t state.Task, reportedDone bool) bool {
+	return t.Kind == state.KindShip && t.PR != "" && reportedDone
+}
+
+// gateRunReader answers "which PRs did completed no-mistakes runs record" for one clone path.
+type gateRunReader func(clonePath string) (map[string]bool, error)
+
+// newGateRunReader caches each clone path's answer for the life of one render, so a fleet with
+// several done ship tasks on the same project spawns one no-mistakes process for it, not one per
+// task. Failures are cached too: a clone that could not be asked once is not worth re-asking within
+// the same render.
+func newGateRunReader() gateRunReader {
+	type answer struct {
+		prs map[string]bool
+		err error
+	}
+	cache := map[string]answer{}
+	return func(clonePath string) (map[string]bool, error) {
+		a, ok := cache[clonePath]
+		if !ok {
+			a.prs, a.err = project.GateRunPRs(clonePath)
+			cache[clonePath] = a
+		}
+		return a.prs, a.err
+	}
+}
+
 // gateRunIssue reports why a done ship task's recorded PR cannot be confirmed to have gone through a
 // no-mistakes gate run, using the same "unreachable" bucket gateIssue (cmd/project.go) uses for any
-// failure to ask no-mistakes at all - a missing clone, an unrunnable binary - so a question this check
-// cannot answer never renders as the stronger claim "no run found".
+// failure to ask no-mistakes at all - a missing clone, an unrunnable binary, a gate never
+// initialized - so a question this check cannot answer never renders as the stronger claim "no run
+// found".
 //
-// Only a done ship task with a recorded PR on a registered no-mistakes project has anything for this
-// check to say; an in-progress or scout task, a PR-less task, or a project not registered or not run
-// through no-mistakes stays silent, since the check does not apply to it.
-func gateRunIssue(home string, t state.Task, reportedDone bool, p project.Project, registered bool) string {
-	if t.Kind != state.KindShip || t.PR == "" || !reportedDone {
+// A project not registered or not run through no-mistakes stays silent alongside every task
+// gateRunApplies rejects, since the check does not apply to it either.
+func gateRunIssue(home string, t state.Task, reportedDone bool, p project.Project, registered bool, runPRs gateRunReader) string {
+	if !gateRunApplies(t, reportedDone) {
 		return ""
 	}
 	if !registered || p.Mode != project.ModeNoMistakes {
 		return ""
 	}
-	clonePath := filepath.Join(home, "projects", p.Name)
-	ran, err := project.GateRanForPR(clonePath, t.PR)
+	prs, err := runPRs(filepath.Join(home, "projects", p.Name))
 	if err != nil {
 		return "unreachable"
 	}
-	if !ran {
+	if !prs[t.PR] {
 		return "no run found"
 	}
 	return ""
@@ -239,12 +269,20 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 
 	// Best-effort, like project.List elsewhere in this fleet view: a registry
 	// read fault degrades every task's gate-run check to silent rather than
-	// failing the whole fleet overview over it.
-	projects, _ := project.List(home)
+	// failing the whole fleet overview over it. Named on stderr all the same -
+	// silently dropping every (gate: ...) marker fleet-wide would render an
+	// ungated PR as clean, the false all-clear this feature exists to avoid.
+	projects, projectsErr := project.List(home)
+	if projectsErr != nil {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: project registry unreadable, gate-run checks skipped: %v\n", projectsErr); err != nil {
+			return err
+		}
+	}
 	projectByName := make(map[string]project.Project, len(projects))
 	for _, p := range projects {
 		projectByName[p.Name] = p
 	}
+	runPRs := newGateRunReader()
 
 	rows := make([]statusJSON, 0, len(tasks))
 	suffixes := make([]string, 0, len(tasks))
@@ -257,7 +295,7 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		}
 		reported, reportedOK := state.LastReportedState(lines)
 		p, registered := projectByName[t.Project]
-		runIssue := gateRunIssue(home, t, reportedOK && reported.State == state.ReportDone, p, registered)
+		runIssue := gateRunIssue(home, t, reportedOK && reported.State == state.ReportDone, p, registered, runPRs)
 		rows = append(rows, statusJSON{
 			ID: t.ID, Project: t.Project, Kind: t.Kind, Harness: t.Harness,
 			AgentState: agentState,
@@ -402,14 +440,20 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		heldJSON = &j
 	}
 
-	// Propagated, not degraded: a single task's own project is the one fact
-	// this check is about, unlike the fleet view's best-effort lookup across
-	// every task's project at once.
-	p, registered, err := project.Find(home, t.Project)
-	if err != nil {
-		return err
+	// Looked up only when the check applies, so a registry this id's detail view
+	// does not need can never fail the command. When it does apply the failure is
+	// propagated, not degraded: a single task's own project is the one fact this
+	// check is about, unlike the fleet view's best-effort lookup across every
+	// task's project at once.
+	reportedDone := lastReportedOK && lastReported.State == state.ReportDone
+	var runIssue string
+	if gateRunApplies(t, reportedDone) {
+		p, registered, err := project.Find(home, t.Project)
+		if err != nil {
+			return err
+		}
+		runIssue = gateRunIssue(home, t, reportedDone, p, registered, newGateRunReader())
 	}
-	runIssue := gateRunIssue(home, t, lastReportedOK && lastReported.State == state.ReportDone, p, registered)
 
 	if asJSON {
 		out := statusJSON{

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1203,3 +1203,61 @@ func TestStatusSingleTaskPropagatesAnUnreadableHoldStore(t *testing.T) {
 		t.Fatal("got nil error, want the unreadable hold store to fail the command")
 	}
 }
+
+func TestStatusFleetEmptyIsAPositiveStatement(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) != "no tasks (0)" {
+		t.Fatalf("got %q, want an explicit no-tasks count and nothing else", out.String())
+	}
+}
+
+func TestStatusFleetEmptyJSONCarriesACount(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"task_count": 0`) {
+		t.Fatalf("got %q, want an explicit task_count of 0", out.String())
+	}
+}
+
+// An empty fleet must never read as "nothing to see" when a hold is still open on a torn-down
+// task's id - the exact false-all-clear atqamz/secondhand#63 guards against.
+func TestStatusFleetEmptyStillShowsHeldBlock(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := state.SetHold(home, state.Hold{ID: "gone-task", Kind: state.HoldKindOperator,
+		Reason: "needs a call", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "no tasks (0)") || !strings.Contains(out.String(), "held:") ||
+		!strings.Contains(out.String(), "needs a call") {
+		t.Fatalf("got %q, want both the no-tasks count and the held block", out.String())
+	}
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1486,3 +1486,166 @@ func TestStatusSingleTaskNoGateLineWhenRunFound(t *testing.T) {
 		t.Fatalf("got %q, want no Gate run line once a completed run recorded this PR", out.String())
 	}
 }
+
+// countingNoMistakesPath is fakeNoMistakesPath plus an append to countFile per invocation, so a test
+// can assert how many no-mistakes processes one render actually spawned.
+func countingNoMistakesPath(t *testing.T, stdout, countFile string) string {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\necho x >> " + countFile + "\ncat <<'EOF'\n" + stdout + "\nEOF\n"
+	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin + string(os.PathListSeparator) + os.Getenv("PATH")
+}
+
+// TestStatusFleetAsksNoMistakesOncePerProject pins the per-clone caching: without it every done ship
+// task on one project spawns its own `no-mistakes runs` and re-parses identical output, on the
+// command CLAUDE.md makes the first step of every session.
+func TestStatusFleetAsksNoMistakesOncePerProject(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	countFile := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("PATH", countingNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n", countFile))
+
+	for _, id := range []string{"task-1", "task-2", "task-3"} {
+		if err := state.Write(home, state.Task{ID: id, Project: "gated", Kind: state.KindShip,
+			PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+			t.Fatal(err)
+		}
+		writeDoneReport(t, home, id, "PR "+gateRunTestPR+" checks green")
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(out.String(), "(gate: no run found)") != 3 {
+		t.Fatalf("got %q, want all three ungated tasks marked", out.String())
+	}
+	calls, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(strings.Fields(string(calls))); got != 1 {
+		t.Fatalf("no-mistakes ran %d times for one project, want 1", got)
+	}
+}
+
+// writeBrokenRegistry writes a data/projects.md line the registry parser rejects, so project.List
+// and project.Find both fail on this home.
+func writeBrokenRegistry(t *testing.T, home string) {
+	t.Helper()
+	if err := os.WriteFile(project.RegistryPath(home), []byte("- broken line with no url or mode\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// An unreadable registry silently drops every (gate: ...) marker fleet-wide, which renders an
+// ungated PR as clean - so the overview still prints, but says on stderr that it did.
+func TestStatusFleetNamesAnUnreadableRegistryOnStderr(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeBrokenRegistry(t, home)
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want a registry fault to degrade the gate check rather than fail the overview", err)
+	}
+	if !strings.Contains(out.String(), "task-1") {
+		t.Fatalf("got %q, want the task table to still print", out.String())
+	}
+	if !strings.Contains(errOut.String(), "warning:") || !strings.Contains(errOut.String(), "registry") {
+		t.Fatalf("got stderr %q, want a warning naming the unreadable project registry", errOut.String())
+	}
+}
+
+// TestStatusSingleTaskReadsRegistryOnlyWhenTheGateCheckApplies covers a scout task on a home whose
+// registry does not parse: the gate-run check has nothing to say about it, so the detail view must
+// not fail over a lookup it never needed.
+func TestStatusSingleTaskReadsRegistryOnlyWhenTheGateCheckApplies(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeBrokenRegistry(t, home)
+	if err := state.Write(home, state.Task{ID: "scout-1", Project: "gated", Kind: state.KindScout,
+		CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"scout-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want the detail view to print without reading the registry", err)
+	}
+	if !strings.Contains(out.String(), "Task:        scout-1") {
+		t.Fatalf("got %q, want the detail view rendered", out.String())
+	}
+}
+
+// The counterpart: when the check does apply, the same unreadable registry fails the command rather
+// than silently degrading to no marker - this id's own project is the one fact the check is about.
+func TestStatusSingleTaskPropagatesAnUnreadableRegistryWhenTheGateCheckApplies(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeBrokenRegistry(t, home)
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("got nil error, want the unreadable registry to fail the check it is needed for")
+	}
+}
+
+// TestStatusGateRunUnreachableWhenGateNotInitialized is the uninitialized-gate half of the
+// unreachable bucket: no-mistakes still holds that repo's completed runs, so reading its refusal as
+// an empty run list would report a genuinely gated PR as never gated.
+func TestStatusGateRunUnreachableWhenGateNotInitialized(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "(gate: unreachable)") {
+		t.Fatalf("got %q, want an uninitialized gate read as unreachable, never as no run found", out.String())
+	}
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1630,7 +1630,7 @@ func TestStatusGateRunUnreachableWhenGateNotInitialized(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	registerNoMistakesProject(t, home, "gated")
-	t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)"))
+	t.Setenv("PATH", fakeNoMistakesPathExit(t, "repo not initialized (run 'no-mistakes init' first)", 1))
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
 		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 	"github.com/atqamz/secondhand/internal/store"
 )
@@ -1259,5 +1260,229 @@ func TestStatusFleetEmptyStillShowsHeldBlock(t *testing.T) {
 	if !strings.Contains(out.String(), "no tasks (0)") || !strings.Contains(out.String(), "held:") ||
 		!strings.Contains(out.String(), "needs a call") {
 		t.Fatalf("got %q, want both the no-tasks count and the held block", out.String())
+	}
+}
+
+// registerNoMistakesProject registers a no-mistakes-mode project and creates its clone directory, so
+// gateRunIssue's os.Stat(clonePath) check and its no-mistakes invocation both have something to find.
+func registerNoMistakesProject(t *testing.T, home, name string) {
+	t.Helper()
+	if err := project.Add(home, project.Project{Name: name, URL: "https://example.com/" + name + ".git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeDoneReport writes a single done report line, so LastReportedState reads the task as reported done.
+func writeDoneReport(t *testing.T, home, id, note string) {
+	t.Helper()
+	if err := os.WriteFile(state.ReportPath(home, id), []byte("done: "+note+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const gateRunTestPR = "https://github.com/atqamz/secondhand/pull/120"
+
+func TestStatusFleetFlagsShippedPRWithNoGateRun(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "(gate: no run found)") {
+		t.Fatalf("got %q, want a gate marker naming the shipped PR never ran through the gate", out.String())
+	}
+}
+
+func TestStatusFleetJSONFlagsShippedPRWithNoGateRun(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"gate_run_issue": "no run found"`) {
+		t.Fatalf("got %q, want gate_run_issue naming no run found", out.String())
+	}
+}
+
+func TestStatusFleetNoGateMarkerWhenRunFound(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  "+gateRunTestPR+"\n"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "(gate:") {
+		t.Fatalf("got %q, want no gate marker once a completed run recorded this PR", out.String())
+	}
+}
+
+func TestStatusFleetGateRunUnreachableWhenNoMistakesBinaryMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", t.TempDir())
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "(gate: unreachable)") {
+		t.Fatalf("got %q, want the gate check named unreachable rather than the stronger no-run-found claim", out.String())
+	}
+}
+
+// TestStatusFleetSkipsGateCheckWhenItDoesNotApply covers a scout task with a PR-like field unset and
+// no report at all: the check has nothing to say about a task that never shipped, so it must stay
+// silent rather than misreport it as an ungated ship.
+func TestStatusFleetSkipsGateCheckWhenItDoesNotApply(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", t.TempDir())
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindScout,
+		CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "(gate:") {
+		t.Fatalf("got %q, want no gate marker for a scout task with no shipped PR", out.String())
+	}
+}
+
+func TestStatusSingleTaskFlagsShippedPRWithNoGateRun(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Gate run:    no run found") {
+		t.Fatalf("got %q, want a Gate run line naming the shipped PR never ran through the gate", out.String())
+	}
+}
+
+func TestStatusSingleTaskJSONFlagsShippedPRWithNoGateRun(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"gate_run_issue": "no run found"`) {
+		t.Fatalf("got %q, want gate_run_issue naming no run found", out.String())
+	}
+}
+
+func TestStatusSingleTaskNoGateLineWhenRunFound(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	registerNoMistakesProject(t, home, "gated")
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  "+gateRunTestPR+"\n"))
+
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR "+gateRunTestPR+" checks green")
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "Gate run:") {
+		t.Fatalf("got %q, want no Gate run line once a completed run recorded this PR", out.String())
 	}
 }

--- a/internal/project/gaterun.go
+++ b/internal/project/gaterun.go
@@ -12,39 +12,49 @@ import (
 // literally unbounded output on every check.
 const gateRunLimit = "10000"
 
-// GateRanForPR reports whether a completed no-mistakes run's own recorded PR is exactly prURL, read
-// from `no-mistakes runs` text in clonePath - the same read-only, text-scraping approach GateStatus
-// already uses, never `~/.no-mistakes/state.sqlite` directly.
+// GateRunPRs returns the set of PR URLs recorded by completed no-mistakes runs in clonePath, read
+// from `no-mistakes runs` text - the same read-only, text-scraping approach GateStatus already uses,
+// never `~/.no-mistakes/state.sqlite` directly. It answers per clone rather than per PR so a caller
+// checking many tasks on one project pays one no-mistakes process, not one per task.
 //
-// This establishes only that the no-mistakes `pr` step opened this exact PR from a run that reached
-// `completed`. It is deliberately not a per-commit answer: no-mistakes' own state is keyed on
+// Membership establishes only that the no-mistakes `pr` step opened that exact PR from a run that
+// reached `completed`. It is deliberately not a per-commit answer: no-mistakes' own state is keyed on
 // working_path, not per-PR (see SPECS.md's "Gate preflight"), and hand records no head commit for a
 // task's PR to compare against. A push to the same branch after the matched run completed - amending
 // the PR without a new run - reads as gated here exactly as it did before that push; that gap is real
 // and is documented rather than papered over with a false confidence this data cannot support. A PR
 // opened by hand outside the no-mistakes `pr` step, even behind a run that did complete, also reads
-// as not found, for the same reason: nothing ties that URL to that run's own bookkeeping.
-func GateRanForPR(clonePath, prURL string) (bool, error) {
-	if prURL == "" {
-		return false, nil
-	}
+// as absent, for the same reason: nothing ties that URL to that run's own bookkeeping.
+//
+// Every way of failing to ask no-mistakes at all is an error, never an empty set, so a caller can
+// keep "the gate recorded no such run" separate from "the question could not be asked": a missing
+// clone path, an unrunnable binary, and - read from the output text rather than the exit code, the
+// same way GateStatus reads them, since no-mistakes can print either while exiting 0 - an
+// uninitialized gate or a clone path that is not a git repository at all.
+func GateRunPRs(clonePath string) (map[string]bool, error) {
 	if _, err := os.Stat(clonePath); err != nil {
-		return false, fmt.Errorf("no-mistakes clone path: %w", err)
+		return nil, fmt.Errorf("no-mistakes clone path: %w", err)
 	}
 	cmd := exec.Command("no-mistakes", "runs", "--limit", gateRunLimit)
 	cmd.Dir = clonePath
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
+	text := string(out)
+	if strings.Contains(text, gateNotInitializedMarker) {
+		return nil, fmt.Errorf("no-mistakes gate not initialized: %s", GateInitCommand(clonePath))
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	if strings.Contains(text, notGitRepoMarker) {
+		return nil, fmt.Errorf("no-mistakes clone path is not a git repository: %s", clonePath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
+	}
+	prs := make(map[string]bool)
+	for _, line := range strings.Split(text, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 2 || fields[0] != "completed" {
 			continue
 		}
-		if fields[len(fields)-1] == prURL {
-			return true, nil
-		}
+		prs[fields[len(fields)-1]] = true
 	}
-	return false, nil
+	return prs, nil
 }

--- a/internal/project/gaterun.go
+++ b/internal/project/gaterun.go
@@ -29,7 +29,8 @@ const gateRunLimit = "10000"
 // Every way of failing to ask no-mistakes at all is an error, never an empty set, so a caller can
 // keep "the gate recorded no such run" separate from "the question could not be asked": a missing
 // clone path, an unrunnable binary, and - read from the output text rather than the exit code, the
-// same way GateStatus reads them, since no-mistakes can print either while exiting 0 - an
+// same way GateStatus reads them, because `no-mistakes runs` exits 1 for both an uninitialized gate
+// and a non-git clone path, leaving the exit code with nothing to tell the two apart - an
 // uninitialized gate or a clone path that is not a git repository at all.
 func GateRunPRs(clonePath string) (map[string]bool, error) {
 	if _, err := os.Stat(clonePath); err != nil {

--- a/internal/project/gaterun.go
+++ b/internal/project/gaterun.go
@@ -1,0 +1,50 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// gateRunLimit bounds how far back `no-mistakes runs` is asked to look. Large enough to cover any
+// project's real history (the busiest project here sits under 30 runs total) without asking for
+// literally unbounded output on every check.
+const gateRunLimit = "10000"
+
+// GateRanForPR reports whether a completed no-mistakes run's own recorded PR is exactly prURL, read
+// from `no-mistakes runs` text in clonePath - the same read-only, text-scraping approach GateStatus
+// already uses, never `~/.no-mistakes/state.sqlite` directly.
+//
+// This establishes only that the no-mistakes `pr` step opened this exact PR from a run that reached
+// `completed`. It is deliberately not a per-commit answer: no-mistakes' own state is keyed on
+// working_path, not per-PR (see SPECS.md's "Gate preflight"), and hand records no head commit for a
+// task's PR to compare against. A push to the same branch after the matched run completed - amending
+// the PR without a new run - reads as gated here exactly as it did before that push; that gap is real
+// and is documented rather than papered over with a false confidence this data cannot support. A PR
+// opened by hand outside the no-mistakes `pr` step, even behind a run that did complete, also reads
+// as not found, for the same reason: nothing ties that URL to that run's own bookkeeping.
+func GateRanForPR(clonePath, prURL string) (bool, error) {
+	if prURL == "" {
+		return false, nil
+	}
+	if _, err := os.Stat(clonePath); err != nil {
+		return false, fmt.Errorf("no-mistakes clone path: %w", err)
+	}
+	cmd := exec.Command("no-mistakes", "runs", "--limit", gateRunLimit)
+	cmd.Dir = clonePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "completed" {
+			continue
+		}
+		if fields[len(fields)-1] == prURL {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/project/gaterun_test.go
+++ b/internal/project/gaterun_test.go
@@ -5,66 +5,85 @@ import (
 	"testing"
 )
 
-func TestGateRanForPRMatchesCompletedRun(t *testing.T) {
+func TestGateRunPRsCollectsCompletedRunPRs(t *testing.T) {
 	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n"+
 		"  running      74-workspace-leak    b2f584f9  2026-08-03 04:20\n")
 
-	got, err := GateRanForPR(t.TempDir(), "https://github.com/atqamz/secondhand/pull/120")
+	prs, err := GateRunPRs(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got {
-		t.Fatal("expected a completed run with this exact PR URL to be found")
+	if !prs["https://github.com/atqamz/secondhand/pull/120"] {
+		t.Fatal("expected a completed run's own recorded PR URL to be collected")
+	}
+	if prs["https://github.com/atqamz/secondhand/pull/999"] {
+		t.Fatal("expected no entry for a PR no completed run recorded")
 	}
 }
 
-func TestGateRanForPRNoMatchingRun(t *testing.T) {
-	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n")
-
-	got, err := GateRanForPR(t.TempDir(), "https://github.com/atqamz/secondhand/pull/999")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got {
-		t.Fatal("expected no match for a PR no completed run recorded")
-	}
-}
-
-// TestGateRanForPRIgnoresNonCompletedRuns covers a run that shares a PR URL but never reached
+// TestGateRunPRsIgnoresNonCompletedRuns covers a run that recorded a PR URL but never reached
 // completed - running or failed both leave the gate un-cleared for that commit, so neither should
 // count as evidence a run happened.
-func TestGateRanForPRIgnoresNonCompletedRuns(t *testing.T) {
+func TestGateRunPRsIgnoresNonCompletedRuns(t *testing.T) {
 	fakeNoMistakes(t, "  failed       97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n")
 
-	got, err := GateRanForPR(t.TempDir(), "https://github.com/atqamz/secondhand/pull/120")
+	prs, err := GateRunPRs(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got {
-		t.Fatal("a failed run must not count as gate coverage even if it shares the PR URL")
+	if prs["https://github.com/atqamz/secondhand/pull/120"] {
+		t.Fatal("a failed run must not count as gate coverage even though it recorded the PR URL")
 	}
 }
 
-func TestGateRanForPREmptyPRNeverRuns(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
-
-	got, err := GateRanForPR(t.TempDir(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got {
-		t.Fatal("an empty PR URL can never match")
-	}
-}
-
-func TestGateRanForPRMissingClonePath(t *testing.T) {
+func TestGateRunPRsMissingClonePath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
 
-	got, err := GateRanForPR(missing, "https://github.com/atqamz/secondhand/pull/120")
+	prs, err := GateRunPRs(missing)
 	if err == nil {
 		t.Fatal("expected error for a clone path that does not exist")
 	}
-	if got {
-		t.Fatal("a missing clone path must never report a match")
+	if prs != nil {
+		t.Fatal("a missing clone path must never report a run set")
+	}
+}
+
+func TestGateRunPRsMissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	prs, err := GateRunPRs(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when the no-mistakes binary is not on PATH")
+	}
+	if prs != nil {
+		t.Fatal("an unrunnable binary must never report a run set")
+	}
+}
+
+// TestGateRunPRsNotInitializedIsAnError covers the uninitialized gate and the stale renamed
+// working_path from atqamz/secondhand#60, which print this text identically. An empty run set here
+// would render as the far stronger claim that the PR never went through a gate run, when in truth
+// no-mistakes was never asked - the state it would have answered from still holds those runs.
+func TestGateRunPRsNotInitializedIsAnError(t *testing.T) {
+	fakeNoMistakes(t, "repo not initialized (run 'no-mistakes init' first)")
+
+	prs, err := GateRunPRs(t.TempDir())
+	if err == nil {
+		t.Fatal("expected an uninitialized gate to be an error, not an empty run set")
+	}
+	if prs != nil {
+		t.Fatal("an uninitialized gate must never report a run set")
+	}
+}
+
+func TestGateRunPRsNotAGitRepoIsAnError(t *testing.T) {
+	fakeNoMistakes(t, "not in a git repository")
+
+	prs, err := GateRunPRs(t.TempDir())
+	if err == nil {
+		t.Fatal("expected a non-git clone path to be an error, not an empty run set")
+	}
+	if prs != nil {
+		t.Fatal("a non-git clone path must never report a run set")
 	}
 }

--- a/internal/project/gaterun_test.go
+++ b/internal/project/gaterun_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -65,7 +66,7 @@ func TestGateRunPRsMissingBinary(t *testing.T) {
 // would render as the far stronger claim that the PR never went through a gate run, when in truth
 // no-mistakes was never asked - the state it would have answered from still holds those runs.
 func TestGateRunPRsNotInitializedIsAnError(t *testing.T) {
-	fakeNoMistakes(t, "repo not initialized (run 'no-mistakes init' first)")
+	fakeNoMistakesExit(t, "repo not initialized (run 'no-mistakes init' first)", 1)
 
 	prs, err := GateRunPRs(t.TempDir())
 	if err == nil {
@@ -74,16 +75,32 @@ func TestGateRunPRsNotInitializedIsAnError(t *testing.T) {
 	if prs != nil {
 		t.Fatal("an uninitialized gate must never report a run set")
 	}
+	// The real binary exits 1 here, so the text has to be read before the exit code: reading the
+	// exit code first would report a healthy binary refusing a known repo as an unrunnable binary,
+	// naming a remedy that would not help.
+	if !strings.Contains(err.Error(), "no-mistakes init") {
+		t.Fatalf("err = %v, want it to name the init remedy for an uninitialized gate", err)
+	}
+	if strings.Contains(err.Error(), "binary not found or not runnable") {
+		t.Fatalf("err = %v, must not blame the binary for a gate that was never initialized", err)
+	}
 }
 
 func TestGateRunPRsNotAGitRepoIsAnError(t *testing.T) {
-	fakeNoMistakes(t, "not in a git repository")
+	dir := t.TempDir()
+	fakeNoMistakesExit(t, "not in a git repository", 1)
 
-	prs, err := GateRunPRs(t.TempDir())
+	prs, err := GateRunPRs(dir)
 	if err == nil {
 		t.Fatal("expected a non-git clone path to be an error, not an empty run set")
 	}
 	if prs != nil {
 		t.Fatal("a non-git clone path must never report a run set")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") || !strings.Contains(err.Error(), dir) {
+		t.Fatalf("err = %v, want it to name the non-git clone path %s", err, dir)
+	}
+	if strings.Contains(err.Error(), "binary not found or not runnable") {
+		t.Fatalf("err = %v, must not blame the binary for a clone path that is not a git repository", err)
 	}
 }

--- a/internal/project/gaterun_test.go
+++ b/internal/project/gaterun_test.go
@@ -1,0 +1,70 @@
+package project
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGateRanForPRMatchesCompletedRun(t *testing.T) {
+	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n"+
+		"  running      74-workspace-leak    b2f584f9  2026-08-03 04:20\n")
+
+	got, err := GateRanForPR(t.TempDir(), "https://github.com/atqamz/secondhand/pull/120")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("expected a completed run with this exact PR URL to be found")
+	}
+}
+
+func TestGateRanForPRNoMatchingRun(t *testing.T) {
+	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n")
+
+	got, err := GateRanForPR(t.TempDir(), "https://github.com/atqamz/secondhand/pull/999")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("expected no match for a PR no completed run recorded")
+	}
+}
+
+// TestGateRanForPRIgnoresNonCompletedRuns covers a run that shares a PR URL but never reached
+// completed - running or failed both leave the gate un-cleared for that commit, so neither should
+// count as evidence a run happened.
+func TestGateRanForPRIgnoresNonCompletedRuns(t *testing.T) {
+	fakeNoMistakes(t, "  failed       97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n")
+
+	got, err := GateRanForPR(t.TempDir(), "https://github.com/atqamz/secondhand/pull/120")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("a failed run must not count as gate coverage even if it shares the PR URL")
+	}
+}
+
+func TestGateRanForPREmptyPRNeverRuns(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	got, err := GateRanForPR(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("an empty PR URL can never match")
+	}
+}
+
+func TestGateRanForPRMissingClonePath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	got, err := GateRanForPR(missing, "https://github.com/atqamz/secondhand/pull/120")
+	if err == nil {
+		t.Fatal("expected error for a clone path that does not exist")
+	}
+	if got {
+		t.Fatal("a missing clone path must never report a match")
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -189,6 +189,11 @@ const (
 
 const gateNotInitializedMarker = "repo not initialized"
 
+// notGitRepoMarker is what `no-mistakes status` prints, exiting 0, when clonePath exists but isn't
+// a git repository at all - a different, unrepairable outcome from GateNotInitialized: `no-mistakes
+// init` fixes a repo that was never initialized, not a directory that isn't a git repo.
+const notGitRepoMarker = "not in a git repository"
+
 // GateInitCommand is the exact remedy for GateNotInitialized. no-mistakes init is idempotent and
 // repairs a stale working_path in place, so callers should print this verbatim rather than describe it.
 func GateInitCommand(clonePath string) string {
@@ -200,16 +205,25 @@ func GateInitCommand(clonePath string) string {
 // no-mistakes status exits 0 whether or not the repo is initialized, so the outcome is read from
 // its output text, not its exit code. Any failure to run the binary at all (missing, unexecutable,
 // unexpected nonzero exit) is returned as an error distinct from GateNotInitialized: the remedy for
-// a missing binary is not `no-mistakes init`.
+// a missing binary is not `no-mistakes init`. clonePath not existing on disk, and clonePath existing
+// but not being a git repository, are both returned as plain errors naming the real cause too - not
+// GateReady, which would let a caller dispatch into a project the gate cannot cover.
 func GateStatus(clonePath string) (GateState, error) {
+	if _, err := os.Stat(clonePath); err != nil {
+		return GateReady, fmt.Errorf("no-mistakes clone path: %w", err)
+	}
 	cmd := exec.Command("no-mistakes", "status")
 	cmd.Dir = clonePath
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return GateReady, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
 	}
-	if strings.Contains(string(out), gateNotInitializedMarker) {
+	text := string(out)
+	if strings.Contains(text, gateNotInitializedMarker) {
 		return GateNotInitialized, nil
+	}
+	if strings.Contains(text, notGitRepoMarker) {
+		return GateReady, fmt.Errorf("no-mistakes clone path is not a git repository: %s", clonePath)
 	}
 	return GateReady, nil
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -218,14 +218,23 @@ func TestRemoveNotFound(t *testing.T) {
 	}
 }
 
-// fakeNoMistakes puts a fake no-mistakes binary at the front of PATH. It only ever needs to
-// answer `status`, so it ignores its arguments and always exits 0, matching the real binary's
-// observed behavior: no-mistakes status exits 0 whether the repo is initialized or not, so
-// GateStatus reads the outcome from stdout text rather than the exit code.
+// fakeNoMistakes puts a fake no-mistakes binary at the front of PATH. It ignores its arguments and
+// always exits 0, matching the real binary's observed behavior for `status`: it exits 0 whether the
+// repo is initialized or not, so GateStatus reads the outcome from stdout text rather than the exit
+// code. Fakes for `runs` refusals need fakeNoMistakesExit instead.
 func fakeNoMistakes(t *testing.T, stdout string) {
+	fakeNoMistakesExit(t, stdout, 0)
+}
+
+// fakeNoMistakesExit is fakeNoMistakes with an explicit exit code, for the invocations the real
+// binary refuses non-zero: `no-mistakes runs` exits 1 on both "repo not initialized" and "not in a
+// git repository", where `no-mistakes status` exits 0 printing the same text. A caller must read
+// the refusal from the text either way, so the fake reproduces the exit code rather than flattening
+// every refusal to 0 and letting a text-check-after-exit-check regression pass here.
+func fakeNoMistakesExit(t *testing.T, stdout string, code int) {
 	t.Helper()
 	bin := t.TempDir()
-	script := "#!/bin/sh\ncat <<'EOF'\n" + stdout + "\nEOF\n"
+	script := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\nexit %d\n", stdout, code)
 	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -276,6 +276,49 @@ func TestGateStatusMissingBinaryIsDistinctFromNotInitialized(t *testing.T) {
 	}
 }
 
+// TestGateStatusNotGitRepo covers atqamz/secondhand#97's first clone-path outcome: clonePath exists
+// but isn't a git repository at all. no-mistakes status still exits 0 and prints this text verbatim,
+// so without this branch GateStatus would fall through to GateReady and let a caller dispatch into a
+// project the gate cannot cover.
+func TestGateStatusNotGitRepo(t *testing.T) {
+	fakeNoMistakes(t, "not in a git repository")
+
+	dir := t.TempDir()
+	gotState, err := GateStatus(dir)
+	if err == nil {
+		t.Fatal("expected error when clone path is not a git repository")
+	}
+	if gotState == GateNotInitialized {
+		t.Fatal("not-a-git-repo must not report GateNotInitialized, it has a different (unrepairable) remedy")
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Fatalf("err = %v, want it to name the clone path", err)
+	}
+}
+
+// TestGateStatusMissingClonePath covers atqamz/secondhand#97's second clone-path outcome: clonePath
+// does not exist on disk at all, so exec.Command's chdir fails before the binary ever runs. Without
+// the os.Stat check, this used to read as "no-mistakes binary not found or not runnable", which is
+// true in the letter and misleading in substance - the binary is fine, the clone directory is missing.
+// No fake binary is installed for this test: os.Stat must fail before GateStatus ever tries to exec.
+func TestGateStatusMissingClonePath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	gotState, err := GateStatus(missing)
+	if err == nil {
+		t.Fatal("expected error for a clone path that does not exist")
+	}
+	if gotState == GateNotInitialized {
+		t.Fatal("missing clone path must not report GateNotInitialized, it has a different remedy")
+	}
+	if strings.Contains(err.Error(), "no-mistakes binary not found or not runnable") {
+		t.Fatalf("err = %v, must not read as a binary problem", err)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("err = %v, want it to name the missing clone path", err)
+	}
+}
+
 func TestGateInitCommand(t *testing.T) {
 	got := GateInitCommand("/home/atqa/secondhand/projects/secondhand")
 	want := "cd /home/atqa/secondhand/projects/secondhand && no-mistakes init"

--- a/tests/e2e/gate_visibility_test.go
+++ b/tests/e2e/gate_visibility_test.go
@@ -1,0 +1,201 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+// writeFakeNoMistakes writes a fake no-mistakes that answers `status` and `runs` with fixed text.
+// `status` always exits 0, which is what the real binary does for every outcome hand reads from it -
+// an uninitialized repo, a non-git directory and a healthy gate all print their answer behind exit 0
+// (verified against no-mistakes itself), so hand reads the text. `runs` carries its own exit code,
+// since the real binary exits 1 on those same two refusals while printing the identical text.
+// `init` is answered too, since `hand project add --mode no-mistakes` initializes the fresh clone's
+// gate before anything can be dispatched into it.
+func writeFakeNoMistakes(t *testing.T, dir, statusOut, runsOut string, runsExit int) {
+	t.Helper()
+	body := fmt.Sprintf(`  status) printf '%%s\n' %s ;;
+  runs) printf '%%s\n' %s; exit %d ;;
+  init) echo 'gate initialized' ;;`, shellSingleQuote(statusOut), shellSingleQuote(runsOut), runsExit)
+	writeFakeDispatch(t, dir, "no-mistakes", "", "$1", body)
+}
+
+const gateReadyStatus = "    repo:  /home/atqa/secondhand/projects/demo\n" +
+	"  remote:  git@github.com:owner/demo.git\n" +
+	"    gate:  /home/atqa/.no-mistakes/repos/0b474f2021dd.git\n" +
+	"  daemon:  running\n\n  no active run"
+
+// TestStatusEmptyFleetStatesItsCount covers atqamz/secondhand#100 on the real binary: an empty
+// fleet must say so, and must still surface a hold left open on a torn-down task's id rather than
+// reading as nothing to see.
+func TestStatusEmptyFleetStatesItsCount(t *testing.T) {
+	home := newHome(t)
+
+	empty := runHand(t, home, "status")
+	if empty.code != 0 {
+		t.Fatalf("status: exit %d, stderr %q", empty.code, empty.stderr)
+	}
+	if strings.TrimSpace(empty.stdout) != "no tasks (0)" {
+		t.Fatalf("status stdout = %q, want an explicit no-tasks count and nothing else", empty.stdout)
+	}
+
+	emptyJSON := runHand(t, home, "status", "--json")
+	if emptyJSON.code != 0 || !strings.Contains(emptyJSON.stdout, `"task_count": 0`) {
+		t.Fatalf("status --json stdout = %q (exit %d), want an explicit task_count of 0",
+			emptyJSON.stdout, emptyJSON.code)
+	}
+
+	held := runHand(t, home, "hold", "set", "torn-down-task",
+		"--kind", "operator", "--reason", "two ways to do this, needs a call")
+	if held.code != 0 {
+		t.Fatalf("hold set: exit %d, stderr %q", held.code, held.stderr)
+	}
+
+	withHold := runHand(t, home, "status")
+	if withHold.code != 0 {
+		t.Fatalf("status: exit %d, stderr %q", withHold.code, withHold.stderr)
+	}
+	if !strings.Contains(withHold.stdout, "no tasks (0)") ||
+		!strings.Contains(withHold.stdout, "torn-down-task") ||
+		!strings.Contains(withHold.stdout, "two ways to do this, needs a call") {
+		t.Fatalf("status stdout = %q, want the no-tasks count alongside the still-open hold", withHold.stdout)
+	}
+}
+
+// TestStatusFlagsAShippedPRThatNeverRanThroughTheGate covers atqamz/secondhand#92 through the
+// operator's own sequence: spawn a ship task into a no-mistakes project, record its PR, let the
+// worker report done, then read `hand status`. The gate holds no completed run for that PR, so
+// both the fleet overview and the task's own detail view have to say so - and stop saying it the
+// moment a completed run records that exact URL.
+func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
+	prURL := "https://github.com/owner/demo/pull/7"
+
+	remote := filepath.Join(t.TempDir(), "remote")
+	initGitRepo(t, remote)
+	redirectGitRemote(t, "https://github.com/owner/demo.git", remote)
+
+	home := newHome(t)
+	worktree := filepath.Join(t.TempDir(), "wt-ship-login-fix")
+
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, worktree)
+	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo", PaneStatus: "idle"})
+	writeFakeDispatch(t, dir, "gh", "", "$1 $2", `  "pr view") echo '{"state":"OPEN"}' ;;`)
+	writeFakeNoMistakes(t, dir, gateReadyStatus,
+		"  completed    other-branch  758d72bf  2026-08-03 04:29  https://github.com/owner/demo/pull/4", 0)
+
+	added := runHand(t, home, "project", "add", "https://github.com/owner/demo.git", "--mode", "no-mistakes")
+	if added.code != 0 {
+		t.Fatalf("project add: exit %d, stderr %q", added.code, added.stderr)
+	}
+	writeBrief(t, home, "ship-login-fix")
+
+	spawned := runHand(t, home, "spawn", "ship-login-fix", "demo")
+	if spawned.code != 0 {
+		t.Fatalf("spawn: exit %d, stderr %q", spawned.code, spawned.stderr)
+	}
+
+	recorded := runHand(t, home, "pr", "ship-login-fix", prURL)
+	if recorded.code != 0 {
+		t.Fatalf("pr record: exit %d, stderr %q", recorded.code, recorded.stderr)
+	}
+	if err := os.WriteFile(state.ReportPath(home, "ship-login-fix"),
+		[]byte("done: PR "+prURL+" opened, checks green\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fleet := runHand(t, home, "status")
+	if fleet.code != 0 {
+		t.Fatalf("status: exit %d, stderr %q", fleet.code, fleet.stderr)
+	}
+	if !strings.Contains(fleet.stdout, "(gate: no run found)") {
+		t.Fatalf("status stdout = %q, want the shipped PR flagged as never having run through the gate", fleet.stdout)
+	}
+
+	single := runHand(t, home, "status", "ship-login-fix")
+	if single.code != 0 || !strings.Contains(single.stdout, "Gate run:    no run found") {
+		t.Fatalf("status ship-login-fix stdout = %q (exit %d), want the Gate run line", single.stdout, single.code)
+	}
+
+	singleJSON := runHand(t, home, "status", "ship-login-fix", "--json")
+	if singleJSON.code != 0 || !strings.Contains(singleJSON.stdout, `"gate_run_issue": "no run found"`) {
+		t.Fatalf("status --json stdout = %q (exit %d), want gate_run_issue", singleJSON.stdout, singleJSON.code)
+	}
+
+	writeFakeNoMistakes(t, dir, gateReadyStatus,
+		"  completed    ship-login-fix  758d72bf  2026-08-03 04:29  "+prURL, 0)
+
+	gated := runHand(t, home, "status")
+	if gated.code != 0 {
+		t.Fatalf("status: exit %d, stderr %q", gated.code, gated.stderr)
+	}
+	if strings.Contains(gated.stdout, "(gate:") {
+		t.Fatalf("status stdout = %q, want no gate marker once a completed run recorded this PR", gated.stdout)
+	}
+}
+
+// TestGateCheckNamesAMissingOrNonGitClonePath covers atqamz/secondhand#97 on both operator
+// surfaces. A clone path that is missing, and one that exists but is not a git repository, are
+// different failures from a gate that was never initialized: `no-mistakes init` repairs neither,
+// so neither may be reported as "not initialized" nor - the worse outcome - pass as ready and let
+// a worker be dispatched into a project the gate cannot cover.
+func TestGateCheckNamesAMissingOrNonGitClonePath(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "no-mistakes")
+	writeBrief(t, home, "task-1")
+
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, filepath.Join(t.TempDir(), "unused-worktree"))
+	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+	writeFakeNoMistakes(t, dir, "not in a git repository", "not in a git repository", 1)
+
+	clonePath := filepath.Join(home, "projects", "demo")
+
+	// The clone directory does not exist at all: the chdir fails before no-mistakes ever runs, and
+	// the refusal has to name that path rather than blame the binary.
+	missing := runHand(t, home, "spawn", "task-1", "demo")
+	if missing.code == 0 {
+		t.Fatalf("spawn into a project with no clone on disk succeeded, stdout %q", missing.stdout)
+	}
+	if !strings.Contains(missing.stderr, clonePath) {
+		t.Fatalf("spawn stderr = %q, want it to name the missing clone path %s", missing.stderr, clonePath)
+	}
+	if strings.Contains(missing.stderr, "binary not found or not runnable") {
+		t.Fatalf("spawn stderr = %q, must not blame the no-mistakes binary for a missing clone path", missing.stderr)
+	}
+	if _, err := state.Read(home, "task-1"); err == nil {
+		t.Fatal("a refused spawn must leave no task row behind")
+	}
+
+	// The clone directory exists but is not a git repository: no-mistakes prints that, exiting 0.
+	if err := os.MkdirAll(clonePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nonGit := runHand(t, home, "spawn", "task-1", "demo")
+	if nonGit.code == 0 {
+		t.Fatalf("spawn into a non-git clone path succeeded, stdout %q", nonGit.stdout)
+	}
+	if !strings.Contains(nonGit.stderr, "not a git repository") || !strings.Contains(nonGit.stderr, clonePath) {
+		t.Fatalf("spawn stderr = %q, want it to name the non-git clone path %s", nonGit.stderr, clonePath)
+	}
+	if strings.Contains(nonGit.stderr, "no-mistakes init") {
+		t.Fatalf("spawn stderr = %q, must not offer no-mistakes init as the remedy for a non-git path", nonGit.stderr)
+	}
+
+	// The same misclassification on the surface an operator watches before dispatching: unreachable,
+	// never the "not initialized" bucket whose remedy would not help here.
+	listed := runHand(t, home, "project", "list")
+	if listed.code != 0 {
+		t.Fatalf("project list: exit %d, stderr %q", listed.code, listed.stderr)
+	}
+	if !strings.Contains(listed.stdout, "(gate: unreachable)") || strings.Contains(listed.stdout, "(gate: not initialized)") {
+		t.Fatalf("project list stdout = %q, want the non-git clone reported as unreachable", listed.stdout)
+	}
+}


### PR DESCRIPTION
## Intent

Fix no-mistakes gate misclassification for a missing or non-git clone path (atqamz/secondhand#97), give hand status an explicit task count on an empty fleet without hiding open holds (atqamz/secondhand#100), and surface a shipped PR that never went through a no-mistakes gate run (atqamz/secondhand#92)

Closes atqamz/secondhand#97
Closes atqamz/secondhand#100
Closes atqamz/secondhand#92

## What Changed

- `hand status` now checks every `done` ship task with a recorded PR against `no-mistakes runs` for that project's clone, rendering `(gate: no run found)` / `(gate: unreachable)` in the table, a `Gate run:` line in the detail view, and a `gate_run_issue` field in JSON. The new `project.GateRunPRs` reads completed runs' PR URLs from `no-mistakes runs` text and returns an error - never an empty set - for a missing clone, unrunnable binary, uninitialized gate, or non-git clone path, so an unanswerable question buckets as `unreachable` instead of the stronger `no run found`. The lookup is memoized per clone path for the life of one render, and a fleet-wide registry read fault degrades the check to silent while naming itself on stderr.
- `project.GateStatus` no longer reports `GateReady` when the clone path is missing on disk or is not a git repository; both now return plain errors naming the real cause, so gate preflight cannot dispatch into a project the gate cannot cover.
- An empty fleet prints `no tasks (0)` and always emits `task_count` in JSON (zero included) while still printing the held block, so a fleet with no tasks reads as a positive statement rather than the same empty output a broken command produces. SPECS.md and the `--skip-gate-check` help text now name all four preflight refusals the flag bypasses.

## Risk Assessment

ok: Low: All four round-1 findings are fixed at the shared boundaries (marker-before-exit-code handling in GateRunPRs, a single gateRunApplies predicate gating the project lookup, per-clone memoized run reads, and a non-fatal stderr warning for a registry fault), each pinned by a new test, with SPECS.md updated in step and no new source risk found in a full re-pass.

## Testing

Ran the full internal/project package and the status/gate-preflight/project subset of cmd under -race, then wrote and ran a new e2e test that drives the built hand binary through the operator's own sequence for each of the three intents, capturing the resulting CLI transcripts: an empty fleet printing \"no tasks (0)\" with an open hold still listed and \"task_count\": 0 in JSON; a done ship task whose PR no completed gate run recorded rendering as \"(gate: no run found)\" in the fleet row, \"Gate run: no run found\" in the detail view and \"gate_run_issue\" in JSON, with the marker vanishing once a completed run records that URL; and hand spawn / hand project list naming a missing or non-git clone path instead of blaming the no-mistakes binary or offering an init remedy that would not help. While confirming the fakes matched reality I found that the real `no-mistakes runs` exits 1 on the refusals `status` exits 0 on, and that the marker tests only asserted an error occurred, so a check-ordering regression passed; I made the fakes reproduce the real exit codes and the assertions name the real cause, then proved the tests now catch that regression via a temporary mutation. Everything passes and no product code was modified.

<details>
<summary>Evidence: hand CLI transcript for all three intents (empty fleet count, ungated shipped PR, clone-path gate refusals)</summary>

<code>$ hand status&#10;stdout: no tasks (0)&#10;&#10;$ hand status --json&#10;stdout: {&#10;&#34;task_count&#34;: 0,&#10;&#34;tasks&#34;: [],&#10;&#34;holds&#34;: []&#10;}&#10;&#10;$ hand status (after: hold set torn-down-task --kind operator)&#10;stdout: no tasks (0)&#10;&#10;held:&#10;torn-down-task operator two ways to do this, needs a call just now&#10;&#10;$ hand status&#10;stdout: id project kind state age last report&#10;ship-login-fix demo ship idle (reported: done) (gate: no run found) just now just now&#10;&#10;$ hand status ship-login-fix&#10;stdout: Task: ship-login-fix&#10;...&#10;PR: https://github.com/owner/demo/pull/7&#10;Reported: done: PR https://github.com/owner/demo/pull/7 opened, checks green&#10;Gate run: no run found&#10;&#10;$ hand status ship-login-fix --json&#10;stdout: &#34;pr&#34;: &#34;https://github.com/owner/demo/pull/7&#34;,&#10;&#34;gate_run_issue&#34;: &#34;no run found&#34;&#10;&#10;$ hand status (after a completed run records that exact PR)&#10;stdout: ship-login-fix demo ship idle (reported: done) just now just now&#10;&#10;$ hand spawn task-1 demo (clone path missing)&#10;exit 1&#10;stderr: check no-mistakes gate for project &#34;demo&#34;: no-mistakes clone path: stat .../projects/demo: no such file or directory&#10;&#10;$ hand spawn task-1 demo (clone path exists, not a git repo)&#10;exit 1&#10;stderr: check no-mistakes gate for project &#34;demo&#34;: no-mistakes clone path is not a git repository: .../projects/demo&#10;&#10;$ hand project list&#10;stdout: demo https://example.com/demo.git no-mistakes (gate: unreachable)</code>

```text
=== RUN   TestStatusEmptyFleetStatesItsCount
    gate_visibility_test.go:39: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.EWr3JW/TestStatusEmptyFleetStatesItsCount653650862/002
          stderr: 
    gate_visibility_test.go:41: $ hand status
          exit 0
          stdout: no tasks (0)
          stderr: 
    gate_visibility_test.go:49: $ hand status --json
          exit 0
          stdout: {
          "task_count": 0,
          "tasks": [],
          "holds": []
        }
          stderr: 
    gate_visibility_test.go:55: $ hand hold set torn-down-task --kind operator --reason two ways to do this, needs a call
          exit 0
          stdout: hold set on torn-down-task (kind=operator)
          stderr: 
    gate_visibility_test.go:61: $ hand status
          exit 0
          stdout: no tasks (0)
        
        held:
          torn-down-task  operator  two ways to do this, needs a call  just now
          stderr: 
--- PASS: TestStatusEmptyFleetStatesItsCount (0.10s)
=== RUN   TestStatusFlagsAShippedPRThatNeverRanThroughTheGate
    gate_visibility_test.go:84: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.EWr3JW/TestStatusFlagsAShippedPRThatNeverRanThroughTheGate1832013111/003
          stderr: 
    gate_visibility_test.go:94: $ hand project add https://github.com/owner/demo.git --mode no-mistakes
          exit 0
          stdout: added project demo (https://github.com/owner/demo.git) mode=no-mistakes
          stderr: 
    gate_visibility_test.go:100: $ hand spawn ship-login-fix demo
          exit 0
          stdout: spawned ship-login-fix project=demo kind=ship harness=claude worktree=/tmp/nix-shell.EWr3JW/TestStatusFlagsAShippedPRThatNeverRanThroughTheGate1832013111/004/wt-ship-login-fix
          stderr: 
    gate_visibility_test.go:105: $ hand pr ship-login-fix https://github.com/owner/demo/pull/7
          exit 0
          stdout: recorded PR for ship-login-fix: https://github.com/owner/demo/pull/7
          stderr: 
    gate_visibility_test.go:114: $ hand status
          exit 0
          stdout: id              project  kind  state                                       age       last report
        ship-login-fix  demo     ship  idle (reported: done) (gate: no run found)  just now  just now
          stderr: 
    gate_visibility_test.go:122: $ hand status ship-login-fix
          exit 0
          stdout: Task:        ship-login-fix
        Project:     demo
        Kind:        ship
        Harness:     claude
        Model:       
        State:       idle
        Worktree:    /tmp/nix-shell.EWr3JW/TestStatusFlagsAShippedPRThatNeverRanThroughTheGate1832013111/004/wt-ship-login-fix
        Herdr:       default / tab-1
        Created:     just now
        Last report: just now
        PR:          https://github.com/owner/demo/pull/7
        Reported:    done: PR https://github.com/owner/demo/pull/7 opened, checks green
        Gate run:    no run found
        Report file: /tmp/nix-shell.EWr3JW/TestStatusFlagsAShippedPRThatNeverRanThroughTheGate1832013111/003/state/ship-login-fix.status
          stderr: 
    gate_visibility_test.go:127: $ hand status ship-login-fix --json
          exit 0
          stdout: {
          "id": "ship-login-fix",
          "project": "demo",
          "kind": "ship",
          "harness": "claude",
          "agent_state": "idle",
          "worktree": "/tmp/nix-shell.EWr3JW/TestStatusFlagsAShippedPRThatNeverRanThroughTheGate1832013111/004/wt-ship-login-fix",
          "herdr": {
            "session": "default",
            "workspace_id": "ws-1",
            "tab_id": "tab-1",
            "pane_id": "pane-1"
          },
          "pr": "https://github.com/owner/demo/pull/7",
          "merged": false,
          "pr_merged_observed": false,
          "created_at": "2026-08-03T00:37:04Z",
          "last_report_at": "2026-08-03T00:37:04Z",
          "reported": {
            "state": "done",
            "note": "PR https://github.com/owner/demo/pull/7 opened, checks green"
          },
          "report_history": [
            "done: PR https://github.com/owner/demo/pull/7 opened, checks green"
          ],
          "gate_run_issue": "no run found"
        }
          stderr: 
    gate_visibility_test.go:135: $ hand status
          exit 0
          stdout: id              project  kind  state                  age       last report
        ship-login-fix  demo     ship  idle (reported: done)  just now  just now
          stderr: 
--- PASS: TestStatusFlagsAShippedPRThatNeverRanThroughTheGate (0.34s)
=== RUN   TestGateCheckNamesAMissingOrNonGitClonePath
    gate_visibility_test.go:150: $ hand init
          exit 0
          stdout: initialized secondhand home at /tmp/nix-shell.EWr3JW/TestGateCheckNamesAMissingOrNonGitClonePath366626631/002
          stderr: 
    gate_visibility_test.go:163: $ hand spawn task-1 demo
          exit 1
          stdout: 
          stderr: check no-mistakes gate for project "demo": no-mistakes clone path: stat /tmp/nix-shell.EWr3JW/TestGateCheckNamesAMissingOrNonGitClonePath366626631/002/projects/demo: no such file or directory
    gate_visibility_test.go:181: $ hand spawn task-1 demo
          exit 1
          stdout: 
          stderr: check no-mistakes gate for project "demo": no-mistakes clone path is not a git repository: /tmp/nix-shell.EWr3JW/TestGateCheckNamesAMissingOrNonGitClonePath366626631/002/projects/demo
    gate_visibility_test.go:194: $ hand project list
          exit 0
          stdout: demo  https://example.com/demo.git  no-mistakes  (gate: unreachable)
          stderr: 
--- PASS: TestGateCheckNamesAMissingOrNonGitClonePath (0.10s)
PASS
ok  	github.com/atqamz/secondhand/tests/e2e	1.162s
```
</details>
<details>
<summary>Evidence: Real no-mistakes binary exit codes behind both refusals (premise check for the text-before-exit-code reads)</summary>

<code>$ cd /tmp &amp;&amp; no-mistakes status&#10;not in a git repository&#10;exit=0&#10;&#10;$ cd /tmp &amp;&amp; no-mistakes runs --limit 5&#10;not in a git repository&#10;exit=1&#10;&#10;$ cd &lt;repo&gt; &amp;&amp; no-mistakes status&#10;repo not initialized (run &#39;no-mistakes init&#39; first)&#10;exit=0&#10;&#10;$ cd &lt;repo&gt; &amp;&amp; no-mistakes runs --limit 5&#10;repo not initialized (run &#39;no-mistakes init&#39; first)&#10;exit=1</code>

```text
# Real no-mistakes binary, both refusals hand must read as text (verified, not faked)

$ cd /tmp && no-mistakes status
not in a git repository
exit=0

$ cd /tmp && no-mistakes runs --limit 5
not in a git repository
exit=1

$ cd /home/atqa/.no-mistakes/worktrees/0b474f2021dd/01KZ2FDR2YH733FHR6PC0FCJ2N && no-mistakes status
repo not initialized (run 'no-mistakes init' first)
exit=0

$ cd /home/atqa/.no-mistakes/worktrees/0b474f2021dd/01KZ2FDR2YH733FHR6PC0FCJ2N && no-mistakes runs --limit 5
repo not initialized (run 'no-mistakes init' first)
exit=1
```
</details>
<details>
<summary>Evidence: Mutation check proving the strengthened marker tests catch a check-ordering regression</summary>

<code>before mutation: ok github.com/atqamz/secondhand/internal/project&#10;&#10;=== exit-code check moved ahead of the text markers ===&#10;--- FAIL: TestGateRunPRsNotInitializedIsAnError&#10;err = no-mistakes binary not found or not runnable: exit status 1, want it to name the init remedy for an uninitialized gate&#10;--- FAIL: TestGateRunPRsNotAGitRepoIsAnError&#10;err = no-mistakes binary not found or not runnable: exit status 1, want it to name the non-git clone path&#10;&#10;(gaterun.go restored byte-identical afterwards)</code>

```text
warning: Git tree '/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01KZ2FDR2YH733FHR6PC0FCJ2N' is dirty
ok  	github.com/atqamz/secondhand/internal/project	0.021s
=== now mutate: exit-code check moved ahead of the text markers ===
43:		return nil, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
52:		return nil, fmt.Errorf("no-mistakes binary not found or not runnable: %w", err)
--- FAIL: TestGateRunPRsNotInitializedIsAnError (0.01s)
    gaterun_test.go:82: err = no-mistakes binary not found or not runnable: exit status 1, want it to name the init remedy for an uninitialized gate
--- FAIL: TestGateRunPRsNotAGitRepoIsAnError (0.01s)
    gaterun_test.go:101: err = no-mistakes binary not found or not runnable: exit status 1, want it to name the non-git clone path /tmp/nix-shell.ZGNL0n/TestGateRunPRsNotAGitRepoIsAnError2236825188/001
FAIL
FAIL	github.com/atqamz/secondhand/internal/project	0.019s
FAIL
```
</details>
- Outcome: warning: 2 infos across 1 run (9m46s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>fix: **Review** - 4 issues found -> auto-fixed ok:</summary>

- warning: `internal/project/gaterun.go:40` - internal/project/gaterun.go:40 - `no-mistakes runs` exits 0 printing `repo not initialized (run &#39;no-mistakes init&#39; first)` (verified against the real binary in this worktree). GateRanForPR reads that as an empty run list and returns (false, nil), so gateRunIssue renders the stronger claim `no run found`. SPECS.md&#39;s own &#34;Gate preflight&#34; section says that text covers a stale renamed `working_path` too - in which case completed runs for the PR still exist in no-mistakes&#39; state, and `hand status` falsely reports a genuinely gated PR as never gated, violating the invariant this change documents (&#34;a question the check could not answer never renders as the stronger claim `no run found`&#34;). This is the same exit-0-plain-text hazard the branch just fixed in GateStatus; fix it at the same boundary by treating `gateNotInitializedMarker` / `notGitRepoMarker` in the runs output as an error so the check buckets as `unreachable`.
- info: `cmd/status.go:408` - cmd/status.go:408 - project.Find is called and its error propagated before checking whether the gate-run check applies, while SPECS.md step 6 conditions the lookup on &#34;a `ship` task reported `done` with a recorded PR&#34;. A malformed `data/projects.md` line still awaiting legacy import now fails `hand status &lt;scout-id&gt;` entirely, where it previously rendered the detail view. Move the lookup behind the same ship/PR/reported-done predicate gateRunIssue applies.
- info: `cmd/status.go:260` - cmd/status.go:260 - the fleet loop calls GateRanForPR per task, so N done ship tasks on the same project each spawn `no-mistakes runs --limit 10000` against the same clone and re-parse identical output, on the command CLAUDE.md makes the first step of every session. Memoize the parsed run list per clonePath for the render; no behavior change.
- info: `cmd/status.go:243` - cmd/status.go:243 - `projects, _ := project.List(home)` discards the error, so a registry fault silently removes every `(gate: ...)` marker and `gate_run_issue` field fleet-wide, rendering ungated PRs as clean. SPECS.md step 7 explicitly authorizes the best-effort degrade, so this is not a blocker, but the adjacent holds path refuses exactly this shape of false all-clear; a one-line stderr note when the registry read fails would keep the overview non-failing while making the blind spot visible.

fix: Fix: harden gate-run check against unaskable gates and cache it per clone
ok: Re-checked - no issues remain.

</details>

<details>
<summary>warning: **Test** - 2 infos</summary>

- info: `internal/project/gaterun.go:32` - internal/project/gaterun.go&#39;s GateRunPRs doc comment states the uninitialized-gate and non-git markers are read from text &#34;since no-mistakes can print either while exiting 0&#34;. Verified against the real binary: `no-mistakes runs` exits 1 for both refusals (only `no-mistakes status` exits 0). The code is correct - it checks the markers before the exit code - but the stated rationale is wrong, and a maintainer trusting it could reorder the checks and reintroduce exactly the #97 misclassification. Test-side fidelity is now fixed so that reorder fails loudly; the comment itself is a review-phase call, not a test change.
- info: `tests/e2e/gate_visibility_test.go` - new test file written by agent: tests/e2e/gate_visibility_test.go
- <code>`go test -race -count=1 ./internal/project/...` (full package, includes new TestGateRunPRs* and TestGateStatusNotGitRepo / TestGateStatusMissingClonePath)</code>
- `go test -race -count=1 ./cmd/... -run 'TestStatus|GatePreflight|SkipGateCheck|TestProject'`
- <code>`go test -tags=e2e -count=1 -v ./tests/e2e/... -run &#39;TestStatusEmptyFleetStatesItsCount|TestStatusFlagsAShippedPRThatNeverRanThroughTheGate|TestGateCheckNamesAMissingOrNonGitClonePath&#39;` (new e2e file driving the built hand binary)</code>
- <code>Manual real-binary check of the change&#39;s premise: `cd /tmp &amp;&amp; no-mistakes status` (exit 0, &#34;not in a git repository&#34;) vs `no-mistakes runs --limit 5` (exit 1, same text), and both in an uninitialized git repo</code>
- `Mutation check: moved GateRunPRs' exit-code branch ahead of its text markers and confirmed TestGateRunPRsNotInitializedIsAnError / TestGateRunPRsNotAGitRepoIsAnError now fail with "binary not found or not runnable"; gaterun.go restored byte-identical afterwards`

</details>

<details>
<summary>fix: **Document** - 1 issue found -> auto-fixed ok:</summary>

- info: `SPECS.md:352` - The --skip-gate-check flag is described as bypassing the gate check &#34;even if its gate is not initialized&#34; in SPECS.md (lines 352 and 1050) and verbatim in the flag help strings (cmd/spawn.go:194, cmd/promote.go:205). This change added two more preflight refusals - clone path missing on disk, clone path not a git repository - which the flag also bypasses, so all four surfaces now understate what it skips. Left unresolved because fixing the docs alone would diverge them from the flag help strings, and editing those strings is a code change outside this pass&#39;s remit.

fix: Fix: name all bypassed refusals in --skip-gate-check docs
ok: Re-checked - no issues remain.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>


