### PR TITLE
port test fakes to portable executables

### DIFF
--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -27,34 +26,10 @@ func fakeNoMistakesPath(t *testing.T, stdout string) string {
 // `no-mistakes status` exits 0 printing the same text.
 func fakeNoMistakesPathExit(t *testing.T, stdout string, code int) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake no-mistakes is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	// GateRunPRs reads the refusal from the text either way, so the fake reproduces the exit code rather
-	// than flattening every refusal to 0.
-	script := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\nexit %d\n", stdout, code)
-	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return bin + string(os.PathListSeparator) + os.Getenv("PATH")
+	bin := faketool.Bin(t)
+	faketool.NoMistakes{Stdout: stdout, Exit: code}.Install(t, bin)
+	return os.Getenv("PATH")
 }
-
-// Fakes only "pane get", answering the pane as done (not busy), enough for promote's precondition
-// check to pass through to gatePreflight without needing the rest of a clean promote's herdr calls,
-// which gatePreflight's refusal preempts.
-const fakeHerdrPaneDone = `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tOld","workspace_id":"wA","agent_status":"done"}}}' "$3"
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
 
 // Registers a no-mistakes-mode project and nothing else: gatePreflight fires in spawn before
 // state.Claim, the brief check, or any herdr/treehouse call, so none of those need to exist here.
@@ -82,9 +57,6 @@ func setupSpawnHomeGate(t *testing.T, noMistakesPath string) string {
 // worktree.Get, so those three must be satisfied while nothing past gatePreflight needs to exist.
 func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	useFastLaunchPolling(t)
 	home := t.TempDir()
 
@@ -114,11 +86,14 @@ func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
 
 	// noMistakesPath becomes PATH verbatim except for the fake herdr binary this helper always adds,
 	// letting each test control whether no-mistakes is reachable.
-	herdrBin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(herdrBin, "herdr"), []byte(fakeHerdrPaneDone), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", herdrBin+string(os.PathListSeparator)+noMistakesPath)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Tabs: []faketool.HerdrTab{{
+			ID: "wA:tOld", Pane: "wA:pOld",
+		}}}},
+		PaneStatus: "done",
+	}.Install(t, bin)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+noMistakesPath)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	return home

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -3,12 +3,11 @@ package cmd
 import (
 	"os"
 	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/herdr"
 )
 
@@ -50,60 +49,20 @@ func exited(text string) launchFrame { return launchFrame{text: text} }
 // out, and appends every key sent to a log the test reads back.
 func fakeLaunchPane(t *testing.T, frames ...launchFrame) (keyLog string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	dir := t.TempDir()
-	framesDir := filepath.Join(dir, "frames")
-	if err := os.MkdirAll(framesDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	for i, frame := range frames {
-		base := filepath.Join(framesDir, strconv.Itoa(i))
-		if err := os.WriteFile(base, []byte(frame.text), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(base+".agent", []byte(frame.agent), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
 	keyLog = filepath.Join(dir, "keys.log")
-	// A poll is a "pane get" followed by a "pane read", so the get arm advances the frame and the read
-	// arm serves whatever the get arm landed on.
-	script := `#!/bin/sh
-last=$(($LAUNCH_FRAME_COUNT - 1))
-case "$1 $2" in
-"pane get")
-	n=$(cat "$LAUNCH_FRAME_COUNTER" 2>/dev/null || echo 0)
-	echo $((n + 1)) > "$LAUNCH_FRAME_COUNTER"
-	[ "$n" -gt "$last" ] && n=$last
-	echo "$n" > "$LAUNCH_FRAME_CURRENT"
-	agent=$(cat "$LAUNCH_FRAMES_DIR/$n.agent")
-	printf '{"result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"%s","agent_status":"idle"}}}' "$3" "$agent"
-	;;
-"pane read")
-	cat "$LAUNCH_FRAMES_DIR/$(cat "$LAUNCH_FRAME_CURRENT")"
-	;;
-"pane send-keys")
-	shift 3
-	echo "$@" >> "$LAUNCH_KEY_LOG"
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
+	herdrFrames := make([]faketool.HerdrFrame, len(frames))
+	for i, frame := range frames {
+		herdrFrames[i] = faketool.HerdrFrame{Text: frame.text, Agent: frame.agent, Status: "idle"}
 	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("LAUNCH_FRAMES_DIR", framesDir)
-	t.Setenv("LAUNCH_FRAME_COUNT", strconv.Itoa(len(frames)))
-	t.Setenv("LAUNCH_FRAME_COUNTER", filepath.Join(dir, "counter"))
-	t.Setenv("LAUNCH_FRAME_CURRENT", filepath.Join(dir, "current"))
-	t.Setenv("LAUNCH_KEY_LOG", keyLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Tabs: []faketool.HerdrTab{{
+			ID: "wA:tB", Pane: "wA:pC",
+		}}}},
+		Frames: herdrFrames,
+		KeyLog: keyLog,
+	}.Install(t, bin)
 	return keyLog
 }
 

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -69,16 +68,12 @@ func TestMergeRejectsConflictingMethodFlags(t *testing.T) {
 	}
 }
 
-func writeFakeGh(t *testing.T, script string) {
+func writeFakeGh(t *testing.T, checks string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.GH{Responses: []faketool.GHResponse{{
+		Command: "pr checks", Stdout: checks,
+	}}}.Install(t, bin)
 }
 
 const mergeTestPR = "https://github.com/org/repo/pull/42"
@@ -99,9 +94,7 @@ func mergeTestGH(checks ...string) faketool.GH {
 func TestPRChecksGreenAllPass(t *testing.T) {
 	// Faithful to real gh here: an all-pass `pr checks --json bucket` prints
 	// this array on stdout and exits 0.
-	writeFakeGh(t, `#!/bin/sh
-printf '[{"bucket":"pass"},{"bucket":"skipping"}]'
-`)
+	writeFakeGh(t, `[{"bucket":"pass"},{"bucket":"skipping"}]`)
 	green, err := prChecksGreen("https://example.com/pr/1")
 	if err != nil {
 		t.Fatal(err)
@@ -114,9 +107,7 @@ printf '[{"bucket":"pass"},{"bucket":"skipping"}]'
 func TestPRChecksGreenFailingCheck(t *testing.T) {
 	// Exit 0 with a "fail" bucket instead of real gh's exit 1, same reason as
 	// fakeGhChecksRed above.
-	writeFakeGh(t, `#!/bin/sh
-printf '[{"bucket":"pass"},{"bucket":"fail"}]'
-`)
+	writeFakeGh(t, `[{"bucket":"pass"},{"bucket":"fail"}]`)
 	green, err := prChecksGreen("https://example.com/pr/1")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -4,11 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -36,21 +33,14 @@ func addOriginRemote(t *testing.T, dir, url string) {
 
 func writeFakeGhPRView(t *testing.T, exitCode int) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\n"
+	bin := faketool.Bin(t)
+	response := faketool.GHResponse{Command: "pr view", Exit: exitCode}
 	if exitCode != 0 {
-		script += "echo 'gh: pull request not found' >&2\n"
-		script += fmt.Sprintf("exit %d\n", exitCode)
+		response.Stderr = "gh: pull request not found\n"
 	} else {
-		script += "printf '{\"state\":\"OPEN\"}'\n"
+		response.Stdout = "{\"state\":\"OPEN\"}"
 	}
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.GH{Responses: []faketool.GHResponse{response}}.Install(t, bin)
 }
 
 func setupPRHome(t *testing.T) (home, clonePath string) {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -315,16 +315,16 @@ func TestRepointProjectReportsOriginRestoreFailure(t *testing.T) {
 }
 
 func TestProjectAddRemovesIncompleteCloneOnGitFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake git is a POSIX shell script, not supported on windows")
-	}
 	home := t.TempDir()
-	bin := t.TempDir()
-	gitPath := filepath.Join(bin, "git")
-	if err := os.WriteFile(gitPath, []byte("#!/bin/sh\nmkdir -p \"$3\"\nprintf partial > \"$3/partial\"\necho clone failed >&2\nexit 1\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Command{
+		Name:   "git",
+		Stderr: "clone failed\n",
+		Exit:   1,
+		FileAction: &faketool.FileAction{
+			PathArg: 2, Relative: "partial", Content: "partial",
+		},
+	}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 
@@ -340,9 +340,6 @@ func TestProjectAddRemovesIncompleteCloneOnGitFailure(t *testing.T) {
 }
 
 func TestProjectAddRefusesExistingCloneDestination(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake git is a POSIX shell script, not supported on windows")
-	}
 	home := t.TempDir()
 	dest := filepath.Join(home, "projects", "repo")
 	if err := os.MkdirAll(dest, 0o755); err != nil {
@@ -352,12 +349,9 @@ func TestProjectAddRefusesExistingCloneDestination(t *testing.T) {
 	if err := os.WriteFile(marker, []byte("user data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	bin := t.TempDir()
-	gitPath := filepath.Join(bin, "git")
-	if err := os.WriteFile(gitPath, []byte("#!/bin/sh\necho git clone should not run >&2\nexit 1\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	log := filepath.Join(t.TempDir(), "git.log")
+	faketool.Command{Name: "git", Stderr: "git clone should not run\n", Exit: 1, Log: log}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 
@@ -368,6 +362,9 @@ func TestProjectAddRefusesExistingCloneDestination(t *testing.T) {
 	}
 	if got, err := os.ReadFile(marker); err != nil || string(got) != "user data" {
 		t.Fatalf("existing clone changed: %q, %v", got, err)
+	}
+	if data, err := os.ReadFile(log); err == nil && len(data) != 0 {
+		t.Fatalf("git invocation log = %q, want no invocation", data)
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -4,72 +4,32 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Covers the herdr calls a clean promote makes, same void-command-as-envelope simplification as
-// fakeHerdrSpawnScript in spawn_test.go: real "pane run" succeeds with empty stdout, but callVoid takes
-// this envelope too, and promote only checks for a non-nil error, so the response shape is not the point.
-const fakeHerdrPromoteScript = `#!/bin/sh
-[ -z "$HERDR_CALL_LOG" ] || echo "$@" >> "$HERDR_CALL_LOG"
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tOld","workspace_id":"wA","agent":"claude","agent_status":"done"}}}' "$3"
-	;;
-"tab list")
-	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tOld","workspace_id":"wA"},{"tab_id":"wA:tOther","workspace_id":"wA"}]}}'
-	;;
-"tab close")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":2}]}}'
-	;;
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
-	;;
-"pane run")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"pane read")
-	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
-// Fakes only a successful "pane get" in the real shape (the query-command contract is at
-// internal/herdr/client.go's call doc), reporting the scout's pane as still "working" so promote's
-// precondition check refuses the promotion before any other herdr call is needed.
-const fakeHerdrPromotePaneWorking = `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pOld","tab_id":"wA:tOld","workspace_id":"wA","agent_status":"working"}}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
-func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string) string {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
+func promoteHerdr(agent, status string) faketool.Herdr {
+	return faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "hand:myproj",
+			Tabs: []faketool.HerdrTab{
+				{ID: "wA:tOld", Label: "old", Pane: "wA:pOld"},
+				{ID: "wA:tOther", Label: "other", Pane: "wA:pOther"},
+			},
+		}},
+		TabCreates: []faketool.HerdrTab{{ID: "wA:tNew", Label: "task-1", Pane: "wA:pNew"}},
+		PaneAgent:  agent, PaneStatus: status,
 	}
+}
+
+func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faketool.Herdr) string {
+	t.Helper()
 	useFastLaunchPolling(t)
 	t.Setenv("HAND_HARNESS", harness.Claude)
 	home := t.TempDir()
@@ -100,12 +60,12 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string
 		t.Fatal(err)
 	}
 
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	writeFakeTreehouseGet(t, bin, newWorktree)
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	herdr.Log = callLog
+	herdr.Install(t, bin)
+	faketool.Treehouse{Slots: []string{newWorktree, oldWorktree}}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	return home
@@ -114,8 +74,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree, herdrScript string
 func TestPromoteUsesDetectedHarnessWithoutConfiguredOverride(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	codexHerdr := strings.ReplaceAll(fakeHerdrPromoteScript, `"agent":"claude"`, `"agent":"codex"`)
-	home := setupPromoteHome(t, oldWt, newWt, codexHerdr)
+	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr("codex", "done"))
 	t.Setenv("HAND_HARNESS", harness.Codex)
 
 	cmd := newPromoteCmd()
@@ -145,10 +104,9 @@ func TestPromoteUsesDetectedHarnessWithoutConfiguredOverride(t *testing.T) {
 func TestPromoteLaunchCarriesWorkerRoleAndResolvedFleetHome(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	home := setupPromoteHome(t, oldWt, newWt, fakeHerdrPromoteScript)
+	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr("claude", "done"))
 	t.Setenv("HAND_HOME", ".")
-	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	callLog := os.Getenv("HERDR_CALL_LOG")
 
 	cmd := newPromoteCmd()
 	cmd.SetArgs([]string{"task-1"})
@@ -172,7 +130,7 @@ func TestPromoteLaunchCarriesWorkerRoleAndResolvedFleetHome(t *testing.T) {
 }
 
 func TestPromoteConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
-	home := setupPromoteHome(t, filepath.Join(t.TempDir(), "old-wt"), filepath.Join(t.TempDir(), "new-wt"), fakeHerdrPromoteScript)
+	home := setupPromoteHome(t, filepath.Join(t.TempDir(), "old-wt"), filepath.Join(t.TempDir(), "new-wt"), promoteHerdr("claude", "done"))
 	t.Setenv("HAND_HARNESS", harness.Codex)
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
 		t.Fatal(err)
@@ -196,7 +154,7 @@ func TestPromoteConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
 }
 
 func TestPromoteUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.T) {
-	home := setupPromoteHome(t, filepath.Join(t.TempDir(), "old-wt"), filepath.Join(t.TempDir(), "new-wt"), fakeHerdrPromoteScript)
+	home := setupPromoteHome(t, filepath.Join(t.TempDir(), "old-wt"), filepath.Join(t.TempDir(), "new-wt"), promoteHerdr("claude", "done"))
 	t.Setenv("HAND_HARNESS", "unknown")
 	bin := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))[0]
 
@@ -219,7 +177,7 @@ func TestPromoteUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.
 func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	home := setupPromoteHome(t, oldWt, newWt, fakeHerdrPromoteScript)
+	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr("claude", "done"))
 
 	scout, err := state.Read(home, "task-1")
 	if err != nil {
@@ -380,55 +338,23 @@ func TestPromoteRefusesUnregisteredProject(t *testing.T) {
 	}
 }
 
-// Mirrors fakeHerdrLeakScript in spawn_test.go for promote, its bare-exit-1 simplification included: it
-// logs every call and fails "pane run" so the promotion always fails after the new tab exists, with
-// $HERDR_WS_EXISTS_FLAG choosing between the created-workspace and pre-existing-workspace cases.
-const fakeHerdrPromoteLeakScript = `#!/bin/sh
-echo "$@" >> "$HERDR_CALL_LOG"
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pOld","tab_id":"wA:tOld","workspace_id":"wA","agent_status":"done"}}}'
-	;;
-"workspace list")
-	if [ -e "$HERDR_WS_EXISTS_FLAG" ]; then
-		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":2}]}}'
-	else
-		printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	fi
-	;;
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
-	;;
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pNew","tab_id":"wA:tNew","agent_status":"idle"}}}'
-	;;
-"tab rename")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tNew","workspace_id":"wA","label":"task-1"}}}'
-	;;
-"pane run")
-	exit 1
-	;;
-"workspace close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-"tab list")
-	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tOld","workspace_id":"wA"},{"tab_id":"wA:tNew","workspace_id":"wA"}]}}'
-	;;
-"tab close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
+func promoteLeakHerdr(workspaceExists bool) faketool.Herdr {
+	herdr := promoteHerdr("claude", "done")
+	herdr.Responses = []faketool.HerdrResponse{{Command: "pane run", Exit: 1}}
+	if !workspaceExists {
+		herdr.Workspaces = nil
+		herdr.Creates = []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "myproj",
+			Tabs: []faketool.HerdrTab{{ID: "wA:tNew", Label: "1", Pane: "wA:pNew"}},
+		}}
+	}
+	return herdr
+}
 
 func TestPromoteFailureClosesWorkspaceItCreated(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	home := setupPromoteHome(t, oldWt, newWt, fakeHerdrPromoteLeakScript)
+	home := setupPromoteHome(t, oldWt, newWt, promoteLeakHerdr(false))
 	callLog := setupSpawnLeakEnv(t, false)
 
 	cmd := newPromoteCmd()
@@ -456,7 +382,7 @@ func TestPromoteFailureClosesWorkspaceItCreated(t *testing.T) {
 func TestPromoteFailureKeepsPreexistingWorkspace(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	setupPromoteHome(t, oldWt, newWt, fakeHerdrPromoteLeakScript)
+	setupPromoteHome(t, oldWt, newWt, promoteLeakHerdr(true))
 	callLog := setupSpawnLeakEnv(t, true)
 
 	cmd := newPromoteCmd()
@@ -480,7 +406,7 @@ func TestPromoteFailureKeepsPreexistingWorkspace(t *testing.T) {
 func TestPromoteRefusesWhenAgentStillWorking(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	home := setupPromoteHome(t, oldWt, newWt, fakeHerdrPromotePaneWorking)
+	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr("claude", "working"))
 	_ = home
 
 	cmd := newPromoteCmd()

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -4,27 +4,26 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
-func setupSendHome(t *testing.T, herdrScript string) string {
+func setupSendHome(t *testing.T, h faketool.Herdr) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
-		t.Fatal(err)
+	if len(h.Workspaces) == 0 {
+		h.Workspaces = []faketool.HerdrWorkspace{{ID: "wA", Tabs: []faketool.HerdrTab{{
+			ID: "wA:tB", Pane: "wA:pB",
+		}}}}
 	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	h.Install(t, bin)
 	return home
 }
 
@@ -32,24 +31,7 @@ func TestSendHappyPathWhenIdle(t *testing.T) {
 	// "pane send-text"/"pane send-keys" are void commands: real success is empty stdout, not this envelope
 	// (callVoid's doc comment, client.go). callVoid only checks env.Error, which is nil here, so the extra
 	// body is harmless and this still exercises the real success path.
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
-	;;
-"pane send-text")
- printf '{"id":"cli:1","result":{}}'
-	;;
-"pane send-keys")
- printf '{"id":"cli:1","result":{}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -65,10 +47,11 @@ func TestSendFailsWhenPaneNotFound(t *testing.T) {
 	// "pane get" is a query command (call(), client.go); call() checks env.Error before runErr, so this fake
 	// would behave identically without the exit 1 - kept only because it is a plausible real exit status for
 	// a failed query, not because call() requires it.
-	home := setupSendHome(t, `#!/bin/sh
-printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
-exit 1
-`)
+	home := setupSendHome(t, faketool.Herdr{Responses: []faketool.HerdrResponse{{
+		Command: "pane get",
+		Stdout:  "{\"id\":\"cli:1\",\"error\":{\"code\":\"pane_not_found\",\"message\":\"no such pane\"}}",
+		Exit:    1,
+	}}})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:gone"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -83,33 +66,7 @@ exit 1
 func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 	// Same send-text/send-keys envelope simplification as
 	// TestSendHappyPathWhenIdle above.
-	counterFile := filepath.Join(t.TempDir(), "calls")
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	n=0
-	if [ -f "`+counterFile+`" ]; then n=$(cat "`+counterFile+`"); fi
-	n=$((n+1))
-	echo "$n" > "`+counterFile+`"
-	if [ "$n" -lt 2 ]; then
-		printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'
-	else
-		printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
-	fi
-	;;
-"pane send-text")
- printf '{"id":"cli:1","result":{}}'
-	;;
-"pane send-keys")
- printf '{"id":"cli:1","result":{}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{PaneStatusSequence: []string{"working", "idle"}})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -123,25 +80,7 @@ esac
 
 func TestSendReadsMessageFromFile(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "sent.log")
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
-	;;
-"pane send-text")
-	printf '%s\n' "$4" >> "`+logPath+`"
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"pane send-keys")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -167,10 +106,7 @@ esac
 }
 
 func TestSendRejectsFileAndMessageTogether(t *testing.T) {
-	setupSendHome(t, `#!/bin/sh
-echo "unexpected herdr invocation: $@" >&2
-exit 1
-`)
+	setupSendHome(t, faketool.Herdr{})
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"task-1", "hello", "--file", "/does/not/matter"})
@@ -178,10 +114,7 @@ exit 1
 }
 
 func TestSendRequiresMessageOrFile(t *testing.T) {
-	setupSendHome(t, `#!/bin/sh
-echo "unexpected herdr invocation: $@" >&2
-exit 1
-`)
+	setupSendHome(t, faketool.Herdr{})
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"task-1"})
@@ -192,10 +125,7 @@ func TestSendRejectsEmptyFileFlag(t *testing.T) {
 	// An unset shell variable expanding into --file is neither a message source
 	// nor two positional arguments, so it has to land on the usage error rather
 	// than on args[1].
-	setupSendHome(t, `#!/bin/sh
-echo "unexpected herdr invocation: $@" >&2
-exit 1
-`)
+	setupSendHome(t, faketool.Herdr{})
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"task-1", "--file", ""})
@@ -205,28 +135,9 @@ exit 1
 func TestSendFailsWhenPaneDisappearsDuringWait(t *testing.T) {
 	// The pane answers "working" once, then stops answering at all: no retry can
 	// succeed, so this must not take the retryable exit-6 busy-composer path.
-	counterFile := filepath.Join(t.TempDir(), "calls")
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	n=0
-	if [ -f "`+counterFile+`" ]; then n=$(cat "`+counterFile+`"); fi
-	n=$((n+1))
-	echo "$n" > "`+counterFile+`"
-	if [ "$n" -lt 2 ]; then
-		printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'
-	else
-		printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
-		exit 1
-	fi
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatusSequence: []string{"working", "pane-gone"},
+	})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -254,25 +165,14 @@ esac
 func TestSendRecordsUndeliveredMessageWhenSubmitFails(t *testing.T) {
 	// The text reached the composer but was never submitted - a steer with no
 	// evidence it landed, so it owes the same trace the wait bound does.
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
-	;;
-"pane send-text")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"pane send-keys")
-	printf '{"id":"cli:1","error":{"code":"send_failed","message":"keystroke rejected"}}'
-	exit 1
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatus: "idle",
+		Responses: []faketool.HerdrResponse{{
+			Command: "pane send-keys",
+			Stdout:  "{\"id\":\"cli:1\",\"error\":{\"code\":\"send_failed\",\"message\":\"keystroke rejected\"}}",
+			Exit:    1,
+		}},
+	})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -303,18 +203,7 @@ esac
 func TestSendRecordsUndeliveredMessageWhenComposerStaysBusy(t *testing.T) {
 	// The composer never frees, so WaitComposerEmpty always exhausts --wait;
 	// a short --wait keeps the test itself fast.
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "working"})
 	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -340,24 +229,7 @@ esac
 }
 
 func TestSendClearsAPreviouslyRecordedUndeliveredSendOnSuccess(t *testing.T) {
-	home := setupSendHome(t, `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'
-	;;
-"pane send-text")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"pane send-keys")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
 	if err := state.Write(home, state.Task{
 		ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"},
 		SendUndeliveredMessage: "an earlier abandoned steer",
@@ -385,10 +257,7 @@ func TestSendFailsForUnknownTask(t *testing.T) {
 	// send resolves the task before it ever reaches herdr, so this fake refuses every invocation instead of
 	// imitating a herdr response: a regression that called herdr first would surface that message here
 	// rather than the expected "not found".
-	setupSendHome(t, `#!/bin/sh
-echo "unexpected herdr invocation: $@" >&2
-exit 1
-`)
+	setupSendHome(t, faketool.Herdr{})
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"missing-task", "hello"})

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -11,13 +11,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
@@ -164,9 +164,6 @@ func TestSessionStartMissingRequiredContextNamesPathAndRecovery(t *testing.T) {
 }
 
 func TestSessionStartRecoveryCommandQuotesFleetHomeForPOSIXShell(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake hand is a POSIX shell script, not supported on windows")
-	}
 	parent := t.TempDir()
 	home := filepath.Join(parent, "fleet path's `printf injected`;printf injected")
 	mkFleetDirs(t, home)
@@ -179,11 +176,8 @@ func TestSessionStartRecoveryCommandQuotesFleetHomeForPOSIXShell(t *testing.T) {
 	t.Setenv(harness.RoleEnv, "")
 	t.Chdir(parent)
 
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "hand"), []byte("#!/bin/sh\nprintf '%s\\n' \"$#\" \"$1\" \"$2\"\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Command{Name: "hand", Args: true}.Install(t, bin)
 
 	_, err := executeSessionStart(t, nil)
 	assertExitCode(t, err, 3)

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
@@ -29,57 +29,19 @@ func TestSpawnCleanupReportsAllErrors(t *testing.T) {
 	}
 }
 
-// Covers the herdr calls a clean spawn makes: a pane herdr sees claude running in, painted past its
-// startup frame with no first-run dialog, so confirmLaunch confirms on its first poll. It echoes an
-// envelope for the void "pane run" too, which callVoid accepts (real shapes: internal/faketool/FIDELITY.md).
-const fakeHerdrSpawnScript = `#!/bin/sh
-if [ -n "$HERDR_CALL_LOG" ]; then
-	echo "$@" >> "$HERDR_CALL_LOG"
-fi
-cmd="$1 $2"
-case "$cmd" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":1}]}}'
-	;;
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
-	;;
-"pane run")
- printf '{"id":"cli:1","result":{}}'
-	;;
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"claude","agent_status":"idle"}}}' "$3"
-	;;
-"pane read")
-	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
-// Fakes "treehouse get" as always leasing worktreePath. Real treehouse writes a banner to stderr ahead
-// of its JSON on "get" (internal/worktree/worktree.go's Get doc); omitted here since
-// tests/e2e/fakes_test.go's writeFakeTreehouse covers the stdout-only parsing where the banner matters.
-func writeFakeTreehouseGet(t *testing.T, bin, worktreePath string) {
-	t.Helper()
-	// A fresh lease_id per invocation, because that - not the recycled slot path - is what real treehouse
-	// guarantees unique per acquisition, and what the spawn collision guard keys on.
-	counter := filepath.Join(bin, ".treehouse-leases")
-	script := "#!/bin/sh\nn=$(cat " + counter + " 2>/dev/null || echo 0)\nn=$((n+1))\necho \"$n\" > " + counter +
-		"\nprintf '{\"path\":\"" + worktreePath + "\",\"lease_id\":\"lease-%s\"}' \"$n\"\n"
-	if err := os.WriteFile(filepath.Join(bin, "treehouse"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
+func defaultSpawnHerdr(agent string) faketool.Herdr {
+	return faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "hand:myproj",
+			Tabs: []faketool.HerdrTab{{ID: "wA:root", Label: "root", Pane: "wA:pRoot"}},
+		}},
+		TabCreates: []faketool.HerdrTab{{ID: "wA:tB", Label: "task-1", Pane: "wA:pC"}},
+		PaneAgent:  agent, PaneStatus: "idle",
 	}
 }
 
-func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
+func setupSpawnHome(t *testing.T, worktreePath string, herdr faketool.Herdr) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	useFastLaunchPolling(t)
 	t.Setenv("HAND_HARNESS", harness.Claude)
 	home := t.TempDir()
@@ -97,12 +59,14 @@ func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 		t.Fatal(err)
 	}
 
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(herdrScript), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	writeFakeTreehouseGet(t, bin, worktreePath)
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	herdr.Log = callLog
+	herdr.Install(t, bin)
+	treehouseLog := filepath.Join(t.TempDir(), "treehouse.log")
+	t.Setenv("TREEHOUSE_CALL_LOG", treehouseLog)
+	faketool.Treehouse{Slots: []string{worktreePath}, Log: treehouseLog}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	return home
@@ -110,8 +74,7 @@ func setupSpawnHome(t *testing.T, worktreePath, herdrScript string) string {
 
 func TestSpawnUsesDetectedHarnessWithoutConfiguredOverride(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	codexHerdr := strings.ReplaceAll(fakeHerdrSpawnScript, `"agent":"claude"`, `"agent":"codex"`)
-	home := setupSpawnHome(t, wt, codexHerdr)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("codex"))
 	t.Setenv("HAND_HARNESS", harness.Codex)
 
 	cmd := newSpawnCmd()
@@ -130,7 +93,7 @@ func TestSpawnUsesDetectedHarnessWithoutConfiguredOverride(t *testing.T) {
 
 func TestSpawnConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
 	t.Setenv("HAND_HARNESS", harness.Codex)
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
 		t.Fatal(err)
@@ -154,10 +117,8 @@ func TestSpawnConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
 }
 
 func TestSpawnUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	t.Setenv("HAND_HARNESS", "unknown")
-	bin := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))[0]
-
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj"})
 	err := cmd.Execute()
@@ -165,8 +126,8 @@ func TestSpawnUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.T)
 	if !strings.Contains(err.Error(), "current supervisor harness is unknown") {
 		t.Fatalf("error = %v, want unknown-supervisor remedy", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(bin, ".treehouse-leases")); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("treehouse acquisition counter exists: %v", statErr)
+	if _, statErr := os.Stat(os.Getenv("TREEHOUSE_CALL_LOG")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("treehouse was invoked: %v", statErr)
 	}
 	if _, readErr := state.Read(home, "task-1"); !errors.Is(readErr, state.ErrTaskNotFound) {
 		t.Fatalf("task state after refusal = %v", readErr)
@@ -175,10 +136,12 @@ func TestSpawnUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.T)
 
 func TestSpawnHappyPath(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
 	t.Setenv("HAND_HOME", ".")
-	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	callLog := os.Getenv("HERDR_CALL_LOG")
+	if callLog == "" {
+		t.Fatal("setupSpawnHome did not configure the herdr call log")
+	}
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj"})
@@ -217,37 +180,16 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 }
 
-// Pins atqamz/hand#118: the plain-labelled "myproj" workspace here sorts first in "workspace list"
-// and would have won the old bare-label lookup, so hand must resolve to its own "hand:myproj" whatever
-// the order, never one it did not create (how a human's workspace collides: internal/faketool/FIDELITY.md).
-const fakeHerdrTwoWorkspacesOneLabelScript = `#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wHuman","label":"myproj","tab_count":1},{"workspace_id":"wA","label":"hand:myproj","tab_count":1}]}}'
-	;;
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
-	;;
-"pane run")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"claude","agent_status":"idle"}}}' "$3"
-	;;
-"pane read")
-	printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
 func TestSpawnIgnoresSameLabelledWorkspaceHandDidNotCreate(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrTwoWorkspacesOneLabelScript)
