### PR TITLE
fix: restore README onboarding guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Optional:
 - [no-mistakes](https://github.com/yes2games/no-mistakes) - required only by projects using `no-mistakes` mode
 - [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
 
-`hand init` reports required tools it cannot find on `PATH`. `hand doctor` checks the fleet home's generated agent instructions and related drift.
+`hand init` reports checked tools it cannot find on `PATH`. `hand doctor` checks the fleet home's generated agent instructions and related drift.
 
 Building from source additionally requires Go 1.26.5 or newer.
 

--- a/README.md
+++ b/README.md
@@ -1,134 +1,51 @@
 # Secondhand
 
-Talk to one agent. Ship with a crew.
+**You lead. `hand` runs the crew.**
 
-Secondhand is a single Go CLI binary, `hand`, that orchestrates a fleet of coding agents across projects.
-A supervisory agent runs in a fleet home - a standalone directory anywhere on disk, or the secondhand checkout itself - records tasks in a markdown backlog, and calls `hand` to spawn autonomous workers into isolated git worktrees.
-The CLI owns lifecycle correctness, state management, and process supervision.
-It was born from [firstmate](https://github.com/kunchenguid/firstmate), an agent fleet supervisor built as 34K lines of shell, and rebuilds that concept as a clean CLI.
+Secondhand turns one coding-agent session into a supervisor for a fleet of coding agents.
+
+You talk to one agent. It plans the work, writes briefs, dispatches workers into isolated git worktrees, watches them, steers them when needed, and brings the results back to you.
+
+`hand` is the CLI underneath that workflow. It owns lifecycle, state, isolation, and process supervision so the supervising agent can focus on judgment and coordination.
+
+```mermaid
+flowchart LR
+    user["You"] --> supervisor["Supervising agent"]
+    supervisor --> hand["hand"]
+    hand --> worker1["Worker"]
+    hand --> worker2["Worker"]
+    hand --> scout["Scout"]
+    worker1 --> pr1["PR / branch"]
+    worker2 --> pr2["PR / branch"]
+    scout --> report["Report"]
+    pr1 --> supervisor
+    pr2 --> supervisor
+    report --> supervisor
+```
+
+Secondhand was inspired by [firstmate](https://github.com/kunchenguid/firstmate), rebuilding the same agent-fleet idea as a focused Go CLI.
+
+## Why Secondhand?
+
+Coding agents are good at working on a task. Running several of them reliably is a different problem.
+
+Someone still has to:
+
+- give each worker enough context
+- keep concurrent work isolated
+- know which worker is running, blocked, or done
+- steer a worker without restarting it
+- preserve task state across supervising sessions
+- decide when work is ready to merge or hand off
+- clean up worktrees and processes without losing unfinished work
+
+Secondhand splits those responsibilities cleanly: **the supervisor handles judgment; `hand` handles mechanics.**
 
 ## Quick start
 
-Install `hand` (see "Installation" below for every option), then create a fleet home:
+### 1. Install `hand`
 
-```sh
-mkdir ~/fleet
-cd ~/fleet
-hand init
-# Launch any supported harness here; AGENTS.md tells it to run hand session start.
-```
-
-`hand init` asks nothing.
-It creates runtime directories, skeleton files, and a managed instruction block in `AGENTS.md`, with a `CLAUDE.md` symlink when that name is absent.
-The instructions make every supported supervising harness run `hand session start`, which loads the current fleet context and reports the first next action.
-That session uses the detected supervisor harness for workers and leaves model and effort selection to that harness's native defaults.
-It can register a project with `hand project add <repo-url>`; `hand config set <key> <value>` is only for an explicit persisted worker override.
-Detected and native values are effective defaults, not configuration written on your behalf.
-
-A fleet home is a plain directory, anywhere on disk, unrelated to any project's own repo.
-`hand init` never places a `hand` binary in it, so install `hand` on `PATH` first.
-
-The worker lifecycle commands are available, including `hand spawn`, `hand status`, `hand send`, and `hand teardown`.
-
-## Set up a fleet home
-
-The maintainers dogfood a fleet home inside the secondhand checkout itself; see [CONTRIBUTING.md](CONTRIBUTING.md) for that setup.
-
-Every `hand` command resolves its fleet home the same way: the `HAND_HOME` environment variable if set, otherwise the current directory or the nearest ancestor holding `state/hand.db`.
-`state/hand.db` is the marker because only `hand` ever writes it, so a project clone under `projects/` carrying its own generic top-level `data/` and `state/` never captures the walk up.
-Set `HAND_HOME` to run `hand` from outside the fleet home, for example from a script or a different working directory; pointed at a directory that is not a fleet home it refuses rather than falling back.
-
-## Core concepts
-
-- **Projects**: git repositories cloned under `projects/`, registered in `hand`'s machine state and projected to `data/projects.md`. Each has a delivery mode: `no-mistakes`, `direct-pr`, or `local-only`.
-- **Tasks**: units of work identified by a unique ID. Ship tasks produce a branch and PR; scout tasks investigate and produce `data/<id>/report.md`.
-- **Briefs**: task instructions at `data/<id>/brief.md`, written by the supervisory agent before spawning a worker.
-- **herdr tabs**: each worker runs in its own herdr tab. herdr provides semantic agent state (working/idle/blocked/done/unknown) and push events, so no terminal scraping. Herdr state says whether a pane is busy, not whether a task finished.
-- **Report channel**: `state/<id>.status` is an append-only file the worker writes and `hand` only reads. It carries the task outcome herdr cannot (working/paused/blocked/needs-decision/done/failed), surfaces in `hand status` and `hand watch`, and auto-records a PR URL the worker reports.
-- **treehouse worktrees**: workers operate in isolated git checkouts acquired from a treehouse pool, never in the project clone itself.
-- **Backlog**: `data/backlog.md` is a plain markdown task queue, read and edited directly by the supervisory agent. Finished entries roll off into `data/done-archive.md`, dropped ones into `data/note-archive.md`.
-- **Operator context and learnings**: `data/operator.md` is written by the operator for the agent to read first - identity, authority, hard constraints - and `data/learnings.md` is the agent's own curated record of operational facts that cost real time to discover. The agent reads `data/operator.md` and never rewrites it, which is what lets its constraints outrank the agent's judgment. `hand init` seeds both, `hand update` seeds whichever an older home is missing, and neither ever overwrites one that exists; nothing under `data/` is maintained by hand for the operator to read, since `hand status` and the issue tracker are their view of the fleet.
-- **Supervisor bootstrap**: `hand init` and `hand update` maintain one small `AGENTS.md` block that tells a supervising harness to run `hand session start` and load bounded startup context without reading stdin. Claude reads the same contract through `CLAUDE.md`. A process marked `HAND_ROLE=worker` is refused before context is read; supervisor startup is strictly read-only, so an older state schema requires an explicit `hand init <home>` migration before the overview can load.
-- **Agent-shaped output**: every command prints TOON on stdout - `key: value` fields, `name[N]{f1,f2}:` row blocks with pre-computed aggregates above them, and a `help[N]:` list of what to run next - because the consumer is an LLM agent rather than a human terminal, with `hand watch`'s per-line event stream as the one exception. `--fields` narrows a row block to the columns you name, `--json` retains its existing object, and a failure renders its own document on stderr carrying `error`, `kind` and `exit` so a caller branches on a word instead of a number.
-- **Machine state vs. the prose corpus**: machine state - tasks, PR state, pane ids, the project registry, holds - is authoritative in sqlite at `state/hand.db`. The prose under `data/` stays authoritative in files, with a derived full-text index at `state/index.db` that `hand search` reads and that is safe to delete at any time. When the database and a `state/<id>.status` file disagree about what a worker said, believe the file: it is readable without a working `hand`, which is what recovery has actually needed.
-
-## CLI overview
-
-| Command | Description | Status |
-| --- | --- | --- |
-| `hand` | With no subcommand in a fleet home: render the same supervisor startup digest as `hand session start`; outside one, report the binary, version and how to initialize a home | Available |
-| `hand init` | Initialize runtime directories, skeleton files and the managed supervisor instructions; asks nothing and persists no worker override | Available |
-| `hand config` | Report the effective detected/native worker defaults and optional persisted overrides; `hand config set <key> <value>` validates and persists one override | Available |
-| `hand session start` | Canonical supervisor startup: load bounded fleet context and choose the next action; refuses `HAND_ROLE=worker` before reading context and never reads stdin | Available |
-| `hand project add` | Clone and register a repository | Available |
-| `hand project list` | List registered projects | Available |
-| `hand project remove` | Unregister a project, keeping its clone | Available |
-| `hand project sync` | Fast-forward project clones to their remote default branch | Available |
-| `hand project upstream` | Declare the repo a fork project opens its PRs against, so `hand pr` accepts a PR living there and gate-opened-PR detection looks for one there | Available |
-| `hand spawn` | Spawn a worker agent in an isolated worktree | Available |
-| `hand status` | Show fleet overview or single-task detail | Available |
-| `hand send` | Send a message to a running worker, from an argument or `--file`; waits out a busy composer up to `--wait` instead of failing, and records the message as undelivered when it never reaches the pane | Available |
-| `hand hold set` | Record that an id is waiting on a human or on another id; survives the task's teardown, so `hand spawn` refuses to reuse a held id | Available |
-| `hand hold clear` | Clear the hold on an id | Available |
-| `hand watch` | Blocking watcher that prints actionable fleet events, including a worker gone silent with no herdr transition at all (`parked`), and steers a worker whose harness stopped on a usage limit back into its task once the quota plausibly returned, instead of leaving it dead until someone notices; `--until-event` exits on the first one - narrowed to chosen kinds with `--event` - so the exit itself wakes the supervisory agent, and exits `5` naming any worker it can't reach before arming; one watcher per fleet home, so a second exits `3` naming the incumbent unless it passes `--takeover` | Available |
-| `hand merge` | Merge a task's completed work | Available |
-| `hand pr` | Record a task's pull request URL | Available |
-| `hand search` | Full-text search the prose corpus under `data/` | Available |
-| `hand doctor` | Report perishable content and generated-block drift in the fleet home's `AGENTS.md`; fixes nothing | Available |
-| `hand deliver` | Record that a task's work is handed off and landing it is someone else's decision, so `hand teardown` accepts it without `--force` and the completion says delivered, not merged | Available |
-| `hand teardown` | Clean up a completed task, fail-closed on unlanded work, recording it in `state/completions.jsonl` first | Available |
-| `hand promote` | Promote a completed scout task into a ship task | Available |
-| `hand notify` | Send an out-of-band notification via a configured command; `hand watch` also calls it in-process for events worth reaching the operator | Available |
-| `hand update` | Update the installed binary from the latest GitHub Release; `--check` reports availability without installing | Available |
-
-Run `hand --help` for details on currently available commands.
-
-## Architecture
-
-```mermaid
-flowchart TD
-    user[User] -->|"requests, decisions, merge it"| supervisor["Supervisory agent<br/>reads AGENTS.md and data/<br/>edits data/backlog.md<br/>calls hand commands"]
-    supervisor --> task1["Task 1 worker<br/>herdr tab"]
-    supervisor --> task2["Task 2 worker<br/>herdr tab"]
-    supervisor --> taskN["Task N worker<br/>herdr tab"]
-    task1 --> worktrees["Treehouse worktrees<br/>isolated git checkouts"]
-    task2 --> worktrees
-    taskN --> worktrees
-    worktrees --> ship["Ship: branch to PR to merge to teardown"]
-    worktrees --> scout["Scout: investigate to report.md to teardown"]
-```
-
-## Requirements
-
-`hand` itself is a static binary with no runtime dependencies.
-It shells out to these tools, and reports the ones it cannot find on `PATH` when you run `hand init` or `hand doctor`:
-
-- [herdr](https://github.com/ogulcancelik/herdr) - terminal multiplexer with semantic agent state; every worker runs in a herdr pane, so spawning needs it
-- [treehouse](https://github.com/kunchenguid/treehouse) v2.1.0 or newer - git worktree pool manager; workers are given worktrees leased from it
-- [gh](https://github.com/cli/cli) - GitHub CLI, used for every PR and release operation
-- [no-mistakes](https://github.com/yes2games/no-mistakes) - validation pipeline, needed only by projects registered in `no-mistakes` mode
-- [qmd](https://github.com/tobi/qmd) - semantic search over historical task data, beyond `hand search`'s keyword matching; optional
-
-A worker also needs its own agent harness installed - `claude`, `codex`, `grok`, `pi` or `opencode`.
-`hand config` lists the supported ones, which of them are on `PATH`, and which accept a model or effort at launch.
-
-Building from source additionally needs Go 1.26.5 or newer.
-
-`hand` never installs or configures qmd, and every command works without it.
-To point it at a fleet home's corpus by hand:
-
-```sh
-qmd collection add data/ --name secondhand
-qmd context add qmd://secondhand "Task briefs, scout reports, decisions, and backlog history"
-qmd embed
-
-qmd search "login auth decision" --json
-qmd vsearch "how did we handle the deploy failure" -c secondhand
-```
-
-## Installation
-
-From a release, the way most installs should go:
+From a release:
 
 ```sh
 curl -fsSLO https://github.com/atqamz/hand/releases/latest/download/hand-linux-amd64.tar.gz
@@ -136,75 +53,319 @@ tar xzf hand-linux-amd64.tar.gz
 install -m755 hand ~/.local/bin/hand
 ```
 
-Releases carry `hand-linux-amd64`, `hand-linux-arm64`, `hand-darwin-amd64` and `hand-darwin-arm64` as `.tar.gz`, alongside a `checksums.txt` to verify against.
-The [releases page](https://github.com/atqamz/hand/releases) lists every asset.
-
-From nix, either into your profile or for a single command:
+Or with Nix:
 
 ```sh
 nix profile install github:atqamz/hand
+```
+
+See [Installation](#installation) for every supported option.
+
+### 2. Create a fleet home
+
+A fleet home is the directory where the supervising agent lives and where Secondhand keeps fleet state.
+
+```sh
+mkdir ~/fleet
+cd ~/fleet
+hand init
+```
+
+`hand init` is non-interactive. It creates the fleet structure and writes a managed block into `AGENTS.md` telling any supervising harness to run `hand session start` before acting, with a `CLAUDE.md` symlink to the same file when that name is otherwise absent.
+
+### 3. Add a project
+
+```sh
+hand project add https://github.com/you/project
+```
+
+Secondhand clones the repository under the fleet home and prepares it for isolated worker worktrees.
+
+### 4. Open a supervising session
+
+For Claude Code:
+
+```sh
+cd ~/fleet
+claude
+```
+
+The generated `AGENTS.md` block tells the harness to run `hand session start` before responding or acting; that command loads bounded fleet context and reports the first next action, and refuses outright inside a worker's isolated worktree. Any other supported harness reads the same instructions from `AGENTS.md` directly.
+
+On the first session, the supervisor may ask which worker harness, model, or effort level you want. Your answers are persisted with `hand config`; nothing is guessed on your behalf.
+
+### 5. Give it work
+
+Talk to the supervisor normally:
+
+> Fix the login regression. Also investigate why the integration tests are flaky, but do not change anything for that investigation yet.
+
+The supervisor can dispatch the fix as a **ship task** and the investigation as a **scout task**, then coordinate both while you keep talking to one agent.
+
+## How it works
+
+```mermaid
+flowchart TD
+    request["Your request"] --> brief["Supervisor writes a brief"]
+    brief --> spawn["hand spawn"]
+    spawn --> worktree["Worker in an isolated worktree"]
+    worktree --> supervise["Watch and steer"]
+    supervise --> outcome{"Task kind"}
+    outcome -->|Ship| ship["PR or local branch"]
+    outcome -->|Scout| scout["Investigation report"]
+    ship --> finish["Merge or deliver"]
+    scout --> finish
+    finish --> teardown["hand teardown"]
+```
+
+### Ship tasks
+
+Ship tasks make changes. A worker receives its own git worktree, works independently, and produces a pull request or local branch according to the project's delivery mode.
+
+### Scout tasks
+
+Scout tasks investigate without being expected to ship code. They return `data/<id>/report.md`, and a completed scout can later be promoted into a ship task.
+
+## What `hand` manages
+
+### Isolated workers
+
+Every worker operates in a git worktree leased through [treehouse](https://github.com/kunchenguid/treehouse). Workers never edit the registered project clone directly.
+
+### Live supervision
+
+Workers run interactively inside [herdr](https://github.com/ogulcancelik/herdr), so the supervisor can observe semantic agent state, send follow-up instructions with `hand send`, and react to fleet events with `hand watch` without scraping a terminal for meaning.
+
+### Durable fleet state
+
+Machine state lives in SQLite while operator context, briefs, reports, backlog history, and learnings remain plain files. The fleet survives the supervising agent's session, so a later session can pick up where the previous one stopped.
+
+### Safe lifecycle boundaries
+
+`hand` fails closed around destructive or irreversible transitions. Teardown refuses unlanded work unless it was explicitly delivered, and the generated supervisor rules prohibit merging without operator authorization.
+
+### Agent-first output
+
+`hand` is designed primarily for agent callers rather than as a terminal dashboard. Commands return compact structured TOON documents with named fields, aggregates, machine-readable states, and suggested next actions. Read commands that support it retain `--json` as an alternative.
+
+## Project delivery modes
+
+Each registered project has a delivery mode:
+
+| Mode | Workflow |
+| --- | --- |
+| `direct-pr` | Workers produce normal branches and pull requests. This is the default. |
+| `no-mistakes` | Delivery is guarded by a [no-mistakes](https://github.com/yes2games/no-mistakes) validation pipeline. |
+| `local-only` | Work stays local instead of using a remote pull-request workflow. |
+
+Choose a mode when registering a project:
+
+```sh
+hand project add https://github.com/you/project --mode direct-pr
+```
+
+For a fork, declare the upstream repository that receives pull requests:
+
+```sh
+hand project upstream project-name upstream-owner/project
+```
+
+## Worker harnesses
+
+Secondhand can launch workers through:
+
+- Claude Code (`claude`)
+- Codex (`codex`)
+- Grok (`grok`)
+- Pi (`pi`)
+- OpenCode (`opencode`)
+
+Without an override, workers inherit the harness detected as the current supervisor; only when none can be detected does `hand config` report the harness as `missing`. Inspect and configure fleet defaults with:
+
+```sh
+hand config
+hand config set harness claude
+hand config set model claude-opus-5
+```
+
+Model and effort support depends on the harness: `hand config` reports each as `native-default`, `configured`, or `unsupported` instead of silently storing a setting a harness cannot carry. Overrides are stored per harness, so switching harnesses never hands a worker a model or effort chosen for a different tool.
+
+A task brief can also declare model and effort for that specific worker; explicit spawn or promote flags win over brief values, which win over these defaults.
+
+## Fleet home
+
+A fleet home is deliberately separate from the repositories being worked on.
+
+```text
+~/fleet/
+├── AGENTS.md
+├── CLAUDE.md -> AGENTS.md
+├── config/
+├── data/
+│   ├── backlog.md
+│   ├── operator.md
+│   ├── learnings.md
+│   └── ...
+├── projects/
+└── state/
+```
+
+The important pieces are:
+
+- `AGENTS.md` - operating instructions for the supervising agent
+- `data/operator.md` - your standing constraints and preferences
+- `data/backlog.md` - the supervisor's task queue
+- `data/learnings.md` - durable operational knowledge discovered by the fleet
+- `projects/` - registered project clones
+- `state/hand.db` - authoritative machine state
+
+You normally do not manage these by hand. The supervisor and `hand` own the workflow.
+
+Every command resolves the fleet home from `HAND_HOME` when set, otherwise from the current directory or the nearest ancestor containing `state/hand.db`.
+
+## Requirements
+
+`hand` itself is a self-contained Go binary. Operating a fleet relies on a few external tools:
+
+- [herdr](https://github.com/ogulcancelik/herdr) - interactive worker sessions and semantic agent state
+- [treehouse](https://github.com/kunchenguid/treehouse) v2.1.0 or newer - isolated git worktree pools
+- [gh](https://github.com/cli/cli) - GitHub pull-request and release operations
+- at least one supported coding-agent harness
+
+Optional:
+
+- [no-mistakes](https://github.com/yes2games/no-mistakes) - required only by projects using `no-mistakes` mode
+- [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
+
+`hand init` reports required tools it cannot find on `PATH`. `hand doctor` checks the fleet home's generated agent instructions and related drift.
+
+Building from source additionally requires Go 1.26.5 or newer.
+
+## Installation
+
+### Release binary
+
+Release archives are available for Linux and macOS on AMD64 and ARM64, with `checksums.txt` alongside the assets.
+
+```sh
+curl -fsSLO https://github.com/atqamz/hand/releases/latest/download/hand-linux-amd64.tar.gz
+tar xzf hand-linux-amd64.tar.gz
+install -m755 hand ~/.local/bin/hand
+```
+
+See the [releases page](https://github.com/atqamz/hand/releases) for every asset.
+
+### Nix
+
+Install into your profile:
+
+```sh
+nix profile install github:atqamz/hand
+```
+
+Or run it without installing:
+
+```sh
 nix shell github:atqamz/hand -c hand --version
 ```
 
-The flake covers `aarch64-darwin`, `aarch64-linux` and `x86_64-linux`.
-On Intel macOS, use a release binary or `go install`.
+The flake covers `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`. On Intel macOS, use a release binary or `go install`.
 
-From Go:
+### Go
 
 ```sh
 go install github.com/atqamz/hand@latest
 ```
 
-That embeds no version, so it prints `dev` and never reports available updates.
-Prefer a release asset for a versioned build.
+`go install` does not embed release-version metadata, so the binary reports `dev` and never checks for updates. Prefer a release binary or Nix installation for a versioned build.
 
-To build a checkout - the path for working on secondhand itself - see [CONTRIBUTING.md](CONTRIBUTING.md).
+To build a checkout for contributing to Secondhand itself, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-To update an installed binary, run `hand update`.
-It downloads the release asset for the current OS and architecture, verifies its SHA256 checksum, and replaces the running binary in place.
-When run inside a fleet home it then refreshes the generated part of that home's AGENTS.md, leaving your own additions untouched, and prints the new release's notes.
-`hand update --check` reports whether an update is available without installing it.
-Every other command run in a fleet home prints a one-line notice to stderr when a newer release exists, checked at most once a day and cached in `state/.version-check`.
-Builds without an embedded version never print the notice.
+## Command map
 
-## Configuration
+You normally let the supervising agent drive the CLI. The main lifecycle is:
 
-Optional worker overrides live as plain files under `config/`, one value per file.
-`hand config` reports three effective settings - `harness`, `model` and `effort` - and validates any override before writing it atomically:
+| Command | Purpose |
+| --- | --- |
+| `hand init` | Create or refresh a fleet home. |
+| `hand project add` | Register a repository with the fleet. |
+| `hand spawn` | Dispatch a worker into an isolated worktree. |
+| `hand status` | Read fleet or task state. |
+| `hand watch` | Wait for actionable fleet events. |
+| `hand send` | Steer a running worker. |
+| `hand merge` | Merge completed work after authorization. |
+| `hand deliver` | Mark work as handed off when landing is someone else's decision. |
+| `hand teardown` | Clean up a completed task safely. |
+
+Other commands cover session bootstrap, configuration, project sync and upstreams, holds, scout promotion, search, notifications, diagnostics, PR recording, and self-update.
+
+Run `hand --help` for the authoritative command reference.
+
+Running bare `hand` returns the resolved fleet home, worker configuration, and live fleet overview rather than a generic help screen.
+
+## Updating
+
+Release installations can update themselves:
 
 ```sh
-hand config                             # effective defaults, optional overrides and harness capabilities
-hand config set harness claude
-hand config set model claude-opus-5
+hand update
 ```
 
-Without `config/harness`, workers inherit the detected supervisor harness. Applicable but unset model and effort values stay with that harness's native defaults; a harness with no such launch flag reports them as `unsupported`.
-Only when no supported harness can be detected is the harness `missing`, with model and effort `pending-harness` until that one choice is supplied.
-Persisted model and effort overrides are stored per harness (`config/model.claude`), so switching harnesses never hands a worker an identifier chosen for a different tool.
+Check without installing:
 
-`hand init` writes none of these overrides.
-It reports the effective states, and every `hand session start` repeats them so an operator can add an override when one is actually wanted.
+```sh
+hand update --check
+```
 
-A brief can start with a `---` fenced block declaring `model` and `effort` for one task. Those values win over fleet defaults and lose only to a `hand spawn` or `hand promote` flag.
+When run inside a fleet home, an update also refreshes the generated section of `AGENTS.md` without overwriting your own additions. Other commands check for a newer release at most once a day and print a one-line notice when one is available.
 
-Other optional files tune supervision:
+## Architecture
 
-- `notify`: shell command template run with `HAND_MESSAGE` set; `hand notify` reports an error when it is absent.
-- `send-wait`: how long `hand send` waits for a busy composer, as a Go duration (default `2m`).
-- `watch-interval`: watcher poll interval, as a Go duration (default `5s`).
-- `stale-threshold`: seconds without an agent-state transition before `stale` (default `300`).
-- `parked-paused-bound`: seconds of report-channel silence after `paused` (default `3600`).
-- `parked-done-bound`: seconds of silence after `done` or `failed` (default `5400`).
-- `parked-other-bound`: seconds of silence in every other report state (default `1200`).
+Secondhand deliberately separates judgment from mechanics.
 
-Workers run their harness interactively so they can be steered and watched.
-For Claude Code that means first-run dialogs, and `hand spawn` and `hand promote` answer the workspace-trust and bypass-permissions ones for you, then confirm the worker is actually running before reporting success.
-A worker that never comes up fails the spawn instead of being reported as started.
-Claude Code's managed-settings approval prompt and Codex's directory-trust prompt are exceptions: each enables settings or policies that can run project or host code, so `hand` refuses to accept the security decision for you and tells you to run the harness yourself once before respawning.
+```mermaid
+flowchart LR
+    user["You<br/>requests and irreversible decisions"] --> supervisor["Supervising agent<br/>planning and coordination"]
+    supervisor --> hand["hand<br/>lifecycle, state, isolation, supervision"]
+
+    hand --> worker1["Ship worker"]
+    hand --> worker2["Ship worker"]
+    hand --> scout["Scout worker"]
+
+    worker1 --> tree1["treehouse worktree"]
+    worker2 --> tree2["treehouse worktree"]
+    scout --> tree3["treehouse worktree"]
+
+    tree1 --> pr1["PR / branch"]
+    tree2 --> pr2["PR / branch"]
+    tree3 --> report["Report"]
+
+    pr1 --> supervisor
+    pr2 --> supervisor
+    report --> supervisor
+    supervisor --> user
+```
+
+The supervisor owns planning and judgment. `hand` owns lifecycle, state, isolation, and supervision. Workers own individual tasks. You remain the authority for irreversible decisions.
+
+For durable architectural rationale, see [`docs/adr/`](docs/adr/). Behavioral command contracts live with their implementation, help, and focused tests.
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+The short path is:
+
+```sh
+git clone https://github.com/atqamz/hand
+cd hand
+nix develop
+make build
+make lint
+make test
+```
+
+Run `make e2e` when changing CLI behavior. Secondhand uses conventional commits and release-please for versioning and changelogs.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Restore README.md's atqamz/hand#175 rewrite, which atqamz/hand#173's squash-merge (from a branch that predated it) had clobbered back to stale content still referencing the retired SPECS.md.
- Reapply what atqamz/hand#173 and atqamz/hand#179 legitimately added since: the `hand session start` / AGENTS.md supervisor-bootstrap contract, `hand config`'s per-harness override states, and the `atqamz/hand` identity in install and clone URLs.
- Leave the Installation section's structure untouched; that is reserved for the Windows portability work.

Closes atqamz/hand#181

Related: atqamz/hand#177

## Test plan

- `no-mistakes axi` pipeline: review, test, lint, and document steps all passed.
- Cross-checked restored prose against current source: `internal/sessionhook` (retires the SessionStart hook the old text described), `docs/adr/supervisor-bootstrap-is-an-agents-md-contract.md`, `cmd/config.go`, `cmd/init.go`, and `CONTRIBUTING.md`.
- Confirmed no test file depends on literal README.md content.