### PR TITLE
feat(cmd): bound and serialize hand send, harden herdr workspace and tab creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a sc
 | `hand project sync` | Fast-forward project clones to their remote default branch | Available |
 | `hand spawn` | Spawn a worker agent in an isolated worktree | Available |
 | `hand status` | Show fleet overview or single-task detail | Available |
-| `hand send` | Send a message to a running worker | Available |
+| `hand send` | Send a message to a running worker, from an argument or `--file`; waits out a busy composer up to `--wait` instead of failing, and records the message as undelivered when it never reaches the pane | Available |
 | `hand hold set` | Record that an id is waiting on a human or on another id; survives the task's teardown, so `hand spawn` refuses to reuse a held id | Available |
 | `hand hold clear` | Clear the hold on an id | Available |
 | `hand watch` | Blocking watcher that prints actionable fleet events, including a worker gone silent with no herdr transition at all (`parked`); `--until-event` exits on the first one so the exit itself wakes the supervisory agent, and exits `5` naming any worker it can't reach before arming | Available |
@@ -138,7 +138,7 @@ Builds without an embedded version never print the notice.
 
 ## Configuration
 
-Currently supported preferences live as plain files under `config/`: default worker harness, model, and effort.
+Preferences live as plain files under `config/`, one value per file - default worker harness, model, and effort among them; SPECS.md's "Directory layout" section lists every key `hand` reads.
 Run `hand init --setup` to discover installed harnesses and tools and write the defaults interactively.
 A brief can declare its own `model` and `effort` for one task, which win over these defaults and lose only to a `hand spawn`/`hand promote` flag - see SPECS.md's "Brief format" section.
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -1459,7 +1459,18 @@ The herdr server must be running before any `hand` operation that touches tabs/p
 
 ### Workspace and tab model
 
-- One workspace per project. Workspace label = project name.
+- One workspace per project. Workspace label = `hand:<project-name>`, not the bare project name
+  (atqamz/secondhand#118): herdr derives a label from a workspace root directory's basename, so it
+  is neither unique nor owned by `hand` - a project cloned to a directory sharing that basename
+  with something else on the machine (the fleet home itself, another tool's workspace) produces a
+  second workspace with the identical bare label, and `FindWorkspaceByLabel` returning whichever one
+  `herdr workspace list` happens to return first is a silent dispatch into a workspace `hand` never
+  created. The `hand:` prefix is `hand`'s own namespace, mirroring the existing `hand:<task-id>`
+  convention for treehouse worktree ownership - it does not make the label unique on its own, but it
+  does mean a collision now requires another `hand`-managed project to coincidentally share the same
+  name, not any directory on the system. A workspace already created under the bare label from
+  before this change is not adopted; `hand spawn` creates a new `hand:<project-name>` workspace
+  alongside it, and the old one is orphaned (still functional, just no longer found by lookup).
 - One tab per task within the project workspace. Tab label = task ID.
 - The supervisory agent's own session is a separate herdr workspace (or the user's own terminal).
 
@@ -1508,7 +1519,7 @@ herdr workspace list
 # creates a root tab and pane too, at --cwd; hand points --cwd at the worktree (not the clone) and
 # reuses that root tab as the first task's tab (see "herdr tab rename" below) rather than
 # discarding it and creating a second tab, which would leave it behind as an orphan shell
-herdr workspace create --no-focus --cwd <worktree> --label <project-name>
+herdr workspace create --no-focus --cwd <worktree> --label hand:<project-name>
 
 # create tab in an already-existing workspace
 herdr tab create --workspace <ws-id> --no-focus --cwd <worktree> --label <task-id>

--- a/SPECS.md
+++ b/SPECS.md
@@ -439,7 +439,9 @@ Task row written to the `task` table in `state/hand.db`, one column per field be
   "status_changed_at": "",
   "status_changed_for": "",
   "last_report_state": "",
-  "last_report_note": ""
+  "last_report_note": "",
+  "send_undelivered_message": "",
+  "send_undelivered_at": ""
 }
 ```
 
@@ -591,19 +593,51 @@ Errors:
 
 ---
 
-### `hand send <id> <message>`
+### `hand send <id> [message]`
 
 Send a text message to a running worker's herdr pane.
 
 ```
 hand send fix-login "focus on the auth middleware, not the test framework"
+hand send fix-login --file data/fix-login/steer.md
 ```
+
+A busy composer (agent mid-response) is the normal state a steer arrives into, not an error
+condition (atqamz/secondhand#102): `hand send` waits for it to free rather than failing
+immediately, so a caller does not have to reimplement that retry in shell. The wait is bounded,
+not indefinite - a composer that stays busy for the whole bound means the message never reached
+the pane, and that has to surface as a distinct, terminal-for-this-invocation outcome rather than
+a hang.
+
+Flags:
+- `--file <path>`: read the message from this file instead of the positional argument, trailing
+  newlines trimmed. A multi-paragraph steer going through the shell as a positional argument has
+  to survive quoting, embedded newlines, and backticks intact; `--file` is the way to send one
+  without gambling on that. Mutually exclusive with the positional `message` - exactly one of the
+  two is required.
+- `--wait <duration>`: how long to wait for a busy composer to free before giving up. Default
+  `config/send-wait`, or `2m` if that is unset too. Long enough that an ordinary agent turn does
+  not need the caller to retry at all, short enough that an invocation still returns in bounded
+  time; a steer into an unusually long-running turn is a `--wait` argument, not a bigger polling
+  loop.
 
 Behavior:
 1. Read the task's row for herdr pane coordinates.
 2. Check herdr pane exists and agent is present.
-3. Wait for composer to be empty (agent not mid-response).
-4. Submit the message text.
+3. Acquire a per-task send lock (`send:<id>`), held for the rest of this list. A second `hand send`
+   against the same task waits behind the first rather than polling the same pane at the same
+   time - two unsynchronized retry loops racing the same busy composer is the exact hazard
+   atqamz/secondhand#102 traced a lost steer to.
+4. If the composer is busy, poll until it frees or `--wait` elapses.
+5. If `--wait` elapses first: durably record the message and a timestamp on the task row
+   (`send_undelivered_message`, `send_undelivered_at`) under a separate, short-lived task-row lock,
+   so a steer that never arrives leaves a trace instead of vanishing with the process that
+   attempted it - and exit distinctly (see "Exit codes"). This lock is not held for the wait
+   itself: a `hand send` waiting out its bound must not stall `hand watch`'s polling or a `hand
+   status` read on the same task.
+6. Otherwise, submit the message text and clear any previously recorded undelivered-send trace on
+   the task row (whatever message that trace carries) - a send that reaches the pane moots it,
+   whether or not it is a retry of the exact message that was previously abandoned.
 
 Output:
 ```
@@ -611,9 +645,14 @@ sent to fix-login
 ```
 
 Errors:
-- Task not found.
-- Herdr pane doesn't exist (agent died, tab closed).
-- Composer not empty after timeout (agent busy, message queued or refused).
+- Task not found (exit 3).
+- Neither or both of the positional `message` and `--file` given (exit 2).
+- Invalid `--wait` value (exit 2 from the flag, exit 1 from a bad `config/send-wait`).
+- Herdr pane doesn't exist (agent died, tab closed) - exit 1, distinct from a busy composer because
+  this send can never succeed, no matter how long it waits.
+- Composer still busy after `--wait` elapses - exit 6, distinct from the pane-not-found case above:
+  this is a transient state a caller can retry (e.g. with a longer `--wait`), not a terminal
+  failure. The message is durably recorded as undelivered rather than lost; see step 5 above.
 
 ---
 
@@ -1936,6 +1975,7 @@ An existing fleet home has live state on disk, and the import has to meet it wit
   Two more apply to every command, since each one resolves a fleet home before it does anything: the working directory has no fleet home at or above it and `HAND_HOME` is unset, or `HAND_HOME` is set to a directory that is not a fleet home. The second refuses rather than falling back to the walk up, because a silent fallback is how an operator dispatches into the wrong fleet.
 - `4`: no event delivered, only from `hand watch --until-event`: its `--timeout` elapsed, or it was signaled, without a transition. This includes the timeout elapsing anywhere in arming, the herdr reachability probe as well as the per-task probe sweep - the window is over either way, and no one task is at fault. Distinct from `0` because there the exit *is* the event delivery, and from `1` because the watcher itself did not fail (see "Delivering an event to a supervisory agent").
 - `5`: arm-time probe failure, only from `hand watch --until-event`: one named task's herdr pane answered its pre-wait probe with a failure, named on stderr. Distinct from `4` because a specific worker is at fault and can be acted on, and from `0` because nothing was delivered (see "Delivering an event to a supervisory agent").
+- `6`: send undelivered, only from `hand send`: the composer stayed busy for the whole `--wait` bound, so the message never reached the pane. Distinct from `1`, which for `hand send` means the send can never succeed (no such herdr pane, herdr itself erroring) - `6` means the opposite, a transient state a caller can retry, most simply with a longer `--wait`. Not `4` or `5`: those are reserved to `hand watch --until-event`.
 
 ### Error output
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -200,6 +200,7 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
     notify                  # notification command template (optional)
     stale-threshold         # seconds before a task is considered stale (default: 300)
     watch-interval          # poll interval for `hand watch` (default: 5s)
+    send-wait               # how long `hand send` waits for a busy composer (default: 2m)
     parked-paused-bound     # seconds a paused-and-silent task may sit before it's parked (default: 3600)
     parked-other-bound      # seconds a silent task in any other state may sit before it's parked (default: 1200)
 ```
@@ -368,8 +369,8 @@ Behavior:
 6. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
 7. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in the store. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
 8. Acquire the task's herdr tab in the project's workspace.
-   - Workspace naming: one workspace per project, named after the project.
-   - Tab naming: task ID.
+   - Workspace and tab labels: one workspace per project, one tab per task - see "Workspace and
+     tab model" under "Herdr integration detail" for the labels themselves.
    - If the project's workspace does not exist yet, create it at the worktree's cwd. herdr has no
      way to create an empty workspace - it always creates a root tab and pane alongside it - so
      this reuses that root tab as the task's tab (renamed to the task ID) instead of creating a
@@ -1296,7 +1297,7 @@ Only the append-only sections have per-command rules, because only they carry an
 
 A mutating command re-renders the whole file, and the derived sections follow from the store and the report channel wherever the write came from.
 It re-renders unconditionally, never after testing whether its own effect reached a section: `hand promote` changes the `kind` the Active Tasks row derives, while `hand project sync` and `hand merge`'s PR path may leave every derived value identical, and a command that had to know which case it was in would be deciding from outside the render what the render already answers.
-Five commands still write nothing at all: `hand send` and `hand notify` reach a worker without touching the store, `hand hold set` and `hand hold clear` mutate only the `hold` table, which no section of this file derives from (see "Holds" under "State management"), and `hand merge --local` writes only a merge flag no section reads and runs no project sync.
+Five commands still leave this file untouched: `hand notify` reaches a worker without touching the store at all, and what the other four do write is nothing any section of this file derives from - `hand send`'s undelivered-send trace on the task row (see `hand send` step 5), `hand hold set`'s and `hand hold clear`'s rows in the `hold` table (see "Holds" under "State management"), and `hand merge --local`'s merge flag, which also runs no project sync.
 
 Recent Completions is a capped view, not the record of truth: every entry `hand teardown` moves here also lands, uncapped, in `state/completions.jsonl` first (see "Completion store" under `hand teardown`), so the 10-entry cap loses nothing that store still has.
 