+	home := setupSpawnHome(t, wt, faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{
+			{ID: "wHuman", Label: "myproj", Tabs: []faketool.HerdrTab{{ID: "wHuman:root", Label: "root", Pane: "wHuman:pHuman"}}},
+			{ID: "wA", Label: "hand:myproj", Tabs: []faketool.HerdrTab{{ID: "wA:root", Label: "root", Pane: "wA:pRoot"}}},
+		},
+		TabCreates: []faketool.HerdrTab{{ID: "wA:tB", Label: "task-1", Pane: "wA:pC"}},
+		PaneAgent:  "claude", PaneStatus: "idle",
+	})
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj"})
@@ -266,7 +208,7 @@ func TestSpawnIgnoresSameLabelledWorkspaceHandDidNotCreate(t *testing.T) {
 
 func TestSpawnPersistsResolvedNotDeclaredTierValues(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
 	briefPath := filepath.Join(home, "data", "task-1", "brief.md")
 	if err := os.WriteFile(briefPath, []byte("---\nmodel: brief-model\neffort: brief-effort\n---\n# Title\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -292,7 +234,7 @@ func TestSpawnPersistsResolvedNotDeclaredTierValues(t *testing.T) {
 
 func TestSpawnScoutFlag(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj", "--scout"})
@@ -310,7 +252,7 @@ func TestSpawnScoutFlag(t *testing.T) {
 }
 
 func TestSpawnRejectsUnregisteredProject(t *testing.T) {
-	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "unknown-proj"})
@@ -322,7 +264,7 @@ func TestSpawnRejectsUnregisteredProject(t *testing.T) {
 }
 
 func TestSpawnRejectsAlreadyActiveTask(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	if err := state.Write(home, state.Task{ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +282,7 @@ func TestSpawnRejectsAlreadyActiveTask(t *testing.T) {
 // be free while its question is still open. Reusing that id has to refuse rather
 // than reattach the old question to unrelated work.
 func TestSpawnRejectsHeldIDWithNoTaskRow(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +300,7 @@ func TestSpawnRejectsHeldIDWithNoTaskRow(t *testing.T) {
 }
 
 func TestSpawnAcceptsIDWhoseHoldWasCleared(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +319,7 @@ func TestSpawnAcceptsIDWhoseHoldWasCleared(t *testing.T) {
 }
 
 func TestSpawnRejectsMissingBrief(t *testing.T) {
-	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	if err := os.Remove(filepath.Join(home, "data", "task-1", "brief.md")); err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +334,7 @@ func TestSpawnRejectsMissingBrief(t *testing.T) {
 }
 
 func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
-	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), fakeHerdrSpawnScript)
+	setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 
 	cmd := newSpawnCmd()
 	cmd.SetArgs([]string{"task-1", "myproj", "--harness", "nonexistent"})
@@ -409,7 +351,7 @@ func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
 // is still guarded by worktree path, and that guard is still wired into spawn.
 func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
 	if err := state.Write(home, state.Task{ID: "other-task", Worktree: wt}); err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +372,7 @@ func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.
 // that is not a collision, and the spawn has to go through.
 func TestSpawnAllowsAReusedWorktreePathUnderAFreshLease(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrSpawnScript)
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
 	if err := state.Write(home, state.Task{ID: "stale-task", Worktree: wt, LeaseID: "lease-0"}); err != nil {
 		t.Fatal(err)
 	}
@@ -450,100 +392,49 @@ func TestSpawnAllowsAReusedWorktreePathUnderAFreshLease(t *testing.T) {
 	}
 }
 
-// Logs every invocation to $HERDR_CALL_LOG and fails "pane run" so a spawn always fails after tab
-// creation, with $HERDR_WS_EXISTS_FLAG driving both leak scenarios, created and pre-existing. Bare exit
-// 1, not herdr's void-failure shape: spawn.go branches only on whether PaneRun errored (client_test.go).
-const fakeHerdrLeakScript = `#!/bin/sh
-echo "$@" >> "$HERDR_CALL_LOG"
-cmd="$1 $2"
-case "$cmd" in
-"workspace list")
-	if [ -e "$HERDR_WS_EXISTS_FLAG" ]; then
-		printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"hand:myproj","tab_count":2}]}}'
-	else
-		printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	fi
-	;;
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
-	;;
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
-	;;
-"tab rename")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}}}'
-	;;
-"pane run")
-	exit 1
-	;;
-"workspace close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-"tab list")
-	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:root","workspace_id":"wA","label":"root"},{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}]}}'
-	;;
-"tab close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
+func spawnLeakHerdr(workspaceExists bool) faketool.Herdr {
+	herdr := faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{Command: "pane run", Exit: 1}},
+		PaneAgent: "claude", PaneStatus: "idle",
+	}
+	if workspaceExists {
+		herdr.Workspaces = []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "hand:myproj",
+			Tabs: []faketool.HerdrTab{
+				{ID: "wA:root", Label: "root", Pane: "wA:pRoot"},
+				{ID: "wA:other", Label: "other", Pane: "wA:pOther"},
+			},
+		}}
+		herdr.TabCreates = []faketool.HerdrTab{{ID: "wA:tB", Label: "task-1", Pane: "wA:pC"}}
+		return herdr
+	}
+	herdr.Creates = []faketool.HerdrWorkspace{{
+		ID: "wA", Label: "myproj",
+		Tabs: []faketool.HerdrTab{{ID: "wA:tB", Label: "1", Pane: "wA:pC"}},
+	}}
+	return herdr
+}
 
 func setupSpawnLeakEnv(t *testing.T, workspaceExists bool) string {
 	t.Helper()
-	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
-
-	flag := filepath.Join(t.TempDir(), "ws-exists")
-	if workspaceExists {
-		if err := os.WriteFile(flag, nil, 0o644); err != nil {
-			t.Fatal(err)
-		}
+	callLog := os.Getenv("HERDR_CALL_LOG")
+	if callLog == "" {
+		t.Fatal("setupSpawnHome did not configure the herdr call log")
 	}
-	t.Setenv("HERDR_WS_EXISTS_FLAG", flag)
+
+	_ = workspaceExists
 	return callLog
 }
 
-// Launches fine but reports a pane sitting on a dialog nothing answers, the shape confirmLaunch must
-// fail rather than record as a spawned task.
-const fakeHerdrStuckPaneScript = `#!/bin/sh
-echo "$@" >> "$HERDR_CALL_LOG"
-cmd="$1 $2"
-case "$cmd" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	;;
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
-	;;
-"tab rename")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}}}'
-	;;
-"pane run")
-	printf '{"id":"cli:1","result":{}}'
-	;;
-"pane get")
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"%s","tab_id":"wA:tB","workspace_id":"wA","agent":"claude","agent_status":"idle"}}}' "$3"
-	;;
-"pane read")
-	printf 'Some brand new dialog\n> 1. Sure\n  2. Nope\n\nEnter to confirm\n'
-	;;
-"workspace close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
 func TestSpawnRollsBackWhenWorkerNeverStarts(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrStuckPaneScript)
+	home := setupSpawnHome(t, wt, faketool.Herdr{
+		Creates: []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "myproj",
+			Tabs: []faketool.HerdrTab{{ID: "wA:tB", Label: "1", Pane: "wA:pC"}},
+		}},
+		PaneAgent: "claude", PaneStatus: "idle", PaneReadOut: "Some brand new dialog\n> 1. Sure\n  2. Nope\n\nEnter to confirm\n",
+	})
 	expectLaunchTimeout()
 	callLog := setupSpawnLeakEnv(t, false)
 
@@ -568,7 +459,7 @@ func TestSpawnRollsBackWhenWorkerNeverStarts(t *testing.T) {
 
 func TestSpawnFailureClosesWorkspaceItCreated(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	setupSpawnHome(t, wt, fakeHerdrLeakScript)
+	setupSpawnHome(t, wt, spawnLeakHerdr(false))
 	callLog := setupSpawnLeakEnv(t, false)
 
 	cmd := newSpawnCmd()
@@ -586,32 +477,12 @@ func TestSpawnFailureClosesWorkspaceItCreated(t *testing.T) {
 	}
 }
 
-// Answers "workspace create" as a herdr predating the tab/root_pane fields would, reporting the workspace
-// and omitting both - the partial-response shape atqamz/hand#74 fixes. It accepts and logs
-// "workspace close" too, since the workspace exists by then and a test could otherwise pass unfixed.
-const fakeHerdrPartialWorkspaceCreateScript = `#!/bin/sh
-echo "$@" >> "$HERDR_CALL_LOG"
-cmd="$1 $2"
-case "$cmd" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	;;
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}'
-	;;
-"workspace close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
 func TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrPartialWorkspaceCreateScript)
+	home := setupSpawnHome(t, wt, faketool.Herdr{Responses: []faketool.HerdrResponse{
+		{Command: "workspace create", Stdout: `{"id":"cli:workspace:create","result":{"workspace":{"workspace_id":"wA","label":"myproj"}}}`},
+		{Command: "workspace close", Stdout: `{"id":"cli:workspace:close","result":{"type":"ok"}}`},
+	}})
 	callLog := setupSpawnLeakEnv(t, false)
 
 	cmd := newSpawnCmd()
@@ -633,35 +504,15 @@ func TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind(t *testing.T) {
 	}
 }
 
-// Answers "workspace create" in full and then fails the rename of the root tab into the task's - the
-// one failure that lands between herdr creating the workspace and the caller arming its own rollback,
-// so the workspace has to be closed by the acquisition step itself.
-const fakeHerdrTabRenameFailureScript = `#!/bin/sh
-echo "$@" >> "$HERDR_CALL_LOG"
-cmd="$1 $2"
-case "$cmd" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	;;
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"myproj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'
-	;;
-"tab rename")
-	exit 1
-	;;
-"workspace close")
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
 func TestSpawnTabRenameFailureClosesWorkspaceItCreated(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	home := setupSpawnHome(t, wt, fakeHerdrTabRenameFailureScript)
+	home := setupSpawnHome(t, wt, faketool.Herdr{
+		Creates: []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "myproj",
+			Tabs: []faketool.HerdrTab{{ID: "wA:tB", Label: "1", Pane: "wA:pC"}},
+		}},
+		Responses: []faketool.HerdrResponse{{Command: "tab rename", Exit: 1}},
+	})
 	callLog := setupSpawnLeakEnv(t, false)
 
 	cmd := newSpawnCmd()
@@ -685,7 +536,7 @@ func TestSpawnTabRenameFailureClosesWorkspaceItCreated(t *testing.T) {
 
 func TestSpawnFailureKeepsPreexistingWorkspace(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
-	setupSpawnHome(t, wt, fakeHerdrLeakScript)
+	setupSpawnHome(t, wt, spawnLeakHerdr(true))
 	callLog := setupSpawnLeakEnv(t, true)
 
 	cmd := newSpawnCmd()

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
@@ -23,15 +23,11 @@ import (
 // (no fake, empty PATH) by TestStatusFleetDegradesToUnknownWhenHerdrUnreachable below.
 func writeFakeHerdrPaneStatus(t *testing.T, status string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\nprintf '{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"" + status + "\"}}}'\n"
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{
+		Command: "pane get",
+		Stdout:  "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"" + status + "\"}}}",
+	}}}.Install(t, bin)
 }
 
 // The tasks[] row whose first cell is id, so a test can assert on one row's cells without matching the
@@ -1697,15 +1693,9 @@ func TestStatusSingleTaskNoGateLineWhenRunFound(t *testing.T) {
 // no-mistakes processes one render actually spawned.
 func countingNoMistakesPath(t *testing.T, stdout, countFile string) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake no-mistakes is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\necho x >> " + countFile + "\ncat <<'EOF'\n" + stdout + "\nEOF\n"
-	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return bin + string(os.PathListSeparator) + os.Getenv("PATH")
+	bin := faketool.Bin(t)
+	faketool.NoMistakes{Stdout: stdout, CountLog: countFile}.Install(t, bin)
+	return os.Getenv("PATH")
 }
 
 // Pins the per-clone caching: without it every done ship task on one project spawns its own

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -1118,9 +1117,6 @@ func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
 }
 
 func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	home, worktree := setupTeardownHome(t)
 	writeScoutReport(t, home, "task-1")
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout, Worktree: worktree,
@@ -1129,14 +1125,14 @@ func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
 	}
 
 	marker := filepath.Join(t.TempDir(), "herdr-called")
-	bin := t.TempDir()
-	// This and the herdr fakes further down this file all return a non-null object result for "tab
-	// list"/"tab close"/"workspace close", exactly what call() requires for success (client.go). All
-	// three are query commands, not callVoid's void pane commands, so no exit-code split to reproduce.
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte("#!/bin/sh\ntouch '"+marker+"'\nprintf '{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\"}]}}'\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{
+			Command: "tab list",
+			Stdout:  "{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\"}]}}",
+		}},
+		Log: marker,
+	}.Install(t, bin)
 
 	releaseProject, err := state.Lock(home, "project:myproj")
 	if err != nil {
@@ -1173,33 +1169,12 @@ func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
 }
 
 func TestTeardownClosesWorkspaceWhenLastTab(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	home, worktree := setupTeardownHome(t)
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
-cmd="$1 $2"
-case "$cmd" in
-"tab list")
-	printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
-	;;
-"workspace close")
- printf '{"id":"cli:1","result":{}}'
-	;;
-"tab close")
-	echo "should not close a tab when it is the last one" >&2
-	exit 1
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{
+		{Command: "tab list", Stdout: "{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"} ]}}"},
+		{Command: "workspace close", Stdout: "{\"id\":\"cli:1\",\"result\":{}}"},
+	}}.Install(t, bin)
 
 	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
@@ -1218,51 +1193,22 @@ esac
 // fail the command: teardown's later steps can fault, and the retry that follows
 // finds exactly this state.
 func TestCloseTaskTabTreatsAbsentTabAsClosed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
