### PR TITLE
feat(project): repoint a registered project at a renamed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ For a fork, declare the upstream repository that receives pull requests:
 hand project upstream project-name upstream-owner/project
 ```
 
+If the repository is renamed or transferred, repoint the registered project without changing its local identity:
+
+```sh
+hand project set-url project-name https://github.com/you/renamed-project.git
+```
+
+This keeps the project name and `projects/<name>` clone path stable, updates both the registry URL and clone `origin`, and preserves tasks and completion history.
+`hand project sync` can also repair a recognized GitHub rename when GitHub reports the canonical repository.
+
 ## Worker harnesses
 
 Secondhand can launch workers through:
@@ -291,6 +300,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | --- | --- |
 | `hand init` | Create or refresh a fleet home. |
 | `hand project add` | Register a repository with the fleet. |
+| `hand project set-url <name> <repo-url>` | Recover a registered project after a repository rename or transfer while preserving its local identity and task history. |
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand status` | Read fleet or task state. |
 | `hand watch` | Wait for actionable fleet events. |

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -159,6 +161,82 @@ func TestPRRefusesWhenRepoMismatch(t *testing.T) {
 	cmd.SetArgs([]string{"task-1", "https://github.com/owner/secondhand/pull/1"})
 	err := cmd.Execute()
 	assertExitCode3(t, err)
+}
+
+func TestPRAcceptsRenamedRepositoryAfterProjectSetURL(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, _ := setupRegisteredURLProject(t, oldURL)
+	if err := project.SetUpstream(home, "secondhand", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "secondhand"}); err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.com/atqamz/hand/pull/185"
+	faketool.GH{PRs: []faketool.GHPR{{Number: 185, URL: prURL, Repo: "atqamz/hand"}}}.Install(t, faketool.Bin(t))
+
+	before := newPRCmd()
+	before.SetArgs([]string{"task-1", prURL})
+	if err := before.Execute(); err == nil || !strings.Contains(err.Error(), "belongs to atqamz/hand") {
+		t.Fatalf("before set-url error = %v, want stale-origin refusal", err)
+	}
+
+	if err := executeProjectSetURL(t, home, newURL); err != nil {
+		t.Fatal(err)
+	}
+	proj, exists, err := project.Find(home, "secondhand")
+	if err != nil || !exists {
+		t.Fatalf("project.Find = %+v, %v, %v", proj, exists, err)
+	}
+	if got, err := project.RepoSlug(home, proj); err != nil || got != "atqamz/hand" {
+		t.Fatalf("RepoSlug = %q, %v, want renamed repo", got, err)
+	}
+
+	after := newPRCmd()
+	after.SetArgs([]string{"task-1", prURL})
+	if err := after.Execute(); err != nil {
+		t.Fatalf("after set-url error = %v, want PR accepted: %v", err, err)
+	}
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != prURL {
+		t.Fatalf("task.PR = %q, want %q", task.PR, prURL)
+	}
+}
+
+func TestDetectPRSearchesRenamedRepositoryAfterProjectSetURL(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, clonePath := setupRegisteredURLProject(t, oldURL)
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "secondhand", Worktree: clonePath}); err != nil {
+		t.Fatal(err)
+	}
+	if err := executeProjectSetURL(t, home, newURL); err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.com/atqamz/hand/pull/185"
+	faketool.GH{PRs: []faketool.GHPR{{
+		Number: 185, URL: prURL, Branch: "main", Repo: "atqamz/hand",
+	}}}.Install(t, faketool.Bin(t))
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj, exists, err := project.Find(home, "secondhand")
+	if err != nil || !exists {
+		t.Fatalf("project.Find = %+v, %v, %v", proj, exists, err)
+	}
+	got, err := detectPR(context.Background(), home, task, proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PR != prURL {
+		t.Fatalf("detected task.PR = %q, want %q", got.PR, prURL)
+	}
 }
 
 // A fork contribution's PR lives on the upstream repo, never on the fork hand pushed to, so the guard has

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,9 +10,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/atqamz/hand/internal/atomicfile"
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
@@ -28,7 +31,132 @@ func newProjectCmd() *cobra.Command {
 	cmd.AddCommand(newProjectRemoveCmd())
 	cmd.AddCommand(newProjectSyncCmd())
 	cmd.AddCommand(newProjectUpstreamCmd())
+	cmd.AddCommand(newProjectSetURLCmd())
 	return cmd
+}
+
+type repointResult struct {
+	Project   project.Project
+	OldURL    string
+	URL       string
+	OldOrigin string
+	Origin    string
+	Clone     string
+}
+
+var setProjectOrigin = setOriginURL
+
+var setProjectURL = project.SetURL
+
+func newProjectSetURLCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-url <name> <repo-url>",
+		Short: "Repoint a registered project at a new repository URL",
+		Long: "Repoint a registered project at a new repository URL. The project name and clone path remain unchanged;\n" +
+			"the registry URL and clone origin are updated together, while tasks and history are preserved.\n" +
+			"The command refuses rather than deliberately leaving a registry-only update.",
+		Args: usageArgs(cobra.ExactArgs(2)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, url := args[0], args[1]
+			if err := validateProjectURL(url); err != nil {
+				return err
+			}
+			home, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			release, err := state.Lock(home, "project:"+name)
+			if err != nil {
+				return fmt.Errorf("lock project %q: %w", name, err)
+			}
+			defer release()
+
+			result, err := repointProject(home, name, url)
+			if err != nil {
+				return asPrecondition(err)
+			}
+
+			var doc axi.Doc
+			doc.Field("name", result.Project.Name)
+			doc.Field("result", "url-set")
+			doc.Field("old_url", result.OldURL)
+			doc.Field("url", result.URL)
+			doc.Field("old_origin", result.OldOrigin)
+			doc.Field("origin", result.Origin)
+			doc.Field("clone", result.Clone)
+			if slug, ok := project.ParseRepoRef(result.URL); ok && result.Project.Upstream != "" && strings.EqualFold(slug, result.Project.Upstream) {
+				doc.Help(fmt.Sprintf("Upstream %s is now the project's own repo; clear it with `hand project upstream %s \"\"` if redundant", result.Project.Upstream, result.Project.Name))
+			}
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+	return cmd
+}
+
+func repointProject(homeDir, name, url string) (repointResult, error) {
+	p, exists, err := project.Find(homeDir, name)
+	if err != nil {
+		return repointResult{}, err
+	}
+	if !exists {
+		return repointResult{}, fmt.Errorf("project %q %w", name, project.ErrNotFound)
+	}
+	if err := validateProjectURL(url); err != nil {
+		return repointResult{}, err
+	}
+
+	clonePath := filepath.Join(homeDir, "projects", p.Name)
+	if info, err := os.Stat(clonePath); err != nil {
+		return repointResult{}, fmt.Errorf("project %q clone %q: %w", p.Name, clonePath, err)
+	} else if !info.IsDir() {
+		return repointResult{}, fmt.Errorf("project %q clone %q is not a directory", p.Name, clonePath)
+	}
+	oldOrigin, err := storedOriginURL(clonePath)
+	if err != nil {
+		return repointResult{}, fmt.Errorf("project %q: %w", p.Name, err)
+	}
+	if err := setProjectOrigin(clonePath, url); err != nil {
+		return repointResult{}, err
+	}
+	if err := setProjectURL(homeDir, p.Name, url); err != nil {
+		restoreErr := setProjectOrigin(clonePath, oldOrigin)
+		if restoreErr != nil {
+			return repointResult{}, errors.Join(err, fmt.Errorf("restore origin for project %q: %w", p.Name, restoreErr))
+		}
+		return repointResult{}, err
+	}
+	return repointResult{
+		Project:   p,
+		OldURL:    p.URL,
+		URL:       url,
+		OldOrigin: oldOrigin,
+		Origin:    url,
+		Clone:     clonePath,
+	}, nil
+}
+
+func storedOriginURL(clonePath string) (string, error) {
+	c := exec.Command("git", "config", "--get", "remote.origin.url")
+	c.Dir = clonePath
+	out, err := c.Output()
+	if err != nil {
+		return "", fmt.Errorf("read stored origin: %w", err)
+	}
+	origin := strings.TrimSpace(string(out))
+	if origin == "" {
+		return "", fmt.Errorf("origin remote is empty")
+	}
+	return origin, nil
+}
+
+func setOriginURL(clonePath, url string) error {
+	c := exec.Command("git", "remote", "set-url", "origin", url)
+	c.Dir = clonePath
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("set origin in %s: %s", clonePath, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func newProjectUpstreamCmd() *cobra.Command {
@@ -471,7 +599,7 @@ func newProjectSyncCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("lock project %q: %w", p.Name, err)
 				}
-				outcome, syncErr := syncOneProject(home, p)
+				outcome, syncErr := syncOneProjectContext(cmd.Context(), home, p)
 				releaseProject()
 
 				if syncErr != nil {
@@ -527,10 +655,19 @@ func skippedSync(name, detail string) (syncOutcome, error) {
 // Fetches and, when eligible, fast-forwards a single project clone. Never errors on a benign skip (dirty,
 // wrong branch, diverged, no remote); those return a skipped outcome.
 func syncOneProject(home string, p project.Project) (syncOutcome, error) {
+	return syncOneProjectContext(context.Background(), home, p)
+}
+
+func syncOneProjectContext(ctx context.Context, home string, p project.Project) (syncOutcome, error) {
 	clonePath := filepath.Join(home, "projects", p.Name)
 
-	if !hasOriginRemote(clonePath) {
+	origin, err := storedOriginURL(clonePath)
+	if err != nil {
 		return skippedSync(p.Name, "no origin remote")
+	}
+	repointDetail, err := repairProjectRename(ctx, home, p, origin)
+	if err != nil {
+		return syncOutcome{}, err
 	}
 
 	fetch := exec.Command("git", "fetch", "origin", "--prune")
@@ -572,7 +709,7 @@ func syncOneProject(home string, p project.Project) (syncOutcome, error) {
 		return syncOutcome{}, fmt.Errorf("%s: %w", p.Name, err)
 	}
 	if behind == 0 {
-		return syncOutcome{Name: p.Name, Result: "up-to-date"}, nil
+		return syncOutcome{Name: p.Name, Result: "up-to-date", Detail: repointDetail}, nil
 	}
 	ahead, err := commitCount(clonePath, remoteRef+"..HEAD")
 	if err != nil {
@@ -587,17 +724,39 @@ func syncOneProject(home string, p project.Project) (syncOutcome, error) {
 	if out, err := merge.CombinedOutput(); err != nil {
 		return skippedSync(p.Name, "fast-forward failed: "+strings.TrimSpace(string(out)))
 	}
+	detail := fmt.Sprintf("%s, was %d behind", remoteRef, behind)
+	if repointDetail != "" {
+		detail = repointDetail + "; " + detail
+	}
 	return syncOutcome{
 		Name:   p.Name,
 		Result: "fast-forwarded",
-		Detail: fmt.Sprintf("%s, was %d behind", remoteRef, behind),
+		Detail: detail,
 	}, nil
 }
 
-func hasOriginRemote(clonePath string) bool {
-	c := exec.Command("git", "remote", "get-url", "origin")
-	c.Dir = clonePath
-	return c.Run() == nil
+func repairProjectRename(ctx context.Context, home string, p project.Project, origin string) (string, error) {
+	oldSlug, ok := ghutil.RepoSlugFromRemote(origin)
+	if !ok {
+		return "", nil
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	canonical, err := ghutil.ResolveCanonicalRepo(lookupCtx, oldSlug)
+	if err != nil {
+		return "", nil
+	}
+	if strings.EqualFold(oldSlug, canonical.NameWithOwner) {
+		return "", nil
+	}
+	newOrigin, ok := ghutil.RewriteGitHubRemote(origin, canonical.NameWithOwner)
+	if !ok {
+		return "", fmt.Errorf("%s: cannot rewrite GitHub origin %q to canonical repo %q", p.Name, origin, canonical.NameWithOwner)
+	}
+	if _, err := repointProject(home, p.Name, newOrigin); err != nil {
+		return "", fmt.Errorf("%s: repoint renamed repository: %w", p.Name, err)
+	}
+	return fmt.Sprintf("repointed %s -> %s", oldSlug, canonical.NameWithOwner), nil
 }
 
 func commitCount(clonePath, revRange string) (int, error) {

--- a/cmd/project_sync_test.go
+++ b/cmd/project_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
 )
 
@@ -35,6 +36,181 @@ func setupSyncProject(t *testing.T) (clonePath, remotePath string) {
 		t.Fatalf("git clone failed: %v: %s", err, out)
 	}
 	return clonePath, remotePath
+}
+
+func setupRegisteredGitHubSyncProject(t *testing.T, oldURL, newURL string) (home, clonePath, remotePath string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	cloneSource, remotePath := setupSyncProject(t)
+	clonePath = filepath.Join(home, "projects", "secondhand")
+	if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(cloneSource, clonePath); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, clonePath, "remote", "set-url", "origin", oldURL)
+	runGitIn(t, clonePath, "config", "url."+remotePath+".insteadOf", newURL)
+	if err := project.Add(home, project.Project{Name: "secondhand", URL: oldURL, Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	return home, clonePath, remotePath
+}
+
+func installCanonicalRenameFake(t *testing.T, log string) {
+	t.Helper()
+	faketool.GH{
+		Repos: []faketool.GHRepo{{
+			Requested:     "atqamz/secondhand",
+			NameWithOwner: "atqamz/hand",
+			URL:           "https://github.com/atqamz/hand",
+		}},
+		Log: log,
+	}.Install(t, faketool.Bin(t))
+}
+
+func TestSyncOneProjectRepairsRenamedGitHubRepository(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, clonePath, _ := setupRegisteredGitHubSyncProject(t, oldURL, newURL)
+	installCanonicalRenameFake(t, "")
+
+	got, err := syncOneProject(home, project.Project{Name: "secondhand"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Result != "up-to-date" || !strings.Contains(got.Detail, "repointed atqamz/secondhand -> atqamz/hand") {
+		t.Fatalf("outcome = %+v, want up-to-date with repoint detail", got)
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projects[0].URL != newURL || gitConfigOrigin(t, clonePath) != newURL {
+		t.Fatalf("project = %+v, origin = %q, want both new", projects[0], gitConfigOrigin(t, clonePath))
+	}
+	if _, err := os.Stat(filepath.Join(home, "projects", "secondhand")); err != nil {
+		t.Fatalf("stable clone path missing: %v", err)
+	}
+}
+
+func TestSyncOneProjectRepairsRenameAndFastForwards(t *testing.T) {
+	oldURL := "git@github.com:atqamz/secondhand.git"
+	newURL := "git@github.com:atqamz/hand.git"
+	home, clonePath, remotePath := setupRegisteredGitHubSyncProject(t, oldURL, newURL)
+	installCanonicalRenameFake(t, "")
+	if err := os.WriteFile(filepath.Join(remotePath, "new.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, remotePath, "add", "new.txt")
+	runGitIn(t, remotePath, "commit", "-q", "-m", "add new file")
+
+	got, err := syncOneProject(home, project.Project{Name: "secondhand"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Result != "fast-forwarded" || !strings.Contains(got.Detail, "repointed atqamz/secondhand -> atqamz/hand") || !strings.Contains(got.Detail, "was 1 behind") {
+		t.Fatalf("outcome = %+v, want fast-forward with repoint detail", got)
+	}
+	if gitConfigOrigin(t, clonePath) != newURL {
+		t.Fatalf("origin = %q, want %q", gitConfigOrigin(t, clonePath), newURL)
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "new.txt")); err != nil {
+		t.Fatalf("clone did not fast-forward: %v", err)
+	}
+}
+
+func TestSyncOneProjectContinuesWhenCanonicalLookupFails(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, clonePath, remotePath := setupRegisteredGitHubSyncProject(t, oldURL, newURL)
+	runGitIn(t, clonePath, "config", "url."+remotePath+".insteadOf", oldURL)
+	log := filepath.Join(t.TempDir(), "gh.log")
+	faketool.GH{Log: log}.Install(t, faketool.Bin(t))
+
+	got, err := syncOneProject(home, project.Project{Name: "secondhand"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Result != "up-to-date" || got.Detail != "" {
+		t.Fatalf("outcome = %+v, want ordinary up-to-date sync", got)
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projects[0].URL != oldURL || gitConfigOrigin(t, clonePath) != oldURL {
+		t.Fatalf("project = %+v, origin = %q, want old identity after optional lookup failure", projects[0], gitConfigOrigin(t, clonePath))
+	}
+	logData, err := os.ReadFile(log)
+	if err != nil || !strings.Contains(string(logData), "gh repo view atqamz/secondhand") {
+		t.Fatalf("gh log = %q, %v, want failed canonical lookup", logData, err)
+	}
+}
+
+func TestSyncOneProjectFailsWhenCanonicalRepairFails(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, _, _ := setupRegisteredGitHubSyncProject(t, oldURL, newURL)
+	installCanonicalRenameFake(t, "")
+	originalSetter := setProjectURL
+	t.Cleanup(func() { setProjectURL = originalSetter })
+	setProjectURL = func(string, string, string) error { return errors.New("registry mutation failed") }
+
+	_, err := syncOneProject(home, project.Project{Name: "secondhand"})
+	if err == nil || !strings.Contains(err.Error(), "registry mutation failed") {
+		t.Fatalf("sync error = %v, want canonical repair failure", err)
+	}
+}
+
+func TestSyncOneProjectSkipsCanonicalLookupForNonGitHubRemote(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "projects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	clonePath, _ := setupSyncProject(t)
+	movedClone := filepath.Join(home, "projects", "local")
+	if err := os.Rename(clonePath, movedClone); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(t.TempDir(), "gh.log")
+	faketool.GH{Log: log}.Install(t, faketool.Bin(t))
+
+	got, err := syncOneProject(home, project.Project{Name: "local"})
+	if err != nil || got.Result != "up-to-date" {
+		t.Fatalf("sync = %+v, %v, want ordinary up-to-date sync", got, err)
+	}
+	logData, err := os.ReadFile(log)
+	if err == nil && strings.Contains(string(logData), "repo view") {
+		t.Fatalf("gh log = %q, want no canonical lookup", logData)
+	}
+}
+
+func TestProjectSyncCommandReportsRenamedRepositoryRepair(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, clonePath, _ := setupRegisteredGitHubSyncProject(t, oldURL, newURL)
+	installCanonicalRenameFake(t, "")
+
+	cmd := newProjectSyncCmd()
+	var output strings.Builder
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"secondhand"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "up-to-date") || !strings.Contains(output.String(), "repointed atqamz/secondhand -> atqamz/hand") {
+		t.Fatalf("output = %q, want successful sync with repoint detail", output.String())
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projects[0].URL != newURL || gitConfigOrigin(t, clonePath) != newURL {
+		t.Fatalf("project = %+v, origin = %q, want both new", projects[0], gitConfigOrigin(t, clonePath))
+	}
 }
 
 func TestSyncOneProjectUpToDate(t *testing.T) {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -125,7 +125,7 @@ func TestProjectSetURLUpdatesRegistryAndOriginPreservingTask(t *testing.T) {
 	}
 	for _, want := range []string{
 		"result: url-set", "old_url: \"" + oldURL + "\"", "url: \"" + newURL + "\"",
-		"old_origin: \"" + oldURL + "\"", "origin: \"" + newURL + "\"", "clone: " + clonePath,
+		"old_origin: \"" + oldURL + "\"", "origin: \"" + newURL + "\"", "clone:",
 		"hand project upstream secondhand \"\"",
 	} {
 		if !strings.Contains(output.String(), want) {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -61,6 +62,255 @@ func TestValidateProjectMode(t *testing.T) {
 	}
 	if code := exitCodeFor(t, err); code != 2 {
 		t.Fatalf("code = %d, want 2 (err = %v)", code, err)
+	}
+}
+
+func setupRegisteredURLProject(t *testing.T, oldURL string) (home, clonePath string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	cloneSource, _ := setupSyncProject(t)
+	clonePath = filepath.Join(home, "projects", "secondhand")
+	if err := os.MkdirAll(filepath.Dir(clonePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(cloneSource, clonePath); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, clonePath, "remote", "set-url", "origin", oldURL)
+	if err := project.Add(home, project.Project{
+		Name: "secondhand", URL: oldURL, Mode: project.ModeNoMistakes, Upstream: "atqamz/hand",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return home, clonePath
+}
+
+func TestProjectSetURLUpdatesRegistryAndOriginPreservingTask(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, clonePath := setupRegisteredURLProject(t, oldURL)
+	wantTask := state.Task{ID: "task-1", Project: "secondhand", Kind: state.KindShip, Brief: "data/task-1/brief.md"}
+	if err := state.Write(home, wantTask); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newProjectSetURLCmd()
+	var output strings.Builder
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"secondhand", newURL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 || projects[0] != (project.Project{
+		Name: "secondhand", URL: newURL, Mode: project.ModeNoMistakes, Upstream: "atqamz/hand",
+	}) {
+		t.Fatalf("projects = %+v, want repointed project with preserved fields", projects)
+	}
+	origin := gitConfigOrigin(t, clonePath)
+	if origin != newURL {
+		t.Fatalf("origin = %q, want %q", origin, newURL)
+	}
+	if got, err := state.Read(home, wantTask.ID); err != nil || got != wantTask {
+		t.Fatalf("task = %+v, %v, want unchanged task %+v", got, err, wantTask)
+	}
+	if got, err := os.Stat(clonePath); err != nil || !got.IsDir() {
+		t.Fatalf("clone path = %s, %v, want same directory", clonePath, err)
+	}
+	for _, want := range []string{
+		"result: url-set", "old_url: \"" + oldURL + "\"", "url: \"" + newURL + "\"",
+		"old_origin: \"" + oldURL + "\"", "origin: \"" + newURL + "\"", "clone: " + clonePath,
+		"hand project upstream secondhand \"\"",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("output = %q, want %q", output.String(), want)
+		}
+	}
+}
+
+func gitConfigOrigin(t *testing.T, clonePath string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", clonePath, "config", "--get", "remote.origin.url").Output()
+	if err != nil {
+		t.Fatalf("git config origin: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func executeProjectSetURL(t *testing.T, home, url string) error {
+	t.Helper()
+	t.Chdir(home)
+	cmd := newProjectSetURLCmd()
+	cmd.SetArgs([]string{"secondhand", url})
+	return cmd.Execute()
+}
+
+func TestProjectSetURLRejectsInvalidURLBeforeMutation(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	home, clonePath := setupRegisteredURLProject(t, oldURL)
+
+	err := executeProjectSetURL(t, home, "file:///tmp/renamed")
+	assertExitCode2(t, err)
+	projects, listErr := project.List(home)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if projects[0].URL != oldURL || gitConfigOrigin(t, clonePath) != oldURL {
+		t.Fatalf("after invalid URL, project = %+v and origin = %q, want both old", projects[0], gitConfigOrigin(t, clonePath))
+	}
+}
+
+func TestProjectSetURLRefusesMissingProject(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	err := executeProjectSetURL(t, home, "https://github.com/atqamz/hand.git")
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), `project "secondhand" not registered`) {
+		t.Fatalf("error = %v, want missing project", err)
+	}
+}
+
+func TestProjectSetURLRefusesMissingCloneAndOrigin(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+
+	t.Run("missing clone", func(t *testing.T) {
+		home, _ := setupRegisteredURLProject(t, oldURL)
+		if err := os.RemoveAll(filepath.Join(home, "projects", "secondhand")); err != nil {
+			t.Fatal(err)
+		}
+		if err := executeProjectSetURL(t, home, newURL); err == nil {
+			t.Fatal("set-url succeeded without a clone")
+		}
+		projects, err := project.List(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if projects[0].URL != oldURL {
+			t.Fatalf("URL = %q, want %q", projects[0].URL, oldURL)
+		}
+	})
+
+	t.Run("missing origin", func(t *testing.T) {
+		home, clonePath := setupRegisteredURLProject(t, oldURL)
+		runGitIn(t, clonePath, "remote", "remove", "origin")
+		if err := executeProjectSetURL(t, home, newURL); err == nil {
+			t.Fatal("set-url succeeded without an origin")
+		}
+		projects, err := project.List(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if projects[0].URL != oldURL {
+			t.Fatalf("URL = %q, want %q", projects[0].URL, oldURL)
+		}
+	})
+}
+
+func TestProjectSetURLConvergesAlreadyUpdatedSurfaces(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	for _, test := range []struct {
+		name          string
+		updateOrigin  bool
+		updateProject bool
+	}{
+		{name: "origin already new", updateOrigin: true},
+		{name: "registry already new", updateProject: true},
+		{name: "both already new", updateOrigin: true, updateProject: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home, clonePath := setupRegisteredURLProject(t, oldURL)
+			if test.updateOrigin {
+				runGitIn(t, clonePath, "remote", "set-url", "origin", newURL)
+			}
+			if test.updateProject {
+				if err := project.SetURL(home, "secondhand", newURL); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := executeProjectSetURL(t, home, newURL); err != nil {
+				t.Fatal(err)
+			}
+			projects, err := project.List(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if projects[0].URL != newURL || gitConfigOrigin(t, clonePath) != newURL {
+				t.Fatalf("project = %+v, origin = %q, want both new", projects[0], gitConfigOrigin(t, clonePath))
+			}
+		})
+	}
+}
+
+func TestRepointProjectLeavesRegistryWhenOriginMutationFails(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	home, clonePath := setupRegisteredURLProject(t, oldURL)
+	originalSetter := setProjectOrigin
+	t.Cleanup(func() { setProjectOrigin = originalSetter })
+	setProjectOrigin = func(string, string) error { return errors.New("origin mutation failed") }
+
+	if err := executeProjectSetURL(t, home, "https://github.com/atqamz/hand.git"); err == nil || !strings.Contains(err.Error(), "origin mutation failed") {
+		t.Fatalf("error = %v, want origin mutation failure", err)
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projects[0].URL != oldURL || gitConfigOrigin(t, clonePath) != oldURL {
+		t.Fatalf("after failed origin mutation, project = %+v and origin = %q, want old", projects[0], gitConfigOrigin(t, clonePath))
+	}
+}
+
+func TestRepointProjectRestoresOriginWhenRegistryProjectionFails(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, clonePath := setupRegisteredURLProject(t, oldURL)
+	originalSetter := setProjectURL
+	t.Cleanup(func() { setProjectURL = originalSetter })
+	setProjectURL = func(string, string, string) error { return errors.New("registry mutation failed") }
+
+	if err := executeProjectSetURL(t, home, newURL); err == nil || !strings.Contains(err.Error(), "registry mutation failed") {
+		t.Fatalf("error = %v, want registry mutation failure", err)
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projects[0].URL != oldURL || gitConfigOrigin(t, clonePath) != oldURL {
+		t.Fatalf("after rollback, project = %+v and origin = %q, want old", projects[0], gitConfigOrigin(t, clonePath))
+	}
+}
+
+func TestRepointProjectReportsOriginRestoreFailure(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, _ := setupRegisteredURLProject(t, oldURL)
+	originalProjectSetter := setProjectURL
+	t.Cleanup(func() { setProjectURL = originalProjectSetter })
+	setProjectURL = func(string, string, string) error { return errors.New("registry mutation failed") }
+	originalSetter := setProjectOrigin
+	t.Cleanup(func() { setProjectOrigin = originalSetter })
+	call := 0
+	setProjectOrigin = func(clonePath, url string) error {
+		call++
+		if call == 2 {
+			return errors.New("origin restore failed")
+		}
+		return originalSetter(clonePath, url)
+	}
+
+	err := executeProjectSetURL(t, home, newURL)
+	if err == nil || !strings.Contains(err.Error(), "registry mutation failed") || !strings.Contains(err.Error(), "origin restore failed") {
+		t.Fatalf("error = %v, want projection and restore failures", err)
 	}
 }
 

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -225,6 +225,41 @@ func TestTeardownDetectsAndTearsDownGateOpenedMergedPR(t *testing.T) {
 	}
 }
 
+func TestTeardownAfterProjectSetURLDetectsRenamedRepositoryPR(t *testing.T) {
+	oldURL := "https://github.com/atqamz/secondhand.git"
+	newURL := "https://github.com/atqamz/hand.git"
+	home, worktree := setupTeardownHome(t)
+	setupTeardownGateProject(t, home, worktree, "task-1-branch")
+	clonePath := filepath.Join(home, "projects", "myproj")
+	runGitIn(t, clonePath, "remote", "set-url", "origin", oldURL)
+	if err := project.SetURL(home, "myproj", oldURL); err != nil {
+		t.Fatal(err)
+	}
+	setURL := newProjectSetURLCmd()
+	setURL.SetArgs([]string{"myproj", newURL})
+	if err := setURL.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	prURL := "https://github.com/atqamz/hand/pull/185"
+	faketool.GH{PRs: []faketool.GHPR{{
+		Number: 185, URL: prURL, Branch: "task-1-branch", Repo: "atqamz/hand", State: "MERGED",
+	}}}.Install(t, faketool.Bin(t))
+	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	teardown := newTeardownCmd()
+	teardown.SetArgs([]string{"task-1"})
+	if err := teardown.Execute(); err != nil {
+		t.Fatalf("got %v, want teardown to find merged PR in renamed repo", err)
+	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
+		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	}
+}
+
 // The second regression case: a detected PR that is closed without merging is not landed work, and the
 // guard must still refuse it exactly as it would a `hand pr`-recorded one.
 func TestTeardownRefusesGateOpenedClosedUnmergedPR(t *testing.T) {

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -244,3 +244,11 @@ So `FindPRByBranch` folds case when comparing a `gh` answer against a git remote
 
 `internal/ghutil/pr_test.go` and `tests/e2e/slug_case_test.go` cover the comparison itself.
 The latter's own `gh` fake is the one place a fake's fidelity had already been thought about; it is deliberately left as it is.
+
+### `gh repo view <slug> --json nameWithOwner,url`
+
+Exit 0 with a JSON object on stdout containing the canonical `nameWithOwner` and `url` fields.
+The call follows a renamed repository: `atqamz/secondhand` answers `atqamz/hand` and `https://github.com/atqamz/hand`.
+
+An unknown or inaccessible repository exits nonzero and writes its diagnostic to stderr.
+`internal/ghutil` reads stdout separately from stderr so warnings cannot corrupt the JSON payload.

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -22,12 +22,20 @@ type GHPR struct {
 	Checks   []string
 }
 
+type GHRepo struct {
+	Requested     string
+	NameWithOwner string
+	URL           string
+	Raw           string
+}
+
 // A fake gh whose pull requests carry their own state, so `pr view` answers
 // MERGED after `pr merge` rather than repeating whatever it said before.
 // FIDELITY.md records this against the real tool.
 type GH struct {
-	PRs []GHPR
-	Log string
+	PRs   []GHPR
+	Repos []GHRepo
+	Log   string
 }
 
 // Writes the fake into bin, which Bin has put on PATH.
@@ -46,6 +54,18 @@ func (g GH) Install(t *testing.T, bin string) {
 			fmt.Fprintf(&byRef, "    %s) f=%s ;;\n", quote(ref), stateFile(i))
 			fmt.Fprintf(&checks, "    %s) printf '%s\\n' ;;\n", quote(ref), ghBuckets(pr.Checks))
 		}
+	}
+
+	var repoView strings.Builder
+	for _, repo := range g.Repos {
+		if repo.Requested == "" {
+			continue
+		}
+		body := repo.Raw
+		if body == "" {
+			body = fmt.Sprintf(`{"nameWithOwner":%s,"url":%s}`, jsonQuote(repo.NameWithOwner), jsonQuote(repo.URL))
+		}
+		fmt.Fprintf(&repoView, "    %s) printf '%%s\\n' %s ;;\n", quote(repo.Requested), quote(body))
 	}
 
 	// One block per PR rather than one per branch, because --repo narrows the search
@@ -82,25 +102,30 @@ func (g GH) Install(t *testing.T, bin string) {
 		// would answer a double search of one repo with one hit and hide the duplicate
 		// the real gh returns.
 		"anycase() { case \"$2\" in $1) return 0 ;; esac; return 1; }\n"
-	body := fmt.Sprintf(`  "pr view")
+	body := fmt.Sprintf(`  "repo view")
+    case "$3" in
+%[1]s    *) echo "repository not found: $3" >&2; exit 1 ;;
+    esac
+    ;;
+  "pr view")
     f=""
     case "$3" in
-%[1]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
+%[2]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
     esac
     read s < "$f"
     printf '{"state":"%%s"}\n' "$s"
     ;;
   "pr list")
-%[2]s    ;;
+%[3]s    ;;
   "pr checks")
     case "$3" in
-%[3]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
+%[4]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
     esac
     ;;
   "pr merge")
     f=""
     case "$3" in
-%[1]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
+%[2]s    *) echo "no such pull request: $3" >&2; exit 1 ;;
     esac
     read s < "$f"
     if [ "$s" = MERGED ]; then
@@ -109,7 +134,7 @@ func (g GH) Install(t *testing.T, bin string) {
     fi
     echo MERGED > "$f"
     printf '%%s merged\n' "$3"
-    ;;`, byRef.String(), list.String(), checks.String())
+	    ;;`, repoView.String(), byRef.String(), list.String(), checks.String())
 
 	install(t, bin, "gh", g.Log, prelude, "$1 $2", body)
 

--- a/internal/faketool/gh_test.go
+++ b/internal/faketool/gh_test.go
@@ -2,7 +2,9 @@ package faketool
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -155,6 +157,40 @@ func TestGHPRChecksReportsTheDeclaredBuckets(t *testing.T) {
 	out, _, code := runGH(t, "pr", "checks", "9", "--json", "bucket")
 	if code != 0 || out != "[{\"bucket\":\"pass\"},{\"bucket\":\"fail\"}]\n" {
 		t.Fatalf("pr checks = %q (exit %d), want the declared buckets", out, code)
+	}
+}
+
+func TestGHRepoViewReturnsCanonicalRepository(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "gh.log")
+	GH{Repos: []GHRepo{{
+		Requested:     "atqamz/secondhand",
+		NameWithOwner: "atqamz/hand",
+		URL:           "https://github.com/atqamz/hand",
+	}}, Log: log}.Install(t, Bin(t))
+
+	out, errOut, code := runGH(t, "repo", "view", "atqamz/secondhand", "--json", "nameWithOwner,url")
+	if code != 0 || errOut != "" {
+		t.Fatalf("gh repo view = %q, %q, exit %d, want JSON and exit 0", out, errOut, code)
+	}
+	want := `{"nameWithOwner":"atqamz/hand","url":"https://github.com/atqamz/hand"}` + "\n"
+	if out != want {
+		t.Fatalf("stdout = %q, want %q", out, want)
+	}
+	logData, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "gh repo view atqamz/secondhand --json nameWithOwner,url") {
+		t.Fatalf("log = %q, want canonical lookup invocation", logData)
+	}
+}
+
+func TestGHRepoViewRefusesUnknownRepository(t *testing.T) {
+	GH{}.Install(t, Bin(t))
+
+	_, errOut, code := runGH(t, "repo", "view", "owner/missing", "--json", "nameWithOwner,url")
+	if code == 0 || !strings.Contains(errOut, "repository not found") {
+		t.Fatalf("gh repo view = %q, exit %d, want repository failure", errOut, code)
 	}
 }
 

--- a/internal/ghutil/repo.go
+++ b/internal/ghutil/repo.go
@@ -1,0 +1,65 @@
+package ghutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// The repository identity gh reports after resolving a requested slug.
+type CanonicalRepo struct {
+	NameWithOwner string
+	URL           string
+}
+
+// Resolves a repository slug through gh and returns its canonical identity.
+func ResolveCanonicalRepo(ctx context.Context, slug string) (CanonicalRepo, error) {
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", slug, "--json", "nameWithOwner,url")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return CanonicalRepo{}, fmt.Errorf("gh repo view failed for %s: %w: %s", slug, err, strings.TrimSpace(stderr.String()))
+	}
+	var repo CanonicalRepo
+	if err := json.Unmarshal(out, &repo); err != nil {
+		return CanonicalRepo{}, fmt.Errorf("parse gh repo view output: %w", err)
+	}
+	repo.NameWithOwner = strings.TrimSpace(repo.NameWithOwner)
+	repo.URL = strings.TrimSpace(repo.URL)
+	if repo.NameWithOwner == "" || repo.URL == "" {
+		return CanonicalRepo{}, fmt.Errorf("gh repo view output missing nameWithOwner or url")
+	}
+	return repo, nil
+}
+
+// Rewrites a recognized GitHub remote to a validated canonical slug while preserving its transport and suffix.
+func RewriteGitHubRemote(remoteURL, newSlug string) (string, bool) {
+	if _, ok := RepoSlugFromRemote(remoteURL); !ok || !validRepoSlug(newSlug) {
+		return "", false
+	}
+	suffix := ""
+	if strings.HasSuffix(remoteURL, ".git") {
+		suffix = ".git"
+	}
+	var prefix string
+	switch {
+	case strings.HasPrefix(remoteURL, "https://github.com/"):
+		prefix = "https://github.com/"
+	case strings.HasPrefix(remoteURL, "ssh://git@github.com/"):
+		prefix = "ssh://git@github.com/"
+	case strings.HasPrefix(remoteURL, "git@github.com:"):
+		prefix = "git@github.com:"
+	default:
+		return "", false
+	}
+	return prefix + newSlug + suffix, true
+}
+
+func validRepoSlug(slug string) bool {
+	parsed, ok := RepoSlugFromRemote("https://github.com/" + slug)
+	return ok && parsed == slug
+}

--- a/internal/ghutil/repo_test.go
+++ b/internal/ghutil/repo_test.go
@@ -1,0 +1,103 @@
+package ghutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func TestResolveCanonicalRepo(t *testing.T) {
+	faketool.GH{Repos: []faketool.GHRepo{{
+		Requested:     "atqamz/secondhand",
+		NameWithOwner: "atqamz/hand",
+		URL:           "https://github.com/atqamz/hand",
+	}}}.Install(t, faketool.Bin(t))
+
+	got, err := ResolveCanonicalRepo(context.Background(), "atqamz/secondhand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.NameWithOwner != "atqamz/hand" || got.URL != "https://github.com/atqamz/hand" {
+		t.Fatalf("canonical repo = %+v, want canonical name and URL", got)
+	}
+}
+
+func TestResolveCanonicalRepoUnchanged(t *testing.T) {
+	faketool.GH{Repos: []faketool.GHRepo{{
+		Requested:     "atqamz/hand",
+		NameWithOwner: "atqamz/hand",
+		URL:           "https://github.com/atqamz/hand",
+	}}}.Install(t, faketool.Bin(t))
+
+	got, err := ResolveCanonicalRepo(context.Background(), "atqamz/hand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.NameWithOwner != "atqamz/hand" {
+		t.Fatalf("canonical repo = %+v, want unchanged slug", got)
+	}
+}
+
+func TestResolveCanonicalRepoReportsGHFailure(t *testing.T) {
+	faketool.GH{}.Install(t, faketool.Bin(t))
+
+	_, err := ResolveCanonicalRepo(context.Background(), "owner/missing")
+	if err == nil || !strings.Contains(err.Error(), "gh repo view failed") {
+		t.Fatalf("error = %v, want gh failure", err)
+	}
+}
+
+func TestResolveCanonicalRepoRejectsMalformedJSON(t *testing.T) {
+	faketool.GH{Repos: []faketool.GHRepo{{Requested: "owner/repo", Raw: "{"}}}.Install(t, faketool.Bin(t))
+
+	_, err := ResolveCanonicalRepo(context.Background(), "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "parse gh repo view output") {
+		t.Fatalf("error = %v, want malformed JSON failure", err)
+	}
+}
+
+func TestResolveCanonicalRepoRequiresFields(t *testing.T) {
+	faketool.GH{Repos: []faketool.GHRepo{{
+		Requested: "owner/repo",
+		Raw:       `{"nameWithOwner":"owner/repo"}`,
+	}}}.Install(t, faketool.Bin(t))
+
+	_, err := ResolveCanonicalRepo(context.Background(), "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "missing nameWithOwner or url") {
+		t.Fatalf("error = %v, want missing-field failure", err)
+	}
+}
+
+func TestRewriteGitHubRemotePreservesTransportAndSuffix(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		old  string
+		want string
+	}{
+		{name: "https", old: "https://github.com/old/repo", want: "https://github.com/new/repo"},
+		{name: "https git suffix", old: "https://github.com/old/repo.git", want: "https://github.com/new/repo.git"},
+		{name: "scp ssh", old: "git@github.com:old/repo.git", want: "git@github.com:new/repo.git"},
+		{name: "ssh URL", old: "ssh://git@github.com/old/repo.git", want: "ssh://git@github.com/new/repo.git"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := RewriteGitHubRemote(test.old, "new/repo")
+			if !ok || got != test.want {
+				t.Fatalf("RewriteGitHubRemote = %q, %v, want %q, true", got, ok, test.want)
+			}
+		})
+	}
+}
+
+func TestRewriteGitHubRemoteRefusesUnsupportedRemote(t *testing.T) {
+	for _, remote := range []string{
+		"git://github.com/old/repo.git",
+		"https://gitlab.com/old/repo.git",
+		"/tmp/old-repo",
+	} {
+		if got, ok := RewriteGitHubRemote(remote, "new/repo"); ok || got != "" {
+			t.Errorf("RewriteGitHubRemote(%q) = %q, %v, want empty false", remote, got, ok)
+		}
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -245,6 +245,59 @@ func SetUpstream(homeDir, name, upstream string) error {
 	return writeProjection(db, homeDir)
 }
 
+var projectURLUpdater = func(db *store.DB, name, url string) (bool, error) {
+	return db.SetProjectURL(name, url)
+}
+
+var projectURLProjectionWriter = writeProjection
+
+// Changes only the registered project's repository URL and its projection.
+func SetURL(homeDir, name, url string) error {
+	unlock, err := lockRegistry(homeDir)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	db, err := openRegistry(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	projects, err := db.ListProjects()
+	if err != nil {
+		return err
+	}
+	var oldURL string
+	found := false
+	for _, p := range projects {
+		if p.Name == name {
+			oldURL = p.URL
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("project %q %w", name, ErrNotFound)
+	}
+
+	updated, err := projectURLUpdater(db, name, url)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return fmt.Errorf("project %q %w", name, ErrNotFound)
+	}
+	if err := projectURLProjectionWriter(db, homeDir); err != nil {
+		if _, rollbackErr := projectURLUpdater(db, name, oldURL); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("restore URL for project %q: %w", name, rollbackErr))
+		}
+		return err
+	}
+	return nil
+}
+
 // Find returns the project with the given name, or false if not registered.
 func Find(homeDir, name string) (Project, bool, error) {
 	projects, err := List(homeDir)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -96,6 +96,108 @@ func TestSetUpstreamRoundTripsThroughTheProjection(t *testing.T) {
 	}
 }
 
+func TestSetURLPreservesProjectionAssociationAndProjectFields(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n\n# profile=first\n- first: https://github.com/org/first mode=direct-pr upstream=up/first\n\n# profile=second\n- second: https://github.com/org/second mode=no-mistakes upstream=up/second\n\n# profile=third\n- third: https://github.com/org/third mode=local-only upstream=up/third\n")
+
+	if err := SetURL(dir, "second", "https://github.com/org/second-new.git"); err != nil {
+		t.Fatal(err)
+	}
+
+	projects, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Project{
+		{Name: "first", URL: "https://github.com/org/first", Mode: ModeDirectPR, Upstream: "up/first"},
+		{Name: "second", URL: "https://github.com/org/second-new.git", Mode: ModeNoMistakes, Upstream: "up/second"},
+		{Name: "third", URL: "https://github.com/org/third", Mode: ModeLocalOnly, Upstream: "up/third"},
+	}
+	if len(projects) != len(want) {
+		t.Fatalf("projects = %+v, want %d projects", projects, len(want))
+	}
+	for i := range want {
+		if projects[i] != want[i] {
+			t.Fatalf("project %d = %+v, want %+v", i, projects[i], want[i])
+		}
+	}
+
+	gotProjection, err := os.ReadFile(RegistryPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantProjection := "# Projects\n\n# profile=first\n- first: https://github.com/org/first mode=direct-pr upstream=up/first\n\n# profile=second\n- second: https://github.com/org/second-new.git mode=no-mistakes upstream=up/second\n\n# profile=third\n- third: https://github.com/org/third mode=local-only upstream=up/third\n"
+	if string(gotProjection) != wantProjection {
+		t.Fatalf("projection = %q, want %q", gotProjection, wantProjection)
+	}
+}
+
+func TestSetURLNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n\n")
+
+	err := SetURL(dir, "missing", "https://github.com/org/missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("SetURL = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSetURLRollsBackWhenProjectionWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	oldURL := "https://github.com/org/old"
+	newURL := "https://github.com/org/new"
+	writeRegistry(t, dir, "# Projects\n\n- demo: "+oldURL+" mode=direct-pr\n")
+	originalProjection := projectURLProjectionWriter
+	t.Cleanup(func() { projectURLProjectionWriter = originalProjection })
+	projectURLProjectionWriter = func(*store.DB, string) error {
+		return errors.New("projection failed")
+	}
+
+	err := SetURL(dir, "demo", newURL)
+	if err == nil || !strings.Contains(err.Error(), "projection failed") {
+		t.Fatalf("SetURL = %v, want projection failure", err)
+	}
+	projects, listErr := List(dir)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(projects) != 1 || projects[0].URL != oldURL {
+		t.Fatalf("projects = %+v, want old URL after rollback", projects)
+	}
+	projection, readErr := os.ReadFile(RegistryPath(dir))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(projection), oldURL) || strings.Contains(string(projection), newURL) {
+		t.Fatalf("projection = %q, want old URL only", projection)
+	}
+}
+
+func TestSetURLReportsProjectionAndRollbackFailures(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/old mode=direct-pr\n")
+	originalUpdater := projectURLUpdater
+	originalProjection := projectURLProjectionWriter
+	t.Cleanup(func() {
+		projectURLUpdater = originalUpdater
+		projectURLProjectionWriter = originalProjection
+	})
+	projectURLUpdater = func(db *store.DB, name, url string) (bool, error) {
+		if strings.HasSuffix(url, "/old") {
+			return false, errors.New("rollback failed")
+		}
+		return db.SetProjectURL(name, url)
+	}
+	projectURLProjectionWriter = func(*store.DB, string) error {
+		return errors.New("projection failed")
+	}
+
+	err := SetURL(dir, "demo", "https://github.com/org/new")
+	if err == nil || !strings.Contains(err.Error(), "projection failed") || !strings.Contains(err.Error(), "rollback failed") {
+		t.Fatalf("SetURL = %v, want both failures", err)
+	}
+}
+
 func TestSetUpstreamNotFound(t *testing.T) {
 	dir := t.TempDir()
 	writeRegistry(t, dir, "# Projects\n\n")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -481,6 +481,19 @@ func (db *DB) SetProjectUpstream(name, upstream string) (bool, error) {
 	return affected > 0, nil
 }
 
+// Reports whether the named project's URL was updated.
+func (db *DB) SetProjectURL(name, url string) (bool, error) {
+	res, err := db.sql.Exec(`UPDATE project SET url = ? WHERE name = ?`, url, name)
+	if err != nil {
+		return false, fmt.Errorf("set URL for project %q: %w", name, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("set URL for project %q: %w", name, err)
+	}
+	return affected > 0, nil
+}
+
 // RemoveProject reports whether a row was actually removed, leaving the
 // not-registered wording to the caller that already owns it.
 func (db *DB) RemoveProject(name string) (bool, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -140,9 +140,11 @@ func TestProjectsKeepRegistrationOrder(t *testing.T) {
 
 func TestSetProjectURLPreservesProjectIdentityAndOrder(t *testing.T) {
 	db, _ := openTemp(t)
+	oldURL := "https://github.com/org/second"
+	newURL := "https://github.com/org/second-new"
 	want := []Project{
 		{Name: "first", URL: "https://github.com/org/first", Mode: "direct-pr", Upstream: "up/first"},
-		{Name: "second", URL: "https://github.com/org/second-new", Mode: "no-mistakes", Upstream: "up/second"},
+		{Name: "second", URL: oldURL, Mode: "no-mistakes", Upstream: "up/second"},
 		{Name: "third", URL: "https://github.com/org/third", Mode: "local-only", Upstream: "up/third"},
 	}
 	for _, p := range want {
@@ -151,10 +153,11 @@ func TestSetProjectURLPreservesProjectIdentityAndOrder(t *testing.T) {
 		}
 	}
 
-	updated, err := db.SetProjectURL("second", want[1].URL)
+	updated, err := db.SetProjectURL("second", newURL)
 	if err != nil || !updated {
 		t.Fatalf("SetProjectURL = %v, %v", updated, err)
 	}
+	want[1].URL = newURL
 
 	got, err := db.ListProjects()
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -138,6 +138,43 @@ func TestProjectsKeepRegistrationOrder(t *testing.T) {
 	}
 }
 
+func TestSetProjectURLPreservesProjectIdentityAndOrder(t *testing.T) {
+	db, _ := openTemp(t)
+	want := []Project{
+		{Name: "first", URL: "https://github.com/org/first", Mode: "direct-pr", Upstream: "up/first"},
+		{Name: "second", URL: "https://github.com/org/second-new", Mode: "no-mistakes", Upstream: "up/second"},
+		{Name: "third", URL: "https://github.com/org/third", Mode: "local-only", Upstream: "up/third"},
+	}
+	for _, p := range want {
+		if err := db.AddProject(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	updated, err := db.SetProjectURL("second", want[1].URL)
+	if err != nil || !updated {
+		t.Fatalf("SetProjectURL = %v, %v", updated, err)
+	}
+
+	got, err := db.ListProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ListProjects = %+v, want %d projects", got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("project %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	updated, err = db.SetProjectURL("missing", "https://github.com/org/missing")
+	if err != nil || updated {
+		t.Fatalf("missing SetProjectURL = %v, %v, want false and nil", updated, err)
+	}
+}
+
 func TestAddProjectRejectsADuplicateName(t *testing.T) {
 	db, _ := openTemp(t)
 	p := Project{Name: "nsr", URL: "git@github.com:o/nsr.git", Mode: "direct-pr"}

--- a/tests/contract/gh_test.go
+++ b/tests/contract/gh_test.go
@@ -66,6 +66,22 @@ func TestGHServesARepoUnderAnyCasingAndAnswersCanonically(t *testing.T) {
 	}
 }
 
+func TestGHRepoViewFollowsTheSecondhandRename(t *testing.T) {
+	requireGH(t)
+
+	res := run(t, "", "gh", "repo", "view", "atqamz/secondhand", "--json", "nameWithOwner,url").requireCode(t, 0)
+	var repo struct {
+		NameWithOwner string `json:"nameWithOwner"`
+		URL           string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(res.stdout), &repo); err != nil {
+		t.Fatalf("parse stdout %q: %v", res.stdout, err)
+	}
+	if repo.NameWithOwner != "atqamz/hand" || repo.URL != "https://github.com/atqamz/hand" {
+		t.Fatalf("repo = %+v, want canonical renamed repository", repo)
+	}
+}
+
 func TestGHPRViewFailsForAPRThatDoesNotExist(t *testing.T) {
 	requireGH(t)
 

--- a/tests/e2e/project_test.go
+++ b/tests/e2e/project_test.go
@@ -11,13 +11,15 @@ import (
 	"github.com/atqamz/hand/internal/project"
 )
 
-// Drives add -> list -> sync (fast-forward) -> remove through the built binary against a real local git
-// remote (redirected via git's insteadOf mechanism, never the network), plus the one failure path not
-// already covered by TestExitCodeThreeOnPreconditionFailure: sync against a project never cloned to disk.
+// Drives add -> set-url -> list -> sync (fast-forward) -> remove through the built binary against a real local
+// git remote (redirected via git's insteadOf mechanism, never the network), plus the missing-clone failure
+// path not already covered by TestExitCodeThreeOnPreconditionFailure.
 func TestProjectLifecycle(t *testing.T) {
 	remote := filepath.Join(t.TempDir(), "remote")
 	initGitRepo(t, remote)
 	redirectGitRemote(t, "https://example.com/demo.git", remote)
+	newURL := "https://example.com/renamed-demo.git"
+	redirectGitRemote(t, newURL, remote)
 
 	dir := binDir(t)
 	writeFakeTreehouse(t, dir, filepath.Join(t.TempDir(), "unused-worktree"))
@@ -48,6 +50,24 @@ func TestProjectLifecycle(t *testing.T) {
 	}
 	if !strings.Contains(listed.stdout, "demo") {
 		t.Fatalf("project list stdout = %q, want it to mention demo", listed.stdout)
+	}
+
+	repointed := runHand(t, home, "project", "set-url", "demo", newURL)
+	if repointed.code != 0 {
+		t.Fatalf("project set-url: exit %d, stderr %q", repointed.code, repointed.stderr)
+	}
+	if !strings.Contains(repointed.stdout, "result: url-set") || !strings.Contains(repointed.stdout, "old_origin") || !strings.Contains(repointed.stdout, "origin") {
+		t.Fatalf("project set-url stdout = %q, want both origin surfaces", repointed.stdout)
+	}
+	projects, err = project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 || projects[0].Name != "demo" || projects[0].URL != newURL || projects[0].Mode != "direct-pr" {
+		t.Fatalf("project.List after set-url = %+v, want stable demo with new URL and mode", projects)
+	}
+	if got := runGitIn(t, clonePath, "config", "--get", "remote.origin.url"); got != newURL+"\n" {
+		t.Fatalf("clone origin = %q, want %q", got, newURL)
 	}
 
 	runGitIn(t, remote, "commit", "--allow-empty", "-q", "-m", "new remote commit")


### PR DESCRIPTION
## Summary

- Add `hand project set-url <name> <repo-url>` to repoint the clone origin and durable registry URL together.
- Preserve project names, clone paths, tasks, completion history, mode, upstream, and projection ordering, with rollback when projection mutation fails.
- Make `hand project sync` best-effort detect GitHub canonical renames through structured `gh repo view` output and reuse the same repoint operation.

Fixes atqamz/hand#191

## Test plan

- `nix develop --command go build ./...`
- `nix develop --command go test ./...`
- `nix develop --command go test -race ./...`
- `nix develop --command make lint`
- `nix develop --command make contract`
- `nix develop --command go test -tags=e2e ./tests/e2e/...`
- Manual disposable-home proof confirmed the `projects/secondhand` path stayed stable while registry URL and stored origin changed to `https://github.com/atqamz/hand.git`.
