### PR TITLE
feat(cmd): add hand doctor and carry the operator-decision rule into worker launch prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Secondhand
 
 `hand` is a CLI that manages a fleet of coding agents from a fleet home (`data/`, `state/`, this file).
-This checkout is the tool's own source, not a fleet home itself - `internal/home.IsHome` reports false here.
+This checkout is the tool's own source, not a fleet home itself - there is no `state/hand.db` here, so `internal/home.IsHome` reports false.
 `internal/agentsmd`'s `generatedBody` constant is the authoritative template `hand init` writes and `hand update` refreshes into every real fleet home's `AGENTS.md`; see SPECS.md's "AGENTS.md (target)" section for the full design, and `hand --help` for the command reference.
 
 ## Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,11 @@
 # Secondhand
 
-You manage a fleet of coding agents using the `hand` CLI.
-Run `hand --help` for the full command reference.
-
-## Workflow
-
-1. Read `data/dashboard.md` for current fleet state.
-2. Match the request to a project in `data/projects.md`.
-3. Edit `data/backlog.md` to record the task with a unique ID.
-4. Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it. The brief may open with a `---` fenced block declaring `model` and `effort` for the task, which spawn and promote apply unless a flag overrides them.
-5. `hand spawn <id> <project>` to start a worker.
-6. `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event and that exit is what reaches you, so re-arm it every time you act on one. Bound the wait with `--timeout <duration>`; exit 4 means the window passed with nothing happening, exit 5 means a worker named on stderr couldn't be reached before it even started waiting.
-7. Act on watch output: steer blocked workers with `hand send`, relay results.
-8. When told to merge: `hand merge <id>`.
-9. `hand teardown <id>` after work is landed.
+`hand` is a CLI that manages a fleet of coding agents from a fleet home (`data/`, `state/`, this file).
+This checkout is the tool's own source, not a fleet home itself - `internal/home.IsHome` reports false here.
+`internal/agentsmd`'s `generatedBody` constant is the authoritative template `hand init` writes and `hand update` refreshes into every real fleet home's `AGENTS.md`; see SPECS.md's "AGENTS.md (target)" section for the full design, and `hand --help` for the command reference.
 
 ## Rules
 
-- Never edit files under `projects/`. Workers do that in worktrees.
-- Never merge without explicit authorization.
-- Never force-teardown without explicit authorization.
-- Report outcomes plainly. If work failed, say so with evidence.
-- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from `HAND_HOME` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
-- Ship tasks produce PRs or local branches. Scout tasks produce `data/<id>/report.md`.
-- `data/backlog.md` is your task queue. Edit it directly.
-- For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.
-- Use `hand search <query>` to find historical context in data/. `qmd search` adds semantic matching when installed.
-- `hand status <id>` shows a worker's reported state; see SPECS.md's state management section for the report vocabulary (working/paused/blocked/needs-decision/done/failed).
 - Zero comments by default. Only add one when the WHY is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug. Never restate code, narrate what, add banners, or docstring the obvious.
 - Harness/herdr syntax, exit-code enforcement, watch's stdout/errOut split, per-command dashboard rules, and first-run prompt handling are commented at point of use (`internal/herdr`, `internal/harness`, `cmd/root.go`, `cmd/precondition.go`, `internal/watcher`, `cmd/teardown.go`, `cmd/prdetect.go`, `cmd/merge.go`, `cmd/launch.go`); SPECS.md's "Exit codes" and each command's spec section own the authoritative tables.
 - Test, release, and write conventions live as doc comments: `tests/e2e` (`fakes_test.go`, `e2e_test.go`), GitHub access via `gh` (`internal/ghutil`), AGENTS.md refresh (`internal/agentsmd`), atomic writes (`internal/atomicfile`); SPECS.md's "Testing strategy" owns the fake-fidelity rule every faked backend invocation follows.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a sc
 | `hand merge` | Merge a task's completed work | Available |
 | `hand pr` | Record a task's pull request URL | Available |
 | `hand search` | Full-text search the prose corpus under `data/` | Available |
+| `hand doctor` | Report perishable content and generated-block drift in the fleet home's `AGENTS.md`; fixes nothing | Available |
 | `hand teardown` | Clean up a completed task, fail-closed on unlanded work, recording it in `state/completions.jsonl` first | Available |
 | `hand promote` | Promote a completed scout task into a ship task | Available |
 | `hand notify` | Send an out-of-band notification via a configured command; operator-invoked, nothing in the fleet calls it yet | Available |

--- a/SPECS.md
+++ b/SPECS.md
@@ -1178,10 +1178,14 @@ Behavior:
    - self-expiring phrasing outside the generated span - `until #N lands`, `once #N lands`, `awaiting #N` - the same shape of problem as a bare date. Each shape needs an issue to expire against, so a bare "awaiting" with nothing to anchor it is durable prose and is not flagged,
    - an em dash or emoji anywhere in the file, generated span included,
    - a code fence that is never closed, since it silences the date and self-expiring checks for every line after it,
-   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`, or the `hand:generated` markers being absent altogether, which is the case `hand init` and `hand update` both decline to touch and so can never refresh itself.
+   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`, or the `hand:generated` markers being absent altogether. Both come from `generatedBlockSpan`, the same pure content match `agentsmd.mergeGenerated` uses to decide whether to touch a file, so the absent-markers finding states exactly the fact a refresh already acts on: nothing in `hand` will ever update this file's template.
 3. Print one line per hit to stdout, prefixed with the resolved fleet home's absolute path to `AGENTS.md` (`generatedBody`'s absolute-path rule applies to the checker's own output too - a bare `AGENTS.md:12:` is ambiguous once more than one fleet home is in scope) - `<path>:<line>: <finding>` for a line-anchored finding, `<path>: <finding>` for the whole-file block checks - and exit `1` if anything was found, `0` if the file is clean.
 
 A remedy naming a command that takes a path spells that path out: `hand init` with no argument targets the working directory, which is a new nested fleet home whenever the operator ran `hand doctor` from anywhere but the home itself.
+
+A marker-less `AGENTS.md` can be an accident or a deliberate choice, and nothing in the file distinguishes the two, so `hand doctor` reports both and a human judges which one it is.
+A maintainer who has deliberately kept a file marker-less - this repo's own checkout being the example, see "AGENTS.md (target)" - sees that finding on every `hand doctor` run in that home, permanently.
+That is the checker working: an accurate report of a known and accepted state, not a bug to fix and not something to suppress.
 
 A date or self-expiring phrase inside inline code (`` `...` ``) or a URL is not flagged: a changelog entry or an example command legitimately names a date or says "awaiting #12" without going stale, since it is documenting a fixed past event or literal text rather than making a claim about the present.
 
@@ -2179,8 +2183,9 @@ Deliverable: ready for daily use.
 
 ## AGENTS.md (target)
 
-**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content and generated-block drift in a real fleet home's `AGENTS.md` without fixing either.
+**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content, generated-block drift, and absent generated markers in a real fleet home's `AGENTS.md` without fixing any of them.
 
 One rule in that template, `agentsmd.OperatorDecisionRule`, is also an exported constant, because a worker runs in a worktree that is never under the fleet home and so never loads the home's `AGENTS.md`. `internal/harness` appends that same constant to the launch prompt (see "Harness launch templates"), which is the only channel the rule has to a worker. It stays one string in one place rather than two copies that drift.
 
 This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even if a maintainer runs `hand init` in the checkout and `state/hand.db` makes `internal/home.IsHome` report true for it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.
+`hand doctor` run in that checkout therefore reports the absent markers every time, which is correct and expected rather than a contradiction: the report says the template will never refresh here, and here that is the intent.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1165,7 +1165,7 @@ Both are general errors (`1`), never usage errors: the operator typed the comman
 
 ### `hand doctor`
 
