### PR TITLE
fix(herdr): sanitize inherited harness-identity env on pane creation and document holds in the fleet-home template

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -1477,11 +1477,16 @@ herdr workspace list
 # create workspace without focusing it - herdr cannot create an empty workspace, so this always
 # creates a root tab and pane too, at --cwd; hand points --cwd at the worktree (not the clone) and
 # reuses that root tab as the first task's tab (see "herdr tab rename" below) rather than
-# discarding it and creating a second tab, which would leave it behind as an orphan shell
-herdr workspace create --no-focus --cwd <worktree> --label hand:<project-name>
+# discarding it and creating a second tab, which would leave it behind as an orphan shell.
+# --env blanks any CLAUDE_CODE_CHILD_SESSION/CLAUDE_CODE_SESSION_ID/CLAUDECODE the herdr server
+# itself inherited, so a server started from inside a Claude Code session never hands its own
+# session identity, or a silently disabled transcript, to a pane it creates (atqamz/secondhand#109)
+herdr workspace create --no-focus --cwd <worktree> --label hand:<project-name> \
+  --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=
 
-# create tab in an already-existing workspace
-herdr tab create --workspace <ws-id> --no-focus --cwd <worktree> --label <task-id>
+# create tab in an already-existing workspace - same sanitized --env set as workspace create above
+herdr tab create --workspace <ws-id> --no-focus --cwd <worktree> --label <task-id> \
+  --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=
 
 # rename a tab - used to turn workspace create's own root tab into the first task's tab
 herdr tab rename <tab-id> <task-id>

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -58,6 +58,7 @@ Run ` + "`hand --help`" + ` for the full command reference.
 - Never force-teardown without explicit authorization.
 - Report outcomes plainly. If work failed, say so with evidence.
 - ` + OperatorDecisionRule + `
+- Waiting on the operator or on another task: ` + "`hand hold set <id> --kind operator --reason <text>`" + ` or ` + "`--kind blocked --reason <text> --blocked-on <id>`" + `, and ` + "`hand hold clear <id>`" + ` once resolved.
 - Name a path in a brief, a status report, or an operator message: full and absolute, never relative. ` + "`hand`" + ` resolves the home from ` + "`HAND_HOME`" + ` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
 - Ship tasks produce PRs or local branches. Scout tasks produce ` + "`data/<id>/report.md`" + `.
 - ` + "`data/backlog.md`" + ` is your task queue. Edit it directly.

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -198,6 +198,15 @@ func TestGeneratedRulesCoverSelfDecidedCallsInFirstPerson(t *testing.T) {
 	}
 }
 
