### PR TITLE
fix(worktree): key the collision guard on the treehouse lease id

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,10 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # A full major.minor.patch pin resolves locally; "latest" makes the
+          # action fetch a remote version mapping that fails the job on any
+          # network blip. Keep in sync with nixpkgs' golangci-lint in flake.nix.
+          version: v2.12.2
 
   test:
     name: Test (${{ matrix.os }})

--- a/SPECS.md
+++ b/SPECS.md
@@ -367,8 +367,8 @@ Behavior:
 3. Validate no active task with this ID exists.
 4. Validate no hold is set on this ID (see "Holds" under "State management"). A hold survives the teardown of the task it was set on, so reusing the id for new work would reattach the previous incarnation's open question to an unrelated task; the error names `hand hold clear <id>` as the remedy.
 5. Validate `data/<id>/brief.md` exists (the agent must write it before spawning).
-6. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd).
-7. **Collision guard:** cross-check the acquired worktree path against all active tasks' recorded worktree paths in the store. If the path matches another active task, return the worktree to treehouse and fail with an error naming the conflicting task. This prevents the stale-lease-after-crash bug (firstmate #947).
+6. Acquire a treehouse worktree: `treehouse get --lease --json --lease-holder hand:<id>`, run inside the project clone (treehouse resolves the pool from cwd). Both the slot path and the lease identity treehouse returns are kept, and both are recorded on the task row.
+7. **Collision guard:** cross-check the acquired lease against every other task row in the store. If one matches, return the worktree to treehouse and fail with an error naming the conflicting task. See "Collision guard" under "State management" for what counts as a match, and why it is the lease identity rather than the worktree path.
 8. Acquire the task's herdr tab in the project's workspace.
    - Workspace and tab labels: one workspace per project, one tab per task - see "Workspace and
      tab model" under "Herdr integration detail" for the labels themselves.
@@ -442,7 +442,8 @@ Task row written to the `task` table in `state/hand.db`, one column per field be
   "last_report_state": "",
   "last_report_note": "",
   "send_undelivered_message": "",
-  "send_undelivered_at": ""
+  "send_undelivered_at": "",
+  "lease_id": "5fe5412a4aabdeb85a148d6d73eb42d8"
 }
 ```
 
@@ -1145,7 +1146,7 @@ Behavior:
 4. Acquire a fresh treehouse worktree (with collision guard).
 5. Acquire the task's herdr tab in the project's workspace - same workspace-create-vs-reuse logic as `hand spawn` step 8, including reusing a freshly created workspace's own root tab instead of leaving it as an orphan.
 6. Launch the worker and confirm it started (same as `hand spawn`).
-7. Rewrite the task's row in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree` and the `herdr` coordinates describe the new worker. Every field anchored to the scout's pane is reset: `done_verified` to false, `status_changed_at` restamped to the promotion time with `status_changed_for` cleared, and `last_report_state` / `last_report_note` emptied. Every pane-independent field is carried, including `created_at` and the watcher's `report_offset` - see "Pane-anchored facts across `hand promote`", which classifies each of them and covers the matching in-memory cache a live `hand watch` has to drop.
+7. Rewrite the task's row in place: `kind` changes from `scout` to `ship`, and `harness`, `model`, `effort`, `worktree`, `lease_id` and the `herdr` coordinates describe the new worker. Every field anchored to the scout's pane is reset: `done_verified` to false, `status_changed_at` restamped to the promotion time with `status_changed_for` cleared, and `last_report_state` / `last_report_note` emptied. Every pane-independent field is carried, including `created_at` and the watcher's `report_offset` - see "Pane-anchored facts across `hand promote`", which classifies each of them and covers the matching in-memory cache a live `hand watch` has to drop.
 8. Only now tear down the scout's herdr tab and return its worktree; a failure here is a warning, not an error.
 
 The scout side is torn down last on purpose: the same rollback contract as `hand spawn` applies up
@@ -1888,6 +1889,26 @@ Set with `hand hold set`, which upserts - a second call on the same id replaces 
 - **Concurrent tasks on same project:** allowed. Each gets its own treehouse worktree. The collision guard in `hand spawn` prevents worktree overlap. File-level conflicts are resolved at merge time (rebase or conflict resolution), not at spawn time. The agent should avoid spawning tasks that touch the same files when possible, but this is a judgment call, not an enforced constraint.
 - **No session lock.** Multiple supervisory sessions can run `hand` commands. The agent is responsible for not conflicting with itself. sqlite's own locking prevents corruption; duplicate work is an agent-level problem, not a CLI-level problem.
 - **No daemon and no connection pool.** Every command opens the database, does its work and closes it, on a single connection (see "Not Postgres, and no daemon").
+
+### Collision guard
+
+`hand spawn` and `hand promote` both acquire a worktree and then cross-check it against every other task row before committing to it.
+What they compare is the lease identity treehouse mints per acquisition (`lease_id` in `treehouse get --lease --json`, recorded on the task row), not the worktree path.
+
+The path is the wrong key because treehouse recycles it.
+A pool slot returned to its pool keeps its directory and is handed straight back out to the next task under a brand-new identity: treehouse regenerates `lease_id` on every acquisition, including a same-holder reacquisition of the same slot, so the identity is the only part of a lease that is never reused.
+
+Keying on the path produced a false positive, not a missed collision.
+`hand teardown` returns the worktree before it removes the task's row, deliberately, so a fault in the later step leaves the whole command retryable (see `hand teardown`).
+If that removal does fail, the row survives naming a path treehouse has already freed; the next spawn or promote legitimately acquires that path, matches the stale row on path equality, force-returns its own exclusive lease and fails over a collision that never existed concurrently.
+The guard cannot miss a real one: `worktree.Get` always passes `--lease`, and treehouse's pool lock refuses to hand out a currently-leased slot, so two tasks cannot concurrently hold one path in the first place.
+It is defense-in-depth against `hand`'s own bookkeeping going stale, and the older claim that it prevented the stale-lease-after-crash bug (firstmate #947) was wrong: that bug was pid-based ownership, which `hand` has never used.
+
+Path comparison remains the fallback whenever either side has no identity - a task row written before the `lease_id` column existed, or a treehouse older than v2.1.0, which is the version floor for the field.
+Existing rows therefore keep being guarded through the migration and gain a real identity as each task is torn down and respawned; nothing has to be rewritten in place.
+
+Every task row is compared, done and failed ones included.
+Status says nothing about whether a worktree is still held - a task keeps its lease until teardown returns it - so a status filter here would drop rows that genuinely still hold the slot.
 
 ### Recovery
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -150,7 +150,7 @@ secondhand/                 # maintainer's in-repo fleet home = repo checkout
       report.go             # read/classify state/<id>.status (see "Report channel")
       pr.go                 # PR URL validation and extraction
     worktree/               # treehouse integration
-      worktree.go           # get, return, status, collision check
+      worktree.go           # get, return, collision check
     brief/                  # brief parsing
       brief.go              # read the brief's declared model/effort (see "Brief format")
     watcher/                # fleet supervision
@@ -407,7 +407,7 @@ Errors:
 - Task ID has an open hold (names `hand hold clear <id>` as the remedy).
 - Brief not found at `data/<id>/brief.md`.
 - Treehouse worktree acquisition failed (pool exhausted, git error).
-- Worktree collision with another active task (names the conflicting task).
+- Worktree collision with another task row (names the conflicting task; see "Collision guard").
 - Herdr tab creation failed (herdr not running, session error).
 - Harness not recognized.
 - Worker never confirmed started within the poll window, or is waiting on a first-run prompt hand
@@ -1886,7 +1886,7 @@ Set with `hand hold set`, which upserts - a second call on the same id replaces 
 - File locking: machine state is written through sqlite, which serializes writers itself.
 - Multiple `hand` invocations against different tasks are safe in parallel.
 - Multiple `hand` invocations against the same task should be avoided (agent discipline, not locking).
-- **Concurrent tasks on same project:** allowed. Each gets its own treehouse worktree. The collision guard in `hand spawn` prevents worktree overlap. File-level conflicts are resolved at merge time (rebase or conflict resolution), not at spawn time. The agent should avoid spawning tasks that touch the same files when possible, but this is a judgment call, not an enforced constraint.
+- **Concurrent tasks on same project:** allowed. Each gets its own treehouse worktree, kept off every other task's by treehouse's own pool lock; the collision guard in `hand spawn` and `hand promote` is defense-in-depth over `hand`'s bookkeeping on top of that (see "Collision guard"). File-level conflicts are resolved at merge time (rebase or conflict resolution), not at spawn time. The agent should avoid spawning tasks that touch the same files when possible, but this is a judgment call, not an enforced constraint.
 - **No session lock.** Multiple supervisory sessions can run `hand` commands. The agent is responsible for not conflicting with itself. sqlite's own locking prevents corruption; duplicate work is an agent-level problem, not a CLI-level problem.
 - **No daemon and no connection pool.** Every command opens the database, does its work and closes it, on a single connection (see "Not Postgres, and no daemon").
 

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -98,17 +98,18 @@ func newPromoteCmd() *cobra.Command {
 			oldWorkspaceID := t.Herdr.WorkspaceID
 			oldTabID := t.Herdr.TabID
 
-			wt, err := worktree.Get(clonePath, "hand:"+id)
+			lease, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
 			}
+			wt := lease.Path
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
 				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
 			}
 			defer releaseWorktree()
 
