### PR TITLE
docs: define canonical orchestration vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,19 @@ You talk to one agent. It plans the work, writes briefs, dispatches workers into
 
 `hand` is the CLI underneath that workflow. It owns lifecycle, state, isolation, and process supervision so the supervising agent can focus on judgment and coordination.
 
+The canonical cross-cutting terms for this workflow are defined in [Hand orchestration vocabulary](docs/vocabulary.md).
+
 ```mermaid
 flowchart LR
     user["You"] --> supervisor["Supervising agent"]
     supervisor --> hand["hand"]
-    hand --> worker1["Worker"]
-    hand --> worker2["Worker"]
-    hand --> scout["Scout"]
+    hand --> shipTask["Task: ship"]
+    hand --> scoutTask["Task: scout"]
+    shipTask --> worker1["Worker"]
+    scoutTask --> worker2["Worker"]
     worker1 --> pr1["PR / branch"]
-    worker2 --> pr2["PR / branch"]
-    scout --> report["Report"]
+    worker2 --> report["Report"]
     pr1 --> supervisor
-    pr2 --> supervisor
     report --> supervisor
 ```
 
@@ -111,8 +112,8 @@ flowchart TD
     spawn --> worktree["Worker in an isolated worktree"]
     worktree --> supervise["Watch and steer"]
     supervise --> outcome{"Task kind"}
-    outcome -->|Ship| ship["PR or local branch"]
-    outcome -->|Scout| scout["Investigation report"]
+    outcome -->|ship| ship["PR or local branch"]
+    outcome -->|scout| scout["Investigation report"]
     ship --> finish["Merge or deliver"]
     scout --> finish
     finish --> teardown["hand teardown"]
@@ -155,8 +156,11 @@ Each registered project has a delivery mode:
 | Mode | Workflow |
 | --- | --- |
 | `direct-pr` | Workers produce normal branches and pull requests. This is the default. |
