### PR TITLE
feat: establish hand project identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ Thumbs.db
 treehouse.toml
 
 # etc
-.superpowers/
+docs/superpowers/*
+.superpowers/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Getting started
 
-git clone https://github.com/atqamz/secondhand
-cd secondhand
+git clone https://github.com/atqamz/hand
+cd hand
 nix develop
 make build
 make test
@@ -26,7 +26,7 @@ The tracked managed block is already current, so initialization preserves the so
 5. make e2e if you changed CLI behavior (end-to-end suite, excluded from make test).
 6. make contract if you changed how hand calls herdr, treehouse or gh, and you have those installed. It checks the records in internal/faketool/FIDELITY.md against the real tools, skipping whichever is absent, so CI never runs it.
 7. nix build .#default if you changed Go dependencies (CI builds the flake, and a stale vendorHash in flake.nix fails it).
-8. Open a PR whose body carries a closing keyword (Closes, Fixes, or Resolves) directly preceding a fully qualified atqamz/secondhand#N, on its own line. A bare #N links but reads ambiguously outside the repo, and a reference without the keyword links the issue without ever closing it.
+8. Open a PR whose body carries a closing keyword (Closes, Fixes, or Resolves) directly preceding a fully qualified atqamz/hand#N, on its own line. A bare #N links but reads ambiguously outside the repo, and a reference without the keyword links the issue without ever closing it.
 
 Commits use conventional commits: feat:, fix:, chore:, etc.
 release-please handles versioning and changelogs from these.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= dev
 LDFLAGS := -s -w -X main.version=$(VERSION)
 
 build:
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o hand .
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" .
 
 test:
 	go test -race ./...

--- a/README.md
+++ b/README.md
@@ -131,19 +131,19 @@ qmd vsearch "how did we handle the deploy failure" -c secondhand
 From a release, the way most installs should go:
 
 ```sh
-curl -fsSLO https://github.com/atqamz/secondhand/releases/latest/download/hand-linux-amd64.tar.gz
+curl -fsSLO https://github.com/atqamz/hand/releases/latest/download/hand-linux-amd64.tar.gz
 tar xzf hand-linux-amd64.tar.gz
 install -m755 hand ~/.local/bin/hand
 ```
 
 Releases carry `hand-linux-amd64`, `hand-linux-arm64`, `hand-darwin-amd64` and `hand-darwin-arm64` as `.tar.gz`, alongside a `checksums.txt` to verify against.
-The [releases page](https://github.com/atqamz/secondhand/releases) lists every asset.
+The [releases page](https://github.com/atqamz/hand/releases) lists every asset.
 
 From nix, either into your profile or for a single command:
 
 ```sh
-nix profile install github:atqamz/secondhand
-nix shell github:atqamz/secondhand -c hand --version
+nix profile install github:atqamz/hand
+nix shell github:atqamz/hand -c hand --version
 ```
 
 The flake covers `aarch64-darwin`, `aarch64-linux` and `x86_64-linux`.
@@ -152,11 +152,11 @@ On Intel macOS, use a release binary or `go install`.
 From Go:
 
 ```sh
-go install github.com/atqamz/secondhand@latest
+go install github.com/atqamz/hand@latest
 ```
 
-That produces a binary named `secondhand`, not `hand`, and embeds no version, so it prints `dev` and never reports available updates.
-Rename it or prefer a release asset.
+That embeds no version, so it prints `dev` and never reports available updates.
+Prefer a release asset for a versioned build.
 
 To build a checkout - the path for working on secondhand itself - see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/atomicfile"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/home"
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/atqamz/hand/internal/harness"
 )
 
 func setupConfigHome(t *testing.T) string {

--- a/cmd/deliver.go
+++ b/cmd/deliver.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/deliver_test.go
+++ b/cmd/deliver_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func TestDeliverRecordsTheReasonOnTheTask(t *testing.T) {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
+	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/agentsmd"
 )
 
 // A clean file is the one answer silence used to be indistinguishable from a

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/axi"
+	"github.com/atqamz/hand/internal/axi"
 )
 
 // Resolves --fields against cols, defaulting to def. An unknown name is a usage error, not a silently

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -117,7 +117,7 @@ func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
 	return home
 }
 
-// Stands in for both real histories from atqamz/secondhand#60 (a never-initialized project, and one
+// Stands in for both real histories from atqamz/hand#60 (a never-initialized project, and one
 // whose working_path went stale after the fleet home was renamed): both were checked against the real
 // binary and emit the same status text, so one refusal test covers both.
 func TestSpawnRefusesWhenNoMistakesGateNotInitialized(t *testing.T) {
@@ -205,7 +205,7 @@ func TestPromoteRefusesWhenNoMistakesGateNotInitialized(t *testing.T) {
 	}
 }
 
-// Pins the ordering from atqamz/secondhand#156: a gate refusal must preempt launch warnings because
+// Pins the ordering from atqamz/hand#156: a gate refusal must preempt launch warnings because
 // no launch will occur.
 func TestPromoteGateRefusalWarnsNothingAboutTheLaunch(t *testing.T) {
 	path := fakeNoMistakesPath(t, "repo not initialized (run 'no-mistakes init' first)")

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Writes a fake no-mistakes binary that answers every subcommand with the same text, mirroring the

--- a/cmd/hold.go
+++ b/cmd/hold.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/hold_test.go
+++ b/cmd/hold_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func setupHoldHome(t *testing.T) string {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/sessionhook"
+	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/sessionhook"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/home"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
 )
 
 func TestInitCreatesTheHandDbMarker(t *testing.T) {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
 )
 
 // Holds confirmLaunch's timings. They are a package var rather than consts so tests can shrink the

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/herdr"
+	"github.com/atqamz/hand/internal/herdr"
 )
 
 // Shrinks confirmLaunch's poll window for the rest of the test, so a command test costs milliseconds

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -220,7 +220,7 @@ func TestConfirmLaunch(t *testing.T) {
 			wantKeys: "Enter\nDown\nEnter\n",
 		},
 		{
-			// atqamz/secondhand#28's actual timeline: the pane starts as a bash prompt echoing the launch
+			// atqamz/hand#28's actual timeline: the pane starts as a bash prompt echoing the launch
 			// command, claude comes up a beat later on the trust dialog, then settles.
 			name:    "a dialog that appears after a cold start is still answered",
 			harness: "claude",

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -93,7 +93,7 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 		return &ExitError{Err: fmt.Errorf("no PR recorded for %s", t.ID), Code: 3}
 	}
 
-	// A gate-opened PR (atqamz/secondhand#69) can populate t.PR without hand having merged it, so t.PR no
+	// A gate-opened PR (atqamz/hand#69) can populate t.PR without hand having merged it, so t.PR no
 	// longer implies hand hasn't seen it merged yet; check before running CI checks against a PR gh
 	// already closed.
 	merged, err := ghutil.PRIsMerged(cmd.Context(), t.PR)

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -142,7 +142,7 @@ func TestMergeRefusesWhenNoPRRecorded(t *testing.T) {
 	}
 }
 
-// Covers the gap noted in atqamz/secondhand#69: a gate-opened PR can populate t.PR without hand having
+// Covers the gap noted in atqamz/hand#69: a gate-opened PR can populate t.PR without hand having
 // merged it, so t.PR != "" no longer implies hand hasn't seen it land yet.
 func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
 	home := t.TempDir()

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/faketool"
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func TestResolveMergeMethodDefaultsToSquash(t *testing.T) {

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/notify"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/notify"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func assertExitCode2(t *testing.T, err error) {

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Looks for a PR whose head ref is t's current branch, for a task whose PR was never recorded because a
-// no-mistakes gate opened it directly instead of going through hand pr (atqamz/secondhand#69). Called only
+// no-mistakes gate opened it directly instead of going through hand pr (atqamz/hand#69). Called only
 // where t.PR == "" already, so a task with a PR on record never reaches here.
 func detectPR(ctx context.Context, home string, t state.Task, proj project.Project) (state.Task, error) {
 	branch, err := currentBranch(t.Worktree)
@@ -28,7 +28,7 @@ func detectPR(ctx context.Context, home string, t state.Task, proj project.Proje
 	// twice and make every PR its own same-tier duplicate.
 	if proj.Upstream != "" && !strings.EqualFold(proj.Upstream, repoSlug) {
 		// A fork project's PR lives on the upstream while hand pushes the branch to the fork
-		// (atqamz/secondhand#78), so the upstream is searched too, restricted to head refs in the fork - it
+		// (atqamz/hand#78), so the upstream is searched too, restricted to head refs in the fork - it
 		// also carries same-named branches from every other contributor's fork.
 		targets = append(targets, ghutil.PRSearchTarget{Repo: proj.Upstream, HeadRepo: repoSlug})
 	}

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Looks for a PR whose head ref is t's current branch, for a task whose PR was never recorded because a

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"errors"
 
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // These package errors are precondition failures rather than general errors. The imported packages

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/atomicfile"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/project_sync_test.go
+++ b/cmd/project_sync_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/hand/internal/project"
 )
 
 func runGitIn(t *testing.T, dir string, args ...string) {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func TestValidateProjectName(t *testing.T) {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -332,7 +332,7 @@ func TestProjectListQuotesAURLRatherThanLettingItSplitTheRow(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 
-	url := "https://github.com/atqamz/secondhand.git"
+	url := "https://github.com/atqamz/hand.git"
 	if err := project.Add(home, project.Project{Name: "secondhand", URL: url, Mode: project.ModeNoMistakes}); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -6,13 +6,13 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/worktree"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Covers the herdr calls a clean promote makes, same void-command-as-envelope simplification as

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/store"
 )
 
 func writeCorpusFile(t *testing.T, home, rel, body string) {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -60,7 +60,7 @@ func newSendCmd() *cobra.Command {
 			}
 
 			// Serializes concurrent sends to the same task: two retry loops racing against the same busy
-			// composer is the exact hazard atqamz/secondhand#102 traced a lost steer to. A second send waits
+			// composer is the exact hazard atqamz/hand#102 traced a lost steer to. A second send waits
 			// behind the first, its own --wait clock starting only once it holds this lock.
 			release, err := state.Lock(home, "send:"+id)
 			if err != nil {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func setupSendHome(t *testing.T, herdrScript string) string {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -7,14 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/shellquote"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/shellquote"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
 )
 
 func setupSessionHome(t *testing.T) string {

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -234,7 +234,7 @@ func gatePreflight(cmd *cobra.Command, proj project.Project, clonePath string, s
 
 // The label hand gives, and searches for, a project's shared workspace. A bare project name is not a
 // safe search key: herdr derives a workspace's label from its root directory's basename, so any
-// workspace a human opens under a directory named after the project carries it (atqamz/secondhand#118).
+// workspace a human opens under a directory named after the project carries it (atqamz/hand#118).
 func herdrWorkspaceLabel(projName string) string {
 	// Prefixed the same way worktree.Get's pool name already does ("hand:"+id), so the label is one only
 	// hand itself would ever set and a same-labelled workspace hand did not create can never match, no

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/worktree"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func TestSpawnCleanupReportsAllErrors(t *testing.T) {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -213,7 +213,7 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 }
 
-// Pins atqamz/secondhand#118: the plain-labelled "myproj" workspace here sorts first in "workspace list"
+// Pins atqamz/hand#118: the plain-labelled "myproj" workspace here sorts first in "workspace list"
 // and would have won the old bare-label lookup, so hand must resolve to its own "hand:myproj" whatever
 // the order, never one it did not create (how a human's workspace collides: internal/faketool/FIDELITY.md).
 const fakeHerdrTwoWorkspacesOneLabelScript = `#!/bin/sh
@@ -583,7 +583,7 @@ func TestSpawnFailureClosesWorkspaceItCreated(t *testing.T) {
 }
 
 // Answers "workspace create" as a herdr predating the tab/root_pane fields would, reporting the workspace
-// and omitting both - the partial-response shape atqamz/secondhand#74 fixes. It accepts and logs
+// and omitting both - the partial-response shape atqamz/hand#74 fixes. It accepts and logs
 // "workspace close" too, since the workspace exists by then and a test could otherwise pass unfixed.
 const fakeHerdrPartialWorkspaceCreateScript = `#!/bin/sh
 echo "$@" >> "$HERDR_CALL_LOG"

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -523,7 +523,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 }
 
 // The report tail with the entry the report field already shows dropped - repeating it was the core of
-// atqamz/secondhand#65, doubling the cost of every terminal report. --full keeps the tail whole.
+// atqamz/hand#65, doubling the cost of every terminal report. --full keeps the tail whole.
 func historyBlock(v taskView, tail []state.ReportLine, full bool) []string {
 	// Which entry the report field shows. Found rather than assumed last: with the unacknowledged flag
 	// applied that line is the classified terminal report, which the worker may have followed with text.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/age"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/age"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -255,7 +255,7 @@ func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 	}
 }
 
-// hand status's half of atqamz/secondhand#69: a task whose PR a no-mistakes gate opened directly
+// hand status's half of atqamz/hand#69: a task whose PR a no-mistakes gate opened directly
 // (bypassing hand pr) still shows the PR, once status looks it up by branch.
 func TestStatusSingleTaskDetectsGateOpenedPR(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
@@ -509,7 +509,7 @@ func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 
 // A worker that appends `paused:` and leaves its harness running used to render
 // as a bare `working`: the column showed the pane and hid the only party that
-// said why. One of the two live symptoms atqamz/secondhand#89 names.
+// said why. One of the two live symptoms atqamz/hand#89 names.
 func TestStatusFleetCarriesAPausedReportThroughABusyPane(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
@@ -536,7 +536,7 @@ func TestStatusFleetCarriesAPausedReportThroughABusyPane(t *testing.T) {
 	}
 }
 
-// The second live symptom in atqamz/secondhand#89: an hours-old figure sitting
+// The second live symptom in atqamz/hand#89: an hours-old figure sitting
 // next to a status file touched minutes earlier, which reads as a stalled
 // worker that is in fact reporting.
 func TestStatusFleetDwellTimeFollowsTheReportFileNotTheTaskAge(t *testing.T) {
@@ -706,7 +706,7 @@ func TestStatusSingleTaskDegradesOnAnUnreadableReport(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#65: a worker's report prose has run 2.7-4.3 KB for a
+// atqamz/hand#65: a worker's report prose has run 2.7-4.3 KB for a
 // single task, and hand status rendered it in full - the point of this test.
 func TestTruncateReportLineKeepsVocabularyPrefixIntactUnderAnAdversarialBudget(t *testing.T) {
 	line := state.ParseReportLine("done: " + strings.Repeat("x", 500))
@@ -742,7 +742,7 @@ func TestTruncateReportLineDoesNotSplitAMultibyteRune(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#65's core complaint: hand status <id> printed the latest
+// atqamz/hand#65's core complaint: hand status <id> printed the latest
 // report twice, once under Reported: and again as the last entry of Report
 // history. This asserts the fix at the command level, not just the helper.
 func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing.T) {
@@ -1442,7 +1442,7 @@ func TestStatusFleetEmptyJSONCarriesACount(t *testing.T) {
 }
 
 // An empty fleet must never read as "nothing to see" when a hold is still open on a torn-down
-// task's id - the exact false-all-clear atqamz/secondhand#63 guards against.
+// task's id - the exact false-all-clear atqamz/hand#63 guards against.
 func TestStatusFleetEmptyStillShowsHeldBlock(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
@@ -1486,14 +1486,14 @@ func writeDoneReport(t *testing.T, home, id, note string) {
 	}
 }
 
-const gateRunTestPR = "https://github.com/atqamz/secondhand/pull/120"
+const gateRunTestPR = "https://github.com/atqamz/hand/pull/120"
 
 func TestStatusFleetFlagsShippedPRWithNoGateRun(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	registerNoMistakesProject(t, home, "gated")
-	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n"))
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
 		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
@@ -1518,7 +1518,7 @@ func TestStatusFleetJSONFlagsShippedPRWithNoGateRun(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	registerNoMistakesProject(t, home, "gated")
-	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n"))
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
 		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
@@ -1619,7 +1619,7 @@ func TestStatusSingleTaskFlagsShippedPRWithNoGateRun(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	registerNoMistakesProject(t, home, "gated")
-	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n"))
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
 		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
@@ -1644,7 +1644,7 @@ func TestStatusSingleTaskJSONFlagsShippedPRWithNoGateRun(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	registerNoMistakesProject(t, home, "gated")
-	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n"))
+	t.Setenv("PATH", fakeNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n"))
 
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
 		PR: gateRunTestPR, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
@@ -1710,7 +1710,7 @@ func TestStatusFleetAsksNoMistakesOncePerProject(t *testing.T) {
 	mkFleetDirs(t, home)
 	registerNoMistakesProject(t, home, "gated")
 	countFile := filepath.Join(t.TempDir(), "calls")
-	t.Setenv("PATH", countingNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/999\n", countFile))
+	t.Setenv("PATH", countingNoMistakesPath(t, "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n", countFile))
 
 	for _, id := range []string{"task-1", "task-2", "task-3"} {
 		if err := state.Write(home, state.Task{ID: id, Project: "gated", Kind: state.KindShip,
@@ -1850,7 +1850,7 @@ func TestStatusGateRunUnreachableWhenGateNotInitialized(t *testing.T) {
 	}
 }
 
-// The whole point of atqamz/secondhand#70: a worker that finished while nobody was
+// The whole point of atqamz/hand#70: a worker that finished while nobody was
 // attached has to be visible in the next hand status, not only in the stream of the
 // watcher that was not running.
 func TestStatusFleetFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
@@ -2114,7 +2114,7 @@ func TestUnacknowledgedAnswersForTheStateTheRowPrints(t *testing.T) {
 }
 
 // The watcher leaves an unterminated line for its next tick, so a done written without a trailing
-// newline has been announced to nobody. Flagging it is the whole of atqamz/secondhand#70; skipping it
+// newline has been announced to nobody. Flagging it is the whole of atqamz/hand#70; skipping it
 // would let the same silent completion back in through the newline.
 func TestStatusFleetFlagsATerminalReportWithNoTrailingNewline(t *testing.T) {
 	home := t.TempDir()

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
 )
 
 // Fakes "pane get" as a query command per internal/herdr/client.go's call() doc: a non-null result

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // One task as both status renderers see it: the durable row plus everything derived for display, so the

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -134,7 +134,7 @@ func completionFor(t state.Task, forced bool) completion.Record {
 		c.Detail = "forced (landed-work checks skipped)"
 	// A task whose landing was never ours to decide has to stay distinguishable from a merged one in
 	// the permanent record, or the fleet's history claims upstream merges that never happened
-	// (atqamz/secondhand#78).
+	// (atqamz/hand#78).
 	case t.DeliveredAt != "" && !t.MergeExecuted && !t.MergeAnnounced:
 		c.Outcome = "delivered"
 		c.Detail = t.DeliveredReason
@@ -183,7 +183,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 	// instead - the work is out of this worktree and accounted for - so it is terminal here.
 
 	// Terminal without --force too, and recorded as delivered rather than merged
-	// (atqamz/secondhand#78). Placed after the dirt check and the scout report check deliberately:
+	// (atqamz/hand#78). Placed after the dirt check and the scout report check deliberately:
 	// --force keeps its one meaning of discarding work nobody delivered, so both of those still refuse.
 	if t.DeliveredAt != "" {
 		return t, dirtWasSafe, nil
@@ -205,7 +205,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 			return t, dirtWasSafe, nil
 		}
 
-		// A gate-opened PR bypasses hand pr entirely (atqamz/secondhand#69), so t.PR can still be empty
+		// A gate-opened PR bypasses hand pr entirely (atqamz/hand#69), so t.PR can still be empty
 		// for landed work; detect it here rather than only refusing on it, so the merged check below
 		// reads the same PR state hand pr would have recorded.
 		if exists {
@@ -213,7 +213,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 			var ambiguous *ghutil.AmbiguousPRError
 			// An ambiguous branch is a different failure and must not fall through the same way: "no PR
 			// recorded" reads as unlanded, but ambiguous means unknown, and picking either meaning here
-			// for the operator is the guess atqamz/secondhand#77 exists to remove.
+			// for the operator is the guess atqamz/hand#77 exists to remove.
 			if errors.As(err, &ambiguous) {
 				return t, false, &ExitError{Err: fmt.Errorf("PR for %s is ambiguous, refusing to guess: %w", t.ID, ambiguous), Code: 3}
 			}
@@ -227,7 +227,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 
 		if t.PR == "" {
 			// kind is the one field spawn records that nothing can correct afterwards
-			// (atqamz/secondhand#129), so a scout spawned without --scout arrives here as a ship row and
+			// (atqamz/hand#129), so a scout spawned without --scout arrives here as a ship row and
 			// refuses on a PR it was never going to open. The guard reads the work rather than the record.
 
 			// Here rather than earlier so it can only decide the case nothing else claims: a delivery, a
@@ -236,7 +236,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 
 			// A report deliverable on disk and a branch carrying no commits of its own is a completed scout
 			// whatever the row says, and is recorded as one. Merge evidence excludes the path outright - work
-			// hand merged or watched merge landed as a merge, and the record has to say so (atqamz/secondhand#78).
+			// hand merged or watched merge landed as a merge, and the record has to say so (atqamz/hand#78).
 			if !t.MergeExecuted && !t.MergeAnnounced && isCompletedScout(home, t) {
 				t.Kind = state.KindScout
 				return t, dirtWasSafe, nil
@@ -297,7 +297,7 @@ func hasUncommittedChanges(worktreePath string) (bool, error) {
 	return status != "", nil
 }
 
-// Bounds the refusal's git status dump (atqamz/secondhand#65 is the same lesson for report rendering):
+// Bounds the refusal's git status dump (atqamz/hand#65 is the same lesson for report rendering):
 // an unbounded dump into a session is its own problem, so this prints the first N entries and a count
 // of the rest.
 const maxDirtStatusLines = 20
@@ -317,7 +317,7 @@ func capStatusLines(status string) string {
 
 // Reports whether every uncommitted change in status - the worktree's `git status --porcelain` output -
 // is a tracked modification whose content already matches the local default branch's tip, byte for
-// byte: the gate re-editing a file to what its own merged fix carries (atqamz/secondhand#79).
+// byte: the gate re-editing a file to what its own merged fix carries (atqamz/hand#79).
 func dirtIsSafeToDiscard(worktreePath, status string) bool {
 	if status == "" {
 		return true

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/completion"
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/worktree"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -101,7 +101,7 @@ type ghFakePR struct {
 
 // The two calls gate-opened-PR detection makes: `gh pr list --repo <repo> --head <branch>`
 // (FindPRByBranch) then `gh pr view <url> --json state` (project.ValidatePR, then checkLandedWork).
-// Several PRs exercise FindPRByBranch's preference tier (atqamz/secondhand#77), not its single result.
+// Several PRs exercise FindPRByBranch's preference tier (atqamz/hand#77), not its single result.
 func writeFakeGHPRListAndView(t *testing.T, prs ...ghFakePR) {
 	t.Helper()
 	g := faketool.GH{}
@@ -138,7 +138,7 @@ func registerGateProject(t *testing.T, home string) {
 
 // The fork variant: the PR lives on the upstream while the branch lives in headRepo, so a search of
 // the project's own repo comes back empty and the fork filter has a headRepository to read. Without a
-// fake that narrows on --repo no test can express the atqamz/secondhand#134 shape at all.
+// fake that narrows on --repo no test can express the atqamz/hand#134 shape at all.
 func writeFakeGHForkPRListAndView(t *testing.T, upstream, headRepo string, pr ghFakePR) {
 	t.Helper()
 	faketool.GH{PRs: []faketool.GHPR{{
@@ -147,7 +147,7 @@ func writeFakeGHForkPRListAndView(t *testing.T, upstream, headRepo string, pr gh
 	}}}.Install(t, faketool.Bin(t))
 }
 
-// The atqamz/secondhand#134 regression: a fork project's gate opens its PR on the declared upstream,
+// The atqamz/hand#134 regression: a fork project's gate opens its PR on the declared upstream,
 // so detection that searches the project's own repo alone finds nothing and teardown refuses landed
 // work as unlanded.
 func TestTeardownDetectsGateOpenedPRonDeclaredUpstream(t *testing.T) {
@@ -201,7 +201,7 @@ func TestTeardownDetectsPRWithUpstreamDeclaredAsOwnRepoInOtherCasing(t *testing.
 	}
 }
 
-// First of the two regression cases atqamz/secondhand#69 requires: a no-mistakes gate's own `pr` step
+// First of the two regression cases atqamz/hand#69 requires: a no-mistakes gate's own `pr` step
 // opens a PR directly, bypassing `hand pr`, so t.PR is empty even though the PR is merged and the work
 // landed. Teardown must detect it by branch and tear down without --force, not refuse until forced.
 func TestTeardownDetectsAndTearsDownGateOpenedMergedPR(t *testing.T) {
@@ -256,7 +256,7 @@ func TestTeardownRefusesGateOpenedClosedUnmergedPR(t *testing.T) {
 	}
 }
 
-// The atqamz/secondhand#77 landed case: a branch carrying a closed-unmerged PR alongside a merged one
+// The atqamz/hand#77 landed case: a branch carrying a closed-unmerged PR alongside a merged one
 // (a duplicate opened by mistake, say) must tear down on the merged PR, not fall to an arbitrary pick
 // that could land on the unmerged one instead.
 func TestTeardownTearsDownWhenBranchHasMergedAndClosedUnmergedPR(t *testing.T) {
@@ -281,7 +281,7 @@ func TestTeardownTearsDownWhenBranchHasMergedAndClosedUnmergedPR(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#77's refusal case: two merged PRs on the same branch do not resolve to a winner,
+// atqamz/hand#77's refusal case: two merged PRs on the same branch do not resolve to a winner,
 // and teardown must refuse naming both rather than guess which one to trust - the exact guess that
 // could wave through unlanded work.
 func TestTeardownRefusesAmbiguousBranch(t *testing.T) {
@@ -762,7 +762,7 @@ func TestTeardownScoutSucceedsWhenReportPresent(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#129: a scout spawned without --scout is recorded as a ship task and nothing can
+// atqamz/hand#129: a scout spawned without --scout is recorded as a ship task and nothing can
 // correct the record, so its report-and-no-PR shape hits the landed-work refusal and --force plus a
 // respawn was the only way out. Teardown reads the work instead, and the permanent record says scout.
 func TestTeardownAcceptsAShipRowThatDeliveredAScoutReport(t *testing.T) {
@@ -793,7 +793,7 @@ func TestTeardownAcceptsAShipRowThatDeliveredAScoutReport(t *testing.T) {
 	}
 }
 
-// The half of atqamz/secondhand#129's fix that matters: the scout-deliverable path must not become "no PR
+// The half of atqamz/hand#129's fix that matters: the scout-deliverable path must not become "no PR
 // and some file exists". This task carries a report next to a commit nobody landed, and the commit is
 // what keeps the refusal. A guard that only checked for the report would throw the commit away.
 func TestTeardownStillRefusesAShipTaskWhosePRWasNeverOpened(t *testing.T) {
@@ -825,7 +825,7 @@ func TestTeardownStillRefusesAShipTaskWhosePRWasNeverOpened(t *testing.T) {
 
 // A promoted scout keeps its report on disk while its row turns into a ship, so a task that then merged
 // locally has every shape the scout-deliverable path reads: report present, no PR, and a branch that was
-// fast-forwarded in and so adds no commit. It landed as a merge - the inverse of atqamz/secondhand#78.
+// fast-forwarded in and so adds no commit. It landed as a merge - the inverse of atqamz/hand#78.
 func TestTeardownRecordsMergedWhenALocallyMergedShipRowKeptItsScoutReport(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
@@ -892,7 +892,7 @@ func TestTeardownStillRefusesAMergedShipRowWithNoPRToConfirm(t *testing.T) {
 	}
 }
 
-// The central case for atqamz/secondhand#78: a contribution offered to a repo this fleet does not control.
+// The central case for atqamz/hand#78: a contribution offered to a repo this fleet does not control.
 // Landing it is the upstream maintainer's decision, so the PR stays open indefinitely and the fake gh
 // reports that. Teardown accepts it without --force and records delivered - a merge nobody made is the risk.
 func TestTeardownAcceptsDeliveredWorkWithAnOpenPRWithoutForce(t *testing.T) {
@@ -932,7 +932,7 @@ func TestTeardownAcceptsDeliveredWorkWithAnOpenPRWithoutForce(t *testing.T) {
 }
 
 // A task filed as a ship whose deliverable was a report, no branch and no commit behind it - the shape
-// a misfiled kind produces (atqamz/secondhand#129). The delivered state keys off the delivery, not off
+// a misfiled kind produces (atqamz/hand#129). The delivered state keys off the delivery, not off
 // Kind, so this tears down cleanly without anyone having to correct the kind first.
 func TestTeardownAcceptsDeliveredWorkWithNoPRRegardlessOfKind(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
@@ -1239,7 +1239,7 @@ func diverge(t *testing.T, worktree, readmeContent string) {
 	runGitIn(t, worktree, "checkout", "-q", "task-1-branch")
 }
 
-// atqamz/secondhand#79's safe case: the worktree's uncommitted edit to README.md reproduces
+// atqamz/hand#79's safe case: the worktree's uncommitted edit to README.md reproduces
 // byte-for-byte content main already carries (the no-mistakes gate's own re-edit of a file its merged
 // fix already covers), so discarding it on teardown loses nothing.
 func TestTeardownProceedsWhenDirtAlreadyMatchesMergedBase(t *testing.T) {
@@ -1484,7 +1484,7 @@ func TestTeardownRefusesDirtWithUntrackedFileEvenWhenTrackedChangeMatchesBase(t 
 	}
 }
 
-// The refusal's git status dump is bounded (atqamz/secondhand#65 is the same lesson for report
+// The refusal's git status dump is bounded (atqamz/hand#65 is the same lesson for report
 // rendering): the first 20 entries print, the rest collapse to a count.
 func TestTeardownRefusalCapsGitStatusOutput(t *testing.T) {
 	home, worktree := setupTeardownHome(t)

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/completion"
-	"github.com/atqamz/secondhand/internal/faketool"
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func assertExitCode3(t *testing.T, err error) {

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/brief"
-	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/atqamz/hand/internal/brief"
+	"github.com/atqamz/hand/internal/harness"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -34,7 +34,7 @@ func resolveTier(cmd *cobra.Command, home, briefAbs, harnessName, model, effort 
 	}
 
 	// One line per launch rather than one per dropped value: consecutive warnings all naming the
-	// same harness read as separate problems (atqamz/secondhand#151).
+	// same harness read as separate problems (atqamz/hand#151).
 	if len(dropped) > 0 {
 		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: harness %q cannot carry %s; launching anyway\n", harnessName, strings.Join(dropped, ", ")); err != nil {
 			return "", "", false, err

--- a/cmd/tier_test.go
+++ b/cmd/tier_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/harness"
+	"github.com/atqamz/hand/internal/harness"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
-	"github.com/atqamz/secondhand/internal/axi"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/selfupdate"
-	"github.com/atqamz/secondhand/internal/sessionhook"
+	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/sessionhook"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -22,7 +22,13 @@ import (
 func writeFakeGHReleaseView(t *testing.T, tag string) {
 	t.Helper()
 	bin := t.TempDir()
-	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' %q\n", tag)
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" != "release" ] || [ "$2" != "view" ] || [ "$3" != "--repo" ] || [ "$4" != "atqamz/hand" ]; then
+  echo "unexpected gh invocation: $@" >&2
+  exit 1
+fi
+printf '%%s' %q
+`, tag)
 	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/selfupdate"
 )
 
 // Fakes "release view --jq" as real gh's --jq flattens its JSON to the raw field value on stdout

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/watcher"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/watcher"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/watcher"
+	"github.com/atqamz/hand/internal/watcher"
 )
 
 // Fakes "workspace list" as a query command per internal/herdr/client.go's call() doc comment: a non-null

--- a/docs/adr/ambient-context-is-a-session-hook-not-a-file.md
+++ b/docs/adr/ambient-context-is-a-session-hook-not-a-file.md
@@ -2,8 +2,8 @@
 
 - Date: 2026-08-04
 - Status: superseded by [Supervisor bootstrap is an AGENTS.md contract](supervisor-bootstrap-is-an-agents-md-contract.md)
-- Issues: atqamz/secondhand#62, atqamz/secondhand#64
-- PRs: atqamz/secondhand#122
+- Issues: atqamz/hand#62, atqamz/hand#64
+- PRs: atqamz/hand#122
 
 ## Context
 

--- a/docs/adr/gate-checks-read-no-mistakes-output-not-its-database.md
+++ b/docs/adr/gate-checks-read-no-mistakes-output-not-its-database.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#92, atqamz/secondhand#97
+- Issues: atqamz/hand#92, atqamz/hand#97
 - PRs: none single
 
 ## Context

--- a/docs/adr/harness-templates-launch-interactively.md
+++ b/docs/adr/harness-templates-launch-interactively.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#28, atqamz/secondhand#152
+- Issues: atqamz/hand#28, atqamz/hand#152
 - PRs: none single
 
 ## Context

--- a/docs/adr/holds-are-their-own-table.md
+++ b/docs/adr/holds-are-their-own-table.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#63, atqamz/secondhand#111, atqamz/secondhand#136
+- Issues: atqamz/hand#63, atqamz/hand#111, atqamz/hand#136
 - PRs: none single
 
 ## Context

--- a/docs/adr/one-stateful-fake-per-external-tool.md
+++ b/docs/adr/one-stateful-fake-per-external-tool.md
@@ -2,8 +2,8 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#40
-- PRs: atqamz/secondhand#158
+- Issues: atqamz/hand#40
+- PRs: atqamz/hand#158
 
 ## Context
 

--- a/docs/adr/one-watcher-per-fleet-home-guarded-by-an-flock.md
+++ b/docs/adr/one-watcher-per-fleet-home-guarded-by-an-flock.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-04
 - Status: accepted
 - Issues: none
-- PRs: atqamz/secondhand#138
+- PRs: atqamz/hand#138
 
 ## Context
 

--- a/docs/adr/output-is-toon-by-default-and-json-is-retained.md
+++ b/docs/adr/output-is-toon-by-default-and-json-is-retained.md
@@ -2,8 +2,8 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#45, atqamz/secondhand#100
-- PRs: atqamz/secondhand#155
+- Issues: atqamz/hand#45, atqamz/hand#100
+- PRs: atqamz/hand#155
 
 ## Context
 

--- a/docs/adr/supervisor-bootstrap-is-an-agents-md-contract.md
+++ b/docs/adr/supervisor-bootstrap-is-an-agents-md-contract.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-07
 - Status: accepted
-- Issues: atqamz/secondhand#172
+- Issues: atqamz/hand#172
 - PRs: none
 
 ## Context

--- a/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
+++ b/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#78
+- Issues: atqamz/hand#78
 - PRs: none single
 
 ## Context

--- a/docs/adr/the-landed-work-guard-reads-the-work-not-the-record.md
+++ b/docs/adr/the-landed-work-guard-reads-the-work-not-the-record.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#79, atqamz/secondhand#129
+- Issues: atqamz/hand#79, atqamz/hand#129
 - PRs: none single
 
 ## Context

--- a/docs/adr/the-report-channel-is-the-only-outcome-signal.md
+++ b/docs/adr/the-report-channel-is-the-only-outcome-signal.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#53, atqamz/secondhand#87
+- Issues: atqamz/hand#53, atqamz/hand#87
 - PRs: none single
 
 ## Context

--- a/docs/adr/the-schema-version-lives-in-pragma-user-version.md
+++ b/docs/adr/the-schema-version-lives-in-pragma-user-version.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#111, atqamz/secondhand#48, atqamz/secondhand#78, atqamz/secondhand#128, atqamz/secondhand#136
+- Issues: atqamz/hand#111, atqamz/hand#48, atqamz/hand#78, atqamz/hand#128, atqamz/hand#136
 - PRs: none single
 
 ## Context

--- a/docs/adr/the-until-event-exit-is-the-delivery.md
+++ b/docs/adr/the-until-event-exit-is-the-delivery.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-04
 - Status: accepted
 - Issues: none
-- PRs: atqamz/secondhand#125
+- PRs: atqamz/hand#125
 
 ## Context
 

--- a/docs/adr/usage-limit-detection-is-a-harness-capability.md
+++ b/docs/adr/usage-limit-detection-is-a-harness-capability.md
@@ -2,8 +2,8 @@
 
 - Date: 2026-08-04
 - Status: accepted
-- Issues: atqamz/secondhand#136, atqamz/secondhand#81, atqamz/secondhand#84, atqamz/secondhand#85, atqamz/secondhand#128
-- PRs: atqamz/secondhand#154
+- Issues: atqamz/hand#136, atqamz/hand#81, atqamz/hand#84, atqamz/hand#85, atqamz/hand#128
+- PRs: atqamz/hand#154
 
 ## Context
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,12 @@
       packages = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system}; in {
           default = pkgs.buildGoModule {
-            pname = "secondhand";
+            pname = "hand";
             inherit version;
             src = ./.;
             vendorHash = "sha256-v84XwEQIPE8kqHDOhWcOS9pwk+ebjRJ/3XFuuwa0+aU=";
             ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
             nativeCheckInputs = [ pkgs.git ]; # test suite execs git directly
-            # buildGoModule names the output after the module (secondhand);
-            # every other build path (Makefile, .gitignore) expects hand.
-            postInstall = "mv $out/bin/secondhand $out/bin/hand";
             meta.mainProgram = "hand";
           };
         }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/atqamz/secondhand
+module github.com/atqamz/hand
 
 go 1.26.5
 

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -186,7 +186,7 @@ var (
 
 	// Stripped from a line before it is tested above: a date in a quoted example or a
 	// URL is not an incident, and flagging it anyway is the false positive that gets a
-	// checker ignored (atqamz/secondhand#90).
+	// checker ignored (atqamz/hand#90).
 	inlineCodeRe = regexp.MustCompile("`[^`]*`")
 	urlRe        = regexp.MustCompile(`https?://\S+`)
 )

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -10,9 +10,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/atomicfile"
-	"github.com/atqamz/secondhand/internal/home"
-	"github.com/atqamz/secondhand/internal/shellquote"
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/shellquote"
 )
 
 const (

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -267,7 +267,7 @@ func TestThisRepoAgentsMdIsCurrentForDogfood(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#87's fix has to reach every worker without a new report-vocabulary word, since the
+// atqamz/hand#87's fix has to reach every worker without a new report-vocabulary word, since the
 // watcher's classifier and hand status's renderer were outside that change's scope: the working: prefix
 // plus a first-person convention was the only lever available.
 func TestGeneratedRulesCoverSelfDecidedCallsInFirstPerson(t *testing.T) {
@@ -280,7 +280,7 @@ func TestGeneratedRulesCoverSelfDecidedCallsInFirstPerson(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#114: a fleet agent following the template had no reason
+// atqamz/hand#114: a fleet agent following the template had no reason
 // to reach for hand hold, since every "waiting on" case routed through
 // data/backlog.md and hand send.
 func TestGeneratedRulesCoverHolds(t *testing.T) {
@@ -290,8 +290,8 @@ func TestGeneratedRulesCoverHolds(t *testing.T) {
 	}
 }
 
-// atqamz/secondhand#47: the four files hand init seeds are inert unless the template says
-// who reads each one and when. atqamz/secondhand#64: the one direction data/ does not carry
+// atqamz/hand#47: the four files hand init seeds are inert unless the template says
+// who reads each one and when. atqamz/hand#64: the one direction data/ does not carry
 // has to be stated, or the agent invents a hand-written operator channel again.
 func TestGeneratedRulesCoverOperatorContextLearningsAndArchives(t *testing.T) {
 	instructions := strings.Join(SupervisorInstructions(), "\n")

--- a/internal/brief/brief_test.go
+++ b/internal/brief/brief_test.go
@@ -17,7 +17,7 @@ const realBriefFixture = `You are a crewmate: an autonomous worker agent managed
 
 Record a minimum supported treehouse version in the README. This is a one-line documentation change. Do not expand it.
 
-Issue: https://github.com/atqamz/secondhand/issues/41. Read it, including the most recent comment, which narrows the issue to exactly this.
+Issue: https://github.com/atqamz/hand/issues/41. Read it, including the most recent comment, which narrows the issue to exactly this.
 
 ## Background (verified by the first mate)
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,6 +1,6 @@
 // Package completion is the durable record of tasks hand teardown has finished
 // with: state/completions.jsonl, one JSON object per line, uncapped - see
-// atqamz/secondhand#61. Every line is readable on its own terms without
+// atqamz/hand#61. Every line is readable on its own terms without
 // parsing markdown.
 package completion
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Record is one task's teardown outcome.

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -44,7 +44,7 @@ func TestListMissingStore(t *testing.T) {
 	}
 }
 
-// The storage half of atqamz/secondhand#61's "uncapped, or capped somewhere other
+// The storage half of atqamz/hand#61's "uncapped, or capped somewhere other
 // than the display layer" requirement.
 func TestAppendUncapped(t *testing.T) {
 	dir := t.TempDir()
@@ -104,7 +104,7 @@ func TestListSkipsDamagedLine(t *testing.T) {
 	}
 }
 
-// The concurrency guarantee the brief for atqamz/secondhand#61 requires explaining: two Append calls
+// The concurrency guarantee the brief for atqamz/hand#61 requires explaining: two Append calls
 // racing must never lose either line, unlike state/events.log's read-modify-write pattern over the
 // whole file.
 func TestAppendConcurrent(t *testing.T) {

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -239,7 +239,7 @@ Both merge entries were observed on a throwaway PR and are the one part of this 
 
 ### Slug case
 
-GitHub serves a repo under any casing of its slug and answers with the canonical one: `--repo AtqaMZ/SecondHand` succeeds and reports `"nameWithOwner":"atqamz/secondhand"`.
+GitHub serves a repo under any casing of its slug and answers with the canonical one: `--repo AtqaMZ/Hand` succeeds and reports `"nameWithOwner":"atqamz/hand"`.
 So `FindPRByBranch` folds case when comparing a `gh` answer against a git remote, and the fake matches `--repo` case-insensitively - a case-sensitive fake would answer a double search of one repo with one hit and hide the duplicate the real `gh` returns.
 
 `internal/ghutil/pr_test.go` and `tests/e2e/slug_case_test.go` cover the comparison itself.

--- a/internal/ghutil/pr.go
+++ b/internal/ghutil/pr.go
@@ -16,7 +16,7 @@ import (
 
 // PRIsMerged reports whether the PR is merged. gh writes warnings to stderr ahead of the JSON, so the
 // payload must be read from stdout alone; CombinedOutput here corrupts the parse
-// (atqamz/secondhand#21).
+// (atqamz/hand#21).
 func PRIsMerged(ctx context.Context, pr string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "state")
 	var stderr bytes.Buffer
@@ -103,7 +103,7 @@ func FindPRByBranch(ctx context.Context, branch string, targets ...PRSearchTarge
 
 	// A merged PR coexisting with an open one refuses too: the open PR is live evidence the branch
 	// may still carry unlanded work. Guessing here is what let cmd/teardown.go's landed-work guard
-	// trust a merged PR while the branch's real state was closed-unmerged (atqamz/secondhand#77).
+	// trust a merged PR while the branch's real state was closed-unmerged (atqamz/hand#77).
 	if len(mergedPRs) > 0 && len(openPRs) > 0 {
 		return "", false, false, ambiguousPRError(branch, results)
 	}

--- a/internal/ghutil/pr_test.go
+++ b/internal/ghutil/pr_test.go
@@ -91,7 +91,7 @@ func TestFindPRByBranchReturnsMatch(t *testing.T) {
 	}
 }
 
-// The atqamz/secondhand#77 regression: a branch carrying a merged PR alongside a closed-unmerged
+// The atqamz/hand#77 regression: a branch carrying a merged PR alongside a closed-unmerged
 // one (a duplicate opened by mistake, say) must resolve to the merged PR rather than an arbitrary
 // pick.
 func TestFindPRByBranchPrefersMergedOverClosedUnmerged(t *testing.T) {
@@ -208,7 +208,7 @@ func TestFindPRByBranchPrefersOpenOverClosedUnmerged(t *testing.T) {
 
 // Fakes `gh pr list` for a fork search, dispatching on the --repo argument the old single-body
 // fake ignored: without that, no test can express "the PR is on repo B while the project's repo is
-// A", and a fork test would pass against a shape gh never returns (atqamz/secondhand#40).
+// A", and a fork test would pass against a shape gh never returns (atqamz/hand#40).
 func writeFakeGHPRListPerRepo(t *testing.T, bodies map[string]string) {
 	t.Helper()
 	bin := t.TempDir()
@@ -259,7 +259,7 @@ func forkTargets() []PRSearchTarget {
 	return []PRSearchTarget{{Repo: "me/repo"}, {Repo: "up/repo", HeadRepo: "me/repo"}}
 }
 
-// The atqamz/secondhand#134 regression: a fork contribution's PR lives on the declared upstream,
+// The atqamz/hand#134 regression: a fork contribution's PR lives on the declared upstream,
 // so searching the project's own repo alone finds nothing.
 func TestFindPRByBranchFindsUpstreamPRForFork(t *testing.T) {
 	writeFakeGHPRListPerRepo(t, map[string]string{
@@ -362,14 +362,14 @@ func TestRepoSlugFromRemote(t *testing.T) {
 		slug   string
 		ok     bool
 	}{
-		{"https://github.com/atqamz/secondhand", "atqamz/secondhand", true},
-		{"https://github.com/atqamz/secondhand.git", "atqamz/secondhand", true},
-		{"git@github.com:atqamz/secondhand.git", "atqamz/secondhand", true},
-		{"ssh://git@github.com/atqamz/secondhand.git", "atqamz/secondhand", true},
+		{"https://github.com/atqamz/hand", "atqamz/hand", true},
+		{"https://github.com/atqamz/hand.git", "atqamz/hand", true},
+		{"git@github.com:atqamz/hand.git", "atqamz/hand", true},
+		{"ssh://git@github.com/atqamz/hand.git", "atqamz/hand", true},
 		{"local", "", false},
-		{"https://gitlab.com/atqamz/secondhand", "", false},
+		{"https://gitlab.com/atqamz/hand", "", false},
 		{"https://github.com/atqamz", "", false},
-		{"https://github.com/atqamz/secondhand/extra", "", false},
+		{"https://github.com/atqamz/hand/extra", "", false},
 		{"", "", false},
 	}
 	for _, c := range cases {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -168,7 +168,7 @@ func SupportsEffort(name string) bool {
 
 // False means the builder hands the brief over as a file and has no prompt to append to, so
 // briefPrompt's operator-decision rule and front-matter disclaimer never reach the worker.
-// Carrying them properly needs flags verified against a real --help (atqamz/secondhand#36).
+// Carrying them properly needs flags verified against a real --help (atqamz/hand#36).
 func CarriesPrompt(name string) bool {
 	return promptCapable[name]
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -7,8 +7,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
-	"github.com/atqamz/secondhand/internal/shellquote"
+	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/shellquote"
 )
 
 const (

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/agentsmd"
 )
 
 // The shell-quoted first message a harness launches with. The operator-decision rule is a paragraph

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -23,7 +23,7 @@ func NewClient() *Client {
 }
 
 // The harness-identity variables a pane must never inherit from the herdr server it is a child of
-// (atqamz/secondhand#109). A server inside a Claude Code session passes its own session identity
+// (atqamz/hand#109). A server inside a Claude Code session passes its own session identity
 // down, and CLAUDE_CODE_CHILD_SESSION disables the pane's transcript - a worker's only record.
 var sanitizedEnvKeys = []string{"CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDECODE"}
 

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -79,7 +79,7 @@ func TestWorkspaceCreateParsesRootTabAndPane(t *testing.T) {
 	}
 }
 
-// Pins the fix for atqamz/secondhand#109: a pane is a child of the herdr server, so it otherwise
+// Pins the fix for atqamz/hand#109: a pane is a child of the herdr server, so it otherwise
 // inherits any CLAUDE_CODE_CHILD_SESSION, CLAUDE_CODE_SESSION_ID, or CLAUDECODE the server was
 // started under, silently killing the worker's transcript. All three are blanked either way.
 func TestWorkspaceCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
@@ -114,7 +114,7 @@ func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
 	}
 }
 
-// Pins the fix for atqamz/secondhand#74: a workspace_created result missing tab or root_pane still
+// Pins the fix for atqamz/hand#74: a workspace_created result missing tab or root_pane still
 // means herdr created the workspace (a protocol predating those fields), so WorkspaceCreate closes
 // it before the parse error reaches the caller - nothing downstream learns the ID.
 func TestWorkspaceCreateClosesWorkspaceOnPartialResponse(t *testing.T) {
@@ -332,8 +332,8 @@ printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"ro
 	}
 }
 
-// Pins the fix for atqamz/secondhand#119: a tab-create result missing root_pane still means herdr
-// created the tab (same as atqamz/secondhand#74's WorkspaceCreate case), so TabCreate closes it
+// Pins the fix for atqamz/hand#119: a tab-create result missing root_pane still means herdr
+// created the tab (same as atqamz/hand#74's WorkspaceCreate case), so TabCreate closes it
 // before the parse error reaches the caller - nothing downstream learns the tab ID.
 func TestTabCreateClosesTabOnPartialResponse(t *testing.T) {
 	writeFakeHerdr(t, `

--- a/internal/project/gaterun_test.go
+++ b/internal/project/gaterun_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 func TestGateRunPRsCollectsCompletedRunPRs(t *testing.T) {
-	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n"+
+	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/120\n"+
 		"  running      74-workspace-leak    b2f584f9  2026-08-03 04:20\n")
 
 	prs, err := GateRunPRs(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !prs["https://github.com/atqamz/secondhand/pull/120"] {
+	if !prs["https://github.com/atqamz/hand/pull/120"] {
 		t.Fatal("expected a completed run's own recorded PR URL to be collected")
 	}
-	if prs["https://github.com/atqamz/secondhand/pull/999"] {
+	if prs["https://github.com/atqamz/hand/pull/999"] {
 		t.Fatal("expected no entry for a PR no completed run recorded")
 	}
 }
@@ -25,13 +25,13 @@ func TestGateRunPRsCollectsCompletedRunPRs(t *testing.T) {
 // Covers a run that recorded a PR URL but never reached completed - running or failed both leave
 // the gate un-cleared for that commit, so neither should count as evidence a run happened.
 func TestGateRunPRsIgnoresNonCompletedRuns(t *testing.T) {
-	fakeNoMistakes(t, "  failed       97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/secondhand/pull/120\n")
+	fakeNoMistakes(t, "  failed       97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/120\n")
 
 	prs, err := GateRunPRs(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if prs["https://github.com/atqamz/secondhand/pull/120"] {
+	if prs["https://github.com/atqamz/hand/pull/120"] {
 		t.Fatal("a failed run must not count as gate coverage even though it recorded the PR URL")
 	}
 }
@@ -60,7 +60,7 @@ func TestGateRunPRsMissingBinary(t *testing.T) {
 	}
 }
 
-// Covers the uninitialized gate and atqamz/secondhand#60's stale renamed working_path, which print
+// Covers the uninitialized gate and atqamz/hand#60's stale renamed working_path, which print
 // this text identically. An empty run set would claim the PR never went through a gate run, when
 // in truth no-mistakes was never asked - the state it answers from still holds those runs.
 func TestGateRunPRsNotInitializedIsAnError(t *testing.T) {

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // ValidatePR is the single gate every PR URL passes before it is recorded on a task, from

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/atqamz/secondhand/internal/atomicfile"
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/store"
 )
 
 const (

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -407,7 +407,7 @@ func fakeNoMistakesExit(t *testing.T, stdout string, code int) {
 }
 
 func TestGateStatusReady(t *testing.T) {
-	fakeNoMistakes(t, "    repo:  /home/atqa/secondhand/projects/secondhand\n  remote:  git@github.com:atqamz/secondhand.git\n    gate:  /home/atqa/.no-mistakes/repos/0b474f2021dd.git\n  daemon:  running\n\n  no active run")
+	fakeNoMistakes(t, "    repo:  /home/atqa/secondhand/projects/secondhand\n  remote:  git@github.com:atqamz/hand.git\n    gate:  /home/atqa/.no-mistakes/repos/0b474f2021dd.git\n  daemon:  running\n\n  no active run")
 
 	got, err := GateStatus(t.TempDir())
 	if err != nil {
@@ -418,7 +418,7 @@ func TestGateStatusReady(t *testing.T) {
 	}
 }
 
-// Covers both real histories from atqamz/secondhand#60 at once: a project never given a
+// Covers both real histories from atqamz/hand#60 at once: a project never given a
 // no-mistakes init, and one whose working_path went stale when the fleet home was renamed. Both
 // print this text byte-for-byte, so a second test on the same literal asserts nothing.
 func TestGateStatusNotInitialized(t *testing.T) {
@@ -448,7 +448,7 @@ func TestGateStatusMissingBinaryIsDistinctFromNotInitialized(t *testing.T) {
 	}
 }
 
-// Covers atqamz/secondhand#97's first clone-path outcome: clonePath exists but isn't a git
+// Covers atqamz/hand#97's first clone-path outcome: clonePath exists but isn't a git
 // repository. no-mistakes status still exits 0 printing this text verbatim, so without the branch
 // GateStatus falls through to GateReady and lets a caller dispatch into an uncovered project.
 func TestGateStatusNotGitRepo(t *testing.T) {
@@ -467,7 +467,7 @@ func TestGateStatusNotGitRepo(t *testing.T) {
 	}
 }
 
-// Covers atqamz/secondhand#97's second clone-path outcome: clonePath does not exist, so
+// Covers atqamz/hand#97's second clone-path outcome: clonePath does not exist, so
 // exec.Command's chdir fails before the binary runs. Without the os.Stat check this read as "binary
 // not found or not runnable" - true in the letter, misleading in substance.
 func TestGateStatusMissingClonePath(t *testing.T) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/store"
 )
 
 func TestDeriveName(t *testing.T) {

--- a/internal/selfupdate/notice_test.go
+++ b/internal/selfupdate/notice_test.go
@@ -11,7 +11,7 @@ func TestCheckNoticeSkipsWithoutStateDir(t *testing.T) {
 	home := t.TempDir()
 	writeFakeGH(t, "v0.5.0", t.TempDir())
 
-	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+	if notice := CheckNotice(home, "atqamz/hand", "v0.1.0"); notice != "" {
 		t.Fatalf("got %q, want empty notice without state dir", notice)
 	}
 }
@@ -23,7 +23,7 @@ func TestCheckNoticeReturnsMessageWhenNewer(t *testing.T) {
 	}
 	writeFakeGH(t, "v0.5.0", t.TempDir())
 
-	notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0")
+	notice := CheckNotice(home, "atqamz/hand", "v0.1.0")
 	want := "A new version of hand is available: v0.1.0 -> v0.5.0\nRun \"hand update\" to update"
 	if notice != want {
 		t.Fatalf("got %q, want %q", notice, want)
@@ -37,7 +37,7 @@ func TestCheckNoticeEmptyWhenUpToDate(t *testing.T) {
 	}
 	writeFakeGH(t, "v0.1.0", t.TempDir())
 
-	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+	if notice := CheckNotice(home, "atqamz/hand", "v0.1.0"); notice != "" {
 		t.Fatalf("got %q, want empty notice when up to date", notice)
 	}
 }
@@ -64,7 +64,7 @@ func TestCheckNoticeUsesFreshCacheWithoutCallingGH(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0")
+	notice := CheckNotice(home, "atqamz/hand", "v0.1.0")
 	want := "A new version of hand is available: v0.1.0 -> v0.5.0\nRun \"hand update\" to update"
 	if notice != want {
 		t.Fatalf("got %q, want %q", notice, want)
@@ -85,7 +85,7 @@ func TestCheckNoticeRefreshesStaleCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0")
+	notice := CheckNotice(home, "atqamz/hand", "v0.1.0")
 	want := "A new version of hand is available: v0.1.0 -> v0.6.0\nRun \"hand update\" to update"
 	if notice != want {
 		t.Fatalf("got %q, want %q", notice, want)
@@ -99,7 +99,7 @@ func TestCheckNoticeEmptyWhenGHUnreachable(t *testing.T) {
 	}
 	t.Setenv("PATH", t.TempDir())
 
-	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+	if notice := CheckNotice(home, "atqamz/hand", "v0.1.0"); notice != "" {
 		t.Fatalf("got %q, want empty notice when gh unreachable", notice)
 	}
 }
@@ -111,7 +111,7 @@ func TestCheckNoticeCachesFailedCheck(t *testing.T) {
 	}
 	t.Setenv("PATH", t.TempDir())
 
-	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+	if notice := CheckNotice(home, "atqamz/hand", "v0.1.0"); notice != "" {
 		t.Fatalf("got %q, want empty notice when gh unreachable", notice)
 	}
 
@@ -127,7 +127,7 @@ func TestCheckNoticeCachesFailedCheck(t *testing.T) {
 	}
 
 	writeFakeGH(t, "v0.5.0", t.TempDir())
-	if notice := CheckNotice(home, "atqamz/secondhand", "v0.1.0"); notice != "" {
+	if notice := CheckNotice(home, "atqamz/hand", "v0.1.0"); notice != "" {
 		t.Fatalf("got %q, want empty notice while the failed check is still cached", notice)
 	}
 }
@@ -147,7 +147,7 @@ func TestCheckNoticeSkipsUnparseableCurrentVersion(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if notice := CheckNotice(home, "atqamz/secondhand", "dev"); notice != "" {
+	if notice := CheckNotice(home, "atqamz/hand", "dev"); notice != "" {
 		t.Fatalf("got %q, want empty notice for an unversioned build", notice)
 	}
 	if _, err := os.Stat(filepath.Join(home, "state", cacheFile)); err == nil {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 )
 
-const Repo = "atqamz/secondhand"
+const Repo = "atqamz/hand"
 
 const binaryName = "hand"
 

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -107,7 +107,7 @@ func buildFixture(t *testing.T, binaryContent []byte) string {
 
 func TestLatestTag(t *testing.T) {
 	writeFakeGH(t, "v0.5.0", t.TempDir())
-	tag, err := LatestTag("atqamz/secondhand")
+	tag, err := LatestTag("atqamz/hand")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestApplyReplacesRunningBinary(t *testing.T) {
 	ExecutableOverride = func() (string, error) { return execPath, nil }
 	defer func() { ExecutableOverride = restore }()
 
-	if err := Apply("atqamz/secondhand", "v0.5.0"); err != nil {
+	if err := Apply("atqamz/hand", "v0.5.0"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -191,7 +191,7 @@ func TestApplyLeavesNoStagedFileWhenExtractionFails(t *testing.T) {
 	ExecutableOverride = func() (string, error) { return execPath, nil }
 	defer func() { ExecutableOverride = restore }()
 
-	if err := Apply("atqamz/secondhand", "v0.5.0"); err == nil {
+	if err := Apply("atqamz/hand", "v0.5.0"); err == nil {
 		t.Fatal("want error when the asset is not a valid archive")
 	}
 

--- a/internal/sessionhook/sessionhook.go
+++ b/internal/sessionhook/sessionhook.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/atomicfile"
 )
 
 const (

--- a/internal/state/hold.go
+++ b/internal/state/hold.go
@@ -3,7 +3,7 @@ package state
 import (
 	"errors"
 
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/store"
 )
 
 // ErrHoldNotFound is wrapped into errors returned by ClearHold when no hold

--- a/internal/state/pr_test.go
+++ b/internal/state/pr_test.go
@@ -3,13 +3,13 @@ package state
 import "testing"
 
 func TestValidatePRURLAcceptsCanonicalForm(t *testing.T) {
-	if !ValidatePRURL("https://github.com/atqamz/secondhand/pull/31") {
+	if !ValidatePRURL("https://github.com/atqamz/hand/pull/31") {
 		t.Fatal("want canonical PR URL to validate")
 	}
 }
 
 func TestValidatePRURLAgainstDogfoodDoneLine(t *testing.T) {
-	urls := FindPRURLs("done: PR https://github.com/atqamz/secondhand/pull/31 checks green")
+	urls := FindPRURLs("done: PR https://github.com/atqamz/hand/pull/31 checks green")
 	if len(urls) != 1 {
 		t.Fatalf("got %+v", urls)
 	}
@@ -20,15 +20,15 @@ func TestValidatePRURLAgainstDogfoodDoneLine(t *testing.T) {
 
 func TestValidatePRURLRejectsMalformed(t *testing.T) {
 	cases := []string{
-		"http://github.com/atqamz/secondhand/pull/31",
-		"https://github.com/atqamz/secondhand/pull/31/files",
-		"https://github.com/atqamz/secondhand/pull/",
-		"https://github.com/atqamz/secondhand/pull/31 ",
-		" https://github.com/atqamz/secondhand/pull/31",
-		"https://github.com/atqamz/secondhand/issues/31",
-		"https://not-github.com/atqamz/secondhand/pull/31",
-		"https://github.com.evil.com/atqamz/secondhand/pull/31",
-		"https://github.com/atqamz/secondhand/pull/31; rm -rf /",
+		"http://github.com/atqamz/hand/pull/31",
+		"https://github.com/atqamz/hand/pull/31/files",
+		"https://github.com/atqamz/hand/pull/",
+		"https://github.com/atqamz/hand/pull/31 ",
+		" https://github.com/atqamz/hand/pull/31",
+		"https://github.com/atqamz/hand/issues/31",
+		"https://not-github.com/atqamz/hand/pull/31",
+		"https://github.com.evil.com/atqamz/hand/pull/31",
+		"https://github.com/atqamz/hand/pull/31; rm -rf /",
 		"https://github.com/atqamz/pull/31",
 		"",
 	}
@@ -40,8 +40,8 @@ func TestValidatePRURLRejectsMalformed(t *testing.T) {
 }
 
 func TestParsePRURLExtractsSlug(t *testing.T) {
-	slug, ok := ParsePRURL("https://github.com/atqamz/secondhand/pull/31")
-	if !ok || slug != "atqamz/secondhand" {
+	slug, ok := ParsePRURL("https://github.com/atqamz/hand/pull/31")
+	if !ok || slug != "atqamz/hand" {
 		t.Fatalf("got slug=%q ok=%v", slug, ok)
 	}
 }
@@ -69,7 +69,7 @@ func TestFindPRURLsSkipsURLWithAdjacentPunctuation(t *testing.T) {
 func TestFindPRURLsAgainstDogfoodDoneLine(t *testing.T) {
 	lines := splitDogfoodLines(t)
 	urls := FindPRURLs(lines[2])
-	if len(urls) != 1 || urls[0] != "https://github.com/atqamz/secondhand/pull/31" {
+	if len(urls) != 1 || urls[0] != "https://github.com/atqamz/hand/pull/31" {
 		t.Fatalf("got %+v, want exactly the one embedded PR URL", urls)
 	}
 	if urls := FindPRURLs(lines[0]); len(urls) != 0 {

--- a/internal/state/report.go
+++ b/internal/state/report.go
@@ -78,7 +78,7 @@ func ParseReportLine(line string) ReportLine {
 
 // How far a task's report channel has been consumed. A worker reporting with a truncating redirect
 // rewrites the file in place rather than appending, and a rewrite whose length happens to equal the
-// offset leaves every quantity the offset alone can offer identical (atqamz/secondhand#149).
+// offset leaves every quantity the offset alone can offer identical (atqamz/hand#149).
 type ReportCursor struct {
 	Offset int64
 	// What tells that same-length rewrite apart: it still sits just past a final newline with nothing
@@ -98,7 +98,7 @@ func (c ReportCursor) covers(data []byte) bool {
 	}
 	// An empty digest is a cursor persisted before hand recorded one, so the check falls back to the
 	// newline boundary every persisted offset sits on: an offset whose preceding byte is not a newline
-	// points into the middle of a line a longer rewrite replaced (atqamz/secondhand#140).
+	// points into the middle of a line a longer rewrite replaced (atqamz/hand#140).
 	return c.Offset == 0 || data[c.Offset-1] == '\n'
 }
 
@@ -222,9 +222,9 @@ func TerminalReport(s string) bool {
 // durable report cursor is the marker: the poll loop advances it only after a tick's events are
 // announced, and every announcement reaches state/events.log and the notify hook.
 func UnacknowledgedTerminalReport(homeDir, id string, cur ReportCursor) (bool, error) {
-	// So a terminal line still past that cursor has reached nobody (atqamz/secondhand#70). A cursor the
+	// So a terminal line still past that cursor has reached nobody (atqamz/hand#70). A cursor the
 	// file's content no longer supports covers nothing, so a rewritten channel is read whole - the
-	// length-preserving rewrite included, whose `done:` no watcher announced (atqamz/secondhand#149).
+	// length-preserving rewrite included, whose `done:` no watcher announced (atqamz/hand#149).
 	data, base, err := readReport(ReportPath(homeDir, id), cur)
 	if err != nil {
 		return false, err

--- a/internal/state/report_test.go
+++ b/internal/state/report_test.go
@@ -11,7 +11,7 @@ import (
 // time and hand read nothing. Verbatim, not invented, so the parser meets real data.
 const dogfoodReportLines = `working: workflow_dispatch added to release.yaml, invoking no-mistakes
 needs-decision: review gate on PR for #20 raised 2 ask-user findings - (1) concurrency group release-${{ github.ref }} does not serialize manual dispatch against push-triggered runs on main, risking concurrent release-please runs; (2) dispatch replays same release-please step that already no-op'd on issue #20, may not unblock the conflicted PR without also deleting/recreating the release branch. Run parked at review gate, run id 01KYEVGV26MD8X08MZY2VXXCSR on branch 20-release-workflow-dispatch.
-done: PR https://github.com/atqamz/secondhand/pull/31 checks green
+done: PR https://github.com/atqamz/hand/pull/31 checks green
 `
 
 func TestParseReportLineAgainstDogfoodData(t *testing.T) {
@@ -32,7 +32,7 @@ func TestParseReportLineAgainstDogfoodData(t *testing.T) {
 	}
 
 	got = ParseReportLine(lines[2])
-	if got.State != ReportDone || got.Note != "PR https://github.com/atqamz/secondhand/pull/31 checks green" {
+	if got.State != ReportDone || got.Note != "PR https://github.com/atqamz/hand/pull/31 checks green" {
 		t.Fatalf("got %+v", got)
 	}
 }
@@ -138,7 +138,7 @@ func TestTailReportRestartsFromZeroWhenFileShrinks(t *testing.T) {
 
 // Three reports captured off this fleet's live report files, each rewritten in place over a
 // shorter consumed one. All were announced as "malformed report" with a mid-word fragment of
-// themselves (atqamz/secondhand#140): the consumed offset survived the rewrite, mid-line.
+// themselves (atqamz/hand#140): the consumed offset survived the rewrite, mid-line.
 func TestTailReportAfterInPlaceRewrite(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -150,9 +150,9 @@ func TestTailReportAfterInPlaceRewrite(t *testing.T) {
 		{
 			name:     "paused report carrying a PR URL",
 			consumed: "paused: gate slot requested, PR opening next\n",
-			rewrite:  "paused: PR https://github.com/atqamz/secondhand/pull/139 open and ready, waiting on gate slot go\n",
+			rewrite:  "paused: PR https://github.com/atqamz/hand/pull/139 open and ready, waiting on gate slot go\n",
 			state:    ReportPaused,
-			note:     "PR https://github.com/atqamz/secondhand/pull/139 open and ready, waiting on gate slot go",
+			note:     "PR https://github.com/atqamz/hand/pull/139 open and ready, waiting on gate slot go",
 		},
 		{
 			name:     "working report carrying owner:branch",
@@ -220,7 +220,7 @@ func TestUnacknowledgedTerminalReportAfterInPlaceRewrite(t *testing.T) {
 	if err := os.WriteFile(ReportPath(home, "task-1"), []byte(consumed), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/secondhand/pull/139 merged and issue closed\n"), 0o644); err != nil {
+	if err := os.WriteFile(ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/hand/pull/139 merged and issue closed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,7 +235,7 @@ func TestUnacknowledgedTerminalReportAfterInPlaceRewrite(t *testing.T) {
 
 // The rewrite that carries no length change at all: reports are one line of house-style prose, so two
 // consecutive ones landing on the same byte count is a matter of time, and every quantity the offset
-// has to offer is identical across it - so the new report was skipped entirely (atqamz/secondhand#149).
+// has to offer is identical across it - so the new report was skipped entirely (atqamz/hand#149).
 func TestTailReportAfterSameLengthInPlaceRewrite(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -328,7 +328,7 @@ func TestUnacknowledgedTerminalReportAfterSameLengthRewrite(t *testing.T) {
 }
 
 // A cursor from a row written before report_digest existed keeps the guard it was written under: the
-// same-length rewrite is missed exactly as before, and the longer one atqamz/secondhand#140 covers is
+// same-length rewrite is missed exactly as before, and the longer one atqamz/hand#140 covers is
 // still caught. The alternative is replaying every consumed line on the tick after an upgrade.
 func TestTailReportFallsBackToTheNewlineBoundaryWithoutADigest(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "task-1.status")

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/store"
 )
 
 // ErrTaskNotFound is wrapped into errors returned by Read and Delete when no

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/store"
 )
 
 func TestWriteReadRoundTrip(t *testing.T) {

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -3,7 +3,7 @@
 // state/<id>.status that hand only ever reads.
 package state
 
-import "github.com/atqamz/secondhand/internal/store"
+import "github.com/atqamz/hand/internal/store"
 
 const (
 	KindShip  = store.KindShip

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -236,7 +236,7 @@ func (ix *Index) Search(query string, limit int) ([]Hit, error) {
 	return hits, nil
 }
 
-// Nothing renders data/dashboard.md any more (atqamz/secondhand#62), but a home initialized
+// Nothing renders data/dashboard.md any more (atqamz/hand#62), but a home initialized
 // before its deletion keeps the last render on disk forever, and indexing that would answer a
 // prose search out of a frozen snapshot of removed functionality.
 var generatedCorpusFiles = map[string]bool{

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -95,7 +95,7 @@ func readLegacyTask(path, id string) (Task, error) {
 	}
 	// A file predating the pane-start column carries no such key, so the import lands as an
 	// INSERT the backfill never sees. Same CASE as that backfill, so a task promoted before
-	// either existed gets its own pane's start, not atqamz/secondhand#128's false one.
+	// either existed gets its own pane's start, not atqamz/hand#128's false one.
 	if t.PaneStartedAt == "" {
 		t.PaneStartedAt = t.StatusChangedAt
 		if t.PaneStartedAt == "" {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,7 +26,7 @@ const (
 	HoldKindBlocked  = "blocked"
 	// HoldKindLimit is the one machine-set kind: hand watch sets it when a worker's
 	// harness stops on a usage limit and clears it when the worker runs again, so
-	// `hand hold set` refuses it (atqamz/secondhand#136).
+	// `hand hold set` refuses it (atqamz/hand#136).
 	HoldKindLimit = "limit"
 )
 
@@ -98,16 +98,16 @@ type Task struct {
 	LeaseID string `json:"lease_id"`
 	// Set when landing the work belongs outside the fleet - an upstream maintainer, or a
 	// deliverable that is a report, not a commit. Terminal without MergeExecuted's claim that
-	// it landed (atqamz/secondhand#78). Reason required, so the record says what and to whom.
+	// it landed (atqamz/hand#78). Reason required, so the record says what and to whom.
 	DeliveredAt     string `json:"delivered_at"`
 	DeliveredReason string `json:"delivered_reason"`
 	// When this task's pane began, written by spawn and restamped by hand promote. Unlike
 	// StatusChangedAt, which the outage-dwell clock restamps for an unreachable pane, one field
-	// cannot mean both pane-start and last-observed transition (atqamz/secondhand#128).
+	// cannot mean both pane-start and last-observed transition (atqamz/hand#128).
 	PaneStartedAt string `json:"pane_started_at"`
 	// The silence instant hand watch last fired `parked` against. Durable: a terminal task's
 	// report file never grows, so a re-derived latch would re-fire that frozen instant every
-	// restart and evict real history from events.log (atqamz/secondhand#127).
+	// restart and evict real history from events.log (atqamz/hand#127).
 	ParkedFiredFor string `json:"parked_fired_for"`
 	// The earliest instant hand watch may next try to resume a worker its harness stopped on a usage
 	// limit. Non-empty is what makes a task limited; the `limit` hold is the operator-visible
@@ -115,13 +115,13 @@ type Task struct {
 	UsageLimitRetryAt string `json:"usage_limit_retry_at"`
 	// How many such attempts have been made. Both are durable because a re-derived schedule lets every
 	// watcher restart attempt immediately against an account still limited - the retry storm this is
-	// bounded to avoid - and a restart that forgot it never resumes at all (atqamz/secondhand#136).
+	// bounded to avoid - and a restart that forgot it never resumes at all (atqamz/hand#136).
 	UsageLimitAttempts int `json:"usage_limit_attempts"`
 }
 
 // Upstream is the "owner/repo" a fork project opens its PRs against, empty when it contributes to
 // its own repo. A fork has two repos, the one URL names and the one its PRs live on, and only a
-// declared upstream tells that pair from an unauthorized one (atqamz/secondhand#78).
+// declared upstream tells that pair from an unauthorized one (atqamz/hand#78).
 type Project struct {
 	Name     string
 	URL      string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/shellquote"
+	"github.com/atqamz/hand/internal/shellquote"
 	_ "modernc.org/sqlite"
 )
 

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/age"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/age"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Kind values classify an Event for stdout/log routing. There is deliberately no bare "done" kind -

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Covers herdr's two spellings of "pane stopped being busy" - see herdr.Status's doc for why idle

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -342,7 +342,7 @@ func TestClassifyReportLineAgainstDogfoodData(t *testing.T) {
 		t.Fatalf("got %+v ts=%+v, want report-needs-decision", e, ts)
 	}
 
-	line = state.ParseReportLine("done: PR https://github.com/atqamz/secondhand/pull/31 checks green")
+	line = state.ParseReportLine("done: PR https://github.com/atqamz/hand/pull/31 checks green")
 	e = ClassifyReportLine(home, ts, task, line)
 	if e == nil || e.Kind != KindReportDone {
 		t.Fatalf("got %+v, want report-done", e)

--- a/internal/watcher/ownership.go
+++ b/internal/watcher/ownership.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // ErrAttached is wrapped into Acquire's refusal so cmd can render it as a

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -130,7 +130,7 @@ func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 // started working.
 func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t state.Task, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
 	// The same `send:<id>` lock hand send holds, because two writers racing one composer is the lost
-	// steer atqamz/secondhand#102 traced. TryLock, never Lock: a tick must not block behind an operator's
+	// steer atqamz/hand#102 traced. TryLock, never Lock: a tick must not block behind an operator's
 	// whole --wait, and an operator send landing right now is itself the thing that ends the limit.
 	release, err := state.TryLock(cfg.Home, "send:"+t.ID)
 	if err != nil {

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/harness"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // The bounds on resuming a usage-limited worker. The failure mode designed against is a retry storm

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
 )
 
 const claudeLimitText = "Claude usage limit reached. Your limit will reset at 3pm (UTC)."
@@ -158,7 +158,7 @@ func TestTickLeavesAWorkerThatStoppedForAnotherReasonAlone(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
-	paneLog := paneScript(t, limitedPaneAgent, "$ go test -race ./...\nok  github.com/atqamz/secondhand/internal/watcher\n")
+	paneLog := paneScript(t, limitedPaneAgent, "$ go test -race ./...\nok  github.com/atqamz/hand/internal/watcher\n")
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -76,7 +76,7 @@ func setLimitRetryAt(t *testing.T, home, id string, at time.Time) {
 	}
 }
 
-// The behavior atqamz/secondhand#136 asks for, end to end through tick: a worker whose harness stopped
+// The behavior atqamz/hand#136 asks for, end to end through tick: a worker whose harness stopped
 // on a usage limit is detected, recorded, steered once its schedule comes due, and released the moment
 // it is running again. Recognising the message is only the first of the four.
 func TestTickResumesALimitedWorkerAndLetsGoWhenItRuns(t *testing.T) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -14,12 +14,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/atomicfile"
-	"github.com/atqamz/secondhand/internal/ghutil"
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/notify"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/notify"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
 )
 
 const maxEventLogLines = 200

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -174,7 +174,7 @@ func setupWatcherHome(t *testing.T, taskOpts state.Task) (home string) {
 	return home
 }
 
-// Proves the working->idle fix (atqamz/secondhand#30, atqamz/secondhand#32, atqamz/secondhand#33)
+// Proves the working->idle fix (atqamz/hand#30, atqamz/hand#32, atqamz/hand#33)
 // against the spelling hand's headless polling observes: herdr renders working/blocked->idle as "done",
 // not "idle", unless a live OS-focused client has that tab active then (see herdr.Status's doc).
 func TestTickClassifiesNotBusyAsIdleUnreportedRegardlessOfHerdrSpelling(t *testing.T) {
@@ -244,7 +244,7 @@ func TestTickRecordsVerifiedDoneOnlyOnceReportedDoneIsVerified(t *testing.T) {
 
 	home := setupWatcherHome(t, state.Task{
 		ID: "task-1", Project: "nsr", Kind: state.KindShip,
-		PR: "https://github.com/atqamz/secondhand/pull/1", MergeExecuted: true,
+		PR: "https://github.com/atqamz/hand/pull/1", MergeExecuted: true,
 		Herdr: state.Herdr{PaneID: "p1"},
 	})
 
@@ -256,7 +256,7 @@ func TestTickRecordsVerifiedDoneOnlyOnceReportedDoneIsVerified(t *testing.T) {
 	var buf bytes.Buffer
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/secondhand/pull/1 checks green\n"), 0o644); err != nil {
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/hand/pull/1 checks green\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	buf.Reset()
@@ -412,7 +412,7 @@ func TestTickAutoRecordsPRFromReportLine(t *testing.T) {
 	writeFakeGh(t, "OPEN")
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -422,7 +422,7 @@ func TestTickAutoRecordsPRFromReportLine(t *testing.T) {
 	var buf bytes.Buffer
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/secondhand/pull/31 checks green\n"), 0o644); err != nil {
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/hand/pull/31 checks green\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	buf.Reset()
@@ -436,7 +436,7 @@ func TestTickAutoRecordsPRFromReportLine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if task.PR != "https://github.com/atqamz/secondhand/pull/31" {
+	if task.PR != "https://github.com/atqamz/hand/pull/31" {
 		t.Fatalf("task.PR = %q, want the embedded URL auto-recorded", task.PR)
 	}
 }
@@ -447,8 +447,8 @@ func TestTickDoesNotOverwriteAlreadyRecordedPR(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "OPEN")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/secondhand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -458,7 +458,7 @@ func TestTickDoesNotOverwriteAlreadyRecordedPR(t *testing.T) {
 	var buf bytes.Buffer
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/secondhand/pull/99 checks green\n"), 0o644); err != nil {
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR https://github.com/atqamz/hand/pull/99 checks green\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	tick(ctx, cfg, client, states, &buf, io.Discard)
@@ -467,7 +467,7 @@ func TestTickDoesNotOverwriteAlreadyRecordedPR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if task.PR != "https://github.com/atqamz/secondhand/pull/1" {
+	if task.PR != "https://github.com/atqamz/hand/pull/1" {
 		t.Fatalf("task.PR = %q, want the already-recorded PR left untouched", task.PR)
 	}
 }
@@ -481,7 +481,7 @@ func TestTickRefusesToAutoRecordAForeignRepoPR(t *testing.T) {
 	writeFakeGh(t, "OPEN")
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -529,7 +529,7 @@ func TestTickKeepsAWorkerQuestionWhenItsPRURLIsRefused(t *testing.T) {
 	writeFakeGh(t, "OPEN")
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -568,7 +568,7 @@ func TestTickSurfacesAContendedAutoRecordInsteadOfWaiting(t *testing.T) {
 	writeFakeGh(t, "OPEN")
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -578,7 +578,7 @@ func TestTickSurfacesAContendedAutoRecordInsteadOfWaiting(t *testing.T) {
 	var buf, errBuf bytes.Buffer
 	tick(ctx, cfg, client, states, &buf, &errBuf)
 
-	url := "https://github.com/atqamz/secondhand/pull/7"
+	url := "https://github.com/atqamz/hand/pull/7"
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: "+url+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -628,9 +628,9 @@ func TestTickStaysSilentWhenTheLockHolderRecordedTheSamePR(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
-	url := "https://github.com/atqamz/secondhand/pull/7"
+	url := "https://github.com/atqamz/hand/pull/7"
 	// The holder's write has to land after tick's own state.List snapshot, or the pre-existing "task
 	// already has a PR" guard absorbs the URL and the contention path under test is never reached -
 	// which is what made an earlier version of this test vacuous.
@@ -702,9 +702,9 @@ func TestTickReportsAnUnreadableTaskWhenTheLockIsContended(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
-	url := "https://github.com/atqamz/secondhand/pull/7"
+	url := "https://github.com/atqamz/hand/pull/7"
 	corrupt := filepath.Join(t.TempDir(), "corrupt.db")
 	if err := os.WriteFile(corrupt, []byte("this is not a database"), 0o644); err != nil {
 		t.Fatal(err)
@@ -752,7 +752,7 @@ func TestTickAnnouncesPRMergedBeforePersistingIt(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "MERGED")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/secondhand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -806,7 +806,7 @@ func TestTickDoesNotReannounceAPollObservedMergeAfterRestart(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "MERGED")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/secondhand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -904,7 +904,7 @@ func TestTickResumesReportTailAfterRestart(t *testing.T) {
 }
 
 // A `done:` rewrite landing on the byte count of the `working:` line before it was skipped outright
-// (atqamz/secondhand#149): the offset still sat just past the final newline with nothing after it, so
+// (atqamz/hand#149): the offset still sat just past the final newline with nothing after it, so
 // nothing was announced, LastReportState stayed `working`, and ClassifyDeferredDone - gated on it - never ran.
 func TestTickAnnouncesADoneRewrittenToTheSameLengthAcrossARestart(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
@@ -1686,7 +1686,7 @@ func TestTickKeepsAMultiLineAutoRecordFailureOnOneLine(t *testing.T) {
 	writeFakeGhFailingMultiline(t)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
-	registerProject(t, home, "nsr", "https://github.com/atqamz/secondhand.git")
+	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -1696,7 +1696,7 @@ func TestTickKeepsAMultiLineAutoRecordFailureOnOneLine(t *testing.T) {
 	var buf, errBuf bytes.Buffer
 	tick(ctx, cfg, client, states, &buf, &errBuf)
 
-	url := "https://github.com/atqamz/secondhand/pull/7"
+	url := "https://github.com/atqamz/hand/pull/7"
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: "+url+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -2012,7 +2012,7 @@ func TestRunUntilEventDeliversTheFirstTransitionAndReturns(t *testing.T) {
 	}
 }
 
-// Covers atqamz/secondhand#85: a caller that only wants to wake on blocked must not be woken by a
+// Covers atqamz/hand#85: a caller that only wants to wake on blocked must not be woken by a
 // routine idle-unreported transition, but the filtered-out event still has to reach events.log exactly
 // like a baseline tick's events already do - the filter gates the wake, not the record.
 func TestRunUntilEventFiltersWakesToTheRequestedKinds(t *testing.T) {
@@ -2407,7 +2407,7 @@ func TestTickSetsTheStateColumnOnAReportedStop(t *testing.T) {
 	}
 }
 
-// Covers atqamz/secondhand#81's hard part: a task whose very first sighting finds its pane unreachable
+// Covers atqamz/hand#81's hard part: a task whose very first sighting finds its pane unreachable
 // must not be dropped (the old !tracked branch's bare continue), but a probe failure that clears before
 // the dwell matures - a blink - must produce nothing at all.
 func TestTickStaysSilentOnABlinkAtFirstSighting(t *testing.T) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/herdr"
-	"github.com/atqamz/secondhand/internal/project"
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
 )
 
 // Drives the fake into herdr's failure shape for `pane get` - an error envelope on stdout with exit 0,

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -30,7 +30,7 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	// Banners land on stderr ahead of the JSON, so the payload has to be read from stdout alone -
-	// CombinedOutput here corrupts every parse (atqamz/secondhand#21).
+	// CombinedOutput here corrupts every parse (atqamz/hand#21).
 	out, err := cmd.Output()
 	if err != nil {
 		return Lease{}, fmt.Errorf("treehouse get failed: %w: %s", err, strings.TrimSpace(stderr.String()))

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Lease is one acquisition of a treehouse pool slot. ID is empty when treehouse

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/faketool"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // One-off treehouse for a single response shape, used only where the call changes

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/atqamz/secondhand/cmd"
+import "github.com/atqamz/hand/cmd"
 
 var version = "dev"
 

--- a/tests/contract/gh_test.go
+++ b/tests/contract/gh_test.go
@@ -12,8 +12,8 @@ import (
 // call below is read-only: nothing in a contract run may open, close or merge a
 // real PR, so `pr merge` is recorded in FIDELITY.md and left unexercised here.
 const (
-	ghRepo      = "atqamz/secondhand"
-	ghRepoCased = "AtqaMZ/SecondHand"
+	ghRepo      = "atqamz/hand"
+	ghRepoCased = "AtqaMZ/Hand"
 	ghMergedPR  = "154"
 	ghMergedRef = "136-usage-limit-resume"
 )
@@ -36,7 +36,7 @@ func TestGHPRListAnswersAnEmptyArrayForABranchWithNoPR(t *testing.T) {
 	}
 }
 
-// The slug case atqamz/secondhand#147 fixed: gh serves a repo under any casing and answers with
+// The slug case atqamz/hand#147 fixed: gh serves a repo under any casing and answers with
 // the canonical one, so a comparison against a git remote has to fold case.
 func TestGHServesARepoUnderAnyCasingAndAnswersCanonically(t *testing.T) {
 	requireGH(t)

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/faketool"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Writes a brief whose body the test controls, so a declaration block can be put in front of real prose.

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Builds the two-task, one-pool-slot fixture both tests below spawn into, and returns the fake bin

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 var handBin string

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/faketool"
+	"github.com/atqamz/hand/internal/faketool"
 )
 
 // Everything hand execs beyond these three is faked per test and left unreachable, so a missing fake fails

--- a/tests/e2e/gate_visibility_test.go
+++ b/tests/e2e/gate_visibility_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Writes a fake no-mistakes that answers `status` and `runs` with fixed text. `init` is answered too, since

--- a/tests/e2e/gate_visibility_test.go
+++ b/tests/e2e/gate_visibility_test.go
@@ -31,7 +31,7 @@ const gateReadyStatus = "    repo:  /home/atqa/secondhand/projects/demo\n" +
 	"    gate:  /home/atqa/.no-mistakes/repos/0b474f2021dd.git\n" +
 	"  daemon:  running\n\n  no active run"
 
-// Covers atqamz/secondhand#100 on the real binary: an empty fleet must say so, and must still surface a
+// Covers atqamz/hand#100 on the real binary: an empty fleet must say so, and must still surface a
 // hold left open on a torn-down task's id rather than reading as nothing to see.
 func TestStatusEmptyFleetStatesItsCount(t *testing.T) {
 	home := newHome(t)
@@ -67,7 +67,7 @@ func TestStatusEmptyFleetStatesItsCount(t *testing.T) {
 	}
 }
 
-// Covers atqamz/secondhand#92 through the operator's own sequence: spawn a ship task into a no-mistakes
+// Covers atqamz/hand#92 through the operator's own sequence: spawn a ship task into a no-mistakes
 // project, record its PR, let the worker report done, then read `hand status`.
 func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
 	prURL := "https://github.com/owner/demo/pull/7"
@@ -139,7 +139,7 @@ func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
 	}
 }
 
-// Covers atqamz/secondhand#97 on both operator surfaces. A clone path that is missing, and one that exists
+// Covers atqamz/hand#97 on both operator surfaces. A clone path that is missing, and one that exists
 // but is not a git repository, are different failures from a gate that was never initialized: `no-mistakes
 // init` repairs neither.
 func TestGateCheckNamesAMissingOrNonGitClonePath(t *testing.T) {

--- a/tests/e2e/hold_test.go
+++ b/tests/e2e/hold_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 type fleetStatus struct {

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/faketool"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives `hand merge` through a faked gh, no real remote: all-green checks merge cleanly, a failing

--- a/tests/e2e/migrate_test.go
+++ b/tests/e2e/migrate_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/store"
+	"github.com/atqamz/hand/internal/store"
 )
 
 // A fleet home the way a pre-sqlite hand left one. Deliberately not built by

--- a/tests/e2e/pr_test.go
+++ b/tests/e2e/pr_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // The clone is redirected to a GitHub URL via git's insteadOf mechanism, so

--- a/tests/e2e/project_test.go
+++ b/tests/e2e/project_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/project"
+	"github.com/atqamz/hand/internal/project"
 )
 
 // Drives add -> list -> sync (fast-forward) -> remove through the built binary against a real local git

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives `hand promote` through the built binary: the brief-missing failure path first, then a clean

--- a/tests/e2e/report_watch_test.go
+++ b/tests/e2e/report_watch_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Proves the bug atqamz/secondhand#30 and atqamz/secondhand#32 set out to kill: herdr's idle and done are
+// Proves the bug atqamz/hand#30 and atqamz/hand#32 set out to kill: herdr's idle and done are
 // the same "pane stopped being busy" signal (see herdr.Status's doc comment for why), so a working -> idle
 // transition right after a "needs-decision" report must never be classified as done.
 func TestWatchIdleAfterReportedNeedsDecisionIsNotDone(t *testing.T) {
@@ -133,7 +133,7 @@ func TestWatchReportRewrittenInPlaceIsNotMalformed(t *testing.T) {
 	watch := startHandBackground(t, home, "watch", "--poll", "30ms")
 	waitForInvocation(t, herdrLog, "herdr pane get pane-1", 5*time.Second)
 
-	// Two live samples from atqamz/secondhand#140, verbatim: both were announced as "malformed report"
+	// Two live samples from atqamz/hand#140, verbatim: both were announced as "malformed report"
 	// carrying a mid-word fragment of themselves, and neither contains anything a parser could object to.
 	notes := []string{
 		"reading the ghutil call sites for --head",
@@ -202,7 +202,7 @@ func TestWatchDoneRewrittenToTheSameLengthReachesVerifiedDone(t *testing.T) {
 
 	// The `done:` variant is the one that costs a completion: the deferred verification is gated on the last
 	// recorded report state, so a skipped done means a scout that finished is never announced as finished
-	// (atqamz/secondhand#149).
+	// (atqamz/hand#149).
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(done), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/report_watch_test.go
+++ b/tests/e2e/report_watch_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Proves the bug atqamz/secondhand#30 and atqamz/secondhand#32 set out to kill: herdr's idle and done are

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives two `hand send` processes at one busy pane. The send lock is cross-process by construction, so no

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -14,7 +14,7 @@ import (
 
 // Drives two `hand send` processes at one busy pane. The send lock is cross-process by construction, so no
 // cmd-level test can cover it: what has to hold is that one sender waits out the other's whole retry loop
-// instead of both firing their text into the same composer at once (atqamz/secondhand#102's lost steer).
+// instead of both firing their text into the same composer at once (atqamz/hand#102's lost steer).
 func TestConcurrentSendsToTheSameTaskSerialize(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")

--- a/tests/e2e/slug_case_test.go
+++ b/tests/e2e/slug_case_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Fakes `gh pr list` the way GitHub actually serves a repo: the same PR list comes back under every casing

--- a/tests/e2e/spawn_teardown_test.go
+++ b/tests/e2e/spawn_teardown_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/completion"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives a full spawn -> refused teardown -> local merge -> successful teardown cycle through the built

--- a/tests/e2e/status_unacknowledged_test.go
+++ b/tests/e2e/status_unacknowledged_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Drives atqamz/secondhand#70 end to end: a worker that finished while no watcher was attached has to be
+// Drives atqamz/hand#70 end to end: a worker that finished while no watcher was attached has to be
 // visible to the next hand status, and has to stop being flagged once a watcher really consumed it. Only
 // real processes prove the second half, because what clears the flag is a persisted report_offset.
 func TestStatusFlagsATerminalReportNoWatcherEverRead(t *testing.T) {

--- a/tests/e2e/status_unacknowledged_test.go
+++ b/tests/e2e/status_unacknowledged_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives atqamz/secondhand#70 end to end: a worker that finished while no watcher was attached has to be

--- a/tests/e2e/teardown_return_test.go
+++ b/tests/e2e/teardown_return_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/faketool"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // The one treehouse failure its exit status does not report: an unforced return of a dirty worktree

--- a/tests/e2e/upstream_deliver_test.go
+++ b/tests/e2e/upstream_deliver_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/atqamz/secondhand/internal/completion"
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives the whole case atqamz/secondhand#78 describes through the built binary: work pushed to a fork, its

--- a/tests/e2e/upstream_deliver_test.go
+++ b/tests/e2e/upstream_deliver_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Drives the whole case atqamz/secondhand#78 describes through the built binary: work pushed to a fork, its
+// Drives the whole case atqamz/hand#78 describes through the built binary: work pushed to a fork, its
 // PR opened on an upstream repo the fleet does not control, and a maintainer who has not merged it.
 func TestForkContributionDeliveredNotLanded(t *testing.T) {
 	// The upstream repo here is a fixture, never the live one: the real contribution is offered to a project

--- a/tests/e2e/watch_ownership_test.go
+++ b/tests/e2e/watch_ownership_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
-	"github.com/atqamz/secondhand/internal/watcher"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/watcher"
 )
 
 // Drives atqamz/secondhand#73 end to end with real processes, which is the only way to prove the contract

--- a/tests/e2e/watch_ownership_test.go
+++ b/tests/e2e/watch_ownership_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/atqamz/hand/internal/watcher"
 )
 
-// Drives atqamz/secondhand#73 end to end with real processes, which is the only way to prove the contract
+// Drives atqamz/hand#73 end to end with real processes, which is the only way to prove the contract
 // that matters: a second watcher is refused rather than added to the fleet's pool of pollers, and
 // --takeover replaces a genuinely live incumbent that has to be signaled and reaped.
 func TestWatchIsASingletonPerFleetHome(t *testing.T) {

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -280,7 +280,7 @@ func TestWatchParksADoneWorkerUnderItsOwnBound(t *testing.T) {
 	}
 }
 
-// The bug atqamz/secondhand#127 tracks, exercised through a real restart rather than through the latch
+// The bug atqamz/hand#127 tracks, exercised through a real restart rather than through the latch
 // alone: a done task's report file never grows again, so the silence parked fired against stays frozen, and
 // a re-derived latch re-announces it on every re-arm.
 func TestWatchDoesNotRefireParkedForADoneTaskAcrossARestart(t *testing.T) {

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atqamz/secondhand/internal/state"
+	"github.com/atqamz/hand/internal/state"
 )
 
 // Drives `hand watch` as a background process against two seeded tasks and asserts on its actual contract:


### PR DESCRIPTION
## Intent

The developer wanted Secondhand’s supervisor startup journey audited and redesigned around a canonical, idempotent `hand session start` flow. It needed to support both onboarding paths: initializing an empty directory as a fleet home and opening the Secondhand source checkout in any supported harness, with automatic bootstrap where appropriate. They chose a harness-agnostic AGENTS.md-first approach, including current-harness detection, safe managed-block composition for existing instructions, consistent prerequisites for mutating commands, and retirement of the Claude-only hook. They also asked to file a separate issue for a later audit of all other CLI lifecycle flows.

## What Changed

- Rename the Go module and internal imports from `github.com/atqamz/secondhand` to `github.com/atqamz/hand`.
- Point release downloads, self-update checks, documentation, and issue references at the `atqamz/hand` repository.
- Build the binary directly as `hand` across Makefile and Nix packaging, removing legacy renames.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