-			if conflict, err := worktree.CheckCollision(home, wt, id); err != nil {
+			if conflict, err := worktree.CheckCollision(home, lease, id); err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			} else if conflict != "" {
 				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
@@ -156,6 +157,7 @@ func newPromoteCmd() *cobra.Command {
 			t.Model = model
 			t.Effort = effort
 			t.Worktree = wt
+			t.LeaseID = lease.ID
 			t.Herdr = state.Herdr{
 				Session:     "default",
 				WorkspaceID: ws.WorkspaceID,

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -94,17 +94,18 @@ func newSpawnCmd() *cobra.Command {
 			}
 			defer releaseProject()
 
-			wt, err := worktree.Get(clonePath, "hand:"+id)
+			lease, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
 			}
+			wt := lease.Path
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
 				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
 			}
 			defer releaseWorktree()
 
-			if conflict, err := worktree.CheckCollision(home, wt, id); err != nil {
+			if conflict, err := worktree.CheckCollision(home, lease, id); err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			} else if conflict != "" {
 				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
@@ -161,6 +162,7 @@ func newSpawnCmd() *cobra.Command {
 				Model:    model,
 				Effort:   effort,
 				Worktree: wt,
+				LeaseID:  lease.ID,
 				Brief:    briefRel,
 				Herdr: state.Herdr{
 					Session:     "default",

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -64,10 +64,15 @@ esac
 // Real treehouse writes a banner to stderr ahead of its JSON on "get"
 // (internal/worktree/worktree.go's Get doc comment); this fake omits it since
 // worktree.Get's own stdout-only parsing is covered where the banner matters,
-// in tests/e2e/fakes_test.go's writeFakeTreehouse.
+// in tests/e2e/fakes_test.go's writeFakeTreehouse. It does mint a fresh
+// lease_id per invocation, because that - not the recycled slot path - is what
+// real treehouse guarantees is unique per acquisition, and it is what the spawn
+// collision guard keys on.
 func writeFakeTreehouseGet(t *testing.T, bin, worktreePath string) {
 	t.Helper()
-	script := "#!/bin/sh\nprintf '{\"path\":\"" + worktreePath + "\"}'\n"
+	counter := filepath.Join(bin, ".treehouse-leases")
+	script := "#!/bin/sh\nn=$(cat " + counter + " 2>/dev/null || echo 0)\nn=$((n+1))\necho \"$n\" > " + counter +
+		"\nprintf '{\"path\":\"" + worktreePath + "\",\"lease_id\":\"lease-%s\"}' \"$n\"\n"
 	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -124,6 +129,9 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 	if got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tB" || got.Herdr.PaneID != "wA:pC" {
 		t.Fatalf("got herdr %+v", got.Herdr)
+	}
+	if got.LeaseID != "lease-1" {
+		t.Fatalf("got lease id %q, want the identity treehouse handed back", got.LeaseID)
 	}
 }
 
@@ -318,7 +326,9 @@ func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
 	}
 }
 
-func TestSpawnDetectsWorktreeCollision(t *testing.T) {
+// A row with no lease identity - written before the lease_id column existed -
+// is still guarded by worktree path, and that guard is still wired into spawn.
+func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
 	if err := state.Write(home, state.Task{ID: "other-task", Worktree: wt}); err != nil {
@@ -333,6 +343,31 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 
 	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
 		t.Fatalf("state written after collision: exists=%v err=%v", exists, err)
+	}
+}
+
+// A row left behind by a teardown whose state.Delete failed still names the pool
+// slot treehouse has since freed and handed out again. Under a lease of its own
+// that is not a collision, and the spawn has to go through.
+func TestSpawnAllowsAReusedWorktreePathUnderAFreshLease(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	if err := state.Write(home, state.Task{ID: "stale-task", Worktree: wt, LeaseID: "lease-0"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got err %v, want the spawn to proceed past a stale row on the same path", err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LeaseID != "lease-1" {
+		t.Fatalf("got lease id %q, want the identity treehouse handed back", got.LeaseID)
 	}
 }
 

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -62,12 +62,12 @@ func (db *DB) migrateLegacy() error {
 		// An id already in the database wins: it is what hand has been writing
 		// since the import, and the JSON file is a snapshot from before it.
 		if _, err := db.sql.Exec(`INSERT OR IGNORE INTO task (`+taskColumns+`)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			t.ID, t.Project, t.Kind, t.Harness, t.Model, t.Effort, t.Worktree, t.Brief,
 			t.Herdr.Session, t.Herdr.WorkspaceID, t.Herdr.TabID, t.Herdr.PaneID, t.PR,
 			t.MergeExecuted, t.MergeExecutedAt, t.ReportOffset, t.MergeAnnounced, t.DoneVerified,
 			t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote,
-			t.SendUndeliveredMessage, t.SendUndeliveredAt); err != nil {
+			t.SendUndeliveredMessage, t.SendUndeliveredAt, t.LeaseID); err != nil {
 			return fmt.Errorf("import task %q: %w", t.ID, err)
 		}
 	}

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -19,6 +19,7 @@ var ErrSchemaNewer = errors.New("schema version newer than this build of hand su
 var migrations = []string{
 	`ALTER TABLE task ADD COLUMN send_undelivered_message TEXT NOT NULL DEFAULT '';
 	ALTER TABLE task ADD COLUMN send_undelivered_at TEXT NOT NULL DEFAULT '';`,
+	`ALTER TABLE task ADD COLUMN lease_id TEXT NOT NULL DEFAULT '';`,
 }
 
 func (db *DB) schemaVersion() (int, error) {

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -198,7 +198,9 @@ func TestSendUndeliveredColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	migrations = restore
+	// Only through this step: a later migration's column is still present from
+	// `schema`, so replaying it here would fail on "duplicate column name".
+	migrations = restore[:1]
 
 	reopened, err := Open(home)
 	if err != nil {
@@ -212,5 +214,57 @@ func TestSendUndeliveredColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
 	}
 	if got.SendUndeliveredMessage != "" || got.SendUndeliveredAt != "" {
 		t.Fatalf("migrated columns not empty-defaulted: %+v", got)
+	}
+}
+
+// The live fleet home holds rows written before lease_id existed, and they have
+// to keep being readable through the migration rather than only after their task
+// is respawned - so the column arrives empty on every one of them, which is
+// exactly what worktree.CheckCollision's path fallback keys on.
+func TestLeaseIDColumnMigratesOntoAnExistingDatabase(t *testing.T) {
+	home := t.TempDir()
+
+	restore := migrations
+	t.Cleanup(func() { migrations = restore })
+
+	// Every migration but the last, so the database this first open builds sits
+	// one step behind - the shape a fleet home upgraded to this commit is in.
+	// `schema` still creates lease_id (it cannot be swapped the way `migrations`
+	// can), so the column is dropped by hand to complete that shape.
+	migrations = restore[:len(restore)-1]
+	existing, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN lease_id`); err != nil {
+		t.Fatal(err)
+	}
+	// WriteTask always targets the full, current taskColumns, which still names
+	// the dropped column - so this row goes in with a raw insert against the
+	// pre-migration column set instead.
+	if _, err := existing.sql.Exec(`INSERT INTO task (id, worktree) VALUES ('t1', '/w/nsr')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := existing.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrations = restore
+
+	reopened, err := Open(home)
+	if err != nil {
+		t.Fatalf("reopen replaying the real lease_id migration: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	got, found, err := reopened.ReadTask("t1")
+	if err != nil || !found {
+		t.Fatalf("ReadTask = %v, %v", found, err)
+	}
+	if got.LeaseID != "" {
+		t.Fatalf("migrated column not empty-defaulted: %+v", got)
+	}
+	if got.Worktree != "/w/nsr" {
+		t.Fatalf("migration lost the pre-existing row's worktree: %+v", got)
 	}
 }

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -227,11 +227,12 @@ func TestLeaseIDColumnMigratesOntoAnExistingDatabase(t *testing.T) {
 	restore := migrations
 	t.Cleanup(func() { migrations = restore })
 
-	// Every migration but the last, so the database this first open builds sits
-	// one step behind - the shape a fleet home upgraded to this commit is in.
+	// Only the migrations before the lease_id step, so the database this first
+	// open builds sits exactly one step behind it - the shape a fleet home
+	// upgraded to this commit is in - however many migrations land later.
 	// `schema` still creates lease_id (it cannot be swapped the way `migrations`
 	// can), so the column is dropped by hand to complete that shape.
-	migrations = restore[:len(restore)-1]
+	migrations = restore[:1]
 	existing, err := Open(home)
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +250,9 @@ func TestLeaseIDColumnMigratesOntoAnExistingDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	migrations = restore
+	// Only through the lease_id step: a later migration's column is still present
+	// from `schema`, so replaying it here would fail on "duplicate column name".
+	migrations = restore[:2]
 
 	reopened, err := Open(home)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -86,6 +86,11 @@ type Task struct {
 	// reaches the pane, whatever message that send carries.
 	SendUndeliveredMessage string `json:"send_undelivered_message"`
 	SendUndeliveredAt      string `json:"send_undelivered_at"`
+	// treehouse mints a fresh identity on every acquisition, so this - unlike
+	// Worktree, whose pool slot path is recycled - names the one lease this task
+	// holds and no other. Empty on a row written before the column existed, or by
+	// a treehouse that predates lease identities; see worktree.CheckCollision.
+	LeaseID string `json:"lease_id"`
 }
 
 type Project struct {
@@ -150,7 +155,8 @@ CREATE TABLE IF NOT EXISTS task (
 	last_report_state  TEXT NOT NULL DEFAULT '',
 	last_report_note   TEXT NOT NULL DEFAULT '',
 	send_undelivered_message TEXT NOT NULL DEFAULT '',
-	send_undelivered_at      TEXT NOT NULL DEFAULT ''
+	send_undelivered_at      TEXT NOT NULL DEFAULT '',
+	lease_id                 TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS project (
 	name     TEXT PRIMARY KEY,
@@ -239,7 +245,7 @@ const taskColumns = `id, project, kind, harness, model, effort, worktree, brief,
 	herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id, pr,
 	merge_executed, merge_executed_at, report_offset, merge_announced, done_verified,
 	created_at, status_changed_at, status_changed_for, last_report_state, last_report_note,
-	send_undelivered_message, send_undelivered_at`
+	send_undelivered_message, send_undelivered_at, lease_id`
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
@@ -247,7 +253,7 @@ func scanTask(row interface{ Scan(...any) error }) (Task, error) {
 		&t.Herdr.Session, &t.Herdr.WorkspaceID, &t.Herdr.TabID, &t.Herdr.PaneID, &t.PR,
 		&t.MergeExecuted, &t.MergeExecutedAt, &t.ReportOffset, &t.MergeAnnounced, &t.DoneVerified,
 		&t.CreatedAt, &t.StatusChangedAt, &t.StatusChangedFor, &t.LastReportState, &t.LastReportNote,
-		&t.SendUndeliveredMessage, &t.SendUndeliveredAt)
+		&t.SendUndeliveredMessage, &t.SendUndeliveredAt, &t.LeaseID)
 	return t, err
 }
 
@@ -265,7 +271,7 @@ func (db *DB) ReadTask(id string) (Task, bool, error) {
 
 func (db *DB) WriteTask(t Task) error {
 	_, err := db.sql.Exec(`INSERT INTO task (`+taskColumns+`)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project, kind = excluded.kind, harness = excluded.harness,
 			model = excluded.model, effort = excluded.effort, worktree = excluded.worktree,
@@ -278,12 +284,12 @@ func (db *DB) WriteTask(t Task) error {
 			status_changed_at = excluded.status_changed_at, status_changed_for = excluded.status_changed_for,
 			last_report_state = excluded.last_report_state, last_report_note = excluded.last_report_note,
 			send_undelivered_message = excluded.send_undelivered_message,
-			send_undelivered_at = excluded.send_undelivered_at`,
+			send_undelivered_at = excluded.send_undelivered_at, lease_id = excluded.lease_id`,
 		t.ID, t.Project, t.Kind, t.Harness, t.Model, t.Effort, t.Worktree, t.Brief,
 		t.Herdr.Session, t.Herdr.WorkspaceID, t.Herdr.TabID, t.Herdr.PaneID, t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.ReportOffset, t.MergeAnnounced, t.DoneVerified,
 		t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote,
-		t.SendUndeliveredMessage, t.SendUndeliveredAt)
+		t.SendUndeliveredMessage, t.SendUndeliveredAt, t.LeaseID)
 	if err != nil {
 		return fmt.Errorf("write task %q: %w", t.ID, err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -41,6 +41,8 @@ func sampleTask() Task {
 
 		SendUndeliveredMessage: "stop and wait for review",
 		SendUndeliveredAt:      "2026-07-24T13:00:00Z",
+
+		LeaseID: "5fe5412a4aabdeb85a148d6d73eb42d8",
 	}
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -73,23 +73,13 @@ func Return(worktreePath string, force bool) error {
 // recorded one, returning the ID of the conflicting task or "" for no collision.
 //
 // Keyed on the lease identity rather than the worktree path, because a pool slot
-// path is recycled across leases while an identity never is. The guard's older doc
-// comment claimed the stale-lease-after-crash bug (firstmate #947) as its origin;
-// that bug is not reachable here, since Get always passes --lease and treehouse's
-// pool lock will not hand out a currently-leased slot. What path comparison did
-// produce is a false positive: teardown returns the worktree before state.Delete
-// (deliberately, so a fault stays retryable - see state.Delete), so a failed Delete
-// leaves a row still naming path P after treehouse has freed it, and the next spawn
-// or promote to legitimately acquire P was refused over a collision that never
-// existed concurrently.
-//
-// Path comparison stays the fallback whenever either side has no identity: rows
-// written before the lease_id column existed, and any treehouse older than v2.1.0,
-// still have to be checked against something.
-//
+// path is recycled across leases while an identity never is: a row a failed
+// teardown left behind still names a path treehouse has already freed, and path
+// equality refused the next spawn over that instead of over a real holder.
+// Path comparison stays the fallback whenever either side has no identity - rows
+// written before the lease_id column existed, and any treehouse older than v2.1.0.
 // Every task row is compared, done and failed ones included, because a task keeps
-// its lease until teardown returns it - status says nothing about whether the
-// worktree is still held.
+// its lease until teardown returns it. SPECS.md's "Collision guard" owns the rest.
 func CheckCollision(homeDir string, lease Lease, excludeID string) (string, error) {
 	tasks, err := state.List(homeDir)
 	if err != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -11,11 +11,18 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
+// Lease is one acquisition of a treehouse pool slot. ID is empty when treehouse
+// reported no identity, which a version older than v2.1.0 does.
+type Lease struct {
+	Path string
+	ID   string
+}
+
 // Get acquires a worktree from the project clone's treehouse pool.
 // clonePath must be the project clone directory (treehouse resolves the pool from cwd).
 // treehouse writes banners to stderr ahead of the JSON, so the payload must be read
 // from stdout alone; CombinedOutput here corrupts every parse (issue #21).
-func Get(clonePath, leaseHolder string) (string, error) {
+func Get(clonePath, leaseHolder string) (Lease, error) {
 	args := []string{"get", "--lease", "--json"}
 	if leaseHolder != "" {
 		args = append(args, "--lease-holder", leaseHolder)
@@ -26,19 +33,20 @@ func Get(clonePath, leaseHolder string) (string, error) {
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("treehouse get failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+		return Lease{}, fmt.Errorf("treehouse get failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
-	var lease struct {
-		Path string `json:"path"`
+	var payload struct {
+		Path    string `json:"path"`
+		LeaseID string `json:"lease_id"`
 	}
-	if err := json.Unmarshal(out, &lease); err != nil {
-		return "", fmt.Errorf("parse treehouse get output: %w", err)
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return Lease{}, fmt.Errorf("parse treehouse get output: %w", err)
 	}
-	if lease.Path == "" {
-		return "", fmt.Errorf("treehouse get returned no worktree path")
+	if payload.Path == "" {
+		return Lease{}, fmt.Errorf("treehouse get returned no worktree path")
 	}
-	return lease.Path, nil
+	return Lease{Path: payload.Path, ID: payload.LeaseID}, nil
 }
 
 // Return releases a worktree back to its treehouse pool. Returning a worktree
@@ -61,10 +69,28 @@ func Return(worktreePath string, force bool) error {
 	return nil
 }
 
-// CheckCollision cross-checks worktreePath against every other active task's recorded
-// worktree path, guarding against the stale-lease-after-crash bug (firstmate #947).
-// It returns the ID of the conflicting task, or "" if there is no collision.
-func CheckCollision(homeDir, worktreePath, excludeID string) (string, error) {
+// CheckCollision cross-checks a freshly acquired lease against every other task's
+// recorded one, returning the ID of the conflicting task or "" for no collision.
+//
+// Keyed on the lease identity rather than the worktree path, because a pool slot
+// path is recycled across leases while an identity never is. The guard's older doc
+// comment claimed the stale-lease-after-crash bug (firstmate #947) as its origin;
+// that bug is not reachable here, since Get always passes --lease and treehouse's
+// pool lock will not hand out a currently-leased slot. What path comparison did
+// produce is a false positive: teardown returns the worktree before state.Delete
+// (deliberately, so a fault stays retryable - see state.Delete), so a failed Delete
+// leaves a row still naming path P after treehouse has freed it, and the next spawn
+// or promote to legitimately acquire P was refused over a collision that never
+// existed concurrently.
+//
+// Path comparison stays the fallback whenever either side has no identity: rows
+// written before the lease_id column existed, and any treehouse older than v2.1.0,
+// still have to be checked against something.
+//
+// Every task row is compared, done and failed ones included, because a task keeps
+// its lease until teardown returns it - status says nothing about whether the
+// worktree is still held.
+func CheckCollision(homeDir string, lease Lease, excludeID string) (string, error) {
 	tasks, err := state.List(homeDir)
 	if err != nil {
 		return "", err
@@ -73,7 +99,13 @@ func CheckCollision(homeDir, worktreePath, excludeID string) (string, error) {
 		if t.ID == excludeID {
 			continue
 		}
-		if t.Worktree == worktreePath {
+		if lease.ID != "" && t.LeaseID != "" {
+			if t.LeaseID == lease.ID {
+				return t.ID, nil
+			}
+			continue
+		}
+		if t.Worktree == lease.Path {
 			return t.ID, nil
 		}
 	}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -49,14 +49,29 @@ func writeFakeTreehouse(t *testing.T, script string) {
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-func TestGetParsesLeasePath(t *testing.T) {
+func TestGetParsesLeasePathAndIdentity(t *testing.T) {
+	writeFakeTreehouse(t, `printf '{"path":"/tmp/wt-1","lease_id":"5fe5412a4aabdeb85a148d6d73eb42d8"}'`)
+	got, err := Get(t.TempDir(), "hand:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := Lease{Path: "/tmp/wt-1", ID: "5fe5412a4aabdeb85a148d6d73eb42d8"}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// A treehouse older than v2.1.0 reports no identity at all, and that has to
+// stay a usable lease rather than an error - CheckCollision falls back to the
+// path for it.
+func TestGetAcceptsAPayloadWithoutALeaseIdentity(t *testing.T) {
 	writeFakeTreehouse(t, `printf '{"path":"/tmp/wt-1"}'`)
 	got, err := Get(t.TempDir(), "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "/tmp/wt-1" {
-		t.Fatalf("got %q, want /tmp/wt-1", got)
+	if got != (Lease{Path: "/tmp/wt-1"}) {
+		t.Fatalf("got %+v, want path-only lease", got)
 	}
 }
 
@@ -133,13 +148,66 @@ func TestReturnFailsOnAWorktreeNoPoolManages(t *testing.T) {
 	}
 }
 
-func TestCheckCollisionDetectsConflict(t *testing.T) {
+func TestCheckCollisionDetectsAConflictOnLeaseIdentity(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-shared"}); err != nil {
+	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
 		t.Fatal(err)
 	}
 
-	conflict, err := CheckCollision(home, "/tmp/wt-shared", "new-task")
+	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-1"}, "new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "other-task" {
+		t.Fatalf("got conflict %q, want other-task", conflict)
+	}
+}
+
+// The whole point of keying on identity: teardown returns the worktree before
+// state.Delete, so a failed Delete leaves a row still naming path P while
+// treehouse has already freed P and handed it to the next task under a lease of
+// its own. That is not a collision, and refusing the spawn over it was the bug.
+func TestCheckCollisionAllowsAReusedPathUnderAFreshLease(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.Task{ID: "stale-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-2"}, "new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "" {
+		t.Fatalf("got conflict %q, want none: a recycled pool slot under a new lease is not a collision", conflict)
+	}
+}
+
+// A row written before the lease_id column existed has no identity to compare,
+// so it keeps being checked by path until its task is torn down and respawned.
+func TestCheckCollisionFallsBackToPathForARowWithNoIdentity(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.Task{ID: "legacy-task", Worktree: "/tmp/wt-shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-2"}, "new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflict != "legacy-task" {
+		t.Fatalf("got conflict %q, want legacy-task", conflict)
+	}
+}
+
+// The mirror case: a treehouse older than v2.1.0 reports no identity, so even
+// rows that have one are compared by path.
+func TestCheckCollisionFallsBackToPathForALeaseWithNoIdentity(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared"}, "new-task")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,11 +218,11 @@ func TestCheckCollisionDetectsConflict(t *testing.T) {
 
 func TestCheckCollisionExcludesOwnTask(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "same-task", Worktree: "/tmp/wt-shared"}); err != nil {
+	if err := state.Write(home, state.Task{ID: "same-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
 		t.Fatal(err)
 	}
 
-	conflict, err := CheckCollision(home, "/tmp/wt-shared", "same-task")
+	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-1"}, "same-task")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,11 +233,11 @@ func TestCheckCollisionExcludesOwnTask(t *testing.T) {
 
 func TestCheckCollisionNoConflict(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-other"}); err != nil {
+	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-other", LeaseID: "lease-1"}); err != nil {
 		t.Fatal(err)
 	}
 
-	conflict, err := CheckCollision(home, "/tmp/wt-shared", "new-task")
+	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-2"}, "new-task")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +247,7 @@ func TestCheckCollisionNoConflict(t *testing.T) {
 }
 
 func TestCheckCollisionEmptyStateDir(t *testing.T) {
-	conflict, err := CheckCollision(t.TempDir(), "/tmp/wt-shared", "new-task")
+	conflict, err := CheckCollision(t.TempDir(), Lease{Path: "/tmp/wt-shared", ID: "lease-1"}, "new-task")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/atqamz/secondhand/internal/state"
 )
 
-// TestSpawnDetectsWorktreeCollision proves worktree.CheckCollision is actually
-// wired into the built spawn command, not just unit-tested in isolation: a
-// second spawn that leases the same worktree path treehouse already handed
-// task-1 (the firstmate #947 stale-lease-after-crash scenario) must be
-// refused before it ever reaches herdr, and must leave no trace of task-2.
-func TestSpawnDetectsWorktreeCollision(t *testing.T) {
+// setupCollisionHome builds the two-task, one-pool-slot fixture both tests below
+// spawn into, and returns the fake bin directory so each can install the
+// treehouse fake whose lease behavior it is about.
+func setupCollisionHome(t *testing.T) (string, string) {
+	t.Helper()
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 	writeBrief(t, home, "task-1")
@@ -27,10 +26,26 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sharedWorktree := filepath.Join(home, "wt-shared")
 	dir := binDir(t)
-	writeFakeTreehouse(t, dir, sharedWorktree)
 	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+	return home, dir
+}
+
+// TestSpawnDetectsWorktreeCollision proves worktree.CheckCollision is actually
+// wired into the built spawn command, not just unit-tested in isolation: a
+// second spawn handed a worktree path task-1 already holds must be refused
+// before it ever reaches herdr, and must leave no trace of task-2.
+//
+// The fake here is a treehouse older than v2.1.0, reporting no lease identity at
+// all, which is what drives the guard down its path-comparison fallback - the
+// same branch a task row written before the lease_id column existed takes.
+func TestSpawnDetectsWorktreeCollision(t *testing.T) {
+	home, dir := setupCollisionHome(t)
+
+	sharedWorktree := filepath.Join(home, "wt-shared")
+	writeFakeDispatch(t, dir, "treehouse", "", "$1", `  get) echo 'treehouse 0.7.4' >&2; printf '{"path":"%s"}\n' `+shellSingleQuote(sharedWorktree)+` ;;
+  return) echo ok ;;
+  init) echo ok ;;`)
 
 	first := runHand(t, home, "spawn", "task-1", "demo")
 	if first.code != 0 {
@@ -52,5 +67,39 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 	}
 	if task1.Worktree != sharedWorktree {
 		t.Fatalf("task-1 worktree = %q, want %q (collision handling must not mutate the winner)", task1.Worktree, sharedWorktree)
+	}
+}
+
+// The other branch, end to end: a real treehouse recycles a returned pool slot's
+// path under a brand-new lease identity, and a task row still naming that path -
+// left behind by a teardown whose state.Delete failed - must not abort the spawn
+// that legitimately acquired it.
+func TestSpawnAllowsARecycledWorktreePathUnderAFreshLease(t *testing.T) {
+	home, dir := setupCollisionHome(t)
+	writeFakeTreehouse(t, dir, filepath.Join(home, "wt-shared"))
+
+	first := runHand(t, home, "spawn", "task-1", "demo")
+	if first.code != 0 {
+		t.Fatalf("spawn task-1: exit %d, stderr %q", first.code, first.stderr)
+	}
+
+	second := runHand(t, home, "spawn", "task-2", "demo")
+	if second.code != 0 {
+		t.Fatalf("spawn task-2: exit %d, stderr %q, want the recycled path to be accepted", second.code, second.stderr)
+	}
+
+	task1, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	task2, err := state.Read(home, "task-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task1.LeaseID == "" || task2.LeaseID == "" {
+		t.Fatalf("lease identities not recorded: task-1 %q, task-2 %q", task1.LeaseID, task2.LeaseID)
+	}
+	if task1.LeaseID == task2.LeaseID {
+		t.Fatalf("both tasks recorded lease %q, so this proved nothing about identity keying", task1.LeaseID)
 	}
 }

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -33,24 +33,25 @@ func setupCollisionHome(t *testing.T) (string, string) {
 
 // TestSpawnDetectsWorktreeCollision proves worktree.CheckCollision is actually
 // wired into the built spawn command, not just unit-tested in isolation: a
-// second spawn handed a worktree path task-1 already holds must be refused
+// second spawn onto a slot a surviving task row still names must be refused
 // before it ever reaches herdr, and must leave no trace of task-2.
 //
 // The fake here is a treehouse older than v2.1.0, reporting no lease identity at
 // all, which is what drives the guard down its path-comparison fallback - the
-// same branch a task row written before the lease_id column existed takes.
+// same branch a task row written before the lease_id column existed takes. With
+// nothing to key on but the path, the fallback cannot tell task-1's row from a
+// live holder, so it refuses; that conservatism is the whole point of keeping it.
 func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 	home, dir := setupCollisionHome(t)
 
 	sharedWorktree := filepath.Join(home, "wt-shared")
-	writeFakeDispatch(t, dir, "treehouse", "", "$1", `  get) echo 'treehouse 0.7.4' >&2; printf '{"path":"%s"}\n' `+shellSingleQuote(sharedWorktree)+` ;;
-  return) echo ok ;;
-  init) echo ok ;;`)
+	writeFakeTreehouseWithoutLeaseIdentity(t, dir, sharedWorktree)
 
 	first := runHand(t, home, "spawn", "task-1", "demo")
 	if first.code != 0 {
 		t.Fatalf("spawn task-1: exit %d, stderr %q", first.code, first.stderr)
 	}
+	returnFakeWorktree(t, sharedWorktree)
 
 	second := runHand(t, home, "spawn", "task-2", "demo")
 	assertInvocation(t, second, 3, "collision")
@@ -73,15 +74,19 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 // The other branch, end to end: a real treehouse recycles a returned pool slot's
 // path under a brand-new lease identity, and a task row still naming that path -
 // left behind by a teardown whose state.Delete failed - must not abort the spawn
-// that legitimately acquired it.
+// that legitimately acquired it. The slot is genuinely back in the pool before
+// task-2 asks for it, because that is the only way the real backend hands one
+// path out twice.
 func TestSpawnAllowsARecycledWorktreePathUnderAFreshLease(t *testing.T) {
 	home, dir := setupCollisionHome(t)
-	writeFakeTreehouse(t, dir, filepath.Join(home, "wt-shared"))
+	sharedWorktree := filepath.Join(home, "wt-shared")
+	writeFakeTreehouse(t, dir, sharedWorktree)
 
 	first := runHand(t, home, "spawn", "task-1", "demo")
 	if first.code != 0 {
 		t.Fatalf("spawn task-1: exit %d, stderr %q", first.code, first.stderr)
 	}
+	returnFakeWorktree(t, sharedWorktree)
 
 	second := runHand(t, home, "spawn", "task-2", "demo")
 	if second.code != 0 {

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -235,32 +235,85 @@ func setPaneStatus(t *testing.T, statusDir, paneID, status string) {
 	}
 }
 
-// writeFakeTreehouse writes a treehouse fake that always leases worktreePath
-// and no-ops on return/init, matching worktree.Get/Return and
+// writeFakeTreehouse writes a treehouse fake managing a one-slot pool at
+// worktreePath and no-oping on init, matching worktree.Get/Return and
 // treehouseInitIfNeeded's invocation shapes ("get"/"return"/"init" as $1).
 // "get" writes a banner line to stderr before its JSON, mirroring real
 // treehouse's documented "all banners go to stderr" behavior, so a
 // CombinedOutput regression at the call site fails the suite.
+//
+// The slot is leased exclusively, the way real treehouse's pool lock holds it: a
+// "get" while it is still out fails instead of handing one path to two holders,
+// and only a "return" of that path frees it again. Without that a test could
+// build the one fixture the real backend cannot produce - two live tasks on one
+// slot - and prove the collision guard against a state that never occurs.
+// Returning any other path stays a no-op success, which is what lets promote
+// hand back a scout worktree this pool never owned.
 //
 // Every "get" mints a fresh lease_id off a counter file, because that is the
 // one thing real treehouse (v2.1.0 and up) guarantees is never reused: a pool
 // slot handed back out keeps its path and gets a new identity, which is exactly
 // what worktree.CheckCollision keys on. A fake reusing one identity across
 // acquisitions could not tell the collision guard's two branches apart. The
-// counter lives beside the fake rather than in a fresh temp dir so that a test
-// reinstalling this fake - a subtest pointing it at its own worktree - keeps
-// counting up instead of reissuing an identity it already handed out.
+// counter and the held marker live beside the fake rather than in a fresh temp
+// dir so that a test reinstalling this fake - a subtest pointing it at its own
+// worktree - keeps counting up instead of reissuing an identity it already
+// handed out, and keeps each slot's held state separate.
 func writeFakeTreehouse(t *testing.T, dir, worktreePath string) {
 	t.Helper()
-	counter := filepath.Join(dir, ".treehouse-leases")
+	writeFakeTreehousePool(t, dir, worktreePath, "treehouse 2.1.0", true)
+}
+
+// writeFakeTreehouseWithoutLeaseIdentity is the same one-slot pool as a
+// treehouse older than v2.1.0: it leases and frees the slot identically but
+// reports no lease_id at all, which is what drives worktree.CheckCollision down
+// its path-comparison fallback - the same branch a task row written before the
+// lease_id column existed takes.
+func writeFakeTreehouseWithoutLeaseIdentity(t *testing.T, dir, worktreePath string) {
+	t.Helper()
+	writeFakeTreehousePool(t, dir, worktreePath, "treehouse 0.7.4", false)
+}
+
+func writeFakeTreehousePool(t *testing.T, dir, worktreePath, banner string, leaseIdentity bool) {
+	t.Helper()
+	counter := shellSingleQuote(filepath.Join(dir, ".treehouse-leases"))
+	held := shellSingleQuote(filepath.Join(dir, ".treehouse-held-"+strings.ReplaceAll(strings.Trim(worktreePath, "/"), "/", "_")))
+	path := shellSingleQuote(worktreePath)
+	payload := `'{"path":"%s","lease_id":"lease-%s"}\n' ` + path + ` "$n"`
+	if !leaseIdentity {
+		payload = `'{"path":"%s"}\n' ` + path
+	}
+	// Truncated rather than removed to free the slot, and tested with -s rather
+	// than -e: rm is not on this suite's hermetic PATH, and redirection is a shell
+	// builtin.
 	body := fmt.Sprintf(`  get)
