### PR TITLE
fix(notify): resolve POSIX sh on PATH with an actionable missing-sh error

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Every command resolves the fleet home from `HAND_HOME` when set, otherwise from 
 
 Optional:
 
+- `sh` - a POSIX-compatible shell, required when a non-empty `config/notify` is configured, including on Windows
 - [no-mistakes](https://github.com/yes2games/no-mistakes) - required only by projects using `no-mistakes` mode
 - [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
 
@@ -291,6 +292,32 @@ go install github.com/atqamz/hand@latest
 `go install` does not embed release-version metadata, so the binary reports `dev` and never checks for updates. Prefer a release binary or Nix installation for a versioned build.
 
 To build a checkout for contributing to Secondhand itself, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Notifications
+
+Configure notifications by writing a text file at `config/notify`.
+The file contains a POSIX shell snippet, and the notification text is available as `$HAND_MESSAGE`.
+
+For every supported operating system, the execution contract is:
+
+```text
+config/notify -> POSIX sh -c
+```
+
+This applies on Linux, macOS, and Windows.
+On Windows, Hand does not reinterpret the template as `cmd.exe` batch syntax, PowerShell, or WSL shell syntax, and it does not invoke `wsl.exe` automatically.
+A POSIX-compatible `sh` executable must be directly resolvable from the Windows process's `PATH`.
+Git for Windows and MSYS2 are examples of environments that may provide such an executable, but installing WSL alone does not satisfy this requirement.
+
+Literal Windows paths are still part of POSIX shell source.
+For example, users should not assume this is safe template source:
+
+```text
+C:\some\path\notifier.exe
+```
+
+Backslashes have meaning to POSIX shells, so quote or escape literal paths according to POSIX shell rules, or use a shell-compatible representation such as a forward-slash Windows path when supported.
+Hand does not rewrite paths or automatically escape arbitrary template source.
 
 ## Command map
 

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -14,7 +14,11 @@ func newNotifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "notify <message>",
 		Short: "Send an out-of-band notification",
-		Args:  usageArgs(cobra.ExactArgs(1)),
+		Long: "config/notify contains POSIX shell source, executed through sh -c on Linux, macOS, and Windows.\n" +
+			"The notification text is available as $HAND_MESSAGE. On Windows, a POSIX-compatible sh must be directly available on PATH;\n" +
+			"Hand does not reinterpret the template as cmd.exe, PowerShell, or WSL syntax, invoke wsl.exe, or rewrite paths.\n" +
+			"Literal Windows paths remain POSIX shell source and need POSIX-compatible quoting or escaping.",
+		Args: usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			message := args[0]
 			home, err := home.Resolve()

--- a/cmd/notify_test.go
+++ b/cmd/notify_test.go
@@ -80,3 +80,21 @@ func TestNotifyFailureIsVisibleRatherThanAWarningBehindExitZero(t *testing.T) {
 		t.Fatal("Execute() error = nil, want the template's failure surfaced")
 	}
 }
+
+func TestNotifyHelpDocumentsThePOSIXShellContract(t *testing.T) {
+	var out bytes.Buffer
+	cmd := newNotifyCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+
+	help := strings.ToLower(out.String())
+	for _, want := range []string{"posix", "sh", "path", "windows", "hand_message", "cmd.exe", "powershell", "quot"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help = %q, want it to mention %q", out.String(), want)
+		}
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,5 +1,6 @@
-// Out-of-band delivery for hand notify and the watcher's in-process notify
-// hook uses config/notify as a POSIX-shell template with the message to send.
+// Package notify implements out-of-band delivery for hand notify and the
+// watcher's in-process notify hook: reading config/notify's POSIX-shell
+// template and running it with the message to send.
 package notify
 
 import (
@@ -19,12 +20,13 @@ import (
 var ErrNotConfigured = errors.New("no config/notify")
 
 // Bounds the template's own run: the watcher calls Send inline in its poll loop,
-// so an unbounded template (the documented curl example has no --max-time) would
+// so an unbounded template (a webhook curl with no --max-time) would
 // wedge polling, --until-event's timeout and shutdown alike. A var so tests cut it.
 var sendTimeout = 10 * time.Second
 
-// Delivery runs config/notify's POSIX-shell template with the message available
-// as $HAND_MESSAGE, and reports whether the template ran and succeeded.
+// Send runs config/notify's POSIX-shell template with the message available as
+// $HAND_MESSAGE, in-process rather than through the hand notify subcommand, and
+// reports whether the template actually ran and succeeded.
 func Send(home, message string) error {
 	template, err := os.ReadFile(filepath.Join(home, "config", "notify"))
 	if err != nil {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,6 +1,5 @@
-// Package notify implements out-of-band delivery for hand notify and the
-// watcher's in-process notify hook: reading config/notify's shell command
-// template and running it with the message to send.
+// Out-of-band delivery for hand notify and the watcher's in-process notify
+// hook uses config/notify as a POSIX-shell template with the message to send.
 package notify
 
 import (
@@ -24,9 +23,8 @@ var ErrNotConfigured = errors.New("no config/notify")
 // wedge polling, --until-event's timeout and shutdown alike. A var so tests cut it.
 var sendTimeout = 10 * time.Second
 
-// Send runs config/notify's shell command template with message available as
-// $HAND_MESSAGE, in-process rather than through the hand notify subcommand,
-// and reports whether the template actually ran and succeeded.
+// Delivery runs config/notify's POSIX-shell template with the message available
+// as $HAND_MESSAGE, and reports whether the template ran and succeeded.
 func Send(home, message string) error {
 	template, err := os.ReadFile(filepath.Join(home, "config", "notify"))
 	if err != nil {
@@ -41,9 +39,14 @@ func Send(home, message string) error {
 		return ErrNotConfigured
 	}
 
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		return fmt.Errorf("config/notify requires a POSIX sh executable on PATH: %w", err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
-	run := exec.CommandContext(ctx, "sh", "-c", command)
+	run := exec.CommandContext(ctx, shell, "-c", command)
 	run.Env = append(os.Environ(), "HAND_MESSAGE="+message)
 	// Without WaitDelay, a template that backgrounds a child holding the output
 	// pipe keeps CombinedOutput waiting past the kill, defeating the timeout.

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,6 +35,59 @@ func TestSendReturnsErrNotConfiguredWithAnEmptyTemplate(t *testing.T) {
 	if !errors.Is(err, ErrNotConfigured) {
 		t.Fatalf("Send() error = %v, want ErrNotConfigured", err)
 	}
+}
+
+func TestSendReportsActionableErrorWhenShIsMissing(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("printf '%s' \"$HAND_MESSAGE\""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	err := Send(home, "hello")
+	if err == nil {
+		t.Fatal("Send() error = nil, want missing-shell failure")
+	}
+	if errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("Send() error = %v, want a configured-template failure", err)
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("Send() error = %v, want exec.ErrNotFound", err)
+	}
+	for _, want := range []string{"config/notify", "posix", "sh", "path"} {
+		if !strings.Contains(strings.ToLower(err.Error()), want) {
+			t.Fatalf("Send() error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestSendDoesNotRequireShWhenNotificationIsUnconfigured(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	t.Run("missing", func(t *testing.T) {
+		err := Send(t.TempDir(), "hello")
+		if !errors.Is(err, ErrNotConfigured) {
+			t.Fatalf("Send() error = %v, want ErrNotConfigured", err)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		home := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("  \n\t\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := Send(home, "hello")
+		if !errors.Is(err, ErrNotConfigured) {
+			t.Fatalf("Send() error = %v, want ErrNotConfigured", err)
+		}
+	})
 }
 
 func TestSendRunsTheTemplateWithTheMessage(t *testing.T) {


### PR DESCRIPTION
## Summary
- Keep config/notify as POSIX shell source executed through sh -c on Linux, macOS, and Windows.
- Add an actionable missing-sh diagnostic, hermetic ordering coverage, CLI help, and README documentation.
- No cmd.exe/PowerShell fallback, WSL invocation, interpreter auto-detection, or path rewriting was introduced.

Fixes atqamz/hand#204

## Test plan
- nix develop -c go test ./...
- nix develop -c go test -race ./...
- nix develop -c go vet ./...
- nix develop -c make lint
- nix develop -c make build
- nix develop -c make e2e
- nix develop -c make contract
- git diff --check
- Disposable-home proof for valid sh, shell-less configured, and shell-less unconfigured notifications
- GitHub Actions: Ubuntu, macOS, Windows, Nix build, lint, and E2E