### PR TITLE
feat(watcher): deliver notifiable events through config/notify in-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a sc
 | `hand doctor` | Report perishable content and generated-block drift in the fleet home's `AGENTS.md`; fixes nothing | Available |
 | `hand teardown` | Clean up a completed task, fail-closed on unlanded work, recording it in `state/completions.jsonl` first | Available |
 | `hand promote` | Promote a completed scout task into a ship task | Available |
-| `hand notify` | Send an out-of-band notification via a configured command; operator-invoked, nothing in the fleet calls it yet | Available |
+| `hand notify` | Send an out-of-band notification via a configured command; `hand watch` also calls it in-process for captain-relevant events | Available |
 | `hand update` | Update the installed binary from the latest GitHub Release; `--check` reports availability without installing | Available |
 
 Run `hand --help` for details on currently available commands.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a sc
 | `hand doctor` | Report perishable content and generated-block drift in the fleet home's `AGENTS.md`; fixes nothing | Available |
 | `hand teardown` | Clean up a completed task, fail-closed on unlanded work, recording it in `state/completions.jsonl` first | Available |
 | `hand promote` | Promote a completed scout task into a ship task | Available |
-| `hand notify` | Send an out-of-band notification via a configured command; `hand watch` also calls it in-process for captain-relevant events | Available |
+| `hand notify` | Send an out-of-band notification via a configured command; `hand watch` also calls it in-process for events worth reaching the operator | Available |
 | `hand update` | Update the installed binary from the latest GitHub Release; `--check` reports availability without installing | Available |
 
 Run `hand --help` for details on currently available commands.

--- a/SPECS.md
+++ b/SPECS.md
@@ -969,14 +969,17 @@ restart's own baseline tick still reaches the operator the same way a live one w
 
 #### Notifying a supervisory agent with no session watching
 
-`internal/watcher.NotifiableKinds` names the event kinds worth waking someone for with no session watching:
-`blocked`, `failed`, `report-failed`, `report-needs-decision`, and `report-done`. `idle-unreported`, `stale`,
-`parked`, `pr-merged` and the `pr-record-*` kinds are left out - each describes a transition the poll loop is already
-tracking toward one of the five above, or one that resolves on its own without a human, so notifying on it too would
-either double up the same fact or wake someone for nothing actionable.
+The notify hook is its own filtered consumer of the same classified event stream `--event` already filters for
+stdout, not a severity test hardcoded into `handleEvent`: `internal/watcher.NotifyFilter` builds an `EventFilter` -
+the identical `EventFilter`/`Matches` mechanism `--event` uses - with its own fixed membership, and `handleEvent`
+checks it the same way it checks `cfg.EventFilter`. Its membership names the event kinds worth waking someone for
+with no session watching: `blocked`, `failed`, `report-failed`, `report-needs-decision`, and `report-done`.
+`idle-unreported`, `stale`, `parked`, `pr-merged` and the `pr-record-*` kinds are left out - each describes a
+transition the poll loop is already tracking toward one of the five above, or one that resolves on its own without a
+human, so notifying on it too would either double up the same fact or wake someone for nothing actionable.
 
-`handleEvent` calls `internal/notify.Send` directly for every notifiable event, never by shelling out to the `hand
-notify` subcommand, so wiring reaches every caller of `hand watch` with no shell wrapper required. An unconfigured
+`handleEvent` calls `internal/notify.Send` directly for every event `NotifyFilter` matches, never by shelling out to
+the `hand notify` subcommand, so wiring reaches every caller of `hand watch` with no shell wrapper required. An unconfigured
 `config/notify` is expected on most fleets - the same silent fallback every other `config/` default gets - so it
 produces no diagnostic; a *configured* template that fails is written to the watcher's own stderr, the same channel
 every other watcher-internal failure (a stuck lock, an unreadable report) already uses, per "Error output" - never a

--- a/SPECS.md
+++ b/SPECS.md
@@ -973,9 +973,13 @@ The notify hook is its own filtered consumer of the same classified event stream
 stdout, not a severity test hardcoded into `handleEvent`: `internal/watcher.NotifyFilter` builds an `EventFilter` -
 the identical `EventFilter`/`Matches` mechanism `--event` uses - with its own fixed membership, and `handleEvent`
 checks it the same way it checks `cfg.EventFilter`. Its membership names the event kinds worth waking someone for
-with no session watching: `blocked`, `failed`, `report-failed`, `report-needs-decision`, and `report-done`.
+with no session watching: `blocked`, `report-blocked`, `failed`, `report-failed`, `report-needs-decision`, and
+`report-done`. `report-blocked` - the worker's own `blocked: <reason>` report line, per "Report channel" - is in the
+set alongside the herdr-transition `blocked` because the two are independent signals, and a worker that reports
+blocked and then goes idle fires no other notifiable kind: `ClassifyStatus` suppresses `idle-unreported` precisely
+because `LastReportState` is set.
 `idle-unreported`, `stale`, `parked`, `pr-merged` and the `pr-record-*` kinds are left out - each describes a
-transition the poll loop is already tracking toward one of the five above, or one that resolves on its own without a
+transition the poll loop is already tracking toward one of the six above, or one that resolves on its own without a
 human, so notifying on it too would either double up the same fact or wake someone for nothing actionable.
 
 `handleEvent` calls `internal/notify.Send` directly for every event `NotifyFilter` matches, never by shelling out to
@@ -1179,7 +1183,9 @@ Behavior:
 2. The notify config contains a shell command template. The message is available as the `$HAND_MESSAGE` environment variable.
 3. Execute the command with `HAND_MESSAGE` set in the environment, under a 10s timeout: a template that hangs must not
    hang its caller, which for the watcher's hook is the poll loop itself.
-4. Print `notified: <message>` to stdout only once the command above has actually succeeded.
+4. Print `notified: <message>` to stdout only once the command above has actually succeeded. A template that
+   backgrounds its work (`... &`) counts as succeeded once its own process exits `0`: the send is not held open for a
+   grandchild that outlives it, and its eventual outcome is not observable here either way.
 
 Example `config/notify`:
 ```

--- a/SPECS.md
+++ b/SPECS.md
@@ -156,6 +156,8 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
     watcher/                # fleet supervision
       watcher.go            # poll/push event loop
       events.go             # event classification
+    notify/                 # out-of-band delivery
+      notify.go             # config/notify template execution, shared by hand notify and the watcher's in-process hook
     project/                # project registry
       project.go            # add, list, remove, resolve
       pr.go                 # shared PR validation: repo-slug match, gh existence check
@@ -959,10 +961,35 @@ Anything that lands between one exit and the next arming is in those same two pl
 
 One invocation delivers one wake, and re-arming is the caller's own next step after acting on the exit, which it takes anyway with no human in it.
 
-This covers the awake path only: an exit reaches a session that exists and re-arms.
-It has no reach when no session is running, and `hand notify` - the channel that would - is not wired to
-anything (see `hand notify` and atqamz/secondhand#80).
-So a fleet left entirely unattended still goes unread; the difference is that an attended one no longer does.
+This covers the awake path only: an exit reaches a session that exists and re-arms, and has no reach when no session
+is running. `hand notify` (see its own section) is the channel that reaches an unattended fleet, and every `hand
+watch` invocation - `Run` and `RunUntilEvent` alike - now calls it in-process for every event `handleEvent` classifies
+as captain-relevant, whether or not that event happened to also be printed to stdout, so a transition discovered on a
+restart's own baseline tick still reaches the operator the same way a live one would.
+
+#### Notifying a supervisory agent with no session watching
+
+`internal/watcher.NotifiableKinds` names the event kinds worth waking someone for with no session watching:
+`blocked`, `failed`, `report-failed`, `report-needs-decision`, and `report-done`. `idle-unreported`, `stale`,
+`parked`, `pr-merged` and the `pr-record-*` kinds are left out - each describes a transition the poll loop is already
+tracking toward one of the five above, or one that resolves on its own without a human, so notifying on it too would
+either double up the same fact or wake someone for nothing actionable.
+
+`handleEvent` calls `internal/notify.Send` directly for every notifiable event, never by shelling out to the `hand
+notify` subcommand, so wiring reaches every caller of `hand watch` with no shell wrapper required. An unconfigured
+`config/notify` is expected on most fleets - the same silent fallback every other `config/` default gets - so it
+produces no diagnostic; a *configured* template that fails is written to the watcher's own stderr, the same channel
+every other watcher-internal failure (a stuck lock, an unreadable report) already uses, per "Error output" - never a
+blocking condition, matching `hand notify`'s own "notification failure never blocks work" contract.
+
+One notifiable kind, `failed` fired from an already-unreachable pane (`ClassifyUnreachable`), can re-fire once per
+`hand watch` restart for a condition that was already true before the restart, because its firing latch
+(`UnreachableFired`) is deliberately non-persisted (see "What survives a `hand watch` restart" below). This is the
+same "duplicate over silence" tradeoff the poll loop already accepts for that latch - a caller re-arming
+`--until-event` gets a repeat notification for a condition that has not changed, rather than one that silently stops
+notifying because the process restarted - so no additional rate limiting is added on top of it. `parked`, where the
+equivalent non-persisted latch (`ParkedFiredFor`) causes the sharper problem of duplicate `state/events.log` lines
+(atqamz/secondhand#127), is not a notifiable kind at all, so that issue's duplicates never reach this channel.
 
 #### What survives a `hand watch` restart
 
@@ -1133,16 +1160,18 @@ Errors:
 ### `hand notify <message>`
 
 Send an out-of-band notification. Uses the command template in `config/notify`.
+The same `internal/notify.Send` this command calls is also the watcher's in-process notify hook - see "Delivering an
+event to a supervisory agent" for that half.
 
 ```
 hand notify "fix-login PR is ready for review"
 ```
 
 Behavior:
-1. Read `config/notify`. If absent, print to stdout only and return.
+1. Read `config/notify`. If absent, nothing is delivered - see "Errors" below.
 2. The notify config contains a shell command template. The message is available as the `$HAND_MESSAGE` environment variable.
 3. Execute the command with `HAND_MESSAGE` set in the environment.
-4. Print the message to stdout regardless.
+4. Print `notified: <message>` to stdout only once the command above has actually succeeded.
 
 Example `config/notify`:
 ```