-| `no-mistakes` | Delivery is guarded by a [no-mistakes](https://github.com/yes2games/no-mistakes) validation pipeline. |
+| `no-mistakes` | Delivery uses [no-mistakes](https://github.com/kunchenguid/no-mistakes) as a gate. |
 | `local-only` | Work stays local instead of using a remote pull-request workflow. |
+
+`no-mistakes` is a delivery gate, not a Hand Task kind.
+Its internal review, test, documentation, lint, PR, and CI stages remain owned by no-mistakes rather than becoming Hand Task kinds.
 
 Choose a mode when registering a project:
 
@@ -244,7 +248,7 @@ Every command resolves the fleet home from `HAND_HOME` when set, otherwise from 
 Optional:
 
 - `sh` - a POSIX-compatible shell, required when a non-empty `config/notify` is configured, including on Windows
-- [no-mistakes](https://github.com/yes2games/no-mistakes) - required only by projects using `no-mistakes` mode
+- [no-mistakes](https://github.com/kunchenguid/no-mistakes) - required only by projects using `no-mistakes` mode
 - [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
 
 `hand init` reports checked tools it cannot find on `PATH`. `hand doctor` checks the fleet home's generated agent instructions and related drift.
@@ -408,16 +412,15 @@ flowchart LR
     user["You<br/>requests and irreversible decisions"] --> supervisor["Supervising agent<br/>planning and coordination"]
     supervisor --> hand["hand<br/>lifecycle, state, isolation, supervision"]
 
-    hand --> worker1["Ship worker"]
-    hand --> worker2["Ship worker"]
-    hand --> scout["Scout worker"]
+    hand --> shipTask["Task: ship"]
+    hand --> scoutTask["Task: scout"]
+    shipTask --> worker1["Worker"]
+    scoutTask --> worker2["Worker"]
 
     worker1 --> tree1["treehouse worktree"]
-    worker2 --> tree2["treehouse worktree"]
-    scout --> tree3["treehouse worktree"]
+    worker2 --> tree3["treehouse worktree"]
 
     tree1 --> pr1["PR / branch"]
-    tree2 --> pr2["PR / branch"]
     tree3 --> report["Report"]
 
     pr1 --> supervisor

--- a/docs/adr/gate-checks-read-no-mistakes-output-not-its-database.md
+++ b/docs/adr/gate-checks-read-no-mistakes-output-not-its-database.md
@@ -9,6 +9,8 @@
 
 Secondhand needs to know whether a repository can use its configured gate and whether a PR appears in a completed gate run. Both answers exist in no-mistakes output and in its private sqlite schema.
 
+The distinction between a Project delivery mode and an optional gate is defined in [Hand orchestration vocabulary](../vocabulary.md).
+
 ## Decision
 
 Secondhand invokes no-mistakes and interprets its public output. It never reads `~/.no-mistakes/state.sqlite`.

--- a/docs/adr/secondhand-rebuilds-firstmate-as-one-go-binary.md
+++ b/docs/adr/secondhand-rebuilds-firstmate-as-one-go-binary.md
@@ -9,6 +9,8 @@
 
 Firstmate proved the fleet-supervision concept but implemented orchestration through shell scripts and a large always-loaded instruction corpus. That shape made portability, recovery, and supervisory context depend on the agent correctly replaying operational procedure.
 
+The cross-cutting orchestration terms used here are defined in [Hand orchestration vocabulary](../vocabulary.md).
+
 ## Decision
 
 Secondhand keeps the fleet model and moves orchestration into one Go CLI binary. The supervising agent is a client. Fleet homes contain state and prose, not executable orchestration, and ordinary commands are short-lived processes.

--- a/docs/adr/supervisor-bootstrap-is-an-agents-md-contract.md
+++ b/docs/adr/supervisor-bootstrap-is-an-agents-md-contract.md
@@ -9,6 +9,8 @@
 
 A supervisor must load current fleet context before it acts, regardless of which supported harness the operator launches. A Claude-only session hook made that guarantee asymmetric, and separate native integrations would give every harness its own trust boundary, configuration surface, and compatibility schedule.
 
+The cross-cutting terms used here are defined in [Hand orchestration vocabulary](../vocabulary.md).
+
 The source checkout also serves as a dogfood fleet home. Its project-owned instructions must survive fleet initialization, while the generated bootstrap must already be current so initialization does not dirty a clean clone.
 
 ## Decision
@@ -19,7 +21,7 @@ This supersedes [Ambient fleet context is a session hook, not a rendered file](a
 
 Dynamic context stays in the command's bounded output rather than the instruction file. Mutating commands enforce their own prerequisites at command level, including refusing dispatch with an unknown harness before acquiring a worktree or herdr workspace.
 
-Worker launches carry an explicit worker role and fleet-home path. `hand session start` refuses under that role, so a worker cannot initialize or act as a second supervisor from its isolated worktree.
+Worker launches carry the `HAND_ROLE=worker` process marker and fleet-home path. `hand session start` refuses under that marker, so a worker cannot initialize or act as a second supervisor from its isolated worktree.
 
 The command help and focused tests own the behavioral details of initialization, session output, prerequisite errors, and worker isolation.
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,0 +1,119 @@
+# Hand orchestration vocabulary
+
+This glossary owns the canonical cross-cutting orchestration terms for Hand 0.5.0.
+It is a terminology reference, not a centralized product specification.
+Command contracts remain owned by command help, implementation, and focused tests, while durable rationale remains in the relevant architecture decision records.
+
+## Authority and runtime
+
+### Operator
+
+The human authority.
+The Operator owns intent and irreversible decisions.
+
+### Supervisor
+
+The user-facing agent session.
+The Supervisor plans work, writes briefs, coordinates the Fleet, invokes Hand, and may persist configuration after talking to the Operator.
+The Supervisor is the normal interface, so routine setup should not require the Operator to hand-edit configuration files.
+
+### Hand
+
+The first-party CLI/runtime.
+Hand owns lifecycle, durable state, isolation, process supervision, routing resolution, and reconciliation.
+
+### Fleet home
+
+The directory containing one Hand Fleet's durable context and state.
+
+### Fleet
+
+The Projects, Tasks, Attempts, Workers, holds, and context coordinated from one Fleet home.
+
+## Work model
+
+### Project
+
+A repository registered with the Fleet.
+A Project has a delivery mode such as `direct-pr`, `local-only`, or `no-mistakes`.
+
+### Task
+
+A durable delegated unit of logical work and history.
+A Task survives individual executor runs.
+
+### Task kind
+
+For Hand 0.5.0, there are exactly two Task kinds:
+
+```text
+scout
+ship
+```
+
+`scout` means the intended deliverable is an investigation or report rather than landed code.
+`ship` means the intended deliverable is a change that must be landed or explicitly delivered.
+
+`scout` and `ship` are Task kinds, not Worker roles.
+A Worker is the generic agent process executing delegated work, regardless of Task kind.
+
+### Brief
+
+The durable task instruction written by the Supervisor for a Worker.
+The execution-ready front matter and planning contract are defined by later runtime work, not by this glossary.
+
+### Execution class
+
+How much executor judgment remains after planning.
+It is not a measure of task size, lines of code, or file count.
+
+For Hand 0.5.0, there are exactly three execution classes:
+
+```text
+mechanical
+standard
+deep
+```
+
+A large exact migration can be `mechanical`, while a five-line concurrency fix can be `deep`.
+This glossary defines the term only and does not add parsing, validation, or routing behavior.
+
+### Attempt
+
+One execution incarnation of a Task.
+A Task may have historical Attempts but at most one active Attempt.
+Concrete execution identity belongs to the Attempt.
+Task, Attempt, and Worker are distinct: the Task is durable history, the Attempt is one execution incarnation, and the Worker is the process executing it.
+
+### Worker
+
+The agent process Hand launches for execution, regardless of Task kind or model.
+`scout` and `ship` do not name Worker roles.
+Compatibility names such as `HAND_ROLE=worker` and `WorkerRole` remain unchanged.
+
+### Harness
+
+The local agent executable or integration Hand launches, such as `codex`, `claude`, `opencode`, `grok`, or `pi`.
+Harness is not synonymous with model provider.
+
+## Configuration and delivery
+
+### Profile
+
+An Operator-defined named execution configuration.
+Profile names are arbitrary.
+Hand does not reserve names such as `cheap`, `normal`, `frontier`, or `premium` as semantic tiers.
+This glossary defines the concept only and does not add Profile persistence, configuration, or routing.
+
+### Route
+
+A deterministic mapping from Task kind plus execution class to a Profile, and eventually to one concrete Attempt execution snapshot.
+This glossary defines the term only and does not add routing behavior.
+
+### Delivery mode / gate
+
+Delivery mode describes how Project work lands.
+`no-mistakes` is an optional gate, add-on, or integration boundary, not a source of Hand core Task kinds.
+Its internal stage names and configuration belong to no-mistakes itself.
+
+See the canonical [no-mistakes upstream](https://github.com/kunchenguid/no-mistakes).

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -53,6 +53,7 @@ Do not run supervisor bootstrap when ` + "`HAND_ROLE=worker`" + `.
 var supervisorInstructions = []string{
 	"Read `data/operator.md` before anything else. Its constraints outrank your own judgment.",
 	"Match the request to a project in `data/projects.md`.",
+	"`scout` and `ship` are Task kinds, not worker roles. Use `scout` when the intended deliverable is an investigation/report and `ship` when it is a change that must be landed or explicitly delivered. A worker is the agent process Hand launches to execute delegated work.",
 	"Edit `data/backlog.md` to record the task with a unique ID.",
 	"Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.",
 	"`hand status <id>` shows a worker's reported state. Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.",

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -128,6 +128,20 @@ func TestSupervisorInstructionsCoverDurableOperatingContract(t *testing.T) {
 	}
 }
 
+func TestSupervisorInstructionsUseCanonicalTaskKinds(t *testing.T) {
+	got := strings.Join(SupervisorInstructions(), "\n")
+	for _, want := range []string{
+		"`scout` and `ship` are Task kinds, not worker roles",
+		"Use `scout` when the intended deliverable is an investigation/report",
+		"`ship` when it is a change that must be landed or explicitly delivered",
+		"A worker is the agent process Hand launches to execute delegated work",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("got supervisor instructions %q, want canonical task-kind rule %q", got, want)
+		}
+	}
+}
+
 func TestSupervisorInstructionsReturnsClone(t *testing.T) {
 	first := SupervisorInstructions()
 	first[0] = "changed by caller"


### PR DESCRIPTION
## Summary
- Add the canonical Hand 0.5.0 orchestration glossary and link it from active README and runtime ADRs.
- Clarify that scout and ship are Task kinds, Workers are generic executor processes, and no-mistakes is an optional delivery gate.
- Add the invariant to generated supervisor instructions with focused coverage.

Fixes atqamz/hand#213

## Test plan
- go test ./internal/agentsmd/...
- go test ./cmd/...
- go test ./...
- go test -race ./...
- go vet ./...
- make lint
- make build
- make contract
- make e2e
- nix flake check --print-build-logs