### PR TITLE
fix(cmd): print HAND_HOME mismatch warning as an absolute path

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -214,7 +214,7 @@ Creates `state/`, `data/`, `projects/`, `config/` if they don't exist.
 Creates `data/backlog.md` and `data/projects.md` with skeleton content, and creates `state/hand.db` if it does not already exist - the fleet-home marker `IsHome` checks for (see "Core principles").
 Idempotent: safe to run multiple times.
 This is the one command that does not resolve its home: it creates the one its argument or the working directory names.
-When `HAND_HOME` is set and names some other directory it still initializes the requested target, and warns on stderr that every other command will use `HAND_HOME` instead.
+When `HAND_HOME` is set and names some other directory it still initializes the requested target, and warns on stderr that every other command will use `HAND_HOME` instead, naming it as the absolute path those commands resolve it to so a relative `HAND_HOME` is not mistaken for a second home.
 
 ```
 hand init

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -223,10 +223,14 @@ func warnHandHomeMismatch(w io.Writer, home string) error {
 	if handHome == "" {
 		return nil
 	}
-	if abs, err := filepath.Abs(handHome); err == nil && abs == home {
-		return nil
+	display := handHome
+	if abs, err := filepath.Abs(handHome); err == nil {
+		if abs == home {
+			return nil
+		}
+		display = abs
 	}
-	_, err := fmt.Fprintf(w, "warning: HAND_HOME is set to %s, so every other hand command will use that home, not %s\n", handHome, home)
+	_, err := fmt.Fprintf(w, "warning: HAND_HOME is set to %s, so every other hand command will use that home, not %s\n", display, home)
 	return err
 }
 

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -385,6 +386,19 @@ func TestWarnHandHomeMismatch(t *testing.T) {
 	}
 	if !strings.Contains(warned.String(), elsewhere) || !strings.Contains(warned.String(), home) {
 		t.Fatalf("got %q, want a warning naming both %q and %q", warned.String(), elsewhere, home)
+	}
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	t.Setenv("HAND_HOME", "fleet")
+	absHandHome := filepath.Join(cwd, "fleet")
+	var relative strings.Builder
+	if err := warnHandHomeMismatch(&relative, home); err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf("warning: HAND_HOME is set to %s, so every other hand command will use that home, not %s\n", absHandHome, home)
+	if relative.String() != want {
+		t.Fatalf("got %q, want %q", relative.String(), want)
 	}
 }
 

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -435,7 +435,7 @@ func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
 
 // TestTeardownRetriesAfterReportRemovalFails proves teardown survives a fault in
 // its last step, which takes both halves of "retryable". state.Delete's removal
-// order (report channel before task JSON) leaves the task JSON untouched, so
+// order (report channel before the task row) leaves the task row untouched, so
 // there is something left to retry; and the retry then re-runs the cleanup steps
 // the first call already completed, which have to treat an already-closed tab and
 // an already-returned worktree as success. Reverting either half fails this test:


### PR DESCRIPTION
## Intent

fix two late-gate findings: print HAND_HOME mismatch warning with an absolute path (issue 106), and reword a stale task-JSON comment in cmd/teardown_test.go to task row (issue 108)

Closes atqamz/secondhand#106
Closes atqamz/secondhand#108

## What Changed

- `warnHandHomeMismatch` in `cmd/init.go` now names `HAND_HOME` by the absolute path other `hand` commands resolve it to, so a relative value like `HAND_HOME=fleet` is no longer printed verbatim and mistaken for a second home; the early return for a `HAND_HOME` that already matches the init target is preserved.
- Extended `TestWarnHandHomeMismatch` with a case that sets a relative `HAND_HOME` from a temp cwd and asserts the warning carries the absolute path, and updated the `hand init` section of SPECS.md to state the absolute-path behavior.
- Reworded a stale comment in `cmd/teardown_test.go` that described the teardown removal order in terms of "task JSON" to say "task row", matching how `state.Delete` actually removes the DB row.

## Risk Assessment

ok: Low: Two tightly scoped changes that exactly match the stated intent: an absolute-path fix that mirrors the existing HAND_HOME resolution in internal/home.Resolve and is covered by a new exact-string test, plus a comment reword verified accurate against state.Delete's actual removal order.

## Testing

Ran the targeted cmd tests covering the init warning and the teardown retry path (including with -race) and they pass, then demonstrated the user-facing fix by building the base and target binaries and running real `hand init` with a relative HAND_HOME: the base warning printed "set to fleet" while the fixed build prints the absolute resolved path, and the three no-warning cases stay silent. Verified the reworded teardown_test.go comment against state.Delete, which deletes a DB task row rather than task JSON. CLI transcript saved as evidence; transient build artifacts removed and the worktree is clean.

<details>
<summary>Evidence: hand init HAND_HOME mismatch warning - before/after CLI transcript</summary>

<code>$ export HAND_HOME=fleet # relative path, as an operator might set it&#10;&#10;--- BEFORE (base commit e40cff8) --------------------------------&#10;$ hand init myhome&#10;warning: HAND_HOME is set to fleet, so every other hand command will use that home, not /tmp/.../demo/before/myhome&#10;initialized secondhand home at /tmp/.../demo/before/myhome&#10;&#10;--- AFTER (this change 91e84fe) ---------------------------------&#10;$ hand init myhome&#10;warning: HAND_HOME is set to /tmp/.../demo/after/fleet, so every other hand command will use that home, not /tmp/.../demo/after/myhome&#10;initialized secondhand home at /tmp/.../demo/after/myhome&#10;&#10;--- no-warning cases still silent (relative HAND_HOME resolving to the same home) ---&#10;$ HAND_HOME=myhome hand init myhome&#10;initialized secondhand home at /tmp/.../demo/same/myhome&#10;$ HAND_HOME=&lt;abs&gt;/myhome hand init myhome&#10;initialized secondhand home at /tmp/.../demo/same/myhome&#10;$ hand init myhome # HAND_HOME unset&#10;initialized secondhand home at /tmp/.../demo/same/myhome</code>

```text
$ cd /tmp/demo-workspace
$ export HAND_HOME=fleet     # relative path, as an operator might set it