-    echo 'treehouse 0.7.4' >&2
-    n=$(cat %[1]s 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > %[1]s
-    printf '{"path":"%%s","lease_id":"lease-%%s"}\n' %[2]s "$n"
+    echo %[1]s >&2
+    if [ -s %[2]s ]; then
+      printf 'treehouse: pool slot %%s is already leased\n' %[3]s >&2
+      exit 1
+    fi
+    n=$(cat %[4]s 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > %[4]s
+    echo "$n" > %[2]s
+    printf %[5]s
     ;;
-  return) echo ok ;;
-  init) echo ok ;;`, shellSingleQuote(counter), shellSingleQuote(worktreePath))
+  return)
+    if [ "$2" = %[3]s ]; then : > %[2]s; fi
+    echo ok
+    ;;
+  init) echo ok ;;`, shellSingleQuote(banner), held, path, counter, payload)
 	writeFakeDispatch(t, dir, "treehouse", "", "$1", body)
+}
+
+// returnFakeWorktree frees a leased pool slot through the fake treehouse's own
+// return arm. It stands in for the return `hand teardown` runs before it deletes
+// the task's row: when that deletion fails, this is exactly the state left
+// behind - the slot back in the pool, a row still naming it.
+func returnFakeWorktree(t *testing.T, worktreePath string) {
+	t.Helper()
+	out, err := exec.Command("treehouse", "return", worktreePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("fake treehouse return %s: %v: %s", worktreePath, err, out)
+	}
 }
 
 // redirectGitRemote makes `git clone <matchURL> <dest>` resolve to a local

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -241,11 +241,25 @@ func setPaneStatus(t *testing.T, statusDir, paneID, status string) {
 // "get" writes a banner line to stderr before its JSON, mirroring real
 // treehouse's documented "all banners go to stderr" behavior, so a
 // CombinedOutput regression at the call site fails the suite.
+//
+// Every "get" mints a fresh lease_id off a counter file, because that is the
+// one thing real treehouse (v2.1.0 and up) guarantees is never reused: a pool
+// slot handed back out keeps its path and gets a new identity, which is exactly
+// what worktree.CheckCollision keys on. A fake reusing one identity across
+// acquisitions could not tell the collision guard's two branches apart. The
+// counter lives beside the fake rather than in a fresh temp dir so that a test
+// reinstalling this fake - a subtest pointing it at its own worktree - keeps
+// counting up instead of reissuing an identity it already handed out.
 func writeFakeTreehouse(t *testing.T, dir, worktreePath string) {
 	t.Helper()
-	body := fmt.Sprintf(`  get) echo 'treehouse 0.7.4' >&2; printf '{"path":"%%s"}\n' %s ;;
+	counter := filepath.Join(dir, ".treehouse-leases")
+	body := fmt.Sprintf(`  get)
+    echo 'treehouse 0.7.4' >&2
+    n=$(cat %[1]s 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > %[1]s
+    printf '{"path":"%%s","lease_id":"lease-%%s"}\n' %[2]s "$n"
+    ;;
   return) echo ok ;;
-  init) echo ok ;;`, shellSingleQuote(worktreePath))
+  init) echo ok ;;`, shellSingleQuote(counter), shellSingleQuote(worktreePath))
 	writeFakeDispatch(t, dir, "treehouse", "", "$1", body)
 }
 

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -38,6 +38,7 @@ func TestPromoteScoutToShip(t *testing.T) {
 	if err := state.Write(home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindScout,
 		Worktree:  oldWorktree,
+		LeaseID:   "lease-old",
 		Herdr:     state.Herdr{WorkspaceID: "ws-old", TabID: "tab-old", PaneID: "pane-old"},
 		CreatedAt: createdAt,
 	}); err != nil {
@@ -52,7 +53,7 @@ func TestPromoteScoutToShip(t *testing.T) {
 	// treehouse return's actual (silent) output; "pane run" below is a void
 	// command whose real success is empty stdout (callVoid doc, client.go) -
 	// callVoid only checks env.Error, so the extra envelope body is harmless.
-	writeFakeDispatch(t, dir, "treehouse", invocationLog, "$1", `  get) printf '{"path":"%s"}\n' `+shellSingleQuote(newWorktree)+` ;;
+	writeFakeDispatch(t, dir, "treehouse", invocationLog, "$1", `  get) printf '{"path":"%s","lease_id":"lease-new"}\n' `+shellSingleQuote(newWorktree)+` ;;
   return) echo ok ;;`)
 	// The scout's old workspace holds a second tab, so releasing the scout is a
 	// tab close rather than closeTaskTab's sole-tab workspace-close shortcut.
@@ -97,6 +98,9 @@ func TestPromoteScoutToShip(t *testing.T) {
 	}
 	if task.Worktree != newWorktree {
 		t.Fatalf("task.Worktree = %q, want the new worktree %q", task.Worktree, newWorktree)
+	}
+	if task.LeaseID != "lease-new" {
+		t.Fatalf("task.LeaseID = %q, want the new lease identity, not the scout's", task.LeaseID)
 	}
 	if task.Herdr.WorkspaceID != "ws-new" || task.Herdr.TabID != "tab-new" || task.Herdr.PaneID != "pane-new" {
 		t.Fatalf("task.Herdr = %+v, want the new ws-new/tab-new/pane-new identifiers", task.Herdr)


### PR DESCRIPTION
## Intent

Key the worktree collision guard on treehouse's lease identity instead of the worktree path, so a pool slot path recycled after a failed teardown no longer produces a false collision, while rows and treehouse versions without a lease identity still fall back to path comparison.

## What Changed

- `worktree.Get` now returns a `Lease{Path, ID}` parsed from treehouse's `lease_id`, and `worktree.CheckCollision` takes that lease: when both the incoming lease and the stored task row carry an identity it compares identities, so a pool slot path recycled after a failed teardown no longer reports a false collision. When either side has no identity (a pre-`lease_id` row, or a treehouse older than v2.1.0) it still falls back to path comparison.
- `store.Task` gains a `LeaseID` field with a new `lease_id` column, added to the base schema, to `taskColumns`/scan/write, and as a migration step so existing fleet homes upgrade in place with the column empty-defaulted on pre-existing rows; `hand spawn` and `hand promote` record the lease id they acquired.
- SPECS.md documents the guard's lease-identity keying and its path fallback; the e2e fakes model exclusive treehouse leases (mint per-acquisition lease ids, plus a pre-v2.1.0 fake without them) and the store migration tests pin their replay windows to the migration under test.

## Risk Assessment

ok: Low: All four prior findings are fully addressed with no new issues: the production change still matches the intent exactly (identity keying with path fallback, recorded by both spawn and promote, additive NOT NULL DEFAULT '' migration against a lease_id key verified present in the pinned treehouse v2.1.0), the e2e fake now enforces the pool-lock invariant instead of contradicting it, and a caller-by-caller sweep shows no existing test regresses from the fake becoming stateful.

## Testing

Ran the targeted unit, cmd, and e2e suites covering the collision guard, lease parsing, and the new lease_id migration (all pass, including with -race), then built the base and target `hand` binaries and drove five operator-shaped CLI scenarios against real fleet homes with a one-slot treehouse pool fake: the base build refuses a spawn onto a slot freed by a failed teardown (exit 3, false collision) while the target build accepts it and persists two distinct lease identities on the same path; an older treehouse reporting no lease id and a fleet home written before the lease_id column both still fall back to path comparison and refuse; the migrated home's pre-existing row remains readable via `hand status`; and a slot still leased is refused by treehouse's pool lock, so the removed path check opens no hole. Evidence is CLI transcripts plus persisted database rows rather than screenshots because the change is CLI/state-layer only with no rendered surface.

<details>
<summary>Evidence: Base build: false collision after a failed teardown</summary>

<code>$ hand spawn task-1 demo&#10;spawned task-1 project=demo kind=ship harness=claude worktree=$HOME/wt-shared&#10;[exit 0]&#10;&#10;# teardown returns the slot to the pool, then its state.Delete fails,&#10;# so task-1&#39;s row survives, still naming the slot path:&#10;$ treehouse return $HOME/wt-shared # the return teardown performs&#10;ok&#10;(task-1&#39;s row deliberately left behind: the failed state.Delete)&#10;&#10;# the slot is genuinely free now, so this spawn legitimately gets it:&#10;$ hand spawn task-2 demo&#10;worktree collision: task-1 already holds $HOME/wt-shared&#10;[exit 3]&#10;&#10;# ^ refused, though nothing holds that slot: the guard only had paths.&#10;&#10;$ sqlite3 state/hand.db &#39;select id, worktree, lease_id from task&#39;&#10;task-1 | $HOME/wt-shared | lease_id=(column does not exist in this build)</code>

```text
==================================================================
BASE BUILD (d135901): false collision after a failed teardown
==================================================================
# treehouse hands task-1 the pool's only slot
$ hand spawn task-1 demo
  spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/lease-demo-UDYS/home-base/wt-shared
  [exit 0]

# teardown returns the slot to the pool, then its state.Delete fails,
# so task-1's row survives, still naming the slot path:
$ treehouse return $HOME/wt-shared      # the return teardown performs
  ok
  (task-1's row deliberately left behind: the failed state.Delete)

# the slot is genuinely free now, so this spawn legitimately gets it:
$ hand spawn task-2 demo
  worktree collision: task-1 already holds /tmp/lease-demo-UDYS/home-base/wt-shared
  [exit 3]

# ^ refused, though nothing holds that slot: the guard only had paths.

$ sqlite3 state/hand.db 'select id, worktree, lease_id from task'
  task-1 | /tmp/lease-demo-UDYS/home-base/wt-shared | lease_id=(column does not exist in this build)
```
</details>
<details>
<summary>Evidence: Target build: recycled slot accepted under a fresh lease, two identities persisted</summary>

<code>$ hand spawn task-1 demo&#10;spawned task-1 project=demo kind=ship harness=claude worktree=$HOME/wt-shared&#10;[exit 0]&#10;&#10;$ treehouse return $HOME/wt-shared # the return teardown performs&#10;ok&#10;(task-1&#39;s row deliberately left behind: the failed state.Delete)&#10;&#10;$ hand spawn task-2 demo&#10;spawned task-2 project=demo kind=ship harness=claude worktree=$HOME/wt-shared&#10;[exit 0]&#10;&#10;# ^ accepted: the recycled slot path arrived under a lease of its own.&#10;&#10;# persisted state - one shared path, two distinct lease identities:&#10;$ sqlite3 state/hand.db &#39;select id, worktree, lease_id from task&#39;&#10;task-1 | $HOME/wt-shared | lease_id=&#39;lease-1&#39;&#10;task-2 | $HOME/wt-shared | lease_id=&#39;lease-2&#39;</code>

```text
==================================================================
TARGET BUILD (c362c83): same scenario, keyed on the lease identity
==================================================================
$ hand spawn task-1 demo
  spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/lease-demo-UDYS/home-target/wt-shared
  [exit 0]

$ treehouse return $HOME/wt-shared      # the return teardown performs
  ok
  (task-1's row deliberately left behind: the failed state.Delete)

$ hand spawn task-2 demo
  spawned task-2 project=demo kind=ship harness=claude worktree=/tmp/lease-demo-UDYS/home-target/wt-shared
  [exit 0]

# ^ accepted: the recycled slot path arrived under a lease of its own.

# persisted state - one shared path, two distinct lease identities:
$ sqlite3 state/hand.db 'select id, worktree, lease_id from task'
  task-1 | /tmp/lease-demo-UDYS/home-target/wt-shared | lease_id='lease-1'
  task-2 | /tmp/lease-demo-UDYS/home-target/wt-shared | lease_id='lease-2'
```
</details>
<details>
<summary>Evidence: Target build + treehouse older than v2.1.0: path fallback still refuses</summary>

<code>$ hand spawn task-1 demo&#10;spawned task-1 ... worktree=$HOME/wt-shared&#10;[exit 0]&#10;&#10;$ treehouse return $HOME/wt-shared&#10;ok&#10;&#10;$ hand spawn task-2 demo&#10;worktree collision: task-1 already holds $HOME/wt-shared&#10;[exit 3]&#10;&#10;# ^ still refused: this treehouse reports no lease identity, so the&#10;# guard falls back to comparing worktree paths.&#10;&#10;$ sqlite3 state/hand.db &#39;select id, worktree, lease_id from task&#39;&#10;task-1 | $HOME/wt-shared | lease_id=&#39;&#39;</code>

```text
==================================================================
TARGET BUILD + treehouse older than v2.1.0: path fallback guards
==================================================================
$ hand spawn task-1 demo
  spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/lease-demo-UDYS/home-oldth/wt-shared
  [exit 0]

$ treehouse return $HOME/wt-shared
  ok

$ hand spawn task-2 demo
  worktree collision: task-1 already holds /tmp/lease-demo-UDYS/home-oldth/wt-shared
  [exit 3]

# ^ still refused: this treehouse reports no lease identity, so the
#   guard falls back to comparing worktree paths.

$ sqlite3 state/hand.db 'select id, worktree, lease_id from task'
  task-1 | /tmp/lease-demo-UDYS/home-oldth/wt-shared | lease_id=''
```
</details>
<details>
<summary>Evidence: Upgrade in place: pre-lease_id fleet home migrates and stays path-guarded</summary>

<code># task-1 spawned by the BASE build, into a db with no lease_id column:&#10;$ sqlite3 state/hand.db &#39;.schema task&#39; # base build&#39;s column set&#10;lease_id columns present: 0&#10;&#10;$ treehouse return $HOME/wt-shared # failed-teardown state again&#10;ok&#10;&#10;# operator now upgrades to the TARGET build against that same home:&#10;$ hand spawn task-2 demo&#10;worktree collision: task-1 already holds $HOME/wt-shared&#10;[exit 3]&#10;&#10;$ sqlite3 state/hand.db &#39;.schema task&#39; # after the migration&#10;lease_id TEXT NOT NULL DEFAULT &#39;&#39;);&#10;$ sqlite3 state/hand.db &#39;select id, worktree, lease_id from task&#39;&#10;task-1 | $HOME/wt-shared | lease_id=&#39;&#39;&#10;&#10;$ hand status # migrated row still readable&#10;id project kind state age last report&#10;task-1 demo ship working just now (none)</code>

```text
==================================================================
UPGRADE IN PLACE: a fleet home written before lease_id existed
==================================================================
# task-1 spawned by the BASE build, into a db with no lease_id column:
$ hand spawn task-1 demo
  spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/lease-demo-UDYS/home-upgrade/wt-shared
  [exit 0]

$ sqlite3 state/hand.db '.schema task'   # base build's column set
  lease_id columns present: 0

$ treehouse return $HOME/wt-shared      # failed-teardown state again
  ok

# operator now upgrades to the TARGET build against that same home:
$ hand spawn task-2 demo
  worktree collision: task-1 already holds /tmp/lease-demo-UDYS/home-upgrade/wt-shared
  [exit 3]

# ^ refused, correctly: task-1's migrated row has no lease identity,
#   so it keeps being guarded by path until it is torn down.

$ sqlite3 state/hand.db '.schema task'   # after the migration
   lease_id TEXT NOT NULL DEFAULT '');
$ sqlite3 state/hand.db 'select id, worktree, lease_id from task'
  task-1 | /tmp/lease-demo-UDYS/home-upgrade/wt-shared | lease_id=''

$ hand status                            # migrated row still readable
  id      project  kind  state    age       last report
  task-1  demo     ship  working  just now  (none)
```
</details>
<details>
<summary>Evidence: Target build: a slot still leased is never handed out twice</summary>

<code>$ hand spawn task-1 demo&#10;spawned task-1 ... worktree=$HOME/wt-shared&#10;[exit 0]&#10;&#10;# no return this time - task-1 still holds the slot:&#10;$ hand spawn task-2 demo&#10;acquire treehouse worktree: treehouse get failed: exit status 1: treehouse 2.1.0&#10;treehouse: pool slot $HOME/wt-shared is already leased&#10;[exit 1]&#10;&#10;# ^ refused by treehouse&#39;s pool lock before hand&#39;s guard is even reached,&#10;# so two live tasks can never share a slot.</code>

```text
==================================================================
TARGET BUILD: a slot still held is never handed out twice
==================================================================
$ hand spawn task-1 demo
  spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/lease-demo-UDYS/home-live/wt-shared
  [exit 0]

# no return this time - task-1 still holds the slot:
$ hand spawn task-2 demo
  acquire treehouse worktree: treehouse get failed: exit status 1: treehouse 2.1.0
  treehouse: pool slot /tmp/lease-demo-UDYS/home-live/wt-shared is already leased
  [exit 1]

# ^ refused by treehouse's pool lock before hand's guard is even reached,
#   so two live tasks can never share a slot.

$ sqlite3 state/hand.db 'select id, worktree, lease_id from task'
  task-1 | /tmp/lease-demo-UDYS/home-live/wt-shared | lease_id='lease-1'
```
</details>
<details>
<summary>Evidence: Reproducible demo harness used to produce the transcripts above</summary>

```text
#!/usr/bin/env bash
# Manual product-level demo of hand's treehouse-lease collision guard.
# Drives the built hand binary (base build vs target build) against a real
# fleet home backed by a one-slot treehouse pool fake, reproducing the
# failed-teardown state that used to produce a false collision.
#
# usage: lease-collision-demo.sh <scratch-dir-holding-hand-base-and-hand-target> <evidence-dir>
set -u

SCRATCH="$1"
EVIDENCE="$2"
SQLITE="$(command -v sqlite3)"

FAKEBIN="$SCRATCH/fakebin"
rm -rf "$FAKEBIN"; mkdir -p "$FAKEBIN"
for b in git sh cat sqlite3; do ln -sf "$(command -v $b)" "$FAKEBIN/$b"; done
# hand (and the treehouse calls standing in for teardown) run under this
# narrowed PATH so they can only reach the fakes; the script keeps the host PATH.
HANDPATH="$FAKEBIN"
export GIT_CONFIG_GLOBAL="$SCRATCH/gitconfig"
export GIT_CONFIG_NOSYSTEM=1
cat > "$GIT_CONFIG_GLOBAL" <<'EOF'
[user]
	name = hand-demo
	email = hand-demo@example.invalid
[init]
	defaultBranch = main
EOF
unset HAND_HOME

# fake treehouse: one exclusive pool slot, fresh lease_id per acquisition,
# freed only by a return of that path - the same contract the e2e fake models.
write_treehouse() {
  local slot="$1" identity="$2" banner="$3"
  local payload='printf "{\"path\":\"%s\",\"lease_id\":\"lease-%s\"}\n" "$SLOT" "$n"'
  [ "$identity" = no ] && payload='printf "{\"path\":\"%s\"}\n" "$SLOT"'
  cat > "$FAKEBIN/treehouse" <<EOF
#!/bin/sh
SLOT='$slot'
HELD='$SCRATCH/.held'
CTR='$SCRATCH/.leases'
case "\$1" in
  get)
    echo '$banner' >&2
    if [ -s "\$HELD" ]; then echo "treehouse: pool slot \$SLOT is already leased" >&2; exit 1; fi
    n=\$(cat "\$CTR" 2>/dev/null || echo 0); n=\$((n+1)); echo "\$n" > "\$CTR"; echo "\$n" > "\$HELD"
    $payload
    ;;
  return) [ "\$2" = "\$SLOT" ] && : > "\$HELD"; echo ok ;;
  init) echo ok ;;
  *) echo "unexpected treehouse invocation: \$@" >&2; exit 1 ;;
