### PR TITLE
test(runtime): freeze pre-refactor lifecycle contracts

### DIFF
--- a/cmd/deliver_test.go
+++ b/cmd/deliver_test.go
@@ -25,6 +25,15 @@ func TestDeliverRecordsTheReasonOnTheTask(t *testing.T) {
 	if !strings.Contains(out.String(), "result: delivered\n") {
 		t.Fatalf("out = %q, want a delivered confirmation", out.String())
 	}
+	for _, want := range []string{
+		"id: task-1\n",
+		"reason: PR 597 offered to kunchenguid/no-mistakes\n",
+		"delivered: ",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("out = %q, want field %q", out.String(), want)
+		}
+	}
 
 	got, err := state.Read(home, "task-1")
 	if err != nil {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -199,6 +199,13 @@ func TestMergePRRefusesRedCI(t *testing.T) {
 	if got.MergeExecuted {
 		t.Fatal("want task not marked merged")
 	}
+	merged, err := ghutil.PRIsMerged(context.Background(), mergeTestPR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged {
+		t.Fatal("want red checks to leave gh's PR unmerged")
+	}
 }
 
 func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
@@ -212,6 +219,8 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 	}
 
 	cmd := newMergeCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"task-1"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -234,6 +243,11 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 	}
 	if !merged {
 		t.Fatal("want the PR merged on gh's side too, not only on the task row")
+	}
+	for _, want := range []string{"id: task-1\n", "result: merged\n", "method: squash\n", "pr: \"https://github.com/org/repo/pull/42\"\n", "merged: "} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output = %q, want field %q", out.String(), want)
+		}
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -177,13 +177,17 @@ func TestPromoteUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.
 func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr("claude", "done"))
+	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr(harness.Codex, "done"))
 
 	scout, err := state.Read(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	scout.DoneVerified = true
+	scout.Harness = harness.Claude
+	scout.Model = "scout-model"
+	scout.Effort = "scout-effort"
+	scout.LeaseID = "lease-old"
 	scout.ReportOffset = 42
 	scout.ReportDigest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 	stale := time.Now().Add(-6 * time.Hour).UTC().Format(time.RFC3339)
@@ -203,7 +207,7 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	}
 
 	cmd := newPromoteCmd()
-	cmd.SetArgs([]string{"task-1"})
+	cmd.SetArgs([]string{"task-1", "--harness", harness.Codex, "--model", "ship-model", "--effort", "ship-effort"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
@@ -214,6 +218,15 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	}
 	if got.DoneVerified {
 		t.Fatal("DoneVerified = true, want the scout's marker cleared for the ship run")
+	}
+	if got.Harness != harness.Codex || got.Model != "ship-model" || got.Effort != "ship-effort" {
+		t.Fatalf("execution tier = %q/%q/%q, want the newly resolved ship values", got.Harness, got.Model, got.Effort)
+	}
+	if got.Worktree != newWt || got.LeaseID != "lease-1" {
+		t.Fatalf("worktree/lease = %q/%q, want the new ship execution identity", got.Worktree, got.LeaseID)
+	}
+	if got.Herdr.Session != "default" || got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tNew" || got.Herdr.PaneID != "wA:pNew" {
+		t.Fatalf("herdr = %+v, want the new ship execution identity", got.Herdr)
 	}
 	if got.ReportOffset != 42 {
 		t.Fatalf("ReportOffset = %d, want the scout's offset carried forward", got.ReportOffset)
@@ -376,6 +389,38 @@ func TestPromoteFailureClosesWorkspaceItCreated(t *testing.T) {
 	}
 	if got.Kind != state.KindScout {
 		t.Fatalf("kind = %q, want the task left as a scout", got.Kind)
+	}
+}
+
+func TestPromoteKeepsShipAfterScoutCleanupFailure(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	herdr := promoteHerdr("claude", "done")
+	herdr.Responses = []faketool.HerdrResponse{{Command: "tab close", Exit: 1}}
+	home := setupPromoteHome(t, oldWt, newWt, herdr)
+
+	var errOut strings.Builder
+	var out strings.Builder
+	cmd := newPromoteCmd()
+	cmd.SetErr(&errOut)
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != state.KindShip || got.Worktree != newWt || got.Herdr.TabID != "wA:tNew" {
+		t.Fatalf("task after scout cleanup failure = %+v, want the durably written ship execution", got)
+	}
+	if !strings.Contains(errOut.String(), "herdr tab close failed") {
+		t.Fatalf("stderr = %q, want a cleanup warning", errOut.String())
+	}
+	if !strings.Contains(out.String(), "result: promoted\n") {
+		t.Fatalf("output = %q, want promotion success after cleanup warning", out.String())
 	}
 }
 

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -37,9 +37,16 @@ func TestSendHappyPathWhenIdle(t *testing.T) {
 	}
 
 	cmd := newSendCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"task-1", "hello worker"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
+	}
+	for _, want := range []string{"id: task-1\n", "result: sent\n", "chars: 12\n"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output = %q, want field %q", out.String(), want)
+		}
 	}
 }
 