--- BEFORE (base commit e40cff8) --------------------------------
$ hand init myhome
warning: HAND_HOME is set to fleet, so every other hand command will use that home, not /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/before/myhome
initialized secondhand home at /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/before/myhome

--- AFTER (this change 91e84fe) ---------------------------------
$ hand init myhome
warning: HAND_HOME is set to /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/after/fleet, so every other hand command will use that home, not /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/after/myhome
initialized secondhand home at /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/after/myhome
--- no-warning cases still silent (relative HAND_HOME resolving to the same home) ---
$ HAND_HOME=myhome hand init myhome
initialized secondhand home at /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/same/myhome
$ HAND_HOME=<abs>/myhome hand init myhome
initialized secondhand home at /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/same/myhome
$ hand init myhome            # HAND_HOME unset
initialized secondhand home at /tmp/no-mistakes-evidence/01KZ3HA1FN1SPC9TJGJ06ZVXDJ/demo/same/myhome
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Review** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Test** - passed</summary>

ok: No issues found.
- `nix develop -c go test ./cmd/ -run 'TestWarnHandHomeMismatch|TestResolveInitHome|TestTeardownShip' -v`
- `nix develop -c go test ./cmd/ -run TestTeardownRetriesAfterReportRemovalFails -race -v`
- <code>Built base (e40cff8) and target (91e84fe) `hand` binaries and ran `HAND_HOME=fleet hand init myhome` in a scratch dir with each, capturing the stderr warning for a before/after comparison</code>
- <code>Ran target binary with `HAND_HOME=myhome hand init myhome`, `HAND_HOME=&lt;abs&gt;/myhome hand init myhome`, and `env -u HAND_HOME hand init myhome` to confirm no spurious warnings</code>
- <code>Read `internal/state/task.go:146-159` to confirm state.Delete&#39;s removal order (report channel, then DB task row) matches the reworded comment in cmd/teardown_test.go</code>

</details>

<details>
<summary>ok: **Document** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>