+// atqamz/secondhand#114: a fleet agent following the template had no reason
+// to reach for hand hold, since every "waiting on" case routed through
+// data/backlog.md and hand send.
+func TestGeneratedRulesCoverHolds(t *testing.T) {
+	if !strings.Contains(generatedBody, "hand hold set") || !strings.Contains(generatedBody, "hand hold clear") {
+		t.Fatalf("got generated body %q, want hand hold set and hand hold clear", generatedBody)
+	}
+}
+
 func TestRefreshDoesNotOverwriteExistingClaudeSymlink(t *testing.T) {
 	dir := makeWorkspace(t)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("placeholder\n"), 0o644); err != nil {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -23,6 +23,22 @@ func NewClient() *Client {
 	return &Client{}
 }
 
+// sanitizedEnvKeys are the harness-identity variables a pane must never inherit from the herdr
+// server it's a child of. A server started from inside a Claude Code session carries these in its
+// own environment, so every pane it spawns afterwards inherits its parent's session identity and,
+// via CLAUDE_CODE_CHILD_SESSION, silently disables its own transcript - the only independent record
+// of what a worker did (atqamz/secondhand#109). Blanking them at creation removes the failure for
+// every pane hand creates rather than depending on the server's environment being clean.
+var sanitizedEnvKeys = []string{"CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDECODE"}
+
+func sanitizedEnvArgs() []string {
+	args := make([]string, 0, len(sanitizedEnvKeys)*2)
+	for _, key := range sanitizedEnvKeys {
+		args = append(args, "--env", key+"=")
+	}
+	return args
+}
+
 type errorBody struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
@@ -156,6 +172,7 @@ func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, Tab, Pane, error
 	if label != "" {
 		args = append(args, "--label", label)
 	}
+	args = append(args, sanitizedEnvArgs()...)
 	res, err := c.call(args...)
 	if err != nil {
 		return Workspace{}, Tab{}, Pane{}, err
@@ -217,6 +234,7 @@ func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
 	if label != "" {
 		args = append(args, "--label", label)
 	}
+	args = append(args, sanitizedEnvArgs()...)
 	res, err := c.call(args...)
 	if err != nil {
 		return Tab{}, Pane{}, err

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -87,6 +87,35 @@ func TestWorkspaceCreateParsesRootTabAndPane(t *testing.T) {
 	}
 }
 
+// TestWorkspaceCreateSanitizesInheritedHarnessMarkers pins the fix for atqamz/secondhand#109: a
+// pane is a child of the herdr server, so it otherwise inherits any CLAUDE_CODE_CHILD_SESSION,
+// CLAUDE_CODE_SESSION_ID, or CLAUDECODE the server itself was started under, silently disabling
+// the worker's transcript. WorkspaceCreate must blank all three on every pane it creates,
+// regardless of whether the server actually carries them.
+func TestWorkspaceCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
+	writeFakeHerdr(t, `
+echo "$@" >> "$HERDR_CALL_LOG"
+printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB"}}}'
+`)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	c := NewClient()
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err != nil {
+		t.Fatal(err)
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"--env CLAUDE_CODE_CHILD_SESSION=", "--env CLAUDE_CODE_SESSION_ID=", "--env CLAUDECODE="} {
+		if !strings.Contains(string(calls), want) {
+			t.Fatalf("calls = %q, want %q", calls, want)
+		}
+	}
+}
+
 func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
 	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"}}}'`)
 	c := NewClient()
@@ -285,6 +314,33 @@ func TestTabCreateParsesTabAndRootPane(t *testing.T) {
 	}
 	if tab.TabID != "wA:tB" || pane.PaneID != "wA:pC" || pane.AgentStatus != StatusIdle {
 		t.Fatalf("got tab=%+v pane=%+v", tab, pane)
+	}
+}
+
+// TestTabCreateSanitizesInheritedHarnessMarkers is TabCreate's half of
+// TestWorkspaceCreateSanitizesInheritedHarnessMarkers: a task landing in an already-existing
+// workspace creates its own tab via TabCreate instead, and that path must be sanitized too.
+func TestTabCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
+	writeFakeHerdr(t, `
+echo "$@" >> "$HERDR_CALL_LOG"
+printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB"}}}'
+`)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+
+	c := NewClient()
+	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err != nil {
+		t.Fatal(err)
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"--env CLAUDE_CODE_CHILD_SESSION=", "--env CLAUDE_CODE_SESSION_ID=", "--env CLAUDECODE="} {
+		if !strings.Contains(string(calls), want) {
+			t.Fatalf("calls = %q, want %q", calls, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Intent

Ship two independent, unrelated fixes as one PR with two separate commits. (1) atqamz/secondhand#114: internal/agentsmd's generatedBody (the AGENTS.md template hand init writes into fresh fleet homes) never mentioned hand hold set/hand hold clear, so a fleet agent had no reason to reach for holds for operator/blocked-waiting cases; added one imperative rule line right after the existing OperatorDecisionRule line, pinned with a new test (TestGeneratedRulesCoverHolds). Note: the original brief also claimed this repo's own AGENTS.md needed updating in lockstep with generatedBody - I verified that claim against the current code and SPECS.md's 'AGENTS.md (target)' section and found it stale: this repo's AGENTS.md is deliberately a pointer to generatedBody/SPECS.md, not a literal mirror (per the fix for atqamz/secondhand#44), and the actual drift test only checks for the string 'generatedBody', so no edit to this repo's own AGENTS.md was needed or made. (2) atqamz/secondhand#109: a herdr pane is a child of the herdr server process and inherits its environment, so if the server was started from inside a Claude Code session, every pane it spawns inherits CLAUDE_CODE_CHILD_SESSION, CLAUDE_CODE_SESSION_ID, and CLAUDECODE, which silently disables Claude Code's transcript saving in that pane - critical because the transcript is the only independent audit trail against a worker's self-reported status file. This design decision (sanitize vs detect/refuse vs both) was left to me to decide, pin with a test, and document. I chose to sanitize unconditionally at pane creation, via herdr's own --env KEY= flag on both WorkspaceCreate and TabCreate, rather than detect-and-warn, because herdr exposes no server PID through any API hand already talks to (checked hand status server and herdr api snapshot), so detection would need fragile /proc cmdline-sniffing or a new external dependency (ss/lsof) this repo does not otherwise take. Sanitizing removes the failure unconditionally regardless of whether the server is actually contaminated, and cannot fail silently: an unsupported or malformed --env makes herdr itself exit non-zero, so a spawn that cannot be sanitized fails loudly rather than silently succeeding unprotected. Pinned with two new tests: TestWorkspaceCreateSanitizesInheritedHarnessMarkers and TestTabCreateSanitizesInheritedHarnessMarkers. Also updated SPECS.md's herdr CLI examples to match, since internal/herdr/types.go documents client.go as the source of truth for that syntax. These two fixes share one PR only because both are small and touch disjoint files; they are otherwise unrelated. PR https://github.com/atqamz/secondhand/pull/130 is already open with both commits, assignee atqamz, milestone 0.2.0, and two separate Closes lines (Closes atqamz/secondhand#114 and Closes atqamz/secondhand#109) verified independently via gh pr view --json closingIssuesReferences. The branch has just been rebased onto the latest origin/main (after PR #126 merged) with zero conflicts and force-pushed.

## What Changed

- `internal/herdr`'s `WorkspaceCreate` and `TabCreate` now append `--env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=` to every pane they create, so a herdr server started from inside a Claude Code session can no longer hand its own harness identity - or a silently disabled transcript - to the panes it spawns. An unsupported or malformed `--env` makes herdr exit non-zero, so a spawn that cannot be sanitized fails loudly instead of succeeding unprotected.
- `internal/agentsmd`'s `generatedBody` gains one rule line pointing fleet agents at `hand hold set <id> --kind operator|blocked` and `hand hold clear <id>`, placed right after the operator-decision rule, so fresh fleet homes' `AGENTS.md` documents holds for operator-waiting and blocked-waiting cases.
- SPECS.md's herdr CLI examples were updated to match the new `workspace create` / `tab create` invocations, and three tests pin the behavior: `TestWorkspaceCreateSanitizesInheritedHarnessMarkers`, `TestTabCreateSanitizesInheritedHarnessMarkers`, and `TestGeneratedRulesCoverHolds`.

## Risk Assessment

ok: Low: Two small, disjoint, well-documented changes with pinning tests; the sanitize fix was verified against the installed herdr (flag exists, empty value parses, unsupported flag fails loudly) and against the installed claude binary (all three markers are truthiness-checked, so blanking restores transcript persistence), and both pane-creating paths are covered with no reachable unsanitized route.

## Testing

Ran the two touched packages' unit tests plus the three new pinning tests, the cmd-level spawn/promote/teardown/hold tests, and the e2e spawn-teardown and promote/hold suites - all green. Beyond that, built the real `hand` binary at both the base and target commits and drove `hand spawn` end-to-end under a contaminated Claude Code environment against a fake herdr that honours `--env` the way real herdr does: the base binary hands the pane CLAUDECODE=1, CLAUDE_CODE_SESSION_ID and CLAUDE_CODE_CHILD_SESSION on both the WorkspaceCreate and TabCreate paths, while the target blanks all three, and a herdr that rejects `--env` makes the spawn exit 1 with the full failing invocation rather than proceeding unprotected. For the template fix, a fleet home initialized by the base binary has no `hand hold` guidance and picks it up when refreshed by the fixed binary, with `hand doctor` reporting no drift, and the rule's exact command syntax was executed against the live CLI to confirm an agent copying it succeeds. No failures, no flakiness, worktree left clean.

<details>
<summary>Evidence: hand spawn pane-environment before/after (atqamz/secondhand#109)</summary>

<code>--- d045762 (before), fresh workspace -&gt; WorkspaceCreate&#10;herdr call: herdr workspace create --no-focus --cwd &lt;tmp&gt;/wt-task-1 --label hand:demo&#10;environment the pane process ends up with:&#10;CLAUDECODE=1&#10;CLAUDE_CODE_CHILD_SESSION=1&#10;CLAUDE_CODE_SESSION_ID=parent-session-abc123&#10;&#10;--- bbeb23d (after), fresh workspace -&gt; WorkspaceCreate&#10;herdr call: herdr workspace create --no-focus --cwd &lt;tmp&gt;/wt-task-1 --label hand:demo --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=&#10;environment the pane process ends up with:&#10;CLAUDECODE=&#10;CLAUDE_CODE_CHILD_SESSION=&#10;CLAUDE_CODE_SESSION_ID=&#10;&#10;--- d045762 (before), existing workspace -&gt; TabCreate&#10;herdr call: herdr tab create --workspace ws-1 --no-focus --cwd &lt;tmp&gt;/wt-task-1 --label task-1&#10;environment the pane process ends up with:&#10;CLAUDECODE=1&#10;CLAUDE_CODE_CHILD_SESSION=1&#10;CLAUDE_CODE_SESSION_ID=parent-session-abc123&#10;&#10;--- bbeb23d (after), existing workspace -&gt; TabCreate&#10;herdr call: herdr tab create --workspace ws-1 --no-focus --cwd &lt;tmp&gt;/wt-task-1 --label task-1 --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=&#10;environment the pane process ends up with:&#10;CLAUDECODE=&#10;CLAUDE_CODE_CHILD_SESSION=&#10;CLAUDE_CODE_SESSION_ID=&#10;&#10;--- bbeb23d, herdr build that rejects --env: the spawn fails loudly&#10;$ hand spawn task-1 demo&#10;herdr workspace lookup/create failed: herdr workspace create --no-focus --cwd &lt;tmp&gt;/wt-task-1 --label hand:demo --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=: invalid_argument: unknown flag: --env&#10;exit=1</code>

```text
atqamz/secondhand#109 - real `hand spawn` CLI run under a contaminated Claude Code environment
(CLAUDECODE=1, CLAUDE_CODE_SESSION_ID=parent-session-abc123, CLAUDE_CODE_CHILD_SESSION=1),
against a fake herdr that applies --env overrides to the pane it spawns, the way real herdr does.
Script: /tmp/no-mistakes-evidence/01KZ3JE501YVA9RG5MW9NPNB78/spawn_env_demo.sh

--- d045762 (before), fresh workspace -> WorkspaceCreate
  herdr call: herdr workspace create --no-focus --cwd <tmp>/wt-task-1 --label hand:demo
  environment the pane process ends up with:
    CLAUDECODE=1
    CLAUDE_CODE_CHILD_SESSION=1
    CLAUDE_CODE_SESSION_ID=parent-session-abc123

--- bbeb23d (after), fresh workspace -> WorkspaceCreate
  herdr call: herdr workspace create --no-focus --cwd <tmp>/wt-task-1 --label hand:demo --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=
  environment the pane process ends up with:
    CLAUDECODE=
    CLAUDE_CODE_CHILD_SESSION=
    CLAUDE_CODE_SESSION_ID=

--- d045762 (before), existing workspace -> TabCreate
  herdr call: herdr tab create --workspace ws-1 --no-focus --cwd <tmp>/wt-task-1 --label task-1
  environment the pane process ends up with:
    CLAUDECODE=1
    CLAUDE_CODE_CHILD_SESSION=1
    CLAUDE_CODE_SESSION_ID=parent-session-abc123

--- bbeb23d (after), existing workspace -> TabCreate
  herdr call: herdr tab create --workspace ws-1 --no-focus --cwd <tmp>/wt-task-1 --label task-1 --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=
  environment the pane process ends up with:
    CLAUDECODE=
    CLAUDE_CODE_CHILD_SESSION=
    CLAUDE_CODE_SESSION_ID=

--- bbeb23d, herdr build that rejects --env: the spawn fails loudly instead of silently running unprotected
  $ hand spawn task-1 demo
  herdr workspace lookup/create failed: herdr workspace create --no-focus --cwd <tmp>/wt-task-1 --label hand:demo --env CLAUDE_CODE_CHILD_SESSION= --env CLAUDE_CODE_SESSION_ID= --env CLAUDECODE=: invalid_argument: unknown flag: --env
  exit=1
```
</details>
<details>
<summary>Evidence: AGENTS.md hold rule appears on init/refresh (atqamz/secondhand#114)</summary>

<code>$ hand init # fleet home created by the pre-fix binary&#10;initialized secondhand home at &lt;tmp&gt;/h&#10;&#10;$ grep -n &#34;hand hold&#34; AGENTS.md # nothing: atqamz/secondhand#114&#10;(no match)&#10;&#10;$ hand init # same home, binary with the fix: refreshes the generated block&#10;initialized secondhand home at &lt;tmp&gt;/h&#10;&#10;$ grep -n &#34;hand hold&#34; AGENTS.md&#10;26:- Waiting on the operator or on another task: `hand hold set &lt;id&gt; --kind operator --reason &lt;text&gt;` or `--kind blocked --reason &lt;text&gt; --blocked-on &lt;id&gt;`, and `hand hold clear &lt;id&gt;` once resolved.&#10;&#10;$ hand doctor # generated block is current, no drift&#10;exit=0</code>

```text
$ hand init                     # fleet home created by the pre-fix binary
  initialized secondhand home at /tmp/tmp.Z8nhzp9JiI/h

$ grep -n "hand hold" AGENTS.md  # nothing: atqamz/secondhand#114
  (no match)

$ hand init                     # same home, binary with the fix: refreshes the generated block
  initialized secondhand home at /tmp/tmp.Z8nhzp9JiI/h

$ grep -n "hand hold" AGENTS.md
  26:- Waiting on the operator or on another task: `hand hold set <id> --kind operator --reason <text>` or `--kind blocked --reason <text> --blocked-on <id>`, and `hand hold clear <id>` once resolved.

$ hand doctor                   # generated block is current, no drift
  exit=0
```
</details>
<details>
<summary>Evidence: New template rule&#39;s CLI syntax run verbatim</summary>

<code>$ hand hold set task-1 --kind operator --reason &#34;needs prod API key&#34;&#10;hold set on task-1 (kind=operator)&#10;$ hand hold set task-2 --kind blocked --reason &#34;needs schema from task-1&#34; --blocked-on task-1&#10;hold set on task-2 (kind=blocked)&#10;$ hand status&#10;no tasks (0)&#10;&#10;held:&#10;task-1 operator needs prod API key just now&#10;task-2 blocked waiting on task-1: needs schema from task-1 just now&#10;$ hand hold clear task-1&#10;hold cleared on task-1&#10;$ hand status&#10;no tasks (0)&#10;&#10;held:&#10;task-2 blocked waiting on task-1: needs schema from task-1 just now</code>

```text
# the rule the template now gives every fleet agent, run verbatim
$ hand hold set task-1 --kind operator --reason "needs prod API key"
hold set on task-1 (kind=operator)
  exit=0
$ hand hold set task-2 --kind blocked --reason "needs schema from task-1" --blocked-on task-1
hold set on task-2 (kind=blocked)
  exit=0
$ hand status
no tasks (0)

held:
  task-1  operator  needs prod API key                           just now
  task-2  blocked   waiting on task-1: needs schema from task-1  just now
$ hand hold clear task-1
hold cleared on task-1
  exit=0
$ hand status
no tasks (0)

held:
  task-2  blocked  waiting on task-1: needs schema from task-1  just now
```
</details>
<details>
<summary>Evidence: AGENTS.md generated by hand init with the fix</summary>

```text
<!-- hand:generated:start -->
# Secondhand

You manage a fleet of coding agents using the `hand` CLI.
Run `hand --help` for the full command reference.

## Workflow

1. Run `hand status` for current fleet state.
2. Match the request to a project in `data/projects.md`.
3. Edit `data/backlog.md` to record the task with a unique ID.
4. Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it. The brief may open with a `---` fenced block declaring `model` and `effort` for the task, which spawn and promote apply unless a flag overrides them.
5. `hand spawn <id> <project>` to start a worker.
6. `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event and that exit is what reaches you, so re-arm it every time you act on one. Bound the wait with `--timeout <duration>`; exit 4 means the window passed with nothing happening, exit 5 means a worker named on stderr couldn't be reached before it even started waiting.
7. Act on watch output: steer blocked workers with `hand send`, relay results.
8. When told to merge: `hand merge <id>`.
9. `hand teardown <id>` after work is landed.

## Rules

- Never edit files under `projects/`. Workers do that in worktrees.
- Never merge without explicit authorization.
- Never force-teardown without explicit authorization.
- Report outcomes plainly. If work failed, say so with evidence.
- Only a `hand send` message carries an operator decision. Answering your own harness's question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - `working: deciding myself: <the call> because <reason>` - and reserve `needs-decision:` for what you cannot take back.
- Waiting on the operator or on another task: `hand hold set <id> --kind operator --reason <text>` or `--kind blocked --reason <text> --blocked-on <id>`, and `hand hold clear <id>` once resolved.
- Name a path in a brief, a status report, or an operator message: full and absolute, never relative. `hand` resolves the home from `HAND_HOME` or the nearest fleet home at or above the working directory, and a project clone can share its name with the home itself, so a relative path resolves against whichever directory happens to be current.
- Ship tasks produce PRs or local branches. Scout tasks produce `data/<id>/report.md`.
- `data/backlog.md` is your task queue. Edit it directly.
- For no-mistakes projects, workers use `no-mistakes axi` directly in the worktree.
- Use `hand search <query>` to find historical context in data/. `qmd search` adds semantic matching when installed.
- `hand status <id>` shows a worker's reported state; see SPECS.md's state management section for the report vocabulary (working/paused/blocked/needs-decision/done/failed).
<!-- hand:generated:end -->
```
</details>
<details>
<summary>Evidence: Reproduction script for the spawn env check</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end check for atqamz/secondhand#109: run the real `hand spawn`
# CLI under a contaminated Claude Code environment against a fake herdr that
# honours `--env KEY=` the way real herdr does, and record what environment the
# pane process actually ends up with.
set -euo pipefail

EVID="$1"      # evidence dir
HAND="$2"      # hand binary under test
TAG="$3"       # label for output files
MODE="${4:-workspace}"  # workspace = fresh workspace (WorkspaceCreate); tab = existing workspace (TabCreate)

ROOT=$(mktemp -d)
HOME_DIR="$ROOT/fleet"
BIN="$ROOT/bin"
CLONE="$HOME_DIR/projects/demo"
WT="$ROOT/wt-task-1"
LOG="$EVID/herdr-calls.$TAG.log"
PANEENV="$EVID/pane-env.$TAG.txt"
mkdir -p "$HOME_DIR" "$BIN"
: > "$LOG"

export GIT_CONFIG_GLOBAL="$ROOT/gitconfig"
export GIT_CONFIG_SYSTEM=/dev/null
git config --file "$GIT_CONFIG_GLOBAL" user.email dev@example.com
git config --file "$GIT_CONFIG_GLOBAL" user.name dev
git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
git config --file "$GIT_CONFIG_GLOBAL" commit.gpgsign false

cat > "$BIN/treehouse" <<EOF
#!/bin/sh
case "\$1" in
  get) echo 'treehouse 0.7.4' >&2; printf '{"path":"%s"}\n' '$WT' ;;
  return|init) echo ok ;;
  *) echo "unexpected treehouse: \$@" >&2; exit 1 ;;
esac
EOF

# Fake herdr. Real herdr spawns the pane as a child of the server process, so
# the pane inherits the server's environment; `--env KEY=VAL` overrides an entry
# for that pane. This fake models exactly that: it records the env a pane would
# be created with, by applying every --env override on top of its own inherited
# environment.
cat > "$BIN/herdr" <<EOF
#!/usr/bin/env bash
echo "herdr \$*" >> '$LOG'
cmd="\$1 \$2"
case "\$cmd" in
  "workspace list")
    if [ '$MODE' = tab ]; then
      printf '{"result":{"workspaces":[{"workspace_id":"ws-1","label":"hand:demo","tab_count":1}]}}\n'
    else
      printf '{"result":{"workspaces":[]}}\n'
    fi ;;
  "tab create")
    overrides=()
    while [ \$# -gt 0 ]; do
      if [ "\$1" = "--env" ]; then overrides+=("\$2"); shift; fi
      shift
    done
    env "\${overrides[@]}" sh -c 'env' | grep -E '^(CLAUDECODE|CLAUDE_CODE_SESSION_ID|CLAUDE_CODE_CHILD_SESSION)=' | sort > '$PANEENV' || true
    printf '{"result":{"tab":{"tab_id":"tab-2","workspace_id":"ws-1","label":"task-1"},"root_pane":{"pane_id":"pane-2","tab_id":"tab-2","workspace_id":"ws-1","agent_status":"working"}}}\n' ;;
  "workspace create")
    # MODE=reject models a herdr build that does not support --env at all:
    # real herdr answers an unsupported flag with an error envelope and a
    # non-zero exit, which is what makes an unsanitizable spawn fail loudly.
    if [ '$MODE' = reject ]; then
      case "\$*" in *--env*) printf '{"error":{"code":"invalid_argument","message":"unknown flag: --env"}}\n'; exit 1 ;; esac
    fi
    overrides=()
    while [ \$# -gt 0 ]; do
      if [ "\$1" = "--env" ]; then overrides+=("\$2"); shift; fi
      shift
    done
    env "\${overrides[@]}" sh -c 'env' | grep -E '^(CLAUDECODE|CLAUDE_CODE_SESSION_ID|CLAUDE_CODE_CHILD_SESSION)=' | sort > '$PANEENV' || true
    printf '{"result":{"workspace":{"workspace_id":"ws-1","label":"demo","tab_count":1},"tab":{"tab_id":"tab-1","workspace_id":"ws-1","label":"1"},"root_pane":{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","agent_status":"working"}}}\n' ;;
  "tab rename") printf '{"result":{"tab":{"tab_id":"tab-1","workspace_id":"ws-1","label":"task-1"}}}\n' ;;
  "tab list") printf '{"result":{"tabs":[{"tab_id":"tab-1","workspace_id":"ws-1","label":"task-1"}]}}\n' ;;
  "pane get") printf '{"result":{"pane":{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","agent":"claude","agent_status":"working"}}}\n' ;;
  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
  "pane run"|"pane send-text"|"pane send-keys") ;;
  *) echo "unexpected herdr invocation: \$*" >&2; exit 1 ;;
esac
EOF
chmod +x "$BIN/treehouse" "$BIN/herdr"
export PATH="$BIN:$PATH"

cd "$HOME_DIR"
"$HAND" init > "$EVID/hand-init.$TAG.out" 2>&1
printf -- '- demo: https://example.com/demo.git mode=local-only\n' >> "$HOME_DIR/data/projects.md"
mkdir -p "$HOME_DIR/data/task-1"
printf '# brief\n' > "$HOME_DIR/data/task-1/brief.md"

mkdir -p "$CLONE"
git -C "$CLONE" init -q -b main
echo hi > "$CLONE/README.md"
git -C "$CLONE" add README.md
git -C "$CLONE" commit -q -m "initial commit"
git -C "$CLONE" worktree add -q -b task-1-branch "$WT"

# The contamination this fix is about: a herdr server started from inside a
# Claude Code session carries these, and hands them to every pane it spawns.
export CLAUDECODE=1
export CLAUDE_CODE_SESSION_ID=parent-session-abc123
export CLAUDE_CODE_CHILD_SESSION=1

"$HAND" spawn task-1 demo
```
</details>
- Outcome: warning: 1 info across 1 run (6m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>warning: **Review** - 2 infos</summary>

- info: `internal/herdr/client_test.go:96` - The two new fakes answer any subcommand with the create envelope and accept any flag, unlike every sibling fake in this file, which dispatches on &#34;$1 $2&#34; and has a `*)` catch-all that exits 1 on unexpected args. They also carry no fake-fidelity note for the flag path, which SPECS.md&#39;s &#34;Testing strategy&#34; requires (&#34;what the real tool does on success and on failure - exit code, stream, response shape - and whether the fake mirrors that or deliberately diverges&#34;). The divergence matters here specifically because the commit message rests on it: real herdr answers an unsupported or malformed --env with empty stdout, exit 2, and &#34;unknown option: --env&#34; / &#34;env must use KEY=VALUE&#34; on stderr (verified against the installed herdr), which is the loud-failure property the sanitize design depends on, while these fakes silently accept it. Add the divergence sentence to both doc comments (and optionally the `*)` guard) so a future reader does not read the fake&#39;s tolerance as herdr&#39;s.
- info: `internal/herdr/client.go:32` - Every pane hand creates now depends on herdr supporting `--env KEY=VALUE`, and no minimum herdr version is recorded anywhere (SPECS.md only says the calls &#34;were verified against the installed herdr version&#34;, and there is no herdr precondition or doctor probe in the repo). Against a herdr predating the flag, spawn and promote fail hard rather than degrading. Verified this is the intended, diagnosable behavior: stdout is empty and exit is 2, so client.call returns &#34;herdr workspace create ...: exit status 2: unknown option: --env&#34; with herdr&#39;s stderr attached. Recording it for the record only - the fail-loud tradeoff is the author&#39;s explicit design choice and the error text is actionable, so no change is needed.

</details>

<details>
<summary>warning: **Test** - 1 info</summary>

- info: `internal/herdr/client.go:29` - The sanitization sets the three markers to empty strings rather than unsetting them, so a pane&#39;s environment contains `CLAUDECODE=`, `CLAUDE_CODE_SESSION_ID=`, `CLAUDE_CODE_CHILD_SESSION=` instead of not containing them (visible in the captured pane env). Any consumer that tests for key presence rather than truthiness would still see them set. Herdr&#39;s --env has no unset form as used here, and empty is falsy for the harness&#39;s own checks, so this is a note rather than a defect.
- `go test -race ./internal/herdr/... ./internal/agentsmd/...`
- `go test -race -v -run 'TestWorkspaceCreateSanitizesInheritedHarnessMarkers|TestTabCreateSanitizesInheritedHarnessMarkers' ./internal/herdr/`
- `go test -race -v -run TestGeneratedRulesCoverHolds ./internal/agentsmd/`
- `go test -race -run 'Spawn|Promote|Teardown|Hold' ./cmd/`
- `go test -tags=e2e -run TestSpawnTeardownCycle ./tests/e2e/`
- `go test -tags=e2e -run 'TestPromote|TestHold' ./tests/e2e/`
- <code>Manual: built `hand` at d045762 and bbeb23d, ran `hand spawn task-1 demo` under CLAUDECODE=1 / CLAUDE_CODE_SESSION_ID / CLAUDE_CODE_CHILD_SESSION against a fake herdr that applies `--env` to the pane it spawns, for both the fresh-workspace (WorkspaceCreate) and existing-workspace (TabCreate) paths, recording each pane&#39;s resulting environment</code>
- <code>Manual: same spawn against a herdr that rejects `--env`, confirming `hand spawn` exits 1 with the failing invocation on stderr</code>
- <code>Manual: `hand init` (base) -&gt; no `hand hold` in AGENTS.md, then `hand init` (fixed) on the same home -&gt; rule present, `hand doctor` exit 0</code>
- <code>Manual: `hand hold set task-1 --kind operator --reason ...`, `hand hold set task-2 --kind blocked --reason ... --blocked-on task-1`, `hand status`, `hand hold clear task-1` run verbatim as the new template rule instructs</code>

</details>

<details>
<summary>ok: **Document** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>


Closes atqamz/secondhand#114
Closes atqamz/secondhand#109
