### PR TITLE
test: isolate harness environment in tests

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -210,6 +210,7 @@ func TestBareInvocationRefusesWorkerRoleBeforeReadingContext(t *testing.T) {
 
 func TestBareInvocationOutsideAFleetHomeSaysSoAndNamesTheWayIn(t *testing.T) {
 	t.Setenv("HAND_HARNESS", harness.Claude)
+	t.Setenv(harness.RoleEnv, "")
 	t.Chdir(t.TempDir())
 	t.Setenv("HAND_HOME", "")
 

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "HAND_ROLE", value: ""},
+		{name: "HAND_HOME", value: ""},
+		{name: "HAND_HARNESS", value: "unknown"},
+	} {
+		if err := os.Setenv(tc.name, tc.value); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+func TestCommandPackageStartsWithNeutralEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: "HAND_ROLE", want: ""},
+		{name: "HAND_HOME", want: ""},
+		{name: "HAND_HARNESS", want: "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := os.Getenv(tc.name); got != tc.want {
+				t.Fatalf("%s = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -110,9 +110,12 @@ func handProcessEnv(extraEnv ...string) []string {
 		"PI_CODING_AGENT": true,
 		"GROK_AGENT":      true,
 	}
+	harnessOverride := false
 	for _, entry := range extraEnv {
 		if name, _, ok := strings.Cut(entry, "="); ok {
-			overridden[strings.ToUpper(name)] = true
+			name = strings.ToUpper(name)
+			overridden[name] = true
+			harnessOverride = harnessOverride || name == "HAND_HARNESS"
 		}
 	}
 	env := make([]string, 0, len(os.Environ())+len(extraEnv))
@@ -121,6 +124,9 @@ func handProcessEnv(extraEnv ...string) []string {
 		if !overridden[strings.ToUpper(name)] {
 			env = append(env, entry)
 		}
+	}
+	if !harnessOverride {
+		env = append(env, "HAND_HARNESS=unknown")
 	}
 	return append(env, extraEnv...)
 }
@@ -140,7 +146,14 @@ func TestHandProcessEnvFiltersAmbientSemanticEnvironment(t *testing.T) {
 	}
 
 	for name := range poison {
-		if got := envValues(handProcessEnv(), name); len(got) != 0 {
+		got := envValues(handProcessEnv(), name)
+		if name == "HAND_HARNESS" {
+			if len(got) != 1 || got[0] != "unknown" {
+				t.Fatalf("handProcessEnv() %s entries = %q, want exactly [unknown]", name, got)
+			}
+			continue
+		}
+		if len(got) != 0 {
 			t.Fatalf("handProcessEnv() contains %s entries %q, want none", name, got)
 		}
 	}
@@ -168,7 +181,7 @@ func envValues(env []string, wantName string) []string {
 	return values
 }
 
-// Child processes start without semantic harness environment; explicit entries replace ambient values.
+// Child processes start with neutral semantic harness state; explicit entries replace it.
 func runHandEnv(t *testing.T, home string, extraEnv []string, args ...string) invocation {
 	t.Helper()
 	cmd := exec.Command(handBin, args...)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -101,7 +101,15 @@ func runHand(t *testing.T, home string, args ...string) invocation {
 }
 
 func handProcessEnv(extraEnv ...string) []string {
-	overridden := map[string]bool{"HAND_ROLE": true}
+	overridden := map[string]bool{
+		"HAND_ROLE":       true,
+		"HAND_HOME":       true,
+		"HAND_HARNESS":    true,
+		"CLAUDECODE":      true,
+		"CODEX_THREAD_ID": true,
+		"PI_CODING_AGENT": true,
+		"GROK_AGENT":      true,
+	}
 	for _, entry := range extraEnv {
 		if name, _, ok := strings.Cut(entry, "="); ok {
 			overridden[strings.ToUpper(name)] = true
@@ -117,8 +125,50 @@ func handProcessEnv(extraEnv ...string) []string {
 	return append(env, extraEnv...)
 }
 
-// Runs hand with explicit entries replacing ambient values; HAND_ROLE is absent unless a worker test
-// opts in, so the suite's own role never changes the child being exercised.
+func TestHandProcessEnvFiltersAmbientSemanticEnvironment(t *testing.T) {
+	poison := map[string]string{
+		"HAND_ROLE":       "worker",
+		"HAND_HOME":       "/poison/home",
+		"HAND_HARNESS":    "claude",
+		"CLAUDECODE":      "1",
+		"CODEX_THREAD_ID": "poison",
+		"PI_CODING_AGENT": "true",
+		"GROK_AGENT":      "true",
+	}
+	for name, value := range poison {
+		t.Setenv(name, value)
+	}
+
+	for name := range poison {
+		if got := envValues(handProcessEnv(), name); len(got) != 0 {
+			t.Fatalf("handProcessEnv() contains %s entries %q, want none", name, got)
+		}
+	}
+
+	overridden := handProcessEnv("HAND_ROLE=worker", "HAND_HARNESS=codex")
+	for name, want := range map[string]string{
+		"HAND_ROLE":    "worker",
+		"HAND_HARNESS": "codex",
+	} {
+		got := envValues(overridden, name)
+		if len(got) != 1 || got[0] != want {
+			t.Fatalf("handProcessEnv() %s entries = %q, want exactly %q", name, got, want)
+		}
+	}
+}
+
+func envValues(env []string, wantName string) []string {
+	values := make([]string, 0, 1)
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(name, wantName) {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+// Child processes start without semantic harness environment; explicit entries replace ambient values.
 func runHandEnv(t *testing.T, home string, extraEnv []string, args ...string) invocation {
 	t.Helper()
 	cmd := exec.Command(handBin, args...)

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -16,7 +16,6 @@ import (
 // promotion asserting the scout's old worktree/herdr identifiers are actually released (not just replaced)
 // and that identity fields carry over unchanged while role fields are fully replaced.
 func TestPromoteScoutToShip(t *testing.T) {
-	t.Setenv("HAND_HARNESS", "claude")
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 


### PR DESCRIPTION
## Summary
- Neutralize worker, fleet-home, and harness-detection environment in command tests.
- Filter semantic harness environment from e2e child processes while preserving explicit overrides.
- Add regression coverage for the environment filter and fix the bare-root supervisor fixture.

Fixes atqamz/hand#199

## Test plan
- `go test ./...`
- `HAND_ROLE=worker go test ./...`
- Worker plus invalid `HAND_HOME` and Codex/Claude marker runs.
- `make lint`
- `make test`
- `make e2e`
- Poisoned e2e runs with worker, invalid home, and Codex/Claude markers.
