### PR TITLE
fix(harness): warn when a harness cannot carry a declared model or prompt

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -422,11 +422,21 @@ Flags:
   clone path is missing from disk, or that path is not a git repository (see "Gate preflight").
 
 Model and effort resolve most-specific-first: the flag, then the brief's `---` declaration (see
-"Brief format"), then the config default, then unset. A resolved value the harness has no flag for
-is a warning on stderr, not a failure: the spawn proceeds with the value recorded in state and
-ignored by the launch command. This covers a resolved effort under anything but claude
-(`harness.SupportsEffort`) and a resolved model under `codex`, `grok` or `pi`
-(`harness.SupportsModel`).
+"Brief format"), then the config default, then unset.
+
+Anything the chosen harness cannot carry is a warning on stderr, not a failure: the spawn proceeds,
+with a resolved model or effort recorded in state and ignored by the launch command. Three things
+can be dropped, and all of them are named on one line per launch rather than one line each, since
+consecutive warnings all naming the same harness read as separate problems:
+
+- a resolved effort under anything but claude (`harness.SupportsEffort`)
+- a resolved model under `codex`, `grok` or `pi` (`harness.SupportsModel`)
+- the operator-decision rule, and the front-matter disclaimer when the brief has front matter,
+  under `codex`, `grok` or `pi` (`harness.CarriesPrompt`, see "Harness launch templates")
+
+The line reads `warning: harness "codex" cannot carry model "opus", effort "high", the
+operator-decision rule, the front-matter disclaimer; launching anyway`, listing only what that
+launch actually drops.
 
 Behavior:
 1. Validate project exists in registry.
@@ -1644,8 +1654,12 @@ Codex, Grok, and Pi retain unverified templates until those binaries are install
 verifies them must confirm interactive (not headless) launch, not just flag names.
 The harness module is the single place that constructs these commands.
 A template that hands the brief over as a file rather than as prompt text (Codex, Grok, Pi) has no
-prompt to append to, so `agentsmd.OperatorDecisionRule` never reaches those workers: the brief is
-all they read.
+prompt to append to, so `agentsmd.OperatorDecisionRule` and the front-matter disclaimer never reach
+those workers: the brief is all they read. `harness.CarriesPrompt` reports this, and `hand spawn`
+warns on stderr rather than dropping it in silence (see `hand spawn`). The warning is a stopgap, not
+the fix: carrying the text properly needs an inline-prompt flag verified against a real `--help` for
+each of the three, which is blocked on the same missing binaries as
+atqamz/secondhand#36.
 
 ## Herdr integration detail
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -422,9 +422,11 @@ Flags:
   clone path is missing from disk, or that path is not a git repository (see "Gate preflight").
 
 Model and effort resolve most-specific-first: the flag, then the brief's `---` declaration (see
-"Brief format"), then the config default, then unset. A resolved effort under a harness with no
-effort flag (anything but claude) is a warning on stderr, not a failure: the spawn proceeds with
-the effort recorded in state and ignored by the launch command.
+"Brief format"), then the config default, then unset. A resolved value the harness has no flag for
+is a warning on stderr, not a failure: the spawn proceeds with the value recorded in state and
+ignored by the launch command. This covers a resolved effort under anything but claude
+(`harness.SupportsEffort`) and a resolved model under `codex`, `grok` or `pi`
+(`harness.SupportsModel`).
 
 Behavior:
 1. Validate project exists in registry.
@@ -1525,7 +1527,9 @@ The brief path is included in the prompt because Claude Code takes prompt text, 
 `<operator-decision-rule>` is `agentsmd.OperatorDecisionRule` verbatim (see "AGENTS.md (target)"), appended to every prompt-carrying template because the worktree is outside the fleet home and the worker never reads the home's `AGENTS.md`.
 When configured, `--model <name>` and `--effort <level>` are inserted before the prompt.
 Claude is the only harness with an effort flag: `opencode` takes `--model` but no effort, and
-`codex`, `grok` and `pi` take neither (`harness.SupportsEffort`).
+`codex`, `grok` and `pi` take neither (`harness.SupportsEffort`, `harness.SupportsModel`).
+A declared value a harness has no flag for is warned about on stderr rather than dropped in
+silence (see `hand spawn`).
 When the brief carries a `---` declaration, the prompt gains a sentence disclaiming it as dispatch
 metadata (see "Brief format").
 `--dangerously-skip-permissions` is required so the unattended worker does not stall on a

--- a/SPECS.md
+++ b/SPECS.md
@@ -1956,7 +1956,10 @@ brief on disk is never rewritten or stripped. Only the prompt-bearing harnesses 
 sentence: `codex`, `grok` and `pi` are handed the brief as a file with no prompt at all, so a
 declaring brief reaches them undisclaimed.
 
-A declared effort under a harness that cannot apply one warns on stderr (see `hand spawn`).
+A declared effort under a harness that cannot apply one warns on stderr, as does a declared model
+under `codex`, `grok` or `pi`, and so does the operator-decision rule and the front-matter
+disclaimer those same three cannot carry. Whatever a given launch drops is named on one combined
+line, never one line per dropped value (see `hand spawn`).
 
 ## Backlog format
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -425,9 +425,9 @@ Model and effort resolve most-specific-first: the flag, then the brief's `---` d
 "Brief format"), then the config default, then unset.
 
 Anything the chosen harness cannot carry is a warning on stderr, not a failure: the spawn proceeds,