-case "$1 $2" in
-"tab list")
- printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:other","workspace_id":"wA"}]}}'
- ;;
-*)
- echo "unexpected herdr args: $@" >&2
- exit 1
- ;;
-esac
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{
+		Command: "tab list",
+		Stdout:  "{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:other\",\"workspace_id\":\"wA\"}]}}",
+	}}}.Install(t, bin)
 	if err := closeTaskTab(herdr.NewClient(), "wA", "wA:missing"); err != nil {
 		t.Fatalf("got %v, want an absent tab treated as already closed", err)
 	}
 }
 
 func TestCloseTaskTabClosesWorkspaceForSoleTab(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(`#!/bin/sh
-case "$1 $2" in
-"tab list")
- printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'
- ;;
-"workspace close")
- printf '{"id":"cli:1","result":{}}'
- ;;
-*)
- echo "unexpected herdr args: $@" >&2
- exit 1
- ;;
-esac
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{
+		{Command: "tab list", Stdout: "{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"}]}}"},
+		{Command: "workspace close", Stdout: "{\"id\":\"cli:1\",\"result\":{}}"},
+	}}.Install(t, bin)
 	if err := closeTaskTab(herdr.NewClient(), "wA", "wA:tB"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -368,8 +368,9 @@ func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
 	if want := appliedUpdateDoc("failed", "no-fleet-home", "fixed the frobnicator"); got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
-	if !strings.Contains(errOut.String(), "warning: refresh AGENTS.md:") || !strings.Contains(errOut.String(), notAHome) {
-		t.Fatalf("got stderr %q, want a warning naming %q", errOut.String(), notAHome)
+	quotedHome := fmt.Sprintf("%q", notAHome)
+	if !strings.Contains(errOut.String(), "warning: refresh AGENTS.md:") || !strings.Contains(errOut.String(), quotedHome) {
+		t.Fatalf("got stderr %q, want a warning naming %q", errOut.String(), quotedHome)
 	}
 }
 

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/selfupdate"
 )
 
@@ -22,57 +23,18 @@ import (
 // shape - no envelope to reproduce here, unlike herdr's call()/callVoid().
 func writeFakeGHReleaseView(t *testing.T, tag string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" != "release" ] || [ "$2" != "view" ] || [ "$3" != "--repo" ] || [ "$4" != "atqamz/hand" ]; then
-  echo "unexpected gh invocation: $@" >&2
-  exit 1
-fi
-printf '%%s' %q
-`, tag)
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.GH{Release: faketool.GHRelease{Tag: tag}}.Install(t, bin)
 }
 
 // Fakes the three gh invocations a full `hand update` makes: the tag lookup and the release notes lookup,
 // both "release view --jq" in the shape writeFakeGHReleaseView documents above, plus the asset download.
 func writeFakeGHUpdate(t *testing.T, tag, notes, fixtureDir string) {
 	t.Helper()
-	bin := t.TempDir()
-	// Real `gh release download` leaves only the assets themselves in --dir and writes its progress to
-	// stderr, so copying the fixture in and printing nothing is the faithful success shape. The trailing
-	// arm mirrors real gh's failure shape too: a diagnostic on stderr and a non-zero exit, never partial.
-	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "release" ] && [ "$2" = "view" ] && [ "$3" = "--repo" ]; then
-  printf '%%s' %q
-  exit 0
-fi
-if [ "$1" = "release" ] && [ "$2" = "view" ]; then
-  printf '%%s' %q
-  exit 0
-fi
-if [ "$1" = "release" ] && [ "$2" = "download" ]; then
-  dir=""
-  prev=""
-  for a in "$@"; do
-    if [ "$prev" = "--dir" ]; then dir="$a"; fi
-    prev="$a"
-  done
-  cp %q/* "$dir"/
-  exit 0
-fi
-echo "unexpected gh invocation: $@" >&2
-exit 1
-`, tag, notes, fixtureDir)
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.GH{Release: faketool.GHRelease{
+		Tag: tag, Notes: notes, FixtureDir: fixtureDir,
+	}}.Install(t, bin)
 }
 
 func buildUpdateFixture(t *testing.T, binaryContent []byte) string {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -139,9 +139,6 @@ func appliedUpdateDoc(agentsMD, sessionHook string, notes ...string) string {
 }
 
 func TestUpdateRefreshesWorkspaceAndReportsChanges(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -183,9 +180,6 @@ func TestUpdateRefreshesWorkspaceAndReportsChanges(t *testing.T) {
 // The refreshed template directs the agent at data files a home initialized
 // before them never had, so update seeds whichever are missing.
 func TestUpdateSeedsDataSkeletonsMissingFromAnOlderHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -228,9 +222,6 @@ func TestUpdateSeedsDataSkeletonsMissingFromAnOlderHome(t *testing.T) {
 // state/hand.db marker, so update has to create the directory it seeds into
 // rather than warning about six files it could not write.
 func TestUpdateRecreatesAMissingDataDirectory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -262,9 +253,6 @@ func TestUpdateRecreatesAMissingDataDirectory(t *testing.T) {
 }
 
 func TestUpdateLeavesExistingOperatorContextAlone(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -296,9 +284,6 @@ func TestUpdateLeavesExistingOperatorContextAlone(t *testing.T) {
 }
 
 func TestUpdateRefreshesHandHomeRatherThanWorkingDirectory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	fleetHome := t.TempDir()
 	mkFleetDirs(t, fleetHome)
@@ -332,9 +317,6 @@ func TestUpdateRefreshesHandHomeRatherThanWorkingDirectory(t *testing.T) {
 }
 
 func TestUpdateSkipsAgentsRefreshOutsideAFleetHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	t.Setenv("HAND_HOME", "")
 	home := t.TempDir()
@@ -364,9 +346,6 @@ func TestUpdateSkipsAgentsRefreshOutsideAFleetHome(t *testing.T) {
 // home" is a misconfiguration, and swallowing it would leave the operator with
 // an unrefreshed AGENTS.md and nothing on stderr saying why.
 func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -395,9 +374,6 @@ func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
 }
 
 func TestUpdateDegradesGracefullyWithoutReleaseNotes(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -423,9 +399,6 @@ func TestUpdateDegradesGracefullyWithoutReleaseNotes(t *testing.T) {
 // The binary is already replaced before the refresh runs, so a refresh failure
 // must not turn a successful update into a nonzero exit.
 func TestUpdateReportsVersionsWhenAgentsRefreshFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "AGENTS.md"), 0o755); err != nil {
@@ -456,9 +429,6 @@ func TestUpdateReportsVersionsWhenAgentsRefreshFails(t *testing.T) {
 }
 
 func TestUpdatePreservesOwnedSessionHookWhenAgentsRefreshFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)
@@ -507,9 +477,6 @@ func TestUpdatePreservesOwnedSessionHookWhenAgentsRefreshFails(t *testing.T) {
 // The binary is already replaced before retirement runs, so malformed operator
 // settings produce a warning and a failed field without changing update success.
 func TestUpdateReportsVersionsWhenSessionHookRetirementFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
 	setFakeExecutable(t)
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -19,10 +20,12 @@ func setupWatchHome(t *testing.T) string {
 	mkFleetDirs(t, home)
 
 	bin := faketool.Bin(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	t.Setenv("HERDR_CALL_LOG", callLog)
 	faketool.Herdr{Responses: []faketool.HerdrResponse{{
 		Command: "workspace list",
 		Stdout:  "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[]}}",
-	}}}.Install(t, bin)
+	}}, Log: callLog}.Install(t, bin)
 	return home
 }
 
@@ -159,7 +162,17 @@ func TestWatchExitsCleanlyOnContextCancel(t *testing.T) {
 		done <- cmd.ExecuteContext(ctx)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		calls, err := os.ReadFile(os.Getenv("HERDR_CALL_LOG"))
+		if err == nil && bytes.Contains(calls, []byte("herdr workspace list\n")) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if time.Now().After(deadline) {
+		t.Fatal("watch did not reach herdr before cancellation")
+	}
 	cancel()
 
 	select {

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -4,42 +4,25 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/watcher"
 )
 
-// Fakes "workspace list" as a query command per internal/herdr/client.go's call() doc comment: a non-null
-// result object on success, here an empty workspace list.
-const fakeHerdrWatchScript = `#!/bin/sh
-case "$1 $2" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-
 func setupWatchHome(t *testing.T) string {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(fakeHerdrWatchScript), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{
+		Command: "workspace list",
+		Stdout:  "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[]}}",
+	}}}.Install(t, bin)
 	return home
 }
 

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
 )
 
 func withWindows(t *testing.T) {
@@ -687,9 +689,6 @@ func TestCheckFlagsMissingGeneratedMarkers(t *testing.T) {
 }
 
 func TestCheckRemediationCommandsQuoteFleetHomeForPOSIXShell(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake hand is a POSIX shell script, not supported on windows")
-	}
 	parent := t.TempDir()
 	dir := filepath.Join(parent, "fleet path's `printf injected`;printf injected")
 	for _, subdir := range []string{"data", "state"} {
@@ -700,11 +699,8 @@ func TestCheckRemediationCommandsQuoteFleetHomeForPOSIXShell(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "state", "hand.db"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "hand"), []byte("#!/bin/sh\nprintf '%s\\n' \"$#\" \"$1\" \"$2\"\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Command{Name: "hand", Args: true}.Install(t, bin)
 
 	assertRecovery := func(finding string) {
 		t.Helper()

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -253,12 +253,17 @@ The call follows a renamed repository: `atqamz/secondhand` answers `atqamz/hand`
 An unknown or inaccessible repository exits nonzero and writes its diagnostic to stderr.
 `internal/ghutil` reads stdout separately from stderr so warnings cannot corrupt the JSON payload.
 
-### `gh release view <tag> --json tagName,body --jq <field>`
+
+### `gh release view --repo <slug> --json <field> --jq <jq>`
+
+The tag lookup omits the positional tag and requests `tagName`.
+
+The notes lookup includes the release tag before `--repo` and requests `body`.
 
 Exit 0 with the selected field as raw text on stdout and no JSON envelope.
 `hand update` reads `.tagName` and `.body` this way.
 
-### `gh release download <tag> --pattern <asset> --dir <directory>`
+### `gh release download <tag> --repo <slug> --dir <directory> --clobber --pattern <asset>...`
 
 Exit 0 with the requested release assets copied into the directory.
 Download progress belongs on stderr and is ignored by `hand update`.

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -267,3 +267,4 @@ Exit 0 with the selected field as raw text on stdout and no JSON envelope.
 
 Exit 0 with the requested release assets copied into the directory.
 Download progress belongs on stderr and is ignored by `hand update`.
+The requested hand asset is `hand-<goos>-<goarch>.tar.gz` on Unix and `hand-windows-<goarch>.zip` on Windows, followed by `checksums.txt`.

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -252,3 +252,13 @@ The call follows a renamed repository: `atqamz/secondhand` answers `atqamz/hand`
 
 An unknown or inaccessible repository exits nonzero and writes its diagnostic to stderr.
 `internal/ghutil` reads stdout separately from stderr so warnings cannot corrupt the JSON payload.
+
+### `gh release view <tag> --json tagName,body --jq <field>`
+
+Exit 0 with the selected field as raw text on stdout and no JSON envelope.
+`hand update` reads `.tagName` and `.body` this way.
+
+### `gh release download <tag> --pattern <asset> --dir <directory>`
+
+Exit 0 with the requested release assets copied into the directory.
+Download progress belongs on stderr and is ignored by `hand update`.

--- a/internal/faketool/cmd/faketool/main.go
+++ b/internal/faketool/cmd/faketool/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func main() {
+	os.Exit(faketool.Run())
+}

--- a/internal/faketool/dispatch.go
+++ b/internal/faketool/dispatch.go
@@ -1,0 +1,139 @@
+package faketool
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Run dispatches an installed fake executable. The helper binary calls this
+// through the same process boundary production code uses for external tools.
+func Run() int {
+	executable, err := os.Executable()
+	if err != nil {
+		return fail("locate fake executable: %v", err)
+	}
+	dir := filepath.Dir(executable)
+	name := strings.TrimSuffix(filepath.Base(executable), filepath.Ext(executable))
+
+	data, err := os.ReadFile(configPath(dir, name))
+	if err != nil {
+		return fail("read fake %s config: %v", name, err)
+	}
+	var spec installSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return fail("decode fake %s config: %v", name, err)
+	}
+
+	switch spec.Kind {
+	case "command":
+		var config commandConfig
+		if err := json.Unmarshal(spec.Payload, &config); err != nil {
+			return fail("decode command fake %s: %v", name, err)
+		}
+		return runCommand(name, config, os.Args[1:])
+	case "gh":
+		return runGHFromPayload(spec.Payload, os.Args[1:])
+	case "herdr":
+		return runHerdrFromPayload(spec.Payload, os.Args[1:])
+	case "treehouse":
+		return runTreehouseFromPayload(spec.Payload, os.Args[1:])
+	case "no-mistakes":
+		return runNoMistakesFromPayload(spec.Payload, os.Args[1:])
+	default:
+		return fail("unknown fake kind %q", spec.Kind)
+	}
+}
+
+func runCommand(name string, config commandConfig, args []string) int {
+	if config.Log != "" {
+		if err := appendInvocation(config.Log, name, args); err != nil {
+			return fail("log %s invocation: %v", name, err)
+		}
+	}
+	if config.FileAction != nil {
+		action := config.FileAction
+		if action.PathArg < 0 || action.PathArg >= len(args) {
+			return fail("file action for %s needs argv[%d], got %d arguments", name, action.PathArg, len(args))
+		}
+		path := filepath.Join(args[action.PathArg], action.Relative)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fail("create file action directory: %v", err)
+		}
+		flags := os.O_CREATE | os.O_WRONLY
+		if action.Append {
+			flags |= os.O_APPEND
+		} else {
+			flags |= os.O_TRUNC
+		}
+		file, err := os.OpenFile(path, flags, 0o644)
+		if err != nil {
+			return fail("write file action: %v", err)
+		}
+		_, writeErr := io.WriteString(file, action.Content)
+		closeErr := file.Close()
+		if writeErr != nil {
+			return fail("write file action: %v", writeErr)
+		}
+		if closeErr != nil {
+			return fail("close file action: %v", closeErr)
+		}
+	}
+	if !config.Args && config.FileAction == nil && len(args) != 0 {
+		return fail("unexpected %s invocation: %s", name, strings.Join(args, " "))
+	}
+	if config.Stdout != "" {
+		_, _ = io.WriteString(os.Stdout, config.Stdout)
+	}
+	if config.Args {
+		_, _ = fmt.Fprintf(os.Stdout, "%d\n", len(args))
+		for _, arg := range args {
+			_, _ = fmt.Fprintln(os.Stdout, arg)
+		}
+	}
+	if config.Stderr != "" {
+		_, _ = io.WriteString(os.Stderr, config.Stderr)
+	}
+	return config.Exit
+}
+
+func appendInvocation(path, name string, args []string) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	_, writeErr := fmt.Fprintln(file, strings.Join(append([]string{name}, args...), " "))
+	closeErr := file.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
+}
+
+func sameArgs(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func fail(format string, args ...any) int {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	return 1
+}
+
+func atomicWrite(path, content string) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/faketool/dispatch.go
+++ b/internal/faketool/dispatch.go
@@ -12,12 +12,10 @@ import (
 // Run dispatches an installed fake executable. The helper binary calls this
 // through the same process boundary production code uses for external tools.
 func Run() int {
-	executable, err := os.Executable()
+	dir, name, err := fakeExecutable()
 	if err != nil {
 		return fail("locate fake executable: %v", err)
 	}
-	dir := filepath.Dir(executable)
-	name := strings.TrimSuffix(filepath.Base(executable), filepath.Ext(executable))
 
 	data, err := os.ReadFile(configPath(dir, name))
 	if err != nil {
@@ -46,6 +44,20 @@ func Run() int {
 	default:
 		return fail("unknown fake kind %q", spec.Kind)
 	}
+}
+
+func fakeExecutable() (string, string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		executable = os.Args[0]
+		if !filepath.IsAbs(executable) {
+			executable, err = filepath.Abs(executable)
+			if err != nil {
+				return "", "", err
+			}
+		}
+	}
+	return filepath.Dir(executable), strings.TrimSuffix(filepath.Base(executable), filepath.Ext(executable)), nil
 }
 
 func runCommand(name string, config commandConfig, args []string) int {

--- a/internal/faketool/exec_test.go
+++ b/internal/faketool/exec_test.go
@@ -1,0 +1,71 @@
+package faketool
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCommandPreservesProcessBoundaries(t *testing.T) {
+	bin := Bin(t)
+	log := t.TempDir() + "/invocations.log"
+	Command{
+		Name:   "argv-probe",
+		Args:   true,
+		Stderr: "warning with spaces and apostrophe\n",
+		Exit:   7,
+		Log:    log,
+	}.Install(t, bin)
+
+	cmd := exec.Command("argv-probe", "one two", "it's", "back`tick")
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("run error = %v, want exit 7", err)
+	}
+	if stdout.String() != "3\none two\nit's\nback`tick\n" {
+		t.Fatalf("stdout = %q, want exact argv", stdout.String())
+	}
+	if stderr.String() != "warning with spaces and apostrophe\n" {
+		t.Fatalf("stderr = %q, want configured stderr", stderr.String())
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "argv-probe one two it's back`tick\n" {
+		t.Fatalf("log = %q, want one invocation with preserved arguments", data)
+	}
+}
+
+func TestCommandCanShareABinAndRejectUnexpectedInvocations(t *testing.T) {
+	bin := Bin(t)
+	Command{Name: "first", Stdout: "one\n"}.Install(t, bin)
+	Command{Name: "second", Stdout: "two\n"}.Install(t, bin)
+
+	for name, want := range map[string]string{"first": "one\n", "second": "two\n"} {
+		out, err := exec.Command(name).Output()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if string(out) != want {
+			t.Fatalf("%s stdout = %q, want %q", name, out, want)
+		}
+	}
+
+	command := exec.Command("first", "unexpected")
+	var stderr strings.Builder
+	command.Stderr = &stderr
+	if err := command.Run(); err == nil {
+		t.Fatal("unexpected invocation succeeded")
+	}
+	if !strings.Contains(stderr.String(), "unexpected first invocation") {
+		t.Fatalf("stderr = %q, want an explicit unexpected-invocation failure", stderr.String())
+	}
+}

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -207,5 +207,5 @@ func writeFile(t *testing.T, path, content string) {
 // Encodes an identifier as a filename, so a fake's state can be one file per
 // entity. Only the separators matter: herdr tab ids carry a colon and treehouse slots are absolute paths.
 func key(id string) string {
-	return strings.NewReplacer("/", "_", ":", "-", ".", "_", " ", "_").Replace(strings.Trim(id, "/"))
+	return strings.NewReplacer("/", "_", "\\", "_", ":", "-", ".", "_", " ", "_").Replace(strings.Trim(id, "/\\"))
 }

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -118,7 +118,15 @@ func installConfigData(t *testing.T, bin, name string, spec installSpec) {
 	if err != nil {
 		t.Fatalf("read faketool helper: %v", err)
 	}
-	if err := os.WriteFile(target, data, 0o755); err != nil {
+	if err := os.WriteFile(target+".tmp", data, 0o755); err != nil {
+		t.Fatalf("install fake %s: %v", name, err)
+	}
+	if runtime.GOOS == "windows" {
+		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("replace fake %s: %v", name, err)
+		}
+	}
+	if err := os.Rename(target+".tmp", target); err != nil {
 		t.Fatalf("install fake %s: %v", name, err)
 	}
 	config, err := json.Marshal(spec)
@@ -134,11 +142,11 @@ func helperBinary(t *testing.T) string {
 		root := moduleRoot()
 		dir, err := os.MkdirTemp("", "hand-faketool-helper-")
 		if err != nil {
-			helperBuild.err = err
+			helperBuild.err = fmt.Errorf("create fake helper directory: %w", err)
 			return
 		}
 		target := filepath.Join(dir, executableName("faketool"))
-		cmd := exec.Command("go", "build", "-o", target, "./internal/faketool/cmd/faketool")
+		cmd := exec.Command(goToolPath(), "build", "-o", target, "./internal/faketool/cmd/faketool")
 		cmd.Dir = root
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -151,6 +159,22 @@ func helperBinary(t *testing.T) string {
 		t.Fatal(helperBuild.err)
 	}
 	return helperBuild.path
+}
+
+func goToolPath() string {
+	name := "go"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	//nolint:staticcheck // hermetic test PATHs can hide go, so the running toolchain is the reliable fallback.
+	path := filepath.Join(runtime.GOROOT(), "bin", name)
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	if path, err := exec.LookPath(name); err == nil {
+		return path
+	}
+	return name
 }
 
 func moduleRoot() string {

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -4,12 +4,14 @@
 package faketool
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -52,23 +54,129 @@ func Bin(t *testing.T) string {
 	return dir
 }
 
-// Dispatches body on selector, the shell expression each case arm matches ("$1",
-// or "$1 $2" for a two-word command). The loud default arm is what keeps an
-// invocation shape the fake does not model from passing as a silent success.
-func install(t *testing.T, bin, name, log, prelude, selector, body string) {
+type commandConfig struct {
+	Name       string
+	Args       bool
+	Stdout     string
+	Stderr     string
+	Exit       int
+	Log        string
+	FileAction *FileAction
+}
+
+// Command installs a narrow fixed-result process for tests that only need to
+// inspect argv or exercise stdout, stderr and exit-code handling.
+type Command struct {
+	Name       string
+	Args       bool
+	Stdout     string
+	Stderr     string
+	Exit       int
+	Log        string
+	FileAction *FileAction
+}
+
+// FileAction is the one filesystem operation supported by Command.
+type FileAction struct {
+	PathArg  int
+	Relative string
+	Content  string
+	Append   bool
+}
+
+func (c Command) Install(t *testing.T, bin string) {
 	t.Helper()
+	installConfig(t, bin, c.Name, "command", commandConfig(c))
+}
+
+type installSpec struct {
+	Kind    string
+	Payload json.RawMessage
+	Log     string
+}
+
+var helperBuild struct {
+	sync.Once
+	path string
+	err  error
+}
+
+func installConfig(t *testing.T, bin, name, kind string, payload any) {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal %s fake config: %v", name, err)
+	}
+	installConfigData(t, bin, name, installSpec{Kind: kind, Payload: data})
+}
+
+func installConfigData(t *testing.T, bin, name string, spec installSpec) {
+	t.Helper()
+	helper := helperBinary(t)
+	target := filepath.Join(bin, executableName(name))
+	data, err := os.ReadFile(helper)
+	if err != nil {
+		t.Fatalf("read faketool helper: %v", err)
+	}
+	if err := os.WriteFile(target, data, 0o755); err != nil {
+		t.Fatalf("install fake %s: %v", name, err)
+	}
+	config, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal %s install config: %v", name, err)
+	}
+	writeFile(t, configPath(bin, name), string(config))
+}
+
+func helperBinary(t *testing.T) string {
+	t.Helper()
+	helperBuild.Do(func() {
+		root := moduleRoot()
+		dir, err := os.MkdirTemp("", "hand-faketool-helper-")
+		if err != nil {
+			helperBuild.err = err
+			return
+		}
+		target := filepath.Join(dir, executableName("faketool"))
+		cmd := exec.Command("go", "build", "-o", target, "./internal/faketool/cmd/faketool")
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			helperBuild.err = fmt.Errorf("build fake helper: %w: %s", err, output)
+			return
+		}
+		helperBuild.path = target
+	})
+	if helperBuild.err != nil {
+		t.Fatal(helperBuild.err)
+	}
+	return helperBuild.path
+}
+
+func moduleRoot() string {
+	_, source, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(source)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}
+
+func executableName(name string) string {
 	if runtime.GOOS == "windows" {
-		t.Skip("fake " + name + " is a POSIX shell script, not supported on windows")
+		return name + ".exe"
 	}
-	script := "#!/bin/sh\n" + prelude
-	if log != "" {
-		script += fmt.Sprintf("echo \"%s $@\" >> %s\n", name, quote(log))
-	}
-	script += fmt.Sprintf("case \"%s\" in\n%s\n  *) echo \"unexpected %s invocation: $@\" >&2; exit 1 ;;\nesac\n",
-		selector, body, name)
-	if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	return name
+}
+
+func configPath(bin, name string) string {
+	return filepath.Join(bin, "."+name+"-config.json")
 }
 
 // Kept beside the fake rather than in a fresh temp dir, so a test that reinstalls
@@ -96,13 +204,8 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-func quote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
 // Encodes an identifier as a filename, so a fake's state can be one file per
-// entity and every existence test is a shell builtin. Only the separators matter:
-// herdr tab ids carry a colon and treehouse slots are absolute paths.
+// entity. Only the separators matter: herdr tab ids carry a colon and treehouse slots are absolute paths.
 func key(id string) string {
 	return strings.NewReplacer("/", "_", ":", "-", ".", "_", " ", "_").Replace(strings.Trim(id, "/"))
 }

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -34,6 +35,8 @@ type GHRelease struct {
 	Tag        string
 	Notes      string
 	FixtureDir string
+	Repo       string
+	Patterns   []string
 }
 
 // GHResponse provides a deliberately fixed result for one modeled gh command.
@@ -260,8 +263,14 @@ func ghReleaseView(spec ghSpec, args []string) int {
 	jq := flagValue(args, "--jq")
 	switch jq {
 	case ".tagName":
+		if !sameArgs(args, []string{"release", "view", "--repo", ghReleaseRepo(spec.Release), "--json", "tagName", "--jq", ".tagName"}) {
+			return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+		}
 		_, _ = io.WriteString(os.Stdout, spec.Release.Tag)
 	case ".body":
+		if !sameArgs(args, []string{"release", "view", spec.Release.Tag, "--repo", ghReleaseRepo(spec.Release), "--json", "body", "--jq", ".body"}) {
+			return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+		}
 		_, _ = io.WriteString(os.Stdout, spec.Release.Notes)
 	default:
 		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
@@ -270,43 +279,66 @@ func ghReleaseView(spec ghSpec, args []string) int {
 }
 
 func ghReleaseDownload(spec ghSpec, args []string) int {
-	if spec.Release.FixtureDir == "" {
+	if spec.Release.Tag == "" || spec.Release.FixtureDir == "" {
 		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
 	}
-	dir := flagValue(args, "--dir")
-	if dir == "" {
+	dir, ok := ghReleaseDownloadDir(spec.Release, args)
+	if !ok {
 		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
-	}
-	entries, err := os.ReadDir(spec.Release.FixtureDir)
-	if err != nil {
-		return fail("read gh release fixture: %v", err)
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fail("create gh release directory: %v", err)
 	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		source := filepath.Join(spec.Release.FixtureDir, entry.Name())
-		target := filepath.Join(dir, entry.Name())
-		in, err := os.Open(source)
+	for _, name := range ghReleasePatterns(spec.Release) {
+		data, err := os.ReadFile(filepath.Join(spec.Release.FixtureDir, name))
 		if err != nil {
-			return fail("open gh release fixture: %v", err)
+			return fail("read gh release fixture %s: %v", name, err)
 		}
-		out, err := os.Create(target)
-		if err != nil {
-			_ = in.Close()
-			return fail("create gh release asset: %v", err)
-		}
-		_, copyErr := io.Copy(out, in)
-		closeOutErr := out.Close()
-		closeInErr := in.Close()
-		if copyErr != nil || closeOutErr != nil || closeInErr != nil {
-			return fail("copy gh release asset: %v", firstError(copyErr, closeOutErr, closeInErr))
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			return fail("write gh release asset %s: %v", name, err)
 		}
 	}
 	return 0
+}
+
+const defaultGHReleaseRepo = "atqamz/hand"
+
+func ghReleaseRepo(release GHRelease) string {
+	if release.Repo != "" {
+		return release.Repo
+	}
+	return defaultGHReleaseRepo
+}
+
+func ghReleasePatterns(release GHRelease) []string {
+	if len(release.Patterns) > 0 {
+		return append([]string(nil), release.Patterns...)
+	}
+	return []string{fmt.Sprintf("hand-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH), "checksums.txt"}
+}
+
+func ghReleaseDownloadDir(release GHRelease, args []string) (string, bool) {
+	patterns := ghReleasePatterns(release)
+	if len(args) != 8+2*len(patterns) {
+		return "", false
+	}
+	expected := []string{"release", "download", release.Tag, "--repo", ghReleaseRepo(release), "--dir"}
+	for i, want := range expected {
+		if args[i] != want {
+			return "", false
+		}
+	}
+	dir := args[len(expected)]
+	if dir == "" || args[len(expected)+1] != "--clobber" {
+		return "", false
+	}
+	for i, pattern := range patterns {
+		index := len(expected) + 2 + 2*i
+		if args[index] != "--pattern" || args[index+1] != pattern {
+			return "", false
+		}
+	}
+	return dir, true
 }
 
 func ghPRIndex(prs []GHPR, ref string) (int, bool) {

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -311,10 +311,22 @@ func ghReleaseRepo(release GHRelease) string {
 }
 
 func ghReleasePatterns(release GHRelease) []string {
+	return ghReleasePatternsFor(release, runtime.GOOS, runtime.GOARCH)
+}
+
+func ghReleasePatternsFor(release GHRelease, goos, goarch string) []string {
 	if len(release.Patterns) > 0 {
 		return append([]string(nil), release.Patterns...)
 	}
-	return []string{fmt.Sprintf("hand-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH), "checksums.txt"}
+	return []string{ghReleaseAssetName(goos, goarch), "checksums.txt"}
+}
+
+func ghReleaseAssetName(goos, goarch string) string {
+	suffix := ".tar.gz"
+	if goos == "windows" {
+		suffix = ".zip"
+	}
+	return fmt.Sprintf("hand-%s-%s%s", goos, goarch, suffix)
 }
 
 func ghReleaseDownloadDir(release GHRelease, args []string) (string, bool) {

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -1,23 +1,23 @@
 package faketool
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-// One pull request the fake gh knows about. State is where it starts; a merge
-// through the fake moves it to MERGED. Checks are the buckets `pr checks`
-// reports, defaulting to a single pass.
+// GHPR describes one pull request and the checks its fake reports.
 type GHPR struct {
-	Number int
-	URL    string
-	Branch string
-	State  string
-	// The repo the PR lives in, which `pr list --repo` matches in any casing.
-	Repo string
-	// The repo the head branch lives in, for a PR opened from a fork. Defaults to
-	// Repo, which is the same-repo case.
+	Number   int
+	URL      string
+	Branch   string
+	State    string
+	Repo     string
 	HeadRepo string
 	Checks   []string
 }
@@ -29,122 +29,297 @@ type GHRepo struct {
 	Raw           string
 }
 
-// A fake gh whose pull requests carry their own state, so `pr view` answers
-// MERGED after `pr merge` rather than repeating whatever it said before.
-// FIDELITY.md records this against the real tool.
-type GH struct {
-	PRs   []GHPR
-	Repos []GHRepo
-	Log   string
+// GHRelease describes the read and download operations used by self-update.
+type GHRelease struct {
+	Tag        string
+	Notes      string
+	FixtureDir string
 }
 
-// Writes the fake into bin, which Bin has put on PATH.
+// GHResponse provides a deliberately fixed result for one modeled gh command.
+type GHResponse struct {
+	Command string
+	Repo    string
+	Stdout  string
+	Stderr  string
+	Exit    int
+	Copy    *GHCopy
+}
+
+type GHCopy struct {
+	Source string
+	Dest   string
+}
+
+// GH models the pull-request and release calls made by hand.
+type GH struct {
+	PRs                 []GHPR
+	Repos               []GHRepo
+	Release             GHRelease
+	Responses           []GHResponse
+	RejectQualifiedHead bool
+	Log                 string
+}
+
+type ghSpec struct {
+	PRs                 []GHPR
+	Repos               []GHRepo
+	Release             GHRelease
+	Responses           []GHResponse
+	RejectQualifiedHead bool
+	StateDir            string
+	Log                 string
+}
+
 func (g GH) Install(t *testing.T, bin string) {
 	t.Helper()
 	state := stateDir(t, bin, "gh")
-	stateFile := func(i int) string { return quote(fmt.Sprintf("%s/pr%d", state, i)) }
-
-	// gh takes a URL or a number here, either of which resolves to the same PR.
-	var byRef, checks strings.Builder
 	for i, pr := range g.PRs {
-		for _, ref := range []string{pr.URL, fmt.Sprintf("%d", pr.Number)} {
-			if ref == "" || ref == "0" {
-				continue
-			}
-			fmt.Fprintf(&byRef, "    %s) f=%s ;;\n", quote(ref), stateFile(i))
-			fmt.Fprintf(&checks, "    %s) printf '%s\\n' ;;\n", quote(ref), ghBuckets(pr.Checks))
+		if pr.State == "" {
+			pr.State = "OPEN"
+		}
+		path := ghStatePath(state, i)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			writeFile(t, path, pr.State+"\n")
+		} else if err != nil {
+			t.Fatal(err)
 		}
 	}
+	installConfig(t, bin, "gh", "gh", ghSpec{
+		PRs: g.PRs, Repos: g.Repos, Release: g.Release, Responses: g.Responses,
+		RejectQualifiedHead: g.RejectQualifiedHead, StateDir: state, Log: g.Log,
+	})
+}
 
-	var repoView strings.Builder
-	for _, repo := range g.Repos {
-		if repo.Requested == "" {
+func runGHFromPayload(payload json.RawMessage, args []string) int {
+	var spec ghSpec
+	if err := json.Unmarshal(payload, &spec); err != nil {
+		return fail("decode gh config: %v", err)
+	}
+	if spec.Log != "" {
+		if err := appendInvocation(spec.Log, "gh", args); err != nil {
+			return fail("log gh invocation: %v", err)
+		}
+	}
+	if len(args) < 2 {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	command := args[0] + " " + args[1]
+	if command == "pr list" && spec.RejectQualifiedHead && strings.Contains(flagValue(args, "--head"), ":") {
+		return fail("qualified head ref matches nothing in real gh: %s", flagValue(args, "--head"))
+	}
+	for _, response := range spec.Responses {
+		if response.Command != command {
+			continue
+		}
+		if response.Repo != "" && !strings.EqualFold(response.Repo, flagValue(args, "--repo")) {
+			continue
+		}
+		if response.Copy != nil {
+			data, err := os.ReadFile(response.Copy.Source)
+			if err != nil {
+				return fail("read gh copy source: %v", err)
+			}
+			if err := atomicWrite(response.Copy.Dest, string(data)); err != nil {
+				return fail("write gh copy destination: %v", err)
+			}
+		}
+		_, _ = io.WriteString(os.Stdout, response.Stdout)
+		_, _ = io.WriteString(os.Stderr, response.Stderr)
+		return response.Exit
+	}
+	switch command {
+	case "repo view":
+		return ghRepoView(spec, args)
+	case "pr view":
+		return ghPRView(spec, args)
+	case "pr list":
+		return ghPRList(spec, args)
+	case "pr checks":
+		return ghPRChecks(spec, args)
+	case "pr merge":
+		return ghPRMerge(spec, args)
+	case "release view":
+		return ghReleaseView(spec, args)
+	case "release download":
+		return ghReleaseDownload(spec, args)
+	default:
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+}
+
+func ghRepoView(spec ghSpec, args []string) int {
+	if len(args) != 5 || args[3] != "--json" || args[4] != "nameWithOwner,url" {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	for _, repo := range spec.Repos {
+		if !strings.EqualFold(repo.Requested, args[2]) {
 			continue
 		}
 		body := repo.Raw
 		if body == "" {
 			body = fmt.Sprintf(`{"nameWithOwner":%s,"url":%s}`, jsonQuote(repo.NameWithOwner), jsonQuote(repo.URL))
 		}
-		fmt.Fprintf(&repoView, "    %s) printf '%%s\\n' %s ;;\n", quote(repo.Requested), quote(body))
+		_, _ = fmt.Fprintln(os.Stdout, body)
+		return 0
 	}
+	return fail("repository not found: %s", args[2])
+}
 
-	// One block per PR rather than one per branch, because --repo narrows the search
-	// independently of --head: a fork project searches two repos for the same branch
-	// and has to see a different answer from each.
-	var list strings.Builder
-	list.WriteString("    branch=$(argval --head \"$@\")\n    repo=$(argval --repo \"$@\")\n    printf '['\n    sep=\"\"\n")
-	for i, pr := range g.PRs {
-		if pr.Branch == "" {
+func ghPRView(spec ghSpec, args []string) int {
+	if len(args) < 3 {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	index, ok := ghPRIndex(spec.PRs, args[2])
+	if !ok {
+		return fail("no such pull request: %s", args[2])
+	}
+	state, err := os.ReadFile(ghStatePath(spec.StateDir, index))
+	if err != nil {
+		return fail("read gh pull request state: %v", err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "{\"state\":%s}\n", jsonQuote(strings.TrimSpace(string(state))))
+	return 0
+}
+
+func ghPRList(spec ghSpec, args []string) int {
+	branch := flagValue(args, "--head")
+	repo := flagValue(args, "--repo")
+	var out strings.Builder
+	out.WriteByte('[')
+	sep := ""
+	for i, pr := range spec.PRs {
+		if pr.Branch == "" || pr.Branch != branch {
 			continue
 		}
-		repo := pr.Repo
-		if repo == "" {
-			repo = "owner/repo"
+		prRepo := pr.Repo
+		if prRepo == "" {
+			prRepo = "owner/repo"
+		}
+		if repo != "" && !strings.EqualFold(repo, prRepo) {
+			continue
 		}
 		headRepo := pr.HeadRepo
 		if headRepo == "" {
-			headRepo = repo
+			headRepo = prRepo
 		}
-		fmt.Fprintf(&list, `    if [ "$branch" = %[1]s ] && { [ -z "$repo" ] || anycase %[2]s "$repo"; }; then
-      read s < %[3]s
-      printf '%%s{"number":%[4]d,"url":%[5]s,"state":"%%s","headRepository":{"id":"R_1","name":%[6]s,"nameWithOwner":%[7]s}}' "$sep" "$s"
-      sep=","
-    fi
-`, quote(pr.Branch), quote(anyCasePattern(repo)), stateFile(i), pr.Number,
-			jsonQuote(pr.URL), jsonQuote(repoName(headRepo)), jsonQuote(headRepo))
-	}
-	// An empty result is exit 0 with an empty array, not a failure: a branch with no
-	// PR is the ordinary case teardown's landed-work check has to handle.
-	list.WriteString("    printf ']\\n'\n")
-
-	prelude := "argval() { flag=\"$1\"; shift; while [ $# -gt 0 ]; do if [ \"$1\" = \"$flag\" ]; then echo \"$2\"; return; fi; shift; done; }\n" +
-		// GitHub serves a repo under any casing of its slug, so a case-sensitive match
-		// would answer a double search of one repo with one hit and hide the duplicate
-		// the real gh returns.
-		"anycase() { case \"$2\" in $1) return 0 ;; esac; return 1; }\n"
-	body := fmt.Sprintf(`  "repo view")
-    case "$3" in
-%[1]s    *) echo "repository not found: $3" >&2; exit 1 ;;
-    esac
-    ;;
-  "pr view")
-    f=""
-    case "$3" in
-%[2]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
-    esac
-    read s < "$f"
-    printf '{"state":"%%s"}\n' "$s"
-    ;;
-  "pr list")
-%[3]s    ;;
-  "pr checks")
-    case "$3" in
-%[4]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
-    esac
-    ;;
-  "pr merge")
-    f=""
-    case "$3" in
-%[2]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
-    esac
-    read s < "$f"
-    if [ "$s" = MERGED ]; then
-      echo "! Pull request $3 was already merged" >&2
-      exit 0
-    fi
-    echo MERGED > "$f"
-    printf '%%s merged\n' "$3"
-	    ;;`, repoView.String(), byRef.String(), list.String(), checks.String())
-
-	install(t, bin, "gh", g.Log, prelude, "$1 $2", body)
-
-	for i, pr := range g.PRs {
-		s := pr.State
-		if s == "" {
-			s = "OPEN"
+		state, err := os.ReadFile(ghStatePath(spec.StateDir, i))
+		if err != nil {
+			return fail("read gh pull request state: %v", err)
 		}
-		writeFile(t, fmt.Sprintf("%s/pr%d", state, i), s+"\n")
+		fmt.Fprintf(&out, "%s{\"number\":%d,\"url\":%s,\"state\":%s,\"headRepository\":{\"id\":\"R_1\",\"name\":%s,\"nameWithOwner\":%s}}",
+			sep, pr.Number, jsonQuote(pr.URL), jsonQuote(strings.TrimSpace(string(state))),
+			jsonQuote(repoName(headRepo)), jsonQuote(headRepo))
+		sep = ","
 	}
+	out.WriteString("]\n")
+	_, _ = io.WriteString(os.Stdout, out.String())
+	return 0
+}
+
+func ghPRChecks(spec ghSpec, args []string) int {
+	if len(args) < 3 {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	index, ok := ghPRIndex(spec.PRs, args[2])
+	if !ok {
+		return fail("no such pull request: %s", args[2])
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n", ghBuckets(spec.PRs[index].Checks))
+	return 0
+}
+
+func ghPRMerge(spec ghSpec, args []string) int {
+	if len(args) < 3 {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	index, ok := ghPRIndex(spec.PRs, args[2])
+	if !ok {
+		return fail("no such pull request: %s", args[2])
+	}
+	path := ghStatePath(spec.StateDir, index)
+	state, err := os.ReadFile(path)
+	if err != nil {
+		return fail("read gh pull request state: %v", err)
+	}
+	if strings.TrimSpace(string(state)) == "MERGED" {
+		_, _ = fmt.Fprintf(os.Stderr, "! Pull request %s was already merged\n", args[2])
+		return 0
+	}
+	if err := atomicWrite(path, "MERGED\n"); err != nil {
+		return fail("write gh pull request state: %v", err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "%s merged\n", args[2])
+	return 0
+}
+
+func ghReleaseView(spec ghSpec, args []string) int {
+	if spec.Release.Tag == "" && spec.Release.Notes == "" {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	jq := flagValue(args, "--jq")
+	switch jq {
+	case ".tagName":
+		_, _ = io.WriteString(os.Stdout, spec.Release.Tag)
+	case ".body":
+		_, _ = io.WriteString(os.Stdout, spec.Release.Notes)
+	default:
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	return 0
+}
+
+func ghReleaseDownload(spec ghSpec, args []string) int {
+	if spec.Release.FixtureDir == "" {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	dir := flagValue(args, "--dir")
+	if dir == "" {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	entries, err := os.ReadDir(spec.Release.FixtureDir)
+	if err != nil {
+		return fail("read gh release fixture: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fail("create gh release directory: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		source := filepath.Join(spec.Release.FixtureDir, entry.Name())
+		target := filepath.Join(dir, entry.Name())
+		in, err := os.Open(source)
+		if err != nil {
+			return fail("open gh release fixture: %v", err)
+		}
+		out, err := os.Create(target)
+		if err != nil {
+			_ = in.Close()
+			return fail("create gh release asset: %v", err)
+		}
+		_, copyErr := io.Copy(out, in)
+		closeOutErr := out.Close()
+		closeInErr := in.Close()
+		if copyErr != nil || closeOutErr != nil || closeInErr != nil {
+			return fail("copy gh release asset: %v", firstError(copyErr, closeOutErr, closeInErr))
+		}
+	}
+	return 0
+}
+
+func ghPRIndex(prs []GHPR, ref string) (int, bool) {
+	for i, pr := range prs {
+		if ref == pr.URL || ref == strconv.Itoa(pr.Number) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func ghStatePath(dir string, index int) string {
+	return filepath.Join(dir, fmt.Sprintf("pr%d", index))
 }
 
 func ghBuckets(checks []string) string {
@@ -153,26 +328,18 @@ func ghBuckets(checks []string) string {
 	}
 	items := make([]string, len(checks))
 	for i, bucket := range checks {
-		items[i] = `{"bucket":"` + bucket + `"}`
+		items[i] = "{\"bucket\":" + jsonQuote(bucket) + "}"
 	}
 	return "[" + strings.Join(items, ",") + "]"
 }
 
-// A glob matching s in any casing, since POSIX sh has no case conversion and the
-// hermetic PATH in tests/e2e has no tr.
-func anyCasePattern(s string) string {
-	var b strings.Builder
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z':
-			b.WriteString("[" + string(r-32) + string(r) + "]")
-		case r >= 'A' && r <= 'Z':
-			b.WriteString("[" + string(r) + string(r+32) + "]")
-		default:
-			b.WriteRune(r)
+func flagValue(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
 		}
 	}
-	return b.String()
+	return ""
 }
 
 func repoName(slug string) string {
@@ -180,4 +347,17 @@ func repoName(slug string) string {
 		return name
 	}
 	return slug
+}
+
+func jsonQuote(s string) string {
+	return strconv.Quote(s)
+}
+
+func firstError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/faketool/gh_test.go
+++ b/internal/faketool/gh_test.go
@@ -208,3 +208,60 @@ func TestGHRefusesAPRItDoesNotKnow(t *testing.T) {
 		}
 	}
 }
+
+func TestGHReleaseRefusesUnexpectedInvocationShapes(t *testing.T) {
+	fixture := t.TempDir()
+	for _, name := range []string{"asset.tar.gz", "checksums.txt", "unexpected.txt"} {
+		if err := os.WriteFile(filepath.Join(fixture, name), []byte(name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	GH{Release: GHRelease{
+		Tag:        "v1.2.3",
+		FixtureDir: fixture,
+		Patterns:   []string{"asset.tar.gz", "checksums.txt"},
+	}}.Install(t, Bin(t))
+
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"release", "view", "--json", "tagName", "--jq", ".tagName"},
+		{"release", "view", "wrong-tag", "--repo", "atqamz/hand", "--json", "body", "--jq", ".body"},
+		{"release", "view", "--repo", "atqamz/hand", "--json", "body", "--jq", ".tagName"},
+		{"release", "download", "v1.2.3", "--repo", "other/repo", "--dir", dir, "--clobber", "--pattern", "asset.tar.gz", "--pattern", "checksums.txt"},
+		{"release", "download", "v1.2.3", "--repo", "atqamz/hand", "--dir", dir, "--pattern", "asset.tar.gz", "--pattern", "checksums.txt"},
+		{"release", "download", "v1.2.3", "--repo", "atqamz/hand", "--dir", dir, "--clobber", "--pattern", "unexpected.txt", "--pattern", "checksums.txt"},
+	} {
+		_, errOut, code := runGH(t, args...)
+		if code == 0 || !strings.Contains(errOut, "unexpected gh invocation") {
+			t.Errorf("gh %v = %q (exit %d), want a loud refusal", args, errOut, code)
+		}
+	}
+}
+
+func TestGHReleaseDownloadCopiesOnlyRequestedPatterns(t *testing.T) {
+	fixture := t.TempDir()
+	for _, name := range []string{"asset.tar.gz", "checksums.txt", "unexpected.txt"} {
+		if err := os.WriteFile(filepath.Join(fixture, name), []byte(name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	GH{Release: GHRelease{
+		Tag:        "v1.2.3",
+		FixtureDir: fixture,
+		Patterns:   []string{"asset.tar.gz", "checksums.txt"},
+	}}.Install(t, Bin(t))
+
+	dir := t.TempDir()
+	_, errOut, code := runGH(t, "release", "download", "v1.2.3", "--repo", "atqamz/hand", "--dir", dir, "--clobber", "--pattern", "asset.tar.gz", "--pattern", "checksums.txt")
+	if code != 0 {
+		t.Fatalf("gh release download = %q (exit %d), want success", errOut, code)
+	}
+	for _, name := range []string{"asset.tar.gz", "checksums.txt"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("downloaded %s: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "unexpected.txt")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected asset stat error = %v, want file absent", err)
+	}
+}

--- a/internal/faketool/gh_test.go
+++ b/internal/faketool/gh_test.go
@@ -238,6 +238,31 @@ func TestGHReleaseRefusesUnexpectedInvocationShapes(t *testing.T) {
 	}
 }
 
+func TestGHReleaseDefaultAssetNameMatchesSelfUpdateContract(t *testing.T) {
+	for _, tt := range []struct {
+		goos, goarch, want string
+	}{
+		{goos: "linux", goarch: "amd64", want: "hand-linux-amd64.tar.gz"},
+		{goos: "darwin", goarch: "arm64", want: "hand-darwin-arm64.tar.gz"},
+		{goos: "windows", goarch: "amd64", want: "hand-windows-amd64.zip"},
+	} {
+		if got := ghReleaseAssetName(tt.goos, tt.goarch); got != tt.want {
+			t.Errorf("ghReleaseAssetName(%q, %q) = %q, want %q", tt.goos, tt.goarch, got, tt.want)
+		}
+	}
+	for _, tt := range []struct {
+		goos, goarch string
+		want         []string
+	}{
+		{goos: "linux", goarch: "amd64", want: []string{"hand-linux-amd64.tar.gz", "checksums.txt"}},
+		{goos: "windows", goarch: "amd64", want: []string{"hand-windows-amd64.zip", "checksums.txt"}},
+	} {
+		if got := ghReleasePatternsFor(GHRelease{}, tt.goos, tt.goarch); !sameArgs(got, tt.want) {
+			t.Errorf("ghReleasePatternsFor(%q, %q) = %v, want %v", tt.goos, tt.goarch, got, tt.want)
+		}
+	}
+}
+
 func TestGHReleaseDownloadCopiesOnlyRequestedPatterns(t *testing.T) {
 	fixture := t.TempDir()
 	for _, name := range []string{"asset.tar.gz", "checksums.txt", "unexpected.txt"} {

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -1,274 +1,662 @@
 package faketool
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
-// One tab of a fake herdr workspace, with the pane herdr creates alongside it.
+// HerdrTab describes a tab and the pane herdr creates with it.
 type HerdrTab struct {
 	ID    string
 	Label string
 	Pane  string
 }
 
-// A workspace of the fake herdr, live from installation when listed in
-// Herdr.Workspaces and from the matching call when listed in Herdr.Creates.
+// HerdrWorkspace describes one workspace and its tabs.
 type HerdrWorkspace struct {
 	ID    string
 	Label string
 	Tabs  []HerdrTab
 }
 
-// A fake herdr whose workspaces, tabs and panes are created and closed by the
-// commands that create and close them, so closing one is visible to every later
-// list, get and close. FIDELITY.md records this against the real tool.
-type Herdr struct {
-	Workspaces []HerdrWorkspace
-	// Handed out by "workspace create", one per call in order.
-	Creates []HerdrWorkspace
-	// Handed out by "tab create", one per call, attached to the workspace asked for.
-	TabCreates  []HerdrTab
-	PaneAgent   string
-	PaneStatus  string
-	PaneReadOut string
-	Log         string
+// HerdrResponse overrides one command while keeping the shared executable and
+// invocation logging. It is useful for deliberately malformed or failed calls.
+type HerdrResponse struct {
+	Command string
+	Args    []string
+	Stdout  string
+	Stderr  string
+	Exit    int
 }
 
-// Frame "pane read" answers with when a test names none: a settled Claude Code
-// prompt with no first-run dialog on it, which is what confirmLaunch waits for.
-const herdrDefaultPaneRead = "Welcome to Claude Code\\n> \\n  ? for shortcuts\\n"
+// HerdrFrame supplies successive pane get/read observations.
+type HerdrFrame struct {
+	Text   string
+	Agent  string
+	Status string
+}
+
+// Herdr models workspace, tab and pane state changes made by hand.
+type Herdr struct {
+	Workspaces         []HerdrWorkspace
+	Creates            []HerdrWorkspace
+	TabCreates         []HerdrTab
+	PaneAgent          string
+	PaneStatus         string
+	PaneStatusSequence []string
+	PaneReadOut        string
+	PaneStatusFile     string
+	Frames             []HerdrFrame
+	Responses          []HerdrResponse
+	Hang               []string
+	Unreachable        bool
+	KeyLog             string
+	TextLog            string
+	Log                string
+	LogCommands        []string
+	PaneAgentEnv       bool
+	PaneReadFileEnv    bool
+	KeyLogEnv          bool
+	TextLogEnv         bool
+	ReadLogEnv         bool
+	AllowUnknownPane   bool
+}
+
+const herdrDefaultPaneRead = "Welcome to Claude Code\n> \n  ? for shortcuts\n"
+
+type herdrSpec struct {
+	Workspaces         []HerdrWorkspace
+	Creates            []HerdrWorkspace
+	TabCreates         []HerdrTab
+	PaneAgent          string
+	PaneStatus         string
+	PaneStatusSequence []string
+	PaneReadOut        string
+	PaneStatusFile     string
+	Frames             []HerdrFrame
+	Responses          []HerdrResponse
+	Hang               []string
+	Unreachable        bool
+	KeyLog             string
+	TextLog            string
+	StateDir           string
+	Log                string
+	LogCommands        []string
+	PaneAgentEnv       bool
+	PaneReadFileEnv    bool
+	KeyLogEnv          bool
+	TextLogEnv         bool
+	ReadLogEnv         bool
+	AllowUnknownPane   bool
+}
 
 type herdrTabRef struct {
-	tab   HerdrTab
-	index int
+	Tab   HerdrTab
+	Index int
 }
 
-// Writes the fake into bin, which Bin has put on PATH.
 func (h Herdr) Install(t *testing.T, bin string) {
 	t.Helper()
 	state := stateDir(t, bin, "herdr")
+	workspaces := append(append([]HerdrWorkspace{}, h.Workspaces...), h.Creates...)
+	tabs := herdrTabs(workspaces, h.TabCreates)
+	for i, ws := range h.Workspaces {
+		ensureFile(t, herdrWorkspacePath(state, i), "live\n")
+		ensureFile(t, herdrLabelPath(state, "w", i), ws.Label+"\n")
+		for _, tab := range ws.Tabs {
+			ref := herdrTabIndex(tabs, tab.ID)
+			ensureFile(t, herdrTabPath(state, ref.Index), ws.ID+"\n")
+			ensureFile(t, herdrLabelPath(state, "t", ref.Index), tab.Label+"\n")
+		}
+	}
+	installConfig(t, bin, "herdr", "herdr", herdrSpec{
+		Workspaces: h.Workspaces, Creates: h.Creates, TabCreates: h.TabCreates,
+		PaneAgent: h.PaneAgent, PaneStatus: h.PaneStatus, PaneReadOut: h.PaneReadOut,
+		PaneStatusSequence: h.PaneStatusSequence,
+		PaneStatusFile:     h.PaneStatusFile, Frames: h.Frames, Responses: h.Responses,
+		Hang: h.Hang, Unreachable: h.Unreachable, KeyLog: h.KeyLog, TextLog: h.TextLog,
+		StateDir: state, Log: h.Log, LogCommands: h.LogCommands,
+		PaneAgentEnv: h.PaneAgentEnv, PaneReadFileEnv: h.PaneReadFileEnv,
+		KeyLogEnv: h.KeyLogEnv, TextLogEnv: h.TextLogEnv,
+		ReadLogEnv: h.ReadLogEnv, AllowUnknownPane: h.AllowUnknownPane,
+	})
+}
 
-	agent, status, paneRead := h.PaneAgent, h.PaneStatus, h.PaneReadOut
-	if agent == "" {
-		agent = "claude"
+func runHerdrFromPayload(payload json.RawMessage, args []string) int {
+	var spec herdrSpec
+	if err := json.Unmarshal(payload, &spec); err != nil {
+		return fail("decode herdr config: %v", err)
+	}
+	if spec.Log != "" && (len(spec.LogCommands) == 0 || containsString(spec.LogCommands, commandName(args))) {
+		if err := appendInvocation(spec.Log, "herdr", args); err != nil {
+			return fail("log herdr invocation: %v", err)
+		}
+	}
+	if len(args) < 2 {
+		return fail("unexpected herdr invocation: %s", strings.Join(args, " "))
+	}
+	command := args[0] + " " + args[1]
+	for _, blocked := range spec.Hang {
+		if blocked == command {
+			for {
+				time.Sleep(time.Hour)
+			}
+		}
+	}
+	if spec.Unreachable {
+		return 1
+	}
+	for _, response := range spec.Responses {
+		if response.Command == command && (response.Args == nil || sameArgs(response.Args, args[2:])) {
+			_, _ = io.WriteString(os.Stdout, response.Stdout)
+			_, _ = io.WriteString(os.Stderr, response.Stderr)
+			return response.Exit
+		}
+	}
+	return runHerdrState(spec, command, args)
+}
+
+func commandName(args []string) string {
+	if len(args) < 2 {
+		return strings.Join(args, " ")
+	}
+	return args[0] + " " + args[1]
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func runHerdrState(spec herdrSpec, command string, args []string) int {
+	workspaces := append(append([]HerdrWorkspace{}, spec.Workspaces...), spec.Creates...)
+	tabs := herdrTabs(workspaces, spec.TabCreates)
+	switch command {
+	case "workspace list":
+		return herdrWorkspaceList(spec, workspaces)
+	case "workspace create":
+		return herdrWorkspaceCreate(spec, workspaces, tabs, args)
+	case "workspace close":
+		return herdrWorkspaceClose(spec, workspaces, tabs, args)
+	case "tab list":
+		return herdrTabList(spec, workspaces, tabs, args)
+	case "tab create":
+		return herdrTabCreate(spec, workspaces, tabs, args)
+	case "tab rename":
+		return herdrTabRename(spec, tabs, args)
+	case "tab close":
+		return herdrTabClose(spec, workspaces, tabs, args)
+	case "pane get":
+		return herdrPaneGet(spec, tabs, args)
+	case "pane read":
+		return herdrPaneRead(spec, tabs, args)
+	case "pane run", "pane send-text", "pane send-keys":
+		return herdrPaneVoid(spec, tabs, command, args)
+	default:
+		return fail("unexpected herdr invocation: %s", strings.Join(args, " "))
+	}
+}
+
+func herdrWorkspaceList(spec herdrSpec, workspaces []HerdrWorkspace) int {
+	var out strings.Builder
+	out.WriteString("{\"id\":\"cli:workspace:list\",\"result\":{\"type\":\"workspace_list\",\"workspaces\":[")
+	sep := ""
+	for i, ws := range workspaces {
+		if !herdrLive(spec.StateDir, herdrWorkspacePath(spec.StateDir, i)) {
+			continue
+		}
+		count := herdrWorkspaceTabCount(spec, ws.ID, workspaces, herdrTabs(workspaces, spec.TabCreates))
+		fmt.Fprintf(&out, "%s{\"workspace_id\":%s,\"label\":%s,\"tab_count\":%d,\"pane_count\":%d,\"active_tab_id\":\"\",\"agent_status\":\"unknown\",\"focused\":false,\"number\":%d}",
+			sep, jsonQuote(ws.ID), jsonQuote(herdrLabel(spec.StateDir, "w", i)), count, count, i+1)
+		sep = ","
+	}
+	out.WriteString("]}}\n")
+	_, _ = io.WriteString(os.Stdout, out.String())
+	return 0
+}
+
+func herdrWorkspaceCreate(spec herdrSpec, workspaces []HerdrWorkspace, tabs []herdrTabRef, args []string) int {
+	index := herdrCounter(spec.StateDir, "creates")
+	if index >= len(spec.Creates) {
+		return fail("the fake declares no further workspace create")
+	}
+	ws := spec.Creates[index]
+	if len(ws.Tabs) == 0 {
+		return fail("the fake workspace has no root tab")
+	}
+	root := ws.Tabs[0]
+	tab := herdrTabIndex(tabs, root.ID)
+	label := flagValue(args, "--label")
+	cwd := flagValue(args, "--cwd")
+	if err := atomicWrite(herdrCounterPath(spec.StateDir, "creates"), strconv.Itoa(index+1)+"\n"); err != nil {
+		return fail("write workspace create counter: %v", err)
+	}
+	if err := atomicWrite(herdrWorkspacePath(spec.StateDir, len(spec.Workspaces)+index), "live\n"); err != nil {
+		return fail("write workspace state: %v", err)
+	}
+	if err := atomicWrite(herdrLabelPath(spec.StateDir, "w", len(spec.Workspaces)+index), label+"\n"); err != nil {
+		return fail("write workspace label: %v", err)
+	}
+	if err := atomicWrite(herdrTabPath(spec.StateDir, tab.Index), ws.ID+"\n"); err != nil {
+		return fail("write root tab state: %v", err)
+	}
+	if err := atomicWrite(herdrLabelPath(spec.StateDir, "t", tab.Index), "1\n"); err != nil {
+		return fail("write root tab label: %v", err)
+	}
+	out := fmt.Sprintf("{\"id\":\"cli:workspace:create\",\"result\":{\"type\":\"workspace_created\",\"workspace\":{\"workspace_id\":%s,\"label\":%s,\"tab_count\":1,\"pane_count\":1,\"active_tab_id\":%s,\"agent_status\":\"unknown\",\"focused\":false,\"number\":%d},\"tab\":{\"tab_id\":%s,\"workspace_id\":%s,\"label\":\"1\",\"number\":1,\"pane_count\":1,\"agent_status\":\"unknown\",\"focused\":false},\"root_pane\":{\"pane_id\":%s,\"tab_id\":%s,\"workspace_id\":%s,\"agent\":\"\",\"agent_status\":\"unknown\",\"cwd\":%s}}}\n",
+		jsonQuote(ws.ID), jsonQuote(label), jsonQuote(root.ID), len(spec.Workspaces)+index+1,
+		jsonQuote(root.ID), jsonQuote(ws.ID), jsonQuote(root.Pane), jsonQuote(root.ID), jsonQuote(ws.ID), jsonQuote(cwd))
+	_, _ = io.WriteString(os.Stdout, out)
+	return 0
+}
+
+func herdrWorkspaceClose(spec herdrSpec, workspaces []HerdrWorkspace, tabs []herdrTabRef, args []string) int {
+	if len(args) < 3 {
+		return fail("workspace_not_found")
+	}
+	index := herdrWorkspaceIndex(workspaces, args[2])
+	if index < 0 || !herdrLive(spec.StateDir, herdrWorkspacePath(spec.StateDir, index)) {
+		return herdrError("workspace_not_found", "workspace "+args[2]+" not found", "cli:workspace:close")
+	}
+	if err := herdrCloseWorkspace(spec.StateDir, workspaces[index].ID, index, tabs); err != nil {
+		return fail("close workspace: %v", err)
+	}
+	_, _ = io.WriteString(os.Stdout, "{\"id\":\"cli:workspace:close\",\"result\":{\"type\":\"ok\"}}\n")
+	return 0
+}
+
+func herdrTabList(spec herdrSpec, workspaces []HerdrWorkspace, tabs []herdrTabRef, args []string) int {
+	ws := flagValue(args, "--workspace")
+	if herdrWorkspaceIndexLive(spec, workspaces, ws) < 0 {
+		return herdrError("workspace_not_found", "workspace "+ws+" not found", "cli:tab:list")
+	}
+	var out strings.Builder
+	out.WriteString("{\"id\":\"cli:tab:list\",\"result\":{\"type\":\"tab_list\",\"tabs\":[")
+	sep := ""
+	for _, ref := range tabs {
+		owner, ok := herdrTabWorkspace(spec, ref)
+		if !ok || owner != ws {
+			continue
+		}
+		fmt.Fprintf(&out, "%s{\"tab_id\":%s,\"workspace_id\":%s,\"label\":%s,\"number\":%d,\"pane_count\":1,\"agent_status\":\"unknown\",\"focused\":false}",
+			sep, jsonQuote(ref.Tab.ID), jsonQuote(ws), jsonQuote(herdrLabel(spec.StateDir, "t", ref.Index)), ref.Index+1)
+		sep = ","
+	}
+	out.WriteString("]}}\n")
+	_, _ = io.WriteString(os.Stdout, out.String())
+	return 0
+}
+
+func herdrTabCreate(spec herdrSpec, workspaces []HerdrWorkspace, tabs []herdrTabRef, args []string) int {
+	ws := flagValue(args, "--workspace")
+	if herdrWorkspaceIndexLive(spec, workspaces, ws) < 0 {
+		return herdrError("workspace_not_found", "workspace "+ws+" not found", "cli:tab:create")
+	}
+	index := herdrCounter(spec.StateDir, "tabcreates")
+	if index >= len(spec.TabCreates) {
+		return fail("the fake declares no further tab create")
+	}
+	tab := spec.TabCreates[index]
+	ref := herdrTabIndex(tabs, tab.ID)
+	if err := atomicWrite(herdrCounterPath(spec.StateDir, "tabcreates"), strconv.Itoa(index+1)+"\n"); err != nil {
+		return fail("write tab create counter: %v", err)
+	}
+	if err := atomicWrite(herdrTabPath(spec.StateDir, ref.Index), ws+"\n"); err != nil {
+		return fail("write tab state: %v", err)
+	}
+	label := flagValue(args, "--label")
+	if err := atomicWrite(herdrLabelPath(spec.StateDir, "t", ref.Index), label+"\n"); err != nil {
+		return fail("write tab label: %v", err)
+	}
+	cwd := flagValue(args, "--cwd")
+	out := fmt.Sprintf("{\"id\":\"cli:tab:create\",\"result\":{\"type\":\"tab_created\",\"tab\":{\"tab_id\":%s,\"workspace_id\":%s,\"label\":%s,\"number\":%d,\"pane_count\":1,\"agent_status\":\"unknown\",\"focused\":false},\"root_pane\":{\"pane_id\":%s,\"tab_id\":%s,\"workspace_id\":%s,\"agent\":\"\",\"agent_status\":\"unknown\",\"cwd\":%s}}}\n",
+		jsonQuote(tab.ID), jsonQuote(ws), jsonQuote(label), ref.Index+1, jsonQuote(tab.Pane), jsonQuote(tab.ID), jsonQuote(ws), jsonQuote(cwd))
+	_, _ = io.WriteString(os.Stdout, out)
+	return 0
+}
+
+func herdrTabRename(spec herdrSpec, tabs []herdrTabRef, args []string) int {
+	if len(args) < 4 {
+		return herdrError("tab_not_found", "tab not found", "cli:tab:rename")
+	}
+	ref := herdrTabIndex(tabs, args[2])
+	if ref.Tab.ID == "" || !herdrLive(spec.StateDir, herdrTabPath(spec.StateDir, ref.Index)) {
+		return herdrError("tab_not_found", "tab "+args[2]+" not found", "cli:tab:rename")
+	}
+	if err := atomicWrite(herdrLabelPath(spec.StateDir, "t", ref.Index), args[3]+"\n"); err != nil {
+		return fail("write tab label: %v", err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "{\"id\":\"cli:tab:rename\",\"result\":{\"type\":\"tab_info\",\"tab\":{\"tab_id\":%s,\"workspace_id\":\"\",\"label\":%s,\"number\":1,\"pane_count\":1,\"agent_status\":\"unknown\",\"focused\":false}}}\n",
+		jsonQuote(args[2]), jsonQuote(args[3]))
+	return 0
+}
+
+func herdrTabClose(spec herdrSpec, workspaces []HerdrWorkspace, tabs []herdrTabRef, args []string) int {
+	if len(args) < 3 {
+		return herdrError("tab_not_found", "tab not found", "cli:tab:close")
+	}
+	ref := herdrTabIndex(tabs, args[2])
+	if ref.Tab.ID == "" || !herdrLive(spec.StateDir, herdrTabPath(spec.StateDir, ref.Index)) {
+		return herdrError("tab_not_found", "tab "+args[2]+" not found", "cli:tab:close")
+	}
+	owner, _ := herdrTabWorkspace(spec, ref)
+	if err := atomicWrite(herdrTabPath(spec.StateDir, ref.Index), ""); err != nil {
+		return fail("close tab: %v", err)
+	}
+	if herdrWorkspaceTabCount(spec, owner, workspaces, tabs) == 0 {
+		index := herdrWorkspaceIndex(workspaces, owner)
+		if index >= 0 {
+			if err := herdrCloseWorkspace(spec.StateDir, owner, index, tabs); err != nil {
+				return fail("close workspace after tab close: %v", err)
+			}
+		}
+	}
+	_, _ = io.WriteString(os.Stdout, "{\"id\":\"cli:tab:close\",\"result\":{\"type\":\"ok\"}}\n")
+	return 0
+}
+
+func herdrPaneGet(spec herdrSpec, tabs []herdrTabRef, args []string) int {
+	if len(args) < 3 {
+		return herdrError("pane_not_found", "pane not found", "cli:pane:get")
+	}
+	ref := herdrPaneRef(spec, tabs, args[2])
+	if ref.Tab.ID == "" && !spec.AllowUnknownPane {
+		return herdrError("pane_not_found", "pane "+args[2]+" not found", "cli:pane:get")
+	}
+	status := spec.PaneStatus
+	if spec.PaneStatusFile != "" {
+		if data, err := os.ReadFile(spec.PaneStatusFile); err == nil {
+			status = strings.TrimSpace(string(data))
+		}
+	}
+	if len(spec.PaneStatusSequence) > 0 {
+		index := herdrStatusAdvance(spec.StateDir, len(spec.PaneStatusSequence))
+		status = spec.PaneStatusSequence[index]
 	}
 	if status == "" {
 		status = "working"
 	}
-	if paneRead == "" {
-		paneRead = herdrDefaultPaneRead
+	if status == "pane-gone" {
+		_, _ = io.WriteString(os.Stdout, "{\"id\":\"cli:1\",\"error\":{\"code\":\"not_found\",\"message\":\"pane "+args[2]+" not found\"}}")
+		return 0
 	}
+	agent := spec.PaneAgent
+	if spec.PaneAgentEnv {
+		agent = os.Getenv("PANE_AGENT")
+	}
+	if len(spec.Frames) > 0 {
+		index := herdrFrameAdvance(spec.StateDir, len(spec.Frames))
+		frame := spec.Frames[index]
+		agent, status = frame.Agent, frame.Status
+		if status == "" {
+			status = "idle"
+		}
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "{\"id\":\"cli:pane:get\",\"result\":{\"type\":\"pane_info\",\"pane\":{\"pane_id\":%s,\"tab_id\":%s,\"workspace_id\":\"\",\"agent\":%s,\"agent_status\":%s}}}\n",
+		jsonQuote(args[2]), jsonQuote(ref.Tab.ID), jsonQuote(agent), jsonQuote(status))
+	return 0
+}
 
-	wsFile := func(i int) string { return quote(fmt.Sprintf("%s/w%d", state, i)) }
-	wsLabel := func(i int) string { return quote(fmt.Sprintf("%s/w%d.label", state, i)) }
-	tabFile := func(j int) string { return quote(fmt.Sprintf("%s/t%d", state, j)) }
-	tabLabel := func(j int) string { return quote(fmt.Sprintf("%s/t%d.label", state, j)) }
+func herdrPaneRead(spec herdrSpec, tabs []herdrTabRef, args []string) int {
+	if len(args) < 3 {
+		return herdrError("pane_not_found", "pane not found", "cli:pane:read")
+	}
+	if herdrPaneRef(spec, tabs, args[2]).Tab.ID == "" && !spec.AllowUnknownPane {
+		return herdrError("pane_not_found", "pane "+args[2]+" not found", "cli:pane:read")
+	}
+	read := spec.PaneReadOut
+	if spec.ReadLogEnv {
+		if path := os.Getenv("PANE_LOG"); path != "" {
+			if err := appendLine(path, "read"); err != nil {
+				return fail("log pane read: %v", err)
+			}
+		}
+	}
+	if spec.PaneReadFileEnv {
+		path := os.Getenv("PANE_TEXT_FILE")
+		if path == "" {
+			read = ""
+		} else if data, err := os.ReadFile(path); err == nil {
+			read = string(data)
+		}
+	}
+	if len(spec.Frames) > 0 {
+		index := herdrFrameCurrent(spec.StateDir, len(spec.Frames))
+		read = spec.Frames[index].Text
+	}
+	if read == "" {
+		read = herdrDefaultPaneRead
+	}
+	_, _ = io.WriteString(os.Stdout, read)
+	return 0
+}
 
-	workspaces := append(append([]HerdrWorkspace{}, h.Workspaces...), h.Creates...)
+func herdrPaneVoid(spec herdrSpec, tabs []herdrTabRef, command string, args []string) int {
+	if len(args) < 3 || herdrPaneRef(spec, tabs, args[2]).Tab.ID == "" {
+		return herdrError("pane_not_found", "pane not found", "cli:request")
+	}
+	keyLog := spec.KeyLog
+	if spec.KeyLogEnv {
+		keyLog = os.Getenv("PANE_LOG")
+	}
+	textLog := spec.TextLog
+	if spec.TextLogEnv {
+		textLog = os.Getenv("PANE_LOG")
+	}
+	if command == "pane send-keys" && keyLog != "" && len(args) > 3 {
+		entry := strings.Join(args[3:], " ")
+		if spec.KeyLogEnv {
+			entry = "send-keys " + entry
+		}
+		if err := appendLine(keyLog, entry); err != nil {
+			return fail("log pane keys: %v", err)
+		}
+	}
+	if command == "pane send-text" && textLog != "" && len(args) > 3 {
+		entry := args[3]
+		if spec.TextLogEnv {
+			entry = "send-text " + entry
+		}
+		if err := appendLine(textLog, entry); err != nil {
+			return fail("log pane text: %v", err)
+		}
+	}
+	return 0
+}
+
+func herdrError(code, message, id string) int {
+	_, _ = fmt.Fprintf(os.Stderr, "{\"error\":{\"code\":%s,\"message\":%s},\"id\":%s}\n", jsonQuote(code), jsonQuote(message), jsonQuote(id))
+	return 1
+}
+
+func herdrTabs(workspaces []HerdrWorkspace, creates []HerdrTab) []herdrTabRef {
 	var tabs []herdrTabRef
 	for _, ws := range workspaces {
 		for _, tab := range ws.Tabs {
-			tabs = append(tabs, herdrTabRef{tab: tab, index: len(tabs)})
+			tabs = append(tabs, herdrTabRef{Tab: tab, Index: len(tabs)})
 		}
 	}
-	tabIndex := map[string]int{}
+	for _, tab := range creates {
+		tabs = append(tabs, herdrTabRef{Tab: tab, Index: len(tabs)})
+	}
+	return tabs
+}
+
+func herdrTabIndex(tabs []herdrTabRef, id string) herdrTabRef {
 	for _, ref := range tabs {
-		tabIndex[ref.tab.ID] = ref.index
-	}
-	for _, tab := range h.TabCreates {
-		tabs = append(tabs, herdrTabRef{tab: tab, index: len(tabs)})
-		tabIndex[tab.ID] = len(tabs) - 1
-	}
-
-	var prelude strings.Builder
-	prelude.WriteString(`err() { printf '{"error":{"code":"%s","message":"%s"},"id":"cli:fake"}\n' "$1" "$2" >&2; exit 1; }
-argval() { flag="$1"; shift; while [ $# -gt 0 ]; do if [ "$1" = "$flag" ]; then echo "$2"; return; fi; shift; done; }
-bump() { n=0; [ -s "$1" ] && read n < "$1"; n=$((n+1)); echo "$n" > "$1"; }
-count_tabs() { n=0
-`)
-	for _, ref := range tabs {
-		fmt.Fprintf(&prelude, "  if [ -s %s ]; then read x < %s; [ \"$x\" = \"$1\" ] && n=$((n+1)); fi\n",
-			tabFile(ref.index), tabFile(ref.index))
-	}
-	prelude.WriteString("}\nclose_ws() { case \"$1\" in\n")
-	for i, ws := range workspaces {
-		fmt.Fprintf(&prelude, "  %s) : > %s ;;\n", quote(ws.ID), wsFile(i))
-	}
-	prelude.WriteString("esac\n")
-	for _, ref := range tabs {
-		fmt.Fprintf(&prelude, "  if [ -s %s ]; then read x < %s; [ \"$x\" = \"$1\" ] && : > %s; fi\n",
-			tabFile(ref.index), tabFile(ref.index), tabFile(ref.index))
-	}
-	prelude.WriteString("}\nlist_tabs() { sep=\"\"\n")
-	for _, ref := range tabs {
-		fmt.Fprintf(&prelude, `  if [ -s %[1]s ]; then read tws < %[1]s
-    if [ "$tws" = "$1" ]; then tl=""; [ -s %[2]s ] && read tl < %[2]s
-      printf '%%s{"tab_id":%[3]s,"workspace_id":"%%s","label":"%%s","number":%[4]d,"pane_count":1,"agent_status":"unknown","focused":false}' "$sep" "$tws" "$tl"
-      sep=","
-    fi
-  fi
-`, tabFile(ref.index), tabLabel(ref.index), jsonQuote(ref.tab.ID), ref.index+1)
-	}
-	prelude.WriteString("}\n")
-
-	var body strings.Builder
-
-	body.WriteString(`  "workspace list")
-    printf '{"id":"cli:workspace:list","result":{"type":"workspace_list","workspaces":['
-    sep=""
-`)
-	for i, ws := range workspaces {
-		fmt.Fprintf(&body, `    if [ -s %[1]s ]; then
-      wl=""; [ -s %[2]s ] && read wl < %[2]s
-      count_tabs %[3]s
-      printf '%%s{"workspace_id":%[4]s,"label":"%%s","tab_count":%%s,"pane_count":%%s,"active_tab_id":"","agent_status":"unknown","focused":false,"number":%[5]d}' "$sep" "$wl" "$n" "$n"
-      sep=","
-    fi
-`, wsFile(i), wsLabel(i), quote(ws.ID), jsonQuote(ws.ID), i+1)
-	}
-	body.WriteString("    printf ']}}\\n'\n    ;;\n")
-
-	body.WriteString(`  "workspace create")
-    label=$(argval --label "$@")
-    cwd=$(argval --cwd "$@")
-    bump ` + quote(state+"/creates") + `
-    case "$n" in
-`)
-	for c, ws := range h.Creates {
-		i := len(h.Workspaces) + c
-		root := ws.Tabs[0]
-		j := tabIndex[root.ID]
-		fmt.Fprintf(&body, `    %d)
-      echo live > %[2]s
-      printf '%%s\n' "$label" > %[3]s
-      printf '%%s\n' %[4]s > %[5]s
-      printf '1\n' > %[6]s
-      printf '{"id":"cli:workspace:create","result":{"type":"workspace_created","workspace":{"workspace_id":%[7]s,"label":"%%s","tab_count":1,"pane_count":1,"active_tab_id":%[8]s,"agent_status":"unknown","focused":false,"number":%[9]d},"tab":{"tab_id":%[8]s,"workspace_id":%[7]s,"label":"1","number":1,"pane_count":1,"agent_status":"unknown","focused":false},"root_pane":{"pane_id":%[10]s,"tab_id":%[8]s,"workspace_id":%[7]s,"agent":"","agent_status":"unknown","cwd":"%%s"}}}\n' "$label" "$cwd"
-      ;;
-`, c+1, wsFile(i), wsLabel(i), quote(ws.ID), tabFile(j), tabLabel(j),
-			jsonQuote(ws.ID), jsonQuote(root.ID), i+1, jsonQuote(root.Pane))
-	}
-	body.WriteString("    *) err workspace_create_exhausted \"the fake declares no further workspace create\" ;;\n    esac\n    ;;\n")
-
-	body.WriteString(`  "tab create")
-    ws=$(argval --workspace "$@")
-    label=$(argval --label "$@")
-    cwd=$(argval --cwd "$@")
-`)
-	body.WriteString(herdrRequireLiveWorkspace(workspaces, wsFile, `"$ws"`))
-	body.WriteString("    bump " + quote(state+"/tabcreates") + "\n    case \"$n\" in\n")
-	for c, tab := range h.TabCreates {
-		j := tabIndex[tab.ID]
-		fmt.Fprintf(&body, `    %d)
-      printf '%%s\n' "$ws" > %[2]s
-      printf '%%s\n' "$label" > %[3]s
-      printf '{"id":"cli:tab:create","result":{"type":"tab_created","tab":{"tab_id":%[4]s,"workspace_id":"%%s","label":"%%s","number":%[5]d,"pane_count":1,"agent_status":"unknown","focused":false},"root_pane":{"pane_id":%[6]s,"tab_id":%[4]s,"workspace_id":"%%s","agent":"","agent_status":"unknown","cwd":"%%s"}}}\n' "$ws" "$label" "$ws" "$cwd"
-      ;;
-`, c+1, tabFile(j), tabLabel(j), jsonQuote(tab.ID), j+1, jsonQuote(tab.Pane))
-	}
-	body.WriteString("    *) err tab_create_exhausted \"the fake declares no further tab create\" ;;\n    esac\n    ;;\n")
-
-	body.WriteString("  \"tab list\")\n    ws=$(argval --workspace \"$@\")\n")
-	body.WriteString(herdrRequireLiveWorkspace(workspaces, wsFile, `"$ws"`))
-	body.WriteString(`    printf '{"id":"cli:tab:list","result":{"type":"tab_list","tabs":['
-    list_tabs "$ws"
-    printf ']}}\n'
-    ;;
-`)
-
-	body.WriteString("  \"tab rename\")\n    case \"$3\" in\n")
-	for _, ref := range tabs {
-		fmt.Fprintf(&body, "    %s) [ -s %s ] || err tab_not_found \"tab $3 not found\"; printf '%%s\\n' \"$4\" > %s ;;\n",
-			quote(ref.tab.ID), tabFile(ref.index), tabLabel(ref.index))
-	}
-	body.WriteString(`    *) err tab_not_found "tab $3 not found" ;;
-    esac
-    printf '{"id":"cli:tab:rename","result":{"type":"tab_info","tab":{"tab_id":"%s","workspace_id":"","label":"%s","number":1,"pane_count":1,"agent_status":"unknown","focused":false}}}\n' "$3" "$4"
-    ;;
-`)
-
-	// Closing a workspace's last tab closes the workspace with it, which is what
-	// real herdr does: nothing refuses the call, and the workspace is simply gone
-	// from every later list, get and close.
-	body.WriteString("  \"tab close\")\n    case \"$3\" in\n")
-	for _, ref := range tabs {
-		fmt.Fprintf(&body, `    %[1]s) [ -s %[2]s ] || err tab_not_found "tab $3 not found"
-      read tws < %[2]s; : > %[2]s
-      count_tabs "$tws"; [ "$n" = 0 ] && close_ws "$tws"
-      ;;
-`, quote(ref.tab.ID), tabFile(ref.index))
-	}
-	body.WriteString(`    *) err tab_not_found "tab $3 not found" ;;
-    esac
-    printf '{"id":"cli:tab:close","result":{"type":"ok"}}\n'
-    ;;
-  "workspace close")
-`)
-	body.WriteString(herdrRequireLiveWorkspace(workspaces, wsFile, `"$3"`))
-	body.WriteString(`    close_ws "$3"
-    printf '{"id":"cli:workspace:close","result":{"type":"ok"}}\n'
-    ;;
-`)
-
-	panes := herdrRequireLivePane(tabs, tabFile)
-	fmt.Fprintf(&body, `  "pane get")
-%[1]s    printf '{"id":"cli:pane:get","result":{"type":"pane_info","pane":{"pane_id":"%%s","tab_id":"%%s","workspace_id":"%%s","agent":%[2]s,"agent_status":%[3]s}}}\n' "$3" "$ptab" "$pws"
-    ;;
-  "pane read")
-%[1]s    printf %[4]s
-    ;;
-  "pane run")
-%[1]s    ;;
-  "pane send-text")
-%[1]s    ;;
-  "pane send-keys")
-%[1]s    ;;`, panes, jsonQuote(agent), jsonQuote(status), quote(paneRead))
-
-	install(t, bin, "herdr", h.Log, prelude.String(), "$1 $2", body.String())
-
-	for i, ws := range h.Workspaces {
-		writeFile(t, fmt.Sprintf("%s/w%d", state, i), "live\n")
-		writeFile(t, fmt.Sprintf("%s/w%d.label", state, i), ws.Label+"\n")
-		for _, tab := range ws.Tabs {
-			j := tabIndex[tab.ID]
-			writeFile(t, fmt.Sprintf("%s/t%d", state, j), ws.ID+"\n")
-			writeFile(t, fmt.Sprintf("%s/t%d.label", state, j), tab.Label+"\n")
+		if ref.Tab.ID == id {
+			return ref
 		}
 	}
+	return herdrTabRef{}
 }
 
-// A workspace closed earlier in the test is not merely absent from the listing:
-// every command naming it answers workspace_not_found, which is what a rerun of
-// teardown actually meets.
-func herdrRequireLiveWorkspace(workspaces []HerdrWorkspace, wsFile func(int) string, arg string) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "    case %s in\n", arg)
-	for i, ws := range workspaces {
-		fmt.Fprintf(&b, "    %s) [ -s %s ] || err workspace_not_found \"workspace %s not found\" ;;\n",
-			quote(ws.ID), wsFile(i), arg)
-	}
-	fmt.Fprintf(&b, "    *) err workspace_not_found \"workspace %s not found\" ;;\n    esac\n", arg)
-	return b.String()
-}
-
-// A pane lives and dies with its tab, so it answers pane_not_found from the
-// moment that tab is closed. $ptab and $pws are left set for the caller.
-func herdrRequireLivePane(tabs []herdrTabRef, tabFile func(int) string) string {
-	var b strings.Builder
-	b.WriteString("    case \"$3\" in\n")
+func herdrPaneRef(spec herdrSpec, tabs []herdrTabRef, pane string) herdrTabRef {
 	for _, ref := range tabs {
-		if ref.tab.Pane == "" {
+		if ref.Tab.Pane == pane && herdrLive(spec.StateDir, herdrTabPath(spec.StateDir, ref.Index)) {
+			return ref
+		}
+	}
+	return herdrTabRef{}
+}
+
+func herdrTabWorkspace(spec herdrSpec, ref herdrTabRef) (string, bool) {
+	data, err := os.ReadFile(herdrTabPath(spec.StateDir, ref.Index))
+	if err != nil {
+		return "", false
+	}
+	owner := strings.TrimSpace(string(data))
+	return owner, owner != ""
+}
+
+func herdrWorkspaceIndex(workspaces []HerdrWorkspace, id string) int {
+	for i, ws := range workspaces {
+		if ws.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func herdrWorkspaceIndexLive(spec herdrSpec, workspaces []HerdrWorkspace, id string) int {
+	index := herdrWorkspaceIndex(workspaces, id)
+	if index < 0 || !herdrLive(spec.StateDir, herdrWorkspacePath(spec.StateDir, index)) {
+		return -1
+	}
+	return index
+}
+
+func herdrWorkspaceTabCount(spec herdrSpec, workspace string, workspaces []HerdrWorkspace, tabs []herdrTabRef) int {
+	count := 0
+	for _, ref := range tabs {
+		owner, ok := herdrTabWorkspace(spec, ref)
+		if ok && owner == workspace {
+			count++
+		}
+	}
+	return count
+}
+
+func herdrCloseWorkspace(state, workspace string, index int, tabs []herdrTabRef) error {
+	if err := atomicWrite(herdrWorkspacePath(state, index), ""); err != nil {
+		return err
+	}
+	for _, ref := range tabs {
+		owner, err := os.ReadFile(herdrTabPath(state, ref.Index))
+		if err != nil {
 			continue
 		}
-		fmt.Fprintf(&b, "    %[1]s) [ -s %[2]s ] || err pane_not_found \"pane $3 not found\"; read pws < %[2]s; ptab=%[3]s ;;\n",
-			quote(ref.tab.Pane), tabFile(ref.index), quote(ref.tab.ID))
+		if strings.TrimSpace(string(owner)) == workspace {
+			if err := atomicWrite(herdrTabPath(state, ref.Index), ""); err != nil {
+				return err
+			}
+		}
 	}
-	b.WriteString("    *) err pane_not_found \"pane $3 not found\" ;;\n    esac\n")
-	return b.String()
+	return nil
 }
 
-func jsonQuote(s string) string {
-	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
+func herdrLive(state, path string) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && strings.TrimSpace(string(data)) != ""
+}
+
+func herdrLabel(state, prefix string, index int) string {
+	data, err := os.ReadFile(herdrLabelPath(state, prefix, index))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func herdrCounter(state, name string) int {
+	data, err := os.ReadFile(herdrCounterPath(state, name))
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+	return n
+}
+
+func herdrFrameAdvance(state string, count int) int {
+	current := herdrCounter(state, "frames")
+	if err := atomicWrite(herdrCounterPath(state, "frames"), strconv.Itoa(current+1)+"\n"); err != nil {
+		return min(current, count-1)
+	}
+	return min(current, count-1)
+}
+
+func herdrFrameCurrent(state string, count int) int {
+	return min(max(herdrCounter(state, "frames")-1, 0), count-1)
+}
+
+func herdrStatusAdvance(state string, count int) int {
+	current := herdrCounter(state, "statuses")
+	if err := atomicWrite(herdrCounterPath(state, "statuses"), strconv.Itoa(current+1)+"\n"); err != nil {
+		return min(current, count-1)
+	}
+	return min(current, count-1)
+}
+
+func herdrWorkspacePath(state string, index int) string {
+	return filepath.Join(state, fmt.Sprintf("w%d", index))
+}
+
+func herdrTabPath(state string, index int) string {
+	return filepath.Join(state, fmt.Sprintf("t%d", index))
+}
+
+func herdrLabelPath(state, prefix string, index int) string {
+	return filepath.Join(state, fmt.Sprintf("%s%d.label", prefix, index))
+}
+
+func herdrCounterPath(state, name string) string {
+	return filepath.Join(state, name)
+}
+
+func ensureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		writeFile(t, path, content)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func appendLine(path, content string) error {
+	return appendRawLine(path, content+"\n")
+}
+
+func appendRawLine(path, content string) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	_, writeErr := io.WriteString(file, content)
+	closeErr := file.Close()
+	return firstError(writeErr, closeErr)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -418,8 +418,9 @@ func herdrPaneGet(spec herdrSpec, tabs []herdrTabRef, args []string) int {
 			status = "idle"
 		}
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "{\"id\":\"cli:pane:get\",\"result\":{\"type\":\"pane_info\",\"pane\":{\"pane_id\":%s,\"tab_id\":%s,\"workspace_id\":\"\",\"agent\":%s,\"agent_status\":%s}}}\n",
-		jsonQuote(args[2]), jsonQuote(ref.Tab.ID), jsonQuote(agent), jsonQuote(status))
+	workspace, _ := herdrTabWorkspace(spec, ref)
+	_, _ = fmt.Fprintf(os.Stdout, "{\"id\":\"cli:pane:get\",\"result\":{\"type\":\"pane_info\",\"pane\":{\"pane_id\":%s,\"tab_id\":%s,\"workspace_id\":%s,\"agent\":%s,\"agent_status\":%s}}}\n",
+		jsonQuote(args[2]), jsonQuote(ref.Tab.ID), jsonQuote(workspace), jsonQuote(agent), jsonQuote(status))
 	return 0
 }
 

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -134,33 +134,48 @@ func runHerdrFromPayload(payload json.RawMessage, args []string) int {
 	if err := json.Unmarshal(payload, &spec); err != nil {
 		return fail("decode herdr config: %v", err)
 	}
-	if spec.Log != "" && (len(spec.LogCommands) == 0 || containsString(spec.LogCommands, commandName(args))) {
-		if err := appendInvocation(spec.Log, "herdr", args); err != nil {
-			return fail("log herdr invocation: %v", err)
-		}
-	}
 	if len(args) < 2 {
 		return fail("unexpected herdr invocation: %s", strings.Join(args, " "))
 	}
 	command := args[0] + " " + args[1]
 	for _, blocked := range spec.Hang {
 		if blocked == command {
+			if err := logHerdrInvocation(spec, args); err != nil {
+				return fail("log herdr invocation: %v", err)
+			}
 			for {
 				time.Sleep(time.Hour)
 			}
 		}
 	}
 	if spec.Unreachable {
+		if err := logHerdrInvocation(spec, args); err != nil {
+			return fail("log herdr invocation: %v", err)
+		}
 		return 1
 	}
 	for _, response := range spec.Responses {
 		if response.Command == command && (response.Args == nil || sameArgs(response.Args, args[2:])) {
 			_, _ = io.WriteString(os.Stdout, response.Stdout)
 			_, _ = io.WriteString(os.Stderr, response.Stderr)
+			if err := logHerdrInvocation(spec, args); err != nil {
+				return fail("log herdr invocation: %v", err)
+			}
 			return response.Exit
 		}
 	}
-	return runHerdrState(spec, command, args)
+	exit := runHerdrState(spec, command, args)
+	if err := logHerdrInvocation(spec, args); err != nil {
+		return fail("log herdr invocation: %v", err)
+	}
+	return exit
+}
+
+func logHerdrInvocation(spec herdrSpec, args []string) error {
+	if spec.Log == "" || (len(spec.LogCommands) > 0 && !containsString(spec.LogCommands, commandName(args))) {
+		return nil
+	}
+	return appendInvocation(spec.Log, "herdr", args)
 }
 
 func commandName(args []string) string {

--- a/internal/faketool/herdr_test.go
+++ b/internal/faketool/herdr_test.go
@@ -2,6 +2,7 @@ package faketool
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -169,6 +170,20 @@ func TestHerdrTabCreateAttachesToTheWorkspaceAskedFor(t *testing.T) {
 	}
 }
 
+func TestHerdrPaneGetReportsItsOwningWorkspace(t *testing.T) {
+	twoTabWorkspace().Install(t, Bin(t))
+
+	out, errOut, code := runHerdr(t, "pane", "get", "wA:p1")
+	if code != 0 {
+		t.Fatalf("pane get = %q (exit %d), want success", errOut, code)
+	}
+	for _, want := range []string{`"pane_id":"wA:p1"`, `"tab_id":"wA:t1"`, `"workspace_id":"wA"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("pane get = %q, want %s", out, want)
+		}
+	}
+}
+
 func TestHerdrTabRenameChangesTheListedLabel(t *testing.T) {
 	twoTabWorkspace().Install(t, Bin(t))
 
@@ -221,7 +236,7 @@ func TestHerdrLogRecordsEveryInvocation(t *testing.T) {
 	runHerdr(t, "tab", "list", "--workspace", "wA")
 	runHerdr(t, "tab", "close", "wA:t1")
 
-	data, err := exec.Command("cat", log).Output()
+	data, err := os.ReadFile(log)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/faketool/nomistakes.go
+++ b/internal/faketool/nomistakes.go
@@ -1,0 +1,76 @@
+package faketool
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+)
+
+// NoMistakes models the text and command-specific exit status hand consumes.
+type NoMistakes struct {
+	Stdout     string
+	Exit       int
+	Status     string
+	StatusExit int
+	Runs       string
+	RunsExit   int
+	Init       string
+	InitExit   int
+	Log        string
+	CountLog   string
+}
+
+type noMistakesSpec struct {
+	Stdout     string
+	Exit       int
+	Status     string
+	StatusExit int
+	Runs       string
+	RunsExit   int
+	Init       string
+	InitExit   int
+	Log        string
+	CountLog   string
+}
+
+func (n NoMistakes) Install(t *testing.T, bin string) {
+	t.Helper()
+	installConfig(t, bin, "no-mistakes", "no-mistakes", noMistakesSpec(n))
+}
+
+func runNoMistakesFromPayload(payload json.RawMessage, args []string) int {
+	var spec noMistakesSpec
+	if err := json.Unmarshal(payload, &spec); err != nil {
+		return fail("decode no-mistakes config: %v", err)
+	}
+	if spec.Log != "" {
+		if err := appendInvocation(spec.Log, "no-mistakes", args); err != nil {
+			return fail("log no-mistakes invocation: %v", err)
+		}
+	}
+	if spec.CountLog != "" {
+		if err := appendRawLine(spec.CountLog, "x\n"); err != nil {
+			return fail("count no-mistakes invocation: %v", err)
+		}
+	}
+	stdout, exit := spec.Stdout, spec.Exit
+	if len(args) > 0 {
+		switch args[0] {
+		case "status":
+			if spec.Status != "" {
+				stdout, exit = spec.Status, spec.StatusExit
+			}
+		case "runs":
+			if spec.Runs != "" {
+				stdout, exit = spec.Runs, spec.RunsExit
+			}
+		case "init":
+			if spec.Init != "" {
+				stdout, exit = spec.Init, spec.InitExit
+			}
+		}
+	}
+	_, _ = io.WriteString(os.Stdout, stdout)
+	return exit
+}

--- a/internal/faketool/treehouse.go
+++ b/internal/faketool/treehouse.go
@@ -1,113 +1,230 @@
 package faketool
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// Version banner written to stderr ahead of a "get" payload, matching the
-// treehouse whose behaviour FIDELITY.md records.
+// Version banner written to stderr ahead of a get payload.
 const TreehouseBanner = "treehouse 2.1.0"
 
-// A fake treehouse pool: "get" leases slots in the order listed and "return"
-// frees them, so it answers differently before and after each command that
-// changes it, and every acquisition gets a lease identity of its own.
+// Treehouse models a pool whose slots are leased and returned across calls.
 type Treehouse struct {
-	Slots []string
-	// Leased before the test began, for a task whose row was seeded not spawned.
-	Held []string
-	// Models a treehouse older than v2.1.0, which reports no lease identity.
+	Slots           []string
+	Held            []string
 	NoLeaseIdentity bool
-	// Version banner, defaulting to TreehouseBanner.
-	Banner string
-	Log    string
+	Banner          string
+	Log             string
+	Responses       []TreehouseResponse
 }
 
-// Writes the fake into bin, which Bin has put on PATH.
+type TreehouseResponse struct {
+	Command string
+	Args    []string
+	Stdout  string
+	Stderr  string
+	Exit    int
+}
+
+type treehouseSpec struct {
+	Slots           []string
+	Held            []string
+	NoLeaseIdentity bool
+	Banner          string
+	StateDir        string
+	Log             string
+	Responses       []TreehouseResponse
+}
+
 func (th Treehouse) Install(t *testing.T, bin string) {
 	t.Helper()
 	state := stateDir(t, bin, "treehouse")
-	counter := quote(state + "/leases")
+	for _, slot := range th.Held {
+		ensureFile(t, treehouseMarker(state, slot), "leased\n")
+	}
 	banner := th.Banner
 	if banner == "" {
 		banner = TreehouseBanner
 	}
+	installConfig(t, bin, "treehouse", "treehouse", treehouseSpec{
+		Slots: th.Slots, Held: th.Held, NoLeaseIdentity: th.NoLeaseIdentity,
+		Banner: banner, StateDir: state, Log: th.Log, Responses: th.Responses,
+	})
+}
 
-	marker := func(slot string) string { return quote(state + "/slot-" + key(slot)) }
-
-	var acquire strings.Builder
-	for _, slot := range th.Slots {
-		payload := fmt.Sprintf(`'{"path":"%%s","lease_id":"lease-%%s","lease_holder":"","leased_at":"2026-01-01T00:00:00Z"}\n' %s "$n"`, quote(slot))
-		if th.NoLeaseIdentity {
-			payload = fmt.Sprintf(`'{"path":"%%s"}\n' %s`, quote(slot))
-		}
-		fmt.Fprintf(&acquire, `    if [ ! -s %[1]s ]; then
-      n=0; [ -f %[2]s ] && read n < %[2]s
-      n=$((n+1)); echo "$n" > %[2]s
-      echo leased > %[1]s
-      printf %[3]s
-      exit 0
-    fi
-`, marker(slot), counter, payload)
+func runTreehouseFromPayload(payload json.RawMessage, args []string) int {
+	var spec treehouseSpec
+	if err := json.Unmarshal(payload, &spec); err != nil {
+		return fail("decode treehouse config: %v", err)
 	}
-
-	var resolve strings.Builder
-	seen := map[string]bool{}
-	for _, slot := range append(append([]string{}, th.Slots...), th.Held...) {
-		if seen[slot] {
+	if spec.Log != "" {
+		if err := appendInvocation(spec.Log, "treehouse", args); err != nil {
+			return fail("log treehouse invocation: %v", err)
+		}
+	}
+	if len(args) == 0 {
+		return fail("unexpected treehouse invocation")
+	}
+	for _, response := range spec.Responses {
+		if response.Command != args[0] || (response.Args != nil && !sameArgs(response.Args, args[1:])) {
 			continue
 		}
-		seen[slot] = true
-		fmt.Fprintf(&resolve, "      %s) marker=%s ;;\n", quote(slot), marker(slot))
+		_, _ = io.WriteString(os.Stdout, response.Stdout)
+		_, _ = io.WriteString(os.Stderr, response.Stderr)
+		return response.Exit
 	}
-
-	// The abort exits 0, which is the whole reason this arm exists: with no answer
-	// to its prompt treehouse reports the abort on stderr and still exits 0, so an
-	// exit-code-only caller reads a return that never happened as success.
-	body := fmt.Sprintf(`  get)
-    echo %[1]s >&2
-%[2]s    printf 'all %[3]d worktrees are in use or dirty (max_trees = %[3]d). Run '"'"'treehouse status'"'"' to see details, or increase max_trees in treehouse.toml\n' >&2
-    exit 1
-    ;;
-  return)
-    path="$2"
-    forced=""
-    for arg in "$@"; do
-      if [ "$arg" = "--force" ]; then forced=1; fi
-    done
-    marker=""
-    case "$path" in
-%[4]s    esac
-    if [ -z "$marker" ]; then
-      echo "worktree $path is not managed by treehouse" >&2
-      exit 1
-    fi
-    dirty=""
-    if [ -e "$path/.git" ] && [ -n "$(git -C "$path" status --porcelain)" ]; then dirty=1; fi
-    if [ -n "$dirty" ] && [ -z "$forced" ]; then
-      echo 'Worktree has uncommitted changes. Clean and return? [Y/n] Aborted.' >&2
-      exit 0
-    fi
-    if [ -n "$dirty" ]; then
-      git -C "$path" reset -q --hard HEAD
-      git -C "$path" clean -qfd
-    fi
-    : > "$marker"
-    echo 'Worktree returned to pool.' >&2
-    ;;
-  init)
-    if [ -f treehouse.toml ]; then
-      echo 'treehouse.toml already exists' >&2
-      exit 1
-    fi
-    echo 'max_trees = 16' > treehouse.toml
-    echo "Created $(pwd)/treehouse.toml" >&2
-    ;;`, quote(banner), acquire.String(), len(th.Slots), resolve.String())
-
-	install(t, bin, "treehouse", th.Log, "", "$1", body)
-
-	for _, slot := range th.Held {
-		writeFile(t, state+"/slot-"+key(slot), "leased\n")
+	switch args[0] {
+	case "get":
+		return treehouseGet(spec)
+	case "return":
+		return treehouseReturn(spec, args)
+	case "init":
+		return treehouseInit()
+	default:
+		return fail("unexpected treehouse invocation: %s", strings.Join(args, " "))
 	}
+}
+
+func treehouseGet(spec treehouseSpec) int {
+	for _, slot := range spec.Slots {
+		marker := treehouseMarker(spec.StateDir, slot)
+		leased, err := treehouseLeased(marker)
+		if err != nil {
+			return fail("inspect treehouse slot: %v", err)
+		}
+		if leased {
+			continue
+		}
+		counter := treehouseCounter(spec.StateDir)
+		if err := atomicWrite(treehouseCounterPath(spec.StateDir), fmt.Sprintf("%d\n", counter+1)); err != nil {
+			return fail("write treehouse lease counter: %v", err)
+		}
+		if err := atomicWrite(marker, "leased\n"); err != nil {
+			return fail("lease treehouse slot: %v", err)
+		}
+		_, _ = fmt.Fprintln(os.Stderr, spec.Banner)
+		if spec.NoLeaseIdentity {
+			_, _ = fmt.Fprintf(os.Stdout, "{\"path\":%s}\n", jsonQuote(slot))
+		} else {
+			_, _ = fmt.Fprintf(os.Stdout, "{\"path\":%s,\"lease_id\":\"lease-%d\",\"lease_holder\":\"\",\"leased_at\":\"2026-01-01T00:00:00Z\"}\n", jsonQuote(slot), counter+1)
+		}
+		return 0
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "all %d worktrees are in use or dirty (max_trees = %d). Run 'treehouse status' to see details, or increase max_trees in treehouse.toml\n", len(spec.Slots), len(spec.Slots))
+	return 1
+}
+
+func treehouseReturn(spec treehouseSpec, args []string) int {
+	if len(args) < 2 {
+		return fail("unexpected treehouse invocation: %s", strings.Join(args, " "))
+	}
+	slot := args[1]
+	marker := ""
+	for _, managed := range append(append([]string{}, spec.Slots...), spec.Held...) {
+		if managed == slot {
+			marker = treehouseMarker(spec.StateDir, managed)
+			break
+		}
+	}
+	if marker == "" {
+		return fail("worktree %s is not managed by treehouse", slot)
+	}
+	forced := false
+	for _, arg := range args[2:] {
+		if arg == "--force" {
+			forced = true
+		}
+	}
+	dirty, err := treehouseDirty(slot)
+	if err != nil {
+		return fail("inspect dirty treehouse slot: %v", err)
+	}
+	if dirty && !forced {
+		_, _ = io.WriteString(os.Stderr, "Worktree has uncommitted changes. Clean and return? [Y/n] Aborted.\n")
+		return 0
+	}
+	if dirty {
+		if err := treehouseClean(slot); err != nil {
+			return fail("clean treehouse slot: %v", err)
+		}
+	}
+	if err := atomicWrite(marker, ""); err != nil {
+		return fail("return treehouse slot: %v", err)
+	}
+	_, _ = io.WriteString(os.Stderr, "Worktree returned to pool.\n")
+	return 0
+}
+
+func treehouseInit() int {
+	path, err := filepath.Abs("treehouse.toml")
+	if err != nil {
+		return fail("locate treehouse.toml: %v", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		_, _ = io.WriteString(os.Stderr, "treehouse.toml already exists\n")
+		return 1
+	} else if !os.IsNotExist(err) {
+		return fail("inspect treehouse.toml: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("max_trees = 16\n"), 0o644); err != nil {
+		return fail("create treehouse.toml: %v", err)
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "Created %s\n", path)
+	return 0
+}
+
+func treehouseDirty(path string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+		return false, nil
+	}
+	out, err := exec.Command("git", "-C", path, "status", "--porcelain").Output()
+	if err != nil {
+		return false, err
+	}
+	return len(out) > 0, nil
+}
+
+func treehouseClean(path string) error {
+	if out, err := exec.Command("git", "-C", path, "reset", "-q", "--hard", "HEAD").CombinedOutput(); err != nil {
+		return fmt.Errorf("git reset: %w: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", path, "clean", "-qfd").CombinedOutput(); err != nil {
+		return fmt.Errorf("git clean: %w: %s", err, out)
+	}
+	return nil
+}
+
+func treehouseMarker(state, slot string) string {
+	return filepath.Join(state, "slot-"+key(slot))
+}
+
+func treehouseCounterPath(state string) string {
+	return filepath.Join(state, "leases")
+}
+
+func treehouseCounter(state string) int {
+	data, err := os.ReadFile(treehouseCounterPath(state))
+	if err != nil {
+		return 0
+	}
+	var counter int
+	_, _ = fmt.Sscanf(string(data), "%d", &counter)
+	return counter
+}
+
+func treehouseLeased(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(data)) != "", nil
 }

--- a/internal/faketool/treehouse_test.go
+++ b/internal/faketool/treehouse_test.go
@@ -1,6 +1,7 @@
 package faketool
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -37,7 +38,10 @@ func TestTreehouseLeasesEachSlotOnceUntilItIsReturned(t *testing.T) {
 	Treehouse{Slots: []string{slot}}.Install(t, bin)
 
 	first, banner, code := runTreehouse(t, t.TempDir(), "get", "--lease", "--json")
-	if code != 0 || !strings.Contains(first, `"path":"`+slot+`"`) {
+	var lease struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(first), &lease); err != nil || code != 0 || lease.Path != slot {
 		t.Fatalf("get = %q (exit %d), want the slot leased", first, code)
 	}
 	if !strings.Contains(banner, TreehouseBanner) {

--- a/internal/ghutil/pr_test.go
+++ b/internal/ghutil/pr_test.go
@@ -3,13 +3,10 @@ package ghutil
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
-	"unicode"
+
+	"github.com/atqamz/hand/internal/faketool"
 )
 
 // Fakes `gh pr view --json state`, emitting a stderr line ahead of the JSON payload so a
@@ -17,23 +14,16 @@ import (
 // output does.
 func writeFakeGHPRView(t *testing.T, state string, exitCode int, stderrLine string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
+	bin := faketool.Bin(t)
+	response := faketool.GHResponse{
+		Command: "pr view",
+		Stderr:  stderrLine,
+		Exit:    exitCode,
 	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\n"
-	if stderrLine != "" {
-		script += fmt.Sprintf("echo %q >&2\n", stderrLine)
+	if exitCode == 0 {
+		response.Stdout = "{\"state\":\"" + state + "\"}\n"
 	}
-	if exitCode != 0 {
-		script += fmt.Sprintf("exit %d\n", exitCode)
-	} else {
-		script += fmt.Sprintf("printf '{\"state\":\"%s\"}\\n'\n", state)
-	}
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin)
+	faketool.GH{Responses: []faketool.GHResponse{response}}.Install(t, bin)
 }
 
 func TestPRIsMergedIgnoresStderrNoise(t *testing.T) {
@@ -68,23 +58,10 @@ func TestPRIsMergedReportsExitStatusWithoutStderr(t *testing.T) {
 // the call site must fail the parse.
 func writeFakeGHPRList(t *testing.T, body string, exitCode int, stderrLine string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\n"
-	if stderrLine != "" {
-		script += fmt.Sprintf("echo %q >&2\n", stderrLine)
-	}
-	if exitCode != 0 {
-		script += fmt.Sprintf("exit %d\n", exitCode)
-	} else {
-		script += fmt.Sprintf("printf '%s'\n", body)
-	}
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin)
+	bin := faketool.Bin(t)
+	faketool.GH{Responses: []faketool.GHResponse{{
+		Command: "pr list", Stdout: body, Stderr: stderrLine, Exit: exitCode,
+	}}}.Install(t, bin)
 }
 
 func TestFindPRByBranchReturnsMatch(t *testing.T) {
@@ -218,49 +195,12 @@ func TestFindPRByBranchPrefersOpenOverClosedUnmerged(t *testing.T) {
 // A", and a fork test would pass against a shape gh never returns (atqamz/hand#40).
 func writeFakeGHPRListPerRepo(t *testing.T, bodies map[string]string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-
-	// A qualified owner:branch --head value is refused below because real gh silently answers it
-	// with an empty list - verified against gh 2.97 on a live cross-repo PR - so the mistake
-	// surfaces as a failure here instead of as "no PR found" in production.
-	script := "#!/bin/sh\n" +
-		"[ \"$1 $2\" = \"pr list\" ] || { echo \"unexpected gh args: $@\" >&2; exit 1; }\n" +
-		"[ \"$3\" = \"--repo\" ] && [ \"$5\" = \"--head\" ] || { echo \"unexpected gh args: $@\" >&2; exit 1; }\n" +
-		"case \"$6\" in *:*) echo \"qualified head ref matches nothing in real gh: $6\" >&2; exit 1 ;; esac\n" +
-		"case \"$4\" in\n"
-	// The dispatch case-folds --repo because GitHub serves a repo under any casing of its slug, so a
-	// case-sensitive fake would answer a differently-cased target with an empty list and hide the
-	// hit real gh returns.
+	bin := faketool.Bin(t)
+	var responses []faketool.GHResponse
 	for repo, body := range bodies {
-		script += fmt.Sprintf("%s) printf '%s' ;;\n", anyCasingGlob(repo), body)
+		responses = append(responses, faketool.GHResponse{Command: "pr list", Repo: repo, Stdout: body})
 	}
-	script += "*) printf '[]' ;;\nesac\n"
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin)
-}
-
-// Turns a repo slug into an unquoted sh case pattern matching it in any casing - a glob rather than
-// tr, because PATH is replaced by the fake's own dir alone and no external binary resolves inside
-// these scripts. Safe unquoted: a slug is [A-Za-z0-9._-/] only, so it carries no metacharacter.
-func anyCasingGlob(slug string) string {
-	var b strings.Builder
-	for _, r := range slug {
-		lower, upper := unicode.ToLower(r), unicode.ToUpper(r)
-		if lower == upper {
-			b.WriteRune(r)
-			continue
-		}
-		b.WriteByte('[')
-		b.WriteRune(upper)
-		b.WriteRune(lower)
-		b.WriteByte(']')
-	}
-	return b.String()
+	faketool.GH{Responses: responses, RejectQualifiedHead: true}.Install(t, bin)
 }
 
 // The target pair a fork project searches with: its own repo, where hand pushes the branch, plus

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -2,6 +2,7 @@ package herdr
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,7 +51,11 @@ type envelope struct {
 // Execs herdr and returns its trimmed stdout and trimmed stderr alongside the process error,
 // letting call and callVoid share one invocation path.
 func (c *Client) run(args ...string) ([]byte, string, error) {
-	cmd := exec.Command("herdr", args...)
+	return c.runContext(context.Background(), args...)
+}
+
+func (c *Client) runContext(ctx context.Context, args ...string) ([]byte, string, error) {
+	cmd := exec.CommandContext(ctx, "herdr", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -69,7 +74,11 @@ func parseEnvelope(args []string, trimmed []byte) (envelope, error) {
 // For query commands, whose real herdr response is always a JSON envelope carrying a non-null
 // result object.
 func (c *Client) call(args ...string) (json.RawMessage, error) {
-	trimmed, stderr, runErr := c.run(args...)
+	return c.callContext(context.Background(), args...)
+}
+
+func (c *Client) callContext(ctx context.Context, args ...string) (json.RawMessage, error) {
+	trimmed, stderr, runErr := c.runContext(ctx, args...)
 
 	if len(trimmed) == 0 {
 		if runErr != nil {
@@ -128,7 +137,15 @@ func (c *Client) callVoid(args ...string) error {
 }
 
 func (c *Client) WorkspaceList() ([]Workspace, error) {
-	res, err := c.call("workspace", "list")
+	return c.workspaceList(context.Background())
+}
+
+func (c *Client) WorkspaceListContext(ctx context.Context) ([]Workspace, error) {
+	return c.workspaceList(ctx)
+}
+
+func (c *Client) workspaceList(ctx context.Context) ([]Workspace, error) {
+	res, err := c.callContext(ctx, "workspace", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +286,15 @@ func (c *Client) TabClose(tabID string) error {
 }
 
 func (c *Client) PaneGet(paneID string) (Pane, error) {
-	res, err := c.call("pane", "get", paneID)
+	return c.paneGet(context.Background(), paneID)
+}
+
+func (c *Client) PaneGetContext(ctx context.Context, paneID string) (Pane, error) {
+	return c.paneGet(ctx, paneID)
+}
+
+func (c *Client) paneGet(ctx context.Context, paneID string) (Pane, error) {
+	res, err := c.callContext(ctx, "pane", "get", paneID)
 	if err != nil {
 		return Pane{}, err
 	}

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -4,30 +4,25 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/atqamz/hand/internal/faketool"
 )
 
-// Fakes herdr with the caller's own script body, so each test picks the response shape it needs.
-// Every real shape is reproduced verbatim - a query's non-null result envelope, a void command's
-// empty stdout, an error envelope at exit 1 and at exit 0 - and other packages cite these.
-func writeFakeHerdr(t *testing.T, script string) {
+func writeFakeHerdr(t *testing.T, responses ...faketool.HerdrResponse) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	path := filepath.Join(bin, "herdr")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: responses}.Install(t, bin)
+}
+
+func herdrResponse(command, stdout string) faketool.HerdrResponse {
+	return faketool.HerdrResponse{Command: command, Stdout: stdout}
 }
 
 func TestWorkspaceListParsesResult(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"proj","tab_count":2}]}}'`)
+	writeFakeHerdr(t, herdrResponse("workspace list", "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[{\"workspace_id\":\"wA\",\"label\":\"proj\",\"tab_count\":2}]}}"))
 	c := NewClient()
 	got, err := c.WorkspaceList()
 	if err != nil {
@@ -39,7 +34,7 @@ func TestWorkspaceListParsesResult(t *testing.T) {
 }
 
 func TestFindWorkspaceByLabelFound(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspaces":[{"workspace_id":"wA","label":"proj"}]}}'`)
+	writeFakeHerdr(t, herdrResponse("workspace list", "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[{\"workspace_id\":\"wA\",\"label\":\"proj\"}]}}"))
 	c := NewClient()
 	ws, found, err := c.FindWorkspaceByLabel("proj")
 	if err != nil {
@@ -51,7 +46,7 @@ func TestFindWorkspaceByLabelFound(t *testing.T) {
 }
 
 func TestFindWorkspaceByLabelNotFound(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspaces":[]}}'`)
+	writeFakeHerdr(t, herdrResponse("workspace list", "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[]}}"))
 	c := NewClient()
 	_, found, err := c.FindWorkspaceByLabel("proj")
 	if err != nil {
@@ -66,7 +61,7 @@ func TestFindWorkspaceByLabelNotFound(t *testing.T) {
 // of creating a workspace, so WorkspaceCreate must return them rather than discard them - a caller
 // that then creates its own tab leaves the root tab behind as an unowned live shell.
 func TestWorkspaceCreateParsesRootTabAndPane(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj","tab_count":1},"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"1"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'`)
+	writeFakeHerdr(t, herdrResponse("workspace create", "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\",\"tab_count\":1},\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\",\"label\":\"1\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\",\"agent_status\":\"idle\"}}}"))
 	c := NewClient()
 	ws, tab, pane, err := c.WorkspaceCreate("/tmp/clone", "proj")
 	if err != nil {
@@ -87,12 +82,15 @@ func TestWorkspaceCreateParsesRootTabAndPane(t *testing.T) {
 // inherits any CLAUDE_CODE_CHILD_SESSION, CLAUDE_CODE_SESSION_ID, or CLAUDECODE the server was
 // started under, silently killing the worker's transcript. All three are blanked either way.
 func TestWorkspaceCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
-	writeFakeHerdr(t, `
-echo "$@" >> "$HERDR_CALL_LOG"
-printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"},"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB"}}}'
-`)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{
+			Command: "workspace create",
+			Stdout:  "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\"},\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\"}}}",
+		}},
+		Log: callLog,
+	}.Install(t, bin)
 
 	c := NewClient()
 	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err != nil {
@@ -111,7 +109,7 @@ printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"}
 }
 
 func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"}}}'`)
+	writeFakeHerdr(t, herdrResponse("workspace create", "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\"}}}"))
 	c := NewClient()
 	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
 		t.Fatal("expected an error when the response omits the root tab and pane")
@@ -122,27 +120,15 @@ func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
 // means herdr created the workspace (a protocol predating those fields), so WorkspaceCreate closes
 // it before the parse error reaches the caller - nothing downstream learns the ID.
 func TestWorkspaceCreateClosesWorkspaceOnPartialResponse(t *testing.T) {
-	writeFakeHerdr(t, `
-echo "$@" >> "$HERDR_CALL_LOG"
-case "$1 $2" in
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"}}}'
-	;;
-"workspace close")
-	if [ "$3" != "wA" ]; then
-		echo "unexpected close target: $@" >&2
-		exit 1
-	fi
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			{Command: "workspace create", Stdout: "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\"}}}"},
+			{Command: "workspace close", Stdout: "{\"id\":\"cli:1\",\"result\":{\"type\":\"ok\"}}"},
+		},
+		Log: callLog,
+	}.Install(t, bin)
 
 	c := NewClient()
 	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
@@ -162,27 +148,15 @@ esac
 // type error, so a response that types a field wrongly still yields a workspace ID herdr has
 // already created and this call must still close.
 func TestWorkspaceCreateClosesWorkspaceOnMalformedResponse(t *testing.T) {
-	writeFakeHerdr(t, `
-echo "$@" >> "$HERDR_CALL_LOG"
-case "$1 $2" in
-"workspace create")
-	printf '{"id":"cli:1","result":{"workspace":{"workspace_id":"wA","label":"proj"},"tab":"none"}}'
-	;;
-"workspace close")
-	if [ "$3" != "wA" ]; then
-		echo "unexpected close target: $@" >&2
-		exit 1
-	fi
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			{Command: "workspace create", Stdout: "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\"},\"tab\":\"none\"}}"},
+			{Command: "workspace close", Stdout: "{\"id\":\"cli:1\",\"result\":{\"type\":\"ok\"}}"},
+		},
+		Log: callLog,
+	}.Install(t, bin)
 
 	c := NewClient()
 	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
@@ -199,13 +173,7 @@ esac
 }
 
 func TestTabRenameSendsCorrectArgs(t *testing.T) {
-	writeFakeHerdr(t, `
-if [ "$1 $2 $3 $4" != "tab rename wA:tB task-1" ]; then
-	echo "unexpected args: $@" >&2
-	exit 1
-fi
-printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task-1"}}}'
-`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "tab rename", Args: []string{"wA:tB", "task-1"}, Stdout: "{\"id\":\"cli:1\",\"result\":{\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\",\"label\":\"task-1\"}}}"})
 	c := NewClient()
 	if err := c.TabRename("wA:tB", "task-1"); err != nil {
 		t.Fatal(err)
@@ -213,7 +181,7 @@ printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","lab
 }
 
 func TestCallReturnsErrorOnEnvelopeError(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"not_found","message":"pane missing"}}'; exit 1`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"error\":{\"code\":\"not_found\",\"message\":\"pane missing\"}}", Exit: 1})
 	c := NewClient()
 	if _, err := c.PaneGet("wA:pB"); err == nil || !strings.Contains(err.Error(), "pane missing") {
 		t.Fatalf("got err %v, want pane missing", err)
@@ -221,7 +189,7 @@ func TestCallReturnsErrorOnEnvelopeError(t *testing.T) {
 }
 
 func TestCallFailsOnNonZeroExitWithNoStdout(t *testing.T) {
-	writeFakeHerdr(t, `echo "binary crashed" >&2; exit 1`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stderr: "binary crashed\n", Exit: 1})
 	c := NewClient()
 	if _, err := c.PaneGet("wA:pB"); err == nil || !strings.Contains(err.Error(), "binary crashed") {
 		t.Fatalf("got err %v, want binary crashed failure", err)
@@ -229,7 +197,7 @@ func TestCallFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 }
 
 func TestCallRejectsNullResult(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":null}'`)
+	writeFakeHerdr(t, herdrResponse("workspace list", "{\"id\":\"cli:1\",\"result\":null}"))
 	c := NewClient()
 	if _, err := c.WorkspaceList(); err == nil || !strings.Contains(err.Error(), "null result") {
 		t.Fatalf("got err %v, want null result failure", err)
@@ -237,7 +205,7 @@ func TestCallRejectsNullResult(t *testing.T) {
 }
 
 func TestCallRejectsNonObjectResult(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":[]}'`)
+	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":[]}"))
 	c := NewClient()
 	if _, err := c.PaneGet("wA:pB"); err == nil || !strings.Contains(err.Error(), "not an object") {
 		t.Fatalf("got err %v, want non-object result failure", err)
@@ -245,7 +213,7 @@ func TestCallRejectsNonObjectResult(t *testing.T) {
 }
 
 func TestPaneRunSucceedsOnEmptyStdout(t *testing.T) {
-	writeFakeHerdr(t, ``)
+	writeFakeHerdr(t, herdrResponse("pane run", ""))
 	c := NewClient()
 	if err := c.PaneRun("wA:pB", "echo hi"); err != nil {
 		t.Fatal(err)
@@ -253,7 +221,7 @@ func TestPaneRunSucceedsOnEmptyStdout(t *testing.T) {
 }
 
 func TestPaneRunSurfacesErrorEnvelopeEvenOnExitZero(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"pane missing"}}'`)
+	writeFakeHerdr(t, herdrResponse("pane run", "{\"id\":\"cli:1\",\"error\":{\"code\":\"pane_not_found\",\"message\":\"pane missing\"}}"))
 	c := NewClient()
 	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "pane missing") {
 		t.Fatalf("got err %v, want pane missing", err)
@@ -261,7 +229,7 @@ func TestPaneRunSurfacesErrorEnvelopeEvenOnExitZero(t *testing.T) {
 }
 
 func TestPaneSendTextSucceedsOnEmptyStdout(t *testing.T) {
-	writeFakeHerdr(t, ``)
+	writeFakeHerdr(t, herdrResponse("pane send-text", ""))
 	c := NewClient()
 	if err := c.PaneSendText("wA:pB", "hello"); err != nil {
 		t.Fatal(err)
@@ -269,12 +237,7 @@ func TestPaneSendTextSucceedsOnEmptyStdout(t *testing.T) {
 }
 
 func TestPaneSendKeysPassesKeys(t *testing.T) {
-	writeFakeHerdr(t, `
-if [ "$1" != "pane" ] || [ "$2" != "send-keys" ] || [ "$3" != "wA:pB" ] || [ "$4" != "Enter" ]; then
-	echo "unexpected args: $@" >&2
-	exit 1
-fi
-`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane send-keys", Args: []string{"wA:pB", "Enter"}})
 	c := NewClient()
 	if err := c.PaneSendKeys("wA:pB", "Enter"); err != nil {
 		t.Fatal(err)
@@ -282,7 +245,7 @@ fi
 }
 
 func TestPaneSendKeysSucceedsOnEmptyStdout(t *testing.T) {
-	writeFakeHerdr(t, ``)
+	writeFakeHerdr(t, herdrResponse("pane send-keys", ""))
 	c := NewClient()
 	if err := c.PaneSendKeys("wA:pB", "Enter"); err != nil {
 		t.Fatal(err)
@@ -290,7 +253,7 @@ func TestPaneSendKeysSucceedsOnEmptyStdout(t *testing.T) {
 }
 
 func TestCallVoidFailsOnNonZeroExitWithNoStdout(t *testing.T) {
-	writeFakeHerdr(t, `echo "binary crashed" >&2; exit 1`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane run", Stderr: "binary crashed\n", Exit: 1})
 	c := NewClient()
 	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "binary crashed") {
 		t.Fatalf("got err %v, want binary crashed failure", err)
@@ -298,7 +261,7 @@ func TestCallVoidFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 }
 
 func TestTabCreateParsesTabAndRootPane(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA","label":"task"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB","agent_status":"idle"}}}'`)
+	writeFakeHerdr(t, herdrResponse("tab create", "{\"id\":\"cli:1\",\"result\":{\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\",\"label\":\"task\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\",\"agent_status\":\"idle\"}}}"))
 	c := NewClient()
 	tab, pane, err := c.TabCreate("wA", "/tmp/wt", "task")
 	if err != nil {
@@ -313,12 +276,15 @@ func TestTabCreateParsesTabAndRootPane(t *testing.T) {
 // already-existing workspace creates its own tab via TabCreate instead, and that path must be
 // sanitized too.
 func TestTabCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
-	writeFakeHerdr(t, `
-echo "$@" >> "$HERDR_CALL_LOG"
-printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"root_pane":{"pane_id":"wA:pC","tab_id":"wA:tB"}}}'
-`)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{
+			Command: "tab create",
+			Stdout:  "{\"id\":\"cli:1\",\"result\":{\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\"}}}",
+		}},
+		Log: callLog,
+	}.Install(t, bin)
 
 	c := NewClient()
 	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err != nil {
@@ -340,27 +306,15 @@ printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"ro
 // created the tab (same as atqamz/hand#74's WorkspaceCreate case), so TabCreate closes it
 // before the parse error reaches the caller - nothing downstream learns the tab ID.
 func TestTabCreateClosesTabOnPartialResponse(t *testing.T) {
-	writeFakeHerdr(t, `
-echo "$@" >> "$HERDR_CALL_LOG"
-case "$1 $2" in
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"}}}'
-	;;
-"tab close")
-	if [ "$3" != "wA:tB" ]; then
-		echo "unexpected close target: $@" >&2
-		exit 1
-	fi
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			{Command: "tab create", Stdout: "{\"id\":\"cli:1\",\"result\":{\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"}}}"},
+			{Command: "tab close", Stdout: "{\"id\":\"cli:1\",\"result\":{\"type\":\"ok\"}}"},
+		},
+		Log: callLog,
+	}.Install(t, bin)
 
 	c := NewClient()
 	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err == nil {
@@ -380,27 +334,15 @@ esac
 // type error, so a response that types a field wrongly still yields a tab ID herdr has already
 // created and this call must still close it.
 func TestTabCreateClosesTabOnMalformedResponse(t *testing.T) {
-	writeFakeHerdr(t, `
-echo "$@" >> "$HERDR_CALL_LOG"
-case "$1 $2" in
-"tab create")
-	printf '{"id":"cli:1","result":{"tab":{"tab_id":"wA:tB","workspace_id":"wA"},"root_pane":"none"}}'
-	;;
-"tab close")
-	if [ "$3" != "wA:tB" ]; then
-		echo "unexpected close target: $@" >&2
-		exit 1
-	fi
-	printf '{"id":"cli:1","result":{"type":"ok"}}'
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	t.Setenv("HERDR_CALL_LOG", callLog)
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			{Command: "tab create", Stdout: "{\"id\":\"cli:1\",\"result\":{\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"},\"root_pane\":\"none\"}}"},
+			{Command: "tab close", Stdout: "{\"id\":\"cli:1\",\"result\":{\"type\":\"ok\"}}"},
+		},
+		Log: callLog,
+	}.Install(t, bin)
 
 	c := NewClient()
 	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err == nil {
@@ -417,7 +359,7 @@ esac
 }
 
 func TestPaneGetParsesAgentStatus(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'`)
+	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"))
 	c := NewClient()
 	pane, err := c.PaneGet("wA:pB")
 	if err != nil {
@@ -429,7 +371,7 @@ func TestPaneGetParsesAgentStatus(t *testing.T) {
 }
 
 func TestWaitComposerEmptyReturnsWhenIdle(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"idle"}}}'`)
+	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"idle\"}}}"))
 	c := NewClient()
 	if err := c.WaitComposerEmpty("wA:pB", time.Second); err != nil {
 		t.Fatal(err)
@@ -437,7 +379,7 @@ func TestWaitComposerEmptyReturnsWhenIdle(t *testing.T) {
 }
 
 func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"pane":{"pane_id":"wA:pB","agent_status":"working"}}}'`)
+	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"))
 	c := NewClient()
 	err := c.WaitComposerEmpty("wA:pB", 10*time.Millisecond)
 	if !errors.Is(err, ErrComposerBusyTimeout) {
@@ -448,8 +390,7 @@ func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
 func TestWaitComposerEmptyPaneFailureIsNotABusyTimeout(t *testing.T) {
 	// A pane that stops answering can never free, so the caller must be able to
 	// tell this apart from the retryable timeout above.
-	writeFakeHerdr(t, `printf '{"id":"cli:1","error":{"code":"pane_not_found","message":"no such pane"}}'
-exit 1`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"error\":{\"code\":\"pane_not_found\",\"message\":\"no such pane\"}}", Exit: 1})
 	c := NewClient()
 	err := c.WaitComposerEmpty("wA:pB", time.Second)
 	if err == nil || errors.Is(err, ErrComposerBusyTimeout) {
@@ -458,7 +399,7 @@ exit 1`)
 }
 
 func TestTabListParsesResult(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"id":"cli:1","result":{"tabs":[{"tab_id":"wA:tB","workspace_id":"wA"}]}}'`)
+	writeFakeHerdr(t, herdrResponse("tab list", "{\"id\":\"cli:1\",\"result\":{\"tabs\":[{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"}]}}"))
 	c := NewClient()
 	tabs, err := c.TabList("wA")
 	if err != nil {
@@ -472,10 +413,7 @@ func TestTabListParsesResult(t *testing.T) {
 // Pins --source recent: a 23-row unattached pane clips the option and footer lines that identify a
 // first-run dialog, and a dialog that matches nothing is confirmed as a started worker.
 func TestPaneReadReadsRecentScrollback(t *testing.T) {
-	writeFakeHerdr(t, `case "$*" in
-*"--source recent"*) printf 'Welcome to Claude Code\n' ;;
-*) echo "unexpected read args: $*" >&2; exit 1 ;;
-esac`)
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane read", Args: []string{"wA:pB", "--source", "recent", "--lines", "60"}, Stdout: "Welcome to Claude Code\n"})
 	c := NewClient()
 	got, err := c.PaneRead("wA:pB", 60)
 	if err != nil {
@@ -489,7 +427,7 @@ esac`)
 // Pins that the bare {code,message} failure body is honored even when herdr exits 0: read as pane
 // text it would look like a dialog-free pane and confirm a worker no one ever observed.
 func TestPaneReadRejectsErrorBodyOnExitZero(t *testing.T) {
-	writeFakeHerdr(t, `printf '{"code":"pane_not_found","message":"no such pane"}'; exit 0`)
+	writeFakeHerdr(t, herdrResponse("pane read", "{\"code\":\"pane_not_found\",\"message\":\"no such pane\"}"))
 	c := NewClient()
 	if _, err := c.PaneRead("wA:pB", 60); err == nil || !strings.Contains(err.Error(), "pane_not_found") {
 		t.Fatalf("got err %v, want pane_not_found", err)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/store"
 )
 
@@ -501,15 +501,8 @@ func fakeNoMistakes(t *testing.T, stdout string) {
 // `status` exits 0 on the same text. Flattening that to 0 would pass a real regression.
 func fakeNoMistakesExit(t *testing.T, stdout string, code int) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake no-mistakes is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\nexit %d\n", stdout, code)
-	if err := os.WriteFile(filepath.Join(bin, "no-mistakes"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.NoMistakes{Stdout: stdout, Exit: code}.Install(t, bin)
 }
 
 func TestGateStatusReady(t *testing.T) {

--- a/internal/selfupdate/notice_test.go
+++ b/internal/selfupdate/notice_test.go
@@ -3,9 +3,10 @@ package selfupdate
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
+
+	"github.com/atqamz/hand/internal/faketool"
 )
 
 func TestCheckNoticeSkipsWithoutStateDir(t *testing.T) {
@@ -44,9 +45,6 @@ func TestCheckNoticeEmptyWhenUpToDate(t *testing.T) {
 }
 
 func TestCheckNoticeUsesFreshCacheWithoutCallingGH(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
 		t.Fatal(err)
@@ -54,12 +52,8 @@ func TestCheckNoticeUsesFreshCacheWithoutCallingGH(t *testing.T) {
 
 	// A refusal fake, not an imitation of gh: a fresh cache must serve the
 	// notice without any gh call at all, so any invocation is the failure.
-	bin := t.TempDir()
-	script := "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n"
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.GH{}.Install(t, bin)
 
 	if err := writeCache(filepath.Join(home, "state", cacheFile), versionCache{
 		CheckedAt: time.Now(),
@@ -137,9 +131,6 @@ func TestCheckNoticeCachesFailedCheck(t *testing.T) {
 }
 
 func TestCheckNoticeSkipsUnparseableCurrentVersion(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
 		t.Fatal(err)
@@ -147,12 +138,8 @@ func TestCheckNoticeSkipsUnparseableCurrentVersion(t *testing.T) {
 
 	// Same refusal fake as TestCheckNoticeUsesFreshCacheWithoutCallingGH above;
 	// an unparseable current version must skip the check entirely.
-	bin := t.TempDir()
-	script := "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n"
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	bin := faketool.Bin(t)
+	faketool.GH{}.Install(t, bin)
 
 	if notice := CheckNotice(home, "atqamz/hand", "dev"); notice != "" {
 		t.Fatalf("got %q, want empty notice for an unversioned build", notice)

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -240,9 +240,6 @@ func TestVerifyChecksumMismatch(t *testing.T) {
 }
 
 func TestApplyLeavesBinaryUnchangedOnChecksumMismatch(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
 	fixture := t.TempDir()
 	assetName := AssetName()
 	if err := os.WriteFile(filepath.Join(fixture, assetName), []byte("payload"), 0o644); err != nil {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -161,7 +161,7 @@ func TestApplyReplacesRunningBinary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o755 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
 		t.Fatalf("got mode %v, want 0755", info.Mode().Perm())
 	}
 

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/atqamz/hand/internal/faketool"
@@ -131,10 +132,6 @@ func TestLatestTag(t *testing.T) {
 }
 
 func TestApplyReplacesRunningBinary(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
-
 	fixture := buildFixture(t, []byte("new binary contents"))
 	writeFakeGH(t, "v0.5.0", fixture)
 
@@ -172,16 +169,27 @@ func TestApplyReplacesRunningBinary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 {
-		t.Fatalf("got %d entries in install dir, want only the replaced binary", len(entries))
+	wantEntries := 1
+	if runtime.GOOS == "windows" {
+		wantEntries = 2
+	}
+	if len(entries) != wantEntries {
+		t.Fatalf("got %d entries in install dir, want %d", len(entries), wantEntries)
+	}
+	if runtime.GOOS == "windows" {
+		backupCount := 0
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), ".hand-update-") && strings.HasSuffix(entry.Name(), ".old.exe") {
+				backupCount++
+			}
+		}
+		if backupCount != 1 {
+			t.Fatalf("got %d updater backups, want one", backupCount)
+		}
 	}
 }
 
 func TestApplyLeavesNoStagedFileWhenExtractionFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("update binary layout targets unix asset names")
-	}
-
 	fixture := t.TempDir()
 	assetName := AssetName()
 	payload := []byte("not a gzip stream")
@@ -205,8 +213,16 @@ func TestApplyLeavesNoStagedFileWhenExtractionFails(t *testing.T) {
 	ExecutableOverride = func() (string, error) { return execPath, nil }
 	defer func() { ExecutableOverride = restore }()
 
-	if err := Apply("atqamz/hand", "v0.5.0"); err == nil {
+	err := Apply("atqamz/hand", "v0.5.0")
+	if err == nil {
 		t.Fatal("want error when the asset is not a valid archive")
+	}
+	wantError := "open gzip stream"
+	if runtime.GOOS == "windows" {
+		wantError = "open zip"
+	}
+	if !strings.Contains(err.Error(), wantError) {
+		t.Fatalf("error = %q, want %q", err, wantError)
 	}
 
 	entries, err := os.ReadDir(execDir)
@@ -259,8 +275,9 @@ func TestApplyLeavesBinaryUnchangedOnChecksumMismatch(t *testing.T) {
 	ExecutableOverride = func() (string, error) { return execPath, nil }
 	t.Cleanup(func() { ExecutableOverride = restore })
 
-	if err := Apply("atqamz/hand", "v0.5.0"); err == nil {
-		t.Fatal("want checksum mismatch")
+	err := Apply("atqamz/hand", "v0.5.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch for "+assetName) {
+		t.Fatalf("error = %v, want checksum mismatch for %s", err, assetName)
 	}
 	got, err := os.ReadFile(execPath)
 	if err != nil {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
 )
 
 func TestIsNewer(t *testing.T) {
@@ -87,32 +89,10 @@ func TestArchiveBinaryName(t *testing.T) {
 // the reason on stderr for a failure. runGH reads stdout only, so that split matters.
 func writeFakeGH(t *testing.T, tag, fixtureDir string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "release" ] && [ "$2" = "view" ]; then
-  printf '%%s' %q
-  exit 0
-fi
-if [ "$1" = "release" ] && [ "$2" = "download" ]; then
-  dir=""
-  prev=""
-  for a in "$@"; do
-    if [ "$prev" = "--dir" ]; then dir="$a"; fi
-    prev="$a"
-  done
-  cp %q/* "$dir"/
-  exit 0
-fi
-echo "unexpected gh invocation: $@" >&2
-exit 1
-`, tag, fixtureDir)
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	portableBin := faketool.Bin(t)
+	faketool.GH{Release: faketool.GHRelease{
+		Tag: tag, FixtureDir: fixtureDir,
+	}}.Install(t, portableBin)
 }
 
 func buildFixture(t *testing.T, binaryContent []byte) string {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -49,6 +49,9 @@ var ErrArmFailed = errors.New("could not arm")
 func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	client, err := connect(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
 		return err
 	}
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -183,7 +183,10 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 			return
 		}
 		seen[t.ID] = true
-		pane, probeErr := client.PaneGet(t.Herdr.PaneID)
+		pane, probeErr := client.PaneGetContext(ctx, t.Herdr.PaneID)
+		if ctx.Err() != nil {
+			return
+		}
 		status := pane.AgentStatus
 
 		// Tracking is keyed by task identity, not by ID: an ID torn down and respawned between two

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -119,7 +119,7 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 func connect(ctx context.Context) (*herdr.Client, error) {
 	client := herdr.NewClient()
 	done := make(chan error, 1)
-	go func() { _, err := client.WorkspaceList(); done <- err }()
+	go func() { _, err := client.WorkspaceListContext(ctx); done <- err }()
 	select {
 	// Losing the race is ErrNoEvent for the same reason probeAllTasks's is: the window closed during
 	// arming, which is exit 4 wherever in arming it happens.
@@ -146,7 +146,7 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 	done := make(chan error, 1)
 	go func() {
 		for _, t := range tasks {
-			if _, err := client.PaneGet(t.Herdr.PaneID); err != nil {
+			if _, err := client.PaneGetContext(ctx, t.Herdr.PaneID); err != nil {
 				done <- fmt.Errorf("%w: %s: %v", ErrArmFailed, t.ID, err)
 				return
 			}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1910,6 +1910,34 @@ func TestRunExitsCleanlyOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestRunExitsWhenPaneProbeIsCanceled(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{{ID: "wA:tA", Label: "task-1", Pane: "p1"}}}},
+		Hang:       []string{"pane get"},
+		Log:        callLog, LogCommands: []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
+	}()
+	waitForPaneGets(t, callLog, 1)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after canceling a pane probe")
+	}
+}
+
 // The regression test for the delivery failure of 2026-07-28: the grep-on-first-line wrapper this
 // mode replaces matched a done worker's startup line, took it for a transition, and left the two real
 // events that followed unread for three hours.

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -4,17 +4,16 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/shellquote"
@@ -32,55 +31,20 @@ const paneGoneStatus = "pane-gone"
 // internal/herdr/client.go's call doc. Those failure paths belong to internal/herdr/client_test.go.
 func writeFakeHerdr(t *testing.T, statusFile string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
+	bin := faketool.Bin(t)
 	// The unexpected-args arm deliberately diverges - a bare stderr line and exit 1 - so a call shape
 	// no test anticipated fails loudly instead of parsing. "pane get" reads its status from statusFile,
 	// so a test can drive transitions between ticks.
-	script := `#!/bin/sh
-case "$1 $2" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	;;
-"pane get")
-	status=$(cat "$STATUS_FILE")
-	# Logged after the read, never before: a test that flips the status on seeing
-	# the Nth call would otherwise still be racing the Nth read of the file.
-	if [ -n "$CALL_LOG" ]; then
-		echo "pane get" >> "$CALL_LOG"
-	fi
-	if [ "$status" = "` + paneGoneStatus + `" ]; then
-		printf '{"id":"cli:1","error":{"code":"not_found","message":"pane p1 not found"}}'
-		exit 0
-	fi
-	# PANE_AGENT is empty unless a test sets it, which is what keeps every test written before the
-	# usage-limit check from reading a pane: an unclassified pane names no harness, so no harness
-	# capability applies to it.
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"p1","agent_status":"%s","agent":"%s"}}}' "$status" "$PANE_AGENT"
-	;;
-"pane read")
-	echo "read" >> "${PANE_LOG:-/dev/null}"
-	# Raw text on stdout, not an envelope: herdr's own contract for this one
-	# command, mirrored here because the client parses it that way.
-	cat "$PANE_TEXT_FILE" 2>/dev/null
-	;;
-"pane send-text"|"pane send-keys")
-	# Empty stdout and exit 0 is real herdr's success shape for a void command.
-	echo "$2 $4" >> "${PANE_LOG:-/dev/null}"
-	;;
-*)
-	echo "unexpected herdr args: $@" >&2
-	exit 1
-	;;
-esac
-`
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("STATUS_FILE", statusFile)
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	faketool.Herdr{
+		Workspaces:     []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{{ID: "wA:tA", Label: "task-1", Pane: "p1"}}}},
+		PaneStatusFile: statusFile,
+		PaneAgentEnv:   true, PaneReadFileEnv: true, KeyLogEnv: true, TextLogEnv: true,
+		ReadLogEnv: true, AllowUnknownPane: true,
+		Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}},
+		Log:       callLog, LogCommands: []string{"pane get"},
+	}.Install(t, bin)
 }
 
 // Fakes `gh pr view --json state`, the only gh call a tick makes (watcher.go's ghutil.PRIsMerged),
@@ -94,18 +58,18 @@ func writeFakeGh(t *testing.T, prState string) {
 // at the instant that matters: after tick's state.List snapshot, before the auto-record re-reads.
 func writeFakeGhWithHook(t *testing.T, prState, hook string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
+	if hook != "" {
+		t.Fatalf("shell hook is not supported by the portable fake: %q", hook)
 	}
-	bin := t.TempDir()
-	// Real gh prefixes its own warnings on stderr and PRIsMerged reads stdout alone, so the fake emits
-	// a stderr line too: a CombinedOutput regression there must fail this watcher path as well, not
-	// only internal/ghutil/pr_test.go.
-	script := "#!/bin/sh\necho 'Warning: gh version is out of date' >&2\n" + hook + "\nprintf '{\"state\":\"" + prState + "\"}'\n"
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.GH{Responses: []faketool.GHResponse{{Command: "pr view", Stdout: `{"state":"` + prState + `"}`, Stderr: "Warning: gh version is out of date\n"}}}.Install(t, faketool.Bin(t))
+}
+
+func writeFakeGhWithCopy(t *testing.T, prState, source, dest string) {
+	t.Helper()
+	faketool.GH{Responses: []faketool.GHResponse{{
+		Command: "pr view", Stdout: `{"state":"` + prState + `"}`, Stderr: "Warning: gh version is out of date\n",
+		Copy: &faketool.GHCopy{Source: source, Dest: dest},
+	}}}.Install(t, faketool.Bin(t))
 }
 
 // Gives a watcher home the two things the auto-record path's validation reads: a registry entry and a
@@ -144,9 +108,7 @@ func setStatus(t *testing.T, statusFile, status string) {
 
 func logPaneGets(t *testing.T) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "pane-get-calls")
-	t.Setenv("CALL_LOG", path)
-	return path
+	return os.Getenv("HERDR_CALL_LOG")
 }
 
 func waitForPaneGets(t *testing.T, callLog string, want int) {
@@ -645,7 +607,7 @@ func TestTickStaysSilentWhenTheLockHolderRecordedTheSamePR(t *testing.T) {
 	snapshot := taskSnapshotWithPR(t, home, "task-1", url)
 	// Hence the gh double writes it: ValidatePR shells out to gh on the way to the lock, so the hook
 	// fires inside exactly that window.
-	writeFakeGhWithHook(t, "OPEN", fmt.Sprintf("cp %q %q", snapshot, store.Path(home)))
+	writeFakeGhWithCopy(t, "OPEN", snapshot, store.Path(home))
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -717,7 +679,7 @@ func TestTickReportsAnUnreadableTaskWhenTheLockIsContended(t *testing.T) {
 	if err := os.WriteFile(corrupt, []byte("this is not a database"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	writeFakeGhWithHook(t, "OPEN", fmt.Sprintf("cp %q %q", corrupt, store.Path(home)))
+	writeFakeGhWithCopy(t, "OPEN", corrupt, store.Path(home))
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -1746,15 +1708,11 @@ func TestTickKeepsAMultiLineAutoRecordFailureOnOneLine(t *testing.T) {
 // written to stdout, as with the real tool on this path.
 func writeFakeGhFailingMultiline(t *testing.T) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake gh is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\nprintf 'error connecting to api.github.com\\ncheck your internet connection or https://githubstatus.com\\n' >&2\nexit 1\n"
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.GH{Responses: []faketool.GHResponse{{
+		Command: "pr view",
+		Stderr:  "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com\n",
+		Exit:    1,
+	}}}.Install(t, faketool.Bin(t))
 }
 
 func TestTickForgetsTornDownTasks(t *testing.T) {
@@ -1914,17 +1872,7 @@ func TestHandleEventReportsAFailingNotifyTemplateToErrOut(t *testing.T) {
 }
 
 func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	// exit 1 with empty stdout is the faithful crashed-or-missing-binary shape, which call()'s
-	// empty-stdout-plus-runErr branch handles. A distinct shape from herdr's ordinary failure (exit 0
-	// plus an error envelope), and only this one means "unreachable".
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.Herdr{Unreachable: true}.Install(t, faketool.Bin(t))
 
 	home := t.TempDir()
 	err := Run(context.Background(), Config{Home: home, PollInterval: time.Second, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
@@ -2161,14 +2109,7 @@ func TestRunUntilEventReportsNoEventOnContextCancel(t *testing.T) {
 }
 
 func TestRunUntilEventFailsWhenHerdrUnreachable(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.Herdr{Unreachable: true}.Install(t, faketool.Bin(t))
 
 	err := RunUntilEvent(context.Background(), Config{Home: t.TempDir(), PollInterval: time.Second, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "herdr unreachable") {
@@ -2180,15 +2121,7 @@ func TestRunUntilEventFailsWhenHerdrUnreachable(t *testing.T) {
 }
 
 func TestRunUntilEventReportsNoEventWhenConnectHangs(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := "#!/bin/sh\nsleep 5\nprintf '{\"id\":\"cli:1\",\"result\":{\"workspaces\":[]}}'\n"
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.Herdr{Hang: []string{"workspace list"}}.Install(t, faketool.Bin(t))
 
 	cfg := Config{Home: t.TempDir(), PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 100 * time.Millisecond}
 	start := time.Now()
@@ -2209,25 +2142,11 @@ func TestRunUntilEventReportsNoEventWhenConnectHangs(t *testing.T) {
 }
 
 func TestRunUntilEventReportsNoEventWhenTheArmProbeHangs(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("fake herdr is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	script := `#!/bin/sh
-case "$1 $2" in
-"workspace list")
-	printf '{"id":"cli:1","result":{"workspaces":[]}}'
-	;;
-"pane get")
-	sleep 5
-	printf '{"id":"cli:1","result":{"pane":{"pane_id":"p1","agent_status":"working"}}}'
-	;;
-esac
-`
-	if err := os.WriteFile(filepath.Join(bin, "herdr"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{{ID: "wA:tA", Label: "task-1", Pane: "p1"}}}},
+		Responses:  []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}},
+		Hang:       []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 100 * time.Millisecond}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -12,24 +11,13 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// One-off treehouse for a single response shape, used only where the call changes
-// no state: payload and exit-status parsing. Everything stateful drives
-// faketool.Treehouse instead, the shared pool fake.
-func writeFakeTreehouse(t *testing.T, script string) {
+func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("fake treehouse is a POSIX shell script, not supported on windows")
-	}
-	bin := t.TempDir()
-	path := filepath.Join(bin, "treehouse")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
 }
 
 func TestGetParsesLeasePathAndIdentity(t *testing.T) {
-	writeFakeTreehouse(t, `printf '{"path":"/tmp/wt-1","lease_id":"5fe5412a4aabdeb85a148d6d73eb42d8"}'`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1","lease_id":"5fe5412a4aabdeb85a148d6d73eb42d8"}`})
 	got, err := Get(t.TempDir(), "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +32,7 @@ func TestGetParsesLeasePathAndIdentity(t *testing.T) {
 // stay a usable lease rather than an error - CheckCollision falls back to the
 // path for it.
 func TestGetAcceptsAPayloadWithoutALeaseIdentity(t *testing.T) {
-	writeFakeTreehouse(t, `printf '{"path":"/tmp/wt-1"}'`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1"}`})
 	got, err := Get(t.TempDir(), "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
@@ -55,27 +43,24 @@ func TestGetAcceptsAPayloadWithoutALeaseIdentity(t *testing.T) {
 }
 
 func TestGetPassesLeaseHolder(t *testing.T) {
-	writeFakeTreehouse(t, `
-if [ "$4" != "--lease-holder" ] || [ "$5" != "hand:task-1" ]; then
-	echo "unexpected args: $@" >&2
-	exit 1
-fi
-printf '{"path":"/tmp/wt-1"}'
-`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{
+		Command: "get", Args: []string{"--lease", "--json", "--lease-holder", "hand:task-1"},
+		Stdout: `{"path":"/tmp/wt-1"}`,
+	})
 	if _, err := Get(t.TempDir(), "hand:task-1"); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestGetFailsOnNonZeroExit(t *testing.T) {
-	writeFakeTreehouse(t, `echo "pool exhausted" >&2; exit 1`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stderr: "pool exhausted\n", Exit: 1})
 	if _, err := Get(t.TempDir(), ""); err == nil || !strings.Contains(err.Error(), "pool exhausted") {
 		t.Fatalf("got err %v, want pool exhausted failure", err)
 	}
 }
 
 func TestGetFailsOnMissingPath(t *testing.T) {
-	writeFakeTreehouse(t, `printf '{}'`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{}`})
 	if _, err := Get(t.TempDir(), ""); err == nil {
 		t.Fatal("expected error for missing path in lease response")
 	}
@@ -83,19 +68,14 @@ func TestGetFailsOnMissingPath(t *testing.T) {
 
 func TestReturnPassesForceFlag(t *testing.T) {
 	wt := t.TempDir()
-	writeFakeTreehouse(t, `
-if [ "$1" != "return" ] || [ "$2" != "`+wt+`" ] || [ "$3" != "--force" ]; then
-	echo "unexpected args: $@" >&2
-	exit 1
-fi
-`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "return", Args: []string{wt, "--force"}})
 	if err := Return(wt, true); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestReturnFailsOnNonZeroExit(t *testing.T) {
-	writeFakeTreehouse(t, `echo "worktree busy" >&2; exit 1`)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "return", Stderr: "worktree busy\n", Exit: 1})
 	if err := Return(t.TempDir(), false); err == nil || !strings.Contains(err.Error(), "worktree busy") {
 		t.Fatalf("got err %v, want worktree busy failure", err)
 	}

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -186,6 +186,7 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 			{ID: "tab-other", Label: "other", Pane: "pane-other"},
 		}}},
 		TabCreates: []faketool.HerdrTab{{ID: "tab-new", Label: "task-1", Pane: "pane-new"}},
+		PaneAgent:  "claude",
 		PaneStatus: "done",
 		Log:        launchLog,
 	}.Install(t, dir)

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -118,6 +118,7 @@ func writeFakeHerdrStaticLogged(t *testing.T, dir, logPath string, ids herdrIDs)
 			{ID: ids.TabID, Label: "1", Pane: ids.PaneID},
 		}}},
 		TabCreates: spares,
+		PaneAgent:  "claude",
 		PaneStatus: ids.PaneStatus,
 		Log:        logPath,
 	}.Install(t, dir)


### PR DESCRIPTION
## Summary

- Replace POSIX-shell faketool execution with one cached Go helper executable and serialized per-tool configurations.
- Migrate shared GH, Herdr, Treehouse, NoMistakes, generic argv, fake git, and issue-scoped test helpers.
- Make GH release fixtures validate repo, tag, JSON field, jq selector, clobber flag, and requested patterns, and restore Herdr pane workspace ownership in `pane get`.
- Keep watcher pane probes cancellation-safe and preserve state transitions, output shapes, exit codes, logging, and cancellation behavior across platforms.

Fixes atqamz/hand#202

## Test plan

- `nix develop -c bash -lc "go test -race ./..."` - passed locally.
- `nix develop -c bash -lc "go test -tags=e2e -count=1 -timeout=10m ./tests/e2e/..."` - passed locally.
- `nix develop -c bash -lc "go build ./..."` - passed locally.
- `nix develop -c bash -lc "make lint"` - passed locally.
- Branch rebased onto current `main` at `f778cb8` including atqamz/hand#207.
- GitHub Actions run 31623041306 on `f5a0047`: Ubuntu, macOS, Windows, Nix build, lint, and E2E all passed.
- Formerly skipped Windows coverage now executes for portable fake substrate, GH, Herdr, Treehouse, NoMistakes, fake git, hand argv probes, watcher, teardown, status, launch, gate preflight, and self-update fixtures.