@@ -1552,7 +1553,7 @@ either one alone.
 |---|---|
 | `hand spawn` | create workspace (if needed, at the worktree's cwd, reusing its own root tab as the task tab) or create tab in an existing workspace + send launch command + poll pane state and read pane text until the worker is confirmed started, sending keys to answer first-run dialogs |
 | `hand status` | get agent state for pane |
-| `hand send` | check composer empty + send keys to pane |
+| `hand send` | poll pane until the composer is empty, bounded by `--wait` + send keys to pane |
 | `hand teardown` | close tab (+ close workspace if empty) |
 | `hand watch` | subscribe to agent_status_changed events, or poll pane states |
 
@@ -1916,7 +1917,7 @@ Set with `hand hold set`, which upserts - a second call on the same id replaces 
 
 ### Concurrency
 
-- Each task is one row. Writes go through sqlite, which serializes them; `hand`'s own named `flock`s (task, project, worktree, dashboard) sit above that and guard whole command sequences, which a per-statement database lock cannot. The project lock is what keeps the `data/projects.md` projection whole: rendering it is a read-modify-write over the file, so a second writer rendering from its own snapshot mid-write would drop a registered project from it.
+- Each task is one row. Writes go through sqlite, which serializes them; `hand`'s own named `flock`s (task, project, worktree, dashboard, send) sit above that and guard whole command sequences, which a per-statement database lock cannot. The send lock is its own name rather than the task lock because it is held for the whole of a `hand send`'s composer wait, which the task lock must not be (see `hand send`). The project lock is what keeps the `data/projects.md` projection whole: rendering it is a read-modify-write over the file, so a second writer rendering from its own snapshot mid-write would drop a registered project from it.
 - `hand watch` is the only long-running process; all other commands are short-lived.
 - File locking: machine state is written through sqlite, which serializes writers itself.
 - Multiple `hand` invocations against different tasks are safe in parallel.

--- a/SPECS.md
+++ b/SPECS.md
@@ -629,15 +629,19 @@ Behavior:
    time - two unsynchronized retry loops racing the same busy composer is the exact hazard
    atqamz/secondhand#102 traced a lost steer to.
 4. If the composer is busy, poll until it frees or `--wait` elapses.
-5. If `--wait` elapses first: durably record the message and a timestamp on the task row
-   (`send_undelivered_message`, `send_undelivered_at`) under a separate, short-lived task-row lock,
-   so a steer that never arrives leaves a trace instead of vanishing with the process that
-   attempted it - and exit distinctly (see "Exit codes"). This lock is not held for the wait
-   itself: a `hand send` waiting out its bound must not stall `hand watch`'s polling or a `hand
-   status` read on the same task.
+5. Whenever the message does not demonstrably land in the pane - `--wait` elapses first, the text
+   fails to send, or the submit keystroke fails after the text went in - durably record the message
+   and a timestamp on the task row (`send_undelivered_message`, `send_undelivered_at`) under a
+   separate, short-lived task-row lock, so a steer that never arrives leaves a trace instead of
+   vanishing with the process that attempted it. Only the elapsed-`--wait` case exits distinctly
+   (see "Exit codes"); the two delivery failures are ordinary exit-1 errors. This lock is not held
+   for the wait itself: a `hand send` waiting out its bound must not stall `hand watch`'s polling
+   or a `hand status` read on the same task.
 6. Otherwise, submit the message text and clear any previously recorded undelivered-send trace on
    the task row (whatever message that trace carries) - a send that reaches the pane moots it,
-   whether or not it is a retry of the exact message that was previously abandoned.
+   whether or not it is a retry of the exact message that was previously abandoned. A failure to
+   clear the trace warns on stderr and still succeeds: the message is already in the pane, so
+   failing here would invite a retry that double-sends the steer.
 
 Output:
 ```
@@ -649,7 +653,11 @@ Errors:
 - Neither or both of the positional `message` and `--file` given (exit 2).
 - Invalid `--wait` value (exit 2 from the flag, exit 1 from a bad `config/send-wait`).
 - Herdr pane doesn't exist (agent died, tab closed) - exit 1, distinct from a busy composer because
-  this send can never succeed, no matter how long it waits.
+  this send can never succeed, no matter how long it waits. This covers a pane that stops answering
+  partway through the wait too, not only one already gone when the wait starts.
+- Sending or submitting the message text failed - exit 1. The message is recorded as undelivered
+  (step 5): text that never left, and text left unsubmitted in the composer, are both a steer with
+  no evidence it landed.
 - Composer still busy after `--wait` elapses - exit 6, distinct from the pane-not-found case above:
   this is a transient state a caller can retry (e.g. with a longer `--wait`), not a terminal
   failure. The message is durably recorded as undelivered rather than lost; see step 5 above.

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -30,7 +30,7 @@ case "$cmd" in
 	printf '{"id":"cli:1","result":{}}'
 	;;
 "workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":2}]}}'
+	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":2}]}}'
 	;;
 "tab create")
 	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
@@ -311,7 +311,7 @@ case "$cmd" in
 	;;
 "workspace list")
 	if [ -e "$HERDR_WS_EXISTS_FLAG" ]; then