-with a resolved model or effort recorded in state and ignored by the launch command. Three things
-can be dropped, and all of them are named on one line per launch rather than one line each, since
-consecutive warnings all naming the same harness read as separate problems:
+with a resolved model or effort recorded in state and ignored by the launch command. Everything a
+launch drops is named on one line rather than one line each, since consecutive warnings all naming
+the same harness read as separate problems. What can be dropped:
 
 - a resolved effort under anything but claude (`harness.SupportsEffort`)
 - a resolved model under `codex`, `grok` or `pi` (`harness.SupportsModel`)

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -18,8 +18,18 @@ func resolveTier(cmd *cobra.Command, home, briefAbs, harnessName, model, effort 
 	resolvedModel = cmp.Or(model, decl.Model, configDefault(home, "model", ""))
 	resolvedEffort = cmp.Or(effort, decl.Effort, configDefault(home, "effort", ""))
 
-	if resolvedEffort != "" && !harness.SupportsEffort(harnessName) {
-		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q has no effort flag, ignoring effort %q\n", harnessName, resolvedEffort); err != nil {
+	for _, dropped := range []struct {
+		kind      string
+		value     string
+		supported bool
+	}{
+		{"model", resolvedModel, harness.SupportsModel(harnessName)},
+		{"effort", resolvedEffort, harness.SupportsEffort(harnessName)},
+	} {
+		if dropped.value == "" || dropped.supported {
+			continue
+		}
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q has no %s flag, ignoring %s %q\n", harnessName, dropped.kind, dropped.kind, dropped.value); err != nil {
 			return "", "", false, err
 		}
 	}

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"cmp"
 	"fmt"
+	"strings"
 
 	"github.com/atqamz/secondhand/internal/brief"
 	"github.com/atqamz/secondhand/internal/harness"
@@ -18,18 +19,24 @@ func resolveTier(cmd *cobra.Command, home, briefAbs, harnessName, model, effort 
 	resolvedModel = cmp.Or(model, decl.Model, configDefault(home, "model", ""))
 	resolvedEffort = cmp.Or(effort, decl.Effort, configDefault(home, "effort", ""))
 
-	for _, dropped := range []struct {
-		kind      string
-		value     string
-		supported bool
-	}{
-		{"model", resolvedModel, harness.SupportsModel(harnessName)},
-		{"effort", resolvedEffort, harness.SupportsEffort(harnessName)},
-	} {
-		if dropped.value == "" || dropped.supported {
-			continue
+	var dropped []string
+	if resolvedModel != "" && !harness.SupportsModel(harnessName) {
+		dropped = append(dropped, fmt.Sprintf("model %q", resolvedModel))
+	}
+	if resolvedEffort != "" && !harness.SupportsEffort(harnessName) {
+		dropped = append(dropped, fmt.Sprintf("effort %q", resolvedEffort))
+	}
+	if !harness.CarriesPrompt(harnessName) {
+		dropped = append(dropped, "the operator-decision rule")
+		if frontMatter {
+			dropped = append(dropped, "the front-matter disclaimer")
 		}
-		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q has no %s flag, ignoring %s %q\n", harnessName, dropped.kind, dropped.kind, dropped.value); err != nil {
+	}
+
+	// One line per launch rather than one per dropped value: consecutive warnings all naming the
+	// same harness read as separate problems (atqamz/secondhand#151).
+	if len(dropped) > 0 {
+		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q cannot carry %s; launching anyway\n", harnessName, strings.Join(dropped, ", ")); err != nil {
 			return "", "", false, err
 		}
 	}

--- a/cmd/tier_test.go
+++ b/cmd/tier_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -149,6 +150,63 @@ func TestResolveTierWarnsWhenHarnessCannotApplyEffort(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "opencode") || !strings.Contains(stderr.String(), "effort") {
 		t.Fatalf("stderr = %q, want a warning naming the harness and effort", stderr.String())
+	}
+}
+
+// TestResolveTierWarnsWhenHarnessCannotApplyModel covers all three model-less harnesses because
+// their launch builders are near-copies: a test that only proves codex warns lets grok or pi
+// regress in silence.
+func TestResolveTierWarnsWhenHarnessCannotApplyModel(t *testing.T) {
+	for _, harnessName := range []string{harness.Codex, harness.Grok, harness.Pi} {
+		t.Run(harnessName, func(t *testing.T) {
+			home := t.TempDir()
+			briefAbs := writeTierBrief(t, home, declaredBrief)
+
+			cmd, stderr := newTierTestCmd()
+			model, _, _, err := resolveTier(cmd, home, briefAbs, harnessName, "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if model != "brief-model" {
+				t.Fatalf("got model=%q, want it still resolved even though %s cannot apply it", model, harnessName)
+			}
+			want := "warning: harness " + strconv.Quote(harnessName) + " has no model flag, ignoring model \"brief-model\"\n"
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("stderr = %q, want it to contain %q", stderr.String(), want)
+			}
+			if !strings.Contains(stderr.String(), "no effort flag") {
+				t.Fatalf("stderr = %q, want the effort warning alongside the model one", stderr.String())
+			}
+		})
+	}
+}
+
+func TestResolveTierNoModelWarningUnderOpenCode(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, declaredBrief)
+
+	cmd, stderr := newTierTestCmd()
+	if _, _, _, err := resolveTier(cmd, home, briefAbs, harness.OpenCode, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr.String(), "model") {
+		t.Fatalf("stderr = %q, want no model warning under a harness that takes --model", stderr.String())
+	}
+}
+
+func TestResolveTierNoWarningWhenNoModelResolved(t *testing.T) {
+	home := t.TempDir()
+	briefAbs := writeTierBrief(t, home, "---\neffort: brief-effort\n---\n# Title\n")
+
+	cmd, stderr := newTierTestCmd()
+	if _, _, _, err := resolveTier(cmd, home, briefAbs, harness.Codex, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr.String(), "model") {
+		t.Fatalf("stderr = %q, want no model warning when no model was resolved at all", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no effort flag") {
+		t.Fatalf("stderr = %q, want the effort warning still reported", stderr.String())
 	}
 }
 

--- a/cmd/tier_test.go
+++ b/cmd/tier_test.go
@@ -153,29 +153,46 @@ func TestResolveTierWarnsWhenHarnessCannotApplyEffort(t *testing.T) {
 	}
 }
 