esac
EOF
  chmod +x "$FAKEBIN/treehouse"
}

cat > "$FAKEBIN/herdr" <<'EOF'
#!/bin/sh
case "$1 $2" in
  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
  "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-1","label":"demo","tab_count":1},"tab":{"tab_id":"tab-1","workspace_id":"ws-1","label":"1"},"root_pane":{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","agent_status":"working"}}}' ;;
  "tab rename") echo '{"result":{"tab":{"tab_id":"tab-1","workspace_id":"ws-1","label":"demo"}}}' ;;
  "pane run"|"pane send-text"|"pane send-keys") ;;
  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
  "tab list") echo '{"result":{"tabs":[{"tab_id":"tab-1","workspace_id":"ws-1","label":"demo"}]}}' ;;
  "tab close"|"workspace close") echo '{"result":{"type":"ok"}}' ;;
  "pane get") echo '{"result":{"pane":{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","agent":"claude","agent_status":"working"}}}' ;;
  *) echo "unexpected herdr invocation: $@" >&2; exit 1 ;;
esac
EOF
chmod +x "$FAKEBIN/herdr"

run() {
  local bin="$1" home="$2"; shift 2
  echo "\$ hand $*"
  ( cd "$home" && env PATH="$HANDPATH" "$bin" "$@" ) 2>&1 | sed 's/^/  /'
  echo "  [exit ${PIPESTATUS[0]}]"
  echo
}