-		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":2}]}}'
+		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":2}]}}'
 	else
 		printf '{"id":"cli:1","result":{"workspaces":[]}}'
 	fi

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/atqamz/secondhand/internal/herdr"
@@ -10,21 +12,61 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const sendComposerTimeout = 10 * time.Second
-
 func newSendCmd() *cobra.Command {
+	var filePath string
+	var wait string
+
 	cmd := &cobra.Command{
-		Use:   "send <id> <message>",
+		Use:   "send <id> [message]",
 		Short: "Send a text message to a running worker's herdr pane",
-		Args:  usageArgs(cobra.ExactArgs(2)),
+		Args: func(c *cobra.Command, args []string) error {
+			want := 2
+			if c.Flags().Changed("file") {
+				want = 1
+			}
+			if len(args) != want {
+				return &ExitError{Err: fmt.Errorf("accepts %d arg(s), received %d", want, len(args)), Code: 2}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := args[0]
-			message := args[1]
 
 			home, err := home.Resolve()
 			if err != nil {
 				return asPrecondition(err)
 			}
+
+			var message string
+			if filePath != "" {
+				data, err := os.ReadFile(filePath)
+				if err != nil {
+					return fmt.Errorf("read --file %q: %w", filePath, err)
+				}
+				message = strings.TrimRight(string(data), "\n")
+			} else {
+				message = args[1]
+			}
+
+			waitFromFlag := wait != ""
+			if !waitFromFlag {
+				wait = configDefault(home, "send-wait", "2m")
+			}
+			waitDuration, err := time.ParseDuration(wait)
+			if err != nil {
+				return usageValue(waitFromFlag, fmt.Errorf("invalid wait duration %q: %w", wait, err))
+			}
+
+			// Serializes concurrent sends to the same task: two retry loops racing
+			// against the same busy composer is the exact hazard atqamz/secondhand#102
+			// traced a lost steer to. A second send now waits behind the first
+			// rather than polling the same pane at the same time, its own
+			// --wait clock starting only once it holds this lock.
+			release, err := state.Lock(home, "send:"+id)
+			if err != nil {
+				return fmt.Errorf("lock send %q: %w", id, err)
+			}
+			defer release()
 
 			t, err := state.Read(home, id)
 			if err != nil {
@@ -38,8 +80,16 @@ func newSendCmd() *cobra.Command {
 			}
 
 			if pane.AgentStatus == herdr.StatusWorking {
-				if err := client.WaitComposerEmpty(t.Herdr.PaneID, sendComposerTimeout); err != nil {
-					return err
+				if waitErr := client.WaitComposerEmpty(t.Herdr.PaneID, waitDuration); waitErr != nil {
+					if err := recordUndeliveredSend(home, id, message); err != nil {
+						return fmt.Errorf("%w; record undelivered send: %w", waitErr, err)
+					}
+					// Code 6: the composer stayed busy for the whole --wait bound, so
+					// the message never reached the pane - a transient state a caller
+					// can retry, distinct from the exit-1 paths above and below that
+					// mean the send can never succeed (no such pane, herdr itself
+					// erroring). 4 and 5 are reserved to hand watch --until-event.
+					return &ExitError{Err: fmt.Errorf("composer still busy after %s, message recorded as undelivered: %w", waitDuration, waitErr), Code: 6}
 				}
 			}
 
@@ -50,11 +100,61 @@ func newSendCmd() *cobra.Command {
 				return fmt.Errorf("submit message failed: %w", err)
 			}
 
+			if err := clearUndeliveredSend(home, id); err != nil {
+				return fmt.Errorf("clear undelivered send trace: %w", err)
+			}
+
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "sent to %s\n", id); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&filePath, "file", "", "read the message from this file instead of the positional argument")
+	cmd.Flags().StringVar(&wait, "wait", "", "how long to wait for a busy composer to free before giving up (default: config/send-wait, or 2m)")
 	return cmd
+}
+
+// recordUndeliveredSend durably records the message hand send gave up on, so
+// an operator or worker learns the steer never arrived instead of it
+// vanishing with the process that attempted it. A short-lived task-row lock,
+// separate from the send lock held for the whole wait above, so a long busy
+// wait never blocks an unrelated reader like hand watch or hand status.
+func recordUndeliveredSend(home, id, message string) error {
+	release, err := state.Lock(home, "task:"+id)
+	if err != nil {
+		return fmt.Errorf("lock task %q: %w", id, err)
+	}
+	defer release()
+
+	t, err := state.Read(home, id)
+	if err != nil {
+		return err
+	}
+	t.SendUndeliveredMessage = message
+	t.SendUndeliveredAt = time.Now().UTC().Format(time.RFC3339)
+	return state.Write(home, t)
+}
+
+// clearUndeliveredSend runs after every send that actually reaches the pane,
+// whatever message that send carries: the trace's job is telling the operator
+// their last attempt did not land, and any successful send moots it.
+func clearUndeliveredSend(home, id string) error {
+	release, err := state.Lock(home, "task:"+id)
+	if err != nil {
+		return fmt.Errorf("lock task %q: %w", id, err)
+	}
+	defer release()
+
+	t, err := state.Read(home, id)
+	if err != nil {
+		return err
+	}
+	if t.SendUndeliveredMessage == "" && t.SendUndeliveredAt == "" {
+		return nil
+	}
+	t.SendUndeliveredMessage = ""
+	t.SendUndeliveredAt = ""
+	return state.Write(home, t)
 }

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -19,16 +20,16 @@ func newSendCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send <id> [message]",
 		Short: "Send a text message to a running worker's herdr pane",
-		Args: func(c *cobra.Command, args []string) error {
+		// filePath, not Flags().Changed("file"): --file "" is no message source at
+		// all, and keying off Changed would accept one positional argument while
+		// RunE still reads args[1].
+		Args: usageArgs(func(c *cobra.Command, args []string) error {
 			want := 2
-			if c.Flags().Changed("file") {
+			if filePath != "" {
 				want = 1
 			}
-			if len(args) != want {
-				return &ExitError{Err: fmt.Errorf("accepts %d arg(s), received %d", want, len(args)), Code: 2}
-			}
-			return nil
-		},
+			return cobra.ExactArgs(want)(c, args)
+		}),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := args[0]
 
@@ -81,6 +82,12 @@ func newSendCmd() *cobra.Command {
 
 			if pane.AgentStatus == herdr.StatusWorking {
 				if waitErr := client.WaitComposerEmpty(t.Herdr.PaneID, waitDuration); waitErr != nil {
+					// The pane stopped answering mid-wait (agent died, tab closed):
+					// no retry can succeed, so this is the same exit-1 outcome as the
+					// PaneGet above, not the retryable busy-composer one below.
+					if !errors.Is(waitErr, herdr.ErrComposerBusyTimeout) {
+						return fmt.Errorf("herdr pane %s not found: %w", t.Herdr.PaneID, waitErr)
+					}
 					if err := recordUndeliveredSend(home, id, message); err != nil {
 						return fmt.Errorf("%w; record undelivered send: %w", waitErr, err)
 					}
@@ -89,19 +96,26 @@ func newSendCmd() *cobra.Command {
 					// can retry, distinct from the exit-1 paths above and below that
 					// mean the send can never succeed (no such pane, herdr itself
 					// erroring). 4 and 5 are reserved to hand watch --until-event.
-					return &ExitError{Err: fmt.Errorf("composer still busy after %s, message recorded as undelivered: %w", waitDuration, waitErr), Code: 6}
+					return &ExitError{Err: fmt.Errorf("%w, message recorded as undelivered", waitErr), Code: 6}
 				}
 			}
 
+			// Both delivery failures leave the steer undemonstrated in the pane -
+			// text that never left, and text sitting unsubmitted in the composer -
+			// so both owe the operator the same durable trace the wait bound does.
 			if err := client.PaneSendText(t.Herdr.PaneID, message); err != nil {
-				return fmt.Errorf("send message failed: %w", err)
+				return withUndeliveredSend(home, id, message, fmt.Errorf("send message failed: %w", err))
 			}
 			if err := client.PaneSendKeys(t.Herdr.PaneID, "Enter"); err != nil {
-				return fmt.Errorf("submit message failed: %w", err)
+				return withUndeliveredSend(home, id, message, fmt.Errorf("submit message failed: %w", err))
 			}
 
 			if err := clearUndeliveredSend(home, id); err != nil {
-				return fmt.Errorf("clear undelivered send trace: %w", err)
+				// The message is already in the pane, so failing here would invite a
+				// retry that double-sends the steer; a stale trace is the lesser harm.
+				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: clear undelivered send trace: %v\n", err); printErr != nil {
+					return printErr
+				}
 			}
 
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "sent to %s\n", id); err != nil {
@@ -116,31 +130,34 @@ func newSendCmd() *cobra.Command {
 	return cmd
 }
 
-// recordUndeliveredSend durably records the message hand send gave up on, so
-// an operator or worker learns the steer never arrived instead of it
-// vanishing with the process that attempted it. A short-lived task-row lock,
-// separate from the send lock held for the whole wait above, so a long busy
-// wait never blocks an unrelated reader like hand watch or hand status.
-func recordUndeliveredSend(home, id, message string) error {
-	release, err := state.Lock(home, "task:"+id)
-	if err != nil {
-		return fmt.Errorf("lock task %q: %w", id, err)
+// withUndeliveredSend records the trace alongside a delivery failure, keeping
+// the cause as the returned error so the exit code of the failing path is
+// unchanged.
+func withUndeliveredSend(home, id, message string, cause error) error {
+	if err := recordUndeliveredSend(home, id, message); err != nil {
+		return fmt.Errorf("%w; record undelivered send: %w", cause, err)
 	}
-	defer release()
+	return cause
+}
 
-	t, err := state.Read(home, id)
-	if err != nil {
-		return err
-	}
-	t.SendUndeliveredMessage = message
-	t.SendUndeliveredAt = time.Now().UTC().Format(time.RFC3339)
-	return state.Write(home, t)
+// recordUndeliveredSend durably records the message hand send could not
+// demonstrably deliver, so an operator or worker learns the steer never
+// arrived instead of it vanishing with the process that attempted it. A
+// short-lived task-row lock, separate from the send lock held for the whole
+// wait above, so a long busy wait never blocks an unrelated reader like hand
+// watch or hand status.
+func recordUndeliveredSend(home, id, message string) error {
+	return setUndeliveredSend(home, id, message, time.Now().UTC().Format(time.RFC3339))
 }
 
 // clearUndeliveredSend runs after every send that actually reaches the pane,
 // whatever message that send carries: the trace's job is telling the operator
 // their last attempt did not land, and any successful send moots it.
 func clearUndeliveredSend(home, id string) error {
+	return setUndeliveredSend(home, id, "", "")
+}
+
+func setUndeliveredSend(home, id, message, at string) error {
 	release, err := state.Lock(home, "task:"+id)
 	if err != nil {
 		return fmt.Errorf("lock task %q: %w", id, err)
@@ -151,10 +168,10 @@ func clearUndeliveredSend(home, id string) error {
 	if err != nil {
 		return err
 	}
-	if t.SendUndeliveredMessage == "" && t.SendUndeliveredAt == "" {
+	if t.SendUndeliveredMessage == message && t.SendUndeliveredAt == at {
 		return nil
 	}
-	t.SendUndeliveredMessage = ""
-	t.SendUndeliveredAt = ""
+	t.SendUndeliveredMessage = message
+	t.SendUndeliveredAt = at
 	return state.Write(home, t)
 }

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -186,6 +186,118 @@ exit 1
 	assertExitCode2(t, cmd.Execute())
 }
 
+func TestSendRejectsEmptyFileFlag(t *testing.T) {
+	// An unset shell variable expanding into --file is neither a message source
+	// nor two positional arguments, so it has to land on the usage error rather
+	// than on args[1].
+	setupSendHome(t, `#!/bin/sh
+echo "unexpected herdr invocation: $@" >&2
+exit 1
+`)
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "--file", ""})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestSendFailsWhenPaneDisappearsDuringWait(t *testing.T) {
+	// The pane answers "working" once, then stops answering at all: no retry can
+	// succeed, so this must not take the retryable exit-6 busy-composer path.
+	counterFile := filepath.Join(t.TempDir(), "calls")
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	n=0
+	if [ -f "`+counterFile+`" ]; then n=$(cat "`+counterFile+`"); fi
+	n=$((n+1))
+	echo "$n" > "`+counterFile+`"
+	if [ "$n" -lt 2 ]; then
+		printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'
+	else
+		printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
+		exit 1
+	fi
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello", "--wait", "5s"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) {
+		t.Fatalf("got ExitError code %d, want a plain exit-1 error", exitErr.Code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got err %v, want pane not found", err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SendUndeliveredMessage != "" {
+		t.Fatalf("SendUndeliveredMessage = %q, want no trace for an unreachable pane", got.SendUndeliveredMessage)
+	}
+}
+
+func TestSendRecordsUndeliveredMessageWhenSubmitFails(t *testing.T) {
+	// The text reached the composer but was never submitted - a steer with no
+	// evidence it landed, so it owes the same trace the wait bound does.
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
+	;;
+"pane send-text")
+	printf '{"id":"cli:1","result":{}}'
+	;;
+"pane send-keys")
+	printf '{"id":"cli:1","error":{"code":"send_failed","message":"keystroke rejected"}}'
+	exit 1
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "stop and wait for review"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) {
+		t.Fatalf("got ExitError code %d, want a plain exit-1 error", exitErr.Code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "submit message failed") {
+		t.Fatalf("got err %v, want the submit failure", err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SendUndeliveredMessage != "stop and wait for review" {
+		t.Fatalf("SendUndeliveredMessage = %q, want the unsubmitted message", got.SendUndeliveredMessage)
+	}
+	if got.SendUndeliveredAt == "" {
+		t.Fatal("SendUndeliveredAt not recorded")
+	}
+}
+
 func TestSendRecordsUndeliveredMessageWhenComposerStaysBusy(t *testing.T) {
 	// The composer never frees, so WaitComposerEmpty always exhausts --wait;
 	// a short --wait keeps the test itself fast.

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,6 +116,154 @@ esac
 	cmd.SetArgs([]string{"task-1", "hello"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSendReadsMessageFromFile(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "sent.log")
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
+	;;
+"pane send-text")
+	printf '%s\n' "$4" >> "`+logPath+`"
+	printf '{"id":"cli:1","result":{}}'
+	;;
+"pane send-keys")
+	printf '{"id":"cli:1","result":{}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	msgPath := filepath.Join(t.TempDir(), "message.txt")
+	if err := os.WriteFile(msgPath, []byte("line one\nline two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "--file", msgPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimRight(string(got), "\n") != "line one\nline two" {
+		t.Fatalf("sent text = %q, want file contents with trailing newline trimmed", got)
+	}
+}
+
+func TestSendRejectsFileAndMessageTogether(t *testing.T) {
+	setupSendHome(t, `#!/bin/sh
+echo "unexpected herdr invocation: $@" >&2
+exit 1
+`)
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello", "--file", "/does/not/matter"})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestSendRequiresMessageOrFile(t *testing.T) {
+	setupSendHome(t, `#!/bin/sh
+echo "unexpected herdr invocation: $@" >&2
+exit 1
+`)
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1"})
+	assertExitCode2(t, cmd.Execute())
+}
+
+func TestSendRecordsUndeliveredMessageWhenComposerStaysBusy(t *testing.T) {
+	// The composer never frees, so WaitComposerEmpty always exhausts --wait;
+	// a short --wait keeps the test itself fast.
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "stop and wait for review", "--wait", "300ms"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("got %v, want ExitError code 6", err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SendUndeliveredMessage != "stop and wait for review" {
+		t.Fatalf("SendUndeliveredMessage = %q, want the abandoned message", got.SendUndeliveredMessage)
+	}
+	if got.SendUndeliveredAt == "" {
+		t.Fatal("SendUndeliveredAt not recorded")
+	}
+}
+
+func TestSendClearsAPreviouslyRecordedUndeliveredSendOnSuccess(t *testing.T) {
+	home := setupSendHome(t, `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
+	;;
+"pane send-text")
+	printf '{"id":"cli:1","result":{}}'
+	;;
+"pane send-keys")
+	printf '{"id":"cli:1","result":{}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	if err := state.Write(home, state.Task{
+		ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"},
+		SendUndeliveredMessage: "an earlier abandoned steer",
+		SendUndeliveredAt:      "2026-08-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SendUndeliveredMessage != "" || got.SendUndeliveredAt != "" {
+		t.Fatalf("undelivered send trace not cleared: %+v", got)
 	}
 }
 

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -221,15 +221,27 @@ func gatePreflight(cmd *cobra.Command, proj project.Project, clonePath string, s
 	return nil
 }
 
+// herdrWorkspaceLabel is the label hand gives, and searches for, a project's shared workspace.
+// A bare project name is not a safe search key: herdr derives a workspace's label from its root
+// directory's basename, so any workspace a human opens under a directory named after the project
+// carries the same label and would otherwise be a candidate (atqamz/secondhand#118). Prefixing it
+// the same way worktree.Get's pool name already does ("hand:"+id) makes the label one only hand
+// itself would ever set, so a same-labelled workspace hand did not create can never match, no
+// matter how the herdr's workspace list happens to be ordered.
+func herdrWorkspaceLabel(projName string) string {
+	return "hand:" + projName
+}
+
 // The caller must invoke the returned rollback, guarded by its own spawned/promoted flag,
 // until state.Write durably records the task.
 func acquireTaskWorkspace(client *herdr.Client, wt, id, projName string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
-	ws, found, err := client.FindWorkspaceByLabel(projName)
+	label := herdrWorkspaceLabel(projName)
+	ws, found, err := client.FindWorkspaceByLabel(label)
 	createdWorkspace := false
 	var rootTab herdr.Tab
 	var rootPane herdr.Pane
 	if err == nil && !found {
-		ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, projName)
+		ws, rootTab, rootPane, err = client.WorkspaceCreate(wt, label)
 		createdWorkspace = err == nil
 	}
 	if err != nil {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -39,7 +39,7 @@ const fakeHerdrSpawnScript = `#!/bin/sh
 cmd="$1 $2"
 case "$cmd" in
 "workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":1}]}}'
+	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":1}]}}'
 	;;
 "tab create")
 	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
@@ -127,6 +127,56 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 	if got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tB" || got.Herdr.PaneID != "wA:pC" {
 		t.Fatalf("got herdr %+v", got.Herdr)
+	}
+}
+
+// TestSpawnIgnoresSameLabelledWorkspaceHandDidNotCreate pins the fix for atqamz/secondhand#118:
+// herdr derives a workspace's label from its root directory's basename, so a human who opens a
+// directory named after the project gets a workspace sharing hand's own bare-label search key.
+// The plain-labelled "myproj" workspace here sorts first in "workspace list" and would have won
+// under the old bare-label lookup; hand must still resolve to its own "hand:myproj" workspace
+// regardless of list order, never the one it did not create.
+const fakeHerdrTwoWorkspacesOneLabelScript = `#!/bin/sh
+cmd="$1 $2"
+case "$cmd" in
+"workspace list")
+	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wHuman","label":"myproj","tab_count":1},{"workspace_id":"wA","label":"hand:myproj","tab_count":1}]}}'
+	;;
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
+	;;
+"pane run")
+	printf '{"id":"cli:1","result":{}}'
+	;;
+"pane get")
+	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"claude","agent_status":"idle"}}}' "$3"
+	;;
+"pane read")
+	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`
+
+func TestSpawnIgnoresSameLabelledWorkspaceHandDidNotCreate(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, fakeHerdrTwoWorkspacesOneLabelScript)
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Herdr.WorkspaceID != "wA" {
+		t.Fatalf("got workspace %q, want hand's own hand:myproj workspace wA, not the same-labelled one it did not create", got.Herdr.WorkspaceID)
 	}
 }
 
@@ -304,7 +354,7 @@ cmd="$1 $2"
 case "$cmd" in
 "workspace list")
 	if [ -e "$HERDR_WS_EXISTS_FLAG" ]; then
-		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"myproj","tab_count":2}]}}'
+		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":2}]}}'
 	else
 		printf '{"id":"cli:1","result":{"workspaces":[]}}'
 	fi

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -3,12 +3,19 @@ package herdr
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// ErrComposerBusyTimeout marks WaitComposerEmpty's own deadline expiry. A
+// caller has to tell it apart from the PaneGet failures the same function
+// returns: a composer that stayed busy is transient and worth retrying, a pane
+// that stopped answering means no retry can ever succeed.
+var ErrComposerBusyTimeout = errors.New("composer still busy")
 
 type Client struct{}
 
@@ -322,7 +329,7 @@ func (c *Client) WaitComposerEmpty(paneID string, timeout time.Duration) error {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("composer not empty after %s", timeout)
+			return fmt.Errorf("%w after %s", ErrComposerBusyTimeout, timeout)
 		}
 		time.Sleep(250 * time.Millisecond)
 	}

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -218,11 +218,22 @@ func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
 		Tab      Tab  `json:"tab"`
 		RootPane Pane `json:"root_pane"`
 	}