-Report-only check of the resolved fleet home's `AGENTS.md` for perishable content and generated-block drift. Fixes nothing; a human or agent reads the findings and edits the file.
+Report-only check of the resolved fleet home's `AGENTS.md` for perishable content and generated-block drift. Fixes nothing; a human or agent reads the findings and edits the file. Findings are not all equal weight - see "Behavior" below for the one that is informational rather than exit-failing.
 
 ```
 hand doctor
@@ -1178,14 +1178,13 @@ Behavior:
    - self-expiring phrasing outside the generated span - `until #N lands`, `once #N lands`, `awaiting #N` - the same shape of problem as a bare date. Each shape needs an issue to expire against, so a bare "awaiting" with nothing to anchor it is durable prose and is not flagged,
    - an em dash or emoji anywhere in the file, generated span included,
    - a code fence that is never closed, since it silences the date and self-expiring checks for every line after it,
-   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`, or the `hand:generated` markers being absent altogether. Both come from `generatedBlockSpan`, the same pure content match `agentsmd.mergeGenerated` uses to decide whether to touch a file, so the absent-markers finding states exactly the fact a refresh already acts on: nothing in `hand` will ever update this file's template.
-3. Print one line per hit to stdout, prefixed with the resolved fleet home's absolute path to `AGENTS.md` (`generatedBody`'s absolute-path rule applies to the checker's own output too - a bare `AGENTS.md:12:` is ambiguous once more than one fleet home is in scope) - `<path>:<line>: <finding>` for a line-anchored finding, `<path>: <finding>` for the whole-file block checks - and exit `1` if anything was found, `0` if the file is clean.
+   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`, a violation,
+   - the `hand:generated` markers being absent altogether - the same `generatedBlockSpan` result `agentsmd.mergeGenerated` uses to decide whether to touch the file at all, so this finding states exactly the fact a refresh already acts on: nothing in `hand` will ever update this file's template. It is informational rather than a violation (see `agentsmd.Severity`), since a marker-less file can be an accident or a deliberate choice and nothing in the file tells the two apart.
+3. Print one line per hit to stdout, prefixed with the resolved fleet home's absolute path to `AGENTS.md` (`generatedBody`'s absolute-path rule applies to the checker's own output too - a bare `AGENTS.md:12:` is ambiguous once more than one fleet home is in scope) - `<path>:<line>: <finding>` for a line-anchored finding, `<path>: <finding>` for the whole-file block checks - and exit `1` if any violation-severity finding was found, `0` if the file is clean or every finding present is informational.
 
 A remedy naming a command that takes a path spells that path out: `hand init` with no argument targets the working directory, which is a new nested fleet home whenever the operator ran `hand doctor` from anywhere but the home itself.
 
-A marker-less `AGENTS.md` can be an accident or a deliberate choice, and nothing in the file distinguishes the two, so `hand doctor` reports both and a human judges which one it is.
-A maintainer who has deliberately kept a file marker-less - this repo's own checkout being the example, see "AGENTS.md (target)" - sees that finding on every `hand doctor` run in that home, permanently.
-That is the checker working: an accurate report of a known and accepted state, not a bug to fix and not something to suppress.
+The missing-markers finding stays informational rather than becoming a violation because `hand doctor` cannot resolve it into a pass/fail verdict on its own: a maintainer who has deliberately kept a file marker-less - this repo's own checkout being the example, see "AGENTS.md (target)" - sees that finding on every `hand doctor` run in that home, permanently, but the command still exits `0` there, so a red `hand doctor` keeps meaning something. A maintainer who left a file marker-less by accident sees the same finding and reads it as a nudge to paste the current generated block back in, not as a command failure to chase down.
 
 A date or self-expiring phrase inside inline code (`` `...` ``) or a URL is not flagged: a changelog entry or an example command legitimately names a date or says "awaiting #12" without going stale, since it is documenting a fixed past event or literal text rather than making a claim about the present.
 
@@ -2186,9 +2185,9 @@ Deliverable: ready for daily use.
 
 ## AGENTS.md (target)
 
-**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content, generated-block drift, and absent generated markers in a real fleet home's `AGENTS.md` without fixing any of them.
+**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content, generated-block drift, and absent generated markers in a real fleet home's `AGENTS.md` without fixing any of them - the first two fail the command, absent markers alone does not (`agentsmd.SeverityInfo`).
 
 One rule in that template, `agentsmd.OperatorDecisionRule`, is also an exported constant, because a worker runs in a worktree that is never under the fleet home and so never loads the home's `AGENTS.md`. `internal/harness` appends that same constant to every prompt-carrying launch template (see "Harness launch templates"), the only channel the rule has to a worker. It stays one string in one place rather than two copies that drift.
 
 This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even if a maintainer runs `hand init` in the checkout and `state/hand.db` makes `internal/home.IsHome` report true for it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.
-`hand doctor` run in that checkout therefore reports the absent markers every time, which is correct and expected rather than a contradiction: the report says the template will never refresh here, and here that is the intent.
+`hand doctor` run in that checkout therefore reports the absent markers every time - correct, since the template really will never refresh here - but that finding is informational (see "`hand doctor`"), so the command still exits `0` in this checkout rather than failing forever over a state the maintainers chose on purpose.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1163,6 +1163,29 @@ Both are general errors (`1`), never usage errors: the operator typed the comman
 
 ---
 
+### `hand doctor`
+
+Report-only check of the resolved fleet home's `AGENTS.md` for perishable content and generated-block drift. Fixes nothing; a human or agent reads the findings and edits the file.
+
+```
+hand doctor
+```
+
+Behavior:
+1. Resolve the fleet home (same resolution as every other command; a `hand doctor` outside one is the same precondition failure as elsewhere).
+2. Scan `AGENTS.md` line by line, tracking fenced code blocks and the `hand:generated` span (see "AGENTS.md (target)"), and flag:
+   - a date (`YYYY-MM-DD`) outside the generated span, since a date only stays true as long as the day it names,
+   - self-expiring phrasing outside the generated span - `until #N lands`, `once #N lands`, `awaiting` - the same shape of problem as a bare date,
+   - an em dash or emoji anywhere in the file, generated span included,
+   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`.
+3. Print one line per hit to stdout - `AGENTS.md:<line>: <finding>` for a line-anchored finding, `AGENTS.md: <finding>` for the whole-file drift check - and exit `1` if anything was found, `0` if the file is clean.
+
+A date or self-expiring phrase inside inline code (`` `...` ``) or a URL is not flagged: a changelog entry or an example command legitimately names a date or says "awaiting" without going stale, since it is documenting a fixed past event or literal text rather than making a claim about the present.
+
+A missing `AGENTS.md` is not an error: same as a directory that is not a fleet home at all, `hand doctor` finds nothing to flag and exits `0` silently, leaving `hand init` to be the one place that complains about an incomplete fleet home.
+
+---
+
 ## Dashboard: `data/dashboard.md`
 
 The dashboard is secondhand's answer to the session clobbering problem.
@@ -1794,6 +1817,8 @@ Fixed vocabulary (anything else is malformed, and malformed lines are surfaced, 
 - `done`: the worker believes the task is complete. `<note>` should include the PR URL for ship tasks.
 - `failed`: the worker gave up. `<note>` is why.
 
+Only a `hand send` message carries an operator decision. A worker answering its own harness's question dialog is deciding for itself, not being told - it must never write that answer as if the operator said it. There is no separate vocabulary word for this: the worker records it as `working: deciding myself: <the call> because <reason>`, first person, and reserves `needs-decision:` for what it cannot take back itself (see atqamz/secondhand#87).
+
 Read/classify semantics:
 
 - `hand watch` tails the file once per task per poll tick from a byte offset persisted as `report_offset` on the task, classifying only whole, newline-terminated lines. A partial trailing line (a write still in flight) is left unconsumed until the next tick. Because the offset is durable, a restarted `hand watch` resumes exactly where it stopped: no already-surfaced line is replayed into stdout, `state/events.log`, or Pending Decisions, and no line written moments before the restart is dropped. The last state and note a line classified to are carried across a restart as `last_report_state` and `last_report_note` rather than re-read from the file, so a pane found not-busy after a restart isn't mistaken for an unexplained stop - see "What survives a `hand watch` restart".
@@ -2150,7 +2175,6 @@ Deliverable: ready for daily use.
 
 ## AGENTS.md (target)
 
-**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh.
+**`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content and generated-block drift in a real fleet home's `AGENTS.md` without fixing either.
 
