### PR TITLE
feat: release pre-major features as minor versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
       "release-type": "go",
       "initial-version": "0.1.0",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "extra-files": ["flake.nix"]
     }
   },


### PR DESCRIPTION
## Summary

Remove Release Please's pre-1.0 patch-bump override. Feature commits can now produce the intended minor release, including 0.2.0.

## Verification

- Fresh Codex no-mistakes review, focused Release Please version calculation, documentation validation, lint, and push passed.
- GitHub CI is running.