@@ -1154,12 +1183,9 @@ Or for macOS:
 osascript -e "display notification \"$HAND_MESSAGE\" with title \"secondhand\""
 ```
 
-Nothing calls `hand notify` yet: it is operator-invoked only, and no watcher code path reaches it.
-Nothing writes `config/notify` either - `hand init --setup` covers `harness`, `model`, and `effort` - so an unconfigured
-notify prints its message and exits 0 having sent nothing.
-The channel is therefore implemented and dark, and it is the only path that would reach the user when no supervisory
-session is awake, since `hand watch --until-event` delivers by exiting into a session that must be there to be woken.
-Wiring it is atqamz/secondhand#80.
+`hand init --setup` still does not write `config/notify` - it covers `harness`, `model`, and `effort` only - so a fresh
+fleet home leaves the channel unconfigured until an operator adds the file by hand. That absence is expected and quiet
+in the watcher's hook (see below); `hand notify` itself is the one place it is loud, per the exit code below.
 
 Output:
 ```
@@ -1167,7 +1193,11 @@ notified: fix-login PR is ready for review
 ```
 
 Errors:
-- Notify command failed (warn and continue - notification failure never blocks work).
+- `config/notify` absent, or its command failed - both exit `1`. Earlier, an absent config printed the `notified:`
+  line and exited `0` regardless, so "not configured" and "delivered" were the same observable outcome: the one path
+  meant to reach an operator with no session watching could report a delivery it never made. Both failure shapes mean
+  the same thing to a caller - nothing reached the channel - so both are the same general error rather than a warning
+  behind exit `0`.
 
 ---
 
@@ -1955,7 +1985,7 @@ These are explicit non-goals. Each lists the firstmate feature it replaces and w
 |---|---|---|
 | Secondmates / federation | `fm-home-seed.sh`, `fm-pending-reply-lib.sh`, `fm-config-inherit-lib.sh`, `fm-backlog-handoff.sh` (3,500 lines) | Solves a scaling problem at 10+ projects. Start with one home. |
 | X-mode / Twitter | `fm-x-*.sh`, `fmx-respond` skill (3,250 lines) | Separate product concern. Build as a separate tool if ever needed. |
-| AFK daemon | `fm-supervise-daemon.sh`, `fm-afk-launch.sh` (2,150 lines) | `hand watch --until-event` as the agent's own background task covers the awake path; `hand notify` is meant to cover the AFK half but is not wired to anything yet (atqamz/secondhand#80). |
+| AFK daemon | `fm-supervise-daemon.sh`, `fm-afk-launch.sh` (2,150 lines) | `hand watch --until-event` as the agent's own background task covers the awake path; `hand watch`'s in-process notify hook (see "Notifying a supervisory agent with no session watching") covers the AFK half through `config/notify`. |
 | Multiple backends | `backends/herdr.sh`, `backends/cmux.sh`, `backends/zellij.sh`, `backends/orca.sh`, `fm-backend.sh` (5,500 lines) | herdr only. Add tmux fallback later if herdr proves insufficient. |
 | Dispatch profiles | `fm-dispatch-select.sh`, `config/crew-dispatch.json` (340 lines + skill) | Pass `--harness`/`--model`/`--effort` explicitly, declare `model`/`effort` in the brief, or set defaults in `config/`. |
 | Decision holds | `fm-decision-hold.sh`, decision-hold-lifecycle skill (500 lines) | No longer cut: `hand hold set`/`hand hold clear` record a hold in the store and `hand status` renders it (see "Holds" under "State management"). Only the lifecycle skill wrapped around it stays out. |

--- a/SPECS.md
+++ b/SPECS.md
@@ -1199,7 +1199,8 @@ osascript -e "display notification \"$HAND_MESSAGE\" with title \"secondhand\""
 
 `hand init --setup` still does not write `config/notify` - it covers `harness`, `model`, and `effort` only - so a fresh
 fleet home leaves the channel unconfigured until an operator adds the file by hand. That absence is expected and quiet
-in the watcher's hook (see below); `hand notify` itself is the one place it is loud, per the exit code below.
+in the watcher's hook (see "Notifying a supervisory agent with no session watching"); `hand notify` itself is the one
+place it is loud, per the exit code below.
 
 Output:
 ```

--- a/SPECS.md
+++ b/SPECS.md
@@ -982,8 +982,12 @@ human, so notifying on it too would either double up the same fact or wake someo
 the `hand notify` subcommand, so wiring reaches every caller of `hand watch` with no shell wrapper required. An unconfigured
 `config/notify` is expected on most fleets - the same silent fallback every other `config/` default gets - so it
 produces no diagnostic; a *configured* template that fails is written to the watcher's own stderr, the same channel
-every other watcher-internal failure (a stuck lock, an unreadable report) already uses, per "Error output" - never a
-blocking condition, matching `hand notify`'s own "notification failure never blocks work" contract.
+every other watcher-internal failure (a stuck lock, an unreadable report) already uses, per "Error output".
+That rule is the whole consequence of a failed send: a diagnostic is written and the poll loop carries on, so the send
+never ends the run nor suppresses the event's own stdout line.
+A template that *hangs* is bounded the same way, by a timeout inside `internal/notify.Send` that surfaces as one more
+such diagnostic - the send runs inline in the poll loop, so an unbounded one would wedge polling, `--until-event`'s
+`--timeout` and shutdown alike.
 
 One notifiable kind, `failed` fired from an already-unreachable pane (`ClassifyUnreachable`), can re-fire once per
 `hand watch` restart for a condition that was already true before the restart, because its firing latch
@@ -1171,9 +1175,10 @@ hand notify "fix-login PR is ready for review"
 ```
 
 Behavior:
-1. Read `config/notify`. If absent, nothing is delivered - see "Errors" below.
+1. Read `config/notify`. If absent, or empty once trimmed, nothing is delivered - see "Errors" below.
 2. The notify config contains a shell command template. The message is available as the `$HAND_MESSAGE` environment variable.
-3. Execute the command with `HAND_MESSAGE` set in the environment.
+3. Execute the command with `HAND_MESSAGE` set in the environment, under a 10s timeout: a template that hangs must not
+   hang its caller, which for the watcher's hook is the poll loop itself.
 4. Print `notified: <message>` to stdout only once the command above has actually succeeded.
 
 Example `config/notify`:
@@ -1196,10 +1201,12 @@ notified: fix-login PR is ready for review
 ```
 
 Errors:
-- `config/notify` absent, or its command failed - both exit `1`. Earlier, an absent config printed the `notified:`
-  line and exited `0` regardless, so "not configured" and "delivered" were the same observable outcome: the one path
-  meant to reach an operator with no session watching could report a delivery it never made. Both failure shapes mean
-  the same thing to a caller - nothing reached the channel - so both are the same general error rather than a warning
+- `config/notify` absent or empty, or its command failed or timed out - all exit `1`. Earlier, an absent config printed
+  the `notified:` line and exited `0` regardless, so "not configured" and "delivered" were the same observable outcome:
+  the one path meant to reach an operator with no session watching could report a delivery it never made. An empty file
+  is the same case wearing a different shape - `touch config/notify` or a truncated one would otherwise run `sh -c ""`,
+  succeed, and claim a delivery just as wrongly - so it is treated as unconfigured, not as a template. All of these mean
+  the same thing to a caller - nothing reached the channel - so all are the same general error rather than a warning
   behind exit `0`.
 
 ---