+	// Same shape as WorkspaceCreate's failed() above: a tab ID on any failure path below means
+	// herdr already created the tab before the response came back unusable, so it must be closed
+	// here or nothing else ever learns the tab exists to clean it up.
+	failed := func(parseErr error) (Tab, Pane, error) {
+		if body.Tab.TabID != "" {
+			if closeErr := c.TabClose(body.Tab.TabID); closeErr != nil {
+				return Tab{}, Pane{}, fmt.Errorf("%w; cleanup failed: %w", parseErr, closeErr)
+			}
+		}
+		return Tab{}, Pane{}, parseErr
+	}
 	if err := json.Unmarshal(res, &body); err != nil {
-		return Tab{}, Pane{}, fmt.Errorf("parse tab create: %w", err)
+		return failed(fmt.Errorf("parse tab create: %w", err))
 	}
 	if body.Tab.TabID == "" || body.RootPane.PaneID == "" {
-		return Tab{}, Pane{}, fmt.Errorf("parse tab create: missing tab or root pane")
+		return failed(fmt.Errorf("parse tab create: missing tab or root pane"))
 	}
 	return body.Tab, body.RootPane, nil
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -287,6 +287,88 @@ func TestTabCreateParsesTabAndRootPane(t *testing.T) {
 	}
 }
 
+// TestTabCreateClosesTabOnPartialResponse pins the fix for atqamz/secondhand#119: a tab-create
+// result missing root_pane still means herdr already created the tab (reachable against a herdr
+// whose protocol predates that field, same as atqamz/secondhand#74's WorkspaceCreate case), so
+// TabCreate must close it itself before the parse error reaches the caller - nothing downstream
+// ever learns the tab ID otherwise.
+func TestTabCreateClosesTabOnPartialResponse(t *testing.T) {
+	writeFakeHerdr(t, `
+echo "$@" >> "$HERDR_CALL_LOG"
+case "$1 $2" in
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"}}}'
+	;;
+"tab close")
+	if [ "$3" != "wA:tB" ]; then
+		echo "unexpected close target: $@" >&2
+		exit 1
+	fi
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	c := NewClient()
+	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err == nil {
+		t.Fatal("expected an error when the response omits the root pane")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "tab close wA:tB") {
+		t.Fatalf("calls = %q, want the tab herdr created to be closed", calls)
+	}
+}
+
+// TestTabCreateClosesTabOnMalformedResponse covers the sibling of the partial-response path:
+// encoding/json keeps decoding past its first type error, so a response that types a field wrongly
+// still yields a tab ID herdr has already created and this call must still close it.
+func TestTabCreateClosesTabOnMalformedResponse(t *testing.T) {
+	writeFakeHerdr(t, `
+echo "$@" >> "$HERDR_CALL_LOG"
+case "$1 $2" in
+"tab create")
+	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"root_pane":"none"}}'
+	;;
+"tab close")
+	if [ "$3" != "wA:tB" ]; then
+		echo "unexpected close target: $@" >&2
+		exit 1
+	fi
+	printf '{"id":"cli:1","result":{"type":"ok"}}'
+	;;
+*)
+	echo "unexpected herdr args: $@" >&2
+	exit 1
+	;;
+esac
+`)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	c := NewClient()
+	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err == nil {
+		t.Fatal("expected an error when the response mistypes the root pane field")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "tab close wA:tB") {
+		t.Fatalf("calls = %q, want the tab herdr created to be closed", calls)
+	}
+}
+
 func TestPaneGetParsesAgentStatus(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'`)
 	c := NewClient()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -1,6 +1,7 @@
 package herdr
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -393,8 +394,20 @@ func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'`)
 	c := NewClient()
 	err := c.WaitComposerEmpty("wA:pB", 10*time.Millisecond)
