### PR TITLE
fix(cmd): resolve promote's tier after task and gate checks

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -565,6 +565,11 @@ The line reads `warning: harness "codex" cannot carry model "opus", effort "high
 operator-decision rule, the front-matter disclaimer; launching anyway`, listing only what that
 launch actually drops.
 
+The warning belongs to a launch that is about to happen, so the tier resolves only after the
+project, gate preflight and brief checks have passed. A run that refuses names its refusal and
+nothing about a launch it never performs; `hand promote` resolves the tier in that same position
+(atqamz/secondhand#156).
+
 Behavior:
 1. Validate project exists in registry.
 2. If the project's mode is `no-mistakes`, run the gate preflight check (see "Gate preflight");

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -208,6 +208,24 @@ func TestPromoteRefusesWhenNoMistakesGateNotInitialized(t *testing.T) {
 	}
 }
 
+// Pins the ordering from atqamz/secondhand#156. Codex carries no prompt, so resolveTier always
+// has something to warn about here, and a gate refusal must preempt that warning.
+func TestPromoteGateRefusalWarnsNothingAboutTheLaunch(t *testing.T) {
+	path := fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)")
+	setupPromoteHomeGate(t, path)
+
+	var errOut bytes.Buffer
+	cmd := newPromoteCmd()
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"task-1", "--harness", "codex"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+
+	if strings.Contains(errOut.String(), "cannot carry") {
+		t.Fatalf("stderr = %q, want no launch warning on a promote that never launches", errOut.String())
+	}
+}
+
 func TestPromoteRefusesDistinctlyWhenNoMistakesBinaryMissing(t *testing.T) {
 	setupPromoteHomeGate(t, t.TempDir())
 

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -70,12 +70,6 @@ func newPromoteCmd() *cobra.Command {
 			if !harness.IsSupported(harnessName) {
 				return usageValue(harnessFromFlag, fmt.Errorf("harness %q not recognized", harnessName))
 			}
-			var briefHasFrontMatter bool
-			model, effort, briefHasFrontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
-			if err != nil {
-				return err
-			}
-
 			proj, exists, err := project.Find(home, t.Project)
 			if err != nil {
 				return err
@@ -86,6 +80,12 @@ func newPromoteCmd() *cobra.Command {
 
 			clonePath := filepath.Join(home, "projects", proj.Name)
 			if err := gatePreflight(cmd, proj, clonePath, skipGateCheck); err != nil {
+				return err
+			}
+
+			var briefHasFrontMatter bool
+			model, effort, briefHasFrontMatter, err = resolveTier(cmd, home, briefAbs, harnessName, model, effort)
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
## Intent

Correct hand promote's ordering so it resolves the tier after task validation and the gate preflight, matching hand spawn, and leave a mutation test that fails if the call moves back above them (atqamz/secondhand#156).

## What Changed

- `cmd/promote.go` now calls `resolveTier` after `project.Find` and the gate preflight instead of before them, so a promote that refuses no longer prints a `cannot carry` harness warning about a launch it never performs - matching `hand spawn`'s ordering.
- Added `TestPromoteGateRefusalWarnsNothingAboutTheLaunch` in `cmd/gatepreflight_test.go`, which fails if the `resolveTier` call moves back above those checks (verified by mutating the source and watching the test fail).
- Documented the ordering rule in SPECS.md alongside the harness warning description.

## Risk Assessment

ok: Low: A six-line statement move within one command, verified to break no data dependency and to leave every existing promote test's outcome unchanged, plus a test that genuinely fails under the reverse mutation.

## Testing

Exercised the promote ordering change three ways. The targeted cmd-package tests around promote, the gate preflight and resolveTier all pass, and the e2e promote tests pass against the built binary. To prove the new test is a real mutation guard, I moved the resolveTier call back above project.Find and the gate preflight: the test fails with the exact spurious "harness codex cannot carry the operator-decision rule" warning in stderr, and it passes again once the ordering is restored (worktree left byte-identical to the target commit). For end-user evidence I built one hand binary from the mutated source and one from the fixed source, then drove each through a real fleet home: hand init, hand spawn of a scout while the no-mistakes gate was healthy, the gate then going stale, and hand promote task-1 --harness codex. The pre-fix binary prints the launch warning ahead of a refusal that never launches anything; the fixed binary prints the gate refusal alone at exit code 3, with the task still a scout. A healthy-gate run on the fixed binary confirms the warning was only reordered, not lost: it still prints and the task is promoted to a ship on codex.

<details>
<summary>Evidence: CLI transcript before the fix (spurious launch warning ahead of the gate refusal)</summary>

<code>=== before-fix: hand promote task-1 --harness codex ===&#10;--- stderr ---&#10;warning: harness &#34;codex&#34; cannot carry the operator-decision rule; launching anyway&#10;error: &#34;no-mistakes gate not initialized for project \&#34;gated\&#34;, run: cd .../projects/gated &amp;&amp; no-mistakes init&#34;&#10;kind: precondition&#10;exit: 3&#10;--- exit code: 3 ---&#10;--- hand status task-1 after the refusal ---&#10;id: task-1&#10;kind: scout&#10;harness: claude</code>

```text
=== before-fix: hand promote task-1 --harness codex ===
--- stdout ---
--- stderr ---
warning: harness "codex" cannot carry the operator-decision rule; launching anyway
error: "no-mistakes gate not initialized for project \"gated\", run: cd /tmp/hand-e2e-before-fix-Fitf1U/home/projects/gated && no-mistakes init"
kind: precondition
exit: 3
help[1]:
  - Nothing changed: this refuses until the state it names is fixed, then the same command runs again
--- exit code: 3 ---
--- hand status task-1 after the refusal ---
id: task-1
kind: scout
harness: claude
report_history[0]:
help[1]:
  - Run `hand send task-1 <message>` to steer this worker
```
</details>
<details>
<summary>Evidence: CLI transcript after the fix (gate refusal alone, no launch warning)</summary>

<code>=== after-fix: hand promote task-1 --harness codex ===&#10;--- stderr ---&#10;error: &#34;no-mistakes gate not initialized for project \&#34;gated\&#34;, run: cd .../projects/gated &amp;&amp; no-mistakes init&#34;&#10;kind: precondition&#10;exit: 3&#10;help[1]:&#10;- Nothing changed: this refuses until the state it names is fixed, then the same command runs again&#10;--- exit code: 3 ---&#10;--- hand status task-1 after the refusal ---&#10;id: task-1&#10;kind: scout&#10;harness: claude</code>

```text
=== after-fix: hand promote task-1 --harness codex ===
--- stdout ---
--- stderr ---
error: "no-mistakes gate not initialized for project \"gated\", run: cd /tmp/hand-e2e-after-fix-Nnqp5q/home/projects/gated && no-mistakes init"
kind: precondition
exit: 3
help[1]:
  - Nothing changed: this refuses until the state it names is fixed, then the same command runs again
--- exit code: 3 ---
--- hand status task-1 after the refusal ---
id: task-1
kind: scout
harness: claude
report_history[0]:
help[1]:
  - Run `hand send task-1 <message>` to steer this worker
```
</details>
<details>
<summary>Evidence: CLI transcript after the fix, healthy gate (warning still emitted, promotion completes)</summary>

<code>=== after-fix-gate-ready: hand promote task-1 --harness codex ===&#10;--- stdout ---&#10;id: task-1&#10;result: promoted&#10;kind: ship&#10;was: scout&#10;project: gated&#10;harness: codex&#10;--- stderr ---&#10;warning: harness &#34;codex&#34; cannot carry the operator-decision rule; launching anyway&#10;--- exit code: 0 ---&#10;--- hand status task-1 after the refusal ---&#10;id: task-1&#10;kind: ship&#10;harness: codex</code>

```text
=== after-fix-gate-ready: hand promote task-1 --harness codex ===
--- stdout ---
id: task-1
result: promoted
kind: ship
was: scout
project: gated
harness: codex
worktree: /tmp/hand-e2e-after-fix-gate-ready-aTnmWR/wt---json
help[2]:
  - The scout's worktree and pane are gone; run `hand status task-1` to read the ship worker
  - The scout's delivery no longer counts for this task, so `hand deliver task-1` runs again on the code
--- stderr ---
warning: harness "codex" cannot carry the operator-decision rule; launching anyway
--- exit code: 0 ---
--- hand status task-1 after the refusal ---
id: task-1
kind: ship
harness: codex
report_history[0]:
help[1]:
  - Run `hand send task-1 <message>` to steer this worker
```
</details>
<details>
<summary>Evidence: Mutation check: new test fails when resolveTier moves back above validation</summary>

<code>gatepreflight_test.go:225: stderr = &#34;warning: harness \&#34;codex\&#34; cannot carry the operator-decision rule; launching anyway\nError: no-mistakes gate not initialized for project \&#34;gated\&#34;, run: ... no-mistakes init\n&#34;, want no launch warning on a promote that never launches&#10;--- FAIL: TestPromoteGateRefusalWarnsNothingAboutTheLaunch (0.10s)&#10;FAIL github.com/atqamz/secondhand/cmd 0.100s</code>

```text
warning: Git tree '/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01KZ69RPPF5E76CR771P13NN9C' is dirty
=== RUN   TestPromoteGateRefusalWarnsNothingAboutTheLaunch
Usage:
  promote <id> [flags]

Flags:
      --effort string     effort override for harnesses that support it
      --harness string    harness for the new ship worker (default: config/harness, or claude)
  -h, --help              help for promote
      --model string      model override for harnesses that support it
      --skip-gate-check   dispatch even if the no-mistakes gate is not initialized, the clone path is missing from disk, or that path is not a git repository

    gatepreflight_test.go:225: stderr = "warning: harness \"codex\" cannot carry the operator-decision rule; launching anyway\nError: no-mistakes gate not initialized for project \"gated\", run: cd /tmp/nix-shell.QleIoM/TestPromoteGateRefusalWarnsNothingAboutTheLaunch3710553673/002/projects/gated && no-mistakes init\n", want no launch warning on a promote that never launches
--- FAIL: TestPromoteGateRefusalWarnsNothingAboutTheLaunch (0.10s)
FAIL
FAIL	github.com/atqamz/secondhand/cmd	0.100s
FAIL
```
</details>
<details>
<summary>Evidence: Driver script used for the end-to-end CLI runs</summary>

```text
#!/usr/bin/env bash
# Drives a real `hand` binary end to end: spawn a scout while the no-mistakes gate is ready,
# then let the gate go stale and run `hand promote --harness codex` (codex carries no prompt,
# so resolveTier always has something to warn about). Prints the operator-visible transcript.
set -uo pipefail

BIN=$1
LABEL=$2
ROOT=$(mktemp -d /tmp/hand-e2e-"$LABEL"-XXXXXX)
HOME_DIR=$ROOT/home
FAKES=$ROOT/fakes
mkdir -p "$HOME_DIR" "$FAKES"

GATE_STALE=$ROOT/gate-stale
cat >"$FAKES/no-mistakes" <<'EOF'
#!/bin/sh
if [ -f "$GATE_STALE" ]; then
  echo "repo not initialized (run 'no-mistakes init' first)"
else
  echo "gate: ready"
  echo "  no active run"
fi
EOF

cat >"$FAKES/treehouse" <<EOF
#!/bin/sh
case "\$1" in
  get) printf '{"path":"%s","lease_id":"lease-%s"}\n' "$ROOT/wt-\$3" "\$3" ;;
  return) echo ok ;;
  *) echo "unexpected treehouse invocation: \$@" >&2; exit 1 ;;
esac
EOF

cat >"$FAKES/herdr" <<'EOF'
#!/bin/sh
case "$1 $2" in
  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
  "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-1","label":"hand:gated","tab_count":1},"tab":{"tab_id":"tab-1","workspace_id":"ws-1","label":"1"},"root_pane":{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","agent_status":"working"}}}' ;;
  "tab rename") echo '{"result":{"tab":{"tab_id":"tab-1","workspace_id":"ws-1","label":"task-1"}}}' ;;
  "pane run") echo '{"result":{}}' ;;
  "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
  "pane get") printf '{"result":{"pane":{"pane_id":"%s","tab_id":"tab-1","workspace_id":"ws-1","agent":"claude","agent_status":"done"}}}\n' "$3" ;;
  "tab list") echo '{"result":{"tabs":[{"tab_id":"tab-1","workspace_id":"ws-1","label":"task-1"}]}}' ;;
  "tab close") echo '{"result":{}}' ;;
  "workspace close") echo '{"result":{}}' ;;
  *) echo "unexpected herdr invocation: $@" >&2; exit 1 ;;
esac
EOF

chmod +x "$FAKES"/*
export PATH=$FAKES:$PATH
export GATE_STALE
export GIT_CONFIG_GLOBAL=$ROOT/gitconfig
export GIT_CONFIG_SYSTEM=/dev/null
: >"$ROOT/gitconfig"

cd "$HOME_DIR" || exit 1
"$BIN" init >/dev/null || exit 1
echo "- gated: https://example.com/gated.git mode=no-mistakes" >>"$HOME_DIR/data/projects.md"
mkdir -p "$HOME_DIR/projects/gated"
git -C "$HOME_DIR/projects/gated" init -q

mkdir -p "$HOME_DIR/data/task-1"
printf '# brief\nimplement the fix\n' >"$HOME_DIR/data/task-1/brief.md"

"$BIN" spawn task-1 gated --scout >/dev/null 2>"$ROOT/spawn.stderr" || {
  echo "spawn failed:"; cat "$ROOT/spawn.stderr"; exit 1
}
printf '# report\nscout findings\n' >"$HOME_DIR/data/task-1/report.md"

# The gate goes stale after the scout ran (the atqamz/secondhand#156 history: a fleet home
# renamed out from under no-mistakes' recorded working_path). Pass "gate-ready" as the third
# argument to keep the gate healthy and drive the promotion that really launches.
if [ "${3:-gate-stale}" = gate-stale ]; then
  : >"$GATE_STALE"
fi

echo "=== $LABEL: hand promote task-1 --harness codex ==="
"$BIN" promote task-1 --harness codex >"$ROOT/promote.stdout" 2>"$ROOT/promote.stderr"
code=$?
echo "--- stdout ---"; cat "$ROOT/promote.stdout"
echo "--- stderr ---"; cat "$ROOT/promote.stderr"
echo "--- exit code: $code ---"
echo "--- hand status task-1 after the refusal ---"
"$BIN" status task-1 --fields id,kind,harness 2>&1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>ok: **intent** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Rebase** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>warning: **Review** - 1 info</summary>

- info: `cmd/gatepreflight_test.go:220` - The ordering guard detects the mutation only because `codex` is currently prompt-incapable (internal/harness/harness.go:135-138), and the brief written by `setupPromoteHomeGate` declares no tier while the test home sets no config/model or config/effort. If `codex` is ever added to `promptCapable`, resolveTier&#39;s `dropped` list becomes empty for this fixture, no warning is emitted, and the test passes vacuously - silently losing the ordering guard atqamz/secondhand#156 asks it to hold. cmd/tier_test.go:183-198 would fail at the same time and force the capability change to be noticed, but nothing points the developer at this test. Writing config/model in the fixture would make `dropped` non-empty independent of the capability table. Noting the tradeoff only; the comment at cmd/gatepreflight_test.go:211 shows it was deliberate.

</details>

<details>
<summary>ok: **Test** - passed</summary>

ok: No issues found.
- <code>`go test ./cmd/ -run &#39;TestPromote|TestSpawnRefuses|TestSpawnProceeds|TestSpawnSkipGateCheck|TestResolveTier|Tier&#39; -v` (all pass, including the new `TestPromoteGateRefusalWarnsNothingAboutTheLaunch`)</code>
- <code>Mutation check: moved `resolveTier` back above `project.Find`/`gatePreflight` in `cmd/promote.go`, then `go test ./cmd/ -run &#39;TestPromoteGateRefusalWarnsNothingAboutTheLaunch&#39;` -&gt; FAIL on the spurious `cannot carry` warning; source restored and confirmed identical to HEAD via `git status --porcelain`</code>
- <code>`go test -tags e2e ./tests/e2e -run &#39;TestPromote&#39; -v` (TestPromoteScoutToShip, TestPromoteHonorsBriefDeclaredTier)</code>
- <code>Manual end-to-end CLI: built `hand` from the mutated source and from the fixed source, then ran `hand init`, `hand spawn task-1 gated --scout`, staled the no-mistakes gate, and ran `hand promote task-1 --harness codex` against each binary (`/tmp/no-mistakes-evidence/01KZ69RPPF5E76CR771P13NN9C/drive-promote.sh`)</code>
- <code>Manual end-to-end CLI happy path: same driver with a healthy gate (`drive-promote.sh &lt;bin&gt; after-fix-gate-ready gate-ready`), confirming the harness warning is still emitted and the promotion completes (`hand status task-1` reports kind ship, harness codex)</code>

</details>

<details>
<summary>ok: **Document** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Lint** - passed</summary>

ok: No issues found.

</details>

<details>
<summary>ok: **Push** - passed</summary>

ok: No issues found.

</details>


Closes atqamz/secondhand#156