-// TestResolveTierWarnsWhenHarnessCannotApplyModel covers all three model-less harnesses because
-// their launch builders are near-copies: a test that only proves codex warns lets grok or pi
-// regress in silence.
-func TestResolveTierWarnsWhenHarnessCannotApplyModel(t *testing.T) {
+// All three prompt-less builders are near-copies, so proving only codex warns is what lets grok or
+// pi regress. Exact-match rather than Contains because the single combined line is the point: the
+// alternative was three warnings per launch all naming the same harness.
+func TestResolveTierWarnsOnceForEverythingAHarnessCannotCarry(t *testing.T) {
 	for _, harnessName := range []string{harness.Codex, harness.Grok, harness.Pi} {
 		t.Run(harnessName, func(t *testing.T) {
 			home := t.TempDir()
 			briefAbs := writeTierBrief(t, home, declaredBrief)
 
 			cmd, stderr := newTierTestCmd()
-			model, _, _, err := resolveTier(cmd, home, briefAbs, harnessName, "", "")
+			model, effort, _, err := resolveTier(cmd, home, briefAbs, harnessName, "", "")
 			if err != nil {
 				t.Fatal(err)
 			}
-			if model != "brief-model" {
-				t.Fatalf("got model=%q, want it still resolved even though %s cannot apply it", model, harnessName)
+			if model != "brief-model" || effort != "brief-effort" {
+				t.Fatalf("got model=%q effort=%q, want both resolved even though %s cannot carry them", model, effort, harnessName)
 			}
-			want := "warning: harness " + strconv.Quote(harnessName) + " has no model flag, ignoring model \"brief-model\"\n"
-			if !strings.Contains(stderr.String(), want) {
-				t.Fatalf("stderr = %q, want it to contain %q", stderr.String(), want)
+			want := "warning: harness " + strconv.Quote(harnessName) + ` cannot carry model "brief-model", effort "brief-effort", the operator-decision rule, the front-matter disclaimer; launching anyway` + "\n"
+			if stderr.String() != want {
+				t.Fatalf("stderr = %q, want exactly %q", stderr.String(), want)
 			}
-			if !strings.Contains(stderr.String(), "no effort flag") {
-				t.Fatalf("stderr = %q, want the effort warning alongside the model one", stderr.String())
+		})
+	}
+}
+
+// A brief with no front matter has no disclaimer to drop, so the operator-decision rule is the
+// only thing left and the line must not claim otherwise.
+func TestResolveTierWarnsOnPromptDropWithNothingDeclared(t *testing.T) {
+	for _, harnessName := range []string{harness.Codex, harness.Grok, harness.Pi} {
+		t.Run(harnessName, func(t *testing.T) {
+			home := t.TempDir()
+			briefAbs := writeTierBrief(t, home, "# Title\n\nno declaration here\n")
+
+			cmd, stderr := newTierTestCmd()
+			if _, _, _, err := resolveTier(cmd, home, briefAbs, harnessName, "", ""); err != nil {
+				t.Fatal(err)
+			}
+			want := "warning: harness " + strconv.Quote(harnessName) + " cannot carry the operator-decision rule; launching anyway\n"
+			if stderr.String() != want {
+				t.Fatalf("stderr = %q, want exactly %q", stderr.String(), want)
 			}
 		})
 	}
@@ -202,11 +219,9 @@ func TestResolveTierNoWarningWhenNoModelResolved(t *testing.T) {
 	if _, _, _, err := resolveTier(cmd, home, briefAbs, harness.Codex, "", ""); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(stderr.String(), "model") {
-		t.Fatalf("stderr = %q, want no model warning when no model was resolved at all", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "no effort flag") {
-		t.Fatalf("stderr = %q, want the effort warning still reported", stderr.String())
+	want := `warning: harness "codex" cannot carry effort "brief-effort", the operator-decision rule, the front-matter disclaimer; launching anyway` + "\n"
+	if stderr.String() != want {
+		t.Fatalf("stderr = %q, want exactly %q (no model named, none was resolved)", stderr.String(), want)
 	}
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -123,8 +123,18 @@ type Options struct {
 	BriefHasFrontMatter bool
 }
 
+var modelCapable = map[string]bool{
+	Claude:   true,
+	OpenCode: true,
+}
+
 var effortCapable = map[string]bool{
 	Claude: true,
+}
+
+// SupportsModel: false means the caller must warn instead of silently dropping the model.
+func SupportsModel(name string) bool {
+	return modelCapable[name]
 }
 
 // SupportsEffort: false means the caller must warn instead of silently dropping the effort.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -132,14 +132,26 @@ var effortCapable = map[string]bool{
 	Claude: true,
 }
 
-// SupportsModel: false means the caller must warn instead of silently dropping the model.
+var promptCapable = map[string]bool{
+	Claude:   true,
+	OpenCode: true,
+}
+
+// False means the caller must warn instead of silently dropping the model.
 func SupportsModel(name string) bool {
 	return modelCapable[name]
 }
 
-// SupportsEffort: false means the caller must warn instead of silently dropping the effort.
+// False means the caller must warn instead of silently dropping the effort.
 func SupportsEffort(name string) bool {
 	return effortCapable[name]
+}
+
+// False means the builder hands the brief over as a file and has no prompt to append to, so
+// briefPrompt's operator-decision rule and front-matter disclaimer never reach the worker.
+// Carrying them properly needs flags verified against a real --help (atqamz/secondhand#36).
+func CarriesPrompt(name string) bool {
+	return promptCapable[name]
 }
 
 // Build constructs the shell command that cds into the worktree and launches the harness

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -197,6 +197,23 @@ func TestBuildCarriesOperatorDecisionRule(t *testing.T) {
 	}
 }
 
+// TestSupportsModel pins the capability against the builders: exactly the harnesses whose build
+// function emits --model may report true, or a caller that trusts it drops the model in silence.
+func TestSupportsModel(t *testing.T) {
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "some-model"})
+		if err != nil {
+			t.Fatalf("Build(%q) error: %v", name, err)
+		}
+		if emits := strings.Contains(got, "--model 'some-model'"); emits != SupportsModel(name) {
+			t.Errorf("SupportsModel(%q) = %v but Build(%q) = %q", name, SupportsModel(name), name, got)
+		}
+	}
+	if SupportsModel("nonexistent") {
+		t.Error("SupportsModel(nonexistent) = true, want false")
+	}
+}
+
 func TestSupportsEffort(t *testing.T) {
 	if !SupportsEffort(Claude) {
 		t.Error("SupportsEffort(claude) = false, want true")

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -197,8 +197,8 @@ func TestBuildCarriesOperatorDecisionRule(t *testing.T) {
 	}
 }
 
-// TestSupportsModel pins the capability against the builders: exactly the harnesses whose build
-// function emits --model may report true, or a caller that trusts it drops the model in silence.
+// Pinned against the builders rather than restating the map: a harness reporting true while its
+// command carries no --model is exactly the silent drop being fixed here.
 func TestSupportsModel(t *testing.T) {
 	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
 		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "some-model"})
@@ -222,6 +222,25 @@ func TestSupportsEffort(t *testing.T) {
 		if SupportsEffort(name) {
 			t.Errorf("SupportsEffort(%q) = true, want false", name)
 		}
+	}
+}
+
+// Pinned against the builders for the same reason as TestSupportsModel: a harness reporting true
+// while its command carries no prompt text drops the operator-decision rule in silence.
+func TestCarriesPrompt(t *testing.T) {
+	quoted := shellQuote(agentsmd.OperatorDecisionRule)
+	escaped := quoted[1 : len(quoted)-1]
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+		if err != nil {
+			t.Fatalf("Build(%q) error: %v", name, err)
+		}
+		if carries := strings.Contains(got, escaped); carries != CarriesPrompt(name) {
+			t.Errorf("CarriesPrompt(%q) = %v but Build(%q) = %q", name, CarriesPrompt(name), name, got)
+		}
+	}
+	if CarriesPrompt("nonexistent") {
+		t.Error("CarriesPrompt(nonexistent) = true, want false")
 	}
 }
 

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -214,14 +214,20 @@ func TestSupportsModel(t *testing.T) {
 	}
 }
 