@@ -197,6 +204,39 @@ func TestSendRecordsUndeliveredMessageWhenSubmitFails(t *testing.T) {
 	}
 	if got.SendUndeliveredAt == "" {
 		t.Fatal("SendUndeliveredAt not recorded")
+	}
+}
+
+func TestSendRecordsUndeliveredMessageWhenTextSendFails(t *testing.T) {
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatus: "idle",
+		Responses: []faketool.HerdrResponse{{
+			Command: "pane send-text",
+			Stdout:  "{\"id\":\"cli:1\",\"error\":{\"code\":\"send_failed\",\"message\":\"text rejected\"}}",
+			Exit:    1,
+		}},
+	})
+	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "stop and wait for review"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) {
+		t.Fatalf("got ExitError code %d, want the underlying operational failure", exitErr.Code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "send message failed") {
+		t.Fatalf("got err %v, want the text-send failure", err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SendUndeliveredMessage != "stop and wait for review" || got.SendUndeliveredAt == "" {
+		t.Fatalf("undelivered trace = %q/%q, want the failed message and timestamp", got.SendUndeliveredMessage, got.SendUndeliveredAt)
 	}
 }
 

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/project"
@@ -116,6 +117,32 @@ func TestSpawnConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
 	}
 }
 
+func TestSpawnExplicitHarnessOverridesConfiguredAndDetectedHarness(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr(harness.Claude))
+	t.Setenv("HAND_HARNESS", harness.Codex)
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "harness"), []byte(harness.Codex+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj", "--harness", harness.Claude})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Harness != harness.Claude {
+		t.Fatalf("harness = %q, want explicit %q", got.Harness, harness.Claude)
+	}
+}
+
 func TestSpawnUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.T) {
 	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	t.Setenv("HAND_HARNESS", "unknown")
@@ -144,6 +171,8 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 
 	cmd := newSpawnCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"task-1", "myproj"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -164,6 +193,18 @@ func TestSpawnHappyPath(t *testing.T) {
 	}
 	if got.LeaseID != "lease-1" {
 		t.Fatalf("got lease id %q, want the identity treehouse handed back", got.LeaseID)
+	}
+	for _, want := range []string{
+		"id: task-1\n",
+		"result: spawned\n",
+		"project: myproj\n",
+		"kind: ship\n",
+		"harness: claude\n",
+		"worktree: " + axi.Value(wt) + "\n",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output = %q, want field %q", out.String(), want)
+		}
 	}
 	calls, err := os.ReadFile(callLog)
 	if err != nil {
@@ -344,6 +385,9 @@ func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
 	}
 	if code := exitCodeFor(t, err); code != 2 {
 		t.Fatalf("code = %d, want 2 (err = %v)", code, err)
+	}
+	if _, statErr := os.Stat(os.Getenv("TREEHOUSE_CALL_LOG")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("treehouse was invoked for an invalid explicit harness: %v", statErr)
 	}
 }
 

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -441,6 +441,12 @@ func TestTeardownShipFailsWhenPRNotMerged(t *testing.T) {
 	if !strings.Contains(err.Error(), "not merged") {
 		t.Fatalf("got err %v, want not merged", err)
 	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state after landed-work refusal = %v, %v, want task to remain", exists, err)
+	}
+	if invocations := readInvocations(t, worktree); len(invocations) != 0 {
+		t.Fatalf("external cleanup before landed-work refusal = %v, want no invocations", invocations)
+	}
 }
 
 func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
@@ -529,6 +535,8 @@ func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 
 	before := time.Now().UTC().Truncate(time.Second)
 	cmd := newTeardownCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"task-1"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
@@ -553,6 +561,14 @@ func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 	want := completion.Record{ID: "task-1", Project: "myproj", Kind: "ship", Outcome: "merged", Detail: "PR https://example.com/pr/1"}
 	if got != want {
 		t.Fatalf("record = %+v, want %+v", got, want)
+	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
+		t.Fatalf("state after successful baseline teardown = %v, %v, want active task row deleted", exists, err)
+	}
+	for _, field := range []string{"id: task-1\n", "result: torn-down\n", "project: myproj\n", "kind: ship\n", "outcome: merged\n", "detail:", "worktree: returned\n"} {
+		if !strings.Contains(out.String(), field) {
+			t.Fatalf("output = %q, want field %q", out.String(), field)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add focused Hand 0.4.0 characterization tests for lifecycle ordering, dispatch precedence, send retryability, and structured TOON fields.
- Freeze the intentional pre-refactor promote overwrite semantics and teardown completion-then-delete semantics, including the newly characterized gaps.
- Preserve legacy unsupported-capability warn-and-launch behavior, read-only session/bootstrap behavior, and all production runtime semantics.

Fixes atqamz/hand#192

## Test plan

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make lint`
- `make build`
- `make e2e`
- `nix flake check --print-build-logs`
- no-mistakes pipeline: review, tests, lint, push, and CI passed.