-This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even once a maintainer runs `hand init` in the checkout and makes it a fleet home: its top section is a hand-kept copy of `generatedBody`, kept in sync manually rather than by the refresh mechanism.
-Drift between the two copies is caught by a unit test in `internal/agentsmd` asserting the repo copy's rules open with the generated ones verbatim, not by the mechanism that would remove the duplication.
+This repo's own `AGENTS.md` is deliberately not a fleet home - `internal/home.IsHome` reports false for this checkout, so `agentsmd.Refresh` has nothing to gate here even if a maintainer ran `hand init` in it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1178,7 +1178,7 @@ Behavior:
    - self-expiring phrasing outside the generated span - `until #N lands`, `once #N lands`, `awaiting` - the same shape of problem as a bare date,
    - an em dash or emoji anywhere in the file, generated span included,
    - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`.
-3. Print one line per hit to stdout - `AGENTS.md:<line>: <finding>` for a line-anchored finding, `AGENTS.md: <finding>` for the whole-file drift check - and exit `1` if anything was found, `0` if the file is clean.
+3. Print one line per hit to stdout, prefixed with the resolved fleet home's absolute path to `AGENTS.md` (the same absolute-path rule this PR adds to `generatedBody` - a bare `AGENTS.md:12:` is ambiguous once more than one fleet home is in scope) - `<path>:<line>: <finding>` for a line-anchored finding, `<path>: <finding>` for the whole-file drift check - and exit `1` if anything was found, `0` if the file is clean.
 
 A date or self-expiring phrase inside inline code (`` `...` ``) or a URL is not flagged: a changelog entry or an example command legitimately names a date or says "awaiting" without going stale, since it is documenting a fixed past event or literal text rather than making a claim about the present.
 
@@ -2177,4 +2177,4 @@ Deliverable: ready for daily use.
 
 **`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content and generated-block drift in a real fleet home's `AGENTS.md` without fixing either.
 
-This repo's own `AGENTS.md` is deliberately not a fleet home - `internal/home.IsHome` reports false for this checkout, so `agentsmd.Refresh` has nothing to gate here even if a maintainer ran `hand init` in it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.
+This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even if a maintainer runs `hand init` in the checkout and `state/hand.db` makes `internal/home.IsHome` report true for it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.

--- a/SPECS.md
+++ b/SPECS.md
@@ -166,7 +166,7 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
     completion/             # durable teardown completion record
       completion.go         # append/list state/completions.jsonl
     agentsmd/               # generated AGENTS.md template
-      agentsmd.go           # write and refresh the generated span
+      agentsmd.go           # write and refresh the generated span, check a home's file (see "`hand doctor`")
     atomicfile/             # shared write-to-temp-then-rename helper
       atomicfile.go         # atomic file replacement
   go.mod
@@ -1447,6 +1447,9 @@ The Claude and OpenCode forms above were verified against the installed CLI vers
 Codex, Grok, and Pi retain unverified templates until those binaries are installable; whoever
 verifies them must confirm interactive (not headless) launch, not just flag names.
 The harness module is the single place that constructs these commands.
+A template that hands the brief over as a file rather than as prompt text (Codex, Grok, Pi) has no
+prompt to append to, so `agentsmd.OperatorDecisionRule` never reaches those workers: the brief is
+all they read.
 
 ## Herdr integration detail
 
@@ -2185,7 +2188,7 @@ Deliverable: ready for daily use.
 
 **`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content, generated-block drift, and absent generated markers in a real fleet home's `AGENTS.md` without fixing any of them.
 
-One rule in that template, `agentsmd.OperatorDecisionRule`, is also an exported constant, because a worker runs in a worktree that is never under the fleet home and so never loads the home's `AGENTS.md`. `internal/harness` appends that same constant to the launch prompt (see "Harness launch templates"), which is the only channel the rule has to a worker. It stays one string in one place rather than two copies that drift.
+One rule in that template, `agentsmd.OperatorDecisionRule`, is also an exported constant, because a worker runs in a worktree that is never under the fleet home and so never loads the home's `AGENTS.md`. `internal/harness` appends that same constant to every prompt-carrying launch template (see "Harness launch templates"), the only channel the rule has to a worker. It stays one string in one place rather than two copies that drift.
 
 This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even if a maintainer runs `hand init` in the checkout and `state/hand.db` makes `internal/home.IsHome` report true for it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.
 `hand doctor` run in that checkout therefore reports the absent markers every time, which is correct and expected rather than a contradiction: the report says the template will never refresh here, and here that is the intent.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1175,12 +1175,15 @@ Behavior:
 1. Resolve the fleet home (same resolution as every other command; a `hand doctor` outside one is the same precondition failure as elsewhere).
 2. Scan `AGENTS.md` line by line, tracking fenced code blocks and the `hand:generated` span (see "AGENTS.md (target)"), and flag:
    - a date (`YYYY-MM-DD`) outside the generated span, since a date only stays true as long as the day it names,
-   - self-expiring phrasing outside the generated span - `until #N lands`, `once #N lands`, `awaiting` - the same shape of problem as a bare date,
+   - self-expiring phrasing outside the generated span - `until #N lands`, `once #N lands`, `awaiting #N` - the same shape of problem as a bare date. Each shape needs an issue to expire against, so a bare "awaiting" with nothing to anchor it is durable prose and is not flagged,
    - an em dash or emoji anywhere in the file, generated span included,
-   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`.
-3. Print one line per hit to stdout, prefixed with the resolved fleet home's absolute path to `AGENTS.md` (the same absolute-path rule this PR adds to `generatedBody` - a bare `AGENTS.md:12:` is ambiguous once more than one fleet home is in scope) - `<path>:<line>: <finding>` for a line-anchored finding, `<path>: <finding>` for the whole-file drift check - and exit `1` if anything was found, `0` if the file is clean.
+   - a code fence that is never closed, since it silences the date and self-expiring checks for every line after it,
+   - the generated span's content having drifted from `internal/agentsmd`'s `generatedBody`, or the `hand:generated` markers being absent altogether, which is the case `hand init` and `hand update` both decline to touch and so can never refresh itself.
+3. Print one line per hit to stdout, prefixed with the resolved fleet home's absolute path to `AGENTS.md` (`generatedBody`'s absolute-path rule applies to the checker's own output too - a bare `AGENTS.md:12:` is ambiguous once more than one fleet home is in scope) - `<path>:<line>: <finding>` for a line-anchored finding, `<path>: <finding>` for the whole-file block checks - and exit `1` if anything was found, `0` if the file is clean.
 
-A date or self-expiring phrase inside inline code (`` `...` ``) or a URL is not flagged: a changelog entry or an example command legitimately names a date or says "awaiting" without going stale, since it is documenting a fixed past event or literal text rather than making a claim about the present.
+A remedy naming a command that takes a path spells that path out: `hand init` with no argument targets the working directory, which is a new nested fleet home whenever the operator ran `hand doctor` from anywhere but the home itself.
+
+A date or self-expiring phrase inside inline code (`` `...` ``) or a URL is not flagged: a changelog entry or an example command legitimately names a date or says "awaiting #12" without going stale, since it is documenting a fixed past event or literal text rather than making a claim about the present.
 
 A missing `AGENTS.md` is not an error: same as a directory that is not a fleet home at all, `hand doctor` finds nothing to flag and exits `0` silently, leaving `hand init` to be the one place that complains about an incomplete fleet home.
 
@@ -1319,10 +1322,11 @@ autonomy/permission flag set so an unattended worker does not stall on a permiss
 ### Claude Code
 
 ```sh