--- a/SPECS.md
+++ b/SPECS.md
@@ -963,9 +963,9 @@ One invocation delivers one wake, and re-arming is the caller's own next step af
 
 This covers the awake path only: an exit reaches a session that exists and re-arms, and has no reach when no session
 is running. `hand notify` (see its own section) is the channel that reaches an unattended fleet, and every `hand
-watch` invocation - `Run` and `RunUntilEvent` alike - now calls it in-process for every event `handleEvent` classifies
-as captain-relevant, whether or not that event happened to also be printed to stdout, so a transition discovered on a
-restart's own baseline tick still reaches the operator the same way a live one would.
+watch` invocation - `Run` and `RunUntilEvent` alike - now calls it in-process for every event that matches
+`NotifyFilter` (see below), whether or not that event happened to also be printed to stdout, so a transition
+discovered on a restart's own baseline tick still reaches the operator the same way a live one would.
 
 #### Notifying a supervisory agent with no session watching
 

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -21,11 +21,9 @@ func newNotifyCmd() *cobra.Command {
 				return asPrecondition(err)
 			}
 
-			// Not configured and delivery failure both mean nothing reached the
-			// channel, so both are the same general error (exit 1) rather than the
-			// historical exit-0 "notified" line: a notifier that can't tell "not
-			// configured" from "delivered" converts an unreachable operator into an
-			// apparently-reached one.
+			// config/notify absent/empty and a failed send are both exit 1, never
+			// the old exit-0 "notified" line - see SPECS.md's hand notify "Errors"
+			// for why.
 			if err := notify.Send(home, message); err != nil {
 				if errors.Is(err, notify.ErrNotConfigured) {
 					return fmt.Errorf("config/notify not set up, nothing delivered: %s", message)

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/atqamz/secondhand/internal/home"
+	"github.com/atqamz/secondhand/internal/notify"
 	"github.com/spf13/cobra"
 )
 
@@ -23,18 +21,16 @@ func newNotifyCmd() *cobra.Command {
 				return asPrecondition(err)
 			}
 
-			template, err := os.ReadFile(filepath.Join(home, "config", "notify"))
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("read notify config: %w", err)
-			}
-			if err == nil {
-				run := exec.Command("sh", "-c", strings.TrimSpace(string(template)))
-				run.Env = append(os.Environ(), "HAND_MESSAGE="+message)
-				if out, runErr := run.CombinedOutput(); runErr != nil {
-					if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: notify command failed: %v: %s\n", runErr, strings.TrimSpace(string(out))); printErr != nil {
-						return printErr
-					}
+			// Not configured and delivery failure both mean nothing reached the
+			// channel, so both are the same general error (exit 1) rather than the
+			// historical exit-0 "notified" line: a notifier that can't tell "not
+			// configured" from "delivered" converts an unreachable operator into an
+			// apparently-reached one.
+			if err := notify.Send(home, message); err != nil {
+				if errors.Is(err, notify.ErrNotConfigured) {
+					return fmt.Errorf("config/notify not set up, nothing delivered: %s", message)
 				}
+				return err
 			}
 
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "notified: %s\n", message); err != nil {

--- a/cmd/notify_test.go
+++ b/cmd/notify_test.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestNotifyWithoutConfigPrintsToStdoutOnly(t *testing.T) {
+func TestNotifyWithoutConfigFailsRatherThanClaimingDelivery(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -17,11 +18,12 @@ func TestNotifyWithoutConfigPrintsToStdoutOnly(t *testing.T) {
 	cmd := newNotifyCmd()
 	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"hello world"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want a failure since nothing was delivered")
 	}
-	if out.String() != "notified: hello world\n" {
-		t.Fatalf("stdout = %q", out.String())
+	if !strings.Contains(err.Error(), "hello world") {
+		t.Fatalf("error = %v, want it to name the undelivered message", err)
 	}
 }
 
@@ -58,7 +60,7 @@ func TestNotifySubstitutesMessageAndExecutesTemplate(t *testing.T) {
 	}
 }
 
-func TestNotifyFailureWarnsButDoesNotBlock(t *testing.T) {
+func TestNotifyFailureIsVisibleRatherThanAWarningBehindExitZero(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -69,18 +71,10 @@ func TestNotifyFailureWarnsButDoesNotBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var out, errOut bytes.Buffer
 	cmd := newNotifyCmd()
-	cmd.SetOut(&out)
-	cmd.SetErr(&errOut)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"hello world"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(errOut.String(), "warning") {
-		t.Fatalf("stderr = %q, want warning", errOut.String())
-	}
-	if out.String() != "notified: hello world\n" {
-		t.Fatalf("stdout = %q", out.String())
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want the template's failure surfaced")
 	}
 }

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -4,19 +4,27 @@
 package notify
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
-// ErrNotConfigured means home has no config/notify template, so Send has
-// nothing to run and delivers nothing. Callers must not treat this as
-// success: the one property this package exists to protect is that "not
+// ErrNotConfigured means home has no config/notify template, or has an empty
+// one, so Send has nothing to run and delivers nothing. Callers must not treat
+// this as success: the one property this package exists to protect is that "not
 // configured" and "delivered" are never the same observable outcome.
 var ErrNotConfigured = errors.New("no config/notify")
+
+// sendTimeout bounds the template's own run. The watcher calls Send inline in
+// its poll loop, so an unbounded template - the documented example is a bare
+// curl with no --max-time - would wedge polling, --until-event's timeout and
+// shutdown alike. A var so tests can shorten it.
+var sendTimeout = 10 * time.Second
 
 // Send runs config/notify's shell command template with message available as
 // $HAND_MESSAGE, in-process rather than through the hand notify subcommand,
@@ -30,9 +38,23 @@ func Send(home, message string) error {
 		return fmt.Errorf("read config/notify: %w", err)
 	}
 
-	run := exec.Command("sh", "-c", strings.TrimSpace(string(template)))
+	command := strings.TrimSpace(string(template))
+	if command == "" {
+		return ErrNotConfigured
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
+	run := exec.CommandContext(ctx, "sh", "-c", command)
 	run.Env = append(os.Environ(), "HAND_MESSAGE="+message)
-	if out, err := run.CombinedOutput(); err != nil {
+	// Without WaitDelay, a template that backgrounds a child holding the output
+	// pipe keeps CombinedOutput waiting past the kill, defeating the timeout.
+	run.WaitDelay = time.Second
+	out, err := run.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("notify command timed out after %s: %w: %s", sendTimeout, ctxErr, strings.TrimSpace(string(out)))
+		}
 		return fmt.Errorf("notify command failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,39 @@
+// Package notify implements out-of-band delivery for hand notify and the
+// watcher's in-process notify hook: reading config/notify's shell command
+// template and running it with the message to send.
+package notify
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ErrNotConfigured means home has no config/notify template, so Send has
+// nothing to run and delivers nothing. Callers must not treat this as
+// success: the one property this package exists to protect is that "not
+// configured" and "delivered" are never the same observable outcome.
+var ErrNotConfigured = errors.New("no config/notify")
+
+// Send runs config/notify's shell command template with message available as
+// $HAND_MESSAGE, in-process rather than through the hand notify subcommand,
+// and reports whether the template actually ran and succeeded.
+func Send(home, message string) error {
+	template, err := os.ReadFile(filepath.Join(home, "config", "notify"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ErrNotConfigured
+		}
+		return fmt.Errorf("read config/notify: %w", err)
+	}
+
+	run := exec.Command("sh", "-c", strings.TrimSpace(string(template)))
+	run.Env = append(os.Environ(), "HAND_MESSAGE="+message)
+	if out, err := run.CombinedOutput(); err != nil {
+		return fmt.Errorf("notify command failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -52,6 +52,13 @@ func Send(home, message string) error {
 	run.WaitDelay = time.Second
 	out, err := run.CombinedOutput()
 	if err != nil {
+		// WaitDelay only bounds how long Send waits on a pipe an orphaned
+		// grandchild still holds ("... &" templates); the template's own process
+		// already exited 0, so the send happened. A real failure is a non-zero
+		// exit code, reported ahead of ErrWaitDelay.
+		if errors.Is(err, exec.ErrWaitDelay) && run.ProcessState != nil && run.ProcessState.Success() {
+			return nil
+		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return fmt.Errorf("notify command timed out after %s: %w: %s", sendTimeout, ctxErr, strings.TrimSpace(string(out)))
 		}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -79,6 +79,34 @@ func TestSendReportsTemplateFailureRatherThanSwallowingIt(t *testing.T) {
 	}
 }
 
+func TestSendCountsADeliveryWhoseTemplateBackgroundsAChildAsDelivered(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, "marker.txt")
+	template := "printf '%s' \"$HAND_MESSAGE\" > " + marker + "; sleep 3 &"
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	if err := Send(home, "hello world"); err != nil {
+		t.Fatalf("Send() error = %v, want nil: the template's own process exited 0, only an orphaned pipe holder lingered", err)
+	}
+	if elapsed := time.Since(start); elapsed >= sendTimeout {
+		t.Fatalf("Send() took %s, want it to stop waiting on the orphaned pipe well before sendTimeout", elapsed)
+	}
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("marker content = %q, want %q", got, "hello world")
+	}
+}
+
 func TestSendGivesUpOnAHangingTemplateRatherThanBlocking(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,63 @@
+package notify
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSendReturnsErrNotConfiguredWithNoTemplate(t *testing.T) {
+	home := t.TempDir()
+
+	err := Send(home, "hello")
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("Send() error = %v, want ErrNotConfigured", err)
+	}
+}
+
+func TestSendRunsTheTemplateWithTheMessage(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, "marker.txt")
+	template := "printf '%s' \"$HAND_MESSAGE\" > " + marker
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Send(home, "hello world"); err != nil {
+		t.Fatalf("Send() error = %v, want nil", err)
+	}
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("marker content = %q, want %q", got, "hello world")
+	}
+}
+
+func TestSendReportsTemplateFailureRatherThanSwallowingIt(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("echo boom >&2; exit 1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Send(home, "hello world")
+	if err == nil {
+		t.Fatal("Send() error = nil, want the template's failure")
+	}
+	if errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("Send() error = %v, want a failure distinct from ErrNotConfigured", err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("Send() error = %v, want it to carry the command's output", err)
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,15 +1,32 @@
 package notify
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSendReturnsErrNotConfiguredWithNoTemplate(t *testing.T) {
 	home := t.TempDir()
+
+	err := Send(home, "hello")
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("Send() error = %v, want ErrNotConfigured", err)
+	}
+}
+
+func TestSendReturnsErrNotConfiguredWithAnEmptyTemplate(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("  \n\t\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := Send(home, "hello")
 	if !errors.Is(err, ErrNotConfigured) {
@@ -59,5 +76,33 @@ func TestSendReportsTemplateFailureRatherThanSwallowingIt(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("Send() error = %v, want it to carry the command's output", err)
+	}
+}
+
+func TestSendGivesUpOnAHangingTemplateRatherThanBlocking(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("sleep 60"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := sendTimeout
+	sendTimeout = 100 * time.Millisecond
+	defer func() { sendTimeout = restore }()
+
+	start := time.Now()
+	err := Send(home, "hello world")
+	if err == nil {
+		t.Fatal("Send() error = nil, want the timeout")
+	}
+	if errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("Send() error = %v, want a timeout distinct from ErrNotConfigured", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Send() error = %v, want it to wrap context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("Send() took %s, want it bounded by sendTimeout", elapsed)
 	}
 }

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -63,10 +63,10 @@ func KnownKinds() []string {
 // same EventFilter/Matches mechanism --event already applies to gate stdout,
 // reused here as a second, independently-curated consumer of the same
 // classified event stream rather than a bespoke severity check hardcoded into
-// handleEvent. Its membership is what SPECS.md's notify section calls
-// captain-relevant. idle-unreported, stale, parked, pr-merged and the
-// pr-record-* kinds are left out - each describes a transition the poll loop
-// already tracks toward one of these five, or one that resolves itself
+// handleEvent. Its membership is the event kinds worth reaching an operator
+// who has no session watching. idle-unreported, stale, parked, pr-merged and
+// the pr-record-* kinds are left out - each describes a transition the poll
+// loop already tracks toward one of these five, or one that resolves itself
 // without a human, so notifying on it too would double up the same fact or
 // wake someone for nothing actionable.
 func NotifyFilter() EventFilter {

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -64,14 +64,19 @@ func KnownKinds() []string {
 // reused here as a second, independently-curated consumer of the same
 // classified event stream rather than a bespoke severity check hardcoded into
 // handleEvent. Its membership is the event kinds worth reaching an operator
-// who has no session watching. idle-unreported, stale, parked, pr-merged and
-// the pr-record-* kinds are left out - each describes a transition the poll
-// loop already tracks toward one of these five, or one that resolves itself
-// without a human, so notifying on it too would double up the same fact or
-// wake someone for nothing actionable.
+// who has no session watching: blocked, report-blocked, failed, report-failed,
+// report-needs-decision and report-done. report-blocked is the worker's own
+// declaration that it is stuck, independent of the herdr transition blocked
+// reports - a worker that reports blocked and then goes idle fires no other
+// notifiable kind, since ClassifyStatus suppresses idle-unreported once
+// LastReportState is set. idle-unreported, stale, parked, pr-merged and the
+// pr-record-* kinds are left out - each describes a transition the poll loop
+// already tracks toward one of these six, or one that resolves itself without a
+// human, so notifying on it too would double up the same fact or wake someone
+// for nothing actionable.
 func NotifyFilter() EventFilter {
 	return NewEventFilter([]string{
-		KindBlocked, KindFailed, KindReportFailed, KindReportNeedsDecision, KindReportDone,
+		KindBlocked, KindReportBlocked, KindFailed, KindReportFailed, KindReportNeedsDecision, KindReportDone,
 	})
 }
 

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -59,21 +59,13 @@ func KnownKinds() []string {
 	}
 }
 
-// NotifyFilter is the EventFilter for the watcher's in-process notify hook: the
-// same EventFilter/Matches mechanism --event already applies to gate stdout,
-// reused here as a second, independently-curated consumer of the same
-// classified event stream rather than a bespoke severity check hardcoded into
-// handleEvent. Its membership is the event kinds worth reaching an operator
-// who has no session watching: blocked, report-blocked, failed, report-failed,
-// report-needs-decision and report-done. report-blocked is the worker's own
-// declaration that it is stuck, independent of the herdr transition blocked
-// reports - a worker that reports blocked and then goes idle fires no other
-// notifiable kind, since ClassifyStatus suppresses idle-unreported once
-// LastReportState is set. idle-unreported, stale, parked, pr-merged and the
-// pr-record-* kinds are left out - each describes a transition the poll loop
-// already tracks toward one of these six, or one that resolves itself without a
-// human, so notifying on it too would double up the same fact or wake someone
-// for nothing actionable.
+// NotifyFilter is the EventFilter for the watcher's in-process notify hook -
+// see SPECS.md's "Notifying a supervisory agent with no session watching" for
+// why its membership differs from --event's. report-blocked has to be listed
+// even though blocked already is: it is the worker's own report-channel
+// declaration that it is stuck, not the herdr transition, and ClassifyStatus
+// suppresses idle-unreported once LastReportState is set - so a worker that
+// reports blocked and then goes idle would otherwise notify no one.
 func NotifyFilter() EventFilter {
 	return NewEventFilter([]string{
 		KindBlocked, KindReportBlocked, KindFailed, KindReportFailed, KindReportNeedsDecision, KindReportDone,

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -59,21 +59,20 @@ func KnownKinds() []string {
 	}
 }
 
-// NotifiableKinds are the event kinds worth reaching an operator with no
-// session watching for - what SPECS.md's notify section calls
+// NotifyFilter is the EventFilter for the watcher's in-process notify hook: the
+// same EventFilter/Matches mechanism --event already applies to gate stdout,
+// reused here as a second, independently-curated consumer of the same
+// classified event stream rather than a bespoke severity check hardcoded into
+// handleEvent. Its membership is what SPECS.md's notify section calls
 // captain-relevant. idle-unreported, stale, parked, pr-merged and the
-// pr-record-* kinds describe transitions the poll loop already tracks toward
-// one of these outcomes or that resolve themselves without a human, so
-// notifying on them too would double up the same fact or wake someone for
-// nothing actionable.
-func NotifiableKinds() map[string]bool {
-	return map[string]bool{
-		KindBlocked:             true,
-		KindFailed:              true,
-		KindReportFailed:        true,
-		KindReportNeedsDecision: true,
-		KindReportDone:          true,
-	}
+// pr-record-* kinds are left out - each describes a transition the poll loop
+// already tracks toward one of these five, or one that resolves itself
+// without a human, so notifying on it too would double up the same fact or
+// wake someone for nothing actionable.
+func NotifyFilter() EventFilter {
+	return NewEventFilter([]string{
+		KindBlocked, KindFailed, KindReportFailed, KindReportNeedsDecision, KindReportDone,
+	})
 }
 
 // EventFilter restricts which event kinds count as a wake for RunUntilEvent. The

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -59,6 +59,23 @@ func KnownKinds() []string {
 	}
 }
 
+// NotifiableKinds are the event kinds worth reaching an operator with no
+// session watching for - what SPECS.md's notify section calls
+// captain-relevant. idle-unreported, stale, parked, pr-merged and the
+// pr-record-* kinds describe transitions the poll loop already tracks toward
+// one of these outcomes or that resolve themselves without a human, so
+// notifying on them too would double up the same fact or wake someone for
+// nothing actionable.
+func NotifiableKinds() map[string]bool {
+	return map[string]bool{
+		KindBlocked:             true,
+		KindFailed:              true,
+		KindReportFailed:        true,
+		KindReportNeedsDecision: true,
+		KindReportDone:          true,
+	}
+}
+
 // EventFilter restricts which event kinds count as a wake for RunUntilEvent. The
 // caller expresses it directly in terms of Kind rather than against a fixed
 // actionable/progress split: report-working is exactly what distinguishes a

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -604,12 +604,9 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 	ts.PersistedChangedFor = string(ts.Status)
 }
 
-// EventFilter gates only the out write: events.log records every event
-// regardless of filter, the same way a baseline tick's events already reach it
-// without reaching stdout. The notify hook runs unconditionally too, since its
-// whole purpose is reaching an operator who left before the transition
-// happened - including one discovered on a restart's baseline tick, which is
-// exactly the case a session watching stdout would otherwise never surface.
+// EventFilter gates only the out write - events.log and the notify hook both
+// run unconditionally, so narrowing --event never narrows what reaches
+// config/notify.
 func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
 	if cfg.EventFilter.Matches(e.Kind) {
 		_, _ = fmt.Fprintln(out, e.Text)
@@ -623,16 +620,9 @@ func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
 	notifyEvent(cfg.Home, e, errOut)
 }
 
-// notifyEvent is notify's own filtered consumer of the same classified event
-// stream handleEvent's stdout write already reads from - NotifyFilter applies
-// the same EventFilter/Matches mechanism --event uses, with its own fixed
-// membership, rather than a severity test bolted onto this function. A match
-// delivers through config/notify in-process, never by shelling out to the
-// hand notify subcommand, so no caller has to wrap hand watch in a shell
-// script to get notifications. An unconfigured channel is expected on most
-// fleets and stays silent here the same way any other config/ default falls
-// back quietly; only a configured template that actually failed is loud, on
-// the same errOut diagnostics channel every other watcher failure uses.
+// notifyEvent is NotifyFilter's own consumer of the classified event stream -
+// see SPECS.md's "Notifying a supervisory agent with no session watching" for
+// why an unconfigured config/notify stays silent while a failed send is loud.
 func notifyEvent(home string, e *Event, errOut io.Writer) {
 	if !NotifyFilter().Matches(e.Kind) {
 		return

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atqamz/secondhand/internal/atomicfile"
 	"github.com/atqamz/secondhand/internal/ghutil"
 	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/secondhand/internal/notify"
 	"github.com/atqamz/secondhand/internal/project"
 	"github.com/atqamz/secondhand/internal/state"
 )
@@ -605,7 +606,10 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 
 // EventFilter gates only the out write: events.log records every event
 // regardless of filter, the same way a baseline tick's events already reach it
-// without reaching stdout.
+// without reaching stdout. The notify hook runs unconditionally too, since its
+// whole purpose is reaching an operator who left before the transition
+// happened - including one discovered on a restart's baseline tick, which is
+// exactly the case a session watching stdout would otherwise never surface.
 func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
 	if cfg.EventFilter.Matches(e.Kind) {
 		_, _ = fmt.Fprintln(out, e.Text)
@@ -614,6 +618,24 @@ func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
 	logPath := filepath.Join(state.Dir(cfg.Home), "events.log")
 	if err := appendEventLog(logPath, time.Now().UTC().Format(time.RFC3339)+" "+e.Text); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: append events.log failed: %v\n", err)
+	}
+
+	notifyEvent(cfg.Home, e, errOut)
+}
+
+// notifyEvent delivers a captain-relevant event through config/notify
+// in-process, never by shelling out to the hand notify subcommand - so no
+// caller has to wrap hand watch in a shell script to get notifications. An
+// unconfigured channel is expected on most fleets and stays silent here the
+// same way any other config/ default falls back quietly; only a configured
+// template that actually failed is loud, on the same errOut diagnostics
+// channel every other watcher failure uses.
+func notifyEvent(home string, e *Event, errOut io.Writer) {
+	if !NotifiableKinds()[e.Kind] {
+		return
+	}
+	if err := notify.Send(home, e.Text); err != nil && !errors.Is(err, notify.ErrNotConfigured) {
+		_, _ = fmt.Fprintf(errOut, "watch: notify failed: %v\n", err)
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -623,15 +623,18 @@ func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
 	notifyEvent(cfg.Home, e, errOut)
 }
 
-// notifyEvent delivers a captain-relevant event through config/notify
-// in-process, never by shelling out to the hand notify subcommand - so no
-// caller has to wrap hand watch in a shell script to get notifications. An
-// unconfigured channel is expected on most fleets and stays silent here the
-// same way any other config/ default falls back quietly; only a configured
-// template that actually failed is loud, on the same errOut diagnostics
-// channel every other watcher failure uses.
+// notifyEvent is notify's own filtered consumer of the same classified event
+// stream handleEvent's stdout write already reads from - NotifyFilter applies
+// the same EventFilter/Matches mechanism --event uses, with its own fixed
+// membership, rather than a severity test bolted onto this function. A match
+// delivers through config/notify in-process, never by shelling out to the
+// hand notify subcommand, so no caller has to wrap hand watch in a shell
+// script to get notifications. An unconfigured channel is expected on most
+// fleets and stays silent here the same way any other config/ default falls
+// back quietly; only a configured template that actually failed is loud, on
+// the same errOut diagnostics channel every other watcher failure uses.
 func notifyEvent(home string, e *Event, errOut io.Writer) {
-	if !NotifiableKinds()[e.Kind] {
+	if !NotifyFilter().Matches(e.Kind) {
 		return
 	}
 	if err := notify.Send(home, e.Text); err != nil && !errors.Is(err, notify.ErrNotConfigured) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1713,6 +1713,82 @@ func TestHandleEventSendsLogFailureToErrOut(t *testing.T) {
 	}
 }
 
+func TestHandleEventRunsConfigNotifyInProcessForANotifiableKind(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, "marker.txt")
+	template := "printf '%s' \"$HAND_MESSAGE\" > " + marker
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf, errBuf bytes.Buffer
+	handleEvent(Config{Home: home}, &Event{Kind: KindBlocked, TaskID: "task-1", Text: "blocked task-1: agent needs help"}, &buf, &errBuf)
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("config/notify was not run in-process for a blocked event: %v", err)
+	}
+	if string(got) != "blocked task-1: agent needs help" {
+		t.Fatalf("marker content = %q, want the event text", got)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("errOut = %q, want no diagnostics for a successful notify", errBuf.String())
+	}
+}
+
+func TestHandleEventSkipsConfigNotifyForANonNotifiableKind(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, "marker.txt")
+	template := "printf '%s' \"$HAND_MESSAGE\" > " + marker
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf, errBuf bytes.Buffer
+	handleEvent(Config{Home: home}, &Event{Kind: KindStale, TaskID: "task-1", Text: "stale task-1"}, &buf, &errBuf)
+
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("config/notify ran for a stale event, want it skipped: err=%v", err)
+	}
+}
+
+func TestHandleEventStaysSilentWhenNotifyIsUnconfigured(t *testing.T) {
+	home := t.TempDir()
+
+	var buf, errBuf bytes.Buffer
+	handleEvent(Config{Home: home}, &Event{Kind: KindBlocked, TaskID: "task-1", Text: "blocked task-1: agent needs help"}, &buf, &errBuf)
+
+	if errBuf.Len() != 0 {
+		t.Fatalf("errOut = %q, want no diagnostic when config/notify is simply absent", errBuf.String())
+	}
+}
+
+func TestHandleEventReportsAFailingNotifyTemplateToErrOut(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("exit 1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf, errBuf bytes.Buffer
+	handleEvent(Config{Home: home}, &Event{Kind: KindBlocked, TaskID: "task-1", Text: "blocked task-1: agent needs help"}, &buf, &errBuf)
+
+	if buf.String() != "blocked task-1: agent needs help\n" {
+		t.Fatalf("out = %q, want the event text unaffected by a failing notify", buf.String())
+	}
+	if !strings.Contains(errBuf.String(), "watch: notify failed") {
+		t.Fatalf("errOut = %q, want a notify failed diagnostic", errBuf.String())
+	}
+}
+
 func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
 	// exit 1 with empty stdout is the faithful crashed-or-missing-binary shape,
 	// which call()'s empty-stdout-plus-runErr branch handles (len(trimmed) == 0

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1713,29 +1713,40 @@ func TestHandleEventSendsLogFailureToErrOut(t *testing.T) {
 	}
 }
 
-func TestHandleEventRunsConfigNotifyInProcessForANotifiableKind(t *testing.T) {
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	marker := filepath.Join(home, "marker.txt")
-	template := "printf '%s' \"$HAND_MESSAGE\" > " + marker
-	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
-		t.Fatal(err)
-	}
+func TestHandleEventRunsConfigNotifyInProcessForEveryNotifiableKind(t *testing.T) {
+	for _, e := range []Event{
+		{Kind: KindBlocked, TaskID: "task-1", Text: "blocked task-1: agent needs help"},
+		{Kind: KindReportBlocked, TaskID: "task-1", Text: "report-blocked task-1: waiting on credentials"},
+		{Kind: KindFailed, TaskID: "task-1", Text: "failed task-1"},
+		{Kind: KindReportFailed, TaskID: "task-1", Text: "report-failed task-1: build broke"},
+		{Kind: KindReportNeedsDecision, TaskID: "task-1", Text: "needs-decision task-1: which API?"},
+		{Kind: KindReportDone, TaskID: "task-1", Text: "done task-1"},
+	} {
+		t.Run(e.Kind, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			marker := filepath.Join(home, "marker.txt")
+			template := "printf '%s' \"$HAND_MESSAGE\" > " + marker
+			if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	var buf, errBuf bytes.Buffer
-	handleEvent(Config{Home: home}, &Event{Kind: KindBlocked, TaskID: "task-1", Text: "blocked task-1: agent needs help"}, &buf, &errBuf)
+			var buf, errBuf bytes.Buffer
+			handleEvent(Config{Home: home}, &e, &buf, &errBuf)
 
-	got, err := os.ReadFile(marker)
-	if err != nil {
-		t.Fatalf("config/notify was not run in-process for a blocked event: %v", err)
-	}
-	if string(got) != "blocked task-1: agent needs help" {
-		t.Fatalf("marker content = %q, want the event text", got)
-	}
-	if errBuf.Len() != 0 {
-		t.Fatalf("errOut = %q, want no diagnostics for a successful notify", errBuf.String())
+			got, err := os.ReadFile(marker)
+			if err != nil {
+				t.Fatalf("config/notify was not run in-process for a %s event: %v", e.Kind, err)
+			}
+			if string(got) != e.Text {
+				t.Fatalf("marker content = %q, want the event text %q", got, e.Text)
+			}
+			if errBuf.Len() != 0 {
+				t.Fatalf("errOut = %q, want no diagnostics for a successful notify", errBuf.String())
+			}
+		})
 	}
 }
 

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -14,11 +14,12 @@ import (
 
 // realBinsOnPath are the only real executables this suite needs to resolve:
 // git, which both hand and the test helpers shell out to for real; sh, which
-// cmd/notify.go execs to run a notify template; and cat, which the fake herdr
-// scripts below use to read a pane's status file. Everything hand execs that is
-// not listed here is faked per test (backendsThisSuiteFakes, e2e_test.go), so
-// leaving those unreachable turns a missing fake into a loud failure instead of
-// a call against the developer's real tools.
+// internal/notify execs to run a notify template (from both cmd/notify.go and
+// the watcher's in-process hook); and cat, which the fake herdr scripts below
+// use to read a pane's status file. Everything hand execs that is not listed
+// here is faked per test (backendsThisSuiteFakes, e2e_test.go), so leaving
+// those unreachable turns a missing fake into a loud failure instead of a call
+// against the developer's real tools.
 var realBinsOnPath = []string{"git", "sh", "cat"}
 
 // hermeticPath is the PATH every test runs under, built once by TestMain from

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -329,6 +329,56 @@ func TestWatchUntilEventWakesOnlyOnTheFilteredKind(t *testing.T) {
 	}
 }
 
+// The notify template writes $HAND_MESSAGE straight to a marker file with no
+// wrapper script of any kind, so a marker that ends up holding the exact event
+// text is only possible if hand watch invoked config/notify in-process itself -
+// the two hard requirements the wiring exists to satisfy.
+func TestWatchNotifiesInProcessForABlockedEvent(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "direct-pr")
+
+	marker := filepath.Join(home, "notify-marker.txt")
+	writeConfig(t, home, "notify", "printf '%s' \"$HAND_MESSAGE\" > "+marker)
+
+	if err := state.Write(home, state.Task{
+		ID: "task-1", Project: "demo", Kind: state.KindShip,
+		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	statusDir := t.TempDir()
+	setPaneStatus(t, statusDir, "pane-1", "working")
+	herdrLog := filepath.Join(t.TempDir(), "herdr-invocations.log")
+	writeFakeHerdrWatch(t, binDir(t), statusDir, herdrLog)
+
+	watch := startHandBackground(t, home, "watch", "--poll", "30ms")
+	waitForInvocation(t, herdrLog, "herdr pane get pane-1", 5*time.Second)
+
+	setPaneStatus(t, statusDir, "pane-1", "blocked")
+	watch.waitForStdout(t, "blocked task-1: agent needs help", 5*time.Second)
+
+	deadline := time.Now().Add(5 * time.Second)
+	var got []byte
+	for time.Now().Before(deadline) {
+		var err error
+		got, err = os.ReadFile(marker)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if string(got) != "blocked task-1: agent needs help" {
+		t.Fatalf("notify marker = %q, want the event text delivered by config/notify in-process", got)
+	}
+
+	result := watch.stop(t, 3*time.Second)
+	if result.code != 0 {
+		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
+	}
+}
+
 // A task first sighted with its pane already unreachable - a re-scan picking up a
 // fresh spawn - has no probed-to-unprobed edge to fire `failed` on, and used to be
 // dropped from tracking entirely. The blink task is the other half of the contract:


### PR DESCRIPTION
## Intent

Wire hand notify into the watcher (atqamz/secondhand#80) so fleet events reach the operator through config/notify with no session awake: call internal/notify.Send in-process from the poll loop's classified event stream rather than shelling out to the notify subcommand, and express notify's kind selection via the same EventFilter/Matches mechanism --event already uses for stdout rather than a hardcoded severity check.

## What Changed

- Extracted `hand notify`'s config/notify template execution into a new `internal/notify` package whose `Send` reports `ErrNotConfigured` for a missing or empty template, bounds the template run with a 10s `exec.CommandContext` deadline plus a `WaitDelay` (treating a backgrounded template whose own process exited 0 as delivered), and made `hand notify` exit 1 instead of printing `notified:` when nothing was actually delivered.
- Hooked the watcher's poll loop into that package: `handleEvent` now calls `notifyEvent`, which selects kinds through a new `watcher.NotifyFilter()` built on the same `EventFilter`/`Matches` mechanism `--event` uses (blocked, report-blocked, failed, report-failed, report-needs-decision, report-done), sends in-process rather than shelling out to `hand notify`, stays silent when config/notify is absent, and reports a real template failure on the watcher's errOut.
- Documented the hook in SPECS.md and README.md, and added unit coverage in `internal/notify`, `internal/watcher`, plus an e2e `hand watch` test that a blocked event fires the configured template without spawning a `hand notify` process.

## Risk Assessment

ok: Low: Both round-2 findings are fixed correctly and covered by new tests, the notify wiring matches the stated intent (in-process Send from the classified event stream, kind selection through the same EventFilter/Matches mechanism), and the only behavior break - hand notify exiting 1 on an unconfigured home - is a deliberate, SPECS-documented decision the author already confirmed.

## Testing

Ran the targeted notify, watcher-handleEvent/filter, cmd notify and tagged e2e watch-notify tests under -race (all pass), then drove the real `hand` binary through a full operator scenario in a temporary fleet home: init, project registration, spawn against a faked herdr, a real config/notify template, and a backgrounded `hand watch` receiving worker report lines. The captured transcript shows the notifiable kinds (needs-decision, report-blocked, blocked, reported-done) arriving in the operator's inbox while `working` stayed stdout-only, no `hand notify` subprocess in the PATH-shim log, a `--event stale` run printing nothing yet still notifying, `watch: notify failed: ... exit status 7` on stderr for a broken template with polling unaffected, and `hand notify` exiting 1 rather than claiming delivery when unconfigured. This is a CLI-only change, so the evidence is a CLI transcript plus the resulting notification log rather than visual artifacts; scratch state (worktree runtime dirs, temp home/binary, the spawned treehouse worktree) was removed afterwards.

<details>
<summary>Evidence: hand watch notify end-to-end CLI transcript</summary>

<code>$ hand watch stdout # the classified event stream a live session would have seen&#10;working task-1: reading the watcher poll loop&#10;needs-decision task-1: keep the shell-out fallback or drop it?&#10;report-blocked task-1: waiting on the staging API credentials&#10;blocked task-1: agent needs help&#10;report-failed task-1: the build never recovered&#10;reported-done task-1: pushed the branch&#10;&#10;$ cat operator-inbox.log # what actually reached the operator with no session awake&#10;[fleet notification] needs-decision task-1: keep the shell-out fallback or drop it?&#10;[fleet notification] report-blocked task-1: waiting on the staging API credentials&#10;[fleet notification] blocked task-1: agent needs help&#10;[fleet notification] reported-done task-1: pushed the branch&#10;&#10;$ grep &#39;notify&#39; over every &#39;hand ...&#39; process run while watch polled&#10;--- all hand invocations recorded by the PATH shim ---&#10;hand init&#10;hand project list&#10;hand spawn task-1 demo --skip-gate-check&#10;hand watch --poll 200ms&#10;--- of those, any &#39;hand notify&#39; shell-out ---&#10;(none: watch delivered every notification through notify.Send in-process)&#10;&#10;$ hand watch stderr # the one loud case: a configured channel that failed&#10;watch: notify failed: notify command failed: exit status 7:&#10;&#10;$ hand watch --until-event --event stale --timeout 6s # stdout filtered to &#39;stale&#39; only; notify keeps its own kind selection&#10;worker appended to state/task-1.status: needs-decision: ship it now or wait for review?&#10;exit 4 (timed out: no stale event, exactly as --event asked)&#10;--- that run&#39;s stdout ---&#10;(empty: needs-decision is not in --event stale)&#10;--- what the notify channel delivered during that same run ---&#10;[fleet notification] needs-decision task-1: ship it now or wait for review?</code>

```text