dump_rows() {
  local home="$1"
  echo "\$ sqlite3 state/hand.db 'select id, worktree, lease_id from task'"
  local col="quote(lease_id)"
  "$SQLITE" "$home/state/hand.db" ".schema task" | grep -q lease_id || col="'(column does not exist in this build)'"
  "$SQLITE" "$home/state/hand.db" \
    "select id || ' | ' || worktree || ' | lease_id=' || $col from task order by id;" 2>&1 | sed 's/^/  /'
  echo
}

new_home() {
  local bin="$1" home="$2"
  rm -rf "$home"; mkdir -p "$home"
  ( cd "$home" && env PATH="$HANDPATH" "$bin" init ) >/dev/null 2>&1
  printf -- '- demo: https://example.com/demo.git mode=direct-pr\n' >> "$home/data/projects.md"
  for id in task-1 task-2; do mkdir -p "$home/data/$id"; printf '# brief\n' > "$home/data/$id/brief.md"; done
  mkdir -p "$home/projects/demo"
  : > "$SCRATCH/.held"; : > "$SCRATCH/.leases"
}

# ---------------------------------------------------------------- scenario 1
HOME_A="$SCRATCH/home-base"
new_home "$SCRATCH/hand-base" "$HOME_A"
write_treehouse "$HOME_A/wt-shared" yes 'treehouse 2.1.0'
{
echo "=================================================================="
echo "BASE BUILD (d135901): false collision after a failed teardown"
echo "=================================================================="
echo "# treehouse hands task-1 the pool's only slot"
run "$SCRATCH/hand-base" "$HOME_A" spawn task-1 demo
echo "# teardown returns the slot to the pool, then its state.Delete fails,"
echo "# so task-1's row survives, still naming the slot path:"
echo "\$ treehouse return \$HOME/wt-shared      # the return teardown performs"
env PATH="$HANDPATH" treehouse return "$HOME_A/wt-shared" | sed 's/^/  /'
echo "  (task-1's row deliberately left behind: the failed state.Delete)"
echo
echo "# the slot is genuinely free now, so this spawn legitimately gets it:"
run "$SCRATCH/hand-base" "$HOME_A" spawn task-2 demo
echo "# ^ refused, though nothing holds that slot: the guard only had paths."
echo
dump_rows "$HOME_A"
} > "$EVIDENCE/1-base-false-collision.txt" 2>&1