-cd <worktree> && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "Read the brief at <brief-path> and carry out the task it describes."
+cd <worktree> && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "Read the brief at <brief-path> and carry out the task it describes. <operator-decision-rule>"
 ```
 
 The brief path is included in the prompt because Claude Code takes prompt text, not a file path.
+`<operator-decision-rule>` is `agentsmd.OperatorDecisionRule` verbatim (see "AGENTS.md (target)"), appended to every prompt-carrying template because the worktree is outside the fleet home and the worker never reads the home's `AGENTS.md`.
 When configured, `--model <name>` and `--effort <level>` are inserted before the prompt.
 Claude is the only harness with an effort flag: `opencode` takes `--model` but no effort, and
 `codex`, `grok` and `pi` take neither (`harness.SupportsEffort`).
@@ -1423,7 +1427,7 @@ Unverified, same caveat as Codex above.
 ### OpenCode
 
 ```sh
-cd <worktree> && OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt "Read the brief at <brief-path> and carry out the task it describes."
+cd <worktree> && OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --prompt "Read the brief at <brief-path> and carry out the task it describes. <operator-decision-rule>"
 ```
 
 The bare `opencode` command opens its interactive TUI, unlike `opencode run`, which is
@@ -2176,5 +2180,7 @@ Deliverable: ready for daily use.
 ## AGENTS.md (target)
 
 **`internal/agentsmd/agentsmd.go`'s `generatedBody` constant** is authoritative - the template `hand init` writes into a new fleet home's `AGENTS.md` and `hand update` refreshes there, delimited by `hand:generated` markers so anything a user adds outside that span survives a refresh. `hand doctor` (see the CLI specification) reports perishable content and generated-block drift in a real fleet home's `AGENTS.md` without fixing either.
+
+One rule in that template, `agentsmd.OperatorDecisionRule`, is also an exported constant, because a worker runs in a worktree that is never under the fleet home and so never loads the home's `AGENTS.md`. `internal/harness` appends that same constant to the launch prompt (see "Harness launch templates"), which is the only channel the rule has to a worker. It stays one string in one place rather than two copies that drift.
 
 This repo's own `AGENTS.md` carries no `hand:generated` markers, so `agentsmd.Refresh` declines to touch it even if a maintainer runs `hand init` in the checkout and `state/hand.db` makes `internal/home.IsHome` report true for it. Rather than hand-keep a second copy of `generatedBody` in sync (the drift #44 was filed against), this file's own Rules section points at `generatedBody` and SPECS.md by name instead of restating it: one prose template, one place it can go stale.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -26,7 +26,11 @@ func newDoctorCmd() *cobra.Command {
 
 			path := filepath.Join(fleetHome, "AGENTS.md")
 			out := cmd.OutOrStdout()
+			failing := 0
 			for _, v := range violations {
+				if v.Severity != agentsmd.SeverityInfo {
+					failing++
+				}
 				if v.Line > 0 {
 					if _, err := fmt.Fprintf(out, "%s:%d: %s\n", path, v.Line, v.Text); err != nil {
 						return err
@@ -37,8 +41,8 @@ func newDoctorCmd() *cobra.Command {
 					return err
 				}
 			}
-			if len(violations) > 0 {
-				return fmt.Errorf("%s: %d issue(s) found", path, len(violations))
+			if failing > 0 {
+				return fmt.Errorf("%s: %d issue(s) found", path, failing)
 			}
 			return nil
 		},

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/atqamz/secondhand/internal/agentsmd"
 	"github.com/atqamz/secondhand/internal/home"
@@ -23,20 +24,21 @@ func newDoctorCmd() *cobra.Command {
 				return err
 			}
 
+			path := filepath.Join(fleetHome, "AGENTS.md")
 			out := cmd.OutOrStdout()
 			for _, v := range violations {
 				if v.Line > 0 {
-					if _, err := fmt.Fprintf(out, "AGENTS.md:%d: %s\n", v.Line, v.Text); err != nil {
+					if _, err := fmt.Fprintf(out, "%s:%d: %s\n", path, v.Line, v.Text); err != nil {
 						return err
 					}
 					continue
 				}
-				if _, err := fmt.Fprintf(out, "AGENTS.md: %s\n", v.Text); err != nil {
+				if _, err := fmt.Fprintf(out, "%s: %s\n", path, v.Text); err != nil {
 					return err
 				}
 			}
 			if len(violations) > 0 {
-				return fmt.Errorf("AGENTS.md: %d issue(s) found", len(violations))
+				return fmt.Errorf("%s: %d issue(s) found", path, len(violations))
 			}
 			return nil
 		},

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/atqamz/secondhand/internal/agentsmd"
+	"github.com/atqamz/secondhand/internal/home"
+	"github.com/spf13/cobra"
+)
+
+func newDoctorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check the fleet home's AGENTS.md for perishable content and generated-block drift",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			violations, err := agentsmd.Check(fleetHome)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			for _, v := range violations {
+				if v.Line > 0 {
+					if _, err := fmt.Fprintf(out, "AGENTS.md:%d: %s\n", v.Line, v.Text); err != nil {
+						return err
+					}
+					continue
+				}
+				if _, err := fmt.Fprintf(out, "AGENTS.md: %s\n", v.Text); err != nil {
+					return err
+				}
+			}
+			if len(violations) > 0 {
+				return fmt.Errorf("AGENTS.md: %d issue(s) found", len(violations))
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -58,8 +58,9 @@ func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
 	if err == nil {
 		t.Fatal("got nil error, want a non-nil error for a perishable-content hit")
 	}
-	if !strings.Contains(out.String(), "AGENTS.md:") {
-		t.Fatalf("stdout = %q, want a per-line AGENTS.md violation", out.String())
+	want := filepath.Join(home, "AGENTS.md") + ":"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("stdout = %q, want a violation anchored at the resolved home's absolute path %q", out.String(), want)
 	}
 }
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -64,6 +64,27 @@ func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
 	}
 }
 
+func TestDoctorMarkerLessAgentsMdIsInformationalNotFailing(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	path := filepath.Join(home, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("# Hand-authored, no generated markers\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got error %v, want nil: a marker-less AGENTS.md can be deliberate, so this finding must not fail the command", err)
+	}
+	if !strings.Contains(out.String(), "no hand:generated markers") {
+		t.Fatalf("stdout = %q, want the missing-markers finding reported even though it does not fail", out.String())
+	}
+}
+
 func TestDoctorOutsideFleetHomeIsPrecondition(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/secondhand/internal/agentsmd"
+)
+
+func TestDoctorCleanFleetHomeExitsZeroSilently(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got error %v, want nil for a clean AGENTS.md", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+}
+
+func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, "AGENTS.md")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("\nFixed on 2026-07-29.\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("got nil error, want a non-nil error for a perishable-content hit")
+	}
+	if !strings.Contains(out.String(), "AGENTS.md:") {
+		t.Fatalf("stdout = %q, want a per-line AGENTS.md violation", out.String())
+	}
+}
+
+func TestDoctorOutsideFleetHomeIsPrecondition(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HAND_HOME", "")
+
+	cmd := newDoctorCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs(nil)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("got nil error, want a precondition failure outside a fleet home")
+	}
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want an ExitError with code 3", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func newRootCmd(version string) *cobra.Command {
 	root.AddCommand(newPromoteCmd())
 	root.AddCommand(newNotifyCmd())
 	root.AddCommand(newSearchCmd())
+	root.AddCommand(newDoctorCmd())
 	root.AddCommand(newUpdateCmd(version))
 	// ExecuteC would add the completion group later, too late for the guard below.
 	root.InitDefaultCompletionCmd()

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -22,6 +22,17 @@ const (
 	endMarker   = "<!-- hand:generated:end -->"
 )
 
+// OperatorDecisionRule is the one AGENTS.md rule a worker needs wherever it
+// runs. A worker's worktree is never under the fleet home, so it never loads
+// the home's AGENTS.md; internal/harness puts this same string in the launch
+// prompt, and generatedBody embeds it, so the two copies cannot drift.
+const OperatorDecisionRule = "Only a `hand send` message carries an operator decision. " +
+	"Answering your own harness's question dialog is you deciding, not the operator - " +
+	"never record that answer as \"operator said\" or \"operator chose\". " +
+	"You may decide anything reversible yourself and proceed; say so in first person - " +
+	"`working: deciding myself: <the call> because <reason>` - " +
+	"and reserve `needs-decision:` for what you cannot take back."
+
 const generatedBody = `# Secondhand
 
 You manage a fleet of coding agents using the ` + "`hand`" + ` CLI.