$ hand init
initialized secondhand home at /tmp/hand-manual-check/run/home

$ register the project: a clone under projects/ plus one line in data/projects.md
demo  https://example.com/demo.git  local-only

$ cat config/notify   # the operator's out-of-band channel, a plain shell template
printf "[fleet notification] %s\n" "$HAND_MESSAGE" >> /tmp/hand-manual-check/run/operator-inbox.log

$ hand spawn task-1 demo --skip-gate-check
spawned task-1 project=demo kind=ship harness=claude worktree=/home/atqa/.treehouse/demo-6e3dff/2/demo

$ hand watch --poll 200ms   # started, then the operator walks away: nobody is reading this stdout

$ the worker reports its own progress into state/task-1.status while nobody watches
worker appended to state/task-1.status: working: reading the watcher poll loop
worker appended to state/task-1.status: needs-decision: keep the shell-out fallback or drop it?
worker appended to state/task-1.status: blocked: waiting on the staging API credentials

$ the worker's herdr pane also goes blocked (a transition the worker never reports itself)

$ the notify channel breaks (expired token, webhook down): template now exits non-zero
worker appended to state/task-1.status: failed: the build never recovered

$ channel restored, worker finishes
worker appended to state/task-1.status: done: pushed the branch
hand watch exited 0 on SIGTERM