# ---------------------------------------------------------------- scenario 2
HOME_B="$SCRATCH/home-target"
new_home "$SCRATCH/hand-target" "$HOME_B"
write_treehouse "$HOME_B/wt-shared" yes 'treehouse 2.1.0'
{
echo "=================================================================="
echo "TARGET BUILD (c362c83): same scenario, keyed on the lease identity"
echo "=================================================================="
run "$SCRATCH/hand-target" "$HOME_B" spawn task-1 demo
echo "\$ treehouse return \$HOME/wt-shared      # the return teardown performs"
env PATH="$HANDPATH" treehouse return "$HOME_B/wt-shared" | sed 's/^/  /'
echo "  (task-1's row deliberately left behind: the failed state.Delete)"
echo
run "$SCRATCH/hand-target" "$HOME_B" spawn task-2 demo
echo "# ^ accepted: the recycled slot path arrived under a lease of its own."
echo
echo "# persisted state - one shared path, two distinct lease identities:"
dump_rows "$HOME_B"
} > "$EVIDENCE/2-target-recycled-slot-accepted.txt" 2>&1

# ---------------------------------------------------------------- scenario 3
HOME_C="$SCRATCH/home-oldth"
new_home "$SCRATCH/hand-target" "$HOME_C"
write_treehouse "$HOME_C/wt-shared" no 'treehouse 0.7.4'
{
echo "=================================================================="
echo "TARGET BUILD + treehouse older than v2.1.0: path fallback guards"
echo "=================================================================="
run "$SCRATCH/hand-target" "$HOME_C" spawn task-1 demo
echo "\$ treehouse return \$HOME/wt-shared"
env PATH="$HANDPATH" treehouse return "$HOME_C/wt-shared" | sed 's/^/  /'
echo
run "$SCRATCH/hand-target" "$HOME_C" spawn task-2 demo
echo "# ^ still refused: this treehouse reports no lease identity, so the"
echo "#   guard falls back to comparing worktree paths."
echo
dump_rows "$HOME_C"
} > "$EVIDENCE/3-target-no-lease-identity-fallback.txt" 2>&1