+// Pinned against the builders for the same reason as TestSupportsModel: a harness reporting true
+// while its command carries no --effort is the silent drop this predicate exists to prevent.
 func TestSupportsEffort(t *testing.T) {
-	if !SupportsEffort(Claude) {
-		t.Error("SupportsEffort(claude) = false, want true")
-	}
-	for _, name := range []string{Codex, Grok, Pi, OpenCode, "nonexistent"} {
-		if SupportsEffort(name) {
-			t.Errorf("SupportsEffort(%q) = true, want false", name)
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "some-effort"})
+		if err != nil {
+			t.Fatalf("Build(%q) error: %v", name, err)
 		}
+		if emits := strings.Contains(got, "--effort 'some-effort'"); emits != SupportsEffort(name) {
+			t.Errorf("SupportsEffort(%q) = %v but Build(%q) = %q", name, SupportsEffort(name), name, got)
+		}
+	}
+	if SupportsEffort("nonexistent") {
+		t.Error("SupportsEffort(nonexistent) = true, want false")
 	}
 }
 

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -239,7 +239,7 @@ func TestSpawnWarnsOnEffortIncapableHarness(t *testing.T) {
 	if spawned.code != 0 {
 		t.Fatalf("spawn: exit %d, stderr %q", spawned.code, spawned.stderr)
 	}
-	if !strings.Contains(spawned.stderr, `warning: harness "opencode" has no effort flag, ignoring effort "high"`) {
+	if !strings.Contains(spawned.stderr, `warning: harness "opencode" cannot carry effort "high"; launching anyway`) {
 		t.Fatalf("stderr = %q, want the effort-incapable warning", spawned.stderr)
 	}
 


### PR DESCRIPTION
## Intent

Close atqamz/secondhand#99 and atqamz/secondhand#151 for the 0.2.0 release: warn the operator when a chosen harness cannot carry something a launch was told to apply, instead of dropping it in silence. This is a completeness fix for a release, not an urgent defect - this fleet dispatches only to claude today, so nothing is being harmed right now.

The defect: codex, grok and pi take no --model flag, so a brief declaring 'model:' launched the worker at the harness default with nothing on stderr, while a declared effort already warned from the same function. The asymmetry inside one resolution step is the bug. Those same three also hand the brief over as a file with no prompt to append to, so agentsmd.OperatorDecisionRule and the front-matter disclaimer never reach those workers either; that was documented only in a test comment and never said out loud at launch.

Deliberate decisions a reviewer reading only the diff would not know:

1. Do NOT refuse the spawn when a value cannot be carried. This was considered in atqamz/secondhand#99 and explicitly rejected: a wrong-but-running worker is recoverable, a fleet that will not dispatch is not. The launch proceeds and a resolved model or effort stays recorded in state.

2. ONE combined stderr line per launch naming everything the harness cannot carry, NOT one warning per dropped value. Atqa decided this explicitly when folding atqamz/secondhand#151 into this PR, because three consecutive warnings all naming the same harness read as three separate problems. The tests exact-match the whole stderr rather than using Contains precisely to pin that single-line shape: a substring check would still pass if it regressed to one line per value. That exact-match strictness is intentional, not brittleness.

3. Actually carrying the prompt text into codex, grok and pi is deliberately OUT OF SCOPE and the PR body says so. It is the real fix and this warning is an honest stopgap, but it needs an inline-prompt flag verified against a real --help for each of the three, and none of those binaries is installed on this host. Blocked on atqamz/secondhand#36 and needs Atqa. Do not propose implementing it here.

4. The capability maps (SupportsModel, CarriesPrompt) are pinned against the builders by tests that call Build for all five harnesses instead of restating the map contents. A map drifting from its builder is the original bug, so that apparent redundancy is the point.

5. All three harnesses are covered as subtests deliberately. The builders that drop these values are near-copies, so a test proving only codex warns is the test that lets grok regress silently.

6. Comments are written to atqamz/secondhand#98's two rules, whose checker lands ahead of this PR: no comment block opens with the identifier it documents, and no block exceeds three lines. That is why the pre-existing SupportsEffort doc comment was rewritten - it opened with its own identifier and this PR adds its sibling SupportsModel. Do not 'restore' Go-conventional doc comments that begin with the function name. This repo is zero-comments-by-default; each comment added carries a WHY the code cannot show.

Scope is deliberately narrow: the model-warning path plus naming the prompt drop, SPECS.md updated to match, and one existing e2e assertion updated for the new wording. Nothing else.

Verified locally inside nix develop before this run: go build ./..., go test -race ./..., go test -race -tags e2e ./tests/e2e/..., make lint (0 issues). Branch rebased onto main at ab2db52.

Constraints on this run: the PR body carries two standalone closing lines, 'Closes atqamz/secondhand#99' and 'Closes atqamz/secondhand#151', each on its own line, and both must survive. Do not add a Co-Authored-By trailer to any commit. No em dash, no emoji anywhere.

## What Changed

- `resolveTier` now emits a single stderr line per launch naming every value the chosen harness cannot carry (`warning: harness %q cannot carry ...; launching anyway`), replacing the effort-only warning. The launch still proceeds and a resolved model or effort stays recorded in state.
- `internal/harness` gains `SupportsModel` and `CarriesPrompt` alongside `SupportsEffort`, so a brief declaring `model:` under codex, grok or pi is named instead of silently dropped, as are the operator-decision rule and the front-matter disclaimer that never reach a harness handed the brief as a file.
- SPECS.md updated to match in the `hand spawn`, launch-template and declared-model-and-effort sections; capability tests call `Build` for all five harnesses so a map cannot drift from its builder, and one existing e2e assertion was updated for the new wording.

Actually carrying the prompt text into codex, grok and pi is out of scope here: it needs an inline-prompt flag verified against a real `--help` for each, blocked on atqamz/secondhand#36. This warning is the honest stopgap.

Closes atqamz/secondhand#99
Closes atqamz/secondhand#151

## Risk Assessment

ok: Low: The follow-up commit resolves both round-1 findings exactly as instructed and touches only a test assertion and one spec paragraph, leaving the branch a narrow, additive warning path routed through the single shared resolution step both launch commands already call, with all three capability predicates now pinned against their builders.

## Testing

Ran the focused unit tests for `resolveTier` and the harness capability predicates plus the one updated e2e spawn test, all green, then went past unit level: built the real `hand` binary and drove `hand spawn` in a throwaway fleet home with fake herdr/treehouse across all five harnesses, capturing a CLI transcript. It shows codex, grok and pi each emitting one combined stderr line naming the dropped model, effort, operator-decision rule and front-matter disclaimer, exit 0 with the resolved model still recorded in `hand status`, and the captured launch command proving those flags and prompt text genuinely are absent; claude warns about nothing and opencode warns only about effort, so there are no false positives. A codex run against a brief with no front matter correctly shortens the line to the operator-decision rule alone. No UI surface is involved, so the reviewer-visible artifact is the CLI transcript rather than a screenshot. Temp fleet home and built binary removed; the worktree is clean.

<details>
<summary>Evidence: hand spawn transcript across all five harnesses (warning, exit code, persisted state, actual launch command)</summary>

<code>===== harness: codex, brief declares model + effort =====&#10;$ hand spawn task-1 demo&#10;spawned task-1 project=demo kind=ship harness=codex worktree=/tmp/nm-manual-codex/home/wt-task-1&#10;warning: harness &#34;codex&#34; cannot carry model &#34;claude-opus-5&#34;, effort &#34;max&#34;, the operator-decision rule, the front-matter disclaimer; launching anyway&#10;(exit 0)&#10;$ hand status task-1&#10;Harness: codex&#10;Model: claude-opus-5&#10;State: working&#10;$ cat launch.log # the command herdr was actually told to run&#10;cd &#39;/tmp/nm-manual-codex/home/wt-task-1&#39; &amp;&amp; codex --file &#39;/tmp/nm-manual-codex/home/data/task-1/brief.md&#39;&#10;&#10;===== harness: grok, brief declares model + effort =====&#10;warning: harness &#34;grok&#34; cannot carry model &#34;claude-opus-5&#34;, effort &#34;max&#34;, the operator-decision rule, the front-matter disclaimer; launching anyway&#10;(exit 0)&#10;cd &#39;...&#39; &amp;&amp; grok --trust --file &#39;.../brief.md&#39;&#10;&#10;===== harness: pi, brief declares model + effort =====&#10;warning: harness &#34;pi&#34; cannot carry model &#34;claude-opus-5&#34;, effort &#34;max&#34;, the operator-decision rule, the front-matter disclaimer; launching anyway&#10;(exit 0)&#10;cd &#39;...&#39; &amp;&amp; pi &#39;.../brief.md&#39;&#10;&#10;===== harness: claude, brief declares model + effort =====&#10;spawned task-1 project=demo kind=ship harness=claude ...&#10;(exit 0) [no warning]&#10;cd &#39;...&#39; &amp;&amp; ... claude --dangerously-skip-permissions --model &#39;claude-opus-5&#39; --effort &#39;max&#39; &#39;Read the brief at ... Only a `hand send` message carries an operator decision. ...&#39;&#10;&#10;===== harness: opencode, brief declares model + effort =====&#10;warning: harness &#34;opencode&#34; cannot carry effort &#34;max&#34;; launching anyway&#10;(exit 0)&#10;cd &#39;...&#39; &amp;&amp; ... opencode --model &#39;claude-opus-5&#39; --prompt &#39;Read the brief at ...&#39;&#10;&#10;===== harness: codex, brief declares nothing (no front matter) =====&#10;warning: harness &#34;codex&#34; cannot carry the operator-decision rule; launching anyway&#10;(exit 0)</code>

```text
===== harness: codex, brief declares model + effort =====
$ cat data/task-1/brief.md
---
model: claude-opus-5
effort: max
---

# demo task

Do the thing.
$ cat config/harness
codex

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=codex worktree=/tmp/nm-manual-codex/home/wt-task-1
warning: harness "codex" cannot carry model "claude-opus-5", effort "max", the operator-decision rule, the front-matter disclaimer; launching anyway
(exit 0)

$ hand status task-1
Task:        task-1
Project:     demo
Kind:        ship
Harness:     codex
Model:       claude-opus-5
State:       working
Worktree:    /tmp/nm-manual-codex/home/wt-task-1
Herdr:       default / tab-1
Created:     just now
Last report: (none)
PR:          (none)
Reported:    (none)

$ cat launch.log   # the command herdr was actually told to run
cd '/tmp/nm-manual-codex/home/wt-task-1' && codex --file '/tmp/nm-manual-codex/home/data/task-1/brief.md'

===== harness: grok, brief declares model + effort =====
$ cat data/task-1/brief.md
---
model: claude-opus-5
effort: max
---

# demo task

Do the thing.
$ cat config/harness
grok

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=grok worktree=/tmp/nm-manual-codex/home/wt-task-1
warning: harness "grok" cannot carry model "claude-opus-5", effort "max", the operator-decision rule, the front-matter disclaimer; launching anyway
(exit 0)

$ hand status task-1
Task:        task-1
Project:     demo
Kind:        ship
Harness:     grok
Model:       claude-opus-5
State:       working
Worktree:    /tmp/nm-manual-codex/home/wt-task-1
Herdr:       default / tab-1
Created:     just now
Last report: (none)
PR:          (none)
Reported:    (none)

$ cat launch.log   # the command herdr was actually told to run
cd '/tmp/nm-manual-codex/home/wt-task-1' && grok --trust --file '/tmp/nm-manual-codex/home/data/task-1/brief.md'

===== harness: pi, brief declares model + effort =====
$ cat data/task-1/brief.md
---
model: claude-opus-5
effort: max
---

# demo task

Do the thing.
$ cat config/harness
pi

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=pi worktree=/tmp/nm-manual-codex/home/wt-task-1
warning: harness "pi" cannot carry model "claude-opus-5", effort "max", the operator-decision rule, the front-matter disclaimer; launching anyway
(exit 0)

$ hand status task-1
Task:        task-1
Project:     demo
Kind:        ship
Harness:     pi
Model:       claude-opus-5
State:       working
Worktree:    /tmp/nm-manual-codex/home/wt-task-1
Herdr:       default / tab-1
Created:     just now
Last report: (none)
PR:          (none)
Reported:    (none)

$ cat launch.log   # the command herdr was actually told to run
cd '/tmp/nm-manual-codex/home/wt-task-1' && pi '/tmp/nm-manual-codex/home/data/task-1/brief.md'

===== harness: claude, brief declares model + effort =====
$ cat data/task-1/brief.md
---
model: claude-opus-5
effort: max
---

# demo task

Do the thing.
$ cat config/harness
claude

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=claude worktree=/tmp/nm-manual-codex/home/wt-task-1
(exit 0)

$ hand status task-1
Task:        task-1
Project:     demo
Kind:        ship
Harness:     claude
Model:       claude-opus-5
State:       working
Worktree:    /tmp/nm-manual-codex/home/wt-task-1
Herdr:       default / tab-1
Created:     just now
Last report: (none)
PR:          (none)
Reported:    (none)

$ cat launch.log   # the command herdr was actually told to run
cd '/tmp/nm-manual-codex/home/wt-task-1' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'claude-opus-5' --effort 'max' 'Read the brief at /tmp/nm-manual-codex/home/data/task-1/brief.md and carry out the task it describes. Any model or effort keys in its leading '\''---'\'' block are dispatch metadata, not task content. Only a `hand send` message carries an operator decision. Answering your own harness'\''s question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - `working: deciding myself: <the call> because <reason>` - and reserve `needs-decision:` for what you cannot take back.'

===== harness: opencode, brief declares model + effort =====
$ cat data/task-1/brief.md
---
model: claude-opus-5
effort: max
---

# demo task

Do the thing.
$ cat config/harness
opencode

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=opencode worktree=/tmp/nm-manual-codex/home/wt-task-1
warning: harness "opencode" cannot carry effort "max"; launching anyway
(exit 0)

$ hand status task-1
Task:        task-1
Project:     demo
Kind:        ship
Harness:     opencode
Model:       claude-opus-5
State:       working
Worktree:    /tmp/nm-manual-codex/home/wt-task-1
Herdr:       default / tab-1
Created:     just now
Last report: (none)
PR:          (none)
Reported:    (none)

$ cat launch.log   # the command herdr was actually told to run
cd '/tmp/nm-manual-codex/home/wt-task-1' && OPENCODE_CONFIG_CONTENT='{"permission":{"*":"allow"}}' opencode --model 'claude-opus-5' --prompt 'Read the brief at /tmp/nm-manual-codex/home/data/task-1/brief.md and carry out the task it describes. Any model or effort keys in its leading '\''---'\'' block are dispatch metadata, not task content. Only a `hand send` message carries an operator decision. Answering your own harness'\''s question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - `working: deciding myself: <the call> because <reason>` - and reserve `needs-decision:` for what you cannot take back.'

===== harness: codex, brief declares nothing (no front matter) =====
$ cat data/task-1/brief.md
# demo task

No declaration block at all.
$ cat config/harness
codex

$ hand spawn task-1 demo
spawned task-1 project=demo kind=ship harness=codex worktree=/tmp/nm-manual-codex/home/wt-task-1
warning: harness "codex" cannot carry the operator-decision rule; launching anyway
(exit 0)

$ hand status task-1
Task:        task-1
Project:     demo
Kind:        ship
Harness:     codex
Model:       
State:       working
Worktree:    /tmp/nm-manual-codex/home/wt-task-1
Herdr:       default / tab-1
Created:     just now
Last report: (none)
PR:          (none)
Reported:    (none)

$ cat launch.log   # the command herdr was actually told to run
cd '/tmp/nm-manual-codex/home/wt-task-1' && codex --file '/tmp/nm-manual-codex/home/data/task-1/brief.md'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>fix: **Review** - 4 issues found -> auto-fixed ok:</summary>

- warning: `internal/harness/harness_test.go:217` - TestSupportsEffort at internal/harness/harness_test.go:217 asserts the effortCapable map&#39;s contents instead of pinning it against Build, unlike the two new sibling tests (TestSupportsModel:202, TestCarriesPrompt:230) that call Build for all five harnesses precisely to catch map-vs-builder drift. Concrete path: remove the `--effort` append from buildClaude (harness.go:201-203) or add an effort flag to buildOpenCode, and effortCapable still reports the stale answer; resolveTier then either drops the effort with no warning (the original bug this PR fixes) or warns about a value the launch actually carried, and TestSupportsEffort passes either way. Fix: rewrite it in the same shape as TestSupportsModel, iterating Claude/Codex/Grok/Pi/OpenCode with Options{Effort: &#34;some-effort&#34;} and comparing strings.Contains(got, &#34;--effort &#39;some-effort&#39;&#34;) against SupportsEffort(name), keeping the nonexistent-harness assertion.
- warning: `SPECS.md:1959` - SPECS.md:1959 (&#34;A declared effort under a harness that cannot apply one warns on stderr&#34;) is now incomplete inside the section titled &#34;Declared model and effort&#34;: a declared model warns too under codex/grok/pi, and lines 1955-1957 state those three get the brief undisclaimed without saying that is now named at launch. The hand spawn section (SPECS.md:427-439) and the launch-template section (SPECS.md:1658) were both updated; this one was missed, leaving the authoritative spec describing only half the warning. Fix: extend line 1959 to cover a declared model and the undisclaimed brief, still pointing at `hand spawn` for the combined line.
- info: `cmd/promote.go:73` - In cmd/promote.go the resolveTier call at line 73 runs before project.Find (78), gatePreflight (87) and state.Lock (91), so the &#34;; launching anyway&#34; line can be printed and then the command aborts without launching anything. Previously this only surfaced when an effort resolved; now it fires on every codex/grok/pi promote because the CarriesPrompt branch is unconditional for those three. cmd/spawn.go already validates and preflights before resolveTier (lines 41-86), so only promote has the inversion. Informational: the subsequent error is loud and the exit code is non-zero, so the operator is not left believing a worker started, and reordering promote&#39;s resolution step is beyond this change&#39;s scope.
- info: `internal/harness/harness.go:126` - internal/harness/harness.go:126-138 now holds three parallel capability maps, and modelCapable and promptCapable have byte-identical contents ({Claude, OpenCode}). Adding a sixth harness means remembering three separate edits, and a forgotten one is the same silent-drop class this PR fixes. A single table keyed by harness name holding a small struct of the three bools would make each harness one row and each predicate a one-line read. Noted as a tradeoff rather than a defect: the current shape follows the pre-existing effortCapable pattern, which is a defensible reason to leave it.

fix: Fix: pin effort capability test against builder, extend spec
ok: Re-checked - no issues remain.

</details>

<details>
<summary>ok: **Test** - passed</summary>

ok: No issues found.
- <code>`go test -race ./cmd/ -run TestResolveTier -v` (covers the new codex/grok/pi subtests, the no-front-matter case, the opencode and claude no-warning cases)</code>
- <code>`go test -race ./internal/harness/ -run &#34;TestSupportsModel|TestSupportsEffort|TestCarriesPrompt|TestBuild&#34; -v` (capability maps pinned against Build for all five harnesses)</code>
- <code>`go test -race -tags e2e ./tests/e2e/ -run TestSpawnWarnsOnEffortIncapableHarness -v` (updated warning wording through the real binary)</code>
- <code>Manual end-to-end: built `hand`, created a fleet home with a fake herdr/treehouse on PATH, ran `hand spawn task-1 demo` under harness codex, grok, pi, claude and opencode with a brief declaring `model:` and `effort:`, then repeated codex with a brief that has no front matter; recorded stderr, exit code, `hand status task-1`, and the launch command herdr was told to run</code>

</details>

<details>
<summary>warning: **Document** - 1 info</summary>

- info: `internal/harness/harness_test.go:182` - Out-of-scope follow-up: TestBuildCarriesOperatorDecisionRule&#39;s comment now duplicates the fact newly owned by harness.CarriesPrompt&#39;s doc comment (brief handed over as a file, no prompt to append to, blocked until a binary is verified), and it also breaks the two comment rules the new comments in this change were written to - it opens with the identifier it documents and runs four lines. Left untouched here because it lives in a test file; worth reducing to a one-line pointer at CarriesPrompt when atqamz/secondhand#98&#39;s checker lands.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>