$ hand watch stdout   # the classified event stream a live session would have seen
working task-1: reading the watcher poll loop
needs-decision task-1: keep the shell-out fallback or drop it?
report-blocked task-1: waiting on the staging API credentials
blocked task-1: agent needs help
report-failed task-1: the build never recovered
reported-done task-1: pushed the branch

$ cat operator-inbox.log   # what actually reached the operator with no session awake
[fleet notification] needs-decision task-1: keep the shell-out fallback or drop it?
[fleet notification] report-blocked task-1: waiting on the staging API credentials
[fleet notification] blocked task-1: agent needs help
[fleet notification] reported-done task-1: pushed the branch

$ grep 'notify' over every 'hand ...' process run while watch polled
--- all hand invocations recorded by the PATH shim ---
hand init
hand project list
hand spawn task-1 demo --skip-gate-check
hand watch --poll 200ms
--- of those, any 'hand notify' shell-out ---
(none: watch delivered every notification through notify.Send in-process)

$ hand watch stderr   # the one loud case: a configured channel that failed
watch: notify failed: notify command failed: exit status 7: 

$ hand watch --until-event --event stale --timeout 6s   # stdout filtered to 'stale' only; notify keeps its own kind selection
worker appended to state/task-1.status: needs-decision: ship it now or wait for review?
exit 4 (timed out: no stale event, exactly as --event asked)
--- that run's stdout ---
(empty: needs-decision is not in --event stale)
--- what the notify channel delivered during that same run ---
[fleet notification] needs-decision task-1: ship it now or wait for review?