# ---------------------------------------------------------------- scenario 4
HOME_D="$SCRATCH/home-upgrade"
new_home "$SCRATCH/hand-base" "$HOME_D"
write_treehouse "$HOME_D/wt-shared" yes 'treehouse 2.1.0'
{
echo "=================================================================="
echo "UPGRADE IN PLACE: a fleet home written before lease_id existed"
echo "=================================================================="
echo "# task-1 spawned by the BASE build, into a db with no lease_id column:"
run "$SCRATCH/hand-base" "$HOME_D" spawn task-1 demo
echo "\$ sqlite3 state/hand.db '.schema task'   # base build's column set"
"$SQLITE" "$HOME_D/state/hand.db" ".schema task" | tr ',' '\n' | grep -c lease_id \
  | sed 's/^/  lease_id columns present: /'
echo
echo "\$ treehouse return \$HOME/wt-shared      # failed-teardown state again"
env PATH="$HANDPATH" treehouse return "$HOME_D/wt-shared" | sed 's/^/  /'
echo
echo "# operator now upgrades to the TARGET build against that same home:"
run "$SCRATCH/hand-target" "$HOME_D" spawn task-2 demo
echo "# ^ refused, correctly: task-1's migrated row has no lease identity,"
echo "#   so it keeps being guarded by path until it is torn down."
echo
echo "\$ sqlite3 state/hand.db '.schema task'   # after the migration"
"$SQLITE" "$HOME_D/state/hand.db" ".schema task" | tr ',' '\n' | grep lease_id | sed 's/^/  /'
dump_rows "$HOME_D"
echo "\$ hand status                            # migrated row still readable"
( cd "$HOME_D" && env PATH="$HANDPATH" "$SCRATCH/hand-target" status ) 2>&1 | sed 's/^/  /'
} > "$EVIDENCE/4-upgrade-migration.txt" 2>&1