-	if err == nil || !strings.Contains(err.Error(), "composer not empty") {
-		t.Fatalf("got err %v, want composer not empty timeout", err)
+	if !errors.Is(err, ErrComposerBusyTimeout) {
+		t.Fatalf("got err %v, want ErrComposerBusyTimeout", err)
+	}
+}
+
+func TestWaitComposerEmptyPaneFailureIsNotABusyTimeout(t *testing.T) {
+	// A pane that stops answering can never free, so the caller must be able to
+	// tell this apart from the retryable timeout above.
+	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
+exit 1`)
+	c := NewClient()
+	err := c.WaitComposerEmpty("wA:pB", time.Second)
+	if err == nil || errors.Is(err, ErrComposerBusyTimeout) {
+		t.Fatalf("got err %v, want a non-timeout pane failure", err)
 	}
 }
 

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -62,11 +62,12 @@ func (db *DB) migrateLegacy() error {
 		// An id already in the database wins: it is what hand has been writing
 		// since the import, and the JSON file is a snapshot from before it.
 		if _, err := db.sql.Exec(`INSERT OR IGNORE INTO task (`+taskColumns+`)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			t.ID, t.Project, t.Kind, t.Harness, t.Model, t.Effort, t.Worktree, t.Brief,
 			t.Herdr.Session, t.Herdr.WorkspaceID, t.Herdr.TabID, t.Herdr.PaneID, t.PR,
 			t.MergeExecuted, t.MergeExecutedAt, t.ReportOffset, t.MergeAnnounced, t.DoneVerified,
-			t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote); err != nil {
+			t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote,
+			t.SendUndeliveredMessage, t.SendUndeliveredAt); err != nil {
 			return fmt.Errorf("import task %q: %w", t.ID, err)
 		}
 	}

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -16,7 +16,10 @@ var ErrSchemaNewer = errors.New("schema version newer than this build of hand su
 // user_version as 0 by sqlite's own default, and that has to mean "the schema
 // this commit ships", not "unknown, refuse to proceed" - otherwise the one
 // fleet home that exists stops opening the moment this merges.
-var migrations = []string{}
+var migrations = []string{
+	`ALTER TABLE task ADD COLUMN send_undelivered_message TEXT NOT NULL DEFAULT '';
+	ALTER TABLE task ADD COLUMN send_undelivered_at TEXT NOT NULL DEFAULT '';`,
+}
 
 func (db *DB) schemaVersion() (int, error) {
 	var version int

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -5,14 +5,18 @@ import (
 	"testing"
 )
 
-func TestFreshOpenRecordsSchemaVersionZero(t *testing.T) {
+// A fresh database is built by `schema`, which already carries every
+// registered migration, so it is stamped straight to the latest version
+// rather than 0 - only a database that predates the mechanism entirely reads
+// as 0 (TestExistingBaselineDatabaseOpensCleanly below).
+func TestFreshOpenRecordsSchemaVersionAtLatest(t *testing.T) {
 	db, _ := openTemp(t)
 	version, err := db.schemaVersion()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if version != 0 {
-		t.Fatalf("schemaVersion = %d, want 0", version)
+	if version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, want %d", version, len(migrations))
 	}
 }
 
@@ -74,6 +78,15 @@ func TestOpenRefusesADatabaseNewerThanThisBuild(t *testing.T) {
 // operator running anything, and cheap to run again on the next open.
 func TestPendingMigrationAppliesAutomaticallyAndOnlyOnce(t *testing.T) {
 	home := t.TempDir()
+
+	restore := migrations
+	t.Cleanup(func() { migrations = restore })
+
+	// Empty migrations for this first open, so the fresh database it stamps
+	// reads as version 0 - the pre-mechanism baseline this test needs -
+	// rather than picking up whatever this build's real migrations already
+	// registered.
+	migrations = []string{}
 	existing, err := Open(home)
 	if err != nil {
 		t.Fatal(err)
@@ -85,9 +98,7 @@ func TestPendingMigrationAppliesAutomaticallyAndOnlyOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	restore := migrations
 	migrations = []string{`ALTER TABLE project ADD COLUMN note TEXT NOT NULL DEFAULT ''`}
-	t.Cleanup(func() { migrations = restore })
 
 	db, err := Open(home)
 	if err != nil {
@@ -151,4 +162,55 @@ func TestFreshDatabaseSkipsAMigrationTheSchemaAlreadyBuilds(t *testing.T) {
 		t.Fatalf("reopening a stamped fresh database: %v", err)
 	}
 	defer func() { _ = second.Close() }()
+}
+
+// Exercises the real migrations entry this commit registers, rather than a
+// swapped-in stand-in like the tests above, so a syntax error in the actual
+// ALTER TABLE statements would fail here instead of only in a synthetic one.
+func TestSendUndeliveredColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
+	home := t.TempDir()
+
+	restore := migrations
+	t.Cleanup(func() { migrations = restore })
+
+	// Empty migrations for this first open, so the fresh database it builds
+	// reads as version 0; `schema` still creates the two new columns (it can't
+	// be swapped the way `migrations` can), so they are dropped by hand to put
+	// the database back into the pre-migration shape this test needs.
+	migrations = []string{}
+	existing, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN send_undelivered_message`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN send_undelivered_at`); err != nil {
+		t.Fatal(err)
+	}
+	// WriteTask always targets the full, current taskColumns, which still
+	// names the two dropped columns - so this row goes in with a raw insert
+	// against the pre-migration column set instead.
+	if _, err := existing.sql.Exec(`INSERT INTO task (id) VALUES ('t1')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := existing.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrations = restore
+
+	reopened, err := Open(home)
+	if err != nil {
+		t.Fatalf("reopen replaying the real send_undelivered migration: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	got, found, err := reopened.ReadTask("t1")
+	if err != nil || !found {
+		t.Fatalf("ReadTask = %v, %v", found, err)
+	}
+	if got.SendUndeliveredMessage != "" || got.SendUndeliveredAt != "" {
+		t.Fatalf("migrated columns not empty-defaulted: %+v", got)
+	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -78,11 +78,12 @@ type Task struct {
 	// re-reading report history it has already consumed past ReportOffset.
 	LastReportState string `json:"last_report_state"`
 	LastReportNote  string `json:"last_report_note"`
-	// Durable so a composer that stayed busy past hand send's --wait bound
-	// leaves a trace instead of vanishing with the process that attempted it -
-	// the operator who ran that send is the only one who would otherwise know
-	// it was ever tried. Cleared on the next send that actually reaches the
-	// pane, whatever message that send carries.
+	// Durable so a hand send message with no evidence it reached the pane -
+	// a composer still busy past the --wait bound, a failed send, a failed
+	// submit - leaves a trace instead of vanishing with the process that
+	// attempted it; the operator who ran that send is the only one who would
+	// otherwise know it was ever tried. Cleared on the next send that actually
+	// reaches the pane, whatever message that send carries.
 	SendUndeliveredMessage string `json:"send_undelivered_message"`
 	SendUndeliveredAt      string `json:"send_undelivered_at"`
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -78,6 +78,13 @@ type Task struct {
 	// re-reading report history it has already consumed past ReportOffset.
 	LastReportState string `json:"last_report_state"`
 	LastReportNote  string `json:"last_report_note"`
+	// Durable so a composer that stayed busy past hand send's --wait bound
+	// leaves a trace instead of vanishing with the process that attempted it -
+	// the operator who ran that send is the only one who would otherwise know
+	// it was ever tried. Cleared on the next send that actually reaches the
+	// pane, whatever message that send carries.
+	SendUndeliveredMessage string `json:"send_undelivered_message"`
+	SendUndeliveredAt      string `json:"send_undelivered_at"`
 }
 
 type Project struct {
@@ -140,7 +147,9 @@ CREATE TABLE IF NOT EXISTS task (
 	status_changed_at  TEXT NOT NULL DEFAULT '',
 	status_changed_for TEXT NOT NULL DEFAULT '',
 	last_report_state  TEXT NOT NULL DEFAULT '',
-	last_report_note   TEXT NOT NULL DEFAULT ''
+	last_report_note   TEXT NOT NULL DEFAULT '',
+	send_undelivered_message TEXT NOT NULL DEFAULT '',
+	send_undelivered_at      TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS project (
 	name     TEXT PRIMARY KEY,
@@ -228,14 +237,16 @@ func (db *DB) setMeta(key, value string) error {
 const taskColumns = `id, project, kind, harness, model, effort, worktree, brief,
 	herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id, pr,
 	merge_executed, merge_executed_at, report_offset, merge_announced, done_verified,
-	created_at, status_changed_at, status_changed_for, last_report_state, last_report_note`
+	created_at, status_changed_at, status_changed_for, last_report_state, last_report_note,
+	send_undelivered_message, send_undelivered_at`
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
 	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Harness, &t.Model, &t.Effort, &t.Worktree, &t.Brief,
 		&t.Herdr.Session, &t.Herdr.WorkspaceID, &t.Herdr.TabID, &t.Herdr.PaneID, &t.PR,
 		&t.MergeExecuted, &t.MergeExecutedAt, &t.ReportOffset, &t.MergeAnnounced, &t.DoneVerified,
-		&t.CreatedAt, &t.StatusChangedAt, &t.StatusChangedFor, &t.LastReportState, &t.LastReportNote)
+		&t.CreatedAt, &t.StatusChangedAt, &t.StatusChangedFor, &t.LastReportState, &t.LastReportNote,
+		&t.SendUndeliveredMessage, &t.SendUndeliveredAt)
 	return t, err
 }
 
@@ -253,7 +264,7 @@ func (db *DB) ReadTask(id string) (Task, bool, error) {
 
 func (db *DB) WriteTask(t Task) error {
 	_, err := db.sql.Exec(`INSERT INTO task (`+taskColumns+`)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project, kind = excluded.kind, harness = excluded.harness,
 			model = excluded.model, effort = excluded.effort, worktree = excluded.worktree,
@@ -264,11 +275,14 @@ func (db *DB) WriteTask(t Task) error {
 			report_offset = excluded.report_offset, merge_announced = excluded.merge_announced,
 			done_verified = excluded.done_verified, created_at = excluded.created_at,
 			status_changed_at = excluded.status_changed_at, status_changed_for = excluded.status_changed_for,
-			last_report_state = excluded.last_report_state, last_report_note = excluded.last_report_note`,
+			last_report_state = excluded.last_report_state, last_report_note = excluded.last_report_note,
+			send_undelivered_message = excluded.send_undelivered_message,
+			send_undelivered_at = excluded.send_undelivered_at`,
 		t.ID, t.Project, t.Kind, t.Harness, t.Model, t.Effort, t.Worktree, t.Brief,
 		t.Herdr.Session, t.Herdr.WorkspaceID, t.Herdr.TabID, t.Herdr.PaneID, t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.ReportOffset, t.MergeAnnounced, t.DoneVerified,
-		t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote)
+		t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote,
+		t.SendUndeliveredMessage, t.SendUndeliveredAt)
 	if err != nil {
 		return fmt.Errorf("write task %q: %w", t.ID, err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -38,6 +38,9 @@ func sampleTask() Task {
 
 		StatusChangedAt: "2026-07-24T11:00:00Z", StatusChangedFor: "working",
 		LastReportState: "working", LastReportNote: "on it",
+
+		SendUndeliveredMessage: "stop and wait for review",
+		SendUndeliveredAt:      "2026-07-24T13:00:00Z",
 	}
 }
 

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -182,6 +182,28 @@ func writeFakeHerdrWatch(t *testing.T, dir, statusDir, logPath string) {
 	writeFakeDispatch(t, dir, "herdr", "", "$1 $2", body)
 }
 
+// writeFakeHerdrSend writes a herdr fake for the send scenario: "pane get"
+// reports whatever status currently sits in statusDir/<pane-id>, so a test can
+// free a busy composer while `hand send` is waiting on it, and
+// "pane send-text"/"pane send-keys" answer with the empty stdout real herdr
+// gives a void command (client.go's callVoid doc comment). Every invocation is
+// logged with the pid of the hand process that made it, which is what lets a
+// test tell two concurrent senders apart; each pane status read is logged after
+// the read for the same reason writeFakeHerdrWatch does it.
+func writeFakeHerdrSend(t *testing.T, dir, statusDir, logPath string) {
+	t.Helper()
+	quotedLog := shellSingleQuote(logPath)
+	body := fmt.Sprintf(`  "pane get")
+    status=$(cat %s/"$3" 2>/dev/null || echo idle)
+    echo "sender=$PPID pane get $3" >> %s
+    printf '{"result":{"pane":{"pane_id":"%%s","tab_id":"t-1","workspace_id":"w-1","agent":"claude","agent_status":"%%s"}}}\n' "$3" "$status"
+    ;;
+  "pane send-text") echo "sender=$PPID pane send-text $4" >> %s ;;
+  "pane send-keys") echo "sender=$PPID pane send-keys $4" >> %s ;;`,
+		shellSingleQuote(statusDir), quotedLog, quotedLog, quotedLog)
+	writeFakeDispatch(t, dir, "herdr", "", "$1 $2", body)
+}
+
 func writeFakeHerdrUnprobeablePanes(t *testing.T, dir string) {
 	t.Helper()
 	body := `  "workspace list") echo '{"result":{"workspaces":[]}}' ;;

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -1,0 +1,141 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/secondhand/internal/state"
+)
+
+// TestConcurrentSendsToTheSameTaskSerialize drives two `hand send` processes at
+// one busy pane. The send lock is cross-process by construction, so no
+// cmd-level test can cover it: what has to hold is that one sender waits out
+// the other's whole retry loop instead of both polling the same composer and
+// firing their text into it at once, which is the lost-steer hazard
+// atqamz/secondhand#102 traced.
+func TestConcurrentSendsToTheSameTaskSerialize(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "direct-pr")
+	seedSendTask(t, home)
+
+	statusDir := t.TempDir()
+	setPaneStatus(t, statusDir, "pane-1", "working")
+
+	dir := binDir(t)
+	herdrLog := filepath.Join(t.TempDir(), "herdr-invocations.log")
+	writeFakeHerdrSend(t, dir, statusDir, herdrLog)
+
+	first := startHandBackground(t, home, "send", "task-1", "steer one", "--wait", "30s")
+	second := startHandBackground(t, home, "send", "task-1", "steer two", "--wait", "30s")
+
+	// Two pane reads prove the lock holder is past its arrival probe and inside
+	// its retry loop, so freeing the composer now means the holder observed a
+	// busy one first rather than never seeing one at all.
+	waitForInvocations(t, herdrLog, "pane get pane-1", 2, 10*time.Second)
+	setPaneStatus(t, statusDir, "pane-1", "idle")
+
+	for name, b := range map[string]*backgroundHand{"first": first, "second": second} {
+		got := b.waitForExit(t, 40*time.Second, "the composer freeing")
+		if got.code != 0 || !strings.Contains(got.stdout, "sent to task-1") {
+			t.Fatalf("%s sender: exit %d, stdout %q, stderr %q", name, got.code, got.stdout, got.stderr)
+		}
+	}
+
+	data, err := os.ReadFile(herdrLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+	// One switch in the sender column across the whole log is the serialization:
+	// a sender that reappears after the other started has been polling the same
+	// composer concurrently, whatever the two exit codes said.
+	switches := 0
+	seen := map[string]bool{}
+	prev := ""
+	for _, line := range log {
+		sender := strings.Fields(line)[0]
+		if sender != prev {
+			if seen[sender] {
+				t.Fatalf("sender %s resumed after the other sender started, so the two overlapped:\n%s",
+					sender, strings.Join(log, "\n"))
+			}
+			switches++
+			seen[sender] = true
+			prev = sender
+		}
+	}
+	if switches != 2 {
+		t.Fatalf("saw %d sender blocks, want one per sender:\n%s", switches, strings.Join(log, "\n"))
+	}
+
+	// Both steers still have to land, each with its own submit: serializing them
+	// must not collapse, drop, or merge one into the other.
+	for _, want := range []string{"pane send-text steer one", "pane send-text steer two"} {
+		if got := strings.Count(string(data), want); got != 1 {
+			t.Fatalf("%q appears %d times, want exactly once:\n%s", want, got, strings.Join(log, "\n"))
+		}
+	}
+	if got := strings.Count(string(data), "pane send-keys Enter"); got != 2 {
+		t.Fatalf("submitted %d times, want one Enter per steer:\n%s", got, strings.Join(log, "\n"))
+	}
+}
+
+// TestSendRecordsAnUndeliveredSteerAndExitsSix covers the outcome an operator or
+// a calling agent actually sees when a composer never frees: the documented exit
+// code off the real process, and a trace of the abandoned message that outlives
+// the process that tried to send it (SPECS.md, `hand send`).
+func TestSendRecordsAnUndeliveredSteerAndExitsSix(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "direct-pr")
+	seedSendTask(t, home)
+
+	statusDir := t.TempDir()
+	setPaneStatus(t, statusDir, "pane-1", "working")
+
+	dir := binDir(t)
+	herdrLog := filepath.Join(t.TempDir(), "herdr-invocations.log")
+	writeFakeHerdrSend(t, dir, statusDir, herdrLog)
+
+	got := runHand(t, home, "send", "task-1", "stop and wait for review", "--wait", "400ms")
+	assertInvocation(t, got, 6, "composer still busy after 400ms, message recorded as undelivered")
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.SendUndeliveredMessage != "stop and wait for review" || task.SendUndeliveredAt == "" {
+		t.Fatalf("task row = %+v, want the abandoned message and a timestamp recorded", task)
+	}
+
+	setPaneStatus(t, statusDir, "pane-1", "idle")
+	delivered := runHand(t, home, "send", "task-1", "different steer entirely")
+	if delivered.code != 0 || !strings.Contains(delivered.stdout, "sent to task-1") {
+		t.Fatalf("send after the composer freed: exit %d, stdout %q, stderr %q",
+			delivered.code, delivered.stdout, delivered.stderr)
+	}
+
+	task, err = state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.SendUndeliveredMessage != "" || task.SendUndeliveredAt != "" {
+		t.Fatalf("task row = %+v, want the undelivered trace cleared by a send that reached the pane", task)
+	}
+}
+
+func seedSendTask(t *testing.T, home string) {
+	t.Helper()
+	if err := state.Write(home, state.Task{
+		ID: "task-1", Project: "demo", Kind: state.KindShip,
+		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Intent

Bundle three independent robustness fixes into one PR: make hand send wait for a busy composer (bounded, configurable) instead of failing outright, serialize concurrent sends to the same task, and durably record a message that stays undelivered through the wait; namespace herdr workspace labels (hand:<project-name>) so FindWorkspaceByLabel can never match a workspace hand did not create; and close the tab herdr already created when TabCreate gets back a partial or malformed response, mirroring the existing WorkspaceCreate fix for the same defect class.

Closes atqamz/secondhand#102
Closes atqamz/secondhand#118
Closes atqamz/secondhand#119

## What Changed

- `hand send` now waits out a busy composer for a bounded, configurable window (`--wait`, defaulting to `config/send-wait` or 2m) instead of failing after a fixed 10s, takes a `send:<id>` lock so concurrent sends to the same task queue rather than race the same pane, and gained a `--file` flag for reading the message from disk. A composer that stays busy for the whole bound exits 6 (new `herdr.ErrComposerBusyTimeout` sentinel keeps a mid-wait pane failure on exit 1).
- Undelivered steers are recorded durably: new `send_undelivered_message` / `send_undelivered_at` task columns (plus the first `internal/store` migration) are written when a send times out, or when `PaneSendText`/`PaneSendKeys` fails, and cleared by the next send that reaches the pane. A failed clear warns on stderr rather than exiting non-zero, so callers do not retry an already-delivered steer.
- `internal/herdr` `TabCreate` now closes the tab herdr already created when the response is partial or unparseable, mirroring the existing `WorkspaceCreate` cleanup, and `cmd/spawn.go` labels and looks up workspaces as `hand:<project>` so `FindWorkspaceByLabel` can never match a workspace hand did not create.

Review flagged five findings on the first pass (arg validation panic on `--file ""`, timeout vs. pane-death conflation, undelivered-trace coverage, exit code on a failed clear); all were fixed in a follow-up commit. The one remaining info note is a known tradeoff: a process killed between `PaneSendText` and `PaneSendKeys` still leaves unsubmitted text with no trace. Nothing currently surfaces the undelivered fields in `hand status`, and the fleet-home `AGENTS.md` template does not yet teach exit 6 - both noted as follow-ups.

## Design notes

### atqamz/secondhand#102: why a wait bound, a lock, and a durable trace, not a queue service

- Busy composer is normal, not exceptional: an agent mid-turn is expected state for the pane a steer targets, so `hand send` waits it out instead of failing immediately. The wait is bounded (`--wait`, default `config/send-wait` or 2m) rather than indefinite, so a caller still gets a bounded-time answer instead of a hang, and the bound is configurable so a caller steering into an unusually long turn reaches for a bigger `--wait`, not a retry loop of its own.
- Serializing through a `send:<id>` lock, not a separate queue process: the failure this closes is two unsynchronized retry loops polling the same pane and firing `send-text` within a millisecond of each other, concatenating two steers into one composer. A per-task lock inside `hand send` itself gives the same serialization a dedicated queue daemon would, without adding a new long-running component or a new place state can drift from `state/hand.db`.
- Recording the undelivered message on the task row, not just returning a distinct exit code: exit 6 tells the failing invocation's own caller the send did not land, but a supervisory agent watching the fleet later, not that caller, is who actually needs to know a steer was lost. `send_undelivered_message` / `send_undelivered_at` persist that past the failing process's lifetime, and the next send that reaches the pane clears it, so the trace tracks "an unacknowledged steer exists," not a history of every attempt.

### atqamz/secondhand#118: why namespacing the label, not the two alternatives considered

- Persisting the workspace ID on the project row was rejected: it only helps for a workspace `hand` itself created, so it does nothing for the actual failure mode - an existing workspace some other tool or a human already labelled with the same bare project name before `hand` ever looked. `FindWorkspaceByLabel` would still have to fall back to label matching for that case, and a fallback path is exactly the silent-dispatch-into-the-wrong-workspace hazard this fix removes.
- Matching on the workspace root directory path instead of the label was rejected because herdr does not return one: `herdr.Workspace` (`internal/herdr/types.go:33-37`) carries only `workspace_id`, `label`, and `tab_count` from `workspace list` - there is no root path in the response to match against.
- Prefixing the label with `hand:` was chosen because it is the one property `hand` fully owns: it does not make the label globally unique, but it does mean a collision now requires another `hand`-managed project to coincidentally share the same name, not any directory on the machine, and it costs nothing beyond the string itself - no new herdr call, no new stored field.

## Risk Assessment

ok: Low: Every round-1 finding the author chose to fix landed correctly with targeted tests, the three intent criteria are all source-verifiable in the change, and the remaining items are the two the author explicitly accepted plus one narrow crash window inherent to the chosen record-on-failure design.

## Testing

`Ran the targeted unit tests for send, herdr and the store schema, then drove the built binary end-to-end through every behavior the intent names, using a base-commit build over the same fakes as the before/after control: busy-composer waiting, the bounded and configurable wait ending in exit 6 with the message persisted in state/hand.db, cross-process serialization of two concurrent sends, namespaced hand:<project> workspace lookup, tab cleanup on both partial and malformed tab-create responses, and in-place migration of the new columns onto a pre-change fleet home. Everything passed, and the full CLI transcript is captured as an artifact. Cross-process send serialization had no automated test, so I added two focused e2e tests and confirmed the serialization one fails when the send lock is removed. This is a CLI-only change with no rendered UI surface, so the terminal transcript plus the persisted database rows are the end-user-visible evidence rather than screenshots.`

<details>
<summary>Evidence: End-to-end CLI transcript: all three fixes, before/after against base 341b151</summary>

```text
###############################################################
# atqamz/secondhand#118 - herdr workspace labels are namespaced
###############################################################

$ herdr workspace list   (what hand sees before it spawns)
{"result":{"workspaces":[{"workspace_id":"ws-human-demo","label":"demo","tab_count":3}]}}
  ^ a human already has a workspace herdr labelled "demo" - the basename of some directory.

BEFORE (base 341b151):
$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-1
exit=0
--- herdr calls:
13:52:30.073 hand_pid=2278131 herdr workspace list
13:52:30.080 hand_pid=2278131 herdr tab create --workspace ws-human-demo --no-focus --cwd /tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-1 --label task-1
13:52:30.088 hand_pid=2278131 herdr pane run ws-human-demo:pane-9 cd '/tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/fleet-base/data/task-1/brief.md and carry out the task it describes. Only a `hand send` message carries an operator decision. Answering your own harness'\''s question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - `working: deciding myself: <the call> because <reason>` - and reserve `needs-decision:` for what you cannot take back.'
13:52:30.093 hand_pid=2278131 herdr pane get ws-human-demo:pane-9
13:52:30.101 hand_pid=2278131 herdr pane read ws-human-demo:pane-9 --source recent --lines 60
  ^ the worker was dispatched into ws-human-demo: a workspace hand never created.

AFTER (this branch):
$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-1
exit=0
--- herdr calls:
13:52:30.232 hand_pid=2278194 herdr workspace list
13:52:30.239 hand_pid=2278194 herdr workspace create --no-focus --cwd /tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-1 --label hand:demo
13:52:30.247 hand_pid=2278194 herdr tab rename tab-1 task-1
13:52:30.252 hand_pid=2278194 herdr pane run ws-hand:pane-1 cd '/tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions 'Read the brief at /tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/fleet/data/task-1/brief.md and carry out the task it describes. Only a `hand send` message carries an operator decision. Answering your own harness'\''s question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - `working: deciding myself: <the call> because <reason>` - and reserve `needs-decision:` for what you cannot take back.'
13:52:30.258 hand_pid=2278194 herdr pane get ws-hand:pane-1
13:52:30.265 hand_pid=2278194 herdr pane read ws-hand:pane-1 --source recent --lines 60
  ^ the bare-labelled workspace never matched; hand created and recorded its own hand:demo.
                 id: task-1
 herdr_workspace_id: ws-hand
      herdr_pane_id: ws-hand:pane-1
undelivered_message: ''
     undelivered_at: ''

###############################################################
# atqamz/secondhand#119 - a partial tab create leaves no orphan
###############################################################

$ herdr tab create ...   (herdr made the tab, then answered without a root pane)
{"result":{"tab":{"tab_id":"tab-orphan-2","workspace_id":"ws-hand","label":"task-2"}}}

$ hand spawn task-2 demo
herdr tab create failed: parse tab create: missing tab or root pane
exit=1
--- herdr calls:
13:52:30.317 hand_pid=2278224 herdr workspace list
13:52:30.324 hand_pid=2278224 herdr tab create --workspace ws-hand --no-focus --cwd /tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-2 --label task-2
13:52:30.331 hand_pid=2278224 herdr tab close tab-orphan-2
  ^ hand closed tab-orphan-2 itself; nothing is left behind that only herdr knows about.

$ herdr tab create ...   (same defect class: the response mistypes root_pane)
{"result":{"tab":{"tab_id":"tab-orphan-3","workspace_id":"ws-hand"},"root_pane":"none"}}

$ hand spawn task-3 demo
herdr tab create failed: parse tab create: json: cannot unmarshal string into Go struct field .root_pane of type herdr.Pane
exit=1
--- herdr calls:
13:52:30.364 hand_pid=2278248 herdr workspace list
13:52:30.371 hand_pid=2278248 herdr tab create --workspace ws-hand --no-focus --cwd /tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/lab/wt-task-3 --label task-3
13:52:30.379 hand_pid=2278248 herdr tab close tab-orphan-3
  ^ same cleanup: the tab herdr had already made is closed before hand gives up.

###############################################################
# atqamz/secondhand#102 - hand send waits out a busy composer
###############################################################

BEFORE (base 341b151): flags, and two concurrent steers into one busy pane
Flags:
  -h, --help   help for send
sent to task-1
A exit=0
sent to task-1
B exit=0
--- herdr calls:
13:52:30.399 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:30.399 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:30.407 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:30.407 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:30.667 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:30.667 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:30.926 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:30.926 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:31.183 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:31.185 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:31.443 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:31.443 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:31.702 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:31.703 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:31.962 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:31.962 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:32.220 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:32.221 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:32.479 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:32.480 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
13:52:32.487 hand_pid=2278278 herdr pane send-text ws-human-demo:pane-9 steer A: check the middleware
13:52:32.489 hand_pid=2278279 herdr pane send-text ws-human-demo:pane-9 steer B: then check the tests
13:52:32.493 hand_pid=2278278 herdr pane send-keys ws-human-demo:pane-9 Enter
13:52:32.494 hand_pid=2278279 herdr pane send-keys ws-human-demo:pane-9 Enter
  ^ both senders polled the same pane in lockstep and fired send-text within a millisecond
    of each other: two steers concatenated in one composer, the lost-steer hazard of #102.

BEFORE: composer stays busy - fixed 10s timeout, exit 1, message gone
composer not empty after 10s
exit=1
elapsed_ms=10151

AFTER (this branch): flags
Flags:
      --file string   read the message from this file instead of the positional argument
  -h, --help          help for send
      --wait string   how long to wait for a busy composer to free before giving up (default: config/send-wait, or 2m)

AFTER: composer busy when the steer arrives, agent frees it 1.5s later
  [t+1.5s] the agent finished its turn -> composer idle
$ hand send task-1 "focus on the auth middleware, not the test framework"
sent to task-1
exit=0
--- herdr calls:
13:52:42.677 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:42.686 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:42.945 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:43.206 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:43.466 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:43.727 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:43.987 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:44.246 hand_pid=2278638 herdr pane get ws-hand:pane-1
13:52:44.254 hand_pid=2278638 herdr pane send-text ws-hand:pane-1 focus on the auth middleware, not the test framework
13:52:44.260 hand_pid=2278638 herdr pane send-keys ws-hand:pane-1 Enter

AFTER: two concurrent steers into one busy pane are serialized
sent to task-1
A exit=0
sent to task-1
B exit=0
--- herdr calls:
13:52:44.286 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:44.293 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:44.552 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:44.811 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:45.072 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:45.332 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:45.592 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:45.851 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:46.112 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:46.373 hand_pid=2278694 herdr pane get ws-hand:pane-1
13:52:46.382 hand_pid=2278694 herdr pane send-text ws-hand:pane-1 steer A: check the middleware
13:52:46.388 hand_pid=2278694 herdr pane send-keys ws-hand:pane-1 Enter
13:52:46.394 hand_pid=2278695 herdr pane get ws-hand:pane-1
13:52:46.403 hand_pid=2278695 herdr pane send-text ws-hand:pane-1 steer B: then check the tests
13:52:46.409 hand_pid=2278695 herdr pane send-keys ws-hand:pane-1 Enter
  ^ one hand pid polls alone and delivers; the other makes no herdr call at all until the
    first has sent Enter, then delivers its own steer. Both steers land, separately.

AFTER: composer stays busy past the bound - exit 6, message recorded (message from --file)
$ hand send task-1 --file data/task-1/steer.md --wait 2s
composer still busy after 2s, message recorded as undelivered
exit=6
elapsed_ms=2134  polls=10
--- persisted task row:
                 id: task-1
 herdr_workspace_id: ws-hand
      herdr_pane_id: ws-hand:pane-1
undelivered_message: 'ship the auth fix in two paragraphs.
                     
                     second paragraph: keep the `backtick` quoting intact.'
     undelivered_at: '2026-08-03T06:52:48Z'

AFTER: the bound comes from config/send-wait when --wait is absent
$ cat config/send-wait
1s
$ hand send task-1 "retry the same steer"
composer still busy after 1s, message recorded as undelivered
exit=6
elapsed_ms=1097

AFTER: the pane dies mid-wait - exit 1, not the retryable 6
$ hand send task-1 "steer into a dying pane" --wait 20s
herdr pane ws-hand:pane-1 not found: herdr pane get ws-hand:pane-1: exit status 1: herdr: pane ws-hand:pane-1 not found
exit=1

AFTER: the next steer that reaches the pane clears the trace
$ hand send task-1 "different steer entirely"
sent to task-1
exit=0
--- persisted task row:
                 id: task-1
 herdr_workspace_id: ws-hand
      herdr_pane_id: ws-hand:pane-1
undelivered_message: ''
     undelivered_at: ''

###############################################################
# the new columns migrate onto a fleet home that already exists
###############################################################

the BEFORE build wrote this home:
PRAGMA user_version=0
send_* columns: (none)

$ hand status   (the new build opening it for the first time)
id      project  kind  state              age       last report
task-1  demo     ship  idle (unreported)  just now  (none)
exit=0
PRAGMA user_version=1
send_* columns: send_undelivered_message,send_undelivered_at
  ^ migrated in place, the existing task row intact.

$ hand-base status   (the old build refusing the migrated home rather than corrupting it)
state/hand.db is schema version 1, newer than this build of hand supports (version 0) - upgrade hand before opening it: schema version newer than this build of hand supports
exit=1
```
</details>
<details>
<summary>Evidence: Reproducible evidence driver (fake herdr/treehouse, hermetic fleet home)</summary>

```text
#!/usr/bin/env bash
# End-to-end driver for the three fixes in 102-118-119-herdr-robustness.
# Real `hand` binaries (target and base commit) against a hermetic fleet home,
# a fake herdr whose composer status / workspace list are file-driven, and a
# fake treehouse. Every herdr call is logged with the calling hand pid.
set -u
EV=/tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN
LAB=$EV/lab; S=$LAB/herdrstate
SQ=/nix/store/46c0qkgri1d3kq1fxgdxq23vg3viznm7-sqlite-3.53.3-bin/bin/sqlite3
export GIT_CONFIG_GLOBAL=$LAB/gitconfig GIT_CONFIG_SYSTEM=/dev/null
export PATH="$LAB/bin:$PATH"
hand() { "$EV/hand" "$@"; }
handbase() { "$EV/hand-base" "$@"; }
log() { printf '\n%s\n' "$*"; }
calls() { echo "--- herdr calls:"; cat "$S/invocations.log"; }
row() { $SQ -line "$HAND_HOME/state/hand.db" \
  "select id, herdr_workspace_id, herdr_pane_id, quote(send_undelivered_message) as undelivered_message, quote(send_undelivered_at) as undelivered_at from task where id='$1';"; }

rm -rf "$LAB"; mkdir -p "$LAB/bin" "$S"
git config --global user.email dev@example.com
git config --global user.name dev
git config --global init.defaultBranch main
git config --global commit.gpgsign false

cat > "$LAB/bin/herdr" <<HERDR
#!/bin/sh
S=$S
printf '%s hand_pid=%s herdr %s\n' "\$(date +%H:%M:%S.%3N)" "\$PPID" "\$*" >> "\$S/invocations.log"
case "\$1 \$2" in
"workspace list") cat "\$S/workspace-list.json" ;;
"workspace create") cat "\$S/workspace-create.json" ;;
"tab create") cat "\$S/tab-create.json" ;;
"tab rename") printf '{"result":{"tab":{"tab_id":"tab-1","workspace_id":"ws-hand","label":"task-1"}}}\n' ;;
"tab close") printf '{"result":{"type":"ok"}}\n' ;;
"pane run"|"pane send-text"|"pane send-keys") ;;
"pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
"pane get")
  if [ -f "\$S/pane-gone" ]; then echo "herdr: pane \$3 not found" >&2; exit 1; fi
  st=\$(cat "\$S/composer-status" 2>/dev/null || echo idle)
  printf '{"result":{"pane":{"pane_id":"%s","tab_id":"tab-1","workspace_id":"ws-hand","agent":"claude","agent_status":"%s"}}}\n' "\$3" "\$st"
  ;;
*) echo "unexpected herdr invocation: \$*" >&2; exit 1 ;;
esac
HERDR
cat > "$LAB/bin/treehouse" <<TH
#!/bin/sh
case "\$1" in
get) holder=task-1
  while [ \$# -gt 0 ]; do case "\$1" in --lease-holder) holder=\$2 ;; esac; shift; done
  echo 'treehouse 0.7.4' >&2; printf '{"path":"%s"}\n' "$LAB/wt-\${holder#hand:}" ;;
return|init) echo ok ;;
*) echo "unexpected treehouse: \$*" >&2; exit 1 ;;
esac
TH
chmod +x "$LAB/bin/herdr" "$LAB/bin/treehouse"

echo idle > "$S/composer-status"; : > "$S/invocations.log"
# a workspace a human opened under some directory named "demo": bare label, not hand's
cat > "$S/workspace-list.json" <<'J'
{"result":{"workspaces":[{"workspace_id":"ws-human-demo","label":"demo","tab_count":3}]}}
J
cat > "$S/workspace-create.json" <<'J'
{"result":{"workspace":{"workspace_id":"ws-hand","label":"hand:demo","tab_count":1},"tab":{"tab_id":"tab-1","workspace_id":"ws-hand","label":"1"},"root_pane":{"pane_id":"ws-hand:pane-1","tab_id":"tab-1","workspace_id":"ws-hand","agent_status":"idle"}}}
J
cat > "$S/tab-create.json" <<'J'
{"result":{"tab":{"tab_id":"tab-base","workspace_id":"ws-human-demo","label":"task-1"},"root_pane":{"pane_id":"ws-human-demo:pane-9","tab_id":"tab-base","workspace_id":"ws-human-demo","agent_status":"idle"}}}
J

newfleet() {
  export HAND_HOME=$1; mkdir -p "$HAND_HOME"; cd "$HAND_HOME" || exit 1
  "$2" init >/dev/null
  printf -- '- demo: https://example.com/demo.git mode=local-only\n' >> data/projects.md
  mkdir -p data/task-1 data/task-2
  printf '# brief\nfix the login flow\n' > data/task-1/brief.md
  printf '# brief\nsecond task\n' > data/task-2/brief.md
  mkdir -p projects/demo; git init -q projects/demo
  git -C projects/demo commit -q --allow-empty -m init
}

echo "###############################################################"
echo "# atqamz/secondhand#118 - herdr workspace labels are namespaced"
echo "###############################################################"
log '$ herdr workspace list   (what hand sees before it spawns)'
cat "$S/workspace-list.json"
echo "  ^ a human already has a workspace herdr labelled \"demo\" - the basename of some directory."

newfleet "$LAB/fleet-base" "$EV/hand-base"
[ -d "$LAB/wt-task-1" ] || git -C projects/demo worktree add -q -b b1 "$LAB/wt-task-1"
: > "$S/invocations.log"
log "BEFORE (base 341b151):"
echo '$ hand spawn task-1 demo'; handbase spawn task-1 demo; echo "exit=$?"; calls
echo "  ^ the worker was dispatched into ws-human-demo: a workspace hand never created."

newfleet "$LAB/fleet" "$EV/hand"
[ -d "$LAB/wt-task-1" ] || git -C projects/demo worktree add -q -b b1 "$LAB/wt-task-1"
git -C projects/demo worktree add -q -b b2 "$LAB/wt-task-2"
: > "$S/invocations.log"
log "AFTER (this branch):"
echo '$ hand spawn task-1 demo'; hand spawn task-1 demo; echo "exit=$?"; calls
echo "  ^ the bare-labelled workspace never matched; hand created and recorded its own hand:demo."
row task-1

echo
echo "###############################################################"
echo "# atqamz/secondhand#119 - a partial tab create leaves no orphan"
echo "###############################################################"
cat > "$S/workspace-list.json" <<'J'
{"result":{"workspaces":[{"workspace_id":"ws-human-demo","label":"demo","tab_count":3},{"workspace_id":"ws-hand","label":"hand:demo","tab_count":2}]}}
J
cat > "$S/tab-create.json" <<'J'
{"result":{"tab":{"tab_id":"tab-orphan-2","workspace_id":"ws-hand","label":"task-2"}}}
J
log '$ herdr tab create ...   (herdr made the tab, then answered without a root pane)'
cat "$S/tab-create.json"
: > "$S/invocations.log"
log '$ hand spawn task-2 demo'; hand spawn task-2 demo; echo "exit=$?"; calls
echo "  ^ hand closed tab-orphan-2 itself; nothing is left behind that only herdr knows about."

cat > "$S/tab-create.json" <<'J'
{"result":{"tab":{"tab_id":"tab-orphan-3","workspace_id":"ws-hand"},"root_pane":"none"}}
J
log '$ herdr tab create ...   (same defect class: the response mistypes root_pane)'
cat "$S/tab-create.json"
mkdir -p data/task-3 && printf '# brief\nthird task\n' > data/task-3/brief.md
git -C projects/demo worktree add -q -b b3 "$LAB/wt-task-3"
: > "$S/invocations.log"
log '$ hand spawn task-3 demo'; hand spawn task-3 demo; echo "exit=$?"; calls
echo "  ^ same cleanup: the tab herdr had already made is closed before hand gives up."

echo
echo "###############################################################"
echo "# atqamz/secondhand#102 - hand send waits out a busy composer"
echo "###############################################################"
log "BEFORE (base 341b151): flags, and two concurrent steers into one busy pane"
export HAND_HOME=$LAB/fleet-base; cd "$HAND_HOME"
handbase send --help 2>&1 | sed -n '/^Flags:/,$p'
echo working > "$S/composer-status"; : > "$S/invocations.log"
( handbase send task-1 "steer A: check the middleware" >"$EV/a.out" 2>&1; echo "A exit=$?" >>"$EV/a.out" ) &
( handbase send task-1 "steer B: then check the tests" >"$EV/b.out" 2>&1; echo "B exit=$?" >>"$EV/b.out" ) &
sleep 2; echo idle > "$S/composer-status"; wait
cat "$EV/a.out" "$EV/b.out"; calls
echo "  ^ both senders polled the same pane in lockstep and fired send-text within a millisecond"
echo "    of each other: two steers concatenated in one composer, the lost-steer hazard of #102."
log 'BEFORE: composer stays busy - fixed 10s timeout, exit 1, message gone'
echo working > "$S/composer-status"
start=$(date +%s%N); handbase send task-1 "steer that never lands"; echo "exit=$?"
echo "elapsed_ms=$(( ($(date +%s%N)-start)/1000000 ))"

export HAND_HOME=$LAB/fleet; cd "$HAND_HOME"
log "AFTER (this branch): flags"
hand send --help 2>&1 | sed -n '/^Flags:/,$p'

log 'AFTER: composer busy when the steer arrives, agent frees it 1.5s later'
echo working > "$S/composer-status"; : > "$S/invocations.log"
( hand send task-1 "focus on the auth middleware, not the test framework" >"$EV/c.out" 2>&1; echo "exit=$?" >>"$EV/c.out" ) &
sleep 1.5; echo "  [t+1.5s] the agent finished its turn -> composer idle"; echo idle > "$S/composer-status"; wait
echo '$ hand send task-1 "focus on the auth middleware, not the test framework"'; cat "$EV/c.out"; calls

log 'AFTER: two concurrent steers into one busy pane are serialized'
echo working > "$S/composer-status"; : > "$S/invocations.log"
( hand send task-1 "steer A: check the middleware" --wait 30s >"$EV/a.out" 2>&1; echo "A exit=$?" >>"$EV/a.out" ) &
( hand send task-1 "steer B: then check the tests" --wait 30s >"$EV/b.out" 2>&1; echo "B exit=$?" >>"$EV/b.out" ) &
sleep 2; echo idle > "$S/composer-status"; wait
cat "$EV/a.out" "$EV/b.out"; calls
echo "  ^ one hand pid polls alone and delivers; the other makes no herdr call at all until the"
echo "    first has sent Enter, then delivers its own steer. Both steers land, separately."

log 'AFTER: composer stays busy past the bound - exit 6, message recorded (message from --file)'
printf 'ship the auth fix in two paragraphs.\n\nsecond paragraph: keep the `backtick` quoting intact.\n' > data/task-1/steer.md
echo working > "$S/composer-status"; : > "$S/invocations.log"
echo '$ hand send task-1 --file data/task-1/steer.md --wait 2s'
start=$(date +%s%N); hand send task-1 --file data/task-1/steer.md --wait 2s; echo "exit=$?"
echo "elapsed_ms=$(( ($(date +%s%N)-start)/1000000 ))  polls=$(grep -c 'pane get' "$S/invocations.log")"
echo "--- persisted task row:"; row task-1

log 'AFTER: the bound comes from config/send-wait when --wait is absent'
printf '1s\n' > config/send-wait
echo '$ cat config/send-wait'; cat config/send-wait
echo '$ hand send task-1 "retry the same steer"'
start=$(date +%s%N); hand send task-1 "retry the same steer"; echo "exit=$?"
echo "elapsed_ms=$(( ($(date +%s%N)-start)/1000000 ))"
rm -f config/send-wait

log 'AFTER: the pane dies mid-wait - exit 1, not the retryable 6'
echo working > "$S/composer-status"; : > "$S/invocations.log"
( sleep 1; touch "$S/pane-gone" ) &
echo '$ hand send task-1 "steer into a dying pane" --wait 20s'
hand send task-1 "steer into a dying pane" --wait 20s; echo "exit=$?"
wait; rm -f "$S/pane-gone"

log 'AFTER: the next steer that reaches the pane clears the trace'
echo idle > "$S/composer-status"
echo '$ hand send task-1 "different steer entirely"'; hand send task-1 "different steer entirely"; echo "exit=$?"
echo "--- persisted task row:"; row task-1

echo
echo "###############################################################"
echo "# the new columns migrate onto a fleet home that already exists"
echo "###############################################################"
export HAND_HOME=$LAB/fleet-base; cd "$HAND_HOME"
log "the BEFORE build wrote this home:"
$SQ "$HAND_HOME/state/hand.db" "select 'PRAGMA user_version=' || (select * from pragma_user_version); select 'send_* columns: ' || coalesce(group_concat(name),'(none)') from pragma_table_info('task') where name like 'send_%';"
log '$ hand status   (the new build opening it for the first time)'
echo idle > "$S/composer-status"; hand status; echo "exit=$?"
$SQ "$HAND_HOME/state/hand.db" "select 'PRAGMA user_version=' || (select * from pragma_user_version); select 'send_* columns: ' || coalesce(group_concat(name),'(none)') from pragma_table_info('task') where name like 'send_%';"
echo "  ^ migrated in place, the existing task row intact."
log '$ hand-base status   (the old build refusing the migrated home rather than corrupting it)'
handbase status; echo "exit=$?"
```
</details>
<details>
<summary>Evidence: Concurrent sends: base 341b151 raced the composer, this branch serializes</summary>

```text
BEFORE (base 341b151): two concurrent steers into one busy pane
sent to task-1 / A exit=0
sent to task-1 / B exit=0
13:52:32.480 hand_pid=2278278 herdr pane get ws-human-demo:pane-9
13:52:32.480 hand_pid=2278279 herdr pane get ws-human-demo:pane-9
... both pids polling in lockstep ...
13:52:32.488 hand_pid=2278278 herdr pane send-text ws-human-demo:pane-9 steer A: check the middleware
13:52:32.489 hand_pid=2278279 herdr pane send-text ws-human-demo:pane-9 steer B: then check the tests
13:52:32.493 hand_pid=2278278 herdr pane send-keys ws-human-demo:pane-9 Enter
13:52:32.494 hand_pid=2278279 herdr pane send-keys ws-human-demo:pane-9 Enter
^ two steers concatenated in one composer: the lost-steer hazard of #102

AFTER (this branch): two concurrent steers into one busy pane are serialized
sent to task-1 / A exit=0
sent to task-1 / B exit=0
13:52:44.286 hand_pid=2278694 herdr pane get ws-hand:pane-1
... 10 polls, all from 2278694 ...
13:52:46.382 hand_pid=2278694 herdr pane send-text ws-hand:pane-1 steer A: check the middleware
13:52:46.388 hand_pid=2278694 herdr pane send-keys ws-hand:pane-1 Enter
13:52:46.394 hand_pid=2278695 herdr pane get ws-hand:pane-1
13:52:46.403 hand_pid=2278695 herdr pane send-text ws-hand:pane-1 steer B: then check the tests
13:52:46.409 hand_pid=2278695 herdr pane send-keys ws-hand:pane-1 Enter
```
</details>
<details>
<summary>Evidence: Bounded wait: exit 6 and the undelivered steer persisted in state/hand.db</summary>

```text
$ hand send task-1 --file data/task-1/steer.md --wait 2s
composer still busy after 2s, message recorded as undelivered
exit=6
elapsed_ms=2130 polls=10
--- persisted task row (sqlite3 state/hand.db):
id: task-1
undelivered_message: 'ship the auth fix in two paragraphs.

second paragraph: keep the `backtick` quoting intact.'
undelivered_at: '2026-08-03T06:52:48Z'

$ cat config/send-wait -> 1s
$ hand send task-1 "retry the same steer"
composer still busy after 1s, message recorded as undelivered
exit=6 elapsed_ms=1092

$ hand send task-1 "steer into a dying pane" --wait 20s (pane dies mid-wait)
herdr pane ws-hand:pane-1 not found: ...
exit=1

$ hand send task-1 "different steer entirely" (composer free again)
sent to task-1 / exit=0
id: task-1
undelivered_message: ''
undelivered_at: ''
```
</details>
<details>
<summary>Evidence: Workspace label namespacing and tab cleanup</summary>

```text
$ herdr workspace list (a human's workspace herdr labelled "demo")
{"result":{"workspaces":[{"workspace_id":"ws-human-demo","label":"demo","tab_count":3}]}}

BEFORE (base 341b151): hand spawn task-1 demo -> exit=0
herdr tab create --workspace ws-human-demo ... --label task-1
herdr pane run ws-human-demo:pane-9 ... claude ...
^ worker dispatched into a workspace hand never created

AFTER (this branch): hand spawn task-1 demo -> exit=0
herdr workspace create --no-focus --cwd .../wt-task-1 --label hand:demo
herdr tab rename tab-1 task-1
task row: herdr_workspace_id = ws-hand

partial tab create {"tab":{"tab_id":"tab-orphan-2"}} (no root pane):
herdr tab create --workspace ws-hand ... --label task-2
herdr tab close tab-orphan-2
hand spawn task-2 demo -> exit=1 "parse tab create: missing tab or root pane"

malformed tab create {"tab":{"tab_id":"tab-orphan-3"},"root_pane":"none"}:
herdr tab close tab-orphan-3
hand spawn task-3 demo -> exit=1 "parse tab create: json: cannot unmarshal string ..."
```
</details>
<details>
<summary>Evidence: send_undelivered columns migrate onto a pre-change fleet home</summary>

```text
the BEFORE build wrote this home:
PRAGMA user_version=0
send_* columns: (none)

$ hand status (the new build opening it for the first time)
id project kind state age last report
task-1 demo ship idle (unreported) just now (none)
exit=0
PRAGMA user_version=1
send_* columns: send_undelivered_message,send_undelivered_at

$ hand-base status (old build against the migrated home)
state/hand.db is schema version 1, newer than this build of hand supports (version 0) - upgrade hand before opening it
exit=1
```
</details>
- Outcome: warning: 1 info across 1 run (13m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>warning: **Review** - 1 info</summary>

- warning: `cmd/send.go:48` - cmd/send.go:48 panics on `hand send task-1 --file &#34;&#34;`. The Args validator keys off `c.Flags().Changed(&#34;file&#34;)` (true for an explicitly empty value), so `want` becomes 1 and one positional arg passes validation; RunE then keys off `filePath != &#34;&#34;`, which is false, and falls into `message = args[1]` - index out of range. This is trivially reachable from a script doing `hand send &#34;$id&#34; --file &#34;$steer&#34;` with an unset variable, and it produces a Go stack trace instead of the exit-2 usage error SPECS:650 promises for &#34;neither ... of the positional message and --file given&#34;. Fix by using the same predicate in both places (e.g. `if c.Flags().Changed(&#34;file&#34;)` in RunE, or reject an empty --file value in the Args validator).
- warning: `cmd/send.go:83` - cmd/send.go:83 treats every error from WaitComposerEmpty as &#34;composer stayed busy&#34;. WaitComposerEmpty also returns PaneGet errors (internal/herdr/client.go:317-320), which is exactly what happens when the agent dies or the tab is closed mid-wait - after the initial PaneGet at line 76 succeeded. That path now exits 6 with the message &#34;composer still busy after 2m&#34;, contradicting the exit-code table this change adds: SPECS:6 says code 6 is &#34;the composer stayed busy for the whole --wait bound&#34; and a retryable state, while &#34;herdr itself erroring&#34; and &#34;no such herdr pane&#34; are explicitly code 1 because the send can never succeed. A caller following the documented contract retries a dead pane with ever-longer --wait forever. Distinguish the two: give the timeout its own sentinel in herdr (e.g. ErrComposerBusy returned by WaitComposerEmpty&#39;s deadline branch) and only map that to code 6, letting a PaneGet failure surface as exit 1.
- warning: `cmd/send.go:96` - The undelivered-send trace only covers the wait path, so the atqamz/secondhand#102 failure class - a steer that vanishes with the process that attempted it - is still reachable. If PaneSendText fails (cmd/send.go:96) the message is never sent and nothing is recorded; worse, if PaneSendText succeeds and PaneSendKeys(&#34;Enter&#34;) fails (line 99), the text is sitting unsubmitted in the worker&#39;s composer, the command exits 1, and no trace exists either. The stated intent scopes recording to &#34;a message that stays undelivered through the wait&#34;, so this is a narrower fix rather than a contradiction - but if the invariant is meant to be &#34;a steer either reaches the pane or leaves a durable trace&#34;, the earliest boundary that makes it hold is to record the trace once before attempting delivery and clear it after PaneSendKeys succeeds, which also collapses the two helpers into one. Flagging for your call on whether to extend the scope now.
- warning: `cmd/send.go:103` - cmd/send.go:103 returns exit 1 (&#34;clear undelivered send trace&#34;) when clearUndeliveredSend fails, even though PaneSendText and PaneSendKeys have already succeeded and the steer is in the worker&#39;s pane. A caller treating non-zero as &#34;not delivered&#34; retries and double-sends the steer - the same duplicate-steer hazard the send lock exists to prevent. SPECS&#39; Errors list for `hand send` does not name this as a failure case either. A failed clear should warn on stderr and still exit 0 (the trace being stale is strictly less harmful than a duplicated steer).
- warning: `cmd/send.go:114` - The `--file` flag (cmd/send.go:114, plus its SPECS section at 613-617 and the argument-count validator) is a fourth change, not one of the three the intent bundles: &#34;make hand send wait for a busy composer ..., serialize concurrent sends ..., and durably record a message that stays undelivered through the wait; namespace herdr workspace labels ...; and close the tab herdr already created ...&#34;. It is a permanent CLI surface addition unrelated to composer robustness. Not forbidden by the intent, but confirm you want it in this PR rather than its own.
- info: `internal/store/store.go:81` - Nothing reads send_undelivered_message / send_undelivered_at outside cmd/send.go and internal/store - not `hand status`, not `hand doctor`, not the AGENTS.md template. The stated purpose in store.go&#39;s field comment and SPECS step 5 is that &#34;an operator or worker learns the steer never arrived&#34;, but today that requires querying state/hand.db by hand. Surfacing it in `hand status &lt;id&gt;` would be a small follow-up; noting it so the gap is a decision rather than an oversight.
- info: `cmd/send.go:22` - The inline Args validator at cmd/send.go:22-30 hand-rolls both the exit-2 wrapper and cobra&#39;s &#34;accepts %d arg(s), received %d&#34; message, which the existing `usageArgs` helper (cmd/root.go:75) and `cobra.ExactArgs` already provide: `Args: usageArgs(func(c *cobra.Command, args []string) error { want := 2; if c.Flags().Changed(&#34;file&#34;) { want = 1 }; return cobra.ExactArgs(want)(c, args) })` keeps this command on the same path as every other one.
- info: `cmd/send.go:143` - recordUndeliveredSend (cmd/send.go:124) and clearUndeliveredSend (cmd/send.go:143) are the same lock -&gt; read -&gt; mutate two fields -&gt; write sequence with different values. One helper taking the message and timestamp (empty strings to clear) removes the duplication; the early-return-if-already-empty in the clear path is the only asymmetry and is just a write elision.

fix: Fix: fix send arg validation, busy-timeout sentinel, undelivered trace coverage
1 info still open:
- info: `cmd/send.go:109` - Residual, no action needed. With the trace now recorded on both delivery-failure returns, the only remaining way a steer vanishes silently is the process dying between PaneSendText succeeding (cmd/send.go:106) and PaneSendKeys returning (line 109) - e.g. an operator Ctrl-C&#39;ing a send whose herdr call is hanging - which leaves text unsubmitted in the composer with no trace. Closing that would require recording before the attempt and clearing after success, which is a different mechanism than the record-on-failure design chosen here; noting it so the window is a known tradeoff rather than an oversight.

</details>

<details>
<summary>warning: **Test** - 1 info</summary>

- info: `tests/e2e/send_test.go` - new test file written by agent: tests/e2e/send_test.go
- `nix develop --command go test -race ./cmd/ -run 'TestSend|TestSpawnIgnoresSameLabelledWorkspaceHandDidNotCreate|TestSpawnHappyPath|TestSpawnPartialWorkspaceCreate' -count=1`
- `nix develop --command go test -race ./internal/herdr/ ./internal/store/ -run 'TestTabCreate|TestWorkspaceCreate|TestWaitComposerEmpty|TestFindWorkspaceByLabel|TestSendUndelivered|TestPendingMigration|TestFresh|TestExistingBaseline' -count=1`
- <code>Added `tests/e2e/send_test.go` (`TestConcurrentSendsToTheSameTaskSerialize`, `TestSendRecordsAnUndeliveredSteerAndExitsSix`) plus a `writeFakeHerdrSend` fake in `tests/e2e/fakes_test.go`; run with `nix develop --command go test -tags=e2e -count=3 -run &#39;TestConcurrentSendsToTheSameTaskSerialize|TestSendRecordsAnUndeliveredSteerAndExitsSix&#39; ./tests/e2e/`</code>
- <code>Red/green check: temporarily replaced the `state.Lock(home, &#34;send:&#34;+id)` call in `cmd/send.go` with a no-op and confirmed `TestConcurrentSendsToTheSameTaskSerialize` fails with interleaved sender pids, then restored the file (worktree diff now contains only the two test files)</code>
- <code>`nix develop --command go test -tags=e2e -count=1 -run &#39;TestSpawnTeardownCycle|TestMigrate&#39; ./tests/e2e/` (neighbouring tests unaffected by the shared fakes change)</code>
- <code>Manual end-to-end driver `/tmp/no-mistakes-evidence/01KZ34KNDRB8C92JZRY2CR5FBN/drive.sh`: real `hand` and base-commit `hand-base` binaries against a hermetic fleet home with fake herdr/treehouse - `hand spawn` with a human&#39;s bare-labelled workspace present (before/after), `hand spawn` against partial and malformed `tab create` responses, `hand send` with a composer that frees mid-wait, two concurrent `hand send` processes (before/after), `hand send --file --wait 2s` past the bound, `config/send-wait` as the default bound, pane death mid-wait, trace clearing, and `hand status` migrating a base-built fleet home in place (verified with `sqlite3` on `state/hand.db`)</code>

</details>

<details>
<summary>warning: **Document** - 1 info</summary>

- info: `internal/agentsmd/agentsmd.go:50` - The fleet-home AGENTS.md template (`generatedBody`, authoritative per SPECS.md&#39;s &#34;AGENTS.md (target)&#34;) tells the supervisory agent to steer workers with `hand send` and spells out `hand watch`&#39;s exit 4/5 explicitly, but says nothing about the new exit 6 or the undelivered-send trace, so a supervisor that gets a busy-composer timeout has no guidance that the steer never landed and is retryable with a longer --wait. Left unchanged deliberately: `generatedBody` is a Go constant whose content is what `hand init` writes and `hand doctor` drift-checks, so editing it changes generated output rather than documentation, which is outside this pass. Worth a follow-up deciding whether the template should teach exit 6 (and, relatedly, whether any command should surface `send_undelivered_message`, which nothing currently reads).

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>