$ hand notify 'manual ping from the operator'   # the subcommand delivers through the same path
notified: manual ping from the operator

$ rm config/notify && hand notify 'nothing is listening'   # unconfigured is a failure, never a silent success
config/notify not set up, nothing delivered: nothing is listening
exit code 1

$ cat operator-inbox.log   # final inbox contents
[fleet notification] needs-decision task-1: keep the shell-out fallback or drop it?
[fleet notification] report-blocked task-1: waiting on the staging API credentials
[fleet notification] blocked task-1: agent needs help
[fleet notification] reported-done task-1: pushed the branch
[fleet notification] needs-decision task-1: ship it now or wait for review?
[fleet notification] manual ping from the operator
```
</details>
<details>
<summary>Evidence: operator notification log written by config/notify</summary>

<code>[fleet notification] needs-decision task-1: keep the shell-out fallback or drop it?&#10;[fleet notification] report-blocked task-1: waiting on the staging API credentials&#10;[fleet notification] blocked task-1: agent needs help&#10;[fleet notification] reported-done task-1: pushed the branch&#10;[fleet notification] needs-decision task-1: ship it now or wait for review?&#10;[fleet notification] manual ping from the operator</code>

```text
[fleet notification] needs-decision task-1: keep the shell-out fallback or drop it?
[fleet notification] report-blocked task-1: waiting on the staging API credentials
[fleet notification] blocked task-1: agent needs help
[fleet notification] reported-done task-1: pushed the branch
[fleet notification] needs-decision task-1: ship it now or wait for review?
[fleet notification] manual ping from the operator
```
</details>
<details>
<summary>Evidence: manual verification script that produced the transcript</summary>

```text
set -eu