# ---------------------------------------------------------------- scenario 5
# the case the path check used to be credited with: a second task trying to
# take a slot that is still leased out. Never returned, so treehouse's own pool
# lock refuses first - dropping the path comparison opens no hole here.
HOME_E="$SCRATCH/home-live"
new_home "$SCRATCH/hand-target" "$HOME_E"
write_treehouse "$HOME_E/wt-shared" yes 'treehouse 2.1.0'
{
echo "=================================================================="
echo "TARGET BUILD: a slot still held is never handed out twice"
echo "=================================================================="
run "$SCRATCH/hand-target" "$HOME_E" spawn task-1 demo
echo "# no return this time - task-1 still holds the slot:"
run "$SCRATCH/hand-target" "$HOME_E" spawn task-2 demo
echo "# ^ refused by treehouse's pool lock before hand's guard is even reached,"
echo "#   so two live tasks can never share a slot."
echo
dump_rows "$HOME_E"
} > "$EVIDENCE/5-target-live-slot-not-double-leased.txt" 2>&1

echo demo complete
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>fix: **Review** - 4 issues found -> auto-fixed ok:</summary>

- warning: `tests/e2e/collision_test.go:79` - The new e2e test&#39;s fake hands out a currently-leased pool slot, which real treehouse cannot do, and the scenario it builds is not the one its comment claims. task-1 is spawned and left live (never torn down), then task-2&#39;s `treehouse get` returns the same path under lease-2 - but SPECS.md:1904 rests the whole safety argument on &#34;treehouse&#39;s pool lock refuses to hand out a currently-leased slot&#34;. The comment above the test says the row is one &#34;left behind by a teardown whose state.Delete failed&#34;, yet no teardown runs and the row is live, so what is actually proven end to end is only &#34;path equality no longer refuses&#34;, against a state the real backend never produces. SPECS.md&#39;s Testing strategy rule requires a state-changing fake to model the state its commands leave behind and to spell out any deliberate divergence; writeFakeTreehouse&#39;s updated note explains the lease_id minting but never records that `get` still returns an already-leased path. Minimal fix: state that divergence in the fidelity note. Faithful fix: spawn task-1, capture its row, run `hand teardown`, re-write the captured row (the failed-state.Delete shape the cmd-level TestSpawnAllowsAReusedWorktreePathUnderAFreshLease already models correctly), then spawn task-2.
- info: `internal/store/schemaversion_test.go:234` - TestLeaseIDColumnMigratesOntoAnExistingDatabase pins its migration window to &#34;all but the last&#34; (`restore[:len(restore)-1]`, then `migrations = restore` at line 252) instead of to the lease_id migration&#39;s own index, so appending a third migration silently breaks it: the first open stamps version 2 with lease_id dropped by hand, the reopen replays only migrations[2], lease_id is never re-added, and ReadTask fails on a missing column - a failure that reads as if the lease_id migration were broken. Pin both ends to the step under test (`restore[:1]` for the first open, `restore[:2]` for the reopen), matching the index-pinned form the sibling send_undelivered test now uses.
- info: `tests/e2e/fakes_test.go:257` - writeFakeTreehouse now models a v2.1.0-or-newer treehouse (it emits lease_id) but still announces `treehouse 0.7.4` on stderr - the same banner collision_test.go:46&#39;s deliberately-pre-v2.1.0 fake prints. This diff introduces a version-based split between the two fakes, so leaving both announcing 0.7.4 makes the version claim non-distinguishing and contradicts README&#39;s v2.1.0 floor. Bump this fake&#39;s banner to a 2.x string.
- info: `tests/e2e/collision_test.go:46` - TestSpawnDetectsWorktreeCollision stopped calling writeFakeTreehouse and hand-inlines a near-copy of it (same banner, same return/init arms) whose only difference is the omitted lease_id. A `writeFakeTreehouseWithoutLeaseIdentity(t, dir, worktreePath)` sibling in fakes_test.go - or a bool on the existing helper - keeps both branches&#39; fakes and their fidelity notes in one place instead of drifting apart.

fix: Fix: model exclusive treehouse leases in e2e fakes, pin migration windows
ok: Re-checked - no issues remain.

</details>

<details>
<summary>ok: **Test** - passed</summary>

ok: No issues found.
- <code>`go test -race -count=1 ./internal/worktree/` (Get lease parsing, all four CheckCollision branches)</code>
- <code>`go test -race -count=1 ./internal/store/ -run &#39;Migrat|LeaseID|Schema&#39; -v` (includes TestLeaseIDColumnMigratesOntoAnExistingDatabase)</code>
- `go test -race -count=1 ./cmd/ -run 'TestSpawn|TestPromote'`
- `go test -count=1 -tags=e2e -timeout=10m ./tests/e2e/ -run 'Collision|RecycledWorktree|Promote|Teardown|Migrat'`
- <code>Manual product-level demo driving the built `hand` binary at base (d135901) and target (c362c83) against real fleet homes with a one-slot treehouse pool fake: `bash /tmp/no-mistakes-evidence/01KZ3Z84KDV7AJS8KKPZ5QJ8SM/lease-collision-demo.sh`</code>
- <code>`hand spawn task-1 demo` then `treehouse return &lt;slot&gt;` then `hand spawn task-2 demo` on the base build (reproduces the false collision, exit 3)</code>
- <code>Same sequence on the target build (spawn accepted, exit 0) plus `sqlite3 state/hand.db &#39;select id, worktree, lease_id from task&#39;` showing one path under lease-1 and lease-2</code>
- <code>Same sequence on the target build against a treehouse fake reporting no `lease_id` (path fallback still refuses, exit 3)</code>
- <code>Fleet home created by the base build (no lease_id column), then upgraded in place to the target build: migration applies, `hand status` still lists the pre-existing row, and the identity-less row stays path-guarded</code>
- <code>Target build with the slot never returned: `hand spawn task-2 demo` refused by treehouse&#39;s own pool lock before hand&#39;s guard</code>

</details>

<details>
<summary>warning: **Document** - 1 info</summary>

- info: `SPECS.md:1907` - Judgment call left for the author: the new &#34;Collision guard&#34; section documents path comparison as a permanent fallback for &#34;a treehouse older than v2.1.0&#34;, but README.md:97 already states treehouse v2.1.0 or newer as a hard prerequisite, so that half of the fallback covers a configuration the product declares unsupported. Docs are internally consistent as written, so nothing was changed. If the prerequisite is meant to be binding, the follow-up is to drop the pre-v2.1.0 branch (leaving the fallback for pre-lease_id rows only) rather than to keep documenting both.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>


Closes atqamz/secondhand#48