@@ -45,7 +56,7 @@ Run ` + "`hand --help`" + ` for the full command reference.
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
-- Only a ` + "`hand send`" + ` message carries an operator decision. Answering your own harness's question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - ` + "`working: deciding myself: <the call> because <reason>`" + ` - and reserve ` + "`needs-decision:`" + ` for what you cannot take back.
+- ` + OperatorDecisionRule + `
 - Name a path in a brief, a status report, or an operator message: full and absolute, never relative. ` + "`hand`" + ` resolves the home from ` + "`HAND_HOME`" + ` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce ` + "`data/<id>/report.md`" + `.
 - ` + "`data/backlog.md`" + ` is your task queue. Edit it directly.
@@ -141,7 +152,7 @@ var (
 	// invariant. hand does not create or own that notes convention, so
 	// neither the violation text nor SPECS.md names a specific path for it.
 	dateRe         = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
-	selfExpiringRe = regexp.MustCompile(`(?i)\b(?:until|once)\s+#\d+\s+lands\b|\bawaiting\b`)
+	selfExpiringRe = regexp.MustCompile(`(?i)\b(?:until|once)\s+#\d+\s+lands\b|\bawaiting\s+#\d+\b`)
 
 	// inlineCodeRe and urlRe are stripped from a line before it's tested against
 	// dateRe/selfExpiringRe: a date in a quoted example or a URL is not an
@@ -151,9 +162,9 @@ var (
 	urlRe        = regexp.MustCompile(`https?://\S+`)
 )
 
-// Violation is one perishable-content or generated-block-drift hit Check
-// found. Line is 1-based, or 0 for a violation that isn't about a single line
-// (generated-block drift).
+// Violation is one perishable-content, malformed-file, or generated-block hit
+// Check found. Line is 1-based, or 0 for a violation that isn't about a single
+// line (a drifted or absent generated block).
 type Violation struct {
 	Line int
 	Text string
@@ -186,6 +197,7 @@ func Check(dir string) ([]Violation, error) {
 
 	var violations []Violation
 	inFence := false
+	fenceOpenedAt := 0
 	offset := 0
 	for i, line := range strings.Split(content, "\n") {
 		lineNo := i + 1
@@ -199,6 +211,9 @@ func Check(dir string) ([]Violation, error) {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "```") {
 			inFence = !inFence
+			if inFence {
+				fenceOpenedAt = lineNo
+			}
 			continue
 		}
 		if inFence || insideBlock {
@@ -214,8 +229,17 @@ func Check(dir string) ([]Violation, error) {
 		}
 	}
 
-	if hasBlock && content[blockStart:blockEnd] != strings.TrimSuffix(generatedBlock(), "\n") {
-		violations = append(violations, Violation{Text: "generated block has drifted from generatedBody: run hand init to refresh"})
+	// An unterminated fence silences every date and self-expiring check after
+	// it, so it has to be reported rather than left to read as a clean file.
+	if inFence {
+		violations = append(violations, Violation{Line: fenceOpenedAt, Text: "unterminated code fence: every date and self-expiring check after this line was skipped"})
+	}
+
+	switch {
+	case !hasBlock:
+		violations = append(violations, Violation{Text: fmt.Sprintf("no hand:generated markers: hand init and hand update leave a marker-less file alone, so this template can never refresh itself; paste the current generated block back in, or move this file aside and run hand init %s", dir)})
+	case content[blockStart:blockEnd] != strings.TrimSuffix(generatedBlock(), "\n"):
+		violations = append(violations, Violation{Text: fmt.Sprintf("generated block has drifted from generatedBody: run hand init %s to refresh", dir)})
 	}
 
 	return violations, nil

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -1,6 +1,7 @@
 // Package agentsmd generates and refreshes the AGENTS.md workflow/rules
-// template that hand init writes into a fleet home, described in SPECS.md's
-// "AGENTS.md (target)" section.
+// template that hand init writes into a fleet home, and checks an existing
+// one for perishable content and generated-block drift (hand doctor), both
+// described in SPECS.md's "AGENTS.md (target)" section.
 package agentsmd
 
 import (

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -170,7 +170,8 @@ type Violation struct {
 	Text string
 }
 
-// Check reports perishable content and generated-block drift in dir's
+// Check reports perishable content, an unterminated code fence, and either
+// generated-block drift or generated markers absent altogether in dir's
 // AGENTS.md, described in SPECS.md's "AGENTS.md (target)" section
 // (atqamz/secondhand#90). It never writes: the point is to make a human look
 // at prose judgment a machine cannot make, not to rewrite it. A nil result

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -136,8 +136,10 @@ func generatedBlockSpan(content string) (start, end int, ok bool) {
 
 var (
 	// dateRe and selfExpiringRe describe the two shapes of perishable content
-	// that belong in data/learnings.md, not AGENTS.md: a dated fact is an
-	// incident, and phrasing that names its own expiry is not an invariant.
+	// that belong in the fleet home's own notes, not AGENTS.md: a dated fact
+	// is an incident, and phrasing that names its own expiry is not an
+	// invariant. hand does not create or own that notes convention, so
+	// neither the violation text nor SPECS.md names a specific path for it.
 	dateRe         = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
 	selfExpiringRe = regexp.MustCompile(`(?i)\b(?:until|once)\s+#\d+\s+lands\b|\bawaiting\b`)
 
@@ -190,33 +192,30 @@ func Check(dir string) ([]Violation, error) {
 		insideBlock := hasBlock && offset >= blockStart && offset < blockEnd
 		offset += len(line) + 1
 
+		if r, found := firstBannedRune(line); found {
+			violations = append(violations, Violation{Line: lineNo, Text: fmt.Sprintf("banned character %q: no em dash or emoji, house rule everywhere in this file", r)})
+		}
+
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "```") {
 			inFence = !inFence
 			continue
 		}
-		if inFence {
-			continue
-		}
-
-		if r, found := firstBannedRune(line); found {
-			violations = append(violations, Violation{Line: lineNo, Text: fmt.Sprintf("banned character %q: no em dash or emoji, house rule everywhere in this file", r)})
-		}
-		if insideBlock {
+		if inFence || insideBlock {
 			continue
 		}
 
 		stripped := urlRe.ReplaceAllString(inlineCodeRe.ReplaceAllString(line, ""), "")
 		if dateRe.MatchString(stripped) {
-			violations = append(violations, Violation{Line: lineNo, Text: "date outside the generated block: a dated fact is an incident, belongs in data/learnings.md"})
+			violations = append(violations, Violation{Line: lineNo, Text: "date outside the generated block: a dated fact is an incident, belongs in the home's own notes, not the generated block"})
 		}
 		if selfExpiringRe.MatchString(stripped) {
-			violations = append(violations, Violation{Line: lineNo, Text: "self-expiring phrasing outside the generated block: not an invariant, belongs in data/learnings.md"})
+			violations = append(violations, Violation{Line: lineNo, Text: "self-expiring phrasing outside the generated block: not an invariant, belongs in the home's own notes, not the generated block"})
 		}
 	}
 
 	if hasBlock && content[blockStart:blockEnd] != strings.TrimSuffix(generatedBlock(), "\n") {
-		violations = append(violations, Violation{Text: "generated block has drifted from generatedBody: run hand update (or hand init) to refresh"})
+		violations = append(violations, Violation{Text: "generated block has drifted from generatedBody: run hand init to refresh"})
 	}
 
 	return violations, nil

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -163,21 +163,38 @@ var (
 	urlRe        = regexp.MustCompile(`https?://\S+`)
 )
 
+// Severity distinguishes a Violation that fails hand doctor from one that is
+// informational: reported because it is real and worth a human's attention,
+// but not something the checker can resolve into a pass/fail verdict on its
+// own - the marker-less case below is the only one so far, since Check has
+// no way to tell a file left marker-less by accident from one left that way
+// on purpose.
+type Severity int
+
+const (
+	SeverityViolation Severity = iota
+	SeverityInfo
+)
+
 // Violation is one perishable-content, malformed-file, or generated-block hit
-// Check found. Line is 1-based, or 0 for a violation that isn't about a single
-// line (a drifted or absent generated block).
+// Check found, at SeverityViolation unless Severity says otherwise. Line is
+// 1-based, or 0 for a violation that isn't about a single line (a drifted or
+// absent generated block).
 type Violation struct {
-	Line int
-	Text string
+	Line     int
+	Text     string
+	Severity Severity
 }
 
 // Check reports perishable content, an unterminated code fence, and either
 // generated-block drift or generated markers absent altogether in dir's
 // AGENTS.md, described in SPECS.md's "AGENTS.md (target)" section
-// (atqamz/secondhand#90). It never writes: the point is to make a human look
-// at prose judgment a machine cannot make, not to rewrite it. A nil result
-// with no error means dir is not a fleet home, or has no AGENTS.md yet -
-// both are an absence, not a violation.
+// (atqamz/secondhand#90). Absent markers come back at SeverityInfo rather
+// than SeverityViolation, since Check cannot tell a marker-less file left
+// that way by accident from one left that way on purpose. It never writes:
+// the point is to make a human look at prose judgment a machine cannot make,
+// not to rewrite it. A nil result with no error means dir is not a fleet
+// home, or has no AGENTS.md yet - both are an absence, not a violation.
 func Check(dir string) ([]Violation, error) {
 	isHome, err := home.IsHome(dir)
 	if err != nil {
@@ -239,7 +256,10 @@ func Check(dir string) ([]Violation, error) {
 
 	switch {
 	case !hasBlock:
-		violations = append(violations, Violation{Text: fmt.Sprintf("no hand:generated markers: hand init and hand update leave a marker-less file alone, so this template can never refresh itself; paste the current generated block back in, or move this file aside and run hand init %s", dir)})
+		violations = append(violations, Violation{
+			Text:     "no hand:generated markers: hand init and hand update leave a marker-less file alone, so this template can never refresh itself here - paste the current generated block back in if that is unintended, or ignore this finding if the file is deliberately hand-authored (see SPECS.md's \"AGENTS.md (target)\" section)",
+			Severity: SeverityInfo,
+		})
 	case content[blockStart:blockEnd] != strings.TrimSuffix(generatedBlock(), "\n"):
 		violations = append(violations, Violation{Text: fmt.Sprintf("generated block has drifted from generatedBody: run hand init %s to refresh", dir)})
 	}

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/atqamz/secondhand/internal/atomicfile"
@@ -44,6 +45,7 @@ Run ` + "`hand --help`" + ` for the full command reference.
 - Never merge without explicit authorization.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
+- Only a ` + "`hand send`" + ` message carries an operator decision. Answering your own harness's question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - ` + "`working: deciding myself: <the call> because <reason>`" + ` - and reserve ` + "`needs-decision:`" + ` for what you cannot take back.
 - Name a path in a brief, a status report, or an operator message: full and absolute, never relative. ` + "`hand`" + ` resolves the home from ` + "`HAND_HOME`" + ` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce ` + "`data/<id>/report.md`" + `.
 - ` + "`data/backlog.md`" + ` is your task queue. Edit it directly.
@@ -110,14 +112,141 @@ func generatedBlock() string {
 // with no markers (never refreshed by this mechanism) is left as-is rather
 // than risk clobbering hand-written content.
 func mergeGenerated(content string) string {
-	start := strings.Index(content, beginMarker)
-	if start == -1 {
+	start, end, ok := generatedBlockSpan(content)
+	if !ok {
 		return content
 	}
-	end := strings.Index(content, endMarker)
-	if end == -1 || end < start {
-		return content
-	}
-	end += len(endMarker)
 	return content[:start] + strings.TrimSuffix(generatedBlock(), "\n") + content[end:]
+}
+
+// generatedBlockSpan returns the byte range of the generated block, including
+// its markers, or ok=false when the markers are absent or malformed (an end
+// marker missing, or appearing before any begin marker).
+func generatedBlockSpan(content string) (start, end int, ok bool) {
+	start = strings.Index(content, beginMarker)
+	if start == -1 {
+		return 0, 0, false
+	}
+	relEnd := strings.Index(content[start:], endMarker)
+	if relEnd == -1 {
+		return 0, 0, false
+	}
+	return start, start + relEnd + len(endMarker), true
+}
+
+var (
+	// dateRe and selfExpiringRe describe the two shapes of perishable content
+	// that belong in data/learnings.md, not AGENTS.md: a dated fact is an
+	// incident, and phrasing that names its own expiry is not an invariant.
+	dateRe         = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
+	selfExpiringRe = regexp.MustCompile(`(?i)\b(?:until|once)\s+#\d+\s+lands\b|\bawaiting\b`)
+
+	// inlineCodeRe and urlRe are stripped from a line before it's tested against
+	// dateRe/selfExpiringRe: a date in a quoted example or a URL is not an
+	// incident, and flagging it anyway is the false positive that gets a
+	// checker ignored (atqamz/secondhand#90).
+	inlineCodeRe = regexp.MustCompile("`[^`]*`")
+	urlRe        = regexp.MustCompile(`https?://\S+`)
+)
+
+// Violation is one perishable-content or generated-block-drift hit Check
+// found. Line is 1-based, or 0 for a violation that isn't about a single line
+// (generated-block drift).
+type Violation struct {
+	Line int
+	Text string
+}
+
+// Check reports perishable content and generated-block drift in dir's
+// AGENTS.md, described in SPECS.md's "AGENTS.md (target)" section
+// (atqamz/secondhand#90). It never writes: the point is to make a human look
+// at prose judgment a machine cannot make, not to rewrite it. A nil result
+// with no error means dir is not a fleet home, or has no AGENTS.md yet -
+// both are an absence, not a violation.
+func Check(dir string) ([]Violation, error) {
+	isHome, err := home.IsHome(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !isHome {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, filename))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", filename, err)
+	}
+	content := string(data)
+	blockStart, blockEnd, hasBlock := generatedBlockSpan(content)
+
+	var violations []Violation
+	inFence := false
+	offset := 0
+	for i, line := range strings.Split(content, "\n") {
+		lineNo := i + 1
+		insideBlock := hasBlock && offset >= blockStart && offset < blockEnd
+		offset += len(line) + 1
+
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		if r, found := firstBannedRune(line); found {
+			violations = append(violations, Violation{Line: lineNo, Text: fmt.Sprintf("banned character %q: no em dash or emoji, house rule everywhere in this file", r)})
+		}
+		if insideBlock {
+			continue
+		}
+
+		stripped := urlRe.ReplaceAllString(inlineCodeRe.ReplaceAllString(line, ""), "")
+		if dateRe.MatchString(stripped) {
+			violations = append(violations, Violation{Line: lineNo, Text: "date outside the generated block: a dated fact is an incident, belongs in data/learnings.md"})
+		}
+		if selfExpiringRe.MatchString(stripped) {
+			violations = append(violations, Violation{Line: lineNo, Text: "self-expiring phrasing outside the generated block: not an invariant, belongs in data/learnings.md"})
+		}
+	}
+
+	if hasBlock && content[blockStart:blockEnd] != strings.TrimSuffix(generatedBlock(), "\n") {
+		violations = append(violations, Violation{Text: "generated block has drifted from generatedBody: run hand update (or hand init) to refresh"})
+	}
+
+	return violations, nil
+}
+
+func firstBannedRune(line string) (rune, bool) {
+	for _, r := range line {
+		if r == '—' || isEmojiRune(r) {
+			return r, true
+		}
+	}
+	return 0, false
+}
+
+// isEmojiRune covers the Unicode blocks an accidental emoji actually comes
+// from, not a formal emoji property table: pictographs, symbols/dingbats,
+// regional-indicator flag letters, and the variation-selector/ZWJ modifiers
+// that ride along with them.
+func isEmojiRune(r rune) bool {
+	switch {
+	case r >= 0x1F300 && r <= 0x1FAFF:
+		return true
+	case r >= 0x2600 && r <= 0x27BF:
+		return true
+	case r >= 0x2B00 && r <= 0x2BFF:
+		return true
+	case r >= 0x1F1E6 && r <= 0x1F1FF:
+		return true
+	case r == 0xFE0F || r == 0x200D:
+		return true
+	}
+	return false
 }

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -169,33 +169,32 @@ func TestRefreshLeavesUpToDateFileOnDiskUntouched(t *testing.T) {
 	}
 }
 
-// This repo keeps a hand-maintained copy of the generated block in its own
-// AGENTS.md instead of deriving it, so a rule edited in one copy and not the
-// other drifts silently until the duplication itself is removed.
-func TestGeneratedRulesMatchThisRepoAgentsMdCopy(t *testing.T) {
+// This repo's own AGENTS.md points at generatedBody instead of keeping a
+// hand-maintained copy of it (atqamz/secondhand#44), so the only thing worth
+// asserting here is that the pointer survives - not the prose around it.
+func TestThisRepoAgentsMdPointsAtGeneratedBody(t *testing.T) {
 	repoCopy, err := os.ReadFile(filepath.Join("..", "..", "AGENTS.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !strings.Contains(string(repoCopy), "generatedBody") {
+		t.Fatalf("got repo AGENTS.md %q, want a pointer to generatedBody", repoCopy)
+	}
+	if strings.Contains(string(repoCopy), beginMarker) {
+		t.Fatalf("got repo AGENTS.md %q, want no generated-block markers: it is not a refresh target", repoCopy)
+	}
+}
 
-	absolutePathRule := "- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from `HAND_HOME` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.\n"
-	if !strings.Contains(generatedBody, absolutePathRule) {
-		t.Fatalf("got generated body %q, want the absolute-path rule verbatim", generatedBody)
+// #87's fix has to reach every worker without a new report-vocabulary word,
+// since internal/watcher's classifier and hand status's renderer are outside
+// this change's scope: reusing the working: prefix with a first-person
+// convention is the only lever available.
+func TestGeneratedRulesCoverSelfDecidedCallsInFirstPerson(t *testing.T) {
+	if !strings.Contains(generatedBody, "hand send") || !strings.Contains(generatedBody, "operator decision") {
+		t.Fatalf("got generated body %q, want the hand send invariant", generatedBody)
 	}
-	if !strings.Contains(string(repoCopy), absolutePathRule) {
-		t.Fatalf("got repo AGENTS.md %q, want the same absolute-path rule byte-for-byte", repoCopy)
-	}
-
-	_, generatedRules, ok := strings.Cut(generatedBody, "## Rules\n")
-	if !ok {
-		t.Fatalf("got generated body %q, want a Rules section", generatedBody)
-	}
-	_, repoRules, ok := strings.Cut(string(repoCopy), "## Rules\n")
-	if !ok {
-		t.Fatalf("got repo AGENTS.md %q, want a Rules section", repoCopy)
-	}
-	if !strings.HasPrefix(repoRules, generatedRules) {
-		t.Fatalf("got repo rules %q, want them to open with the generated rules %q", repoRules, generatedRules)
+	if !strings.Contains(generatedBody, "working: deciding myself:") {
+		t.Fatalf("got generated body %q, want the first-person working: convention", generatedBody)
 	}
 }
 
@@ -221,5 +220,164 @@ func TestRefreshDoesNotOverwriteExistingClaudeSymlink(t *testing.T) {
 	}
 	if link != "OTHER.md" {
 		t.Fatalf("got CLAUDE.md -> %q, want unchanged OTHER.md", link)
+	}
+}
+
+func hasViolation(violations []Violation, substr string) bool {
+	for _, v := range violations {
+		if strings.Contains(v.Text, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCheckSkipsNonFleetHomeAndMissingFile(t *testing.T) {
+	violations, err := Check(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if violations != nil {
+		t.Fatalf("got %v, want nil outside a fleet home", violations)
+	}
+
+	dir := makeWorkspace(t)
+	violations, err = Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if violations != nil {
+		t.Fatalf("got %v, want nil when AGENTS.md does not exist yet", violations)
+	}
+}
+
+func TestCheckCleanRightAfterRefresh(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("got %v, want no violations right after Refresh", violations)
+	}
+}
+
+func TestCheckFlagsDateOutsideGeneratedBlock(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "Fixed the race condition on 2026-07-29.")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "date outside the generated block") {
+		t.Fatalf("got %v, want a date violation", violations)
+	}
+}
+
+func TestCheckIgnoresDateInCodeSpanOrURL(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "Example: `2026-07-29` is an RFC3339 date, see https://example.com/releases/2026-07-29 for the tag.")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasViolation(violations, "date outside the generated block") {
+		t.Fatalf("got %v, want no date violation for a code span or URL", violations)
+	}
+}
+
+func TestCheckFlagsSelfExpiringPhrasing(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "Until #84 lands, do the mtime check by hand.")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "self-expiring phrasing") {
+		t.Fatalf("got %v, want a self-expiring-phrasing violation", violations)
+	}
+}
+
+func TestCheckFlagsEmDashAndEmoji(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "This rule matters a lot — so don't skip it")
+	appendLine(t, path, "Ship it \U0001F680")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := countViolations(violations, "banned character"); n != 2 {
+		t.Fatalf("got %d banned-character violations in %v, want 2 (em dash and emoji)", n, violations)
+	}
+}
+
+func countViolations(violations []Violation, substr string) int {
+	n := 0
+	for _, v := range violations {
+		if strings.Contains(v.Text, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCheckFlagsGeneratedBlockDrift(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := strings.Replace(string(content), "## Rules", "## Rules (edited by hand)", 1)
+	if err := os.WriteFile(path, []byte(drifted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "generated block has drifted") {
+		t.Fatalf("got %v, want a generated-block-drift violation", violations)
+	}
+}
+
+func appendLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("\n" + line + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -383,6 +383,73 @@ func TestCheckFlagsGeneratedBlockDrift(t *testing.T) {
 	if !hasViolation(violations, "generated block has drifted") {
 		t.Fatalf("got %v, want a generated-block-drift violation", violations)
 	}
+	// A bare "run hand init" would target the operator's working directory,
+	// which is a new nested fleet home whenever that is not the home itself.
+	if !hasViolation(violations, "run hand init "+dir+" to refresh") {
+		t.Fatalf("got %v, want the remedy to name the resolved home %q", violations, dir)
+	}
+}
+
+func TestCheckFlagsMissingGeneratedMarkers(t *testing.T) {
+	dir := makeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte("# Hand-written, no markers\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "no hand:generated markers") {
+		t.Fatalf("got %v, want a missing-markers violation: Refresh declines to touch this file, so nothing else reports it", violations)
+	}
+	if hasViolation(violations, "generated block has drifted") {
+		t.Fatalf("got %v, want no drift violation when there is no block to drift", violations)
+	}
+}
+
+func TestCheckFlagsUnterminatedFence(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "```")
+	appendLine(t, path, "Fixed the race condition on 2026-07-29.")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "unterminated code fence") {
+		t.Fatalf("got %v, want an unterminated-fence violation instead of a silently truncated scan", violations)
+	}
+}
+
+func TestCheckIgnoresAwaitingWithNoIssueReference(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "Never merge a PR awaiting review.")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasViolation(violations, "self-expiring phrasing") {
+		t.Fatalf("got %v, want no violation: a bare awaiting with no issue to expire against is durable prose", violations)
+	}
+
+	appendLine(t, path, "Skip the mtime check, awaiting #84.")
+	violations, err = Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "self-expiring phrasing") {
+		t.Fatalf("got %v, want an awaiting-#N violation", violations)
+	}
 }
 
 func appendLine(t *testing.T, path, line string) {

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -401,10 +401,15 @@ func TestCheckFlagsMissingGeneratedMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !hasViolation(violations, "no hand:generated markers") {
-		t.Fatalf("got %v, want a missing-markers violation: Refresh declines to touch this file, so nothing else reports it", violations)
+		t.Fatalf("got %v, want a missing-markers finding: Refresh declines to touch this file, so nothing else reports it", violations)
 	}
 	if hasViolation(violations, "generated block has drifted") {
 		t.Fatalf("got %v, want no drift violation when there is no block to drift", violations)
+	}
+	for _, v := range violations {
+		if strings.Contains(v.Text, "no hand:generated markers") && v.Severity != SeverityInfo {
+			t.Fatalf("got severity %v for the missing-markers finding, want SeverityInfo: Check cannot tell an accidental marker-less file from a deliberate one", v.Severity)
+		}
 	}
 }
 

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -334,6 +334,23 @@ func TestCheckFlagsEmDashAndEmoji(t *testing.T) {
 	}
 }
 
+func TestCheckFlagsBannedCharacterInsideFence(t *testing.T) {
+	dir := makeWorkspace(t)
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	appendLine(t, path, "```\nan example — with an em dash\n```")
+
+	violations, err := Check(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := countViolations(violations, "banned character"); n != 1 {
+		t.Fatalf("got %d banned-character violations in %v, want 1 inside a fenced block", n, violations)
+	}
+}
+
 func countViolations(violations []Violation, substr string) int {
 	n := 0
 	for _, v := range violations {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/atqamz/secondhand/internal/agentsmd"
 )
 
 const (
@@ -208,13 +210,16 @@ func buildOpenCode(o Options) string {
 	return strings.Join(args, " ")
 }
 
-// briefPrompt is shared so the wording cannot drift between harnesses.
+// briefPrompt is shared so the wording cannot drift between harnesses. It ends
+// with agentsmd.OperatorDecisionRule because a worker runs in a worktree that
+// is never under the fleet home, so the home's AGENTS.md never reaches it and
+// the launch prompt is the only channel that rule has.
 func briefPrompt(o Options) string {
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
 	if o.BriefHasFrontMatter {
 		prompt += " Any model or effort keys in its leading '---' block are dispatch metadata, not task content."
 	}
-	return prompt
+	return prompt + " " + agentsmd.OperatorDecisionRule
 }
 
 func shellQuote(s string) string {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -3,7 +3,16 @@ package harness
 import (
 	"strings"
 	"testing"
+
+	"github.com/atqamz/secondhand/internal/agentsmd"
 )
+
+// quotedPrompt is the shell-quoted first message a harness launches with. The
+// operator-decision rule is a paragraph of prose owned by internal/agentsmd, so
+// exact-match wants build the prompt from it instead of restating it here.
+func quotedPrompt(brief string) string {
+	return shellQuote("Read the brief at " + brief + " and carry out the task it describes. " + agentsmd.OperatorDecisionRule)
+}
 
 func TestBuildUnrecognizedHarness(t *testing.T) {
 	if _, err := Build("nonexistent", Options{}); err == nil {
@@ -39,7 +48,7 @@ func TestBuildClaude(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/data/fix-login/brief.md and carry out the task it describes.'"
+	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions " + quotedPrompt("/tmp/data/fix-login/brief.md")
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
@@ -50,7 +59,7 @@ func TestBuildClaudeWithModelAndEffort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'sonnet' --effort 'low' 'Read the brief at /tmp/brief.md and carry out the task it describes.'"
+	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'sonnet' --effort 'low' " + quotedPrompt("/tmp/brief.md")
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
@@ -109,7 +118,7 @@ func TestBuildOpenCode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "cd '/tmp/wt' && OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\"}}' opencode --prompt 'Read the brief at /tmp/brief.md and carry out the task it describes.'"
+	want := "cd '/tmp/wt' && OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\"}}' opencode --prompt " + quotedPrompt("/tmp/brief.md")
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
@@ -167,6 +176,24 @@ func TestBuildOpenCodeFrontMatterDisclaimer(t *testing.T) {
 	}
 	if !strings.Contains(got, "dispatch metadata") {
 		t.Fatalf("got %q, want the front matter disclaimed", got)
+	}
+}
+
+// TestBuildCarriesOperatorDecisionRule pins the only channel that rule has: a
+// worker's worktree is never under the fleet home, so the AGENTS.md copy of it
+// never reaches the worker. Codex, Grok, and Pi launch with a bare --file and
+// no inline prompt, so they are out of reach until one of them is verified.
+func TestBuildCarriesOperatorDecisionRule(t *testing.T) {
+	quoted := shellQuote(agentsmd.OperatorDecisionRule)
+	escaped := quoted[1 : len(quoted)-1]
+	for _, name := range []string{Claude, OpenCode} {
+		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+		if err != nil {
+			t.Fatalf("Build(%q) error: %v", name, err)
+		}
+		if !strings.Contains(got, escaped) {
+			t.Errorf("Build(%q) = %q, want the operator-decision rule %q in the launch prompt", name, got, escaped)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Give workers an honest, first-person way to record self-decided calls (`working: deciding myself: <call> because <reason>`), and state the invariant that only a `hand send` message is an operator decision - carried into every claude/opencode worker's launch prompt via `internal/harness`, not just the fleet home's AGENTS.md a worker's worktree never loads.
- Add `hand doctor`, a report-only, non-fixing check for perishable content (dates, self-expiring phrasing, banned characters, unterminated fences) and generated-block drift in a fleet home's AGENTS.md.
- Stop this repo's own AGENTS.md from hand-duplicating `agentsmd.go`'s `generatedBody`; it now points at `generatedBody` and SPECS.md by name instead of restating the template.

Closes atqamz/secondhand#87
Closes atqamz/secondhand#90
Closes atqamz/secondhand#44

## Test plan

- `go build ./...`, `go vet ./...`, `go test -race ./...`, `make lint` all pass inside `nix develop`.
- Unit tests cover `agentsmd.Check` (perishable content, drift, missing markers, unterminated fence), the `doctor` command, and `internal/harness`'s launch-prompt wiring for `OperatorDecisionRule`.
- Manually drove `hand init` and `hand doctor` through real fleet homes: every documented finding fires with the resolved absolute path, a clean home exits 0 silently, dates/awaiting-prose inside inline code or URLs are correctly not flagged, and this repo's own marker-less AGENTS.md reports exactly the absent-markers finding without failing the command.
- Spawned workers against fake `herdr`/`treehouse` binaries and confirmed the operator-decision rule reaches the real `claude` and `opencode` launch commands verbatim (`codex` takes the brief as a file and carries no prompt, which SPECS.md now documents as the scoping).

## Note on the missing-markers finding

A review round flagged that the missing-markers finding fires unconditionally, including on this repo's own deliberately marker-less AGENTS.md, and that SPECS.md contradicted itself over whether that firing was correct. An initial fix reworded SPECS.md to call the firing "expected" while leaving `hand doctor` exiting 1 forever in that home - correctly rejected as the same permanent-unclearable-finding problem in different words, since it would train a maintainer to ignore doctor.

`Violation` gained a `Severity` field (`SeverityViolation` / `SeverityInfo`); the missing-markers case reports at `SeverityInfo`, so `hand doctor` still prints it every run but no longer counts it toward the command's exit code. A marker-less AGENTS.md in a genuine fleet home still gets flagged - `#90`'s actual value - and this repo's own dogfood home stays green, so a red `hand doctor` keeps meaning something. The remedy text also dropped its "move this file aside and run hand init" half, since that step discards any deliberately hand-authored AGENTS.md, not just this repo's.