ROOT=/tmp/hand-manual-check
RUN=$ROOT/run
rm -rf "$RUN"
mkdir -p "$RUN/bin" "$RUN/status" "$RUN/home"
HOME_DIR=$RUN/home
INBOX=$RUN/operator-inbox.log
SHIMLOG=$RUN/hand-subprocess-invocations.log
: > "$INBOX"
: > "$SHIMLOG"

cat > "$RUN/bin/herdr" <<EOF
#!/bin/sh
case "\$1 \$2" in
  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
  "workspace create") echo '{"result":{"workspace":{"workspace_id":"w-1","label":"demo","tab_count":1},"tab":{"tab_id":"t-1","workspace_id":"w-1","label":"1"},"root_pane":{"pane_id":"pane-1","tab_id":"t-1","workspace_id":"w-1","agent_status":"working"}}}' ;;
  "tab rename") echo '{"result":{"tab":{"tab_id":"t-1","workspace_id":"w-1","label":"task-1"}}}' ;;
  "pane run") ;;
  "pane send-text") ;;
  "pane send-keys") ;;
  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
  "pane get")
    status=\$(cat "$RUN/status/\$3" 2>/dev/null || echo working)
    printf '{"result":{"pane":{"pane_id":"%s","tab_id":"t-1","workspace_id":"w-1","agent":"claude","agent_status":"%s"}}}\n' "\$3" "\$status"
    ;;
  *) echo "unexpected herdr invocation: \$@" >&2; exit 1 ;;
esac
EOF
chmod +x "$RUN/bin/herdr"

cat > "$RUN/bin/hand" <<EOF
#!/bin/sh
echo "hand \$@" >> "$SHIMLOG"
exec $ROOT/bin/hand-real "\$@"
EOF
chmod +x "$RUN/bin/hand"

cat > "$RUN/bin/claude" <<'EOF'
#!/bin/sh
exit 0
EOF
chmod +x "$RUN/bin/claude"

export PATH="$RUN/bin:$PATH"
export GIT_CONFIG_GLOBAL=$RUN/gitconfig
export GIT_CONFIG_SYSTEM=/dev/null
git config --file "$RUN/gitconfig" user.name tester
git config --file "$RUN/gitconfig" user.email tester@example.com
git config --file "$RUN/gitconfig" init.defaultBranch main

mkdir -p "$RUN/upstream"
git -C "$RUN/upstream" init -q
echo hello > "$RUN/upstream/README.md"
git -C "$RUN/upstream" add -A
git -C "$RUN/upstream" commit -qm "initial commit"

step() { printf '\n$ %s\n' "$*"; }

cd "$HOME_DIR"

step hand init
hand init

step "register the project: a clone under projects/ plus one line in data/projects.md"
git clone -q "$RUN/upstream" "$HOME_DIR/projects/demo"
printf -- '- demo: https://example.com/demo.git mode=local-only\n' >> "$HOME_DIR/data/projects.md"
hand project list

step "cat config/notify   # the operator's out-of-band channel, a plain shell template"
printf 'printf "[fleet notification] %%s\\n" "$HAND_MESSAGE" >> %s\n' "$INBOX" > "$HOME_DIR/config/notify"
cat "$HOME_DIR/config/notify"

mkdir -p "$HOME_DIR/data/task-1"
printf '# brief\n\nWire hand notify into the watcher.\n' > "$HOME_DIR/data/task-1/brief.md"

step hand spawn task-1 demo --skip-gate-check
hand spawn task-1 demo --skip-gate-check

step "hand watch --poll 200ms   # started, then the operator walks away: nobody is reading this stdout"
hand watch --poll 200ms > "$RUN/watch.stdout" 2> "$RUN/watch.stderr" &
WATCH_PID=$!
trap 'kill "$WATCH_PID" 2>/dev/null || true' EXIT
sleep 2

REPORT=$HOME_DIR/state/task-1.status
worker() {
  printf '%s\n' "$1" >> "$REPORT"
  printf 'worker appended to state/task-1.status: %s\n' "$1"
  sleep 1.5
}

step "the worker reports its own progress into state/task-1.status while nobody watches"
worker "working: reading the watcher poll loop"
worker "needs-decision: keep the shell-out fallback or drop it?"
worker "blocked: waiting on the staging API credentials"

step "the worker's herdr pane also goes blocked (a transition the worker never reports itself)"
printf 'blocked' > "$RUN/status/pane-1"
sleep 1.5
printf 'working' > "$RUN/status/pane-1"
sleep 1.5

step "the notify channel breaks (expired token, webhook down): template now exits non-zero"
printf 'exit 7\n' > "$HOME_DIR/config/notify"
worker "failed: the build never recovered"

step "channel restored, worker finishes"
printf 'printf "[fleet notification] %%s\\n" "$HAND_MESSAGE" >> %s\n' "$INBOX" > "$HOME_DIR/config/notify"
worker "done: pushed the branch"

sleep 1
cp "$SHIMLOG" "$RUN/hand-subprocess-invocations.during-watch.log"
kill -TERM "$WATCH_PID"
if wait "$WATCH_PID"; then echo "hand watch exited 0 on SIGTERM"; else echo "hand watch exited $?"; fi
trap - EXIT

step "hand watch stdout   # the classified event stream a live session would have seen"
cat "$RUN/watch.stdout"

step "cat operator-inbox.log   # what actually reached the operator with no session awake"
cat "$INBOX"

step "grep 'notify' over every 'hand ...' process run while watch polled"
echo "--- all hand invocations recorded by the PATH shim ---"
cat "$RUN/hand-subprocess-invocations.during-watch.log"
echo "--- of those, any 'hand notify' shell-out ---"
if grep -q "hand notify" "$RUN/hand-subprocess-invocations.during-watch.log"; then
  grep "hand notify" "$RUN/hand-subprocess-invocations.during-watch.log"
  echo "UNEXPECTED: watch shelled out to the notify subcommand"
else
  echo "(none: watch delivered every notification through notify.Send in-process)"
fi

step "hand watch stderr   # the one loud case: a configured channel that failed"
cat "$RUN/watch.stderr"

step "hand watch --until-event --event stale --timeout 6s   # stdout filtered to 'stale' only; notify keeps its own kind selection"
: > "$RUN/inbox-during-filtered-watch.log"
INBOX_BEFORE=$(wc -l < "$INBOX")
hand watch --until-event --event stale --timeout 6s --poll 200ms > "$RUN/watch-filtered.stdout" 2> "$RUN/watch-filtered.stderr" &
FILTERED_PID=$!
sleep 2
printf 'needs-decision: ship it now or wait for review?\n' >> "$REPORT"
echo "worker appended to state/task-1.status: needs-decision: ship it now or wait for review?"
if wait "$FILTERED_PID"; then echo "exit 0 (woke on a stale event)"; else echo "exit $? (timed out: no stale event, exactly as --event asked)"; fi
echo "--- that run's stdout ---"
cat "$RUN/watch-filtered.stdout"
echo "(empty: needs-decision is not in --event stale)"
echo "--- what the notify channel delivered during that same run ---"
tail -n +$((INBOX_BEFORE + 1)) "$INBOX"

step "hand notify 'manual ping from the operator'   # the subcommand delivers through the same path"
hand notify "manual ping from the operator"

step "rm config/notify && hand notify 'nothing is listening'   # unconfigured is a failure, never a silent success"
rm "$HOME_DIR/config/notify"
if hand notify "nothing is listening"; then
  echo "UNEXPECTED: exit 0 with nothing delivered"
