### PR TITLE
make hand update safe on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Running bare `hand` returns the resolved fleet home, worker configuration, and l
 
 ## Updating
 
-Release installations on Linux and macOS can update themselves:
+Release installations can update themselves:
 
 ```sh
 hand update
@@ -320,8 +320,6 @@ hand update --check
 ```
 
 When run inside a fleet home, an update also refreshes the generated section of `AGENTS.md` without overwriting your own additions. Other commands check for a newer release at most once a day and print a one-line notice when one is available.
-
-Self-update is not yet supported on Windows. Download the matching release archive and replace `hand.exe` manually.
 
 ## Architecture
 

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
@@ -78,27 +79,54 @@ func buildUpdateFixture(t *testing.T, binaryContent []byte) string {
 	t.Helper()
 	dir := t.TempDir()
 	assetName := selfupdate.AssetName()
+	archivePath := filepath.Join(dir, assetName)
+	if runtime.GOOS == "windows" {
+		file, err := os.Create(archivePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		zw := zip.NewWriter(file)
+		header := &zip.FileHeader{Name: "hand.exe", Method: zip.Deflate}
+		header.SetMode(0o755)
+		entry, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(binaryContent); err != nil {
+			t.Fatal(err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		var tarBuf bytes.Buffer
+		gz := gzip.NewWriter(&tarBuf)
+		tw := tar.NewWriter(gz)
+		if err := tw.WriteHeader(&tar.Header{Name: "hand", Mode: 0o755, Size: int64(len(binaryContent))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(binaryContent); err != nil {
+			t.Fatal(err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := gz.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(archivePath, tarBuf.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-	var tarBuf bytes.Buffer
-	gz := gzip.NewWriter(&tarBuf)
-	tw := tar.NewWriter(gz)
-	if err := tw.WriteHeader(&tar.Header{Name: "hand", Mode: 0o755, Size: int64(len(binaryContent))}); err != nil {
+	archiveBytes, err := os.ReadFile(archivePath)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := tw.Write(binaryContent); err != nil {
-		t.Fatal(err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, assetName), tarBuf.Bytes(), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	sum := sha256.Sum256(tarBuf.Bytes())
+	sum := sha256.Sum256(archiveBytes)
 	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
 	if err := os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(checksums), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/selfupdate/archive.go
+++ b/internal/selfupdate/archive.go
@@ -1,0 +1,127 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func extractBinary(archivePath, expectedName, destPath string) error {
+	switch {
+	case strings.HasSuffix(archivePath, ".tar.gz"):
+		return extractTarGz(archivePath, expectedName, destPath)
+	case strings.HasSuffix(archivePath, ".zip"):
+		return extractZip(archivePath, expectedName, destPath)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", archivePath)
+	}
+}
+
+func extractTarGz(archivePath, expectedName, destPath string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", archivePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("open gzip stream in %s: %w", archivePath, err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	found := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			if !found {
+				return fmt.Errorf("%s not found in %s", expectedName, archivePath)
+			}
+			return os.Chmod(destPath, 0o755)
+		}
+		if err != nil {
+			return fmt.Errorf("read %s: %w", archivePath, err)
+		}
+		if !tarEntryMatches(hdr, expectedName) {
+			continue
+		}
+		if found {
+			return fmt.Errorf("multiple %s entries in %s", expectedName, archivePath)
+		}
+		if err := copyArchiveMember(destPath, tr); err != nil {
+			return err
+		}
+		found = true
+	}
+}
+
+func extractZip(archivePath, expectedName, destPath string) error {
+	archive, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("open zip %s: %w", archivePath, err)
+	}
+	defer func() { _ = archive.Close() }()
+
+	found := false
+	for _, entry := range archive.File {
+		if !zipEntryMatches(entry, expectedName) {
+			continue
+		}
+		if found {
+			return fmt.Errorf("multiple %s entries in %s", expectedName, archivePath)
+		}
+		reader, err := entry.Open()
+		if err != nil {
+			return fmt.Errorf("open %s in %s: %w", entry.Name, archivePath, err)
+		}
+		err = copyArchiveMember(destPath, reader)
+		closeErr := reader.Close()
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close %s in %s: %w", entry.Name, archivePath, closeErr)
+		}
+		found = true
+	}
+	if !found {
+		return fmt.Errorf("%s not found in %s", expectedName, archivePath)
+	}
+	return os.Chmod(destPath, 0o755)
+}
+
+func tarEntryMatches(entry *tar.Header, expectedName string) bool {
+	return (entry.Typeflag == tar.TypeReg || entry.Typeflag == 0) && archiveBase(entry.Name) == expectedName
+}
+
+func zipEntryMatches(entry *zip.File, expectedName string) bool {
+	return entry.FileInfo().Mode().IsRegular() && archiveBase(entry.Name) == expectedName
+}
+
+func archiveBase(name string) string {
+	name = strings.TrimSuffix(name, "/")
+	if index := strings.LastIndexByte(name, '/'); index >= 0 {
+		return name[index+1:]
+	}
+	return name
+}
+
+func copyArchiveMember(destPath string, reader io.Reader) error {
+	out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", destPath, err)
+	}
+	if _, err := io.Copy(out, reader); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("write %s: %w", destPath, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("write %s: %w", destPath, err)
+	}
+	return nil
+}

--- a/internal/selfupdate/replace_unix.go
+++ b/internal/selfupdate/replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package selfupdate
+
+import "os"
+
+func replaceExecutable(execPath, stagedPath string) error {
+	return os.Rename(stagedPath, execPath)
+}

--- a/internal/selfupdate/replace_unix_test.go
+++ b/internal/selfupdate/replace_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceExecutableRenamesStagedFile(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "hand")
+	stagedPath := filepath.Join(dir, ".hand-update-staged")
+	if err := os.WriteFile(execPath, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replaceExecutable(execPath, stagedPath); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("got %q, want new", got)
+	}
+	if _, err := os.Stat(stagedPath); !os.IsNotExist(err) {
+		t.Fatalf("staged path error = %v, want not exist", err)
+	}
+}

--- a/internal/selfupdate/replace_windows.go
+++ b/internal/selfupdate/replace_windows.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	updaterBackupPrefix = ".hand-update-"
+	updaterBackupSuffix = ".old.exe"
+)
+
+var renameFile = os.Rename
+
+func replaceExecutable(execPath, stagedPath string) error {
+	execDir := filepath.Dir(execPath)
+	cleanupStaleBackups(execDir)
+
+	backupPath, err := newBackupPath(execDir)
+	if err != nil {
+		return fmt.Errorf("choose backup path for %s: %w", execPath, err)
+	}
+	if err := renameFile(execPath, backupPath); err != nil {
+		return fmt.Errorf("rename canonical executable %s to backup %s: %w", execPath, backupPath, err)
+	}
+
+	if err := renameFile(stagedPath, execPath); err != nil {
+		rollbackErr := renameFile(backupPath, execPath)
+		if rollbackErr != nil {
+			return fmt.Errorf("install staged executable %s at canonical path %s failed: %v; rollback %s to %s failed: %v; manual recovery: restore %s to %s after the running process exits, then inspect staged path %s", stagedPath, execPath, err, backupPath, execPath, rollbackErr, backupPath, execPath, stagedPath)
+		}
+		return fmt.Errorf("install staged executable %s at canonical path %s: %w", stagedPath, execPath, err)
+	}
+	return nil
+}
+
+func newBackupPath(dir string) (string, error) {
+	file, err := os.CreateTemp(dir, updaterBackupPrefix+"*.old.exe")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func cleanupStaleBackups(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if isUpdaterBackup(entry.Name()) {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
+}
+
+func isUpdaterBackup(name string) bool {
+	return strings.HasPrefix(name, updaterBackupPrefix) && strings.HasSuffix(name, updaterBackupSuffix) && len(name) > len(updaterBackupPrefix)+len(updaterBackupSuffix)
+}

--- a/internal/selfupdate/replace_windows_test.go
+++ b/internal/selfupdate/replace_windows_test.go
@@ -1,0 +1,251 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWindowsReplacementChildProcess(t *testing.T) {
+	if os.Getenv("HAND_SELFUPDATE_CHILD") != "1" {
+		return
+	}
+	if err := os.WriteFile(os.Getenv("HAND_SELFUPDATE_READY"), []byte("ready"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {}
+}
+
+func TestReplaceExecutableWhileTargetIsRunning(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "hand.exe")
+	testExe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBytes, err := os.ReadFile(testExe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(execPath, oldBytes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	readyPath := filepath.Join(dir, "ready")
+	child := exec.Command(execPath, "-test.run=^TestWindowsReplacementChildProcess$")
+	child.Env = append(os.Environ(), "HAND_SELFUPDATE_CHILD=1", "HAND_SELFUPDATE_READY="+readyPath)
+	child.Stdout = io.Discard
+	child.Stderr = io.Discard
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if child.ProcessState == nil {
+			_ = child.Process.Kill()
+		}
+		_ = child.Wait()
+	})
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child did not signal readiness")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	stagedPath := filepath.Join(dir, ".hand-update-staged.exe")
+	if err := os.WriteFile(stagedPath, []byte("new executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceExecutable(execPath, stagedPath); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new executable" {
+		t.Fatalf("got %q, want new executable", got)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupCount := 0
+	for _, entry := range entries {
+		if isUpdaterBackup(entry.Name()) {
+			backupCount++
+		}
+	}
+	if backupCount != 1 {
+		t.Fatalf("got %d updater backups, want one while child is running", backupCount)
+	}
+
+	if err := child.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := child.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	cleanupStaleBackups(dir)
+	assertNoUpdaterBackups(t, dir)
+}
+
+func TestReplaceExecutableRollsBackWhenStagedRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "hand.exe")
+	stagedPath := filepath.Join(dir, ".hand-update-staged.exe")
+	if err := os.WriteFile(execPath, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRename := renameFile
+	call := 0
+	renameFile = func(oldPath, newPath string) error {
+		call++
+		if call == 2 {
+			return errors.New("install blocked")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameFile = originalRename })
+
+	err := replaceExecutable(execPath, stagedPath)
+	if err == nil || !strings.Contains(err.Error(), "install blocked") {
+		t.Fatalf("replaceExecutable error = %v, want install failure", err)
+	}
+	got, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "old" {
+		t.Fatalf("got %q, want old after rollback", got)
+	}
+	if _, err := os.Stat(stagedPath); err != nil {
+		t.Fatalf("staged path error = %v, want staged file left for cleanup", err)
+	}
+	assertNoUpdaterBackups(t, dir)
+}
+
+func TestReplaceExecutableLeavesCanonicalWhenFirstRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "hand.exe")
+	stagedPath := filepath.Join(dir, ".hand-update-staged.exe")
+	if err := os.WriteFile(execPath, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRename := renameFile
+	renameFile = func(oldPath, newPath string) error {
+		return errors.New("backup blocked")
+	}
+	t.Cleanup(func() { renameFile = originalRename })
+
+	err := replaceExecutable(execPath, stagedPath)
+	if err == nil || !strings.Contains(err.Error(), "backup blocked") {
+		t.Fatalf("replaceExecutable error = %v, want backup failure", err)
+	}
+	got, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "old" {
+		t.Fatalf("got %q, want old after first rename failure", got)
+	}
+	if _, err := os.Stat(stagedPath); err != nil {
+		t.Fatalf("staged path error = %v, want staged file left for cleanup", err)
+	}
+	assertNoUpdaterBackups(t, dir)
+}
+
+func TestReplaceExecutableReportsRollbackFailure(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "hand.exe")
+	stagedPath := filepath.Join(dir, ".hand-update-staged.exe")
+	if err := os.WriteFile(execPath, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRename := renameFile
+	call := 0
+	renameFile = func(oldPath, newPath string) error {
+		call++
+		switch call {
+		case 2:
+			return errors.New("install blocked")
+		case 3:
+			return errors.New("rollback blocked")
+		default:
+			return os.Rename(oldPath, newPath)
+		}
+	}
+	t.Cleanup(func() { renameFile = originalRename })
+
+	err := replaceExecutable(execPath, stagedPath)
+	if err == nil {
+		t.Fatal("want rollback error")
+	}
+	for _, want := range []string{
+		"install blocked",
+		"rollback blocked",
+		execPath,
+		stagedPath,
+		"manual recovery",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestCleanupStaleBackupsOnlyRemovesUpdaterFiles(t *testing.T) {
+	dir := t.TempDir()
+	owned := filepath.Join(dir, ".hand-update-stale.old.exe")
+	unrelated := filepath.Join(dir, "unrelated.old.exe")
+	if err := os.WriteFile(owned, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unrelated, []byte("keep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupStaleBackups(dir)
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("owned backup error = %v, want removed", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Fatalf("unrelated backup error = %v, want retained", err)
+	}
+}
+
+func assertNoUpdaterBackups(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if isUpdaterBackup(entry.Name()) {
+			t.Fatalf("found updater backup %q", entry.Name())
+		}
+	}
+}

--- a/internal/selfupdate/replace_windows_test.go
+++ b/internal/selfupdate/replace_windows_test.go
@@ -45,7 +45,11 @@ func TestReplaceExecutableWhileTargetIsRunning(t *testing.T) {
 	if err := child.Start(); err != nil {
 		t.Fatal(err)
 	}
+	waited := false
 	t.Cleanup(func() {
+		if waited {
+			return
+		}
 		if child.ProcessState == nil {
 			_ = child.Process.Kill()
 		}
@@ -94,8 +98,13 @@ func TestReplaceExecutableWhileTargetIsRunning(t *testing.T) {
 	if err := child.Process.Kill(); err != nil {
 		t.Fatal(err)
 	}
-	if err := child.Wait(); err != nil {
-		t.Fatal(err)
+	waitErr := child.Wait()
+	waited = true
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			t.Fatal(waitErr)
+		}
 	}
 	cleanupStaleBackups(dir)
 	assertNoUpdaterBackups(t, dir)

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,9 +1,7 @@
 package selfupdate
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -22,7 +20,21 @@ const Repo = "atqamz/hand"
 const binaryName = "hand"
 
 func AssetName() string {
-	return fmt.Sprintf("%s-%s-%s.tar.gz", binaryName, runtime.GOOS, runtime.GOARCH)
+	return assetName(runtime.GOOS, runtime.GOARCH)
+}
+
+func assetName(goos, goarch string) string {
+	if goos == "windows" {
+		return fmt.Sprintf("%s-%s-%s.zip", binaryName, goos, goarch)
+	}
+	return fmt.Sprintf("%s-%s-%s.tar.gz", binaryName, goos, goarch)
+}
+
+func archiveBinaryName(goos string) string {
+	if goos == "windows" {
+		return binaryName + ".exe"
+	}
+	return binaryName
 }
 
 func LatestTag(repo string) (string, error) {
@@ -97,22 +109,9 @@ func parseSemver(s string) (major, minor, patch int, err error) {
 // the real test binary produced by `go test`.
 var ExecutableOverride = os.Executable
 
-// Overridable so the Windows refusal path in Apply gets real test coverage on
-// every platform that runs the suite, not only on a Windows CI runner.
-var isWindows = func() bool {
-	return runtime.GOOS == "windows"
-}
-
-// Apply downloads the release tagged tag from repo, verifies its checksum, and replaces
-// the running binary in place. The replacement is atomic - temp file in the same directory,
-// renamed over it - so a crash mid-update never leaves a partial binary at the real path.
+// Downloads the release tagged tag from repo, verifies its checksum, and replaces the running
+// binary with a complete staged file in the executable's directory.
 func Apply(repo, tag string) error {
-	// Windows cannot replace a file open for execution the way POSIX's rename-over-a-
-	// running-inode can; atqamz/hand#200 tracks a Windows-safe replacement design.
-	if isWindows() {
-		return fmt.Errorf("self-update is not supported on windows yet (atqamz/hand#200): download %s from https://github.com/%s/releases and replace the binary manually", tag, repo)
-	}
-
 	execPath, err := ExecutableOverride()
 	if err != nil {
 		return fmt.Errorf("locate running binary: %w", err)
@@ -147,11 +146,11 @@ func Apply(repo, tag string) error {
 		return fmt.Errorf("stage new binary: %w", err)
 	}
 
-	if err := extractBinary(filepath.Join(tmpDir, assetName), tmpBinary); err != nil {
+	if err := extractBinary(filepath.Join(tmpDir, assetName), archiveBinaryName(runtime.GOOS), tmpBinary); err != nil {
 		return err
 	}
 
-	if err := os.Rename(tmpBinary, execPath); err != nil {
+	if err := replaceExecutable(execPath, tmpBinary); err != nil {
 		return fmt.Errorf("replace running binary: %w", err)
 	}
 	return nil
@@ -203,49 +202,6 @@ func verifyChecksum(dir, assetName string) error {
 		return fmt.Errorf("checksum mismatch for %s: want %s, got %s", assetName, want, got)
 	}
 	return nil
-}
-
-func extractBinary(tarGzPath, destPath string) error {
-	f, err := os.Open(tarGzPath)
-	if err != nil {
-		return fmt.Errorf("open %s: %w", tarGzPath, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	gz, err := gzip.NewReader(f)
-	if err != nil {
-		return fmt.Errorf("open gzip stream in %s: %w", tarGzPath, err)
-	}
-	defer func() { _ = gz.Close() }()
-
-	tr := tar.NewReader(gz)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			return fmt.Errorf("%s not found in %s", binaryName, tarGzPath)
-		}
-		if err != nil {
-			return fmt.Errorf("read %s: %w", tarGzPath, err)
-		}
-		if hdr.Typeflag != tar.TypeReg || filepath.Base(hdr.Name) != binaryName {
-			continue
-		}
-
-		out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
-		if err != nil {
-			return fmt.Errorf("write %s: %w", destPath, err)
-		}
-		if _, err := io.Copy(out, tr); err != nil {
-			_ = out.Close()
-			return fmt.Errorf("write %s: %w", destPath, err)
-		}
-		if err := out.Close(); err != nil {
-			return fmt.Errorf("write %s: %w", destPath, err)
-		}
-		// OpenFile's mode only applies when it creates the file, and the
-		// staging path already exists.
-		return os.Chmod(destPath, 0o755)
-	}
 }
 
 func runGH(ctx context.Context, args ...string) (string, error) {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -2,6 +2,7 @@ package selfupdate
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
@@ -10,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -41,6 +41,44 @@ func TestIsNewer(t *testing.T) {
 func TestIsNewerRejectsInvalidLatest(t *testing.T) {
 	if _, err := IsNewer("not-a-version", "v0.3.1"); err == nil {
 		t.Fatal("want error for unparseable latest version")
+	}
+}
+
+func TestAssetName(t *testing.T) {
+	tests := []struct {
+		goos, goarch string
+		want         string
+	}{
+		{goos: "linux", goarch: "amd64", want: "hand-linux-amd64.tar.gz"},
+		{goos: "linux", goarch: "arm64", want: "hand-linux-arm64.tar.gz"},
+		{goos: "darwin", goarch: "amd64", want: "hand-darwin-amd64.tar.gz"},
+		{goos: "darwin", goarch: "arm64", want: "hand-darwin-arm64.tar.gz"},
+		{goos: "windows", goarch: "amd64", want: "hand-windows-amd64.zip"},
+	}
+	for _, tt := range tests {
+		if got := assetName(tt.goos, tt.goarch); got != tt.want {
+			t.Errorf("assetName(%q, %q) = %q, want %q", tt.goos, tt.goarch, got, tt.want)
+		}
+	}
+}
+
+func TestAssetNameUsesRuntimePlatform(t *testing.T) {
+	if got, want := AssetName(), assetName(runtime.GOOS, runtime.GOARCH); got != want {
+		t.Fatalf("AssetName() = %q, want %q", got, want)
+	}
+}
+
+func TestArchiveBinaryName(t *testing.T) {
+	for _, tt := range []struct {
+		goos, want string
+	}{
+		{goos: "linux", want: "hand"},
+		{goos: "darwin", want: "hand"},
+		{goos: "windows", want: "hand.exe"},
+	} {
+		if got := archiveBinaryName(tt.goos); got != tt.want {
+			t.Errorf("archiveBinaryName(%q) = %q, want %q", tt.goos, got, tt.want)
+		}
 	}
 }
 
@@ -81,27 +119,19 @@ func buildFixture(t *testing.T, binaryContent []byte) string {
 	t.Helper()
 	dir := t.TempDir()
 	assetName := AssetName()
-
-	var tarBuf bytes.Buffer
-	gz := gzip.NewWriter(&tarBuf)
-	tw := tar.NewWriter(gz)
-	if err := tw.WriteHeader(&tar.Header{Name: binaryName, Mode: 0o755, Size: int64(len(binaryContent))}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(binaryContent); err != nil {
-		t.Fatal(err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, assetName), tarBuf.Bytes(), 0o644); err != nil {
-		t.Fatal(err)
+	archivePath := filepath.Join(dir, assetName)
+	entry := archiveEntry{name: archiveBinaryName(runtime.GOOS), content: binaryContent, mode: 0o755}
+	if runtime.GOOS == "windows" {
+		writeZip(t, archivePath, []archiveEntry{entry})
+	} else {
+		writeTarGz(t, archivePath, []archiveEntry{entry})
 	}
 
-	sum := sha256.Sum256(tarBuf.Bytes())
+	archiveBytes, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(archiveBytes)
 	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
 	if err := os.WriteFile(filepath.Join(dir, "checksums.txt"), []byte(checksums), 0o644); err != nil {
 		t.Fatal(err)
@@ -117,38 +147,6 @@ func TestLatestTag(t *testing.T) {
 	}
 	if tag != "v0.5.0" {
 		t.Fatalf("got %q, want v0.5.0", tag)
-	}
-}
-
-func TestApplyRefusesOnWindowsWithoutDownloadingOrTouchingTheBinary(t *testing.T) {
-	restore := isWindows
-	isWindows = func() bool { return true }
-	t.Cleanup(func() { isWindows = restore })
-	t.Setenv("PATH", t.TempDir())
-
-	execDir := t.TempDir()
-	execPath := filepath.Join(execDir, "hand")
-	if err := os.WriteFile(execPath, []byte("old binary contents"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	restoreExec := ExecutableOverride
-	ExecutableOverride = func() (string, error) { return execPath, nil }
-	t.Cleanup(func() { ExecutableOverride = restoreExec })
-
-	err := Apply("atqamz/hand", "v0.5.0")
-	if err == nil {
-		t.Fatal("want an error refusing self-update on windows")
-	}
-	if got := err.Error(); !strings.Contains(got, "atqamz/hand#200") {
-		t.Fatalf("got %q, want it to reference the tracked design issue", got)
-	}
-
-	got, readErr := os.ReadFile(execPath)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	if string(got) != "old binary contents" {
-		t.Fatalf("got %q, want the running binary left untouched", got)
 	}
 }
 
@@ -261,6 +259,48 @@ func TestVerifyChecksumMismatch(t *testing.T) {
 	}
 }
 
+func TestApplyLeavesBinaryUnchangedOnChecksumMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh is a POSIX shell script, not supported on windows")
+	}
+	fixture := t.TempDir()
+	assetName := AssetName()
+	if err := os.WriteFile(filepath.Join(fixture, assetName), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, "checksums.txt"), []byte("deadbeef  "+assetName+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGH(t, "v0.5.0", fixture)
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "hand")
+	if err := os.WriteFile(execPath, []byte("old binary contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	restore := ExecutableOverride
+	ExecutableOverride = func() (string, error) { return execPath, nil }
+	t.Cleanup(func() { ExecutableOverride = restore })
+
+	if err := Apply("atqamz/hand", "v0.5.0"); err == nil {
+		t.Fatal("want checksum mismatch")
+	}
+	got, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old binary contents" {
+		t.Fatalf("got %q, want the installed binary unchanged", got)
+	}
+	entries, err := os.ReadDir(execDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d install-directory entries, want only canonical executable", len(entries))
+	}
+}
+
 func TestExtractBinaryMissingFromArchive(t *testing.T) {
 	dir := t.TempDir()
 	var tarBuf bytes.Buffer
@@ -284,7 +324,146 @@ func TestExtractBinaryMissingFromArchive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := extractBinary(archivePath, filepath.Join(dir, "out")); err == nil {
+	if err := extractBinary(archivePath, binaryName, filepath.Join(dir, "out")); err == nil {
 		t.Fatal("want error when binary missing from archive")
+	}
+}
+
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	writeTarGz(t, archivePath, []archiveEntry{
+		{name: "other-before", content: []byte("before"), mode: 0o644},
+		{name: "nested/hand", content: []byte("tar contents"), mode: 0o755},
+		{name: "other-after", content: []byte("after"), mode: 0o644},
+	})
+
+	outPath := filepath.Join(dir, "out")
+	if err := extractBinary(archivePath, "hand", outPath); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "tar contents" {
+		t.Fatalf("got %q, want tar contents", got)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(outPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o755 {
+			t.Fatalf("got mode %o, want 0755", got)
+		}
+	}
+}
+
+func TestExtractBinaryFromZip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.zip")
+	writeZip(t, archivePath, []archiveEntry{
+		{name: "other-before", content: []byte("before"), mode: 0o644},
+		{name: "nested/hand.exe", content: []byte("zip contents"), mode: 0o755},
+		{name: "other-after", content: []byte("after"), mode: 0o644},
+	})
+
+	outPath := filepath.Join(dir, "out")
+	if err := extractBinary(archivePath, "hand.exe", outPath); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "zip contents" {
+		t.Fatalf("got %q, want zip contents", got)
+	}
+}
+
+func TestExtractBinaryRejectsCorruptGzip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.tar.gz")
+	if err := os.WriteFile(archivePath, []byte("not gzip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := extractBinary(archivePath, "hand", filepath.Join(dir, "out")); err == nil {
+		t.Fatal("want corrupt gzip error")
+	}
+}
+
+func TestExtractBinaryRejectsCorruptZip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "archive.zip")
+	if err := os.WriteFile(archivePath, []byte("not zip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := extractBinary(archivePath, "hand.exe", filepath.Join(dir, "out")); err == nil {
+		t.Fatal("want corrupt zip error")
+	}
+}
+
+func TestExtractBinaryRejectsUnsupportedArchive(t *testing.T) {
+	if err := extractBinary("archive.tar", "hand", filepath.Join(t.TempDir(), "out")); err == nil {
+		t.Fatal("want unsupported archive error")
+	}
+}
+
+type archiveEntry struct {
+	name    string
+	content []byte
+	mode    int64
+}
+
+func writeTarGz(t *testing.T, path string, entries []archiveEntry) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, entry := range entries {
+		if err := tw.WriteHeader(&tar.Header{Name: entry.name, Mode: entry.mode, Size: int64(len(entry.content))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(entry.content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeZip(t *testing.T, path string, entries []archiveEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	for _, entry := range entries {
+		header := &zip.FileHeader{Name: entry.name, Method: zip.Deflate}
+		header.SetMode(os.FileMode(entry.mode))
+		w, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(entry.content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add explicit release asset metadata and tar.gz/zip extraction for Unix and Windows release layouts.
- Replace a running Windows `hand.exe` through a rename-away swap with rollback diagnostics and best-effort stale-backup cleanup.
- Add checksum, archive, rollback, and genuine Windows running-executable coverage; update fixtures and remove obsolete refusal wording.

Windows direct replacement of a running executable is avoided.
The updater first renames the running image aside, installs the fully downloaded and checksum-verified staged `hand.exe` at the canonical path, and rolls back the rename if installation fails.
The existing synchronous `hand update` post-update flow remains unchanged.

Fixes atqamz/hand#200

## Test plan

- `nix develop -c go test ./...`
- `nix develop -c go test -race ./...`
- `nix develop -c go vet ./...`
- `nix develop -c make lint`
- `GOOS=windows GOARCH=amd64 nix develop -c go build ./...`
- `GOOS=windows GOARCH=amd64 nix develop -c go test ./internal/selfupdate -c -o /tmp/hand-selfupdate.test.exe`
- GitHub Actions `windows-latest` will execute the live running-executable test.