else
  echo "exit code $?"
fi

step "cat operator-inbox.log   # final inbox contents"
cat "$INBOX"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>fix: **Review** - 5 issues found -> auto-fixed (2) ok:</summary>

- warning: `internal/notify/notify.go:35` - notify.Send executes the config/notify template with exec.Command + CombinedOutput, with no context and no timeout, and handleEvent (internal/watcher/watcher.go:640) calls it synchronously inside tick&#39;s per-task loop. A template that hangs - SPECS&#39; own recommended example is `curl -s -X POST https://api.telegram.org/...` with no --max-time - blocks the entire watcher indefinitely: no further poll ticks, --until-event&#39;s --timeout never fires because the ctx.Done() select at watcher.go:104 is never reached, and SIGTERM shutdown cannot complete. The adjacent external call in the same loop (ghutil.PRIsMerged, watcher.go:231) is explicitly bounded with context.WithTimeout(ctx, 30*time.Second), so this is the only unbounded external command in the poll loop. Fix at the shared boundary: take a ctx in notify.Send, use exec.CommandContext with a bounded timeout, and thread ctx from tick through handleEvent/notifyEvent.
- warning: `internal/notify/notify.go:33` - An existing but empty (or whitespace-only) config/notify passes the os.IsNotExist check, then runs `sh -c &#34;&#34;`, which exits 0, so Send returns nil and hand notify prints `notified: &lt;message&gt;` having delivered nothing. That is precisely the outcome ErrNotConfigured&#39;s doc comment states this package exists to prevent (&#34;&#39;not configured&#39; and &#39;delivered&#39; are never the same observable outcome&#34;), and it is reachable by an operator who runs `touch config/notify` or truncates the file. Treat a template that is empty after strings.TrimSpace as ErrNotConfigured.
- warning: `cmd/notify.go:29` - hand notify&#39;s observable contract changed: an absent config/notify used to exit 0 and print `notified: &lt;message&gt;`, and now exits 1 with no stdout line. SPECS (line 1189) states `hand init --setup` never writes config/notify, so on any fresh fleet home every `hand notify` invocation now fails with exit 1. The stated intent is wiring notify into the watcher and expressing kind selection as an EventFilter; changing the standalone CLI&#39;s exit contract is an additional deliberate decision (documented in SPECS&#39; Errors section) that breaks any existing operator script or agent instruction calling hand notify on an unconfigured home. Confirm this contract break is wanted rather than only having internal/notify.Send report undelivered to the watcher.
- info: `SPECS.md:986` - The watcher notify-hook section justifies its non-blocking behavior as &#34;matching `hand notify`&#39;s own &#39;notification failure never blocks work&#39; contract&#34;, but this same change deleted that contract from the hand notify section - a failing template there is now exit 1, not a warn-and-continue. The citation points at behavior that no longer exists; restate the justification in terms of the watcher&#39;s own error-output rule instead.
- info: `internal/watcher/watcher.go:623` - notifyEvent runs on RunUntilEvent&#39;s two baseline ticks (watcher.go:97-98) where out is io.Discard, so a KindFailed re-fired by ClassifyUnreachable after each restart is suppressed from stdout but still delivered to the operator&#39;s live channel. A supervisory agent re-arming --until-event in a tight loop while one pane stays unreachable therefore sends one duplicate notification per re-arm. SPECS documents and accepts this tradeoff explicitly (non-persisted UnreachableFired, &#34;no additional rate limiting is added on top of it&#34;), so this is noted rather than blocking - only the fact that the amplification is per-restart on a delivery channel, not per-episode.

fix: Fix: bound notify send with a timeout, reject empty template
4 issues (2 warnings, 2 infos) still open:
- warning: `internal/watcher/events.go:74` - NotifyFilter includes KindBlocked (herdr pane status flipped to blocked) but omits KindReportBlocked, the worker&#39;s own `blocked: &lt;reason&gt;` report line - which SPECS&#39; &#34;Report channel&#34; defines as &#34;the worker is stuck and needs help&#34;, i.e. exactly the AFK-actionable case this hook exists for. The two signals are independent: a worker that appends `blocked: waiting on credentials` and then goes idle produces report-blocked (not notified), and ClassifyStatus&#39;s NotBusy branch (events.go:214) suppresses idle-unreported precisely because LastReportState is set, so no notifiable kind ever fires for that task. The operator with no session watching learns nothing about a worker that explicitly declared itself stuck. The exclusion also looks unintended rather than curated: SPECS&#39; rationale enumerates the left-out kinds as &#34;idle-unreported, stale, parked, pr-merged and the pr-record-* kinds&#34; and never mentions report-blocked (nor report-paused/report-working/report-malformed, which are also excluded). Confirm whether report-blocked should join the notifiable set, and make the SPECS/doc-comment exclusion list account for every kind actually left out.
- warning: `internal/notify/notify.go:52` - run.WaitDelay = time.Second makes a template that backgrounds a child inheriting the output pipe report a failure it did not have. For `curl -X POST ... &amp;` (or `notify-send &#34;$HAND_MESSAGE&#34; &amp;`), sh exits 0 immediately, the grandchild keeps the CombinedOutput pipe open, and one second later Wait returns exec.ErrWaitDelay; ctx.Err() is nil, so Send falls into the generic branch and returns &#34;notify command failed: exec: WaitDelay expired first&#34;. Observable effect: `hand notify` exits 1 on a delivery that succeeded, and the watcher prints a bogus &#34;watch: notify failed&#34; diagnostic - the inverse of the property ErrNotConfigured&#39;s doc comment protects. WaitDelay itself is needed for the timeout to bite, so the fix is in the error branch: when errors.Is(err, exec.ErrWaitDelay) and run.ProcessState.ExitCode() == 0 (ctx not expired), the template ran and succeeded, so return nil rather than an error.
- info: `internal/watcher/events.go:74` - KindReportDone fires twice per ship task in the ordinary ordering - once unverified from classifyReportDone (&#34;reported-done &lt;id&gt;: ...&#34;, events.go:359) and again from ClassifyDeferredDone when merge evidence lands (&#34;done &lt;id&gt;: ...&#34;, events.go:374) - so a notifiable channel gets two pings for one task completion. Both are genuinely distinct facts (claim vs verified), so this reads as an accepted tradeoff rather than a defect, but SPECS documents only the `failed`/UnreachableFired duplicate under &#34;duplicate over silence&#34; while asserting the excluded kinds avoid &#34;doubling up the same fact&#34;; this second duplicate is undocumented.
- info: `internal/notify/notify.go:46` - Send builds its own context.Background()-rooted deadline rather than deriving from the watcher&#39;s ctx, which is the containment shape explicitly requested. The wedge is genuinely closed (a hanging template can no longer block polling indefinitely), with two bounded residuals worth knowing: a tick with N notifiable events can overrun --until-event&#39;s --timeout by up to N*11s, since tick&#39;s only cancellation check is at the top of the per-task loop (watcher.go:184) and the send sits inside handleEvent; and SIGTERM cannot cancel an in-flight send, so shutdown can lag ~11s. Threading ctx through handleEvent/notifyEvent would collapse both to the deadline itself if that ever matters.

fix: Fix: notify report-blocked, treat backgrounded template as delivered
ok: Re-checked - no issues remain.

</details>

<details>
<summary>ok: **Test** - passed</summary>

ok: No issues found.
- `go test -race ./internal/notify/...`
- `go test -race -run 'TestSend|TestNotify' ./internal/notify/... ./cmd/...`
- `go test -race -run 'TestHandleEvent|NotifyFilter|EventFilter' ./internal/watcher/...`
- `go test -tags=e2e -run TestWatchNotifiesInProcessForABlockedEvent ./tests/e2e/...`
- <code>Manual end-to-end: built `hand`, `hand init`, project registered, `hand spawn task-1 demo --skip-gate-check` against a faked `herdr`, real `config/notify` template, `hand watch --poll 200ms` in background while worker report lines were appended to `state/task-1.status`</code>
- <code>Manual: PATH `hand` shim logging every `hand ...` process during the watch window to prove no `hand notify` shell-out</code>
- <code>Manual: `hand watch --until-event --event stale --timeout 6s` while a `needs-decision` report landed, to separate stdout filtering from notify kind selection</code>
- <code>Manual: `config/notify` replaced with `exit 7` to check the stderr diagnostic, then restored</code>
- <code>Manual: `hand notify &#39;manual ping from the operator&#39;`, then `rm config/notify &amp;&amp; hand notify &#39;nothing is listening&#39;` (exit 1)</code>

</details>

<details>
<summary>⏭ **Document** - skipped</summary>

- info: `SPECS.md:970` - SPECS.md&#39;s &#34;Notifying a supervisory agent with no session watching&#34; (lines 970-1003) and the doc comments on internal/watcher.NotifyFilter, watcher.notifyEvent and internal/notify.Send now carry the same rationale nearly sentence-for-sentence (NotifyFilter membership and each excluded kind, the silent-unconfigured vs loud-failure split, the inline-send timeout reason). Both surfaces are legitimate owners under the policy - SPECS owns the design contract, code comments own local non-obvious intent - so nothing here is stale, but the two copies will drift the next time the filter membership changes. Left as-is rather than trimming either side, since deciding which sentences belong only in SPECS is a wider consolidation than this change warrants; worth a follow-up pass over the watcher&#39;s spec-vs-comment split.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>



Closes atqamz/secondhand#80
