### PR TITLE
feat(store): split durable tasks from execution attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ flowchart TD
 
 ### Ship tasks
 
-Ship tasks make changes. A worker receives its own git worktree, works independently, and produces a pull request or local branch according to the project's delivery mode.
+Ship tasks make changes. A Task is durable logical work and its worker run is an Attempt with its own disposable execution identity. A worker receives its own git worktree, works independently, and produces a pull request or local branch according to the project's delivery mode.
 
 ### Scout tasks
 
-Scout tasks investigate without being expected to ship code. They return `data/<id>/report.md`, and a completed scout can later be promoted into a ship task.
+Scout tasks investigate without being expected to ship code. They return `data/<id>/report.md`, and a completed scout can later be promoted into a ship task. Promotion preserves the scout Attempt and starts a new ship Attempt.
 
 ## What `hand` manages
 
@@ -363,12 +363,13 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand project add` | Register a repository with the fleet. |
 | `hand project set-url <name> <repo-url>` | Recover a registered project after a repository rename or transfer while preserving its local identity and task history. |
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
+| `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
 | `hand watch` | Wait for actionable fleet events. |
 | `hand send` | Steer a running worker. |
 | `hand merge` | Merge completed work after authorization. |
 | `hand deliver` | Mark work as handed off when landing is someone else's decision. |
-| `hand teardown` | Clean up a completed task safely. |
+| `hand teardown` | Clean up a completed task safely while preserving Task and Attempt history. |
 
 Other commands cover session bootstrap, configuration, project sync and upstreams, holds, scout promotion, search, notifications, diagnostics, PR recording, and self-update.
 

--- a/cmd/deliver.go
+++ b/cmd/deliver.go
@@ -44,7 +44,7 @@ func newDeliverCmd() *cobra.Command {
 			// word on what was delivered is the one worth keeping.
 			t.DeliveredAt = time.Now().UTC().Format(time.RFC3339)
 			t.DeliveredReason = reason
-			if err := state.Write(home, t); err != nil {
+			if err := state.UpdateTask(home, t); err != nil {
 				return fmt.Errorf("write task state: %w", err)
 			}
 

--- a/cmd/deliver.go
+++ b/cmd/deliver.go
@@ -38,6 +38,11 @@ func newDeliverCmd() *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
+			// Teardown already read whatever this mark would have said and wrote the permanent
+			// completion record from it, so a delivery recorded now would never be read at all.
+			if t.Lifecycle == state.TaskTerminal {
+				return &ExitError{Err: fmt.Errorf("task %q is torn down; run hand reopen %s to work on it again", id, id), Code: 3}
+			}
 
 			// Re-running with a new reason is a correction, not a conflict: nothing
 			// downstream has consumed the mark until teardown reads it, and the last

--- a/cmd/gatepreflight_test.go
+++ b/cmd/gatepreflight_test.go
@@ -75,12 +75,7 @@ func setupPromoteHomeGate(t *testing.T, noMistakesPath string) string {
 	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{
-		ID:      "task-1",
-		Project: "gated",
-		Kind:    state.KindScout,
-		Herdr:   state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"},
-	}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "gated", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -53,6 +53,9 @@ func newMergeCmd() *cobra.Command {
 			if t.MergeExecuted {
 				return &ExitError{Err: fmt.Errorf("task %s already merged", t.ID), Code: 3}
 			}
+			if _, err := state.ActiveAttempt(home, id); err != nil {
+				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+			}
 
 			if local {
 				return runLocalMerge(cmd, home, t)
@@ -119,7 +122,7 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 
 	t.MergeExecuted = true
 	t.MergeExecutedAt = time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, t); err != nil {
+	if err := state.UpdateTask(home, t); err != nil {
 		return fmt.Errorf("write task state: %w", err)
 	}
 
@@ -150,6 +153,11 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 }
 
 func runLocalMerge(cmd *cobra.Command, home string, t state.Task) error {
+	active, err := state.ActiveAttempt(home, t.ID)
+	if err != nil {
+		return &ExitError{Err: fmt.Errorf("task %q has no active attempt", t.ID), Code: 3}
+	}
+	t.Worktree = active.Worktree
 	dirty, err := hasUncommittedChanges(t.Worktree)
 	if err != nil {
 		return err
@@ -189,7 +197,7 @@ func runLocalMerge(cmd *cobra.Command, home string, t state.Task) error {
 
 	t.MergeExecuted = true
 	t.MergeExecutedAt = time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, t); err != nil {
+	if err := state.UpdateTask(home, t); err != nil {
 		return fmt.Errorf("write task state: %w", err)
 	}
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -158,16 +158,16 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 }
 
 func runLocalMerge(cmd *cobra.Command, home string, t state.Task, active state.Attempt) error {
-	t.Worktree = active.Worktree
-	dirty, err := hasUncommittedChanges(t.Worktree)
+	worktree := active.Worktree
+	dirty, err := hasUncommittedChanges(worktree)
 	if err != nil {
 		return err
 	}
 	if dirty {
-		return &ExitError{Err: fmt.Errorf("uncommitted changes in worktree %s", t.Worktree), Code: 3}
+		return &ExitError{Err: fmt.Errorf("uncommitted changes in worktree %s", worktree), Code: 3}
 	}
 
-	branch, err := currentBranch(t.Worktree)
+	branch, err := currentBranch(worktree)
 	if err != nil {
 		return err
 	}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -53,12 +54,16 @@ func newMergeCmd() *cobra.Command {
 			if t.MergeExecuted {
 				return &ExitError{Err: fmt.Errorf("task %s already merged", t.ID), Code: 3}
 			}
-			if _, err := state.ActiveAttempt(home, id); err != nil {
-				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+			active, err := state.ActiveAttempt(home, id)
+			if err != nil {
+				if errors.Is(err, state.ErrNoActiveAttempt) {
+					return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+				}
+				return fmt.Errorf("read active attempt for task %q: %w", id, err)
 			}
 
 			if local {
-				return runLocalMerge(cmd, home, t)
+				return runLocalMerge(cmd, home, t, active)
 			}
 			return runPRMerge(cmd, home, t, method)
 		},
@@ -152,11 +157,7 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 	return doc.Render(cmd.OutOrStdout())
 }
 
-func runLocalMerge(cmd *cobra.Command, home string, t state.Task) error {
-	active, err := state.ActiveAttempt(home, t.ID)
-	if err != nil {
-		return &ExitError{Err: fmt.Errorf("task %q has no active attempt", t.ID), Code: 3}
-	}
+func runLocalMerge(cmd *cobra.Command, home string, t state.Task, active state.Attempt) error {
 	t.Worktree = active.Worktree
 	dirty, err := hasUncommittedChanges(t.Worktree)
 	if err != nil {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -121,7 +121,7 @@ func TestMergeRefusesWhenNoPRRecorded(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
-	if err := state.Write(home, state.Task{ID: "task-1"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -147,7 +147,7 @@ func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
 	g.PRs[0].State = "MERGED"
 	g.Install(t, faketool.Bin(t))
 
-	if err := state.Write(home, state.Task{ID: "task-1", PR: mergeTestPR}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,7 +177,7 @@ func TestMergePRRefusesRedCI(t *testing.T) {
 	mkFleetDirs(t, home)
 	mergeTestGH("pass", "fail").Install(t, faketool.Bin(t))
 
-	if err := state.Write(home, state.Task{ID: "task-1", PR: mergeTestPR}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -214,7 +214,7 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 	mkFleetDirs(t, home)
 	mergeTestGH("pass", "skipping").Install(t, faketool.Bin(t))
 
-	if err := state.Write(home, state.Task{ID: "task-1", PR: mergeTestPR}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -263,7 +263,7 @@ func TestMergeRefusesAPRAnEarlierRunAlreadyMerged(t *testing.T) {
 	g.Log = log
 	g.Install(t, faketool.Bin(t))
 
-	if err := state.Write(home, state.Task{ID: "task-1", PR: mergeTestPR}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -313,7 +313,7 @@ func TestMergeLocalRefusesUncommittedChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktreePath, Project: "myproj"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktreePath}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -349,7 +349,7 @@ func TestMergeLocalFastForwardSucceeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, Worktree: worktreePath}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktreePath}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -401,7 +401,7 @@ func TestMergeLocalRefusesWhenNotFastForwardable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, Worktree: worktreePath}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktreePath}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -90,7 +90,7 @@ func recordPR(ctx context.Context, home string, t state.Task, url string) (state
 	}
 
 	t.PR = url
-	if err := state.Write(home, t); err != nil {
+	if err := state.UpdateTask(home, t); err != nil {
 		return t, false, fmt.Errorf("write task state: %w", err)
 	}
 	return t, false, nil

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -75,6 +75,13 @@ func recordPR(ctx context.Context, home string, t state.Task, url string) (state
 		return t, true, nil
 	}
 
+	// After the reconcile no-op above, so a retry that changes nothing still reads as one: what a
+	// torn-down task refuses is a PR that would land on a completion record already written from
+	// the state it had at teardown.
+	if t.Lifecycle == state.TaskTerminal {
+		return t, false, &ExitError{Err: fmt.Errorf("task %s is torn down; run hand reopen %s before recording a PR on it", t.ID, t.ID), Code: 3}
+	}
+
 	proj, exists, err := project.Find(home, t.Project)
 	if err != nil {
 		return t, false, err

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -201,7 +201,7 @@ func TestDetectPRSearchesRenamedRepositoryAfterProjectSetURL(t *testing.T) {
 	oldURL := "https://github.com/atqamz/secondhand.git"
 	newURL := "https://github.com/atqamz/hand.git"
 	home, clonePath := setupRegisteredURLProject(t, oldURL)
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "secondhand", Worktree: clonePath}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "secondhand"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: clonePath}); err != nil {
 		t.Fatal(err)
 	}
 	if err := executeProjectSetURL(t, home, newURL); err != nil {
@@ -220,7 +220,7 @@ func TestDetectPRSearchesRenamedRepositoryAfterProjectSetURL(t *testing.T) {
 	if err != nil || !exists {
 		t.Fatalf("project.Find = %+v, %v, %v", proj, exists, err)
 	}
-	got, err := detectPR(context.Background(), home, task, proj)
+	got, err := detectPR(context.Background(), home, task, state.Attempt{Worktree: clonePath}, proj)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -62,10 +62,10 @@ func detectPR(ctx context.Context, home string, t state.Task, proj project.Proje
 // unregistered or local-only project, a lock held elsewhere, an ambiguous branch, or a failed gh call all
 // just leave t as read.
 func detectPRForStatus(ctx context.Context, home string, t state.Task) state.Task {
-	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - so it skips the lookup
-	// entirely, the same short-circuit checkLandedWork opens with. A forge round trip on an already-recorded
-	// PR is the only cost this can ever add, and only that task pays it once.
-	if t.PR != "" || t.Kind == state.KindScout {
+	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - and a torn-down task's
+	// completion record is already written, so both skip the lookup rather than pay a forge round trip for a
+	// PR recordPR would refuse. The scout half is the short-circuit checkLandedWork opens with.
+	if t.PR != "" || t.Kind == state.KindScout || t.Lifecycle == state.TaskTerminal {
 		return t
 	}
 	proj, exists, err := project.Find(home, t.Project)

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -14,9 +14,6 @@ import (
 // no-mistakes gate opened it directly instead of going through hand pr (atqamz/hand#69). Called only
 // where t.PR == "" already, so a task with a PR on record never reaches here.
 func detectPR(ctx context.Context, home string, t state.Task, proj project.Project) (state.Task, error) {
-	if active, err := state.ActiveAttempt(home, t.ID); err == nil {
-		t.Worktree = active.Worktree
-	}
 	branch, err := currentBranch(t.Worktree)
 	if err != nil {
 		return t, err

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -13,8 +13,8 @@ import (
 // Looks for a PR whose head ref is t's current branch, for a task whose PR was never recorded because a
 // no-mistakes gate opened it directly instead of going through hand pr (atqamz/hand#69). Called only
 // where t.PR == "" already, so a task with a PR on record never reaches here.
-func detectPR(ctx context.Context, home string, t state.Task, proj project.Project) (state.Task, error) {
-	branch, err := currentBranch(t.Worktree)
+func detectPR(ctx context.Context, home string, t state.Task, active state.Attempt, proj project.Project) (state.Task, error) {
+	branch, err := currentBranch(active.Worktree)
 	if err != nil {
 		return t, err
 	}
@@ -65,6 +65,10 @@ func detectPRForStatus(ctx context.Context, home string, t state.Task) state.Tas
 	if t.PR != "" || t.Kind == state.KindScout || t.Lifecycle == state.TaskTerminal {
 		return t
 	}
+	active, err := state.ActiveAttempt(home, t.ID)
+	if err != nil {
+		return t
+	}
 	proj, exists, err := project.Find(home, t.Project)
 	if err != nil || !exists || proj.Mode == project.ModeLocalOnly {
 		return t
@@ -91,7 +95,7 @@ func detectPRForStatus(ctx context.Context, home string, t state.Task) state.Tas
 	defer cancel()
 	// Unlike hand teardown's landed-work guard, nothing here is gated on the answer, so an ambiguous branch
 	// degrades like any other detection failure instead of refusing.
-	detected, err := detectPR(ghCtx, home, fresh, proj)
+	detected, err := detectPR(ghCtx, home, fresh, active, proj)
 	if err != nil {
 		return t
 	}

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -14,6 +14,9 @@ import (
 // no-mistakes gate opened it directly instead of going through hand pr (atqamz/hand#69). Called only
 // where t.PR == "" already, so a task with a PR on record never reaches here.
 func detectPR(ctx context.Context, home string, t state.Task, proj project.Project) (state.Task, error) {
+	if active, err := state.ActiveAttempt(home, t.ID); err == nil {
+		t.Worktree = active.Worktree
+	}
 	branch, err := currentBranch(t.Worktree)
 	if err != nil {
 		return t, err

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -552,7 +552,7 @@ func newProjectRemoveCmd() *cobra.Command {
 }
 
 func hasActiveTasksForProject(home, name string) (bool, error) {
-	tasks, err := state.List(home)
+	tasks, err := state.ListOpen(home)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -117,8 +117,8 @@ func TestProjectSetURLUpdatesRegistryAndOriginPreservingTask(t *testing.T) {
 	if origin != newURL {
 		t.Fatalf("origin = %q, want %q", origin, newURL)
 	}
-	if got, err := state.Read(home, wantTask.ID); err != nil || got != wantTask {
-		t.Fatalf("task = %+v, %v, want unchanged task %+v", got, err, wantTask)
+	if got, err := state.Read(home, wantTask.ID); err != nil || got.ID != wantTask.ID || got.Project != wantTask.Project || got.Kind != wantTask.Kind || got.Brief != wantTask.Brief {
+		t.Fatalf("task = %+v, %v, want unchanged logical task %+v", got, err, wantTask)
 	}
 	if got, err := os.Stat(clonePath); err != nil || !got.IsDir() {
 		t.Fatalf("clone path = %s, %v, want same directory", clonePath, err)

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -43,6 +43,14 @@ func newPromoteCmd() *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
+			history, err := state.ReadHistory(home, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			if history.ActiveAttempt == nil {
+				return &ExitError{Err: fmt.Errorf("task %q has no active scout attempt", id), Code: 3}
+			}
+			active := *history.ActiveAttempt
 			if t.Kind != state.KindScout {
 				return &ExitError{Err: fmt.Errorf("task %q is not a scout", id), Code: 3}
 			}
@@ -53,7 +61,7 @@ func newPromoteCmd() *cobra.Command {
 			}
 
 			client := herdr.NewClient()
-			if s := herdr.Status(paneAgentStatus(client, t.Herdr.PaneID)); !s.NotBusy() && s != herdr.StatusUnknown {
+			if s := herdr.Status(paneAgentStatus(client, active.Herdr.PaneID)); !s.NotBusy() && s != herdr.StatusUnknown {
 				return &ExitError{Err: fmt.Errorf("task %q is not a completed scout (agent state: %s)", id, s), Code: 3}
 			}
 
@@ -103,9 +111,9 @@ func newPromoteCmd() *cobra.Command {
 			}
 			defer releaseProject()
 
-			oldWorktree := t.Worktree
-			oldWorkspaceID := t.Herdr.WorkspaceID
-			oldTabID := t.Herdr.TabID
+			oldWorktree := active.Worktree
+			oldWorkspaceID := active.Herdr.WorkspaceID
+			oldTabID := active.Herdr.TabID
 
 			lease, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
@@ -129,7 +137,7 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 
-			// Same rollback contract as hand spawn: until state.Write records the promotion,
+			// Same rollback contract as hand spawn: until state records the promotion,
 			// this call owns the new workspace or tab and must undo it on any failure; after
 			// that the promoted task owns them and later warnings must not tear them down.
 			promoted := false
@@ -162,40 +170,22 @@ func newPromoteCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
 
-			t.Kind = state.KindShip
-			t.Harness = harnessName
-			t.Model = model
-			t.Effort = effort
-			t.Worktree = wt
-			t.LeaseID = lease.ID
-			t.Herdr = state.Herdr{
-				Session:     "default",
-				WorkspaceID: ws.WorkspaceID,
-				TabID:       tab.TabID,
-				PaneID:      pane.PaneID,
+			promotedAt := time.Now().UTC().Format(time.RFC3339)
+			if err := state.TransitionAttempt(home, active.ID, active.Lifecycle, state.AttemptCompleted); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record scout attempt completion: %w", err), worktree.Return(wt, true))
 			}
-			// Everything below is pane-scoped and so describes a pane this task no longer has, none of it
-			// evidence about the ship. The report cursor is carried instead: promote never touches
-			// state/<id>.status, so the stream is continuous. Cleared here rather than left for a watch that may be off.
-			t.DoneVerified = false
-			// The delivery described the scout's report, not the ship run starting
-			// here: left set, teardown would accept the ship task as terminal on a
-			// delivery nobody made for its code.
+			t.Kind = state.KindShip
 			t.DeliveredAt = ""
 			t.DeliveredReason = ""
-			promotedAt := time.Now().UTC().Format(time.RFC3339)
-			t.PaneStartedAt = promotedAt
-			t.StatusChangedAt = promotedAt
-			t.StatusChangedFor = ""
-			t.LastReportState = ""
-			t.LastReportNote = ""
-			// The scout's harness process is gone along with its pane, and the ship's
-			// runs against whatever quota exists now. Kept, the schedule would steer
-			// the fresh pane on a clock the scout's refusal set.
-			t.UsageLimitRetryAt = ""
-			t.UsageLimitAttempts = 0
-			if err := state.Write(home, t); err != nil {
+			if err := state.UpdateTask(home, t); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
+			}
+			if _, err := state.CreateAttempt(home, state.Attempt{
+				TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort,
+				Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID},
+				CreatedAt: promotedAt, PaneStartedAt: promotedAt, StatusChangedAt: promotedAt,
+			}); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("write ship attempt state: %w", err), worktree.Return(wt, true))
 			}
 			promoted = true
 			if err := state.ClearHoldIfKind(home, id, state.HoldKindLimit); err != nil {

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -177,10 +177,6 @@ func newPromoteCmd() *cobra.Command {
 			t.Kind = state.KindShip
 			t.DeliveredAt = ""
 			t.DeliveredReason = ""
-			// The scout attempt this task still points at is completed as of the line above, and
-			// the ship attempt below owns the slot next. Between them the task owns no attempt,
-			// so a failure there leaves it torn-down-able rather than wedged on a dead one.
-			t.ActiveAttemptID = 0
 			if err := state.UpdateTask(home, t); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
 			}

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -189,7 +189,11 @@ func newPromoteCmd() *cobra.Command {
 				Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID},
 				CreatedAt: promotedAt, PaneStartedAt: promotedAt, StatusChangedAt: promotedAt,
 			}); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write ship attempt state: %w", err), worktree.Return(wt, true))
+				persistErr := state.TransitionTask(home, id, state.TaskOpen, state.TaskTerminal)
+				if persistErr != nil {
+					return reportSpawnCleanup(fmt.Errorf("write ship attempt state: %w; terminalize task: %v", err, persistErr), worktree.Return(wt, true))
+				}
+				return reportSpawnCleanup(fmt.Errorf("write ship attempt state: %w; task is terminal, use hand reopen %s", err, id), worktree.Return(wt, true))
 			}
 			promoted = true
 			if err := state.ClearHoldIfKind(home, id, state.HoldKindLimit); err != nil {

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -177,6 +177,10 @@ func newPromoteCmd() *cobra.Command {
 			t.Kind = state.KindShip
 			t.DeliveredAt = ""
 			t.DeliveredReason = ""
+			// The scout attempt this task still points at is completed as of the line above, and
+			// the ship attempt below owns the slot next. Between them the task owns no attempt,
+			// so a failure there leaves it torn-down-able rather than wedged on a dead one.
+			t.ActiveAttemptID = 0
 			if err := state.UpdateTask(home, t); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
 			}

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -39,10 +39,6 @@ func newPromoteCmd() *cobra.Command {
 			}
 			defer release()
 
-			t, err := state.Read(home, id)
-			if err != nil {
-				return asPrecondition(err)
-			}
 			history, err := state.ReadHistory(home, id)
 			if err != nil {
 				return asPrecondition(err)
@@ -50,6 +46,7 @@ func newPromoteCmd() *cobra.Command {
 			if history.ActiveAttempt == nil {
 				return &ExitError{Err: fmt.Errorf("task %q has no active scout attempt", id), Code: 3}
 			}
+			t := history.Task
 			active := *history.ActiveAttempt
 			if t.Kind != state.KindScout {
 				return &ExitError{Err: fmt.Errorf("task %q is not a scout", id), Code: 3}

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -263,6 +263,19 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	if got.UsageLimitRetryAt != "" || got.UsageLimitAttempts != 0 {
 		t.Fatalf("usage-limit columns = %q/%d, want the scout's limit schedule cleared", got.UsageLimitRetryAt, got.UsageLimitAttempts)
 	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 2 || history.Attempts[0].Lifecycle != state.AttemptCompleted || history.Attempts[1].Lifecycle != state.AttemptRunning {
+		t.Fatalf("promotion attempt lineage = %+v", history.Attempts)
+	}
+	if history.Attempts[0].Harness != scout.Harness || history.Attempts[0].Worktree != scout.Worktree || history.Attempts[0].LeaseID != scout.LeaseID {
+		t.Fatalf("scout attempt was overwritten: %+v", history.Attempts[0])
+	}
+	if history.Task.ReportOffset != scout.ReportOffset || history.Task.ReportDigest != scout.ReportDigest {
+		t.Fatalf("task report cursor changed during promotion: %+v", history.Task)
+	}
 	if _, found, err := state.ReadHold(home, "task-1"); err != nil || found {
 		t.Fatalf("ReadHold = %v, %v, want the scout's limit hold cleared", found, err)
 	}

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -50,13 +50,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 		t.Fatal(err)
 	}
 
-	if err := state.Write(home, state.Task{
-		ID:       "task-1",
-		Project:  "myproj",
-		Kind:     state.KindScout,
-		Worktree: oldWorktree,
-		Herdr:    state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"},
-	}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -83,21 +77,21 @@ func TestPromoteUsesDetectedHarnessWithoutConfiguredOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Kind != state.KindShip {
-		t.Fatalf("kind = %q, want ship", got.Kind)
+	if history.Task.Kind != state.KindShip || history.ActiveAttempt == nil {
+		t.Fatalf("history after promotion = %+v, want ship with active attempt", history)
 	}
-	if got.Worktree != newWt {
-		t.Fatalf("worktree = %q, want %q", got.Worktree, newWt)
+	if history.ActiveAttempt.Worktree != newWt {
+		t.Fatalf("worktree = %q, want %q", history.ActiveAttempt.Worktree, newWt)
 	}
-	if got.Herdr.TabID != "wA:tNew" || got.Herdr.PaneID != "wA:pNew" {
-		t.Fatalf("herdr = %+v, want new tab/pane", got.Herdr)
+	if history.ActiveAttempt.Herdr.TabID != "wA:tNew" || history.ActiveAttempt.Herdr.PaneID != "wA:pNew" {
+		t.Fatalf("herdr = %+v, want new tab/pane", history.ActiveAttempt.Herdr)
 	}
-	if got.Harness != harness.Codex {
-		t.Fatalf("harness = %q, want detected %q", got.Harness, harness.Codex)
+	if history.ActiveAttempt.Harness != harness.Codex {
+		t.Fatalf("harness = %q, want detected %q", history.ActiveAttempt.Harness, harness.Codex)
 	}
 }
 
@@ -144,12 +138,12 @@ func TestPromoteConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	got, err := state.Read(home, "task-1")
+	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Harness != harness.Claude {
-		t.Fatalf("harness = %q, want configured %q", got.Harness, harness.Claude)
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Harness != harness.Claude {
+		t.Fatalf("harness = %+v, want configured %q", history.ActiveAttempt, harness.Claude)
 	}
 }
 
@@ -183,23 +177,30 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scout.DoneVerified = true
-	scout.Harness = harness.Claude
-	scout.Model = "scout-model"
-	scout.Effort = "scout-effort"
-	scout.LeaseID = "lease-old"
+	scoutAttempt, err := state.ActiveAttempt(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scoutAttempt.DoneVerified = true
+	scoutAttempt.Harness = harness.Claude
+	scoutAttempt.Model = "scout-model"
+	scoutAttempt.Effort = "scout-effort"
+	scoutAttempt.LeaseID = "lease-old"
 	scout.ReportOffset = 42
 	scout.ReportDigest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 	stale := time.Now().Add(-6 * time.Hour).UTC().Format(time.RFC3339)
-	scout.StatusChangedAt = stale
-	scout.StatusChangedFor = "working"
-	scout.LastReportState = state.ReportDone
-	scout.LastReportNote = "scout findings"
+	scoutAttempt.StatusChangedAt = stale
+	scoutAttempt.StatusChangedFor = "working"
+	scoutAttempt.LastReportState = state.ReportDone
+	scoutAttempt.LastReportNote = "scout findings"
 	scout.DeliveredAt = "2026-08-03T00:00:00Z"
 	scout.DeliveredReason = "report at data/task-1/report.md, no code to land"
-	scout.UsageLimitRetryAt = "2026-08-03T01:00:00Z"
-	scout.UsageLimitAttempts = 2
+	scoutAttempt.UsageLimitRetryAt = "2026-08-03T01:00:00Z"
+	scoutAttempt.UsageLimitAttempts = 2
 	if err := state.Write(home, scout); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.UpdateAttempt(home, scoutAttempt); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindLimit, Reason: "out of quota"}); err != nil {
@@ -212,10 +213,14 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if history.ActiveAttempt == nil {
+		t.Fatal("promotion has no active attempt")
+	}
+	got := history.ActiveAttempt
 	if got.DoneVerified {
 		t.Fatal("DoneVerified = true, want the scout's marker cleared for the ship run")
 	}
@@ -228,13 +233,13 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	if got.Herdr.Session != "default" || got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tNew" || got.Herdr.PaneID != "wA:pNew" {
 		t.Fatalf("herdr = %+v, want the new ship execution identity", got.Herdr)
 	}
-	if got.ReportOffset != 42 {
-		t.Fatalf("ReportOffset = %d, want the scout's offset carried forward", got.ReportOffset)
+	if history.Task.ReportOffset != 42 {
+		t.Fatalf("ReportOffset = %d, want the scout's offset carried forward", history.Task.ReportOffset)
 	}
 	// The offset is only trusted together with the digest of what it consumed, so
 	// carrying one without the other discards it and replays the scout's history.
-	if got.ReportDigest != scout.ReportDigest {
-		t.Fatalf("ReportDigest = %q, want the scout's digest carried forward with its offset", got.ReportDigest)
+	if history.Task.ReportDigest != scout.ReportDigest {
+		t.Fatalf("ReportDigest = %q, want the scout's digest carried forward with its offset", history.Task.ReportDigest)
 	}
 	if got.StatusChangedAt == stale {
 		t.Fatal("StatusChangedAt kept the scout's transition, want the ship's dwell reseeded at promotion")
@@ -254,8 +259,8 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	}
 	// Carried forward, the mark would let teardown accept the ship task as terminal
 	// on a delivery that only ever described the scout's report.
-	if got.DeliveredAt != "" || got.DeliveredReason != "" {
-		t.Fatalf("DeliveredAt/Reason = %q/%q, want the scout's delivery cleared for the ship run", got.DeliveredAt, got.DeliveredReason)
+	if history.Task.DeliveredAt != "" || history.Task.DeliveredReason != "" {
+		t.Fatalf("DeliveredAt/Reason = %q/%q, want the scout's delivery cleared for the ship run", history.Task.DeliveredAt, history.Task.DeliveredReason)
 	}
 	// The scout's harness process is gone with its pane. Carried forward, the schedule
 	// would steer the ship's fresh pane on a clock the scout's refusal set, and the
@@ -263,14 +268,14 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	if got.UsageLimitRetryAt != "" || got.UsageLimitAttempts != 0 {
 		t.Fatalf("usage-limit columns = %q/%d, want the scout's limit schedule cleared", got.UsageLimitRetryAt, got.UsageLimitAttempts)
 	}
-	history, err := state.ReadHistory(home, "task-1")
+	history, err = state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(history.Attempts) != 2 || history.Attempts[0].Lifecycle != state.AttemptCompleted || history.Attempts[1].Lifecycle != state.AttemptRunning {
 		t.Fatalf("promotion attempt lineage = %+v", history.Attempts)
 	}
-	if history.Attempts[0].Harness != scout.Harness || history.Attempts[0].Worktree != scout.Worktree || history.Attempts[0].LeaseID != scout.LeaseID {
+	if history.Attempts[0].Harness != scoutAttempt.Harness || history.Attempts[0].Worktree != scoutAttempt.Worktree || history.Attempts[0].LeaseID != scoutAttempt.LeaseID {
 		t.Fatalf("scout attempt was overwritten: %+v", history.Attempts[0])
 	}
 	if history.Task.ReportOffset != scout.ReportOffset || history.Task.ReportDigest != scout.ReportDigest {
@@ -422,12 +427,9 @@ func TestPromoteKeepsShipAfterScoutCleanupFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Kind != state.KindShip || got.Worktree != newWt || got.Herdr.TabID != "wA:tNew" {
-		t.Fatalf("task after scout cleanup failure = %+v, want the durably written ship execution", got)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil || history.ActiveAttempt == nil || history.Task.Kind != state.KindShip || history.ActiveAttempt.Worktree != newWt || history.ActiveAttempt.Herdr.TabID != "wA:tNew" {
+		t.Fatalf("task after scout cleanup failure = %+v, want the durably written ship execution", history)
 	}
 	if !strings.Contains(errOut.String(), "herdr tab close failed") {
 		t.Fatalf("stderr = %q, want a cleanup warning", errOut.String())

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -43,6 +43,13 @@ func newReopenCmd() *cobra.Command {
 			if history.Task.Lifecycle != state.TaskTerminal {
 				return &ExitError{Err: fmt.Errorf("task %q is already open", id), Code: 3}
 			}
+			held, hasHold, err := state.ReadHold(homeDir, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			if hasHold {
+				return &ExitError{Err: fmt.Errorf("id %q has an open hold (%s: %s); clear it first: hand hold clear %s", id, held.Kind, held.Reason, id), Code: 3}
+			}
 			t := history.Task
 			proj, exists, err := project.Find(homeDir, t.Project)
 			if err != nil {

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -136,12 +136,7 @@ func newReopenCmd() *cobra.Command {
 			}
 
 			startedAt := time.Now().UTC().Format(time.RFC3339)
-			t.Lifecycle = state.TaskOpen
-			t.ActiveAttemptID = 0
-			if err := state.UpdateTask(homeDir, t); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("reopen task: %w", err), worktree.Return(wt, true))
-			}
-			if _, err := state.CreateAttempt(homeDir, state.Attempt{TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort, Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, CreatedAt: startedAt, PaneStartedAt: startedAt}); err != nil {
+			if _, err := state.ReopenTask(homeDir, state.Attempt{TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort, Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, CreatedAt: startedAt, PaneStartedAt: startedAt}); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("write reopened attempt: %w", err), worktree.Return(wt, true))
 			}
 			started = true

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -140,11 +140,6 @@ func newReopenCmd() *cobra.Command {
 				return reportSpawnCleanup(fmt.Errorf("write reopened attempt: %w", err), worktree.Return(wt, true))
 			}
 			started = true
-			if err := state.ClearHoldIfKind(homeDir, id, state.HoldKindLimit); err != nil {
-				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: clear usage-limit hold failed: %v\n", err); printErr != nil {
-					return printErr
-				}
-			}
 
 			var doc axi.Doc
 			doc.Field("id", id)

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+func newReopenCmd() *cobra.Command {
+	var harnessName, model, effort string
+	var skipGateCheck bool
+
+	cmd := &cobra.Command{
+		Use:   "reopen <id>",
+		Short: "Start a new attempt for a terminal task",
+		Args:  usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			id := args[0]
+			homeDir, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			release, err := state.Lock(homeDir, "task:"+id)
+			if err != nil {
+				return fmt.Errorf("lock task %q: %w", id, err)
+			}
+			defer release()
+
+			history, err := state.ReadHistory(homeDir, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			if history.Task.Lifecycle != state.TaskTerminal {
+				return &ExitError{Err: fmt.Errorf("task %q is already open", id), Code: 3}
+			}
+			t := history.Task
+			proj, exists, err := project.Find(homeDir, t.Project)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return &ExitError{Err: fmt.Errorf("project %q not registered", t.Project), Code: 3}
+			}
+			clonePath := filepath.Join(homeDir, "projects", proj.Name)
+			if err := gatePreflight(cmd, proj, clonePath, skipGateCheck); err != nil {
+				return err
+			}
+
+			briefRel := filepath.Join("data", id, "brief.md")
+			briefAbs := filepath.Join(homeDir, briefRel)
+			if _, err := os.Stat(briefAbs); err != nil {
+				return &ExitError{Err: fmt.Errorf("brief not found at %s", briefRel), Code: 3}
+			}
+			harnessFromFlag := harnessName != ""
+			if !harnessFromFlag {
+				cfg, err := currentWorkerConfig(homeDir)
+				if err != nil {
+					return err
+				}
+				harnessName = cfg.harness
+				if harnessName == "" {
+					return &ExitError{Err: fmt.Errorf("current supervisor harness is unknown and no worker harness override is configured; run hand config set harness <name>"), Code: 3}
+				}
+			}
+			if !harness.IsSupported(harnessName) {
+				return usageValue(harnessFromFlag, fmt.Errorf("harness %q not recognized", harnessName))
+			}
+			var briefHasFrontMatter bool
+			model, effort, briefHasFrontMatter, err = resolveTier(cmd, homeDir, briefAbs, harnessName, model, effort)
+			if err != nil {
+				return err
+			}
+
+			releaseProject, err := state.Lock(homeDir, "project:"+proj.Name)
+			if err != nil {
+				return fmt.Errorf("lock project %q: %w", proj.Name, err)
+			}
+			defer releaseProject()
+			lease, err := worktree.Get(clonePath, "hand:"+id)
+			if err != nil {
+				return fmt.Errorf("acquire treehouse worktree: %w", err)
+			}
+			wt := lease.Path
+			releaseWorktree, err := state.Lock(homeDir, "worktree:"+wt)
+			if err != nil {
+				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
+			}
+			defer releaseWorktree()
+			if conflict, err := worktree.CheckCollision(homeDir, lease, id); err != nil {
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
+			} else if conflict != "" {
+				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
+			}
+
+			client := herdr.NewClient()
+			ws, tab, pane, rollback, err := acquireTaskWorkspace(client, wt, id, proj.Name)
+			if err != nil {
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
+			}
+			started := false
+			defer func() {
+				if started {
+					return
+				}
+				if closeErr := rollback(); closeErr != nil {
+					err = reportSpawnCleanup(err, closeErr)
+				}
+			}()
+
+			launchCmd, err := harness.Build(harnessName, harness.Options{Worktree: wt, Brief: briefAbs, FleetHome: homeDir, Model: model, Effort: effort, BriefHasFrontMatter: briefHasFrontMatter})
+			if err != nil {
+				return reportSpawnCleanup(err, worktree.Return(wt, true))
+			}
+			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
+			}
+			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
+			}
+
+			startedAt := time.Now().UTC().Format(time.RFC3339)
+			t.Lifecycle = state.TaskOpen
+			t.ActiveAttemptID = 0
+			if err := state.UpdateTask(homeDir, t); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("reopen task: %w", err), worktree.Return(wt, true))
+			}
+			if _, err := state.CreateAttempt(homeDir, state.Attempt{TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort, Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, CreatedAt: startedAt, PaneStartedAt: startedAt}); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("write reopened attempt: %w", err), worktree.Return(wt, true))
+			}
+			started = true
+			if err := state.ClearHoldIfKind(homeDir, id, state.HoldKindLimit); err != nil {
+				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: clear usage-limit hold failed: %v\n", err); printErr != nil {
+					return printErr
+				}
+			}
+
+			var doc axi.Doc
+			doc.Field("id", id)
+			doc.Field("result", "reopened")
+			doc.Field("attempt", "new")
+			doc.Field("project", t.Project)
+			doc.Field("kind", string(t.Kind))
+			doc.Field("harness", harnessName)
+			doc.Field("worktree", wt)
+			doc.Help("Run `hand status " + id + "` to read this attempt")
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().StringVar(&harnessName, "harness", "", "agent harness to launch (default: config/harness, then the detected supervisor harness)")
+	cmd.Flags().StringVar(&model, "model", "", "model override for harnesses that support it")
+	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
+	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized, the clone path is missing from disk, or that path is not a git repository")
+	return cmd
+}

--- a/cmd/reopen_test.go
+++ b/cmd/reopen_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/state"
+)
+
+func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
+	herdr := defaultSpawnHerdr(harness.Claude)
+	herdr.TabCreates = []faketool.HerdrTab{
+		{ID: "wA:tB", Label: "task-1", Pane: "wA:pC"},
+		{ID: "wA:tC", Label: "task-1", Pane: "wA:pD"},
+	}
+	home := setupSpawnHome(t, t.TempDir()+"/wt", herdr)
+
+	spawn := newSpawnCmd()
+	spawn.SetArgs([]string{"task-1", "myproj", "--harness", harness.Claude})
+	if err := spawn.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	teardown := newTeardownCmd()
+	teardown.SetArgs([]string{"task-1", "--force"})
+	if err := teardown.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopen := newReopenCmd()
+	reopen.SetArgs([]string{"task-1", "--harness", harness.Codex, "--model", "new-model", "--effort", "high"})
+	if err := reopen.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskOpen || len(history.Attempts) != 2 || history.Attempts[0].Lifecycle != state.AttemptInterrupted || history.Attempts[1].Lifecycle != state.AttemptRunning {
+		t.Fatalf("reopened history = %+v", history)
+	}
+	if history.Attempts[1].Harness != harness.Codex || history.Attempts[1].Model != "new-model" || history.Attempts[1].Ordinal != 2 {
+		t.Fatalf("new attempt = %+v", history.Attempts[1])
+	}
+}
+
+func TestReopenRefusesAnOpenTask(t *testing.T) {
+	home := setupSpawnHome(t, t.TempDir()+"/wt", defaultSpawnHerdr(harness.Claude))
+	if err := state.Write(home, state.Task{ID: "task-1", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newReopenCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("reopen accepted an open task")
+	}
+}

--- a/cmd/reopen_test.go
+++ b/cmd/reopen_test.go
@@ -60,7 +60,7 @@ func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 
 func TestReopenRefusesAnOpenTask(t *testing.T) {
 	home := setupSpawnHome(t, t.TempDir()+"/wt", defaultSpawnHerdr(harness.Claude))
-	if err := state.Write(home, state.Task{ID: "task-1", Lifecycle: state.TaskOpen}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Lifecycle: state.TaskOpen}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 	cmd := newReopenCmd()
@@ -72,7 +72,7 @@ func TestReopenRefusesAnOpenTask(t *testing.T) {
 
 func TestReopenRefusesAnOpenHold(t *testing.T) {
 	home := setupSpawnHome(t, t.TempDir()+"/wt", defaultSpawnHerdr(harness.Claude))
-	if err := state.Write(home, state.Task{ID: "task-1", Lifecycle: state.TaskOpen}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Lifecycle: state.TaskOpen}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
 		t.Fatal(err)
 	}
 	task, err := state.Read(home, "task-1")

--- a/cmd/reopen_test.go
+++ b/cmd/reopen_test.go
@@ -21,6 +21,17 @@ func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 	if err := spawn.Execute(); err != nil {
 		t.Fatal(err)
 	}
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	task.PR = "https://github.com/o/r/pull/1"
+	task.MergeAnnounced = true
+	task.DeliveredAt = "2026-08-03T00:00:00Z"
+	task.DeliveredReason = "offered upstream"
+	if err := state.UpdateTask(home, task); err != nil {
+		t.Fatal(err)
+	}
 	teardown := newTeardownCmd()
 	teardown.SetArgs([]string{"task-1", "--force"})
 	if err := teardown.Execute(); err != nil {
@@ -42,6 +53,9 @@ func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 	if history.Attempts[1].Harness != harness.Codex || history.Attempts[1].Model != "new-model" || history.Attempts[1].Ordinal != 2 {
 		t.Fatalf("new attempt = %+v", history.Attempts[1])
 	}
+	if history.Task.PR != task.PR || !history.Task.MergeAnnounced || history.Task.DeliveredAt != task.DeliveredAt || history.Task.DeliveredReason != task.DeliveredReason {
+		t.Fatalf("reopen erased task history: %+v", history.Task)
+	}
 }
 
 func TestReopenRefusesAnOpenTask(t *testing.T) {
@@ -53,5 +67,31 @@ func TestReopenRefusesAnOpenTask(t *testing.T) {
 	cmd.SetArgs([]string{"task-1"})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("reopen accepted an open task")
+	}
+}
+
+func TestReopenRefusesAnOpenHold(t *testing.T) {
+	home := setupSpawnHome(t, t.TempDir()+"/wt", defaultSpawnHerdr(harness.Claude))
+	if err := state.Write(home, state.Task{ID: "task-1", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionAttempt(home, task.ActiveAttemptID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionTask(home, "task-1", state.TaskOpen, state.TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "wait for review"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newReopenCmd()
+	cmd.SetArgs([]string{"task-1", "--harness", harness.Claude})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("reopen bypassed an open hold")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.AddCommand(newMergeCmd())
 	root.AddCommand(newPRCmd())
 	root.AddCommand(newPromoteCmd())
+	root.AddCommand(newReopenCmd())
 	root.AddCommand(newNotifyCmd())
 	root.AddCommand(newSearchCmd())
 	root.AddCommand(newDoctorCmd())

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -73,7 +73,10 @@ func newSendCmd() *cobra.Command {
 				if errors.Is(err, state.ErrTaskNotFound) {
 					return asPrecondition(err)
 				}
-				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+				if errors.Is(err, state.ErrNoActiveAttempt) {
+					return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+				}
+				return fmt.Errorf("read active attempt for task %q: %w", id, err)
 			}
 			if active.Lifecycle != state.AttemptProvisioning && active.Lifecycle != state.AttemptRunning {
 				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -68,24 +68,30 @@ func newSendCmd() *cobra.Command {
 			}
 			defer release()
 
-			t, err := state.Read(home, id)
+			active, err := state.ActiveAttempt(home, id)
 			if err != nil {
-				return asPrecondition(err)
+				if errors.Is(err, state.ErrTaskNotFound) {
+					return asPrecondition(err)
+				}
+				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+			}
+			if active.Lifecycle != state.AttemptProvisioning && active.Lifecycle != state.AttemptRunning {
+				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
 			}
 
 			client := herdr.NewClient()
-			pane, err := client.PaneGet(t.Herdr.PaneID)
+			pane, err := client.PaneGet(active.Herdr.PaneID)
 			if err != nil {
-				return fmt.Errorf("herdr pane %s not found: %w", t.Herdr.PaneID, err)
+				return fmt.Errorf("herdr pane %s not found: %w", active.Herdr.PaneID, err)
 			}
 
 			if pane.AgentStatus == herdr.StatusWorking {
-				if waitErr := client.WaitComposerEmpty(t.Herdr.PaneID, waitDuration); waitErr != nil {
+				if waitErr := client.WaitComposerEmpty(active.Herdr.PaneID, waitDuration); waitErr != nil {
 					// The pane stopped answering mid-wait (agent died, tab closed):
 					// no retry can succeed, so this is the same exit-1 outcome as the
 					// PaneGet above, not the retryable busy-composer one below.
 					if !errors.Is(waitErr, herdr.ErrComposerBusyTimeout) {
-						return fmt.Errorf("herdr pane %s not found: %w", t.Herdr.PaneID, waitErr)
+						return fmt.Errorf("herdr pane %s not found: %w", active.Herdr.PaneID, waitErr)
 					}
 					if err := recordUndeliveredSend(home, id, message); err != nil {
 						return fmt.Errorf("%w; record undelivered send: %w", waitErr, err)
@@ -100,10 +106,10 @@ func newSendCmd() *cobra.Command {
 			// Both delivery failures leave the steer undemonstrated in the pane -
 			// text that never left, and text sitting unsubmitted in the composer -
 			// so both owe the operator the same durable trace the wait bound does.
-			if err := client.PaneSendText(t.Herdr.PaneID, message); err != nil {
+			if err := client.PaneSendText(active.Herdr.PaneID, message); err != nil {
 				return withUndeliveredSend(home, id, message, fmt.Errorf("send message failed: %w", err))
 			}
-			if err := client.PaneSendKeys(t.Herdr.PaneID, "Enter"); err != nil {
+			if err := client.PaneSendKeys(active.Herdr.PaneID, "Enter"); err != nil {
 				return withUndeliveredSend(home, id, message, fmt.Errorf("submit message failed: %w", err))
 			}
 
@@ -159,14 +165,14 @@ func setUndeliveredSend(home, id, message, at string) error {
 	}
 	defer release()
 
-	t, err := state.Read(home, id)
+	active, err := state.ActiveAttempt(home, id)
 	if err != nil {
 		return err
 	}
-	if t.SendUndeliveredMessage == message && t.SendUndeliveredAt == at {
+	if active.SendUndeliveredMessage == message && active.SendUndeliveredAt == at {
 		return nil
 	}
-	t.SendUndeliveredMessage = message
-	t.SendUndeliveredAt = at
-	return state.Write(home, t)
+	active.SendUndeliveredMessage = message
+	active.SendUndeliveredAt = at
+	return state.UpdateAttempt(home, active)
 }

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -32,7 +32,7 @@ func TestSendHappyPathWhenIdle(t *testing.T) {
 	// (callVoid's doc comment, client.go). callVoid only checks env.Error, which is nil here, so the extra
 	// body is harmless and this still exercises the real success path.
 	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -59,7 +59,7 @@ func TestSendFailsWhenPaneNotFound(t *testing.T) {
 		Stdout:  "{\"id\":\"cli:1\",\"error\":{\"code\":\"pane_not_found\",\"message\":\"no such pane\"}}",
 		Exit:    1,
 	}}})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:gone"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:gone"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,7 +74,7 @@ func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 	// Same send-text/send-keys envelope simplification as
 	// TestSendHappyPathWhenIdle above.
 	home := setupSendHome(t, faketool.Herdr{PaneStatusSequence: []string{"working", "idle"}})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -88,7 +88,7 @@ func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 func TestSendReadsMessageFromFile(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "sent.log")
 	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,7 +145,7 @@ func TestSendFailsWhenPaneDisappearsDuringWait(t *testing.T) {
 	home := setupSendHome(t, faketool.Herdr{
 		PaneStatusSequence: []string{"working", "pane-gone"},
 	})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -160,12 +160,12 @@ func TestSendFailsWhenPaneDisappearsDuringWait(t *testing.T) {
 		t.Fatalf("got err %v, want pane not found", err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	active, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.SendUndeliveredMessage != "" {
-		t.Fatalf("SendUndeliveredMessage = %q, want no trace for an unreachable pane", got.SendUndeliveredMessage)
+	if active.SendUndeliveredMessage != "" {
+		t.Fatalf("SendUndeliveredMessage = %q, want no trace for an unreachable pane", active.SendUndeliveredMessage)
 	}
 }
 
@@ -180,7 +180,7 @@ func TestSendRecordsUndeliveredMessageWhenSubmitFails(t *testing.T) {
 			Exit:    1,
 		}},
 	})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -195,14 +195,14 @@ func TestSendRecordsUndeliveredMessageWhenSubmitFails(t *testing.T) {
 		t.Fatalf("got err %v, want the submit failure", err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	active, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.SendUndeliveredMessage != "stop and wait for review" {
-		t.Fatalf("SendUndeliveredMessage = %q, want the unsubmitted message", got.SendUndeliveredMessage)
+	if active.SendUndeliveredMessage != "stop and wait for review" {
+		t.Fatalf("SendUndeliveredMessage = %q, want the unsubmitted message", active.SendUndeliveredMessage)
 	}
-	if got.SendUndeliveredAt == "" {
+	if active.SendUndeliveredAt == "" {
 		t.Fatal("SendUndeliveredAt not recorded")
 	}
 }
@@ -216,7 +216,7 @@ func TestSendRecordsUndeliveredMessageWhenTextSendFails(t *testing.T) {
 			Exit:    1,
 		}},
 	})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -231,12 +231,12 @@ func TestSendRecordsUndeliveredMessageWhenTextSendFails(t *testing.T) {
 		t.Fatalf("got err %v, want the text-send failure", err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	active, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.SendUndeliveredMessage != "stop and wait for review" || got.SendUndeliveredAt == "" {
-		t.Fatalf("undelivered trace = %q/%q, want the failed message and timestamp", got.SendUndeliveredMessage, got.SendUndeliveredAt)
+	if active.SendUndeliveredMessage != "stop and wait for review" || active.SendUndeliveredAt == "" {
+		t.Fatalf("undelivered trace = %q/%q, want the failed message and timestamp", active.SendUndeliveredMessage, active.SendUndeliveredAt)
 	}
 }
 
@@ -244,7 +244,7 @@ func TestSendRecordsUndeliveredMessageWhenComposerStaysBusy(t *testing.T) {
 	// The composer never frees, so WaitComposerEmpty always exhausts --wait;
 	// a short --wait keeps the test itself fast.
 	home := setupSendHome(t, faketool.Herdr{PaneStatus: "working"})
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -256,25 +256,21 @@ func TestSendRecordsUndeliveredMessageWhenComposerStaysBusy(t *testing.T) {
 		t.Fatalf("got %v, want ExitError code 6", err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	active, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.SendUndeliveredMessage != "stop and wait for review" {
-		t.Fatalf("SendUndeliveredMessage = %q, want the abandoned message", got.SendUndeliveredMessage)
+	if active.SendUndeliveredMessage != "stop and wait for review" {
+		t.Fatalf("SendUndeliveredMessage = %q, want the abandoned message", active.SendUndeliveredMessage)
 	}
-	if got.SendUndeliveredAt == "" {
+	if active.SendUndeliveredAt == "" {
 		t.Fatal("SendUndeliveredAt not recorded")
 	}
 }
 
 func TestSendClearsAPreviouslyRecordedUndeliveredSendOnSuccess(t *testing.T) {
 	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"},
-		SendUndeliveredMessage: "an earlier abandoned steer",
-		SendUndeliveredAt:      "2026-08-01T00:00:00Z",
-	}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}, SendUndeliveredMessage: "an earlier abandoned steer", SendUndeliveredAt: "2026-08-01T00:00:00Z"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -284,12 +280,12 @@ func TestSendClearsAPreviouslyRecordedUndeliveredSendOnSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
+	active, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.SendUndeliveredMessage != "" || got.SendUndeliveredAt != "" {
-		t.Fatalf("undelivered send trace not cleared: %+v", got)
+	if active.SendUndeliveredMessage != "" || active.SendUndeliveredAt != "" {
+		t.Fatalf("undelivered send trace not cleared: %+v", active)
 	}
 }
 

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -299,7 +299,7 @@ func TestSessionOverviewsDoNotMutateFleetState(t *testing.T) {
 			if err := db.AddProject(store.Project{Name: "sqlite-project", URL: "local", Mode: "local-only"}); err != nil {
 				t.Fatal(err)
 			}
-			if err := db.WriteTask(store.Task{ID: "sqlite-task", Project: "sqlite-project", Kind: store.KindShip}); err != nil {
+			if err := db.CreateTask(store.Task{ID: "sqlite-task", Project: "sqlite-project", Kind: store.KindShip}); err != nil {
 				t.Fatal(err)
 			}
 			if err := db.SetHold(store.Hold{ID: "sqlite-hold", Kind: store.HoldKindOperator, Reason: "waiting"}); err != nil {

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -316,18 +316,6 @@ func TestSessionOverviewsDoNotMutateFleetState(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := os.WriteFile(filepath.Join(home, "data", "projects.md"),
-				[]byte("# Projects\n\n- legacy-project: local mode=local-only\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			legacyTask, err := json.Marshal(store.Task{ID: "legacy-task", Project: "legacy-project", Kind: store.KindShip})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(filepath.Join(home, "state", "legacy-task.json"), legacyTask, 0o644); err != nil {
-				t.Fatal(err)
-			}
-
 			before := snapshotFleetTree(t, home)
 			out, _, err := executeRootForTest(t, devBuild("test"), nil, test.args...)
 			if err != nil {
@@ -417,18 +405,6 @@ func downgradeSessionStore(t *testing.T, home string) {
 		t.Fatal(err)
 	}
 	defer func() { _ = db.Close() }()
-	for _, column := range []string{
-		"send_undelivered_message", "send_undelivered_at", "lease_id", "delivered_at",
-		"delivered_reason", "pane_started_at", "parked_fired_for", "report_digest",
-		"usage_limit_retry_at", "usage_limit_attempts",
-	} {
-		if _, err := db.Exec("ALTER TABLE task DROP COLUMN " + column); err != nil {
-			t.Fatalf("drop task.%s: %v", column, err)
-		}
-	}
-	if _, err := db.Exec("ALTER TABLE project DROP COLUMN upstream"); err != nil {
-		t.Fatalf("drop project.upstream: %v", err)
-	}
 	if _, err := db.Exec("PRAGMA user_version = 0"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -51,16 +51,6 @@ func newSpawnCmd() *cobra.Command {
 			if err := gatePreflight(cmd, proj, clonePath, skipGateCheck); err != nil {
 				return err
 			}
-
-			releaseClaim, err := state.Claim(home, id)
-			if err != nil {
-				return asPrecondition(err)
-			}
-			defer releaseClaim()
-
-			// A hold outlives the task row it was set on, by design, so a torn-down task's open question stays
-			// visible, and reusing the id would silently reattach it to unrelated work. Refused rather than
-			// cleared: answering an operator hold is not hand's, and a limit hold means a worker is still here.
 			held, hasHold, err := state.ReadHold(home, id)
 			if err != nil {
 				return asPrecondition(err)
@@ -68,6 +58,12 @@ func newSpawnCmd() *cobra.Command {
 			if hasHold {
 				return &ExitError{Err: fmt.Errorf("id %q has an open hold (%s: %s); clear it first: hand hold clear %s", id, held.Kind, held.Reason, id), Code: 3}
 			}
+
+			releaseClaim, err := state.Claim(home, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			defer releaseClaim()
 
 			briefRel := filepath.Join("data", id, "brief.md")
 			briefAbs := filepath.Join(home, briefRel)
@@ -123,7 +119,7 @@ func newSpawnCmd() *cobra.Command {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
 
-			// Disarms the rollback below once state.Write has durably recorded the task: from that point
+			// Disarms the rollback below once state has durably recorded the task: from that point
 			// its workspace and tab are owned by the running task, not by this call.
 			spawned := false
 			defer func() {
@@ -162,26 +158,22 @@ func newSpawnCmd() *cobra.Command {
 
 			spawnedAt := time.Now().UTC().Format(time.RFC3339)
 			task := state.Task{
-				ID:       id,
-				Project:  proj.Name,
-				Kind:     kind,
-				Harness:  harnessName,
-				Model:    model,
-				Effort:   effort,
-				Worktree: wt,
-				LeaseID:  lease.ID,
-				Brief:    briefRel,
-				Herdr: state.Herdr{
-					Session:     "default",
-					WorkspaceID: ws.WorkspaceID,
-					TabID:       tab.TabID,
-					PaneID:      pane.PaneID,
-				},
-				CreatedAt:     spawnedAt,
-				PaneStartedAt: spawnedAt,
+				ID:        id,
+				Project:   proj.Name,
+				Kind:      kind,
+				Brief:     briefRel,
+				Lifecycle: state.TaskOpen,
+				CreatedAt: spawnedAt,
 			}
-			if err := state.Write(home, task); err != nil {
+			if err := state.CreateTask(home, task); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
+			}
+			if _, err := state.CreateAttempt(home, state.Attempt{
+				TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort,
+				Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID},
+				CreatedAt: spawnedAt, PaneStartedAt: spawnedAt,
+			}); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("write attempt state: %w", err), worktree.Return(wt, true))
 			}
 			spawned = true
 

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -51,6 +51,12 @@ func newSpawnCmd() *cobra.Command {
 			if err := gatePreflight(cmd, proj, clonePath, skipGateCheck); err != nil {
 				return err
 			}
+			releaseClaim, err := state.Claim(home, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			defer releaseClaim()
+
 			held, hasHold, err := state.ReadHold(home, id)
 			if err != nil {
 				return asPrecondition(err)
@@ -58,12 +64,6 @@ func newSpawnCmd() *cobra.Command {
 			if hasHold {
 				return &ExitError{Err: fmt.Errorf("id %q has an open hold (%s: %s); clear it first: hand hold clear %s", id, held.Kind, held.Reason, id), Code: 3}
 			}
-
-			releaseClaim, err := state.Claim(home, id)
-			if err != nil {
-				return asPrecondition(err)
-			}
-			defer releaseClaim()
 
 			briefRel := filepath.Join("data", id, "brief.md")
 			briefAbs := filepath.Join(home, briefRel)

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -83,12 +83,9 @@ func TestSpawnUsesDetectedHarnessWithoutConfiguredOverride(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Harness != harness.Codex {
-		t.Fatalf("harness = %q, want detected %q", got.Harness, harness.Codex)
+	active := readTaskAttempt(t, home, "task-1")
+	if active.Harness != harness.Codex {
+		t.Fatalf("harness = %q, want detected %q", active.Harness, harness.Codex)
 	}
 }
 
@@ -108,12 +105,9 @@ func TestSpawnConfiguredHarnessWinsOverDetectedHarness(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Harness != harness.Claude {
-		t.Fatalf("harness = %q, want configured %q", got.Harness, harness.Claude)
+	active := readTaskAttempt(t, home, "task-1")
+	if active.Harness != harness.Claude {
+		t.Fatalf("harness = %q, want configured %q", active.Harness, harness.Claude)
 	}
 }
 
@@ -134,12 +128,9 @@ func TestSpawnExplicitHarnessOverridesConfiguredAndDetectedHarness(t *testing.T)
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Harness != harness.Claude {
-		t.Fatalf("harness = %q, want explicit %q", got.Harness, harness.Claude)
+	active := readTaskAttempt(t, home, "task-1")
+	if active.Harness != harness.Claude {
+		t.Fatalf("harness = %q, want explicit %q", active.Harness, harness.Claude)
 	}
 }
 
@@ -182,17 +173,18 @@ func TestSpawnHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Project != "myproj" || got.Kind != state.KindShip || got.Harness != "claude" {
+	active := readTaskAttempt(t, home, "task-1")
+	if got.Project != "myproj" || got.Kind != state.KindShip || active.Harness != "claude" {
 		t.Fatalf("got %+v", got)
 	}
-	if got.Worktree != wt {
-		t.Fatalf("got worktree %q, want %q", got.Worktree, wt)
+	if active.Worktree != wt {
+		t.Fatalf("got worktree %q, want %q", active.Worktree, wt)
 	}
-	if got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tB" || got.Herdr.PaneID != "wA:pC" {
-		t.Fatalf("got herdr %+v", got.Herdr)
+	if active.Herdr.WorkspaceID != "wA" || active.Herdr.TabID != "wA:tB" || active.Herdr.PaneID != "wA:pC" {
+		t.Fatalf("got herdr %+v", active.Herdr)
 	}
-	if got.LeaseID != "lease-1" {
-		t.Fatalf("got lease id %q, want the identity treehouse handed back", got.LeaseID)
+	if active.LeaseID != "lease-1" {
+		t.Fatalf("got lease id %q, want the identity treehouse handed back", active.LeaseID)
 	}
 	for _, want := range []string{
 		"id: task-1\n",
@@ -238,12 +230,9 @@ func TestSpawnIgnoresSameLabelledWorkspaceHandDidNotCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Herdr.WorkspaceID != "wA" {
-		t.Fatalf("got workspace %q, want hand's own hand:myproj workspace wA, not the same-labelled one it did not create", got.Herdr.WorkspaceID)
+	active := readTaskAttempt(t, home, "task-1")
+	if active.Herdr.WorkspaceID != "wA" {
+		t.Fatalf("got workspace %q, want hand's own hand:myproj workspace wA, not the same-labelled one it did not create", active.Herdr.WorkspaceID)
 	}
 }
 
@@ -261,15 +250,12 @@ func TestSpawnPersistsResolvedNotDeclaredTierValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
+	active := readTaskAttempt(t, home, "task-1")
+	if active.Model != "flag-model" {
+		t.Fatalf("got model %q, want the flag to win over the brief's declared %q", active.Model, "brief-model")
 	}
-	if got.Model != "flag-model" {
-		t.Fatalf("got model %q, want the flag to win over the brief's declared %q", got.Model, "brief-model")
-	}
-	if got.Effort != "brief-effort" {
-		t.Fatalf("got effort %q, want the brief's declared value since no flag or config overrides it", got.Effort)
+	if active.Effort != "brief-effort" {
+		t.Fatalf("got effort %q, want the brief's declared value since no flag or config overrides it", active.Effort)
 	}
 }
 
@@ -340,6 +326,37 @@ func TestSpawnRejectsHeldIDWithNoTaskRow(t *testing.T) {
 	}
 }
 
+func TestSpawnTerminalTaskWithHoldPointsToReopen(t *testing.T) {
+	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionAttempt(home, attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionTask(home, "task-1", state.TaskOpen, state.TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	err = cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), "hand reopen task-1") {
+		t.Fatalf("got err %v, want terminal-task reopen remedy", err)
+	}
+	if strings.Contains(err.Error(), "open hold") {
+		t.Fatalf("got err %v, want existing terminal-task refusal before hold check", err)
+	}
+}
+
 func TestSpawnAcceptsIDWhoseHoldWasCleared(t *testing.T) {
 	home := setupSpawnHome(t, filepath.Join(t.TempDir(), "wt"), defaultSpawnHerdr("claude"))
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator, Reason: "needs a call"}); err != nil {
@@ -396,7 +413,7 @@ func TestSpawnRejectsUnrecognizedHarness(t *testing.T) {
 func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
-	if err := state.Write(home, state.Task{ID: "other-task", Worktree: wt}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "other-task"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: wt}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -417,7 +434,7 @@ func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.
 func TestSpawnAllowsAReusedWorktreePathUnderAFreshLease(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
-	if err := state.Write(home, state.Task{ID: "stale-task", Worktree: wt, LeaseID: "lease-0"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "stale-task"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: wt, LeaseID: "lease-0"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -427,12 +444,9 @@ func TestSpawnAllowsAReusedWorktreePathUnderAFreshLease(t *testing.T) {
 		t.Fatalf("got err %v, want the spawn to proceed past a stale row on the same path", err)
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.LeaseID != "lease-1" {
-		t.Fatalf("got lease id %q, want the identity treehouse handed back", got.LeaseID)
+	active := readTaskAttempt(t, home, "task-1")
+	if active.LeaseID != "lease-1" {
+		t.Fatalf("got lease id %q, want the identity treehouse handed back", active.LeaseID)
 	}
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -120,27 +120,42 @@ type reportedJSON struct {
 }
 
 type statusJSON struct {
-	ID              string        `json:"id"`
-	Project         string        `json:"project"`
-	Kind            string        `json:"kind"`
-	Harness         string        `json:"harness,omitempty"`
-	AgentState      string        `json:"agent_state"`
-	Worktree        string        `json:"worktree"`
-	Herdr           state.Herdr   `json:"herdr"`
-	PR              string        `json:"pr"`
-	MergeExecuted   bool          `json:"merged"`
-	MergeAnnounced  bool          `json:"pr_merged_observed"`
-	DeliveredAt     string        `json:"delivered_at,omitempty"`
-	DeliveredReason string        `json:"delivered_reason,omitempty"`
-	CreatedAt       string        `json:"created_at"`
-	LastReportAt    string        `json:"last_report_at,omitempty"`
-	Reported        *reportedJSON `json:"reported,omitempty"`
-	ReportHistory   []string      `json:"report_history,omitempty"`
-	Held            *holdJSON     `json:"held,omitempty"`
-	GateRunIssue    string        `json:"gate_run_issue,omitempty"`
+	ID               string        `json:"id"`
+	Project          string        `json:"project"`
+	Kind             string        `json:"kind"`
+	TaskLifecycle    string        `json:"task_lifecycle"`
+	AttemptOrdinal   int           `json:"attempt_ordinal,omitempty"`
+	AttemptLifecycle string        `json:"attempt_lifecycle,omitempty"`
+	Harness          string        `json:"harness,omitempty"`
+	Model            string        `json:"model,omitempty"`
+	Effort           string        `json:"effort,omitempty"`
+	AgentState       string        `json:"agent_state"`
+	Worktree         string        `json:"worktree"`
+	Herdr            state.Herdr   `json:"herdr"`
+	PR               string        `json:"pr"`
+	MergeExecuted    bool          `json:"merged"`
+	MergeAnnounced   bool          `json:"pr_merged_observed"`
+	DeliveredAt      string        `json:"delivered_at,omitempty"`
+	DeliveredReason  string        `json:"delivered_reason,omitempty"`
+	CreatedAt        string        `json:"created_at"`
+	LastReportAt     string        `json:"last_report_at,omitempty"`
+	Reported         *reportedJSON `json:"reported,omitempty"`
+	ReportHistory    []string      `json:"report_history,omitempty"`
+	Held             *holdJSON     `json:"held,omitempty"`
+	GateRunIssue     string        `json:"gate_run_issue,omitempty"`
 	// Omitted when false so a consumer written before this field sees no change
 	// on the fleet it already understands.
-	Unacknowledged bool `json:"unacknowledged,omitempty"`
+	Unacknowledged bool          `json:"unacknowledged,omitempty"`
+	Attempts       []attemptJSON `json:"attempts,omitempty"`
+}
+
+type attemptJSON struct {
+	Ordinal   int    `json:"ordinal"`
+	Lifecycle string `json:"lifecycle"`
+	Harness   string `json:"harness,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Effort    string `json:"effort,omitempty"`
+	Worktree  string `json:"worktree,omitempty"`
 }
 
 // Wraps the task rows with the fleet's holds, which name any id - not only a live task - so a torn-down
@@ -313,7 +328,7 @@ func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, cols [
 }
 
 func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, error) {
-	listTasks := state.List
+	listTasks := state.ListOpen
 	listHolds := state.ListHolds
 	listProjects := project.List
 	if readOnly {
@@ -407,7 +422,20 @@ func unacknowledged(home string, t state.Task, reported state.ReportLine, report
 // Reads everything both status views derive from one task, and returns the report lines alongside so the
 // detail view's history block and the summary line above it can never come from two reads of the file.
 func buildTaskView(home string, client *herdr.Client, t state.Task, full bool) (taskView, []state.ReportLine) {
-	agentState := paneAgentStatus(client, t.Herdr.PaneID)
+	var attempt *state.Attempt
+	var attempts []state.Attempt
+	if history, err := state.ReadHistory(home, t.ID); err == nil {
+		attempts = history.Attempts
+		attempt = history.ActiveAttempt
+		if attempt == nil && len(attempts) != 0 {
+			attempt = &attempts[len(attempts)-1]
+		}
+	}
+	e := state.Attempt{}
+	if attempt != nil {
+		e = *attempt
+	}
+	agentState := paneAgentStatus(client, e.Herdr.PaneID)
 	lines, readErr := state.ReadReportLines(home, t.ID)
 	reported, reportedOK := state.LastReportedState(lines)
 	unacked, readErr := unacknowledged(home, t, reported, reportedOK, readErr)
@@ -418,6 +446,8 @@ func buildTaskView(home string, client *herdr.Client, t state.Task, full bool) (
 	}
 	v := taskView{
 		task:         t,
+		attempt:      attempt,
+		attempts:     attempts,
 		agentState:   agentState,
 		reportedLine: reportSummary(t.ID, lines, readErr, unacked, full),
 		lastReportAt: lastReportAt(home, t.ID),
@@ -433,13 +463,22 @@ func buildTaskView(home string, client *herdr.Client, t state.Task, full bool) (
 }
 
 func (v taskView) json() statusJSON {
+	e := v.execution()
+	attempts := v.attempts
+	if len(attempts) > 5 {
+		attempts = attempts[len(attempts)-5:]
+	}
+	history := make([]attemptJSON, len(attempts))
+	for i, attempt := range attempts {
+		history[i] = attemptJSON{Ordinal: attempt.Ordinal, Lifecycle: string(attempt.Lifecycle), Harness: attempt.Harness, Model: attempt.Model, Effort: attempt.Effort, Worktree: attempt.Worktree}
+	}
 	return statusJSON{
-		ID: v.task.ID, Project: v.task.Project, Kind: v.task.Kind, Harness: v.task.Harness,
-		AgentState: v.agentState, Worktree: v.task.Worktree, Herdr: v.task.Herdr, PR: v.task.PR,
+		ID: v.task.ID, Project: v.task.Project, Kind: v.task.Kind, TaskLifecycle: string(v.task.Lifecycle), AttemptOrdinal: e.Ordinal, AttemptLifecycle: string(e.Lifecycle), Harness: e.Harness, Model: e.Model, Effort: e.Effort,
+		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR,
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt,
-		Reported: v.reported, GateRunIssue: v.gateIssue, Unacknowledged: v.unacked,
+		Reported: v.reported, GateRunIssue: v.gateIssue, Unacknowledged: v.unacked, Attempts: history,
 	}
 }
 
@@ -518,8 +557,21 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		doc.Field(c.Name, c.Value(v))
 	}
 	doc.List("report_history", historyBlock(v, tail, full))
+	doc.List("attempts", attemptHistoryBlock(v))
 	doc.Help(detailHelp(v, full)...)
 	return doc.Render(cmd.OutOrStdout())
+}
+
+func attemptHistoryBlock(v taskView) []string {
+	attempts := v.attempts
+	if len(attempts) > 5 {
+		attempts = attempts[len(attempts)-5:]
+	}
+	lines := make([]string, len(attempts))
+	for i, attempt := range attempts {
+		lines[i] = fmt.Sprintf("Attempt %d: %s (%s, %s, %s)", attempt.Ordinal, attempt.Lifecycle, orNone(attempt.Harness), orNone(attempt.Model), orNone(attempt.Worktree))
+	}
+	return lines
 }
 
 // The report tail with the entry the report field already shows dropped - repeating it was the core of

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -365,7 +365,10 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 
 	views := make([]taskView, 0, len(tasks))
 	for _, t := range tasks {
-		v, _ := buildTaskView(home, client, t, false, readOnly)
+		v, _, err := buildTaskView(home, client, t, false, readOnly)
+		if err != nil {
+			return nil, nil, err
+		}
 		p, registered := projectByName[t.Project]
 		v.gateIssue = gateRunIssue(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)
@@ -421,19 +424,21 @@ func unacknowledged(home string, t state.Task, reported state.ReportLine, report
 
 // Reads everything both status views derive from one task, and returns the report lines alongside so the
 // detail view's history block and the summary line above it can never come from two reads of the file.
-func buildTaskView(home string, client *herdr.Client, t state.Task, full, readOnly bool) (taskView, []state.ReportLine) {
+func buildTaskView(home string, client *herdr.Client, t state.Task, full, readOnly bool) (taskView, []state.ReportLine, error) {
 	var attempt *state.Attempt
 	var attempts []state.Attempt
 	readHistory := state.ReadHistory
 	if readOnly {
 		readHistory = state.ReadHistoryReadOnly
 	}
-	if history, err := readHistory(home, t.ID); err == nil {
-		attempts = history.Attempts
-		attempt = history.ActiveAttempt
-		if attempt == nil && len(attempts) != 0 {
-			attempt = &attempts[len(attempts)-1]
-		}
+	history, err := readHistory(home, t.ID)
+	if err != nil {
+		return taskView{}, nil, fmt.Errorf("read task history %q: %w", t.ID, err)
+	}
+	attempts = history.Attempts
+	attempt = history.ActiveAttempt
+	if attempt == nil && len(attempts) != 0 {
+		attempt = &attempts[len(attempts)-1]
 	}
 	e := state.Attempt{}
 	if attempt != nil {
@@ -463,7 +468,7 @@ func buildTaskView(home string, client *herdr.Client, t state.Task, full, readOn
 	if reportedOK {
 		v.reportedState = reported.State
 	}
-	return v, lines
+	return v, lines, nil
 }
 
 func (v taskView) json() statusJSON {
@@ -509,7 +514,10 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	// An unreadable report degrades exactly as it does in the fleet view: the
 	// fault is named on the report field and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
-	v, reportLines := buildTaskView(home, client, t, full, false)
+	v, reportLines, err := buildTaskView(home, client, t, full, false)
+	if err != nil {
+		return err
+	}
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.
 	hold, held, err := state.ReadHold(home, id)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -365,7 +365,7 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 
 	views := make([]taskView, 0, len(tasks))
 	for _, t := range tasks {
-		v, _ := buildTaskView(home, client, t, false)
+		v, _ := buildTaskView(home, client, t, false, readOnly)
 		p, registered := projectByName[t.Project]
 		v.gateIssue = gateRunIssue(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)
@@ -421,10 +421,14 @@ func unacknowledged(home string, t state.Task, reported state.ReportLine, report
 
 // Reads everything both status views derive from one task, and returns the report lines alongside so the
 // detail view's history block and the summary line above it can never come from two reads of the file.
-func buildTaskView(home string, client *herdr.Client, t state.Task, full bool) (taskView, []state.ReportLine) {
+func buildTaskView(home string, client *herdr.Client, t state.Task, full, readOnly bool) (taskView, []state.ReportLine) {
 	var attempt *state.Attempt
 	var attempts []state.Attempt
-	if history, err := state.ReadHistory(home, t.ID); err == nil {
+	readHistory := state.ReadHistory
+	if readOnly {
+		readHistory = state.ReadHistoryReadOnly
+	}
+	if history, err := readHistory(home, t.ID); err == nil {
 		attempts = history.Attempts
 		attempt = history.ActiveAttempt
 		if attempt == nil && len(attempts) != 0 {
@@ -505,7 +509,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	// An unreadable report degrades exactly as it does in the fleet view: the
 	// fault is named on the report field and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
-	v, reportLines := buildTaskView(home, client, t, full)
+	v, reportLines := buildTaskView(home, client, t, full, false)
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.
 	hold, held, err := state.ReadHold(home, id)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -158,8 +158,8 @@ type attemptJSON struct {
 	Worktree  string `json:"worktree,omitempty"`
 }
 
-// Wraps the task rows with the fleet's holds, which name any id - not only a live task - so a torn-down
-// task's still-open hold keeps surfacing here after its task row is gone.
+// Wraps the task rows with the fleet's holds, which name any id - not only an open task - so a
+// torn-down task's still-open hold keeps surfacing here after the task leaves the open fleet.
 type fleetJSON struct {
 	// Always present, zero included, so an empty fleet is a positive statement ("no tasks") and not the
 	// same absence of output a broken command would also produce.
@@ -328,15 +328,17 @@ func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, cols [
 }
 
 func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, error) {
-	listTasks := state.ListOpen
+	listHistories := state.ListOpenHistories
 	listHolds := state.ListHolds
 	listProjects := project.List
 	if readOnly {
-		listTasks = state.ListReadOnly
+		listHistories = state.ListOpenHistoriesReadOnly
 		listHolds = state.ListHoldsReadOnly
 		listProjects = project.ListReadOnly
 	}
-	tasks, err := listTasks(home)
+	// The one attempt-history read the fleet view makes: rendering re-reads nothing, so a fleet costs
+	// one store handle rather than one per task.
+	histories, err := listHistories(home)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -363,12 +365,10 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 	}
 	runPRs := newGateRunReader()
 
-	views := make([]taskView, 0, len(tasks))
-	for _, t := range tasks {
-		v, _, err := buildTaskView(home, client, t, false, readOnly)
-		if err != nil {
-			return nil, nil, err
-		}
+	views := make([]taskView, 0, len(histories))
+	for _, history := range histories {
+		t := history.Task
+		v, _ := buildTaskView(home, client, history, false)
 		p, registered := projectByName[t.Project]
 		v.gateIssue = gateRunIssue(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)
@@ -422,21 +422,13 @@ func unacknowledged(home string, t state.Task, reported state.ReportLine, report
 	return state.UnacknowledgedTerminalReport(home, t.ID, state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest})
 }
 
-// Reads everything both status views derive from one task, and returns the report lines alongside so the
-// detail view's history block and the summary line above it can never come from two reads of the file.
-func buildTaskView(home string, client *herdr.Client, t state.Task, full, readOnly bool) (taskView, []state.ReportLine, error) {
-	var attempt *state.Attempt
-	var attempts []state.Attempt
-	readHistory := state.ReadHistory
-	if readOnly {
-		readHistory = state.ReadHistoryReadOnly
-	}
-	history, err := readHistory(home, t.ID)
-	if err != nil {
-		return taskView{}, nil, fmt.Errorf("read task history %q: %w", t.ID, err)
-	}
-	attempts = history.Attempts
-	attempt = history.ActiveAttempt
+// Derives everything both status views show from one already-read history, and returns the report lines
+// alongside so the detail view's history block and the summary line above it can never come from two
+// reads of the file.
+func buildTaskView(home string, client *herdr.Client, history state.TaskHistory, full bool) (taskView, []state.ReportLine) {
+	t := history.Task
+	attempts := history.Attempts
+	attempt := history.ActiveAttempt
 	if attempt == nil && len(attempts) != 0 {
 		attempt = &attempts[len(attempts)-1]
 	}
@@ -468,15 +460,23 @@ func buildTaskView(home string, client *herdr.Client, t state.Task, full, readOn
 	if reportedOK {
 		v.reportedState = reported.State
 	}
-	return v, lines, nil
+	return v, lines
+}
+
+// Bounds the attempt window both status renderers show, so the JSON and plain-text views can never
+// disagree about how much of a task's execution history is on screen.
+const attemptHistoryLen = 5
+
+func recentAttempts(attempts []state.Attempt) []state.Attempt {
+	if len(attempts) > attemptHistoryLen {
+		return attempts[len(attempts)-attemptHistoryLen:]
+	}
+	return attempts
 }
 
 func (v taskView) json() statusJSON {
 	e := v.execution()
-	attempts := v.attempts
-	if len(attempts) > 5 {
-		attempts = attempts[len(attempts)-5:]
-	}
+	attempts := recentAttempts(v.attempts)
 	history := make([]attemptJSON, len(attempts))
 	for i, attempt := range attempts {
 		history[i] = attemptJSON{Ordinal: attempt.Ordinal, Lifecycle: string(attempt.Lifecycle), Harness: attempt.Harness, Model: attempt.Model, Effort: attempt.Effort, Worktree: attempt.Worktree}
@@ -505,19 +505,17 @@ func reportedFrom(last state.ReportLine, ok bool, readErr error) *reportedJSON {
 }
 
 func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON, full bool, cols []axi.Column[taskView]) error {
-	t, err := state.Read(home, id)
+	history, err := state.ReadHistory(home, id)
 	if err != nil {
 		return asPrecondition(err)
 	}
-	t = detectPRForStatus(cmd.Context(), home, t)
+	history.Task = detectPRForStatus(cmd.Context(), home, history.Task)
+	t := history.Task
 
 	// An unreadable report degrades exactly as it does in the fleet view: the
 	// fault is named on the report field and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
-	v, reportLines, err := buildTaskView(home, client, t, full, false)
-	if err != nil {
-		return err
-	}
+	v, reportLines := buildTaskView(home, client, history, full)
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.
 	hold, held, err := state.ReadHold(home, id)
@@ -575,10 +573,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 }
 
 func attemptHistoryBlock(v taskView) []string {
-	attempts := v.attempts
-	if len(attempts) > 5 {
-		attempts = attempts[len(attempts)-5:]
-	}
+	attempts := recentAttempts(v.attempts)
 	lines := make([]string, len(attempts))
 	for i, attempt := range attempts {
 		lines[i] = fmt.Sprintf("Attempt %d: %s (%s, %s, %s)", attempt.Ordinal, attempt.Lifecycle, orNone(attempt.Harness), orNone(attempt.Model), orNone(attempt.Worktree))

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -239,6 +239,33 @@ func TestStatusSingleTaskPropagatesUnreadableAttemptHistory(t *testing.T) {
 	}
 }
 
+// The fleet view reads attempt history the same way the detail view does, so a durable fault reading it
+// fails the whole command rather than listing the task with its execution silently blank.
+func TestStatusFleetPropagatesUnreadableAttemptHistory(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := state.CreateTask(home, state.Task{ID: "other", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateAttempt(home, state.Attempt{TaskID: "other", Lifecycle: state.AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Lifecycle: state.TaskOpen, ActiveAttemptID: attempt.ID}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("got nil error and output %q, want the unreadable attempt history to fail the command", out.String())
+	}
+}
+
 func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 	cases := []struct {
 		name             string

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -91,8 +91,8 @@ func TestStatusFleetListsAllTasks(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -118,8 +118,8 @@ func TestStatusFleetRowCellsStaySeparableAtAnyValueWidth(t *testing.T) {
 	writeFakeHerdrPaneStatus(t, "working")
 
 	id := "task-aaaaaaaaaaa"
-	if err := state.Write(home, state.Task{ID: id, Project: "myproject12", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: id, Project: "myproject12", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -141,7 +141,7 @@ func TestStatusFleetDegradesToUnknownWhenHerdrUnreachable(t *testing.T) {
 	mkFleetDirs(t, home)
 	t.Setenv("PATH", t.TempDir())
 
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,8 +163,8 @@ func TestStatusFleetJSON(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -192,8 +192,9 @@ func TestStatusSingleTaskDetail(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, Harness: "claude",
-		Herdr: state.Herdr{Session: "default", TabID: "wA:tB", PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude",
+		Herdr: state.Herdr{Session: "default", TabID: "wA:tB", PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -209,6 +210,32 @@ func TestStatusSingleTaskDetail(t *testing.T) {
 	}
 	if got := detailField(t, out.String(), "state"); got != "idle" {
 		t.Fatalf("state = %q, want idle", got)
+	}
+}
+
+func TestStatusSingleTaskPropagatesUnreadableAttemptHistory(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := state.CreateTask(home, state.Task{ID: "other", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateAttempt(home, state.Attempt{TaskID: "other", Lifecycle: state.AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Lifecycle: state.TaskOpen, ActiveAttemptID: attempt.ID}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "read task history") {
+		t.Fatalf("error = %v, want durable attempt-history read error", err)
 	}
 }
 
@@ -231,9 +258,10 @@ func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 			mkFleetDirs(t, home)
 			writeFakeHerdrPaneStatus(t, "idle")
 
-			if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-				Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-				PR: "https://github.com/a/b/pull/1", MergeExecuted: c.merged, MergeAnnounced: c.prMergedObserved}); err != nil {
+			if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+				CreatedAt: "2026-07-24T10:00:00Z",
+				PR:        "https://github.com/a/b/pull/1", MergeExecuted: c.merged, MergeAnnounced: c.prMergedObserved}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+			); err != nil {
 				t.Fatal(err)
 			}
 
@@ -263,8 +291,9 @@ func TestStatusSingleTaskDetectsGateOpenedPR(t *testing.T) {
 	writeFakeHerdrPaneStatus(t, "idle")
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "OPEN"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -297,8 +326,9 @@ func TestStatusSkipsPRDetectionForScoutTasks(t *testing.T) {
 	writeFakeHerdrPaneStatus(t, "idle")
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "OPEN"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree, Project: "myproj",
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindScout, Project: "myproj",
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -324,9 +354,10 @@ func TestStatusFleetOverviewRendersMergeMarker(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-		PR: "https://github.com/a/b/pull/1", MergeAnnounced: true}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z",
+		PR:        "https://github.com/a/b/pull/1", MergeAnnounced: true}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -348,8 +379,8 @@ func TestStatusFleetOverviewTaskWithNoPRIsUnaffected(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -371,7 +402,7 @@ func TestStatusSingleTaskJSON(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "blocked")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -405,8 +436,8 @@ func TestStatusFleetFlagsIdleWithoutTerminalReportAsUnreported(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -429,8 +460,8 @@ func TestStatusFleetFlagsIdleWithTerminalReportInsteadOfUnreported(t *testing.T)
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("needs-decision: waiting on review\n"), 0o644); err != nil {
@@ -462,8 +493,8 @@ func TestStatusFleetKeepsTheReportedFlagAfterATrailingMalformedLine(t *testing.T
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"),
@@ -489,8 +520,8 @@ func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -516,8 +547,8 @@ func TestStatusFleetCarriesAPausedReportThroughABusyPane(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("paused: waiting on the nightly build\n"), 0o644); err != nil {
@@ -545,9 +576,10 @@ func TestStatusFleetDwellTimeFollowsTheReportFileNotTheTaskAge(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr:     state.Herdr{PaneID: "wA:pB"},
-		CreatedAt: time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+
+		CreatedAt: time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 	report := state.ReportPath(home, "task-1")
@@ -579,9 +611,10 @@ func TestStatusSingleTaskDwellTimeFollowsTheReportFileNotTheTaskAge(t *testing.T
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr:     state.Herdr{PaneID: "wA:pB"},
-		CreatedAt: time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+
+		CreatedAt: time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 	report := state.ReportPath(home, "task-1")
@@ -618,9 +651,10 @@ func TestStatusReportsNoDwellTimeWithoutAReportFile(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr:     state.Herdr{PaneID: "wA:pB"},
-		CreatedAt: time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+
+		CreatedAt: time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -642,8 +676,8 @@ func TestStatusSingleTaskShowsReportedStateAndHistory(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	reportBody := "working: started\nneeds-decision: waiting on review\n"
@@ -679,8 +713,8 @@ func TestStatusSingleTaskDegradesOnAnUnreadableReport(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(state.ReportPath(home, "task-1"), 0o755); err != nil {
@@ -751,8 +785,8 @@ func TestStatusSingleTaskTruncatesALongReportedLineAndPointsAtTheFile(t *testing
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	longNote := strings.Repeat("x", 500)
@@ -797,10 +831,11 @@ func TestStatusSingleTaskEmitsOnlyAddressableFields(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Harness: "claude", Model: "sonnet", Worktree: filepath.Join(home, "wt"),
-		Herdr:     state.Herdr{Session: "default", TabID: "wA:tB", PaneID: "wA:pB"},
-		CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Model: "sonnet", Worktree: filepath.Join(home, "wt"),
+		Herdr: state.Herdr{Session: "default", TabID: "wA:tB", PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: landed\n"), 0o644); err != nil {
@@ -847,8 +882,8 @@ func TestStatusSingleTaskHistoryDoesNotRepeatTheReportedEntry(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	reportBody := "working: started\nneeds-decision: waiting on review\n"
@@ -881,8 +916,8 @@ func TestStatusSingleTaskFullFlagShowsEveryReportUntruncated(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	longNote := strings.Repeat("x", 500)
@@ -913,7 +948,7 @@ func TestStatusSingleTaskJSONKeepsTheFullReportUntruncated(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	longNote := strings.Repeat("x", 500)
@@ -939,7 +974,7 @@ func TestStatusSingleTaskJSONIncludesReportedAndHistory(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("blocked: waiting on secrets\n"), 0o644); err != nil {
@@ -1019,8 +1054,8 @@ func TestStatusFleetStatesZeroHoldsRatherThanOmittingTheBlock(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1150,8 +1185,8 @@ func TestStatusSingleTaskShowsHeldLine(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindBlocked,
@@ -1177,8 +1212,8 @@ func TestStatusSingleTaskStatesNoHoldRatherThanOmittingTheField(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1203,10 +1238,11 @@ func TestStatusShowsDeliveredWorkWithoutClaimingAMerge(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt:   "2026-07-24T10:00:00Z",
 		PR:          "https://github.com/kunchenguid/no-mistakes/pull/597",
-		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream, maintainer decides"}); err != nil {
+		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream, maintainer decides"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1256,7 +1292,7 @@ func TestStatusSingleTaskJSONIncludesHeld(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindOperator,
@@ -1283,7 +1319,7 @@ func TestStatusSingleTaskPropagatesAnUnreadableHoldStore(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.RemoveAll(store.Path(home)); err != nil {
@@ -1352,8 +1388,8 @@ func TestStatusFleetFieldsNarrowsTheSchemaHeaderWithTheRows(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1856,8 +1892,8 @@ func TestStatusFleetFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	writeDoneReport(t, home, "task-1", "PR up")
@@ -1881,9 +1917,10 @@ func TestStatusFleetDoesNotFlagATerminalReportAWatcherConsumed(t *testing.T) {
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	report := "done: PR up\n"
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-		ReportOffset: int64(len(report))}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt:    "2026-07-24T10:00:00Z",
+		ReportOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(report), 0o644); err != nil {
@@ -1912,8 +1949,8 @@ func TestStatusFleetJSONFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	writeDoneReport(t, home, "task-1", "PR up")
@@ -1936,8 +1973,8 @@ func TestStatusSingleTaskFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	writeDoneReport(t, home, "task-1", "PR up")
@@ -1963,8 +2000,8 @@ func TestStatusSingleTaskFlagsATerminalReportBeyondTheHistoryWindow(t *testing.T
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	report := "done: PR up\nstill tidying\nand more\nand more\nand more\nand more\n"
@@ -1993,8 +2030,8 @@ func TestStatusSingleTaskFlagsTheClassifiedLineNotTrailingFreeText(t *testing.T)
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR up\nstill tidying\n"), 0o644); err != nil {
@@ -2025,9 +2062,10 @@ func TestStatusSingleTaskShowsTrailingFreeTextWhenAcknowledged(t *testing.T) {
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	report := "done: PR up\nstill tidying\n"
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-		ReportOffset: int64(len(report))}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt:    "2026-07-24T10:00:00Z",
+		ReportOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(report), 0o644); err != nil {
@@ -2053,9 +2091,10 @@ func TestStatusSingleTaskJSONOmitsUnacknowledgedWhenAcknowledged(t *testing.T) {
 	writeFakeHerdrPaneStatus(t, "idle")
 
 	report := "done: PR up\n"
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z",
-		ReportOffset: int64(len(report))}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt:    "2026-07-24T10:00:00Z",
+		ReportOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(report), 0o644); err != nil {
@@ -2119,8 +2158,8 @@ func TestStatusFleetFlagsATerminalReportWithNoTrailingNewline(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		Herdr: state.Herdr{PaneID: "wA:pB"}, CreatedAt: "2026-07-24T10:00:00Z"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR up"), 0o644); err != nil {

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -13,6 +13,8 @@ import (
 // fleet table and the single-task detail can never disagree about what a task is doing.
 type taskView struct {
 	task          state.Task
+	attempt       *state.Attempt
+	attempts      []state.Attempt
 	agentState    string
 	reportedState string
 	reportedLine  string
@@ -24,6 +26,13 @@ type taskView struct {
 	gateIssue     string
 	held          bool
 	hold          state.Hold
+}
+
+func (v taskView) execution() state.Attempt {
+	if v.attempt != nil {
+		return *v.attempt
+	}
+	return state.Attempt{}
 }
 
 func orNone(s string) string {
@@ -94,9 +103,22 @@ var taskFields = []axi.Column[taskView]{
 	{Name: "id", Value: func(v taskView) string { return v.task.ID }},
 	{Name: "project", Value: func(v taskView) string { return v.task.Project }},
 	{Name: "kind", Value: func(v taskView) string { return v.task.Kind }},
-	{Name: "harness", Value: func(v taskView) string { return orNone(v.task.Harness) }},
-	{Name: "model", Value: func(v taskView) string { return orNone(v.task.Model) }},
-	{Name: "effort", Value: func(v taskView) string { return orNone(v.task.Effort) }},
+	{Name: "task_lifecycle", Value: func(v taskView) string { return string(v.task.Lifecycle) }},
+	{Name: "attempt_ordinal", Value: func(v taskView) string {
+		if v.attempt == nil {
+			return "none"
+		}
+		return fmt.Sprintf("%d", v.attempt.Ordinal)
+	}},
+	{Name: "attempt_lifecycle", Value: func(v taskView) string {
+		if v.attempt == nil {
+			return "none"
+		}
+		return string(v.attempt.Lifecycle)
+	}},
+	{Name: "harness", Value: func(v taskView) string { return orNone(v.execution().Harness) }},
+	{Name: "model", Value: func(v taskView) string { return orNone(v.execution().Model) }},
+	{Name: "effort", Value: func(v taskView) string { return orNone(v.execution().Effort) }},
 	{Name: "state", Value: func(v taskView) string { return v.agentState }},
 	{Name: "reported", Value: func(v taskView) string {
 		if v.unreadable {
@@ -109,9 +131,10 @@ var taskFields = []axi.Column[taskView]{
 	{Name: "created", Value: func(v taskView) string { return orNone(v.task.CreatedAt) }},
 	{Name: "last_report", Value: func(v taskView) string { return formatReportAge(v.lastReportAt) }},
 	{Name: "pr", Value: func(v taskView) string { return orNone(v.task.PR) }},
-	{Name: "worktree", Value: func(v taskView) string { return orNone(v.task.Worktree) }},
+	{Name: "worktree", Value: func(v taskView) string { return orNone(v.execution().Worktree) }},
 	{Name: "herdr", Value: func(v taskView) string {
-		return orNone(strings.Trim(v.task.Herdr.Session+"/"+v.task.Herdr.TabID, "/"))
+		e := v.execution()
+		return orNone(strings.Trim(e.Herdr.Session+"/"+e.Herdr.TabID, "/"))
 	}},
 	{Name: "brief", Value: func(v taskView) string { return orNone(v.task.Brief) }},
 	{Name: "delivered", Value: func(v taskView) string {
@@ -139,7 +162,7 @@ var fleetDefaultFields = []string{"id", "state", "reported", "age", "flags"}
 // The single-task view is one item, not a list, so it defaults to everything
 // the plain-text detail view printed.
 var detailDefaultFields = []string{
-	"id", "project", "kind", "harness", "model", "state", "worktree", "herdr",
+	"id", "project", "kind", "task_lifecycle", "attempt_ordinal", "attempt_lifecycle", "harness", "model", "state", "worktree", "herdr",
 	"age", "last_report", "pr", "reported", "report", "delivered", "held", "gate", "flags", "report_file",
 }
 

--- a/cmd/task_attempt_test.go
+++ b/cmd/task_attempt_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/state"
+)
+
+func TestStatusInspectsTerminalTaskAndAttemptHistory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := initLayout(home); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Harness: "claude", Worktree: "/tmp/wt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionAttempt(home, attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionTask(home, "task-1", state.TaskOpen, state.TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		TaskLifecycle    string `json:"task_lifecycle"`
+		AttemptLifecycle string `json:"attempt_lifecycle"`
+		Attempts         []struct {
+			Ordinal int `json:"ordinal"`
+		} `json:"attempts"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.TaskLifecycle != string(state.TaskTerminal) || got.AttemptLifecycle != string(state.AttemptCompleted) || len(got.Attempts) != 1 || got.Attempts[0].Ordinal != 1 {
+		t.Fatalf("status = %+v", got)
+	}
+}

--- a/cmd/task_attempt_test.go
+++ b/cmd/task_attempt_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/atqamz/hand/internal/state"
+	"github.com/spf13/cobra"
 )
 
 func TestStatusInspectsTerminalTaskAndAttemptHistory(t *testing.T) {
@@ -47,5 +49,63 @@ func TestStatusInspectsTerminalTaskAndAttemptHistory(t *testing.T) {
 	}
 	if got.TaskLifecycle != string(state.TaskTerminal) || got.AttemptLifecycle != string(state.AttemptCompleted) || len(got.Attempts) != 1 || got.Attempts[0].Ordinal != 1 {
 		t.Fatalf("status = %+v", got)
+	}
+}
+
+func terminalTaskHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := initLayout(home); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionAttempt(home, attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionTask(home, "task-1", state.TaskOpen, state.TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// Teardown writes the permanent completion record from the state the task had then, so a
+// delivery or a PR recorded afterwards would sit on the row unread. Both name hand reopen.
+func TestDeliverAndPRRefuseATerminalTask(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  func() *cobra.Command
+		args []string
+	}{
+		{"deliver", newDeliverCmd, []string{"task-1", "--reason", "handed to upstream"}},
+		{"pr", newPRCmd, []string{"task-1", "https://github.com/o/nsr/pull/7"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := terminalTaskHome(t)
+			cmd := tc.cmd()
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("hand %s accepted a terminal task", tc.name)
+			}
+			if !strings.Contains(err.Error(), "hand reopen task-1") {
+				t.Fatalf("error = %v, want it to name the remedy", err)
+			}
+			got, err := state.Read(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.DeliveredAt != "" || got.PR != "" {
+				t.Fatalf("terminal task was written to: %+v", got)
+			}
+		})
 	}
 }

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -41,10 +41,6 @@ func newTeardownCmd() *cobra.Command {
 			}
 			defer release()
 
-			t, err := state.Read(home, id)
-			if err != nil {
-				return asPrecondition(err)
-			}
 			history, err := state.ReadHistory(home, id)
 			if err != nil {
 				return asPrecondition(err)
@@ -52,6 +48,7 @@ func newTeardownCmd() *cobra.Command {
 			if history.ActiveAttempt == nil {
 				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
 			}
+			t := history.Task
 			active := *history.ActiveAttempt
 
 			dirtWasSafe := false

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -82,7 +82,7 @@ func newTeardownCmd() *cobra.Command {
 
 			// Everything the record claims (landed work, a returned worktree) is already true by this
 			// line, --force or not, so a fault after it lands cannot make the record inaccurate, only
-			// late to remove its source.
+			// late to terminalize its source.
 			record := completionFor(t, force)
 			record.TornDownAt = time.Now().UTC().Format(time.RFC3339)
 
@@ -105,12 +105,12 @@ func newTeardownCmd() *cobra.Command {
 				return fmt.Errorf("record task completion: %w", err)
 			}
 
-			// A hold outlives the task row it was set on, which is what an operator hold is for. A limit hold
+			// A hold outlives the work it was set on, which is what an operator hold is for. A limit hold
 			// is the opposite: nothing is left to resume and no watcher will ever clear it, so left behind it
-			// would refuse `hand spawn` on this id forever.
+			// would refuse `hand reopen` on this id forever.
 			if err := state.ClearHoldIfKind(home, id, state.HoldKindLimit); err != nil {
 				// A warning rather than a failure: the teardown itself is done, and re-running it cannot undo
-				// the delete.
+				// the terminal transition.
 				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: clear usage-limit hold failed: %v\n", err); printErr != nil {
 					return printErr
 				}

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -56,7 +56,7 @@ func newTeardownCmd() *cobra.Command {
 
 			dirtWasSafe := false
 			if !force {
-				updated, safeDirt, err := checkLandedWork(cmd.Context(), home, t)
+				updated, safeDirt, err := checkLandedWork(cmd.Context(), home, t, active)
 				if err != nil {
 					return err
 				}
@@ -170,7 +170,7 @@ func completionFor(t state.Task, forced bool) completion.Record {
 // Reports whether the task's work is landed, and whether it got there past dirt it judged safe to
 // discard - the caller has to force the worktree return in that case, since treehouse will not clean a
 // dirty worktree on its own.
-func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task, bool, error) {
+func checkLandedWork(ctx context.Context, home string, t state.Task, active state.Attempt) (state.Task, bool, error) {
 	if t.Kind == state.KindScout {
 		reportPath := filepath.Join("data", t.ID, "report.md")
 		if _, err := os.Stat(filepath.Join(home, reportPath)); err != nil {
@@ -179,14 +179,14 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 		return t, false, nil
 	}
 
-	status, err := gitStatusPorcelain(t.Worktree)
+	status, err := gitStatusPorcelain(active.Worktree)
 	if err != nil {
 		return t, false, err
 	}
 	dirtWasSafe := false
 	if status != "" {
-		if !dirtIsSafeToDiscard(t.Worktree, status) {
-			return t, false, &ExitError{Err: fmt.Errorf("uncommitted changes in worktree %s:\n%s", t.Worktree, capStatusLines(status)), Code: 3}
+		if !dirtIsSafeToDiscard(active.Worktree, status) {
+			return t, false, &ExitError{Err: fmt.Errorf("uncommitted changes in worktree %s:\n%s", active.Worktree, capStatusLines(status)), Code: 3}
 		}
 		dirtWasSafe = true
 	}
@@ -208,7 +208,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 			return t, false, err
 		}
 		if exists && proj.Mode == project.ModeLocalOnly {
-			merged, err := branchIsMerged(filepath.Join(home, "projects", t.Project), t.Worktree)
+			merged, err := branchIsMerged(filepath.Join(home, "projects", t.Project), active.Worktree)
 			if err != nil {
 				return t, false, err
 			}
@@ -222,7 +222,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 		// for landed work; detect it here rather than only refusing on it, so the merged check below
 		// reads the same PR state hand pr would have recorded.
 		if exists {
-			detected, err := detectPR(ctx, home, t, proj)
+			detected, err := detectPR(ctx, home, t, active, proj)
 			var ambiguous *ghutil.AmbiguousPRError
 			// An ambiguous branch is a different failure and must not fall through the same way: "no PR
 			// recorded" reads as unlanded, but ambiguous means unknown, and picking either meaning here
@@ -250,7 +250,7 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 			// A report deliverable on disk and a branch carrying no commits of its own is a completed scout
 			// whatever the row says, and is recorded as one. Merge evidence excludes the path outright - work
 			// hand merged or watched merge landed as a merge, and the record has to say so (atqamz/hand#78).
-			if !t.MergeExecuted && !t.MergeAnnounced && isCompletedScout(home, t) {
+			if !t.MergeExecuted && !t.MergeAnnounced && isCompletedScout(home, t, active.Worktree) {
 				t.Kind = state.KindScout
 				return t, dirtWasSafe, nil
 			}
@@ -273,18 +273,18 @@ func checkLandedWork(ctx context.Context, home string, t state.Task) (state.Task
 // Reports whether a task's work is a delivered scout report and nothing else: the report exists under
 // data/<id>/ and the worktree's branch adds no commit to the local default branch. Both halves are
 // required - a report alone says nothing about code sitting unlanded on the branch beside it.
-func isCompletedScout(home string, t state.Task) bool {
+func isCompletedScout(home string, t state.Task, worktree string) bool {
 	if _, err := os.Stat(filepath.Join(home, "data", t.ID, "report.md")); err != nil {
 		return false
 	}
 	// Resolution failures fail closed, and the branch comparison is local-only like dirtIsSafeToDiscard's:
 	// a stale local ref only misses a real case, it never accepts an unlanded one.
-	baseRef, err := localDefaultBranchRef(t.Worktree)
+	baseRef, err := localDefaultBranchRef(worktree)
 	if err != nil {
 		return false
 	}
 	c := exec.Command("git", "rev-list", "--count", baseRef+"..HEAD")
-	c.Dir = t.Worktree
+	c.Dir = worktree
 	out, err := c.Output()
 	if err != nil {
 		return false

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -45,6 +45,14 @@ func newTeardownCmd() *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
+			history, err := state.ReadHistory(home, id)
+			if err != nil {
+				return asPrecondition(err)
+			}
+			if history.ActiveAttempt == nil {
+				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+			}
+			active := *history.ActiveAttempt
 
 			dirtWasSafe := false
 			if !force {
@@ -62,7 +70,7 @@ func newTeardownCmd() *cobra.Command {
 			defer releaseProject()
 
 			client := herdr.NewClient()
-			if err := closeTaskTab(client, t.Herdr.WorkspaceID, t.Herdr.TabID); err != nil {
+			if err := closeTaskTab(client, active.Herdr.WorkspaceID, active.Herdr.TabID); err != nil {
 				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: herdr tab close failed: %v\n", err); printErr != nil {
 					return printErr
 				}
@@ -71,7 +79,7 @@ func newTeardownCmd() *cobra.Command {
 			// treehouse refuses to clean a dirty worktree without --force, and nothing is left to answer
 			// its prompt here, so dirt this command already judged discardable has to be returned
 			// forcibly or the slot goes back to the pool still dirty.
-			if err := worktree.Return(t.Worktree, force || dirtWasSafe); err != nil {
+			if err := worktree.Return(active.Worktree, force || dirtWasSafe); err != nil {
 				return err
 			}
 
@@ -81,18 +89,23 @@ func newTeardownCmd() *cobra.Command {
 			record := completionFor(t, force)
 			record.TornDownAt = time.Now().UTC().Format(time.RFC3339)
 
-			// Recorded before state.Delete, not after: the record is derived from t, which state.Delete
-			// would remove out from under us. Failing here leaves the task row untouched, so the whole
-			// command is simply retryable and no completion is lost.
+			if err := state.UpdateTask(home, t); err != nil {
+				return fmt.Errorf("record task facts: %w", err)
+			}
+
 			if err := completion.Append(home, record); err != nil {
 				return fmt.Errorf("record completion: %w", err)
 			}
 
-			// Failing here leaves the task row in place, so a retry replays the whole command and
-			// appends a second, identical record - a harmless duplicate this trades for never losing a
-			// completion.
-			if err := state.Delete(home, id); err != nil {
-				return asPrecondition(err)
+			terminalAttempt := state.AttemptCompleted
+			if force {
+				terminalAttempt = state.AttemptInterrupted
+			}
+			if err := state.TransitionAttempt(home, active.ID, active.Lifecycle, terminalAttempt); err != nil {
+				return fmt.Errorf("record attempt completion: %w", err)
+			}
+			if err := state.TransitionTask(home, id, state.TaskOpen, state.TaskTerminal); err != nil {
+				return fmt.Errorf("record task completion: %w", err)
 			}
 
 			// A hold outlives the task row it was set on, which is what an operator hold is for. A limit hold
@@ -114,7 +127,7 @@ func newTeardownCmd() *cobra.Command {
 			doc.Field("outcome", record.Outcome)
 			doc.Field("detail", orNone(record.Detail))
 			doc.Field("worktree", "returned")
-			doc.Help("This id is gone from `hand status`; its completion is the last word on it")
+			doc.Help("This task remains inspectable with `hand status " + id + "`; use `hand reopen " + id + "` for another attempt")
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -169,8 +169,8 @@ func TestTeardownDetectsGateOpenedPRonDeclaredUpstream(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got %v, want teardown to detect the upstream PR and succeed", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -196,8 +196,8 @@ func TestTeardownDetectsPRWithUpstreamDeclaredAsOwnRepoInOtherCasing(t *testing.
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got %v, want the differently-cased self-upstream to be searched once", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -219,8 +219,8 @@ func TestTeardownDetectsAndTearsDownGateOpenedMergedPR(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got %v, want teardown to detect the gate-opened merged PR and succeed", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -254,8 +254,8 @@ func TestTeardownAfterProjectSetURLDetectsRenamedRepositoryPR(t *testing.T) {
 	if err := teardown.Execute(); err != nil {
 		t.Fatalf("got %v, want teardown to find merged PR in renamed repo", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -311,8 +311,8 @@ func TestTeardownTearsDownWhenBranchHasMergedAndClosedUnmergedPR(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got %v, want teardown to tear down on the merged PR", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -463,8 +463,8 @@ func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -491,28 +491,14 @@ func TestTeardownRetriesAfterReportRemovalFails(t *testing.T) {
 	cmd := newTeardownCmd()
 	cmd.SetArgs([]string{"task-1"})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "remove report channel") {
-		t.Fatalf("got err %v, want a remove report channel failure", err)
+	if err != nil {
+		t.Fatalf("got err %v, want teardown to preserve the report channel", err)
 	}
-	// state.Delete's removal order - report channel before the task row - leaves the task row untouched,
-	// so there is something left to retry at all.
 	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
-		t.Fatalf("state gone after failed teardown, want it retryable: %v %v", exists, err)
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
-
-	if err := os.RemoveAll(reportPath); err != nil {
-		t.Fatal(err)
-	}
-
-	// The retry re-runs the cleanup steps the first call already completed, which have to treat an
-	// already-closed tab and an already-returned worktree as success.
-	cmd = newTeardownCmd()
-	cmd.SetArgs([]string{"task-1"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after retried teardown: %v %v", exists, err)
+	if _, err := os.Stat(filepath.Join(reportPath, "blocker")); err != nil {
+		t.Fatalf("report channel was removed: %v", err)
 	}
 
 	records, err := completion.List(home)
@@ -562,8 +548,15 @@ func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 	if got != want {
 		t.Fatalf("record = %+v, want %+v", got, want)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state after successful baseline teardown = %v, %v, want active task row deleted", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state after successful baseline teardown = %v, %v, want terminal task row preserved", exists, err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.Task.ActiveAttemptID != 0 || len(history.Attempts) != 1 || history.Attempts[0].Lifecycle != state.AttemptCompleted {
+		t.Fatalf("terminal teardown history = %+v", history)
 	}
 	for _, field := range []string{"id: task-1\n", "result: torn-down\n", "project: myproj\n", "kind: ship\n", "outcome: merged\n", "detail:", "worktree: returned\n"} {
 		if !strings.Contains(out.String(), field) {
@@ -573,8 +566,7 @@ func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 }
 
 // The ordering in cmd/teardown.go must survive a fault in completion.Append the same way
-// TestTeardownRetriesAfterReportRemovalFails covers state.Delete's report removal: state.Delete never
-// runs, so the task stays retryable, and the retry leaves no duplicate record behind a failed line.
+// Completion append failure leaves the task retryable, and a retry leaves no duplicate record behind a failed line.
 func TestTeardownCompletionAppendFailureLeavesStateIntact(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
@@ -608,8 +600,8 @@ func TestTeardownCompletionAppendFailureLeavesStateIntact(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after retried teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after retried teardown: %v %v", exists, err)
 	}
 
 	records, err := completion.List(home)
@@ -642,11 +634,11 @@ func TestTeardownRetiresTheTasksPendingQuestion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
-	if _, err := os.Stat(state.ReportPath(home, "task-1")); !os.IsNotExist(err) {
-		t.Fatalf("got report path err %v, want the question's report channel gone too", err)
+	if _, err := os.Stat(state.ReportPath(home, "task-1")); err != nil {
+		t.Fatalf("report channel was removed: %v", err)
 	}
 }
 
@@ -962,8 +954,8 @@ func TestTeardownAcceptsDeliveredWorkWithAnOpenPRWithoutForce(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("teardown of delivered work: %v", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 
 	records, err := completion.List(home)
@@ -1127,8 +1119,8 @@ func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after forced teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after forced teardown: %v %v", exists, err)
 	}
 }
 
@@ -1271,8 +1263,8 @@ func TestTeardownProceedsWhenDirtAlreadyMatchesMergedBase(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got %v, want teardown to proceed past dirt that already matches the merged base", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 
@@ -1408,8 +1400,8 @@ func TestTeardownProceedsWhenDirtMatchesOriginDefaultBranchTip(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got %v, want teardown to compare against origin's default branch tip", err)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state still exists after teardown: %v %v", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state not preserved after teardown: %v %v", exists, err)
 	}
 }
 

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -159,7 +159,7 @@ func TestTeardownDetectsGateOpenedPRonDeclaredUpstream(t *testing.T) {
 	writeFakeGHForkPRListAndView(t, "up/repo", "owner/repo",
 		ghFakePR{Number: 7, URL: "https://github.com/up/repo/pull/7", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func TestTeardownDetectsPRWithUpstreamDeclaredAsOwnRepoInOtherCasing(t *testing.
 	writeFakeGHForkPRListAndView(t, "owner/repo", "owner/repo",
 		ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestTeardownDetectsAndTearsDownGateOpenedMergedPR(t *testing.T) {
 	setupTeardownGateProject(t, home, worktree, "task-1-branch")
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestTeardownAfterProjectSetURLDetectsRenamedRepositoryPR(t *testing.T) {
 	faketool.GH{PRs: []faketool.GHPR{{
 		Number: 185, URL: prURL, Branch: "task-1-branch", Repo: "atqamz/hand", State: "MERGED",
 	}}}.Install(t, faketool.Bin(t))
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestTeardownRefusesGateOpenedClosedUnmergedPR(t *testing.T) {
 	setupTeardownGateProject(t, home, worktree, "task-1-branch")
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "CLOSED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestTeardownTearsDownWhenBranchHasMergedAndClosedUnmergedPR(t *testing.T) {
 		ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "CLOSED"},
 		ghFakePR{Number: 5, URL: "https://github.com/owner/repo/pull/5", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +326,7 @@ func TestTeardownRefusesAmbiguousBranch(t *testing.T) {
 		ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "MERGED"},
 		ghFakePR{Number: 5, URL: "https://github.com/owner/repo/pull/5", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -364,7 +364,7 @@ func TestTeardownRefusesMergedAndOpenPR(t *testing.T) {
 		ghFakePR{Number: 5, URL: "https://github.com/owner/repo/pull/5", State: "MERGED"},
 		ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "OPEN"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -413,7 +413,7 @@ func TestTeardownShipFailsOnUncommittedChanges(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(worktree, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -430,7 +430,7 @@ func TestTeardownShipFailsWhenPRNotMerged(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "OPEN")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj", PR: "https://example.com/pr/1"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj", PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -453,8 +453,9 @@ func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -475,8 +476,9 @@ func TestTeardownRetriesAfterReportRemovalFails(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -514,8 +516,9 @@ func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -571,8 +574,9 @@ func TestTeardownCompletionAppendFailureLeavesStateIntact(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -620,8 +624,9 @@ func TestTeardownRetiresTheTasksPendingQuestion(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("needs-decision: which base branch?\n"), 0o644); err != nil {
@@ -657,8 +662,9 @@ func TestTeardownRetiresAMachineSetLimitHoldButNotAnOperatorsOwn(t *testing.T) {
 			home, worktree := setupTeardownHome(t)
 			writeFakeGHPRState(t, "MERGED")
 
-			if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-				PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+			if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+				PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+				Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 				t.Fatal(err)
 			}
 			if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: tt.kind, Reason: "held"}); err != nil {
@@ -726,7 +732,7 @@ func TestTeardownShipLocalOnlyFailsWhenBranchNotMerged(t *testing.T) {
 	if err := os.Rename(clonePath, filepath.Join(home, "projects", "myproj")); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -777,7 +783,7 @@ func TestBranchIsMergedUsesOriginDefaultBranch(t *testing.T) {
 
 func TestTeardownScoutFailsWhenReportMissing(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -793,7 +799,7 @@ func TestTeardownScoutFailsWhenReportMissing(t *testing.T) {
 func TestTeardownScoutSucceedsWhenReportPresent(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeScoutReport(t, home, "task-1")
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree,
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -813,7 +819,7 @@ func TestTeardownAcceptsAShipRowThatDeliveredAScoutReport(t *testing.T) {
 	runGitIn(t, worktree, "checkout", "-q", "-b", "task-1-branch")
 	writeScoutReport(t, home, "task-1")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -849,7 +855,7 @@ func TestTeardownStillRefusesAShipTaskWhosePRWasNeverOpened(t *testing.T) {
 	runGitIn(t, worktree, "commit", "-q", "-m", "feature")
 	writeScoutReport(t, home, "task-1")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -885,8 +891,9 @@ func TestTeardownRecordsMergedWhenALocallyMergedShipRowKeptItsScoutReport(t *tes
 	}
 	writeScoutReport(t, home, "task-1")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		MergeExecuted: true, MergeExecutedAt: "2026-08-04T00:00:00Z",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		MergeExecuted: true, MergeExecutedAt: "2026-08-04T00:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -917,8 +924,9 @@ func TestTeardownStillRefusesAMergedShipRowWithNoPRToConfirm(t *testing.T) {
 	runGitIn(t, worktree, "checkout", "-q", "-b", "task-1-branch")
 	writeScoutReport(t, home, "task-1")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		MergeExecuted: true, MergeExecutedAt: "2026-08-04T00:00:00Z",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		MergeExecuted: true, MergeExecutedAt: "2026-08-04T00:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -943,8 +951,9 @@ func TestTeardownAcceptsDeliveredWorkWithAnOpenPRWithoutForce(t *testing.T) {
 	writeFakeGHPRState(t, "OPEN")
 
 	pr := "https://github.com/kunchenguid/no-mistakes/pull/597"
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: pr, DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream, maintainer decides",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: pr, DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream, maintainer decides"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -979,8 +988,9 @@ func TestTeardownAcceptsDeliveredWorkWithAnOpenPRWithoutForce(t *testing.T) {
 // Kind, so this tears down cleanly without anyone having to correct the kind first.
 func TestTeardownAcceptsDeliveredWorkWithNoPRRegardlessOfKind(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "report at data/task-1/report.md, no code to land",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "report at data/task-1/report.md, no code to land"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1010,8 +1020,9 @@ func TestTeardownStillRefusesUncommittedChangesOnDeliveredWork(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(worktree, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1032,9 +1043,10 @@ func TestTeardownRecordsMergedWhenDeliveredWorkActuallyLanded(t *testing.T) {
 	writeFakeGHPRState(t, "MERGED")
 
 	pr := "https://github.com/kunchenguid/no-mistakes/pull/597"
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
 		PR: pr, DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream, maintainer decides",
-		MergeExecuted: true, MergeExecutedAt: "2026-08-04T00:00:00Z",
+		MergeExecuted: true, MergeExecutedAt: "2026-08-04T00:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1064,10 +1076,11 @@ func TestTeardownRecordsMergedWhenAnObservedMergeFollowedDelivery(t *testing.T) 
 	writeFakeGHPRState(t, "MERGED")
 
 	pr := "https://github.com/kunchenguid/no-mistakes/pull/597"
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
 		PR: pr, DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "offered upstream",
-		MergeAnnounced: true,
-		Herdr:          state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		MergeAnnounced: true}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1090,8 +1103,9 @@ func TestTeardownRecordsMergedWhenAnObservedMergeFollowedDelivery(t *testing.T) 
 // the report check ahead of the delivered short-circuit still refuses it.
 func TestTeardownStillRefusesDeliveredScoutWithNoReport(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree,
-		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "handed over"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindScout,
+		DeliveredAt: "2026-08-03T00:00:00Z", DeliveredReason: "handed over"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1109,7 +1123,7 @@ func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(worktree, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1127,7 +1141,7 @@ func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
 func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeScoutReport(t, home, "task-1")
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout, Worktree: worktree,
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1184,7 +1198,7 @@ func TestTeardownClosesWorkspaceWhenLastTab(t *testing.T) {
 		{Command: "workspace close", Stdout: "{\"id\":\"cli:1\",\"result\":{}}"},
 	}}.Install(t, bin)
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindScout, Worktree: worktree,
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1253,7 +1267,7 @@ func TestTeardownProceedsWhenDirtAlreadyMatchesMergedBase(t *testing.T) {
 	registerGateProject(t, home)
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1333,7 +1347,7 @@ func TestTeardownForcesWorktreeReturnPastSafeDirt(t *testing.T) {
 	registerGateProject(t, home)
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1357,8 +1371,9 @@ func TestTeardownReturnsCleanWorktreeUnforced(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
-		PR: "https://example.com/pr/1", Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1390,7 +1405,7 @@ func TestTeardownProceedsWhenDirtMatchesOriginDefaultBranchTip(t *testing.T) {
 	registerGateProject(t, home)
 	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "MERGED"})
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1420,7 +1435,7 @@ func TestTeardownRefusesDirtWhenStagedContentDiffersFromBase(t *testing.T) {
 	}
 	registerGateProject(t, home)
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1445,7 +1460,7 @@ func TestTeardownRefusesDirtWhenContentDiffersFromBase(t *testing.T) {
 	}
 	registerGateProject(t, home)
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1472,7 +1487,7 @@ func TestTeardownRefusesDirtWithUntrackedFileEvenWhenTrackedChangeMatchesBase(t 
 	}
 	registerGateProject(t, home)
 
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj",
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
 		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1496,7 +1511,7 @@ func TestTeardownRefusalCapsGitStatusOutput(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := state.Write(home, state.Task{ID: "task-1", Kind: state.KindShip, Worktree: worktree, Project: "myproj"}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -4,7 +4,30 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/atqamz/hand/internal/state"
 )
+
+func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.Attempt) error {
+	t.Helper()
+	if err := state.CreateTask(home, task); err != nil {
+		t.Fatal(err)
+	}
+	attempt.TaskID = task.ID
+	if _, err := state.CreateAttempt(home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	return nil
+}
+
+func readTaskAttempt(t *testing.T, home, id string) state.Attempt {
+	t.Helper()
+	attempt, err := state.ActiveAttempt(home, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return attempt
+}
 
 func TestMain(m *testing.M) {
 	for _, tc := range []struct {

--- a/docs/adr/tasks-are-durable-and-attempts-own-execution.md
+++ b/docs/adr/tasks-are-durable-and-attempts-own-execution.md
@@ -1,0 +1,32 @@
+# Tasks are durable and Attempts own execution
+
+- Date: 2026-08-13
+- Status: accepted
+- Issues: atqamz/hand#193
+- PRs: none single
+
+## Context
+
+A task's logical identity and history must survive the disposable worker process, worktree, pane, and harness invocation that execute it.
+The earlier [completion-store decision](the-completion-store-is-an-uncapped-append-only-sibling.md) treated teardown as removing the task row, which made the completion file the only durable record after cleanup.
+
+## Decision
+
+SQLite stores logical work in `task` and each execution incarnation in `attempt`.
+A task has one lifecycle, an authoritative active-attempt relation, and a report cursor that remains continuous across attempts.
+An attempt has its own ordinal, lifecycle, execution identity, resources, pane-scoped bookkeeping, and usage-limit state.
+The database partial unique index permits at most one provisioning or running attempt for a task.
+Terminal attempts are immutable with respect to activation.
+Spawn creates a task and Attempt 1, promotion preserves the scout attempt and creates the next attempt, teardown terminalizes both rows without deleting them, and `hand reopen` explicitly creates a new attempt for a terminal task.
+
+## Rejected alternatives
+
+- Keeping execution columns on `task` makes promotion overwrite history and makes a terminal row look runnable.
+- Deleting task rows at teardown loses logical lineage and makes ID reuse ambiguous.
+- Reusing a terminal attempt resurrects a disposable execution identity and its pane-scoped latches.
+
+## Consequences
+
+Single-task status can inspect terminal tasks and bounded attempt history, while fleet status remains focused on open tasks.
+Completion JSONL remains useful as an independent audit and recovery channel, but it is no longer the sole durable record after teardown.
+Conditional transitions, crash evidence, and orchestration extraction remain later work in #194 and #195; profile and route snapshots remain later work in #215.

--- a/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
+++ b/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
@@ -1,7 +1,7 @@
 # Completions use an uncapped append-only file
 
 - Date: 2026-08-04
-- Status: accepted
+- Status: accepted, superseded in part by [Tasks are durable and Attempts own execution](tasks-are-durable-and-attempts-own-execution.md)
 - Issues: atqamz/hand#78
 - PRs: none single
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -55,7 +55,7 @@ func Append(homeDir string, r Record) error {
 	}
 	// Not deferred and not discarded: a filesystem that reports a write fault only
 	// at close (NFS, delayed-allocation ENOSPC) makes Close the sole signal the record
-	// reached disk, and teardown removes the task's row on this returning nil.
+	// reached disk, and teardown terminalizes the task and its attempt on this returning nil.
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("close completions store: %w", err)
 	}

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -235,15 +235,7 @@ func ListOpen(homeDir string) ([]Task, error) {
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
-	histories, err := db.ListOpenTaskHistories()
-	if err != nil {
-		return nil, err
-	}
-	tasks := make([]Task, 0, len(histories))
-	for _, history := range histories {
-		tasks = append(tasks, history.Task)
-	}
-	return tasks, nil
+	return openTasks(db)
 }
 
 func ListOpenHistories(homeDir string) ([]TaskHistory, error) {
@@ -255,13 +247,27 @@ func ListOpenHistories(homeDir string) ([]TaskHistory, error) {
 	return db.ListOpenTaskHistories()
 }
 
+// ListReadOnly is ListOpen for a presentation reader: same open-only fleet, off a handle that
+// cannot create schema or import legacy state. A torn-down task is history, not fleet.
 func ListReadOnly(homeDir string) ([]Task, error) {
 	db, err := store.OpenReadOnly(homeDir)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
-	return db.ListTasks()
+	return openTasks(db)
+}
+
+func openTasks(db *store.DB) ([]Task, error) {
+	histories, err := db.ListOpenTaskHistories()
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]Task, 0, len(histories))
+	for _, history := range histories {
+		tasks = append(tasks, history.Task)
+	}
+	return tasks, nil
 }
 
 // Delete removes a task's row along with its report channel at state/<id>.status, leaving

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -19,6 +19,8 @@ var ErrTaskNotFound = store.ErrTaskNotFound
 // `task "<id>" already active`.
 var ErrTaskActive = errors.New("already active")
 
+var ErrNoActiveAttempt = errors.New("no active attempt")
+
 // ErrLockBusy is returned by TryLock when another process holds the lock.
 var ErrLockBusy = errors.New("lock held by another process")
 
@@ -56,7 +58,11 @@ func Claim(homeDir, id string) (func(), error) {
 		return nil, err
 	}
 	if active {
+		task, readErr := Read(homeDir, id)
 		release()
+		if readErr == nil && task.Lifecycle == TaskTerminal {
+			return nil, fmt.Errorf("task %q already exists; use hand reopen %s: %w", id, id, ErrTaskActive)
+		}
 		return nil, fmt.Errorf("task %q %w", id, ErrTaskActive)
 	}
 	return release, nil
@@ -109,6 +115,36 @@ func Read(homeDir, id string) (Task, error) {
 	return t, nil
 }
 
+func ReadHistory(homeDir, id string) (TaskHistory, error) {
+	if err := ValidateID(id); err != nil {
+		return TaskHistory{}, err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return TaskHistory{}, err
+	}
+	defer func() { _ = db.Close() }()
+	history, found, err := db.ReadTaskHistory(id)
+	if err != nil {
+		return TaskHistory{}, err
+	}
+	if !found {
+		return TaskHistory{}, fmt.Errorf("task %q %w", id, ErrTaskNotFound)
+	}
+	return history, nil
+}
+
+func ActiveAttempt(homeDir, id string) (Attempt, error) {
+	history, err := ReadHistory(homeDir, id)
+	if err != nil {
+		return Attempt{}, err
+	}
+	if history.ActiveAttempt == nil {
+		return Attempt{}, fmt.Errorf("task %q %w", id, ErrNoActiveAttempt)
+	}
+	return *history.ActiveAttempt, nil
+}
+
 func Write(homeDir string, t Task) error {
 	if err := ValidateID(t.ID); err != nil {
 		return err
@@ -121,6 +157,69 @@ func Write(homeDir string, t Task) error {
 	return db.WriteTask(t)
 }
 
+func CreateTask(homeDir string, t Task) error {
+	if err := ValidateID(t.ID); err != nil {
+		return err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.CreateTask(t)
+}
+
+func UpdateTask(homeDir string, t Task) error {
+	if err := ValidateID(t.ID); err != nil {
+		return err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.UpdateTask(t)
+}
+
+func CreateAttempt(homeDir string, a Attempt) (Attempt, error) {
+	if err := ValidateID(a.TaskID); err != nil {
+		return Attempt{}, err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Attempt{}, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.CreateAttempt(a)
+}
+
+func UpdateAttempt(homeDir string, a Attempt) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.UpdateAttempt(a)
+}
+
+func TransitionAttempt(homeDir string, id int64, from, to AttemptLifecycle) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.TransitionAttempt(id, from, to)
+}
+
+func TransitionTask(homeDir, id string, from, to TaskLifecycle) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.TransitionTask(id, from, to)
+}
+
 func List(homeDir string) ([]Task, error) {
 	db, err := store.Open(homeDir)
 	if err != nil {
@@ -128,6 +227,32 @@ func List(homeDir string) ([]Task, error) {
 	}
 	defer func() { _ = db.Close() }()
 	return db.ListTasks()
+}
+
+func ListOpen(homeDir string) ([]Task, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+	histories, err := db.ListOpenTaskHistories()
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]Task, 0, len(histories))
+	for _, history := range histories {
+		tasks = append(tasks, history.Task)
+	}
+	return tasks, nil
+}
+
+func ListOpenHistories(homeDir string) ([]TaskHistory, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ListOpenTaskHistories()
 }
 
 func ListReadOnly(homeDir string) ([]Task, error) {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -116,10 +116,23 @@ func Read(homeDir, id string) (Task, error) {
 }
 
 func ReadHistory(homeDir, id string) (TaskHistory, error) {
+	return readHistory(homeDir, id, false)
+}
+
+// A read-only history read avoids schema migration and legacy import.
+func ReadHistoryReadOnly(homeDir, id string) (TaskHistory, error) {
+	return readHistory(homeDir, id, true)
+}
+
+func readHistory(homeDir, id string, readOnly bool) (TaskHistory, error) {
 	if err := ValidateID(id); err != nil {
 		return TaskHistory{}, err
 	}
-	db, err := store.Open(homeDir)
+	open := store.Open
+	if readOnly {
+		open = store.OpenReadOnly
+	}
+	db, err := open(homeDir)
 	if err != nil {
 		return TaskHistory{}, err
 	}

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -10,8 +10,9 @@ import (
 	"github.com/atqamz/hand/internal/store"
 )
 
-// ErrTaskNotFound is wrapped into errors returned by Read and Delete when no
-// task row exists for the given ID, rendering as `task "<id>" not found`.
+// ErrTaskNotFound is wrapped into errors returned by the task and history readers
+// and by Delete when no task row exists for the given ID, rendering as
+// `task "<id>" not found`.
 var ErrTaskNotFound = store.ErrTaskNotFound
 
 // ErrTaskActive is wrapped into errors returned by Claim when the task is

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -167,7 +167,14 @@ func Write(homeDir string, t Task) error {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	return db.WriteTask(t)
+	found, err := db.TaskExists(t.ID)
+	if err != nil {
+		return err
+	}
+	if found {
+		return db.UpdateTask(t)
+	}
+	return db.CreateTask(t)
 }
 
 func CreateTask(homeDir string, t Task) error {
@@ -231,6 +238,18 @@ func TransitionTask(homeDir, id string, from, to TaskLifecycle) error {
 	}
 	defer func() { _ = db.Close() }()
 	return db.TransitionTask(id, from, to)
+}
+
+func ReopenTask(homeDir string, a Attempt) (Attempt, error) {
+	if err := ValidateID(a.TaskID); err != nil {
+		return Attempt{}, err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Attempt{}, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ReopenTask(a.TaskID, a)
 }
 
 func List(homeDir string) ([]Task, error) {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -139,7 +139,7 @@ func readHistory(homeDir, id string, readOnly bool) (TaskHistory, error) {
 	defer func() { _ = db.Close() }()
 	history, found, err := db.ReadTaskHistory(id)
 	if err != nil {
-		return TaskHistory{}, err
+		return TaskHistory{}, fmt.Errorf("read task history %q: %w", id, err)
 	}
 	if !found {
 		return TaskHistory{}, fmt.Errorf("task %q %w", id, ErrTaskNotFound)
@@ -262,12 +262,15 @@ func List(homeDir string) ([]Task, error) {
 }
 
 func ListOpen(homeDir string) ([]Task, error) {
-	db, err := store.Open(homeDir)
+	histories, err := ListOpenHistories(homeDir)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = db.Close() }()
-	return openTasks(db)
+	tasks := make([]Task, 0, len(histories))
+	for _, history := range histories {
+		tasks = append(tasks, history.Task)
+	}
+	return tasks, nil
 }
 
 func ListOpenHistories(homeDir string) ([]TaskHistory, error) {
@@ -279,27 +282,15 @@ func ListOpenHistories(homeDir string) ([]TaskHistory, error) {
 	return db.ListOpenTaskHistories()
 }
 
-// ListReadOnly is ListOpen for a presentation reader: same open-only fleet, off a handle that
-// cannot create schema or import legacy state. A torn-down task is history, not fleet.
-func ListReadOnly(homeDir string) ([]Task, error) {
+// ListOpenHistoriesReadOnly is ListOpenHistories for a presentation reader: same open-only fleet, off
+// a handle that cannot create schema or import legacy state. A torn-down task is history, not fleet.
+func ListOpenHistoriesReadOnly(homeDir string) ([]TaskHistory, error) {
 	db, err := store.OpenReadOnly(homeDir)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
-	return openTasks(db)
-}
-
-func openTasks(db *store.DB) ([]Task, error) {
-	histories, err := db.ListOpenTaskHistories()
-	if err != nil {
-		return nil, err
-	}
-	tasks := make([]Task, 0, len(histories))
-	for _, history := range histories {
-		tasks = append(tasks, history.Task)
-	}
-	return tasks, nil
+	return db.ListOpenTaskHistories()
 }
 
 // Delete removes a task's row along with its report channel at state/<id>.status, leaving

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -247,7 +247,7 @@ func TestWriteOverwritesExisting(t *testing.T) {
 
 // The read-only fleet view is what `hand session start` renders, and a torn-down task
 // belongs to history: it stays inspectable by id without crowding the fleet overview.
-func TestListReadOnlyShowsOpenTasksOnly(t *testing.T) {
+func TestListOpenHistoriesReadOnlyShowsOpenTasksOnly(t *testing.T) {
 	dir := t.TempDir()
 	for _, id := range []string{"open-task", "torn-down"} {
 		if err := CreateTask(dir, Task{ID: id}); err != nil {
@@ -268,15 +268,14 @@ func TestListReadOnlyShowsOpenTasksOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tasks, err := ListReadOnly(dir)
+	histories, err := ListOpenHistoriesReadOnly(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(tasks) != 1 || tasks[0].ID != "open-task" {
-		t.Fatalf("ListReadOnly = %+v, want the open task only", tasks)
+	if len(histories) != 1 || histories[0].Task.ID != "open-task" {
+		t.Fatalf("ListOpenHistoriesReadOnly = %+v, want the open task only", histories)
 	}
-	history, err := ReadHistoryReadOnly(dir, "open-task")
-	if err != nil || history.ActiveAttempt == nil || history.ActiveAttempt.Harness != "claude" {
-		t.Fatalf("active attempt was not retained separately: %+v, %v", history, err)
+	if histories[0].ActiveAttempt == nil || histories[0].ActiveAttempt.Harness != "claude" {
+		t.Fatalf("active attempt was not carried with the open task: %+v", histories[0])
 	}
 }

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -270,4 +270,8 @@ func TestListReadOnlyShowsOpenTasksOnly(t *testing.T) {
 	if tasks[0].Harness != "claude" {
 		t.Fatalf("active attempt was not projected onto the row: %+v", tasks[0])
 	}
+	history, err := ReadHistoryReadOnly(dir, "open-task")
+	if err != nil || history.ActiveAttempt == nil {
+		t.Fatalf("ReadHistoryReadOnly = %+v, %v", history, err)
+	}
 }

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -239,3 +239,35 @@ func TestWriteOverwritesExisting(t *testing.T) {
 		t.Fatalf("got harness %q, want codex", got.Harness)
 	}
 }
+
+// The read-only fleet view is what `hand session start` renders, and a torn-down task
+// belongs to history: it stays inspectable by id without crowding the fleet overview.
+func TestListReadOnlyShowsOpenTasksOnly(t *testing.T) {
+	dir := t.TempDir()
+	for _, id := range []string{"open-task", "torn-down"} {
+		if err := Write(dir, Task{ID: id, Harness: "claude"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	done, err := Read(dir, "torn-down")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := TransitionAttempt(dir, done.ActiveAttemptID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := TransitionTask(dir, "torn-down", TaskOpen, TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks, err := ListReadOnly(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "open-task" {
+		t.Fatalf("ListReadOnly = %+v, want the open task only", tasks)
+	}
+	if tasks[0].Harness != "claude" {
+		t.Fatalf("active attempt was not projected onto the row: %+v", tasks[0])
+	}
+}

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -23,12 +23,16 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := Read(dir, "fix-login")
+	history, err := ReadHistory(dir, "fix-login")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != task {
-		t.Fatalf("got %+v, want %+v", got, task)
+	got := history.Task
+	if got.ID != task.ID || got.Project != task.Project || got.Kind != task.Kind || got.Brief != task.Brief || got.CreatedAt != task.CreatedAt {
+		t.Fatalf("task got %+v, want %+v", got, task)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Harness != task.Harness || history.ActiveAttempt.Model != task.Model || history.ActiveAttempt.Effort != task.Effort || history.ActiveAttempt.Worktree != task.Worktree || history.ActiveAttempt.Herdr != task.Herdr {
+		t.Fatalf("attempt got %+v, want execution fields from %+v", history.ActiveAttempt, task)
 	}
 }
 

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -13,13 +13,18 @@ import (
 func TestWriteReadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	task := Task{
-		ID: "fix-login", Project: "nsr", Kind: KindShip, Harness: "claude",
-		Model: "sonnet", Effort: "low", Worktree: "/tmp/wt", Brief: "data/fix-login/brief.md",
-		Herdr:     Herdr{Session: "default", WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pC"},
+		ID: "fix-login", Project: "nsr", Kind: KindShip, Brief: "data/fix-login/brief.md",
 		CreatedAt: "2026-07-24T10:00:00Z",
 	}
+	attempt := Attempt{
+		TaskID: task.ID, Lifecycle: AttemptRunning, Harness: "claude", Model: "sonnet", Effort: "low", Worktree: "/tmp/wt",
+		Herdr: Herdr{Session: "default", WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pC"},
+	}
 
-	if err := Write(dir, task); err != nil {
+	if err := CreateTask(dir, task); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CreateAttempt(dir, attempt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -31,8 +36,8 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	if got.ID != task.ID || got.Project != task.Project || got.Kind != task.Kind || got.Brief != task.Brief || got.CreatedAt != task.CreatedAt {
 		t.Fatalf("task got %+v, want %+v", got, task)
 	}
-	if history.ActiveAttempt == nil || history.ActiveAttempt.Harness != task.Harness || history.ActiveAttempt.Model != task.Model || history.ActiveAttempt.Effort != task.Effort || history.ActiveAttempt.Worktree != task.Worktree || history.ActiveAttempt.Herdr != task.Herdr {
-		t.Fatalf("attempt got %+v, want execution fields from %+v", history.ActiveAttempt, task)
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Harness != attempt.Harness || history.ActiveAttempt.Model != attempt.Model || history.ActiveAttempt.Effort != attempt.Effort || history.ActiveAttempt.Worktree != attempt.Worktree || history.ActiveAttempt.Herdr != attempt.Herdr {
+		t.Fatalf("attempt got %+v, want %+v", history.ActiveAttempt, attempt)
 	}
 }
 
@@ -224,10 +229,10 @@ func TestTryLockReportsBusyInsteadOfWaiting(t *testing.T) {
 
 func TestWriteOverwritesExisting(t *testing.T) {
 	dir := t.TempDir()
-	if err := Write(dir, Task{ID: "fix-login", Harness: "claude"}); err != nil {
+	if err := Write(dir, Task{ID: "fix-login", PR: "old"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := Write(dir, Task{ID: "fix-login", Harness: "codex"}); err != nil {
+	if err := Write(dir, Task{ID: "fix-login", PR: "new"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,8 +240,8 @@ func TestWriteOverwritesExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Harness != "codex" {
-		t.Fatalf("got harness %q, want codex", got.Harness)
+	if got.PR != "new" {
+		t.Fatalf("got PR %q, want new", got.PR)
 	}
 }
 
@@ -245,7 +250,10 @@ func TestWriteOverwritesExisting(t *testing.T) {
 func TestListReadOnlyShowsOpenTasksOnly(t *testing.T) {
 	dir := t.TempDir()
 	for _, id := range []string{"open-task", "torn-down"} {
-		if err := Write(dir, Task{ID: id, Harness: "claude"}); err != nil {
+		if err := CreateTask(dir, Task{ID: id}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := CreateAttempt(dir, Attempt{TaskID: id, Lifecycle: AttemptRunning, Harness: "claude"}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -267,11 +275,8 @@ func TestListReadOnlyShowsOpenTasksOnly(t *testing.T) {
 	if len(tasks) != 1 || tasks[0].ID != "open-task" {
 		t.Fatalf("ListReadOnly = %+v, want the open task only", tasks)
 	}
-	if tasks[0].Harness != "claude" {
-		t.Fatalf("active attempt was not projected onto the row: %+v", tasks[0])
-	}
 	history, err := ReadHistoryReadOnly(dir, "open-task")
-	if err != nil || history.ActiveAttempt == nil {
-		t.Fatalf("ReadHistoryReadOnly = %+v, %v", history, err)
+	if err != nil || history.ActiveAttempt == nil || history.ActiveAttempt.Harness != "claude" {
+		t.Fatalf("active attempt was not retained separately: %+v, %v", history, err)
 	}
 }

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -19,7 +19,24 @@ const (
 // Aliases rather than separate structs: the store owns the columns these map
 // to, and a second definition would be one more place to forget a field.
 type (
-	Herdr = store.Herdr
-	Task  = store.Task
-	Hold  = store.Hold
+	Herdr            = store.Herdr
+	Task             = store.Task
+	Attempt          = store.Attempt
+	TaskHistory      = store.TaskHistory
+	Hold             = store.Hold
+	TaskLifecycle    = store.TaskLifecycle
+	AttemptLifecycle = store.AttemptLifecycle
+)
+
+const (
+	TaskOpen     = store.TaskOpen
+	TaskTerminal = store.TaskTerminal
+)
+
+const (
+	AttemptProvisioning = store.AttemptProvisioning
+	AttemptRunning      = store.AttemptRunning
+	AttemptCompleted    = store.AttemptCompleted
+	AttemptFailed       = store.AttemptFailed
+	AttemptInterrupted  = store.AttemptInterrupted
 )

--- a/internal/store/attempt_test.go
+++ b/internal/store/attempt_test.go
@@ -111,8 +111,8 @@ func TestTaskAndAttemptTransitionsRejectIllegalStates(t *testing.T) {
 	if err := db.TransitionTask("task-1", TaskTerminal, TaskTerminal); !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("terminal -> terminal = %v, want ErrInvalidTransition", err)
 	}
-	if err := db.TransitionTask("task-1", TaskTerminal, TaskOpen); err != nil {
-		t.Fatal(err)
+	if err := db.TransitionTask("task-1", TaskTerminal, TaskOpen); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("terminal -> open = %v, want ErrInvalidTransition", err)
 	}
 }
 
@@ -130,5 +130,36 @@ func TestAttemptTerminalStateCannotBecomeActiveAgain(t *testing.T) {
 	}
 	if err := db.SetActiveAttempt("task-1", attempt.ID); !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("reactivating completed attempt = %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestReopenTaskCreatesANewAttemptWithoutResurrectingHistory(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning, Harness: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(first.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionTask("task-1", TaskOpen, TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	second, err := db.ReopenTask("task-1", Attempt{Lifecycle: AttemptRunning, Harness: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Ordinal != 2 || second.Lifecycle != AttemptRunning || second.Harness != "codex" {
+		t.Fatalf("reopened attempt = %+v, want ordinal 2 running codex", second)
+	}
+	history, found, err := db.ReadTaskHistory("task-1")
+	if err != nil || !found || history.Task.Lifecycle != TaskOpen || history.ActiveAttempt == nil || history.ActiveAttempt.ID != second.ID {
+		t.Fatalf("reopened history = %+v, %v, want task open with second active", history, err)
+	}
+	if len(history.Attempts) != 2 || history.Attempts[0].Lifecycle != AttemptCompleted {
+		t.Fatalf("attempt history = %+v, want completed first attempt and running second", history.Attempts)
 	}
 }

--- a/internal/store/attempt_test.go
+++ b/internal/store/attempt_test.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTaskAndAttemptHaveSeparateIdentityAndExecutionOwnership(t *testing.T) {
+	db, _ := openTemp(t)
+
+	task := Task{ID: "task-1", Project: "demo", Kind: KindScout, Brief: "data/task-1/brief.md", Lifecycle: TaskOpen}
+	if err := db.CreateTask(task); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(Attempt{
+		TaskID: task.ID, Lifecycle: AttemptRunning, Harness: "claude", Model: "opus", Effort: "high",
+		Worktree: "/tmp/wt-1", LeaseID: "lease-1", Herdr: Herdr{PaneID: "pane-1"}, CreatedAt: "2026-08-13T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.ID == 0 || attempt.Ordinal != 1 {
+		t.Fatalf("attempt identity = %+v, want an SQLite ID and ordinal 1", attempt)
+	}
+
+	gotTask, found, err := db.ReadTask(task.ID)
+	if err != nil || !found {
+		t.Fatalf("ReadTask = %+v, %v, want task", gotTask, err)
+	}
+	if gotTask.ActiveAttemptID != attempt.ID {
+		t.Fatalf("active attempt = %d, want %d", gotTask.ActiveAttemptID, attempt.ID)
+	}
+	if gotTask.ReportOffset != 0 || gotTask.ReportDigest != "" {
+		t.Fatalf("task report state changed while creating attempt: %+v", gotTask)
+	}
+	gotAttempt, found, err := db.ReadAttempt(attempt.ID)
+	if err != nil || !found {
+		t.Fatalf("ReadAttempt = %+v, %v, want attempt", gotAttempt, err)
+	}
+	if gotAttempt.TaskID != task.ID || gotAttempt.Harness != "claude" || gotAttempt.Worktree != "/tmp/wt-1" {
+		t.Fatalf("attempt lost execution identity: %+v", gotAttempt)
+	}
+}
+
+func TestAttemptOrdinalIncrementsPerTaskAndHistoryIsRetained(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(first.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	second, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Ordinal != 2 {
+		t.Fatalf("second ordinal = %d, want 2", second.Ordinal)
+	}
+	attempts, err := db.ListAttempts("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(attempts) != 2 || attempts[0].ID != first.ID || attempts[1].ID != second.ID {
+		t.Fatalf("attempt history = %+v, want both attempts in ordinal order", attempts)
+	}
+}
+
+func TestPartialUniqueIndexRejectsSecondActiveAttempt(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := db.sql.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle) VALUES ('task-1', 99, 'provisioning')`)
+	if err == nil {
+		t.Fatal("raw insert accepted a second active attempt")
+	}
+}
+
+func TestTaskAndAttemptTransitionsRejectIllegalStates(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptProvisioning, AttemptRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptRunning, AttemptProvisioning); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("running -> provisioning = %v, want ErrInvalidTransition", err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptRunning, AttemptFailed); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptFailed, AttemptRunning); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("failed -> running = %v, want ErrInvalidTransition", err)
+	}
+	if err := db.TransitionTask("task-1", TaskOpen, TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionTask("task-1", TaskTerminal, TaskTerminal); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("terminal -> terminal = %v, want ErrInvalidTransition", err)
+	}
+	if err := db.TransitionTask("task-1", TaskTerminal, TaskOpen); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAttemptTerminalStateCannotBecomeActiveAgain(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetActiveAttempt("task-1", attempt.ID); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("reactivating completed attempt = %v, want ErrInvalidTransition", err)
+	}
+}

--- a/internal/store/hold_test.go
+++ b/internal/store/hold_test.go
@@ -61,7 +61,7 @@ func TestReadHoldReportsAMissingHoldWithoutAnError(t *testing.T) {
 // question open still answers "what needs the operator" after DeleteTask.
 func TestHoldSurvivesWithNoTaskRowBehindIt(t *testing.T) {
 	db, _ := openTemp(t)
-	if err := db.WriteTask(Task{ID: "fix-login"}); err != nil {
+	if err := db.CreateTask(Task{ID: "fix-login"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.SetHold(sampleHold()); err != nil {

--- a/internal/store/index_test.go
+++ b/internal/store/index_test.go
@@ -160,7 +160,7 @@ func TestDeletingTheIndexCostsNeitherMachineStateNorCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -55,15 +56,42 @@ func (db *DB) migrateLegacy() error {
 
 	for _, name := range names {
 		path := filepath.Join(Dir(db.home), name)
-		t, err := readLegacyTask(path, strings.TrimSuffix(name, ".json"))
+		legacy, err := readLegacyTask(path, strings.TrimSuffix(name, ".json"))
 		if err != nil {
 			return err
 		}
 		// An id already in the database wins: it is what hand has been writing
 		// since the import, and the JSON file is a snapshot from before it.
+		task := Task{
+			ID: legacy.ID, Project: legacy.Project, Kind: legacy.Kind, Brief: legacy.Brief,
+			Lifecycle: TaskOpen, PR: legacy.PR, MergeExecuted: legacy.MergeExecuted,
+			MergeExecutedAt: legacy.MergeExecutedAt, ReportOffset: legacy.ReportOffset,
+			ReportDigest: legacy.ReportDigest, MergeAnnounced: legacy.MergeAnnounced,
+			DeliveredAt: legacy.DeliveredAt, DeliveredReason: legacy.DeliveredReason,
+			CreatedAt: legacy.CreatedAt,
+		}
 		if _, err := db.sql.Exec(`INSERT OR IGNORE INTO task (`+taskColumns+`)
-			VALUES (`+taskPlaceholders+`)`, taskValues(t)...); err != nil {
-			return fmt.Errorf("import task %q: %w", t.ID, err)
+			VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(task)...); err != nil {
+			return fmt.Errorf("import task %q: %w", task.ID, err)
+		}
+		var activeID sql.NullInt64
+		if err := db.sql.QueryRow(`SELECT active_attempt_id FROM task WHERE id = ?`, task.ID).Scan(&activeID); err != nil {
+			return fmt.Errorf("read imported task %q: %w", task.ID, err)
+		}
+		if !activeID.Valid {
+			if _, err := db.CreateAttempt(Attempt{
+				TaskID: legacy.ID, Ordinal: 1, Lifecycle: AttemptRunning,
+				Harness: legacy.Harness, Model: legacy.Model, Effort: legacy.Effort,
+				Worktree: legacy.Worktree, LeaseID: legacy.LeaseID, Herdr: legacy.Herdr,
+				CreatedAt: legacy.CreatedAt, PaneStartedAt: legacy.PaneStartedAt,
+				StatusChangedAt: legacy.StatusChangedAt, StatusChangedFor: legacy.StatusChangedFor,
+				DoneVerified: legacy.DoneVerified, LastReportState: legacy.LastReportState,
+				LastReportNote: legacy.LastReportNote, SendUndeliveredMessage: legacy.SendUndeliveredMessage,
+				SendUndeliveredAt: legacy.SendUndeliveredAt, ParkedFiredFor: legacy.ParkedFiredFor,
+				UsageLimitRetryAt: legacy.UsageLimitRetryAt, UsageLimitAttempts: legacy.UsageLimitAttempts,
+			}); err != nil {
+				return fmt.Errorf("import attempt for task %q: %w", task.ID, err)
+			}
 		}
 	}
 
@@ -81,17 +109,50 @@ func (db *DB) migrateLegacy() error {
 	return nil
 }
 
-func readLegacyTask(path, id string) (Task, error) {
+type legacyTask struct {
+	ID                     string `json:"id"`
+	Project                string `json:"project"`
+	Kind                   string `json:"kind"`
+	Harness                string `json:"harness"`
+	Model                  string `json:"model"`
+	Effort                 string `json:"effort"`
+	Worktree               string `json:"worktree"`
+	Brief                  string `json:"brief"`
+	Herdr                  Herdr  `json:"herdr"`
+	PR                     string `json:"pr"`
+	MergeExecuted          bool   `json:"merged"`
+	MergeExecutedAt        string `json:"merged_at"`
+	ReportOffset           int64  `json:"report_offset"`
+	ReportDigest           string `json:"report_digest"`
+	MergeAnnounced         bool   `json:"pr_merged_observed"`
+	DoneVerified           bool   `json:"done_verified"`
+	CreatedAt              string `json:"created_at"`
+	StatusChangedAt        string `json:"status_changed_at"`
+	StatusChangedFor       string `json:"status_changed_for"`
+	LastReportState        string `json:"last_report_state"`
+	LastReportNote         string `json:"last_report_note"`
+	SendUndeliveredMessage string `json:"send_undelivered_message"`
+	SendUndeliveredAt      string `json:"send_undelivered_at"`
+	LeaseID                string `json:"lease_id"`
+	DeliveredAt            string `json:"delivered_at"`
+	DeliveredReason        string `json:"delivered_reason"`
+	PaneStartedAt          string `json:"pane_started_at"`
+	ParkedFiredFor         string `json:"parked_fired_for"`
+	UsageLimitRetryAt      string `json:"usage_limit_retry_at"`
+	UsageLimitAttempts     int    `json:"usage_limit_attempts"`
+}
+
+func readLegacyTask(path, id string) (legacyTask, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return Task{}, fmt.Errorf("read legacy task state %s: %w", path, err)
+		return legacyTask{}, fmt.Errorf("read legacy task state %s: %w", path, err)
 	}
-	var t Task
+	var t legacyTask
 	if err := json.Unmarshal(data, &t); err != nil {
-		return Task{}, fmt.Errorf("parse legacy task state %s (move it aside to continue): %w", path, err)
+		return legacyTask{}, fmt.Errorf("parse legacy task state %s (move it aside to continue): %w", path, err)
 	}
 	if t.ID != id {
-		return Task{}, fmt.Errorf("legacy task state %s has mismatched ID %q (move it aside to continue)", path, t.ID)
+		return legacyTask{}, fmt.Errorf("legacy task state %s has mismatched ID %q (move it aside to continue)", path, t.ID)
 	}
 	// A file predating the pane-start column carries no such key, so the import lands as an
 	// INSERT the backfill never sees. Same CASE as that backfill, so a task promoted before

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -74,11 +73,16 @@ func (db *DB) migrateLegacy() error {
 			VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(task)...); err != nil {
 			return fmt.Errorf("import task %q: %w", task.ID, err)
 		}
-		var activeID sql.NullInt64
-		if err := db.sql.QueryRow(`SELECT active_attempt_id FROM task WHERE id = ?`, task.ID).Scan(&activeID); err != nil {
+		var lifecycle TaskLifecycle
+		var attempts int
+		if err := db.sql.QueryRow(`SELECT lifecycle, (SELECT COUNT(*) FROM attempt WHERE task_id = task.id)
+			FROM task WHERE id = ?`, task.ID).Scan(&lifecycle, &attempts); err != nil {
 			return fmt.Errorf("read imported task %q: %w", task.ID, err)
 		}
-		if !activeID.Valid {
+		// An id the database already owns attempts for keeps them, for the same reason the row
+		// itself wins: they postdate the snapshot. Attempting one anyway collides on the ordinal,
+		// or is refused outright once the task is terminal, and fails every command on this home.
+		if lifecycle == TaskOpen && attempts == 0 {
 			if _, err := db.CreateAttempt(Attempt{
 				TaskID: legacy.ID, Ordinal: 1, Lifecycle: AttemptRunning,
 				Harness: legacy.Harness, Model: legacy.Model, Effort: legacy.Effort,

--- a/internal/store/migration_v8_test.go
+++ b/internal/store/migration_v8_test.go
@@ -66,6 +66,71 @@ func TestMigrationV8ConvertsReal040Database(t *testing.T) {
 	}
 }
 
+// The fleet home that predates user_version entirely: sqlite's default 0 with none of the
+// columns the registered migrations add. Every one of them has to replay before the split,
+// and version 0 also being what an unstamped current database reports must not stop that.
+func TestPreVersioningDatabaseReplaysEveryMigrationThroughTheSplit(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &DB{sql: sqlDB, home: home}
+	if _, err := db.sql.Exec(preVersioningSchema); err != nil {
+		t.Fatal(err)
+	}
+	values := []any{
+		"baseline", "nsr", "ship", "data/baseline/brief.md", "https://github.com/o/nsr/pull/3", true,
+		"2026-07-24T12:00:00Z", 17, true, "claude", "opus", "high", "/w/nsr", "default", "wA", "wA:tB",
+		"wA:pC", "2026-07-24T10:00:00Z", "2026-07-24T11:00:00Z", "working", true, "working", "on it",
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (
+		id, project, kind, brief, pr, merge_executed, merge_executed_at, report_offset, merge_announced,
+		harness, model, effort, worktree, herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id,
+		created_at, status_changed_at, status_changed_for, done_verified, last_report_state,
+		last_report_note) VALUES (`+placeholders(len(values))+`)`, values...); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position) VALUES ('nsr', 'git@github.com:o/nsr.git', 'direct-pr', 0)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatalf("open a pre-versioning database: %v", err)
+	}
+	defer func() { _ = migrated.Close() }()
+	if version, err := migrated.schemaVersion(); err != nil || version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, len(migrations))
+	}
+	history, found, err := migrated.ReadTaskHistory("baseline")
+	if err != nil || !found {
+		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
+	}
+	if history.Task.Lifecycle != TaskOpen || history.Task.ReportOffset != 17 || history.Task.PR != "https://github.com/o/nsr/pull/3" {
+		t.Fatalf("task-owned state was not preserved: %+v", history.Task)
+	}
+	if history.ActiveAttempt == nil || len(history.Attempts) != 1 {
+		t.Fatalf("attempts = %+v, want one active attempt", history.Attempts)
+	}
+	attempt := *history.ActiveAttempt
+	if attempt.Ordinal != 1 || attempt.Lifecycle != AttemptRunning || attempt.Harness != "claude" || attempt.Worktree != "/w/nsr" || attempt.Herdr.PaneID != "wA:pC" {
+		t.Fatalf("execution state was not preserved: %+v", attempt)
+	}
+	// Migration 5's backfill, carried through the split: only a real replay can have set it,
+	// since the column it reads did not exist on the row this home was written with.
+	if attempt.PaneStartedAt != "2026-07-24T11:00:00Z" {
+		t.Fatalf("pane start = %q, want the backfill from status_changed_at", attempt.PaneStartedAt)
+	}
+	var upstream string
+	if err := migrated.sql.QueryRow(`SELECT upstream FROM project WHERE name = 'nsr'`).Scan(&upstream); err != nil {
+		t.Fatalf("project.upstream did not migrate: %v", err)
+	}
+}
+
 const legacy040Schema = `
 CREATE TABLE task (
  id TEXT PRIMARY KEY, project TEXT NOT NULL DEFAULT '', kind TEXT NOT NULL DEFAULT '', brief TEXT NOT NULL DEFAULT '',
@@ -81,5 +146,22 @@ CREATE TABLE task (
  usage_limit_attempts INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE project (name TEXT PRIMARY KEY, url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT '', position INTEGER NOT NULL DEFAULT 0, upstream TEXT NOT NULL DEFAULT '');
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE hold (id TEXT PRIMARY KEY, kind TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '', blocked_on TEXT NOT NULL DEFAULT '', set_at TEXT NOT NULL DEFAULT '');`
+
+// legacy040Schema minus every column a registered migration adds, which is what the
+// version-0 baseline `schema` built.
+const preVersioningSchema = `
+CREATE TABLE task (
+ id TEXT PRIMARY KEY, project TEXT NOT NULL DEFAULT '', kind TEXT NOT NULL DEFAULT '', brief TEXT NOT NULL DEFAULT '',
+ pr TEXT NOT NULL DEFAULT '', merge_executed INTEGER NOT NULL DEFAULT 0, merge_executed_at TEXT NOT NULL DEFAULT '',
+ report_offset INTEGER NOT NULL DEFAULT 0, merge_announced INTEGER NOT NULL DEFAULT 0, harness TEXT NOT NULL DEFAULT '',
+ model TEXT NOT NULL DEFAULT '', effort TEXT NOT NULL DEFAULT '', worktree TEXT NOT NULL DEFAULT '',
+ herdr_session TEXT NOT NULL DEFAULT '', herdr_workspace_id TEXT NOT NULL DEFAULT '', herdr_tab_id TEXT NOT NULL DEFAULT '',
+ herdr_pane_id TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '', status_changed_at TEXT NOT NULL DEFAULT '',
+ status_changed_for TEXT NOT NULL DEFAULT '', done_verified INTEGER NOT NULL DEFAULT 0,
+ last_report_state TEXT NOT NULL DEFAULT '', last_report_note TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE project (name TEXT PRIMARY KEY, url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT '', position INTEGER NOT NULL DEFAULT 0);
 CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
 CREATE TABLE hold (id TEXT PRIMARY KEY, kind TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '', blocked_on TEXT NOT NULL DEFAULT '', set_at TEXT NOT NULL DEFAULT '');`

--- a/internal/store/migration_v8_test.go
+++ b/internal/store/migration_v8_test.go
@@ -1,0 +1,85 @@
+package store
+
+import "testing"
+
+func TestMigrationV8ConvertsReal040Database(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &DB{sql: sqlDB, home: home}
+	if _, err := db.sql.Exec(legacy040Schema); err != nil {
+		t.Fatal(err)
+	}
+	values := []any{
+		"legacy", "nsr", "ship", "data/legacy/brief.md", "https://github.com/o/nsr/pull/7", true,
+		"2026-07-24T12:00:00Z", 41, "digest-before-upgrade", true, "2026-07-24T13:00:00Z", "merged",
+		"claude", "opus", "high", "/w/nsr", "lease-7", "default", "wA", "wA:tB", "wA:pC",
+		"2026-07-24T10:00:00Z", "2026-07-24T10:30:00Z", "2026-07-24T11:00:00Z", "working", true,
+		"working", "still working", "stop", "2026-07-24T13:30:00Z", "2026-07-24T11:30:00Z",
+		"2026-07-24T15:00:00Z", 2,
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (
+		id, project, kind, brief, pr, merge_executed, merge_executed_at, report_offset, report_digest,
+		merge_announced, delivered_at, delivered_reason, harness, model, effort, worktree, lease_id,
+		herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id, created_at, pane_started_at,
+		status_changed_at, status_changed_for, done_verified, last_report_state, last_report_note,
+		send_undelivered_message, send_undelivered_at, parked_fired_for, usage_limit_retry_at,
+		usage_limit_attempts) VALUES (`+placeholders(len(values))+`)`, values...); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = 7`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatalf("open 0.4.0 database: %v", err)
+	}
+	defer func() { _ = migrated.Close() }()
+	history, found, err := migrated.ReadTaskHistory("legacy")
+	if err != nil || !found {
+		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
+	}
+	if history.Task.Lifecycle != TaskOpen || history.Task.ActiveAttemptID == 0 {
+		t.Fatalf("task lifecycle/active attempt = %q/%d", history.Task.Lifecycle, history.Task.ActiveAttemptID)
+	}
+	if history.Task.ReportOffset != 41 || history.Task.ReportDigest != "digest-before-upgrade" || history.Task.PR != "https://github.com/o/nsr/pull/7" || history.Task.DeliveredAt != "2026-07-24T13:00:00Z" {
+		t.Fatalf("task-owned state was not preserved: %+v", history.Task)
+	}
+	if len(history.Attempts) != 1 {
+		t.Fatalf("attempt count = %d, want 1", len(history.Attempts))
+	}
+	attempt := history.Attempts[0]
+	if attempt.Ordinal != 1 || attempt.Lifecycle != AttemptRunning || attempt.Harness != "claude" || attempt.Model != "opus" || attempt.Effort != "high" || attempt.Worktree != "/w/nsr" || attempt.LeaseID != "lease-7" {
+		t.Fatalf("execution state was not preserved: %+v", attempt)
+	}
+	if attempt.Herdr.PaneID != "wA:pC" || attempt.LastReportState != "working" || attempt.UsageLimitAttempts != 2 || attempt.SendUndeliveredMessage != "stop" {
+		t.Fatalf("attempt bookkeeping was not preserved: %+v", attempt)
+	}
+	if _, err := migrated.sql.Query(`SELECT harness FROM task`); err == nil {
+		t.Fatal("old execution columns remain authoritative on task")
+	}
+}
+
+const legacy040Schema = `
+CREATE TABLE task (
+ id TEXT PRIMARY KEY, project TEXT NOT NULL DEFAULT '', kind TEXT NOT NULL DEFAULT '', brief TEXT NOT NULL DEFAULT '',
+ pr TEXT NOT NULL DEFAULT '', merge_executed INTEGER NOT NULL DEFAULT 0, merge_executed_at TEXT NOT NULL DEFAULT '',
+ report_offset INTEGER NOT NULL DEFAULT 0, report_digest TEXT NOT NULL DEFAULT '', merge_announced INTEGER NOT NULL DEFAULT 0,
+ delivered_at TEXT NOT NULL DEFAULT '', delivered_reason TEXT NOT NULL DEFAULT '', harness TEXT NOT NULL DEFAULT '',
+ model TEXT NOT NULL DEFAULT '', effort TEXT NOT NULL DEFAULT '', worktree TEXT NOT NULL DEFAULT '', lease_id TEXT NOT NULL DEFAULT '',
+ herdr_session TEXT NOT NULL DEFAULT '', herdr_workspace_id TEXT NOT NULL DEFAULT '', herdr_tab_id TEXT NOT NULL DEFAULT '',
+ herdr_pane_id TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '', pane_started_at TEXT NOT NULL DEFAULT '',
+ status_changed_at TEXT NOT NULL DEFAULT '', status_changed_for TEXT NOT NULL DEFAULT '', done_verified INTEGER NOT NULL DEFAULT 0,
+ last_report_state TEXT NOT NULL DEFAULT '', last_report_note TEXT NOT NULL DEFAULT '', send_undelivered_message TEXT NOT NULL DEFAULT '',
+ send_undelivered_at TEXT NOT NULL DEFAULT '', parked_fired_for TEXT NOT NULL DEFAULT '', usage_limit_retry_at TEXT NOT NULL DEFAULT '',
+ usage_limit_attempts INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE project (name TEXT PRIMARY KEY, url TEXT NOT NULL DEFAULT '', mode TEXT NOT NULL DEFAULT '', position INTEGER NOT NULL DEFAULT 0, upstream TEXT NOT NULL DEFAULT '');
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE hold (id TEXT PRIMARY KEY, kind TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '', blocked_on TEXT NOT NULL DEFAULT '', set_at TEXT NOT NULL DEFAULT '');`

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -34,6 +34,71 @@ var migrations = []string{
 	// is the honest reading of every row written before hand could detect a limit.
 	`ALTER TABLE task ADD COLUMN usage_limit_retry_at TEXT NOT NULL DEFAULT '';
 	ALTER TABLE task ADD COLUMN usage_limit_attempts INTEGER NOT NULL DEFAULT 0;`,
+	`DROP TABLE IF EXISTS attempt;
+	CREATE TABLE task_v8 (
+		id TEXT PRIMARY KEY,
+		project TEXT NOT NULL DEFAULT '',
+		kind TEXT NOT NULL DEFAULT '',
+		brief TEXT NOT NULL DEFAULT '',
+		lifecycle TEXT NOT NULL DEFAULT 'open' CHECK (lifecycle IN ('open', 'terminal')),
+		active_attempt_id INTEGER REFERENCES attempt_v8(id),
+		pr TEXT NOT NULL DEFAULT '',
+		merge_executed INTEGER NOT NULL DEFAULT 0,
+		merge_executed_at TEXT NOT NULL DEFAULT '',
+		merge_announced INTEGER NOT NULL DEFAULT 0,
+		delivered_at TEXT NOT NULL DEFAULT '',
+		delivered_reason TEXT NOT NULL DEFAULT '',
+		report_offset INTEGER NOT NULL DEFAULT 0,
+		report_digest TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE attempt_v8 (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id TEXT NOT NULL REFERENCES task_v8(id) ON DELETE CASCADE,
+		ordinal INTEGER NOT NULL,
+		lifecycle TEXT NOT NULL CHECK (lifecycle IN ('provisioning', 'running', 'completed', 'failed', 'interrupted')),
+		harness TEXT NOT NULL DEFAULT '',
+		model TEXT NOT NULL DEFAULT '',
+		effort TEXT NOT NULL DEFAULT '',
+		worktree TEXT NOT NULL DEFAULT '',
+		lease_id TEXT NOT NULL DEFAULT '',
+		herdr_session TEXT NOT NULL DEFAULT '',
+		herdr_workspace_id TEXT NOT NULL DEFAULT '',
+		herdr_tab_id TEXT NOT NULL DEFAULT '',
+		herdr_pane_id TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL DEFAULT '',
+		pane_started_at TEXT NOT NULL DEFAULT '',
+		status_changed_at TEXT NOT NULL DEFAULT '',
+		status_changed_for TEXT NOT NULL DEFAULT '',
+		done_verified INTEGER NOT NULL DEFAULT 0,
+		last_report_state TEXT NOT NULL DEFAULT '',
+		last_report_note TEXT NOT NULL DEFAULT '',
+		send_undelivered_message TEXT NOT NULL DEFAULT '',
+		send_undelivered_at TEXT NOT NULL DEFAULT '',
+		parked_fired_for TEXT NOT NULL DEFAULT '',
+		usage_limit_retry_at TEXT NOT NULL DEFAULT '',
+		usage_limit_attempts INTEGER NOT NULL DEFAULT 0,
+		UNIQUE (task_id, ordinal)
+	);
+	INSERT INTO task_v8 (id, project, kind, brief, lifecycle, pr, merge_executed, merge_executed_at,
+		merge_announced, delivered_at, delivered_reason, report_offset, report_digest, created_at)
+	SELECT id, project, kind, brief, 'open', pr, merge_executed, merge_executed_at,
+		merge_announced, delivered_at, delivered_reason, report_offset, report_digest, created_at
+	FROM task;
+	INSERT INTO attempt_v8 (task_id, ordinal, lifecycle, harness, model, effort, worktree, lease_id,
+		herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id, created_at, pane_started_at,
+		status_changed_at, status_changed_for, done_verified, last_report_state, last_report_note,
+		send_undelivered_message, send_undelivered_at, parked_fired_for, usage_limit_retry_at, usage_limit_attempts)
+	SELECT id, 1, 'running', harness, model, effort, worktree, lease_id,
+		herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id, created_at, pane_started_at,
+		status_changed_at, status_changed_for, done_verified, last_report_state, last_report_note,
+		send_undelivered_message, send_undelivered_at, parked_fired_for, usage_limit_retry_at, usage_limit_attempts
+	FROM task;
+	UPDATE task_v8 SET active_attempt_id = (SELECT id FROM attempt_v8 WHERE task_id = task_v8.id);
+	DROP TABLE task;
+	ALTER TABLE task_v8 RENAME TO task;
+	ALTER TABLE attempt_v8 RENAME TO attempt;
+	CREATE UNIQUE INDEX attempt_one_active ON attempt(task_id) WHERE lifecycle IN ('provisioning', 'running');`,
 }
 
 func (db *DB) schemaVersion() (int, error) {
@@ -98,6 +163,15 @@ func (db *DB) migrateSchema() error {
 	// already-migrated homes keep working - a test-passes, production-fails asymmetry.
 	if isNew {
 		return nil
+	}
+	if current == 0 && latest == 8 {
+		var split int
+		if err := db.sql.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'attempt'`).Scan(&split); err == nil && split != 0 {
+			if _, err := db.sql.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, latest)); err != nil {
+				return fmt.Errorf("record schema version %d: %w", latest, err)
+			}
+			return nil
+		}
 	}
 	for version := current; version < latest; version++ {
 		if err := db.applyMigration(version); err != nil {

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -101,6 +101,21 @@ var migrations = []string{
 	CREATE UNIQUE INDEX attempt_one_active ON attempt(task_id) WHERE lifecycle IN ('provisioning', 'running');`,
 }
 
+// The version whose migration splits task from attempt. A database already carrying that
+// layout has every earlier migration folded into it, whatever user_version claims.
+const splitVersion = 8
+
+// Reports whether the task table already carries the split layout. The attempt table cannot
+// answer this: createSchema builds it on every home before any migration runs, while an
+// existing task table keeps whatever columns it was created with.
+func (db *DB) taskIsSplit() (bool, error) {
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name = 'active_attempt_id'`).Scan(&count); err != nil {
+		return false, fmt.Errorf("detect the split task layout: %w", err)
+	}
+	return count != 0, nil
+}
+
 func (db *DB) schemaVersion() (int, error) {
 	var version int
 	if err := db.sql.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
@@ -164,13 +179,19 @@ func (db *DB) migrateSchema() error {
 	if isNew {
 		return nil
 	}
-	if current == 0 && latest == 8 {
-		var split int
-		if err := db.sql.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'attempt'`).Scan(&split); err == nil && split != 0 {
-			if _, err := db.sql.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, latest)); err != nil {
-				return fmt.Errorf("record schema version %d: %w", latest, err)
+	// Version 0 means both "the pre-versioning baseline" and "already split, never stamped",
+	// and only the task table's own layout tells them apart. Stamped rather than returned, so
+	// a migration added after the split still applies to a home that arrives here unstamped.
+	if current == 0 && latest >= splitVersion {
+		split, err := db.taskIsSplit()
+		if err != nil {
+			return err
+		}
+		if split {
+			if _, err := db.sql.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, splitVersion)); err != nil {
+				return fmt.Errorf("record schema version %d: %w", splitVersion, err)
 			}
-			return nil
+			current = splitVersion
 		}
 	}
 	for version := current; version < latest; version++ {

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -22,7 +22,7 @@ func TestExistingBaselineDatabaseOpensCleanly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {
@@ -39,7 +39,13 @@ func TestExistingBaselineDatabaseOpensCleanly(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	assertTaskProjection(t, history.Task, sampleTask())
+	got := history.Task
+	got.ActiveAttemptID = 0
+	want := sampleTask()
+	want.ActiveAttemptID = 0
+	if got != want {
+		t.Fatalf("task = %+v, want %+v", got, want)
+	}
 	if history.ActiveAttempt == nil || history.ActiveAttempt.Ordinal != 1 || history.ActiveAttempt.Lifecycle != AttemptRunning {
 		t.Fatalf("active attempt = %+v", history.ActiveAttempt)
 	}

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -2,26 +2,9 @@ package store
 
 import (
 	"errors"
-	"strings"
 	"testing"
 )
 
-// Narrows the registered list to the entries naming substr, so a test replays only the one
-// entry it exercises: the whole list would hit "duplicate column name" on every column
-// `schema` builds, and an index would silently shift when another commit appends one.
-func migrationsContaining(substr string) []string {
-	var matched []string
-	for _, m := range migrations {
-		if strings.Contains(m, substr) {
-			matched = append(matched, m)
-		}
-	}
-	return matched
-}
-
-// A fresh database is built by `schema`, which already carries every registered migration,
-// so it is stamped straight to the latest version rather than 0 - only a database predating
-// the mechanism reads as 0 (TestExistingBaselineDatabaseOpensCleanly below).
 func TestFreshOpenRecordsSchemaVersionAtLatest(t *testing.T) {
 	db, _ := openTemp(t)
 	version, err := db.schemaVersion()
@@ -33,9 +16,6 @@ func TestFreshOpenRecordsSchemaVersionAtLatest(t *testing.T) {
 	}
 }
 
-// The mechanism has to treat a real fleet home - version 0, tables already
-// present - as the known baseline, not as unversioned-and-therefore-suspect,
-// or the one home that exists stops working the moment a migration lands.
 func TestExistingBaselineDatabaseOpensCleanly(t *testing.T) {
 	home := t.TempDir()
 	db, err := Open(home)
@@ -55,12 +35,13 @@ func TestExistingBaselineDatabaseOpensCleanly(t *testing.T) {
 	}
 	defer func() { _ = reopened.Close() }()
 
-	got, found, err := reopened.ReadTask(sampleTask().ID)
+	history, found, err := reopened.ReadTaskHistory(sampleTask().ID)
 	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
+		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	if got != sampleTask() {
-		t.Fatalf("reopen lost state: got %+v", got)
+	assertTaskProjection(t, history.Task, sampleTask())
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Ordinal != 1 || history.ActiveAttempt.Lifecycle != AttemptRunning {
+		t.Fatalf("active attempt = %+v", history.ActiveAttempt)
 	}
 }
 
@@ -83,18 +64,11 @@ func TestOpenRefusesADatabaseNewerThanThisBuild(t *testing.T) {
 	}
 }
 
-// The real hand.db this mechanism has to keep working is exactly the shape this sets up:
-// tables from the pre-mechanism schema, user_version at sqlite's default 0, no meta row.
-// One registered entry is meant to be the whole job: automatic, and cheap to run again.
 func TestPendingMigrationAppliesAutomaticallyAndOnlyOnce(t *testing.T) {
 	home := t.TempDir()
-
 	restore := migrations
 	t.Cleanup(func() { migrations = restore })
 
-	// Empty migrations for this first open, so the fresh database it stamps reads as version
-	// 0 - the pre-mechanism baseline this test needs - rather than picking up whatever this
-	// build's real migrations already registered.
 	migrations = []string{}
 	existing, err := Open(home)
 	if err != nil {
@@ -108,7 +82,6 @@ func TestPendingMigrationAppliesAutomaticallyAndOnlyOnce(t *testing.T) {
 	}
 
 	migrations = []string{`ALTER TABLE project ADD COLUMN note TEXT NOT NULL DEFAULT ''`}
-
 	db, err := Open(home)
 	if err != nil {
 		t.Fatal(err)
@@ -117,20 +90,12 @@ func TestPendingMigrationAppliesAutomaticallyAndOnlyOnce(t *testing.T) {
 	if err := db.sql.QueryRow(`SELECT note FROM project WHERE name = 'nsr'`).Scan(&note); err != nil {
 		t.Fatalf("migrated column not usable: %v", err)
 	}
-	version, err := db.schemaVersion()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if version != 1 {
-		t.Fatalf("schemaVersion = %d, want 1", version)
+	if version, err := db.schemaVersion(); err != nil || version != 1 {
+		t.Fatalf("schemaVersion = %d, %v", version, err)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	// A second open re-running `ALTER TABLE ADD COLUMN` against a column that
-	// is already there fails loudly - so this only passes if the migration
-	// did not run twice.
 	second, err := Open(home)
 	if err != nil {
 		t.Fatalf("second open re-ran an already-applied migration: %v", err)
@@ -138,9 +103,6 @@ func TestPendingMigrationAppliesAutomaticallyAndOnlyOnce(t *testing.T) {
 	defer func() { _ = second.Close() }()
 }
 
-// Adding a column puts it in `schema`, so new databases are built with it, and appends the
-// matching ALTER TABLE to `migrations`, so existing ones gain it. A fresh database must take
-// only the first, or replay fails with "duplicate column name"; `mode` stands in.
 func TestFreshDatabaseSkipsAMigrationTheSchemaAlreadyBuilds(t *testing.T) {
 	restore := migrations
 	migrations = []string{`ALTER TABLE project ADD COLUMN mode TEXT NOT NULL DEFAULT ''`}
@@ -151,414 +113,15 @@ func TestFreshDatabaseSkipsAMigrationTheSchemaAlreadyBuilds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fresh database replayed a migration its schema already builds: %v", err)
 	}
-	version, err := db.schemaVersion()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if version != 1 {
-		t.Fatalf("schemaVersion = %d, want 1", version)
+	if version, err := db.schemaVersion(); err != nil || version != 1 {
+		t.Fatalf("schemaVersion = %d, %v", version, err)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	// Stamped, not merely skipped: the next open must not read it as pending.
 	second, err := Open(home)
 	if err != nil {
 		t.Fatalf("reopening a stamped fresh database: %v", err)
 	}
 	defer func() { _ = second.Close() }()
-}
-
-// Exercises the real migrations entry this commit registers, rather than a
-// swapped-in stand-in like the tests above, so a syntax error in the actual
-// ALTER TABLE statements would fail here instead of only in a synthetic one.
-func TestSendUndeliveredColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("send_undelivered_message")
-	t.Cleanup(func() { migrations = restore })
-
-	// Empty migrations for this first open, so the fresh database reads as version 0.
-	// `schema` still creates the two new columns (it cannot be swapped the way `migrations`
-	// can), so they are dropped by hand to reach the pre-migration shape.
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN send_undelivered_message`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN send_undelivered_at`); err != nil {
-		t.Fatal(err)
-	}
-	// WriteTask always targets the full, current taskColumns, which still
-	// names the two dropped columns - so this row goes in with a raw insert
-	// against the pre-migration column set instead.
-	if _, err := existing.sql.Exec(`INSERT INTO task (id) VALUES ('t1')`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real send_undelivered migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	got, found, err := reopened.ReadTask("t1")
-	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
-	}
-	if got.SendUndeliveredMessage != "" || got.SendUndeliveredAt != "" {
-		t.Fatalf("migrated columns not empty-defaulted: %+v", got)
-	}
-}
-
-// The live fleet home holds rows written before lease_id existed, and they stay readable
-// through the migration rather than only after a respawn - so the column arrives empty on
-// every one of them, which is what worktree.CheckCollision's path fallback keys on.
-func TestLeaseIDColumnMigratesOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("lease_id")
-	t.Cleanup(func() { migrations = restore })
-
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN lease_id`); err != nil {
-		t.Fatal(err)
-	}
-	// WriteTask always targets the full, current taskColumns, which still names
-	// the dropped column - so this row goes in with a raw insert against the
-	// pre-migration column set instead.
-	if _, err := existing.sql.Exec(`INSERT INTO task (id, worktree) VALUES ('t1', '/w/nsr')`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real lease_id migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	got, found, err := reopened.ReadTask("t1")
-	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
-	}
-	if got.LeaseID != "" {
-		t.Fatalf("migrated column not empty-defaulted: %+v", got)
-	}
-	if got.Worktree != "/w/nsr" {
-		t.Fatalf("migration lost the pre-existing row's worktree: %+v", got)
-	}
-}
-
-// Exercises the real delivered_at/delivered_reason entry against a database holding a task
-// row written before those columns existed - the live fleet home's shape - so a task spawned
-// earlier stays readable and reads as not delivered rather than blocking the whole open.
-func TestDeliveredColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("delivered_reason")
-	t.Cleanup(func() { migrations = restore })
-
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN delivered_at`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN delivered_reason`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`INSERT INTO task (id, project, pr) VALUES ('t1', 'no-mistakes', 'https://github.com/kunchenguid/no-mistakes/pull/597')`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real delivered migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	got, found, err := reopened.ReadTask("t1")
-	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
-	}
-	if got.DeliveredAt != "" || got.DeliveredReason != "" {
-		t.Fatalf("migrated columns not empty-defaulted: %+v", got)
-	}
-
-	got.DeliveredAt = "2026-08-03T00:00:00Z"
-	got.DeliveredReason = "PR offered upstream, maintainer decides"
-	if err := reopened.WriteTask(got); err != nil {
-		t.Fatal(err)
-	}
-	reread, _, err := reopened.ReadTask("t1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reread.DeliveredAt != got.DeliveredAt || reread.DeliveredReason != got.DeliveredReason {
-		t.Fatalf("delivered mark did not survive a write to the migrated row: %+v", reread)
-	}
-}
-
-// Exercises the real pane_started_at/parked_fired_for entry against a database holding rows
-// written before those columns existed. The pre-migration `parked` floor read
-// status_changed_at and fell back to created_at, so the backfill freezes that same value.
-func TestPaneStartColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("pane_started_at")
-	t.Cleanup(func() { migrations = restore })
-
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN pane_started_at`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN parked_fired_for`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`INSERT INTO task (id, created_at, status_changed_at, status_changed_for)
-		VALUES ('promoted', '2026-07-01T00:00:00Z', '2026-08-01T00:00:00Z', 'working')`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`INSERT INTO task (id, created_at) VALUES ('never-observed', '2026-07-02T00:00:00Z')`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real pane-start migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	promoted, found, err := reopened.ReadTask("promoted")
-	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
-	}
-	if promoted.PaneStartedAt != "2026-08-01T00:00:00Z" {
-		t.Fatalf("pane_started_at = %q, want the row's status_changed_at frozen as its pane start", promoted.PaneStartedAt)
-	}
-	if promoted.ParkedFiredFor != "" {
-		t.Fatalf("parked_fired_for = %q, want empty: no fire has been recorded for this row", promoted.ParkedFiredFor)
-	}
-
-	never, _, err := reopened.ReadTask("never-observed")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if never.PaneStartedAt != "2026-07-02T00:00:00Z" {
-		t.Fatalf("pane_started_at = %q, want created_at for a row with no observed transition", never.PaneStartedAt)
-	}
-}
-
-// Exercises the real project.upstream entry against a database holding a project row written
-// before that column existed - the live fleet home's shape - so a project registered long ago
-// stays readable and gains the column empty rather than the whole registry failing to open.
-func TestProjectUpstreamColumnMigratesOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("project ADD COLUMN upstream")
-	t.Cleanup(func() { migrations = restore })
-
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE project DROP COLUMN upstream`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`INSERT INTO project (name, url, mode, position) VALUES ('no-mistakes', 'https://github.com/atqamz/no-mistakes.git', 'no-mistakes', 0)`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real project.upstream migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	projects, err := reopened.ListProjects()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(projects) != 1 || projects[0].Name != "no-mistakes" || projects[0].Upstream != "" {
-		t.Fatalf("ListProjects = %+v, want the pre-migration row with an empty upstream", projects)
-	}
-
-	updated, err := reopened.SetProjectUpstream("no-mistakes", "kunchenguid/no-mistakes")
-	if err != nil || !updated {
-		t.Fatalf("SetProjectUpstream = %v, %v", updated, err)
-	}
-	projects, err = reopened.ListProjects()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if projects[0].Upstream != "kunchenguid/no-mistakes" {
-		t.Fatalf("upstream = %q, wanted it declared on the migrated row", projects[0].Upstream)
-	}
-}
-
-// Exercises the real report_digest entry against a database holding a task row whose worker has
-// already reported - a live fleet home's shape. The column arrives empty rather than backfilled on
-// purpose: the consumed prefix cannot be recovered from a file that may have been rewritten since.
-func TestReportDigestColumnMigratesOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("report_digest")
-	t.Cleanup(func() { migrations = restore })
-
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN report_digest`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`INSERT INTO task (id, report_offset, last_report_state, last_report_note)
-		VALUES ('t1', 61, 'working', 'rebasing onto main before the last two commits land')`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real report_digest migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	got, found, err := reopened.ReadTask("t1")
-	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
-	}
-	if got.ReportDigest != "" {
-		t.Fatalf("report_digest = %q, want empty: the migration carries no backfill", got.ReportDigest)
-	}
-	// The offset has to survive where the digest does not, or the upgrade replays every line the
-	// previous run already surfaced.
-	if got.ReportOffset != 61 {
-		t.Fatalf("report_offset = %d, want the pre-migration row's 61 intact", got.ReportOffset)
-	}
-	if got.LastReportState != "working" {
-		t.Fatalf("migration lost the pre-existing row's report state: %+v", got)
-	}
-
-	got.ReportDigest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-	if err := reopened.WriteTask(got); err != nil {
-		t.Fatal(err)
-	}
-	reread, _, err := reopened.ReadTask("t1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reread.ReportDigest != got.ReportDigest {
-		t.Fatalf("digest did not survive a write to the migrated row: %+v", reread)
-	}
-}
-
-// Exercises the real usage-limit entry against a database holding rows written before hand could
-// detect a limit. Deliberately no backfill: an empty retry stamp means "this task is not limited", the
-// honest reading of every such row, and an invented value would steer a pane off a schedule nobody saw.
-func TestUsageLimitColumnsMigrateOntoAnExistingDatabase(t *testing.T) {
-	home := t.TempDir()
-
-	restore := migrations
-	own := migrationsContaining("usage_limit_retry_at")
-	t.Cleanup(func() { migrations = restore })
-
-	migrations = []string{}
-	existing, err := Open(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN usage_limit_retry_at`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`ALTER TABLE task DROP COLUMN usage_limit_attempts`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := existing.sql.Exec(`INSERT INTO task (id, created_at) VALUES ('pre-existing', '2026-07-01T00:00:00Z')`); err != nil {
-		t.Fatal(err)
-	}
-	if err := existing.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	migrations = own
-
-	reopened, err := Open(home)
-	if err != nil {
-		t.Fatalf("reopen replaying the real usage-limit migration: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-
-	task, found, err := reopened.ReadTask("pre-existing")
-	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
-	}
-	if task.UsageLimitRetryAt != "" || task.UsageLimitAttempts != 0 {
-		t.Fatalf("usage-limit columns = %q/%d, want an unlimited row", task.UsageLimitRetryAt, task.UsageLimitAttempts)
-	}
-
-	task.UsageLimitRetryAt = "2026-08-04T15:01:00Z"
-	task.UsageLimitAttempts = 3
-	if err := reopened.WriteTask(task); err != nil {
-		t.Fatal(err)
-	}
-	got, _, err := reopened.ReadTask("pre-existing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.UsageLimitRetryAt != task.UsageLimitRetryAt || got.UsageLimitAttempts != task.UsageLimitAttempts {
-		t.Fatalf("round trip on the migrated row = %q/%d, want %q/%d",
-			got.UsageLimitRetryAt, got.UsageLimitAttempts, task.UsageLimitRetryAt, task.UsageLimitAttempts)
-	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -67,38 +67,21 @@ const (
 )
 
 type Task struct {
-	ID                     string        `json:"id"`
-	Project                string        `json:"project"`
-	Kind                   string        `json:"kind"`
-	Brief                  string        `json:"brief"`
-	Lifecycle              TaskLifecycle `json:"lifecycle"`
-	ActiveAttemptID        int64         `json:"active_attempt_id"`
-	PR                     string        `json:"pr"`
-	MergeExecuted          bool          `json:"merged"`
-	MergeExecutedAt        string        `json:"merged_at"`
-	ReportOffset           int64         `json:"report_offset"`
-	ReportDigest           string        `json:"report_digest"`
-	MergeAnnounced         bool          `json:"pr_merged_observed"`
-	DeliveredAt            string        `json:"delivered_at"`
-	DeliveredReason        string        `json:"delivered_reason"`
-	CreatedAt              string        `json:"created_at"`
-	Harness                string        `json:"harness,omitempty"`
-	Model                  string        `json:"model,omitempty"`
-	Effort                 string        `json:"effort,omitempty"`
-	Worktree               string        `json:"worktree,omitempty"`
-	Herdr                  Herdr         `json:"herdr,omitempty"`
-	DoneVerified           bool          `json:"done_verified,omitempty"`
-	StatusChangedAt        string        `json:"status_changed_at,omitempty"`
-	StatusChangedFor       string        `json:"status_changed_for,omitempty"`
-	LastReportState        string        `json:"last_report_state,omitempty"`
-	LastReportNote         string        `json:"last_report_note,omitempty"`
-	SendUndeliveredMessage string        `json:"send_undelivered_message,omitempty"`
-	SendUndeliveredAt      string        `json:"send_undelivered_at,omitempty"`
-	LeaseID                string        `json:"lease_id,omitempty"`
-	PaneStartedAt          string        `json:"pane_started_at,omitempty"`
-	ParkedFiredFor         string        `json:"parked_fired_for,omitempty"`
-	UsageLimitRetryAt      string        `json:"usage_limit_retry_at,omitempty"`
-	UsageLimitAttempts     int           `json:"usage_limit_attempts,omitempty"`
+	ID              string        `json:"id"`
+	Project         string        `json:"project"`
+	Kind            string        `json:"kind"`
+	Brief           string        `json:"brief"`
+	Lifecycle       TaskLifecycle `json:"lifecycle"`
+	ActiveAttemptID int64         `json:"active_attempt_id"`
+	PR              string        `json:"pr"`
+	MergeExecuted   bool          `json:"merged"`
+	MergeExecutedAt string        `json:"merged_at"`
+	ReportOffset    int64         `json:"report_offset"`
+	ReportDigest    string        `json:"report_digest"`
+	MergeAnnounced  bool          `json:"pr_merged_observed"`
+	DeliveredAt     string        `json:"delivered_at"`
+	DeliveredReason string        `json:"delivered_reason"`
+	CreatedAt       string        `json:"created_at"`
 }
 
 type Attempt struct {
@@ -406,13 +389,6 @@ func (db *DB) ReadTask(id string) (Task, bool, error) {
 	if err != nil {
 		return Task{}, false, fmt.Errorf("read task %q: %w", id, err)
 	}
-	if t.ActiveAttemptID != 0 {
-		if attempt, found, err := db.ReadAttempt(t.ActiveAttemptID); err != nil {
-			return Task{}, false, err
-		} else if found {
-			projectAttempt(&t, attempt)
-		}
-	}
 	return t, true, nil
 }
 
@@ -427,88 +403,11 @@ func (db *DB) CreateTask(t Task) error {
 	return nil
 }
 
-// WriteTask is the compatibility adapter for pre-Task/Attempt callers and fixtures.
-// It projects execution fields into the one active Attempt; the database remains split.
-func (db *DB) WriteTask(t Task) error {
-	existing, found, err := db.ReadTask(t.ID)
-	if err != nil {
-		return err
-	}
-	if !found {
-		logical := taskOnly(t)
-		logical.ActiveAttemptID = 0
-		if err := db.CreateTask(logical); err != nil {
-			return err
-		}
-		_, err := db.CreateAttempt(attemptFromTask(t))
-		return err
-	}
-	if t.Lifecycle == "" {
-		t.Lifecycle = existing.Lifecycle
-	}
-	if t.CreatedAt == "" {
-		t.CreatedAt = existing.CreatedAt
-	}
-	activeID := t.ActiveAttemptID
-	if activeID == 0 {
-		activeID = existing.ActiveAttemptID
-		t.ActiveAttemptID = activeID
-	}
-	if err := db.UpdateTask(taskOnly(t)); err != nil {
-		return err
-	}
-	if activeID != 0 {
-		attempt, found, err := db.ReadAttempt(activeID)
-		if err != nil || !found {
-			return err
-		}
-		mergeAttemptProjection(&attempt, t)
-		return db.UpdateAttempt(attempt)
-	}
-	return nil
-}
-
-func taskOnly(t Task) Task {
-	return Task{ID: t.ID, Project: t.Project, Kind: t.Kind, Brief: t.Brief, Lifecycle: t.Lifecycle,
-		ActiveAttemptID: t.ActiveAttemptID, PR: t.PR, MergeExecuted: t.MergeExecuted,
-		MergeExecutedAt: t.MergeExecutedAt, MergeAnnounced: t.MergeAnnounced,
-		DeliveredAt: t.DeliveredAt, DeliveredReason: t.DeliveredReason,
-		ReportOffset: t.ReportOffset, ReportDigest: t.ReportDigest, CreatedAt: t.CreatedAt}
-}
-
-func attemptFromTask(t Task) Attempt {
-	lifecycle := AttemptRunning
-	return Attempt{TaskID: t.ID, Lifecycle: lifecycle, Harness: t.Harness, Model: t.Model, Effort: t.Effort,
-		Worktree: t.Worktree, LeaseID: t.LeaseID, Herdr: t.Herdr, CreatedAt: t.CreatedAt,
-		PaneStartedAt: t.PaneStartedAt, StatusChangedAt: t.StatusChangedAt, StatusChangedFor: t.StatusChangedFor,
-		DoneVerified: t.DoneVerified, LastReportState: t.LastReportState, LastReportNote: t.LastReportNote,
-		SendUndeliveredMessage: t.SendUndeliveredMessage, SendUndeliveredAt: t.SendUndeliveredAt,
-		ParkedFiredFor: t.ParkedFiredFor, UsageLimitRetryAt: t.UsageLimitRetryAt, UsageLimitAttempts: t.UsageLimitAttempts}
-}
-
-func projectAttempt(t *Task, a Attempt) {
-	t.Harness, t.Model, t.Effort, t.Worktree, t.Herdr, t.DoneVerified = a.Harness, a.Model, a.Effort, a.Worktree, a.Herdr, a.DoneVerified
-	t.StatusChangedAt, t.StatusChangedFor = a.StatusChangedAt, a.StatusChangedFor
-	t.LastReportState, t.LastReportNote = a.LastReportState, a.LastReportNote
-	t.SendUndeliveredMessage, t.SendUndeliveredAt = a.SendUndeliveredMessage, a.SendUndeliveredAt
-	t.LeaseID, t.PaneStartedAt, t.ParkedFiredFor = a.LeaseID, a.PaneStartedAt, a.ParkedFiredFor
-	t.UsageLimitRetryAt, t.UsageLimitAttempts = a.UsageLimitRetryAt, a.UsageLimitAttempts
-}
-
-func mergeAttemptProjection(a *Attempt, t Task) {
-	a.Harness, a.Model, a.Effort, a.Worktree, a.LeaseID, a.Herdr = t.Harness, t.Model, t.Effort, t.Worktree, t.LeaseID, t.Herdr
-	a.DoneVerified, a.StatusChangedAt, a.StatusChangedFor = t.DoneVerified, t.StatusChangedAt, t.StatusChangedFor
-	a.LastReportState, a.LastReportNote = t.LastReportState, t.LastReportNote
-	a.SendUndeliveredMessage, a.SendUndeliveredAt = t.SendUndeliveredMessage, t.SendUndeliveredAt
-	a.PaneStartedAt, a.ParkedFiredFor = t.PaneStartedAt, t.ParkedFiredFor
-	a.UsageLimitRetryAt, a.UsageLimitAttempts = t.UsageLimitRetryAt, t.UsageLimitAttempts
-}
-
 func (db *DB) UpdateTask(t Task) error {
-	_, err := db.sql.Exec(`UPDATE task SET project = ?, kind = ?, brief = ?, lifecycle = ?, active_attempt_id = ?,
+	_, err := db.sql.Exec(`UPDATE task SET project = ?, kind = ?, brief = ?,
 		pr = ?, merge_executed = ?, merge_executed_at = ?, merge_announced = ?, delivered_at = ?, delivered_reason = ?,
 		report_offset = ?, report_digest = ?, created_at = ? WHERE id = ?`,
-		t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
+		t.Project, t.Kind, t.Brief, t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
 		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.ID)
 	if err != nil {
@@ -535,15 +434,6 @@ func (db *DB) ListTasks() ([]Task, error) {
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("list tasks: %w", err)
 	}
-	for i := range tasks {
-		if tasks[i].ActiveAttemptID != 0 {
-			if attempt, found, err := db.ReadAttempt(tasks[i].ActiveAttemptID); err != nil {
-				return nil, err
-			} else if found {
-				projectAttempt(&tasks[i], attempt)
-			}
-		}
-	}
 	return tasks, nil
 }
 
@@ -562,6 +452,9 @@ func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
 			history.ActiveAttempt = &attempts[i]
 			break
 		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("task %q active attempt %d not found", id, task.ActiveAttemptID)
 	}
 	return history, true, nil
 }
@@ -592,9 +485,11 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 		for j := range attempts {
 			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
 				histories[i].ActiveAttempt = &histories[i].Attempts[j]
-				projectAttempt(&histories[i].Task, attempts[j])
 				break
 			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("task %q active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
 		}
 	}
 	return histories, nil
@@ -768,7 +663,48 @@ func (db *DB) TransitionTask(id string, from, to TaskLifecycle) error {
 }
 
 func validTaskTransition(from, to TaskLifecycle) bool {
-	return (from == TaskOpen && to == TaskTerminal) || (from == TaskTerminal && to == TaskOpen)
+	return from == TaskOpen && to == TaskTerminal
+}
+
+func (db *DB) ReopenTask(taskID string, a Attempt) (Attempt, error) {
+	if !isActiveAttempt(a.Lifecycle) {
+		return Attempt{}, fmt.Errorf("%w: task reopen requires an active attempt", ErrInvalidTransition)
+	}
+	a.TaskID = taskID
+	a.ID = 0
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return Attempt{}, fmt.Errorf("begin task reopen: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var lifecycle TaskLifecycle
+	if err := tx.QueryRow(`SELECT lifecycle FROM task WHERE id = ?`, taskID).Scan(&lifecycle); errors.Is(err, sql.ErrNoRows) {
+		return Attempt{}, fmt.Errorf("task %q %w", taskID, ErrTaskNotFound)
+	} else if err != nil {
+		return Attempt{}, fmt.Errorf("read task %q for reopen: %w", taskID, err)
+	} else if lifecycle != TaskTerminal {
+		return Attempt{}, fmt.Errorf("%w: task %s -> open", ErrInvalidTransition, lifecycle)
+	}
+	if err := tx.QueryRow(`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM attempt WHERE task_id = ?`, taskID).Scan(&a.Ordinal); err != nil {
+		return Attempt{}, fmt.Errorf("next attempt ordinal for task %q: %w", taskID, err)
+	}
+	args := attemptValues(a)[1:]
+	query := `INSERT INTO attempt (` + strings.Join(attemptColumnNames[1:], ", ") + `) VALUES (` + placeholders(len(attemptColumnNames)-1) + `)`
+	result, err := tx.Exec(query, args...)
+	if err != nil {
+		return Attempt{}, fmt.Errorf("create reopened attempt for task %q: %w", taskID, err)
+	}
+	a.ID, err = result.LastInsertId()
+	if err != nil {
+		return Attempt{}, fmt.Errorf("read reopened attempt ID: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE task SET lifecycle = 'open', active_attempt_id = ? WHERE id = ? AND lifecycle = 'terminal'`, a.ID, taskID); err != nil {
+		return Attempt{}, fmt.Errorf("reopen task %q: %w", taskID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return Attempt{}, fmt.Errorf("reopen task %q: %w", taskID, err)
+	}
+	return a, nil
 }
 
 func validAttemptTransition(from, to AttemptLifecycle) bool {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,8 +30,10 @@ const (
 	HoldKindLimit = "limit"
 )
 
-// Wrapped by DeleteTask, rendered by callers as `task "<id>" not found`.
+// Wrapped by task readers, rendered by callers as `task "<id>" not found`.
 var ErrTaskNotFound = errors.New("not found")
+
+var ErrInvalidTransition = errors.New("invalid lifecycle transition")
 
 // Wrapped by ClearHold, rendered by callers as `hold "<id>" not found`.
 var ErrHoldNotFound = errors.New("not found")
@@ -47,76 +49,87 @@ type Herdr struct {
 	PaneID      string `json:"pane_id"`
 }
 
+type TaskLifecycle string
+
+const (
+	TaskOpen     TaskLifecycle = "open"
+	TaskTerminal TaskLifecycle = "terminal"
+)
+
+type AttemptLifecycle string
+
+const (
+	AttemptProvisioning AttemptLifecycle = "provisioning"
+	AttemptRunning      AttemptLifecycle = "running"
+	AttemptCompleted    AttemptLifecycle = "completed"
+	AttemptFailed       AttemptLifecycle = "failed"
+	AttemptInterrupted  AttemptLifecycle = "interrupted"
+)
+
 type Task struct {
-	ID       string `json:"id"`
-	Project  string `json:"project"`
-	Kind     string `json:"kind"`
-	Harness  string `json:"harness"`
-	Model    string `json:"model"`
-	Effort   string `json:"effort"`
-	Worktree string `json:"worktree"`
-	Brief    string `json:"brief"`
-	Herdr    Herdr  `json:"herdr"`
-	PR       string `json:"pr"`
-	// hand itself ran the merge, not that the PR is merged: one merged by other
-	// means leaves this false and is what MergeAnnounced records instead.
-	MergeExecuted   bool   `json:"merged"`
-	MergeExecutedAt string `json:"merged_at"`
-	// Durable so a watcher restart resumes exactly where it stopped instead of replaying every line
-	// the previous run already surfaced.
-	ReportOffset int64 `json:"report_offset"`
-	// Fingerprints the bytes ReportOffset has consumed, because the offset alone cannot tell a report
-	// file rewritten in place from one nothing was appended to when the rewrite kept its length; see
-	// state.ReportCursor, the pair these two columns store. Empty before the column, or before a report.
-	ReportDigest string `json:"report_digest"`
-	// A merge hand observed rather than performed. Distinct from MergeExecuted:
-	// a restarted watcher needs to know the announcement went out even when
-	// hand itself never ran the merge.
-	MergeAnnounced bool `json:"pr_merged_observed"`
-	// Durable for the same reason MergeAnnounced is: evidence can land while the
-	// watcher is down, and a restart that re-derived this from current evidence
-	// would conclude the line had already gone out and never print it.
-	DoneVerified bool   `json:"done_verified"`
-	CreatedAt    string `json:"created_at"`
-	// Durable because a dwell clock reseeded to "now" on every restart never
-	// accumulates past a threshold. Trustworthy only while StatusChangedFor
-	// still matches the observed status; empty seeds the dwell from CreatedAt.
-	StatusChangedAt  string `json:"status_changed_at"`
-	StatusChangedFor string `json:"status_changed_for"`
-	// Durable so a restart resumes the scout's deferred-done bookkeeping without
-	// re-reading report history it has already consumed past ReportOffset.
-	LastReportState string `json:"last_report_state"`
-	LastReportNote  string `json:"last_report_note"`
-	// Durable so a send with no evidence it reached the pane - a composer busy past the
-	// --wait bound, a failed send, a failed submit - leaves a trace instead of vanishing
-	// with the process that tried it. Cleared by the next send that does reach the pane.
-	SendUndeliveredMessage string `json:"send_undelivered_message"`
-	SendUndeliveredAt      string `json:"send_undelivered_at"`
-	// treehouse mints a fresh identity per acquisition, so unlike Worktree, whose pool slot
-	// path is recycled, this names the one lease this task holds. Empty on a row older than
-	// the column or from a treehouse predating lease identities (worktree.CheckCollision).
-	LeaseID string `json:"lease_id"`
-	// Set when landing the work belongs outside the fleet - an upstream maintainer, or a
-	// deliverable that is a report, not a commit. Terminal without MergeExecuted's claim that
-	// it landed (atqamz/hand#78). Reason required, so the record says what and to whom.
-	DeliveredAt     string `json:"delivered_at"`
-	DeliveredReason string `json:"delivered_reason"`
-	// When this task's pane began, written by spawn and restamped by hand promote. Unlike
-	// StatusChangedAt, which the outage-dwell clock restamps for an unreachable pane, one field
-	// cannot mean both pane-start and last-observed transition (atqamz/hand#128).
-	PaneStartedAt string `json:"pane_started_at"`
-	// The silence instant hand watch last fired `parked` against. Durable: a terminal task's
-	// report file never grows, so a re-derived latch would re-fire that frozen instant every
-	// restart and evict real history from events.log (atqamz/hand#127).
-	ParkedFiredFor string `json:"parked_fired_for"`
-	// The earliest instant hand watch may next try to resume a worker its harness stopped on a usage
-	// limit. Non-empty is what makes a task limited; the `limit` hold is the operator-visible
-	// projection of it.
-	UsageLimitRetryAt string `json:"usage_limit_retry_at"`
-	// How many such attempts have been made. Both are durable because a re-derived schedule lets every
-	// watcher restart attempt immediately against an account still limited - the retry storm this is
-	// bounded to avoid - and a restart that forgot it never resumes at all (atqamz/hand#136).
-	UsageLimitAttempts int `json:"usage_limit_attempts"`
+	ID                     string        `json:"id"`
+	Project                string        `json:"project"`
+	Kind                   string        `json:"kind"`
+	Brief                  string        `json:"brief"`
+	Lifecycle              TaskLifecycle `json:"lifecycle"`
+	ActiveAttemptID        int64         `json:"active_attempt_id"`
+	PR                     string        `json:"pr"`
+	MergeExecuted          bool          `json:"merged"`
+	MergeExecutedAt        string        `json:"merged_at"`
+	ReportOffset           int64         `json:"report_offset"`
+	ReportDigest           string        `json:"report_digest"`
+	MergeAnnounced         bool          `json:"pr_merged_observed"`
+	DeliveredAt            string        `json:"delivered_at"`
+	DeliveredReason        string        `json:"delivered_reason"`
+	CreatedAt              string        `json:"created_at"`
+	Harness                string        `json:"harness,omitempty"`
+	Model                  string        `json:"model,omitempty"`
+	Effort                 string        `json:"effort,omitempty"`
+	Worktree               string        `json:"worktree,omitempty"`
+	Herdr                  Herdr         `json:"herdr,omitempty"`
+	DoneVerified           bool          `json:"done_verified,omitempty"`
+	StatusChangedAt        string        `json:"status_changed_at,omitempty"`
+	StatusChangedFor       string        `json:"status_changed_for,omitempty"`
+	LastReportState        string        `json:"last_report_state,omitempty"`
+	LastReportNote         string        `json:"last_report_note,omitempty"`
+	SendUndeliveredMessage string        `json:"send_undelivered_message,omitempty"`
+	SendUndeliveredAt      string        `json:"send_undelivered_at,omitempty"`
+	LeaseID                string        `json:"lease_id,omitempty"`
+	PaneStartedAt          string        `json:"pane_started_at,omitempty"`
+	ParkedFiredFor         string        `json:"parked_fired_for,omitempty"`
+	UsageLimitRetryAt      string        `json:"usage_limit_retry_at,omitempty"`
+	UsageLimitAttempts     int           `json:"usage_limit_attempts,omitempty"`
+}
+
+type Attempt struct {
+	ID                     int64            `json:"id"`
+	TaskID                 string           `json:"task_id"`
+	Ordinal                int              `json:"ordinal"`
+	Lifecycle              AttemptLifecycle `json:"lifecycle"`
+	Harness                string           `json:"harness"`
+	Model                  string           `json:"model"`
+	Effort                 string           `json:"effort"`
+	Worktree               string           `json:"worktree"`
+	LeaseID                string           `json:"lease_id"`
+	Herdr                  Herdr            `json:"herdr"`
+	CreatedAt              string           `json:"created_at"`
+	PaneStartedAt          string           `json:"pane_started_at"`
+	StatusChangedAt        string           `json:"status_changed_at"`
+	StatusChangedFor       string           `json:"status_changed_for"`
+	DoneVerified           bool             `json:"done_verified"`
+	LastReportState        string           `json:"last_report_state"`
+	LastReportNote         string           `json:"last_report_note"`
+	SendUndeliveredMessage string           `json:"send_undelivered_message"`
+	SendUndeliveredAt      string           `json:"send_undelivered_at"`
+	ParkedFiredFor         string           `json:"parked_fired_for"`
+	UsageLimitRetryAt      string           `json:"usage_limit_retry_at"`
+	UsageLimitAttempts     int              `json:"usage_limit_attempts"`
+}
+
+type TaskHistory struct {
+	Task          Task      `json:"task"`
+	ActiveAttempt *Attempt  `json:"active_attempt,omitempty"`
+	Attempts      []Attempt `json:"attempts"`
 }
 
 // Upstream is the "owner/repo" a fork project opens its PRs against, empty when it contributes to
@@ -160,40 +173,53 @@ type DB struct {
 // schemaversion.go, or no database that already exists ever gains it.
 const schema = `
 CREATE TABLE IF NOT EXISTS task (
-	id                 TEXT PRIMARY KEY,
-	project            TEXT NOT NULL DEFAULT '',
-	kind               TEXT NOT NULL DEFAULT '',
-	harness            TEXT NOT NULL DEFAULT '',
-	model              TEXT NOT NULL DEFAULT '',
-	effort             TEXT NOT NULL DEFAULT '',
-	worktree           TEXT NOT NULL DEFAULT '',
-	brief              TEXT NOT NULL DEFAULT '',
-	herdr_session      TEXT NOT NULL DEFAULT '',
-	herdr_workspace_id TEXT NOT NULL DEFAULT '',
-	herdr_tab_id       TEXT NOT NULL DEFAULT '',
-	herdr_pane_id      TEXT NOT NULL DEFAULT '',
-	pr                 TEXT NOT NULL DEFAULT '',
-	merge_executed     INTEGER NOT NULL DEFAULT 0,
-	merge_executed_at  TEXT NOT NULL DEFAULT '',
-	report_offset      INTEGER NOT NULL DEFAULT 0,
-	merge_announced    INTEGER NOT NULL DEFAULT 0,
-	done_verified      INTEGER NOT NULL DEFAULT 0,
-	created_at         TEXT NOT NULL DEFAULT '',
-	status_changed_at  TEXT NOT NULL DEFAULT '',
-	status_changed_for TEXT NOT NULL DEFAULT '',
-	last_report_state  TEXT NOT NULL DEFAULT '',
-	last_report_note   TEXT NOT NULL DEFAULT '',
+	id                TEXT PRIMARY KEY,
+	project           TEXT NOT NULL DEFAULT '',
+	kind              TEXT NOT NULL DEFAULT '',
+	brief             TEXT NOT NULL DEFAULT '',
+	lifecycle         TEXT NOT NULL DEFAULT 'open' CHECK (lifecycle IN ('open', 'terminal')),
+	active_attempt_id INTEGER REFERENCES attempt(id),
+	pr                TEXT NOT NULL DEFAULT '',
+	merge_executed    INTEGER NOT NULL DEFAULT 0,
+	merge_executed_at TEXT NOT NULL DEFAULT '',
+	merge_announced   INTEGER NOT NULL DEFAULT 0,
+	delivered_at      TEXT NOT NULL DEFAULT '',
+	delivered_reason  TEXT NOT NULL DEFAULT '',
+	report_offset     INTEGER NOT NULL DEFAULT 0,
+	report_digest     TEXT NOT NULL DEFAULT '',
+	created_at        TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS attempt (
+	id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+	task_id                TEXT NOT NULL REFERENCES task(id) ON DELETE CASCADE,
+	ordinal                INTEGER NOT NULL,
+	lifecycle              TEXT NOT NULL CHECK (lifecycle IN ('provisioning', 'running', 'completed', 'failed', 'interrupted')),
+	harness                TEXT NOT NULL DEFAULT '',
+	model                  TEXT NOT NULL DEFAULT '',
+	effort                 TEXT NOT NULL DEFAULT '',
+	worktree               TEXT NOT NULL DEFAULT '',
+	lease_id               TEXT NOT NULL DEFAULT '',
+	herdr_session          TEXT NOT NULL DEFAULT '',
+	herdr_workspace_id    TEXT NOT NULL DEFAULT '',
+	herdr_tab_id           TEXT NOT NULL DEFAULT '',
+	herdr_pane_id          TEXT NOT NULL DEFAULT '',
+	created_at             TEXT NOT NULL DEFAULT '',
+	pane_started_at        TEXT NOT NULL DEFAULT '',
+	status_changed_at      TEXT NOT NULL DEFAULT '',
+	status_changed_for     TEXT NOT NULL DEFAULT '',
+	done_verified          INTEGER NOT NULL DEFAULT 0,
+	last_report_state      TEXT NOT NULL DEFAULT '',
+	last_report_note       TEXT NOT NULL DEFAULT '',
 	send_undelivered_message TEXT NOT NULL DEFAULT '',
 	send_undelivered_at      TEXT NOT NULL DEFAULT '',
-	lease_id                 TEXT NOT NULL DEFAULT '',
-	delivered_at             TEXT NOT NULL DEFAULT '',
-	delivered_reason         TEXT NOT NULL DEFAULT '',
-	pane_started_at          TEXT NOT NULL DEFAULT '',
-	parked_fired_for         TEXT NOT NULL DEFAULT '',
-	report_digest            TEXT NOT NULL DEFAULT '',
-	usage_limit_retry_at     TEXT NOT NULL DEFAULT '',
-	usage_limit_attempts     INTEGER NOT NULL DEFAULT 0
+	parked_fired_for       TEXT NOT NULL DEFAULT '',
+	usage_limit_retry_at   TEXT NOT NULL DEFAULT '',
+	usage_limit_attempts   INTEGER NOT NULL DEFAULT 0,
+	UNIQUE (task_id, ordinal)
 );
+CREATE UNIQUE INDEX IF NOT EXISTS attempt_one_active
+ON attempt(task_id)
+WHERE lifecycle IN ('provisioning', 'running');
 CREATE TABLE IF NOT EXISTS project (
 	name     TEXT PRIMARY KEY,
 	url      TEXT NOT NULL,
@@ -306,61 +332,69 @@ func (db *DB) setMeta(key, value string) error {
 	return nil
 }
 
-// The one list of the task table's columns. Everything a write needs is derived from it -
-// the column list, the placeholders, the upsert's SET clause - so adding a column to
-// `schema` and to taskValues below cannot reach one writer and silently miss another.
 var taskColumnNames = []string{
-	"id", "project", "kind", "harness", "model", "effort", "worktree", "brief",
-	"herdr_session", "herdr_workspace_id", "herdr_tab_id", "herdr_pane_id", "pr",
-	"merge_executed", "merge_executed_at", "report_offset", "merge_announced", "done_verified",
-	"created_at", "status_changed_at", "status_changed_for", "last_report_state", "last_report_note",
-	"send_undelivered_message", "send_undelivered_at", "lease_id",
-	"delivered_at", "delivered_reason",
-	"pane_started_at", "parked_fired_for", "report_digest",
-	"usage_limit_retry_at", "usage_limit_attempts",
+	"id", "project", "kind", "brief", "lifecycle", "active_attempt_id", "pr",
+	"merge_executed", "merge_executed_at", "merge_announced", "delivered_at", "delivered_reason",
+	"report_offset", "report_digest", "created_at",
 }
 
-var (
-	taskColumns      = strings.Join(taskColumnNames, ", ")
-	taskPlaceholders = strings.TrimSuffix(strings.Repeat("?, ", len(taskColumnNames)), ", ")
-	taskUpsertSet    = taskExcludedAssignments()
-)
+var taskColumns = strings.Join(taskColumnNames, ", ")
 
-// Builds the upsert's SET clause for every column but the primary key, which is what the
-// conflict matched on.
-func taskExcludedAssignments() string {
-	assignments := make([]string, 0, len(taskColumnNames)-1)
-	for _, name := range taskColumnNames[1:] {
-		assignments = append(assignments, name+" = excluded."+name)
-	}
-	return strings.Join(assignments, ", ")
+var attemptColumnNames = []string{
+	"id", "task_id", "ordinal", "lifecycle", "harness", "model", "effort", "worktree", "lease_id",
+	"herdr_session", "herdr_workspace_id", "herdr_tab_id", "herdr_pane_id", "created_at", "pane_started_at",
+	"status_changed_at", "status_changed_for", "done_verified", "last_report_state", "last_report_note",
+	"send_undelivered_message", "send_undelivered_at", "parked_fired_for", "usage_limit_retry_at", "usage_limit_attempts",
 }
 
-// One task's columns in taskColumnNames order.
+var attemptColumns = strings.Join(attemptColumnNames, ", ")
+
+func placeholders(count int) string {
+	return strings.TrimSuffix(strings.Repeat("?, ", count), ", ")
+}
+
 func taskValues(t Task) []any {
-	return []any{
-		t.ID, t.Project, t.Kind, t.Harness, t.Model, t.Effort, t.Worktree, t.Brief,
-		t.Herdr.Session, t.Herdr.WorkspaceID, t.Herdr.TabID, t.Herdr.PaneID, t.PR,
-		t.MergeExecuted, t.MergeExecutedAt, t.ReportOffset, t.MergeAnnounced, t.DoneVerified,
-		t.CreatedAt, t.StatusChangedAt, t.StatusChangedFor, t.LastReportState, t.LastReportNote,
-		t.SendUndeliveredMessage, t.SendUndeliveredAt, t.LeaseID,
-		t.DeliveredAt, t.DeliveredReason,
-		t.PaneStartedAt, t.ParkedFiredFor, t.ReportDigest,
-		t.UsageLimitRetryAt, t.UsageLimitAttempts,
+	return []any{t.ID, t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
+		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
+		t.ReportOffset, t.ReportDigest, t.CreatedAt}
+}
+
+func nullableAttemptID(id int64) any {
+	if id == 0 {
+		return nil
 	}
+	return id
 }
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
-	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Harness, &t.Model, &t.Effort, &t.Worktree, &t.Brief,
-		&t.Herdr.Session, &t.Herdr.WorkspaceID, &t.Herdr.TabID, &t.Herdr.PaneID, &t.PR,
-		&t.MergeExecuted, &t.MergeExecutedAt, &t.ReportOffset, &t.MergeAnnounced, &t.DoneVerified,
-		&t.CreatedAt, &t.StatusChangedAt, &t.StatusChangedFor, &t.LastReportState, &t.LastReportNote,
-		&t.SendUndeliveredMessage, &t.SendUndeliveredAt, &t.LeaseID,
-		&t.DeliveredAt, &t.DeliveredReason,
-		&t.PaneStartedAt, &t.ParkedFiredFor, &t.ReportDigest,
-		&t.UsageLimitRetryAt, &t.UsageLimitAttempts)
+	var activeID sql.NullInt64
+	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
+		&t.MergeExecuted, &t.MergeExecutedAt, &t.MergeAnnounced, &t.DeliveredAt, &t.DeliveredReason,
+		&t.ReportOffset, &t.ReportDigest, &t.CreatedAt)
+	if activeID.Valid {
+		t.ActiveAttemptID = activeID.Int64
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
 	return t, err
+}
+
+func attemptValues(a Attempt) []any {
+	return []any{a.ID, a.TaskID, a.Ordinal, a.Lifecycle, a.Harness, a.Model, a.Effort, a.Worktree, a.LeaseID,
+		a.Herdr.Session, a.Herdr.WorkspaceID, a.Herdr.TabID, a.Herdr.PaneID, a.CreatedAt, a.PaneStartedAt,
+		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
+		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts}
+}
+
+func scanAttempt(row interface{ Scan(...any) error }) (Attempt, error) {
+	var a Attempt
+	err := row.Scan(&a.ID, &a.TaskID, &a.Ordinal, &a.Lifecycle, &a.Harness, &a.Model, &a.Effort, &a.Worktree, &a.LeaseID,
+		&a.Herdr.Session, &a.Herdr.WorkspaceID, &a.Herdr.TabID, &a.Herdr.PaneID, &a.CreatedAt, &a.PaneStartedAt,
+		&a.StatusChangedAt, &a.StatusChangedFor, &a.DoneVerified, &a.LastReportState, &a.LastReportNote,
+		&a.SendUndeliveredMessage, &a.SendUndeliveredAt, &a.ParkedFiredFor, &a.UsageLimitRetryAt, &a.UsageLimitAttempts)
+	return a, err
 }
 
 func (db *DB) ReadTask(id string) (Task, bool, error) {
@@ -372,16 +406,118 @@ func (db *DB) ReadTask(id string) (Task, bool, error) {
 	if err != nil {
 		return Task{}, false, fmt.Errorf("read task %q: %w", id, err)
 	}
+	if t.ActiveAttemptID != 0 {
+		if attempt, found, err := db.ReadAttempt(t.ActiveAttemptID); err != nil {
+			return Task{}, false, err
+		} else if found {
+			projectAttempt(&t, attempt)
+		}
+	}
 	return t, true, nil
 }
 
-func (db *DB) WriteTask(t Task) error {
-	_, err := db.sql.Exec(`INSERT INTO task (`+taskColumns+`)
-		VALUES (`+taskPlaceholders+`)
-		ON CONFLICT(id) DO UPDATE SET `+taskUpsertSet,
-		taskValues(t)...)
+func (db *DB) CreateTask(t Task) error {
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	_, err := db.sql.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...)
 	if err != nil {
-		return fmt.Errorf("write task %q: %w", t.ID, err)
+		return fmt.Errorf("create task %q: %w", t.ID, err)
+	}
+	return nil
+}
+
+// WriteTask is the compatibility adapter for pre-Task/Attempt callers and fixtures.
+// It projects execution fields into the one active Attempt; the database remains split.
+func (db *DB) WriteTask(t Task) error {
+	existing, found, err := db.ReadTask(t.ID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		logical := taskOnly(t)
+		logical.ActiveAttemptID = 0
+		if err := db.CreateTask(logical); err != nil {
+			return err
+		}
+		attempt, err := db.CreateAttempt(attemptFromTask(t))
+		if err != nil {
+			return err
+		}
+		if attempt.ID != 0 {
+			return nil
+		}
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = existing.Lifecycle
+	}
+	if t.CreatedAt == "" {
+		t.CreatedAt = existing.CreatedAt
+	}
+	activeID := t.ActiveAttemptID
+	if activeID == 0 {
+		activeID = existing.ActiveAttemptID
+		t.ActiveAttemptID = activeID
+	}
+	if err := db.UpdateTask(taskOnly(t)); err != nil {
+		return err
+	}
+	if activeID != 0 {
+		attempt, found, err := db.ReadAttempt(activeID)
+		if err != nil || !found {
+			return err
+		}
+		mergeAttemptProjection(&attempt, t)
+		return db.UpdateAttempt(attempt)
+	}
+	return nil
+}
+
+func taskOnly(t Task) Task {
+	return Task{ID: t.ID, Project: t.Project, Kind: t.Kind, Brief: t.Brief, Lifecycle: t.Lifecycle,
+		ActiveAttemptID: t.ActiveAttemptID, PR: t.PR, MergeExecuted: t.MergeExecuted,
+		MergeExecutedAt: t.MergeExecutedAt, MergeAnnounced: t.MergeAnnounced,
+		DeliveredAt: t.DeliveredAt, DeliveredReason: t.DeliveredReason,
+		ReportOffset: t.ReportOffset, ReportDigest: t.ReportDigest, CreatedAt: t.CreatedAt}
+}
+
+func attemptFromTask(t Task) Attempt {
+	lifecycle := AttemptRunning
+	return Attempt{TaskID: t.ID, Lifecycle: lifecycle, Harness: t.Harness, Model: t.Model, Effort: t.Effort,
+		Worktree: t.Worktree, LeaseID: t.LeaseID, Herdr: t.Herdr, CreatedAt: t.CreatedAt,
+		PaneStartedAt: t.PaneStartedAt, StatusChangedAt: t.StatusChangedAt, StatusChangedFor: t.StatusChangedFor,
+		DoneVerified: t.DoneVerified, LastReportState: t.LastReportState, LastReportNote: t.LastReportNote,
+		SendUndeliveredMessage: t.SendUndeliveredMessage, SendUndeliveredAt: t.SendUndeliveredAt,
+		ParkedFiredFor: t.ParkedFiredFor, UsageLimitRetryAt: t.UsageLimitRetryAt, UsageLimitAttempts: t.UsageLimitAttempts}
+}
+
+func projectAttempt(t *Task, a Attempt) {
+	t.Harness, t.Model, t.Effort, t.Worktree, t.Herdr, t.DoneVerified = a.Harness, a.Model, a.Effort, a.Worktree, a.Herdr, a.DoneVerified
+	t.StatusChangedAt, t.StatusChangedFor = a.StatusChangedAt, a.StatusChangedFor
+	t.LastReportState, t.LastReportNote = a.LastReportState, a.LastReportNote
+	t.SendUndeliveredMessage, t.SendUndeliveredAt = a.SendUndeliveredMessage, a.SendUndeliveredAt
+	t.LeaseID, t.PaneStartedAt, t.ParkedFiredFor = a.LeaseID, a.PaneStartedAt, a.ParkedFiredFor
+	t.UsageLimitRetryAt, t.UsageLimitAttempts = a.UsageLimitRetryAt, a.UsageLimitAttempts
+}
+
+func mergeAttemptProjection(a *Attempt, t Task) {
+	a.Harness, a.Model, a.Effort, a.Worktree, a.LeaseID, a.Herdr = t.Harness, t.Model, t.Effort, t.Worktree, t.LeaseID, t.Herdr
+	a.DoneVerified, a.StatusChangedAt, a.StatusChangedFor = t.DoneVerified, t.StatusChangedAt, t.StatusChangedFor
+	a.LastReportState, a.LastReportNote = t.LastReportState, t.LastReportNote
+	a.SendUndeliveredMessage, a.SendUndeliveredAt = t.SendUndeliveredMessage, t.SendUndeliveredAt
+	a.PaneStartedAt, a.ParkedFiredFor = t.PaneStartedAt, t.ParkedFiredFor
+	a.UsageLimitRetryAt, a.UsageLimitAttempts = t.UsageLimitRetryAt, t.UsageLimitAttempts
+}
+
+func (db *DB) UpdateTask(t Task) error {
+	_, err := db.sql.Exec(`UPDATE task SET project = ?, kind = ?, brief = ?, lifecycle = ?, active_attempt_id = ?,
+		pr = ?, merge_executed = ?, merge_executed_at = ?, merge_announced = ?, delivered_at = ?, delivered_reason = ?,
+		report_offset = ?, report_digest = ?, created_at = ? WHERE id = ?`,
+		t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
+		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
+		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.ID)
+	if err != nil {
+		return fmt.Errorf("update task %q: %w", t.ID, err)
 	}
 	return nil
 }
@@ -404,7 +540,255 @@ func (db *DB) ListTasks() ([]Task, error) {
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("list tasks: %w", err)
 	}
+	for i := range tasks {
+		if tasks[i].ActiveAttemptID != 0 {
+			if attempt, found, err := db.ReadAttempt(tasks[i].ActiveAttemptID); err != nil {
+				return nil, err
+			} else if found {
+				projectAttempt(&tasks[i], attempt)
+			}
+		}
+	}
 	return tasks, nil
+}
+
+func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
+	task, found, err := db.ReadTask(id)
+	if err != nil || !found {
+		return TaskHistory{}, found, err
+	}
+	attempts, err := db.ListAttempts(id)
+	if err != nil {
+		return TaskHistory{}, false, err
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	return history, true, nil
+}
+
+func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
+	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list open tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list open tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list open tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.ListAttempts(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				projectAttempt(&histories[i].Task, attempts[j])
+				break
+			}
+		}
+	}
+	return histories, nil
+}
+
+func (db *DB) CreateAttempt(a Attempt) (Attempt, error) {
+	if a.Lifecycle == "" {
+		a.Lifecycle = AttemptProvisioning
+	}
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return Attempt{}, fmt.Errorf("begin attempt creation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var lifecycle TaskLifecycle
+	if err := tx.QueryRow(`SELECT lifecycle FROM task WHERE id = ?`, a.TaskID).Scan(&lifecycle); errors.Is(err, sql.ErrNoRows) {
+		return Attempt{}, fmt.Errorf("task %q %w", a.TaskID, ErrTaskNotFound)
+	} else if err != nil {
+		return Attempt{}, fmt.Errorf("read task %q for attempt: %w", a.TaskID, err)
+	} else if lifecycle != TaskOpen {
+		return Attempt{}, fmt.Errorf("task %q is terminal", a.TaskID)
+	}
+	if a.Ordinal == 0 {
+		if err := tx.QueryRow(`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM attempt WHERE task_id = ?`, a.TaskID).Scan(&a.Ordinal); err != nil {
+			return Attempt{}, fmt.Errorf("next attempt ordinal for task %q: %w", a.TaskID, err)
+		}
+	}
+	args := attemptValues(a)
+	if a.ID == 0 {
+		args = args[1:]
+		query := `INSERT INTO attempt (` + strings.Join(attemptColumnNames[1:], ", ") + `) VALUES (` + placeholders(len(attemptColumnNames)-1) + `)`
+		result, err := tx.Exec(query, args...)
+		if err != nil {
+			return Attempt{}, fmt.Errorf("create attempt for task %q: %w", a.TaskID, err)
+		}
+		a.ID, err = result.LastInsertId()
+		if err != nil {
+			return Attempt{}, fmt.Errorf("read new attempt ID: %w", err)
+		}
+	} else if _, err := tx.Exec(`INSERT INTO attempt (`+attemptColumns+`) VALUES (`+placeholders(len(attemptColumnNames))+`)`, args...); err != nil {
+		return Attempt{}, fmt.Errorf("create attempt %d: %w", a.ID, err)
+	}
+	if isActiveAttempt(a.Lifecycle) {
+		if _, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ?`, a.ID, a.TaskID); err != nil {
+			return Attempt{}, fmt.Errorf("set active attempt %d: %w", a.ID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return Attempt{}, fmt.Errorf("create attempt for task %q: %w", a.TaskID, err)
+	}
+	return a, nil
+}
+
+func (db *DB) ReadAttempt(id int64) (Attempt, bool, error) {
+	row := db.sql.QueryRow(`SELECT `+attemptColumns+` FROM attempt WHERE id = ?`, id)
+	a, err := scanAttempt(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Attempt{}, false, nil
+	}
+	if err != nil {
+		return Attempt{}, false, fmt.Errorf("read attempt %d: %w", id, err)
+	}
+	return a, true, nil
+}
+
+func (db *DB) ListAttempts(taskID string) ([]Attempt, error) {
+	rows, err := db.sql.Query(`SELECT `+attemptColumns+` FROM attempt WHERE task_id = ? ORDER BY ordinal`, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list attempts for task %q: %w", taskID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var attempts []Attempt
+	for rows.Next() {
+		a, err := scanAttempt(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list attempts for task %q: %w", taskID, err)
+		}
+		attempts = append(attempts, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list attempts for task %q: %w", taskID, err)
+	}
+	return attempts, nil
+}
+
+func (db *DB) UpdateAttempt(a Attempt) error {
+	_, err := db.sql.Exec(`UPDATE attempt SET task_id = ?, ordinal = ?, lifecycle = ?, harness = ?, model = ?, effort = ?,
+		worktree = ?, lease_id = ?, herdr_session = ?, herdr_workspace_id = ?, herdr_tab_id = ?, herdr_pane_id = ?,
+		created_at = ?, pane_started_at = ?, status_changed_at = ?, status_changed_for = ?, done_verified = ?,
+		last_report_state = ?, last_report_note = ?, send_undelivered_message = ?, send_undelivered_at = ?,
+		parked_fired_for = ?, usage_limit_retry_at = ?, usage_limit_attempts = ? WHERE id = ?`,
+		a.TaskID, a.Ordinal, a.Lifecycle, a.Harness, a.Model, a.Effort, a.Worktree, a.LeaseID,
+		a.Herdr.Session, a.Herdr.WorkspaceID, a.Herdr.TabID, a.Herdr.PaneID, a.CreatedAt, a.PaneStartedAt,
+		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
+		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts, a.ID)
+	if err != nil {
+		return fmt.Errorf("update attempt %d: %w", a.ID, err)
+	}
+	return nil
+}
+
+func (db *DB) TransitionAttempt(id int64, from, to AttemptLifecycle) error {
+	if !validAttemptTransition(from, to) {
+		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, from, to)
+	}
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin attempt transition: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var current AttemptLifecycle
+	var taskID string
+	if err := tx.QueryRow(`SELECT task_id, lifecycle FROM attempt WHERE id = ?`, id).Scan(&taskID, &current); errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("attempt %d %w", id, ErrTaskNotFound)
+	} else if err != nil {
+		return fmt.Errorf("read attempt %d: %w", id, err)
+	}
+	if current != from || !validAttemptTransition(current, to) {
+		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, current, to)
+	}
+	if _, err := tx.Exec(`UPDATE attempt SET lifecycle = ? WHERE id = ?`, to, id); err != nil {
+		return fmt.Errorf("transition attempt %d: %w", id, err)
+	}
+	if isActiveAttempt(to) {
+		if _, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ?`, id, taskID); err != nil {
+			return fmt.Errorf("set active attempt %d: %w", id, err)
+		}
+	} else if _, err := tx.Exec(`UPDATE task SET active_attempt_id = NULL WHERE id = ? AND active_attempt_id = ?`, taskID, id); err != nil {
+		return fmt.Errorf("clear active attempt %d: %w", id, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("transition attempt %d: %w", id, err)
+	}
+	return nil
+}
+
+func (db *DB) SetActiveAttempt(taskID string, attemptID int64) error {
+	a, found, err := db.ReadAttempt(attemptID)
+	if err != nil {
+		return err
+	}
+	if !found || a.TaskID != taskID || !isActiveAttempt(a.Lifecycle) {
+		return fmt.Errorf("%w: attempt %d cannot be active", ErrInvalidTransition, attemptID)
+	}
+	_, err = db.sql.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ? AND lifecycle = 'open'`, attemptID, taskID)
+	if err != nil {
+		return fmt.Errorf("set active attempt %d: %w", attemptID, err)
+	}
+	return nil
+}
+
+func (db *DB) TransitionTask(id string, from, to TaskLifecycle) error {
+	if !validTaskTransition(from, to) {
+		return fmt.Errorf("%w: task %s -> %s", ErrInvalidTransition, from, to)
+	}
+	task, found, err := db.ReadTask(id)
+	if err != nil {
+		return err
+	}
+	if !found || task.Lifecycle != from {
+		return fmt.Errorf("%w: task %s -> %s", ErrInvalidTransition, task.Lifecycle, to)
+	}
+	if to == TaskTerminal && task.ActiveAttemptID != 0 {
+		return fmt.Errorf("%w: task has active attempt", ErrInvalidTransition)
+	}
+	_, err = db.sql.Exec(`UPDATE task SET lifecycle = ?, active_attempt_id = CASE WHEN ? = 'terminal' THEN NULL ELSE active_attempt_id END WHERE id = ?`, to, to, id)
+	if err != nil {
+		return fmt.Errorf("transition task %q: %w", id, err)
+	}
+	return nil
+}
+
+func validTaskTransition(from, to TaskLifecycle) bool {
+	return (from == TaskOpen && to == TaskTerminal) || (from == TaskTerminal && to == TaskOpen)
+}
+
+func validAttemptTransition(from, to AttemptLifecycle) bool {
+	switch from {
+	case AttemptProvisioning:
+		return to == AttemptRunning || to == AttemptFailed || to == AttemptInterrupted
+	case AttemptRunning:
+		return to == AttemptCompleted || to == AttemptFailed || to == AttemptInterrupted
+	default:
+		return false
+	}
+}
+
+func isActiveAttempt(lifecycle AttemptLifecycle) bool {
+	return lifecycle == AttemptProvisioning || lifecycle == AttemptRunning
 }
 
 func (db *DB) TaskExists(id string) (bool, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -126,8 +126,8 @@ type Project struct {
 }
 
 // Hold is its own row keyed by an arbitrary id, not a foreign key into task: it exists for a
-// question left open by work whose task row hand teardown already removed. BlockedOn carries
-// the id a HoldKindBlocked hold waits on, empty for HoldKindOperator.
+// question left open by work hand teardown already terminalized, or by no task at all. BlockedOn
+// carries the id a HoldKindBlocked hold waits on, empty for HoldKindOperator.
 type Hold struct {
 	ID        string `json:"id"`
 	Kind      string `json:"kind"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -440,13 +440,8 @@ func (db *DB) WriteTask(t Task) error {
 		if err := db.CreateTask(logical); err != nil {
 			return err
 		}
-		attempt, err := db.CreateAttempt(attemptFromTask(t))
-		if err != nil {
-			return err
-		}
-		if attempt.ID != 0 {
-			return nil
-		}
+		_, err := db.CreateAttempt(attemptFromTask(t))
+		return err
 	}
 	if t.Lifecycle == "" {
 		t.Lifecycle = existing.Lifecycle

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -81,10 +82,24 @@ func TestWriteReadPreservesEveryField(t *testing.T) {
 
 func assertTaskProjection(t *testing.T, got, want Task) {
 	t.Helper()
-	if got.ID != want.ID || got.Project != want.Project || got.Kind != want.Kind || got.Brief != want.Brief ||
-		got.PR != want.PR || got.MergeExecuted != want.MergeExecuted || got.MergeExecutedAt != want.MergeExecutedAt ||
-		got.MergeAnnounced != want.MergeAnnounced || got.DeliveredAt != want.DeliveredAt || got.DeliveredReason != want.DeliveredReason ||
-		got.ReportOffset != want.ReportOffset || got.ReportDigest != want.ReportDigest || got.CreatedAt != want.CreatedAt {
+	got.ActiveAttemptID = 0
+	if want.Lifecycle == "" {
+		want.Lifecycle = TaskOpen
+	}
+	got.Harness, got.Model, got.Effort, got.Worktree, got.Herdr = "", "", "", "", Herdr{}
+	got.DoneVerified, got.StatusChangedAt, got.StatusChangedFor = false, "", ""
+	got.LastReportState, got.LastReportNote = "", ""
+	got.SendUndeliveredMessage, got.SendUndeliveredAt = "", ""
+	got.LeaseID, got.PaneStartedAt, got.ParkedFiredFor = "", "", ""
+	got.UsageLimitRetryAt, got.UsageLimitAttempts = "", 0
+	want.ActiveAttemptID = 0
+	want.Harness, want.Model, want.Effort, want.Worktree, want.Herdr = "", "", "", "", Herdr{}
+	want.DoneVerified, want.StatusChangedAt, want.StatusChangedFor = false, "", ""
+	want.LastReportState, want.LastReportNote = "", ""
+	want.SendUndeliveredMessage, want.SendUndeliveredAt = "", ""
+	want.LeaseID, want.PaneStartedAt, want.ParkedFiredFor = "", "", ""
+	want.UsageLimitRetryAt, want.UsageLimitAttempts = "", 0
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("task round trip lost logical state: got %+v want %+v", got, want)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -29,89 +28,87 @@ func openTemp(t *testing.T) (*DB, string) {
 
 func sampleTask() Task {
 	return Task{
-		ID: "fix-login", Project: "nsr", Kind: KindShip, Harness: "claude",
-		Model: "opus", Effort: "high", Worktree: "/w/nsr", Brief: "data/fix-login/brief.md",
-		Herdr:           Herdr{Session: "default", WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pC"},
+		ID: "fix-login", Project: "nsr", Kind: KindShip, Brief: "data/fix-login/brief.md", Lifecycle: TaskOpen,
 		PR:              "https://github.com/o/nsr/pull/1",
 		MergeExecuted:   true,
 		MergeExecutedAt: "2026-07-24T12:00:00Z",
 		ReportOffset:    42,
 		ReportDigest:    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 		MergeAnnounced:  true,
-		DoneVerified:    true,
 		CreatedAt:       "2026-07-24T10:00:00Z",
+	}
+}
 
-		StatusChangedAt: "2026-07-24T11:00:00Z", StatusChangedFor: "working",
-		LastReportState: "working", LastReportNote: "on it",
+func sampleAttempt() Attempt {
+	return Attempt{
+		TaskID: "fix-login", Lifecycle: AttemptRunning, Harness: "claude", Model: "opus", Effort: "high", Worktree: "/w/nsr",
+		Herdr:        Herdr{Session: "default", WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pC"},
+		DoneVerified: true, StatusChangedAt: "2026-07-24T11:00:00Z", StatusChangedFor: "working",
+		LastReportState: "working", LastReportNote: "on it", PaneStartedAt: "2026-07-24T10:30:00Z",
+		ParkedFiredFor: "2026-07-24T11:30:00.123456789Z", UsageLimitRetryAt: "2026-07-24T15:00:00Z",
+		UsageLimitAttempts: 2, SendUndeliveredMessage: "stop and wait for review", SendUndeliveredAt: "2026-07-24T13:00:00Z",
+		LeaseID: "5fe5412a4aabdeb85a148d6d73eb42d8", CreatedAt: "2026-07-24T10:00:00Z",
+	}
+}
 
-		PaneStartedAt:  "2026-07-24T10:30:00Z",
-		ParkedFiredFor: "2026-07-24T11:30:00.123456789Z",
-
-		UsageLimitRetryAt:  "2026-07-24T15:00:00Z",
-		UsageLimitAttempts: 2,
-
-		SendUndeliveredMessage: "stop and wait for review",
-		SendUndeliveredAt:      "2026-07-24T13:00:00Z",
-
+func sampleLegacyTask() legacyTask {
+	return legacyTask{
+		ID: "fix-login", Project: "nsr", Kind: KindShip, Harness: "claude", Model: "opus", Effort: "high", Worktree: "/w/nsr",
+		Brief: "data/fix-login/brief.md", Herdr: Herdr{Session: "default", WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pC"},
+		PR: "https://github.com/o/nsr/pull/1", MergeExecuted: true, MergeExecutedAt: "2026-07-24T12:00:00Z",
+		ReportOffset: 42, ReportDigest: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", MergeAnnounced: true,
+		DoneVerified: true, CreatedAt: "2026-07-24T10:00:00Z", StatusChangedAt: "2026-07-24T11:00:00Z", StatusChangedFor: "working",
+		LastReportState: "working", LastReportNote: "on it", PaneStartedAt: "2026-07-24T10:30:00Z",
+		ParkedFiredFor: "2026-07-24T11:30:00.123456789Z", UsageLimitRetryAt: "2026-07-24T15:00:00Z", UsageLimitAttempts: 2,
+		SendUndeliveredMessage: "stop and wait for review", SendUndeliveredAt: "2026-07-24T13:00:00Z",
 		LeaseID: "5fe5412a4aabdeb85a148d6d73eb42d8",
 	}
 }
 
+func writeSample(db *DB) error {
+	if err := db.CreateTask(sampleTask()); err != nil {
+		return err
+	}
+	_, err := db.CreateAttempt(sampleAttempt())
+	return err
+}
+
 func TestWriteReadPreservesEveryField(t *testing.T) {
 	db, _ := openTemp(t)
-	want := sampleTask()
-	if err := db.WriteTask(want); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
+	want := sampleTask()
 
 	history, found, err := db.ReadTaskHistory(want.ID)
 	if err != nil || !found {
 		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	assertTaskProjection(t, history.Task, want)
+	gotTask := history.Task
+	gotTask.ActiveAttemptID = 0
+	want.ActiveAttemptID = 0
+	if gotTask != want {
+		t.Fatalf("task round trip lost logical state: got %+v want %+v", gotTask, want)
+	}
 	if len(history.Attempts) != 1 {
 		t.Fatalf("attempts = %d, want 1", len(history.Attempts))
 	}
 	got := history.Attempts[0]
-	wantAttempt := attemptFromTask(want)
+	wantAttempt := sampleAttempt()
 	wantAttempt.ID, wantAttempt.Ordinal, wantAttempt.Lifecycle = got.ID, got.Ordinal, got.Lifecycle
 	if got != wantAttempt {
 		t.Fatalf("attempt round trip lost a field:\ngot  %+v\nwant %+v", got, wantAttempt)
 	}
 }
 
-func assertTaskProjection(t *testing.T, got, want Task) {
-	t.Helper()
-	got.ActiveAttemptID = 0
-	if want.Lifecycle == "" {
-		want.Lifecycle = TaskOpen
-	}
-	got.Harness, got.Model, got.Effort, got.Worktree, got.Herdr = "", "", "", "", Herdr{}
-	got.DoneVerified, got.StatusChangedAt, got.StatusChangedFor = false, "", ""
-	got.LastReportState, got.LastReportNote = "", ""
-	got.SendUndeliveredMessage, got.SendUndeliveredAt = "", ""
-	got.LeaseID, got.PaneStartedAt, got.ParkedFiredFor = "", "", ""
-	got.UsageLimitRetryAt, got.UsageLimitAttempts = "", 0
-	want.ActiveAttemptID = 0
-	want.Harness, want.Model, want.Effort, want.Worktree, want.Herdr = "", "", "", "", Herdr{}
-	want.DoneVerified, want.StatusChangedAt, want.StatusChangedFor = false, "", ""
-	want.LastReportState, want.LastReportNote = "", ""
-	want.SendUndeliveredMessage, want.SendUndeliveredAt = "", ""
-	want.LeaseID, want.PaneStartedAt, want.ParkedFiredFor = "", "", ""
-	want.UsageLimitRetryAt, want.UsageLimitAttempts = "", 0
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("task round trip lost logical state: got %+v want %+v", got, want)
-	}
-}
-
-func TestWriteTaskOverwritesInPlace(t *testing.T) {
+func TestUpdateTaskPreservesLogicalFields(t *testing.T) {
 	db, _ := openTemp(t)
 	task := sampleTask()
-	if err := db.WriteTask(task); err != nil {
+	if err := db.CreateTask(task); err != nil {
 		t.Fatal(err)
 	}
 	task.PR = "https://github.com/o/nsr/pull/2"
-	if err := db.WriteTask(task); err != nil {
+	if err := db.UpdateTask(task); err != nil {
 		t.Fatal(err)
 	}
 
@@ -134,7 +131,7 @@ func TestReadTaskReportsAMissingTaskWithoutAnError(t *testing.T) {
 
 func TestDeleteTask(t *testing.T) {
 	db, _ := openTemp(t)
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.DeleteTask("fix-login"); err != nil {
@@ -236,7 +233,7 @@ func TestRemoveProject(t *testing.T) {
 	}
 }
 
-func writeLegacyTask(t *testing.T, home string, task Task) {
+func writeLegacyTask(t *testing.T, home string, task legacyTask) {
 	t.Helper()
 	if err := os.MkdirAll(Dir(home), 0o755); err != nil {
 		t.Fatal(err)
@@ -252,7 +249,7 @@ func writeLegacyTask(t *testing.T, home string, task Task) {
 
 func TestOpenImportsLegacyTaskFiles(t *testing.T) {
 	home := t.TempDir()
-	want := sampleTask()
+	want := sampleLegacyTask()
 	writeLegacyTask(t, home, want)
 
 	db, err := Open(home)
@@ -265,12 +262,18 @@ func TestOpenImportsLegacyTaskFiles(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	assertTaskProjection(t, history.Task, want)
+	gotTask := history.Task
+	gotTask.ActiveAttemptID = 0
+	wantTask := sampleTask()
+	wantTask.ActiveAttemptID = 0
+	if gotTask != wantTask {
+		t.Fatalf("task round trip lost logical state: got %+v want %+v", gotTask, wantTask)
+	}
 	if len(history.Attempts) != 1 {
 		t.Fatalf("attempts = %d, want 1", len(history.Attempts))
 	}
 	got := history.Attempts[0]
-	wantAttempt := attemptFromTask(want)
+	wantAttempt := sampleAttempt()
 	wantAttempt.ID, wantAttempt.Ordinal, wantAttempt.Lifecycle = got.ID, got.Ordinal, got.Lifecycle
 	if got != wantAttempt {
 		t.Fatalf("import lost execution state: got %+v want %+v", got, wantAttempt)
@@ -297,7 +300,7 @@ func TestLegacyImportBackfillsThePaneStart(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
-			legacy := sampleTask()
+			legacy := sampleLegacyTask()
 			legacy.PaneStartedAt = ""
 			legacy.StatusChangedAt = tc.statusChangedAt
 			writeLegacyTask(t, home, legacy)
@@ -308,12 +311,12 @@ func TestLegacyImportBackfillsThePaneStart(t *testing.T) {
 			}
 			defer func() { _ = db.Close() }()
 
-			got, found, err := db.ReadTask(legacy.ID)
+			got, found, err := db.ReadTaskHistory(legacy.ID)
 			if err != nil || !found {
-				t.Fatalf("ReadTask = %v, %v", found, err)
+				t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 			}
-			if got.PaneStartedAt != tc.want {
-				t.Fatalf("PaneStartedAt = %q, want %q", got.PaneStartedAt, tc.want)
+			if got.ActiveAttempt == nil || got.ActiveAttempt.PaneStartedAt != tc.want {
+				t.Fatalf("PaneStartedAt = %q, want %q", got.ActiveAttempt.PaneStartedAt, tc.want)
 			}
 		})
 	}
@@ -323,7 +326,7 @@ func TestLegacyImportBackfillsThePaneStart(t *testing.T) {
 // the store. The second open must find nothing to do and change nothing.
 func TestMigrationIsIdempotent(t *testing.T) {
 	home := t.TempDir()
-	writeLegacyTask(t, home, sampleTask())
+	writeLegacyTask(t, home, sampleLegacyTask())
 
 	first, err := Open(home)
 	if err != nil {
@@ -331,7 +334,7 @@ func TestMigrationIsIdempotent(t *testing.T) {
 	}
 	updated := sampleTask()
 	updated.PR = "https://github.com/o/nsr/pull/99"
-	if err := first.WriteTask(updated); err != nil {
+	if err := first.UpdateTask(updated); err != nil {
 		t.Fatal(err)
 	}
 	if err := first.Close(); err != nil {
@@ -368,7 +371,7 @@ func TestLegacyImportLeavesATerminalTaskAndItsHistoryAlone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	task, _, err := db.ReadTask(sampleTask().ID)
@@ -385,7 +388,7 @@ func TestLegacyImportLeavesATerminalTaskAndItsHistoryAlone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stale := sampleTask()
+	stale := sampleLegacyTask()
 	stale.PR = "https://github.com/o/nsr/pull/999"
 	writeLegacyTask(t, home, stale)
 
@@ -438,7 +441,7 @@ func TestConcurrentOpensImportALegacyHomeExactlyOnce(t *testing.T) {
 	home := t.TempDir()
 	const legacyTasks = 5
 	for i := range legacyTasks {
-		task := sampleTask()
+		task := sampleLegacyTask()
 		task.ID = fmt.Sprintf("task-%d", i)
 		writeLegacyTask(t, home, task)
 	}
@@ -493,7 +496,7 @@ func TestConcurrentOpensImportALegacyHomeExactlyOnce(t *testing.T) {
 // rather than run its own copy alongside.
 func TestLegacyImportWaitsForTheMigrationLock(t *testing.T) {
 	home := t.TempDir()
-	writeLegacyTask(t, home, sampleTask())
+	writeLegacyTask(t, home, sampleLegacyTask())
 
 	unlock, err := Lock(home, MigrationLock, false)
 	if err != nil {
@@ -580,7 +583,7 @@ func TestOpenHandlesAHomePathWithURISyntaxInIt(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	got, ok, err := db.ReadTask(sampleTask().ID)
@@ -597,7 +600,7 @@ func TestOpenHandlesAHomePathWithURISyntaxInIt(t *testing.T) {
 
 func TestOpenReadOnlyReadsCurrentRowsAndRefusesWrites(t *testing.T) {
 	db, home := openTemp(t)
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {
@@ -619,8 +622,8 @@ func TestOpenReadOnlyReadsCurrentRowsAndRefusesWrites(t *testing.T) {
 	if len(tasks) != 1 || tasks[0].ID != sampleTask().ID {
 		t.Fatalf("ListTasks = %+v, want the current SQLite row", tasks)
 	}
-	if err := db.WriteTask(Task{ID: "must-not-write"}); err == nil {
-		t.Fatal("WriteTask through OpenReadOnly succeeded")
+	if err := db.CreateTask(Task{ID: "must-not-write"}); err == nil {
+		t.Fatal("CreateTask through OpenReadOnly succeeded")
 	}
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
@@ -699,7 +702,7 @@ func TestOpenReadOnlyHandlesURISpecialFleetPathWithoutMutation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.WriteTask(sampleTask()); err != nil {
+	if err := writeSample(db); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -345,6 +345,52 @@ func TestMigrationIsIdempotent(t *testing.T) {
 	}
 }
 
+// A snapshot for an id the fleet has since torn down: the row and its attempt history win, and
+// importing an attempt onto a terminal task would fail every command on this home instead.
+func TestLegacyImportLeavesATerminalTaskAndItsHistoryAlone(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.WriteTask(sampleTask()); err != nil {
+		t.Fatal(err)
+	}
+	task, _, err := db.ReadTask(sampleTask().ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(task.ActiveAttemptID, AttemptRunning, AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionTask(task.ID, TaskOpen, TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := sampleTask()
+	stale.PR = "https://github.com/o/nsr/pull/999"
+	writeLegacyTask(t, home, stale)
+
+	reopened, err := Open(home)
+	if err != nil {
+		t.Fatalf("open a home whose legacy file names a terminal task: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	history, found, err := reopened.ReadTaskHistory(stale.ID)
+	if err != nil || !found {
+		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
+	}
+	if history.Task.Lifecycle != TaskTerminal || history.Task.PR == stale.PR {
+		t.Fatalf("the snapshot overwrote the live row: %+v", history.Task)
+	}
+	if len(history.Attempts) != 1 || history.Attempts[0].Lifecycle != AttemptInterrupted {
+		t.Fatalf("attempts = %+v, want the one interrupted attempt", history.Attempts)
+	}
+}
+
 // A legacy file the migration cannot read is a loud failure, not a skipped task:
 // silently continuing would present a partial fleet as the whole one.
 func TestOpenRefusesAnUnreadableLegacyFile(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -63,12 +63,29 @@ func TestWriteReadPreservesEveryField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, found, err := db.ReadTask(want.ID)
+	history, found, err := db.ReadTaskHistory(want.ID)
 	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
+		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	if got != want {
-		t.Fatalf("round trip lost a field:\ngot  %+v\nwant %+v", got, want)
+	assertTaskProjection(t, history.Task, want)
+	if len(history.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(history.Attempts))
+	}
+	got := history.Attempts[0]
+	wantAttempt := attemptFromTask(want)
+	wantAttempt.ID, wantAttempt.Ordinal, wantAttempt.Lifecycle = got.ID, got.Ordinal, got.Lifecycle
+	if got != wantAttempt {
+		t.Fatalf("attempt round trip lost a field:\ngot  %+v\nwant %+v", got, wantAttempt)
+	}
+}
+
+func assertTaskProjection(t *testing.T, got, want Task) {
+	t.Helper()
+	if got.ID != want.ID || got.Project != want.Project || got.Kind != want.Kind || got.Brief != want.Brief ||
+		got.PR != want.PR || got.MergeExecuted != want.MergeExecuted || got.MergeExecutedAt != want.MergeExecutedAt ||
+		got.MergeAnnounced != want.MergeAnnounced || got.DeliveredAt != want.DeliveredAt || got.DeliveredReason != want.DeliveredReason ||
+		got.ReportOffset != want.ReportOffset || got.ReportDigest != want.ReportDigest || got.CreatedAt != want.CreatedAt {
+		t.Fatalf("task round trip lost logical state: got %+v want %+v", got, want)
 	}
 }
 
@@ -229,12 +246,19 @@ func TestOpenImportsLegacyTaskFiles(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	got, found, err := db.ReadTask(want.ID)
+	history, found, err := db.ReadTaskHistory(want.ID)
 	if err != nil || !found {
-		t.Fatalf("ReadTask = %v, %v", found, err)
+		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	if got != want {
-		t.Fatalf("import lost a field:\ngot  %+v\nwant %+v", got, want)
+	assertTaskProjection(t, history.Task, want)
+	if len(history.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(history.Attempts))
+	}
+	got := history.Attempts[0]
+	wantAttempt := attemptFromTask(want)
+	wantAttempt.ID, wantAttempt.Ordinal, wantAttempt.Lifecycle = got.ID, got.Ordinal, got.Lifecycle
+	if got != wantAttempt {
+		t.Fatalf("import lost execution state: got %+v want %+v", got, wantAttempt)
 	}
 	if _, err := os.Stat(filepath.Join(Dir(home), want.ID+".json")); !os.IsNotExist(err) {
 		t.Fatalf("legacy file still in state/: %v", err)

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -114,8 +114,8 @@ type Event struct {
 // TaskState tracks what's already been observed and announced for one task, so the
 // classifier only fires once per transition instead of once per poll tick.
 type TaskState struct {
-	// CreatedAt is the tracked task's identity, not just a timestamp: the poll loop
-	// compares it against the task on disk so a torn-down and respawned ID is
+	// CreatedAt pairs with AttemptID as the tracked execution identity, not just a timestamp:
+	// the poll loop compares both against the task on disk so a reopened or promoted ID is
 	// re-seeded from scratch instead of inheriting this state.
 	CreatedAt    string
 	AttemptID    int64

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -118,6 +118,7 @@ type TaskState struct {
 	// compares it against the task on disk so a torn-down and respawned ID is
 	// re-seeded from scratch instead of inheriting this state.
 	CreatedAt    string
+	AttemptID    int64
 	Status       herdr.Status
 	Probed       bool
 	ChangedAt    time.Time

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -50,7 +50,7 @@ type limitPane interface {
 
 // The whole usage-limit lifecycle for one task on one tick: detect a harness that stopped on a limit,
 // resume it once the limit plausibly lifted, and let go the moment the worker is running again.
-func classifyUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task, pane herdr.Pane, status herdr.Status, probeErr error, justStopped bool, now time.Time, errOut io.Writer) *Event {
+func classifyUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, status herdr.Status, probeErr error, justStopped bool, now time.Time, errOut io.Writer) *Event {
 	// A pane that will not answer PaneGet cannot be read or steered either, and
 	// ClassifyUnreachable already owns that fact.
 	if probeErr != nil {
@@ -63,7 +63,7 @@ func classifyUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 		return nil
 	}
 	if !ts.LimitRetryAt.IsZero() {
-		return continueUsageLimit(cfg, client, ts, t, pane, status, now, errOut)
+		return continueUsageLimit(cfg, client, ts, t, a, pane, status, now, errOut)
 	}
 	// justStopped is computed before ClassifyStatus consumes the transition: it is what makes detection
 	// edge-triggered rather than a per-tick pane read. ts.LimitProbed is the other edge, covering what no
@@ -71,13 +71,13 @@ func classifyUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 	if !status.NotBusy() || (!justStopped && ts.LimitProbed) {
 		return nil
 	}
-	return detectUsageLimit(cfg, client, ts, t, pane, now, errOut)
+	return detectUsageLimit(cfg, client, ts, t, a, pane, now, errOut)
 }
 
 // Reads the stopped pane once and, if the harness stopped on a limit, records the schedule that will
 // resume it. A worker whose report channel already explains the stop is left alone: a done or failed
 // worker is not waiting on quota, and steering one would restart work that is over.
-func detectUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
+func detectUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
 	if reportEndsTask(ts.LastReportState) {
 		return nil
 	}
@@ -86,7 +86,7 @@ func detectUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task,
 	// poll. One attempt per stop edge is the same budget the successful path gets.
 	ts.LimitProbed = true
 
-	text, err := client.PaneRead(t.Herdr.PaneID, limitReadLines)
+	text, err := client.PaneRead(a.Herdr.PaneID, limitReadLines)
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: read pane for %s failed: %v\n", t.ID, err)
 		return nil
@@ -110,7 +110,7 @@ func detectUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task,
 // Runs for a task already known to be limited. The clear check comes first and runs every tick, not only
 // when an attempt is due: the limit can end for reasons this package had no part in - an operator
 // `hand send`, a human typing in the pane - and a visibly running worker must not keep collecting attempts.
-func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task, pane herdr.Pane, status herdr.Status, now time.Time, errOut io.Writer) *Event {
+func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, status herdr.Status, now time.Time, errOut io.Writer) *Event {
 	if status == herdr.StatusWorking || status == herdr.StatusBlocked {
 		return clearUsageLimit(cfg, ts, t, errOut)
 	}
@@ -122,13 +122,13 @@ func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 	if now.Before(ts.LimitRetryAt) {
 		return nil
 	}
-	return attemptUsageLimitResume(cfg, client, ts, t, pane, now, errOut)
+	return attemptUsageLimitResume(cfg, client, ts, t, a, pane, now, errOut)
 }
 
 // Steers the pane and schedules the next attempt. The attempt itself is the observation: nothing here
 // decides whether the limit is over - the next tick's clear check does that, by seeing whether the pane
 // started working.
-func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t state.Task, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
+func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
 	// The same `send:<id>` lock hand send holds, because two writers racing one composer is the lost
 	// steer atqamz/hand#102 traced. TryLock, never Lock: a tick must not block behind an operator's
 	// whole --wait, and an operator send landing right now is itself the thing that ends the limit.
@@ -145,7 +145,7 @@ func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t stat
 	// Read first: the freshest refusal on screen is the harness's own latest prediction of when its quota
 	// returns, and scheduling from it keeps a genuinely long limit off the backoff's much shorter clock.
 	reset := time.Time{}
-	if text, err := client.PaneRead(t.Herdr.PaneID, limitReadLines); err != nil {
+	if text, err := client.PaneRead(a.Herdr.PaneID, limitReadLines); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: read pane for %s failed: %v\n", t.ID, err)
 	} else if at, limited := harness.DetectUsageLimit(pane.Agent, text, now); limited {
 		reset = at
@@ -154,7 +154,7 @@ func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t stat
 	ts.LimitAttempts++
 	ts.LimitRetryAt = nextLimitRetry(reset, ts.LimitAttempts, now)
 
-	if err := steerPane(client, t.Herdr.PaneID, limitResumeMessage); err != nil {
+	if err := steerPane(client, a.Herdr.PaneID, limitResumeMessage); err != nil {
 		// The schedule above is kept deliberately: a steer that did not land is one
 		// lost attempt, and reverting the stamp would put this task back in the due
 		// state every tick, which is the storm.

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -46,15 +46,6 @@ func paneCalls(t *testing.T, paneLog string) string {
 	return string(data)
 }
 
-func readTask(t *testing.T, home, id string) state.Task {
-	t.Helper()
-	task, err := state.Read(home, id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return task
-}
-
 func limitHold(t *testing.T, home, id string) (state.Hold, bool) {
 	t.Helper()
 	h, exists, err := state.ReadHold(home, id)
@@ -69,9 +60,9 @@ func limitHold(t *testing.T, home, id string) (state.Hold, bool) {
 // the attempt is gone, and the one that resumes has nothing but this column to learn from.
 func setLimitRetryAt(t *testing.T, home, id string, at time.Time) {
 	t.Helper()
-	task := readTask(t, home, id)
-	task.UsageLimitRetryAt = at.UTC().Format(time.RFC3339)
-	if err := state.Write(home, task); err != nil {
+	_, attempt := readTaskAttempt(t, home, id)
+	attempt.UsageLimitRetryAt = at.UTC().Format(time.RFC3339)
+	if err := state.UpdateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -85,7 +76,7 @@ func TestTickResumesALimitedWorkerAndLetsGoWhenItRuns(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneLog := paneScript(t, limitedPaneAgent, claudeLimitText)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -110,11 +101,11 @@ func TestTickResumesALimitedWorkerAndLetsGoWhenItRuns(t *testing.T) {
 	if !exists || held.Kind != state.HoldKindLimit {
 		t.Fatalf("hold = %+v, exists = %v, want a %s hold", held, exists, state.HoldKindLimit)
 	}
-	task := readTask(t, home, "task-1")
-	if task.UsageLimitRetryAt == "" {
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.UsageLimitRetryAt == "" {
 		t.Fatal("usage_limit_retry_at is empty, want the schedule a restart resumes from")
 	}
-	retryAt, err := time.Parse(time.RFC3339, task.UsageLimitRetryAt)
+	retryAt, err := time.Parse(time.RFC3339, attempt.UsageLimitRetryAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +123,8 @@ func TestTickResumesALimitedWorkerAndLetsGoWhenItRuns(t *testing.T) {
 	if !strings.Contains(calls, "send-text") || !strings.Contains(calls, "send-keys Enter") {
 		t.Fatalf("pane calls = %q, want the due attempt to steer the pane and submit it", calls)
 	}
-	if got := readTask(t, home, "task-1").UsageLimitAttempts; got != 1 {
+	_, attempt = readTaskAttempt(t, home, "task-1")
+	if got := attempt.UsageLimitAttempts; got != 1 {
 		t.Fatalf("usage_limit_attempts = %d, want 1", got)
 	}
 
@@ -145,9 +137,9 @@ func TestTickResumesALimitedWorkerAndLetsGoWhenItRuns(t *testing.T) {
 	if _, exists := limitHold(t, home, "task-1"); exists {
 		t.Fatal("the limit hold outlived the limit, so hand spawn would refuse this id over quota nobody is waiting on")
 	}
-	task = readTask(t, home, "task-1")
-	if task.UsageLimitRetryAt != "" || task.UsageLimitAttempts != 0 {
-		t.Fatalf("usage-limit columns = %q/%d, want both cleared", task.UsageLimitRetryAt, task.UsageLimitAttempts)
+	_, attempt = readTaskAttempt(t, home, "task-1")
+	if attempt.UsageLimitRetryAt != "" || attempt.UsageLimitAttempts != 0 {
+		t.Fatalf("usage-limit columns = %q/%d, want both cleared", attempt.UsageLimitRetryAt, attempt.UsageLimitAttempts)
 	}
 }
 
@@ -160,7 +152,7 @@ func TestTickLeavesAWorkerThatStoppedForAnotherReasonAlone(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneLog := paneScript(t, limitedPaneAgent, "$ go test -race ./...\nok  github.com/atqamz/hand/internal/watcher\n")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -182,8 +174,9 @@ func TestTickLeavesAWorkerThatStoppedForAnotherReasonAlone(t *testing.T) {
 	if _, exists := limitHold(t, home, "task-1"); exists {
 		t.Fatal("a limit hold was set on a worker that never hit a limit")
 	}
-	if task := readTask(t, home, "task-1"); task.UsageLimitRetryAt != "" {
-		t.Fatalf("usage_limit_retry_at = %q, want empty", task.UsageLimitRetryAt)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.UsageLimitRetryAt != "" {
+		t.Fatalf("usage_limit_retry_at = %q, want empty", attempt.UsageLimitRetryAt)
 	}
 }
 
@@ -196,7 +189,7 @@ func TestTickReadsNoPaneForAHarnessWithoutTheCapability(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneLog := paneScript(t, "codex", claudeLimitText)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -221,7 +214,7 @@ func TestTickDetectsALimitThatPredatesTheWatcher(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneScript(t, limitedPaneAgent, claudeLimitText)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -245,10 +238,9 @@ func TestTickDoesNotResumeALimitedWorkerThatReportedDone(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneLog := paneScript(t, limitedPaneAgent, claudeLimitText)
 
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		LastReportState: state.ReportDone, LastReportNote: "shipped",
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		LastReportState: state.ReportDone, LastReportNote: "shipped"},
+	)
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -275,10 +267,9 @@ func TestTickReleasesALimitTheOperatorEndedItself(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneScript(t, limitedPaneAgent, claudeLimitText)
 
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		UsageLimitRetryAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339), UsageLimitAttempts: 2,
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		UsageLimitRetryAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339), UsageLimitAttempts: 2},
+	)
 	if err := state.SetHold(home, state.Hold{
 		ID: "task-1", Kind: state.HoldKindLimit, Reason: "harness stopped on a usage limit",
 		SetAt: time.Now().UTC().Format(time.RFC3339),
@@ -303,8 +294,9 @@ func TestTickReleasesALimitTheOperatorEndedItself(t *testing.T) {
 	if _, exists := limitHold(t, home, "task-1"); exists {
 		t.Fatal("the limit hold survived the worker running again")
 	}
-	if task := readTask(t, home, "task-1"); task.UsageLimitRetryAt != "" {
-		t.Fatalf("usage_limit_retry_at = %q, want empty", task.UsageLimitRetryAt)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.UsageLimitRetryAt != "" {
+		t.Fatalf("usage_limit_retry_at = %q, want empty", attempt.UsageLimitRetryAt)
 	}
 }
 
@@ -317,10 +309,9 @@ func TestUsageLimitAnnouncesItselfStuckExactlyOnce(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	paneScript(t, limitedPaneAgent, "Claude usage limit reached.")
 
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		UsageLimitAttempts: limitStuckAfter - 1,
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		UsageLimitAttempts: limitStuckAfter - 1},
+	)
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	ctx := context.Background()
@@ -336,7 +327,8 @@ func TestUsageLimitAnnouncesItselfStuckExactlyOnce(t *testing.T) {
 	if got := strings.Count(buf.String(), "usage-limit-stuck task-1"); got != 1 {
 		t.Fatalf("usage-limit-stuck fired %d times, want exactly 1:\n%s", got, buf.String())
 	}
-	if got := readTask(t, home, "task-1").UsageLimitAttempts; got != limitStuckAfter+2 {
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if got := attempt.UsageLimitAttempts; got != limitStuckAfter+2 {
 		t.Fatalf("usage_limit_attempts = %d, want %d: the attempts continue past the stuck announcement", got, limitStuckAfter+2)
 	}
 }
@@ -411,12 +403,13 @@ func TestAFailedSteerStillConsumesItsAttempt(t *testing.T) {
 	ts := &TaskState{LimitRetryAt: time.Now().Add(-time.Minute)}
 	client := &steerFailingPane{}
 	cfg := Config{Home: t.TempDir()}
-	task := state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "p1"}}
+	task := state.Task{ID: "task-1"}
+	attempt := state.Attempt{Herdr: state.Herdr{PaneID: "p1"}}
 	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
 	var errBuf bytes.Buffer
 
 	now := time.Now()
-	if e := classifyUsageLimit(cfg, client, ts, task, pane, herdr.StatusDone, nil, false, now, &errBuf); e != nil {
+	if e := classifyUsageLimit(cfg, client, ts, task, attempt, pane, herdr.StatusDone, nil, false, now, &errBuf); e != nil {
 		t.Fatalf("event = %+v, want none for an ordinary attempt", e)
 	}
 	if ts.LimitAttempts != 1 {
@@ -442,7 +435,7 @@ func (p *steerFailingPane) PaneSendKeys(string, ...string) error { return nil }
 // interleaved into the composer it is already writing. The attempt is deferred rather than spent: the
 // schedule stays due, and the next tick either steers or finds the send has ended the limit for it.
 func TestAnAttemptYieldsToASendHoldingTheLock(t *testing.T) {
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	release, err := state.TryLock(home, "send:task-1")
 	if err != nil {
 		t.Fatal(err)
@@ -453,11 +446,12 @@ func TestAnAttemptYieldsToASendHoldingTheLock(t *testing.T) {
 	ts := &TaskState{LimitRetryAt: due}
 	client := &countingPane{}
 	cfg := Config{Home: home}
-	task := state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "p1"}}
+	task := state.Task{ID: "task-1"}
+	attempt := state.Attempt{Herdr: state.Herdr{PaneID: "p1"}}
 	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
 	var errBuf bytes.Buffer
 
-	if e := classifyUsageLimit(cfg, client, ts, task, pane, herdr.StatusDone, nil, false, time.Now(), &errBuf); e != nil {
+	if e := classifyUsageLimit(cfg, client, ts, task, attempt, pane, herdr.StatusDone, nil, false, time.Now(), &errBuf); e != nil {
 		t.Fatalf("event = %+v, want none", e)
 	}
 	if client.steers != 0 || client.reads != 0 {
@@ -475,7 +469,7 @@ func TestAnAttemptYieldsToASendHoldingTheLock(t *testing.T) {
 // their own. Overwriting it would not merely hide that question: the clear at the end of the limit
 // matches on kind, so the row - operator hold and all - would be deleted once the worker ran again.
 func TestALimitLeavesAnOperatorHoldOnTheSameIDStanding(t *testing.T) {
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	operatorHold := state.Hold{
 		ID: "task-1", Kind: state.HoldKindOperator, Reason: "two ways to fix this, needs a call",
 		SetAt: time.Now().UTC().Format(time.RFC3339),
@@ -487,11 +481,12 @@ func TestALimitLeavesAnOperatorHoldOnTheSameIDStanding(t *testing.T) {
 	ts := &TaskState{}
 	client := &countingPane{}
 	cfg := Config{Home: home}
-	task := state.Task{ID: "task-1", Herdr: state.Herdr{PaneID: "p1"}}
+	task := state.Task{ID: "task-1"}
+	attempt := state.Attempt{Herdr: state.Herdr{PaneID: "p1"}}
 	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
 	var errBuf bytes.Buffer
 
-	e := classifyUsageLimit(cfg, client, ts, task, pane, herdr.StatusDone, nil, true, time.Now(), &errBuf)
+	e := classifyUsageLimit(cfg, client, ts, task, attempt, pane, herdr.StatusDone, nil, true, time.Now(), &errBuf)
 	if e == nil || e.Kind != KindUsageLimit {
 		t.Fatalf("event = %+v, want %s: the limit is real whatever else holds the id", e, KindUsageLimit)
 	}
@@ -506,7 +501,7 @@ func TestALimitLeavesAnOperatorHoldOnTheSameIDStanding(t *testing.T) {
 		t.Fatalf("hold = %+v, exists = %v, want the operator's own hold untouched", held, exists)
 	}
 
-	if e := classifyUsageLimit(cfg, client, ts, task, pane, herdr.StatusWorking, nil, false, time.Now(), &errBuf); e == nil || e.Kind != KindUsageLimitResumed {
+	if e := classifyUsageLimit(cfg, client, ts, task, attempt, pane, herdr.StatusWorking, nil, false, time.Now(), &errBuf); e == nil || e.Kind != KindUsageLimitResumed {
 		t.Fatalf("event = %+v, want %s once the worker runs again", e, KindUsageLimitResumed)
 	}
 	held, exists = limitHold(t, home, "task-1")

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -142,7 +142,7 @@ func connect(ctx context.Context) (*herdr.Client, error) {
 // Confirms every active task's pane answers before RunUntilEvent arms, since an unprobed task would
 // otherwise wait out the timeout with no distinguishing signal.
 func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error {
-	tasks, err := state.List(home)
+	tasks, err := state.ListOpen(home)
 	if err != nil {
 		return fmt.Errorf("list tasks: %w", err)
 	}
@@ -170,7 +170,7 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 }
 
 func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[string]*TaskState, out, errOut io.Writer) {
-	tasks, err := state.List(cfg.Home)
+	tasks, err := state.ListOpen(cfg.Home)
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: list tasks failed: %v\n", err)
 		return
@@ -191,12 +191,12 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 
 		// Tracking is keyed by task identity, not by ID: an ID torn down and respawned between two
 		// ticks is a different task. Same hazard as a surviving report channel, one layer in - see
-		// state.Delete for that half.
+		// A new attempt on the same task ID is a new execution identity.
 		ts, tracked := states[t.ID]
 		// Inheriting the previous run's TaskState would suppress the new task's verified done forever -
 		// syncTaskState writes that inherited done_verified onto the fresh row, making the suppression
 		// durable - and absorb its first unexplained stop.
-		if tracked && ts.CreatedAt != t.CreatedAt {
+		if tracked && (ts.CreatedAt != t.CreatedAt || ts.AttemptID != t.ActiveAttemptID) {
 			tracked = false
 		}
 		if !tracked {
@@ -273,6 +273,7 @@ func resumeTaskState(t state.Task, status herdr.Status, now time.Time) *TaskStat
 	ts.PersistedChangedFor = t.StatusChangedFor
 	ts.PersistedPaneID = t.Herdr.PaneID
 	ts.CreatedAt = t.CreatedAt
+	ts.AttemptID = t.ActiveAttemptID
 	ts.ReportCursor = state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest}
 	ts.PersistedCursor = ts.ReportCursor
 	ts.PRMerged = t.MergeAnnounced
@@ -558,7 +559,7 @@ func recordAutoPR(home, id, url string) error {
 		return nil
 	}
 	t.PR = url
-	if err := state.Write(home, t); err != nil {
+	if err := state.UpdateTask(home, t); err != nil {
 		return fmt.Errorf("write task %s: %w", id, err)
 	}
 	return nil
@@ -619,19 +620,28 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 	// tick would find anything to forget either.
 	forgetPaneScopedCache(ts, t, now)
 
+	active, err := state.ActiveAttempt(home, id)
+	if err != nil {
+		_, _ = fmt.Fprintf(errOut, "watch: read active attempt %s failed: %v\n", id, err)
+		return
+	}
 	t.ReportOffset = ts.ReportCursor.Offset
 	t.ReportDigest = ts.ReportCursor.Digest
 	t.MergeAnnounced = t.MergeAnnounced || ts.PRMerged
-	t.DoneVerified = t.DoneVerified || ts.DoneVerified
-	t.StatusChangedAt = ts.ChangedAt.UTC().Format(time.RFC3339)
-	t.StatusChangedFor = string(ts.Status)
-	t.LastReportState = ts.LastReportState
-	t.LastReportNote = ts.LastReportNote
-	t.ParkedFiredFor = parkedFiredStamp(ts.ParkedFiredFor)
-	t.UsageLimitRetryAt = limitRetryStamp(ts.LimitRetryAt)
-	t.UsageLimitAttempts = ts.LimitAttempts
-	if err := state.Write(home, t); err != nil {
+	active.DoneVerified = active.DoneVerified || ts.DoneVerified
+	active.StatusChangedAt = ts.ChangedAt.UTC().Format(time.RFC3339)
+	active.StatusChangedFor = string(ts.Status)
+	active.LastReportState = ts.LastReportState
+	active.LastReportNote = ts.LastReportNote
+	active.ParkedFiredFor = parkedFiredStamp(ts.ParkedFiredFor)
+	active.UsageLimitRetryAt = limitRetryStamp(ts.LimitRetryAt)
+	active.UsageLimitAttempts = ts.LimitAttempts
+	if err := state.UpdateTask(home, t); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: persist task %s failed: %v\n", id, err)
+		return
+	}
+	if err := state.UpdateAttempt(home, active); err != nil {
+		_, _ = fmt.Fprintf(errOut, "watch: persist attempt %s failed: %v\n", id, err)
 		return
 	}
 	ts.PersistedCursor = ts.ReportCursor

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -199,9 +199,9 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		}
 		status := pane.AgentStatus
 
-		// Tracking is keyed by task identity, not by ID: an ID torn down and respawned between two
-		// ticks is a different task. Same hazard as a surviving report channel, one layer in - see
-		// A new attempt on the same task ID is a new execution identity.
+		// Tracking is keyed by task identity, not by ID: a reopen or a promote gives the same ID a new
+		// attempt, and a new attempt is a new execution identity. Same hazard as a surviving report
+		// channel, one layer in.
 		ts, tracked := states[t.ID]
 		// Inheriting the previous run's TaskState would suppress the new task's verified done forever -
 		// syncTaskState writes that inherited done_verified onto the fresh row, making the suppression
@@ -626,6 +626,19 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 		_, _ = fmt.Fprintf(errOut, "watch: read task %s failed: %v\n", id, err)
 		return
 	}
+	t.ReportOffset = ts.ReportCursor.Offset
+	t.ReportDigest = ts.ReportCursor.Digest
+	t.MergeAnnounced = t.MergeAnnounced || ts.PRMerged
+	// The report cursor is task-owned and lands before the attempt is resolved: dropping it because a
+	// task terminalized mid-tick would replay lines this watcher already consumed, which re-raises
+	// resolved decisions and can auto-record a stale PR URL.
+	if err := state.UpdateTask(home, t); err != nil {
+		_, _ = fmt.Fprintf(errOut, "watch: persist task %s failed: %v\n", id, err)
+		return
+	}
+	ts.PersistedCursor = ts.ReportCursor
+	ts.PersistedPRMerged = ts.PRMerged
+
 	active, err := state.ActiveAttempt(home, id)
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: read active attempt %s failed: %v\n", id, err)
@@ -635,9 +648,6 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 	// erase its restamp and leave the disk value matching what this watcher persisted, so no later
 	// tick would find anything to forget either.
 	forgetPaneScopedCache(ts, t, active, now)
-	t.ReportOffset = ts.ReportCursor.Offset
-	t.ReportDigest = ts.ReportCursor.Digest
-	t.MergeAnnounced = t.MergeAnnounced || ts.PRMerged
 	active.DoneVerified = active.DoneVerified || ts.DoneVerified
 	active.StatusChangedAt = ts.ChangedAt.UTC().Format(time.RFC3339)
 	active.StatusChangedFor = string(ts.Status)
@@ -646,16 +656,10 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 	active.ParkedFiredFor = parkedFiredStamp(ts.ParkedFiredFor)
 	active.UsageLimitRetryAt = limitRetryStamp(ts.LimitRetryAt)
 	active.UsageLimitAttempts = ts.LimitAttempts
-	if err := state.UpdateTask(home, t); err != nil {
-		_, _ = fmt.Fprintf(errOut, "watch: persist task %s failed: %v\n", id, err)
-		return
-	}
 	if err := state.UpdateAttempt(home, active); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: persist attempt %s failed: %v\n", id, err)
 		return
 	}
-	ts.PersistedCursor = ts.ReportCursor
-	ts.PersistedPRMerged = ts.PRMerged
 	ts.PersistedDoneVerified = ts.DoneVerified
 	ts.PersistedChangedAt = ts.ChangedAt
 	ts.PersistedChangedFor = string(ts.Status)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -142,15 +142,19 @@ func connect(ctx context.Context) (*herdr.Client, error) {
 // Confirms every active task's pane answers before RunUntilEvent arms, since an unprobed task would
 // otherwise wait out the timeout with no distinguishing signal.
 func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error {
-	tasks, err := state.ListOpen(home)
+	histories, err := state.ListOpenHistories(home)
 	if err != nil {
 		return fmt.Errorf("list tasks: %w", err)
 	}
 	done := make(chan error, 1)
 	go func() {
-		for _, t := range tasks {
-			if _, err := client.PaneGetContext(ctx, t.Herdr.PaneID); err != nil {
-				done <- fmt.Errorf("%w: %s: %v", ErrArmFailed, t.ID, err)
+		for _, history := range histories {
+			if history.ActiveAttempt == nil {
+				done <- fmt.Errorf("%w: %s has no active attempt", ErrArmFailed, history.Task.ID)
+				return
+			}
+			if _, err := client.PaneGetContext(ctx, history.ActiveAttempt.Herdr.PaneID); err != nil {
+				done <- fmt.Errorf("%w: %s: %v", ErrArmFailed, history.Task.ID, err)
 				return
 			}
 		}
@@ -170,20 +174,26 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 }
 
 func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[string]*TaskState, out, errOut io.Writer) {
-	tasks, err := state.ListOpen(cfg.Home)
+	histories, err := state.ListOpenHistories(cfg.Home)
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: list tasks failed: %v\n", err)
 		return
 	}
 
-	seen := make(map[string]bool, len(tasks))
+	seen := make(map[string]bool, len(histories))
 	now := time.Now()
-	for _, t := range tasks {
+	for _, history := range histories {
 		if ctx.Err() != nil {
 			return
 		}
+		t := history.Task
+		if history.ActiveAttempt == nil {
+			_, _ = fmt.Fprintf(errOut, "watch: task %s has no active attempt\n", t.ID)
+			continue
+		}
+		attempt := *history.ActiveAttempt
 		seen[t.ID] = true
-		pane, probeErr := client.PaneGetContext(ctx, t.Herdr.PaneID)
+		pane, probeErr := client.PaneGetContext(ctx, attempt.Herdr.PaneID)
 		if ctx.Err() != nil {
 			return
 		}
@@ -205,7 +215,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 			if probeErr != nil {
 				status = herdr.StatusUnknown
 			}
-			ts = resumeTaskState(t, status, now)
+			ts = resumeTaskState(t, attempt, status, now)
 			// False starts ClassifyUnreachable's dwell clock immediately, instead of waiting for a second
 			// failed probe to notice this task at all.
 			ts.Probed = probeErr == nil
@@ -213,7 +223,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 			continue
 		}
 
-		forgetPaneScopedCache(ts, t, now)
+		forgetPaneScopedCache(ts, t, attempt, now)
 
 		t = tailReport(ctx, cfg, ts, t, out, errOut)
 
@@ -243,12 +253,12 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		if e := ClassifyDeferredDone(cfg.Home, ts, t); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
-		if mtime, err := reportEvidenceTime(cfg.Home, t); err != nil {
+		if mtime, err := reportEvidenceTime(cfg.Home, t, attempt); err != nil {
 			_, _ = fmt.Fprintf(errOut, "watch: stat report %s failed: %v\n", t.ID, err)
 		} else if e := ClassifyParked(ts, t.ID, ts.LastReportState, lastReportLine(ts), mtime, now, cfg.ParkedBounds); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
-		if e := classifyUsageLimit(cfg, client, ts, t, pane, status, probeErr, justStopped, now, errOut); e != nil {
+		if e := classifyUsageLimit(cfg, client, ts, t, attempt, pane, status, probeErr, justStopped, now, errOut); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
 		// Last, after every event this tick produced has been announced: a marker persisted before its
@@ -266,27 +276,27 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 
 // Every restored fact comes from durable state: re-deriving what landed while the watcher was down
 // would make new evidence look like an announcement that already went out.
-func resumeTaskState(t state.Task, status herdr.Status, now time.Time) *TaskState {
-	changedAt := statusChangeSeed(t, status, now)
+func resumeTaskState(t state.Task, a state.Attempt, status herdr.Status, now time.Time) *TaskState {
+	changedAt := statusChangeSeed(t, a, status, now)
 	ts := NewTaskState(status, changedAt)
 	ts.PersistedChangedAt = changedAt
-	ts.PersistedChangedFor = t.StatusChangedFor
-	ts.PersistedPaneID = t.Herdr.PaneID
+	ts.PersistedChangedFor = a.StatusChangedFor
+	ts.PersistedPaneID = a.Herdr.PaneID
 	ts.CreatedAt = t.CreatedAt
 	ts.AttemptID = t.ActiveAttemptID
 	ts.ReportCursor = state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest}
 	ts.PersistedCursor = ts.ReportCursor
 	ts.PRMerged = t.MergeAnnounced
 	ts.PersistedPRMerged = t.MergeAnnounced
-	ts.DoneVerified = t.DoneVerified
-	ts.PersistedDoneVerified = t.DoneVerified
-	ts.LastReportState = t.LastReportState
-	ts.LastReportNote = t.LastReportNote
-	ts.ParkedFiredFor = parkedFiredSeed(t)
+	ts.DoneVerified = a.DoneVerified
+	ts.PersistedDoneVerified = a.DoneVerified
+	ts.LastReportState = a.LastReportState
+	ts.LastReportNote = a.LastReportNote
+	ts.ParkedFiredFor = parkedFiredSeed(a)
 	ts.PersistedParkedFiredFor = ts.ParkedFiredFor
-	ts.LimitRetryAt = limitRetrySeed(t)
+	ts.LimitRetryAt = limitRetrySeed(a)
 	ts.PersistedLimitRetryAt = ts.LimitRetryAt
-	ts.LimitAttempts = t.UsageLimitAttempts
+	ts.LimitAttempts = a.UsageLimitAttempts
 	ts.PersistedLimitAttempts = ts.LimitAttempts
 	return ts
 }
@@ -294,8 +304,8 @@ func resumeTaskState(t state.Task, status herdr.Status, now time.Time) *TaskStat
 // Reads back the instant a limited worker may next be tried. An unparseable stamp seeds unlimited,
 // losing the schedule rather than inventing one: the next stop edge or first probe re-detects the limit
 // from the pane, whereas a stamp guessed at here would drive real steers off a value nothing wrote.
-func limitRetrySeed(t state.Task) time.Time {
-	parsed, err := time.Parse(time.RFC3339, t.UsageLimitRetryAt)
+func limitRetrySeed(a state.Attempt) time.Time {
+	parsed, err := time.Parse(time.RFC3339, a.UsageLimitRetryAt)
 	if err != nil {
 		return time.Time{}
 	}
@@ -312,8 +322,8 @@ func limitRetryStamp(retryAt time.Time) string {
 // Reads back the silence instant parked last fired against. An unparseable stamp seeds unfired
 // rather than failing the resume: one duplicate event is the same failure direction the whole
 // classifier already prefers over a suppressed one.
-func parkedFiredSeed(t state.Task) time.Time {
-	parsed, err := time.Parse(time.RFC3339Nano, t.ParkedFiredFor)
+func parkedFiredSeed(a state.Attempt) time.Time {
+	parsed, err := time.Parse(time.RFC3339Nano, a.ParkedFiredFor)
 	if err != nil {
 		return time.Time{}
 	}
@@ -333,25 +343,25 @@ func parkedFiredStamp(fired time.Time) string {
 // Drops the cached facts hand promote invalidated: it gives the task a new herdr pane while keeping
 // created_at, so tick's identity check never fires, yet every pane-anchored fact cached here
 // describes a pane the task no longer has.
-func forgetPaneScopedCache(ts *TaskState, t state.Task, now time.Time) {
+func forgetPaneScopedCache(ts *TaskState, t state.Task, a state.Attempt, now time.Time) {
 	// Compared against the persisted mirror, not the live flag: the watcher only ever sets the flag
 	// true, so a disk value gone false since this watcher wrote true is such a rewrite - while a flag
 	// set true earlier in this very tick is simply not persisted yet, which syncTaskState's OR fixes.
-	if !t.DoneVerified && ts.PersistedDoneVerified {
+	if !a.DoneVerified && ts.PersistedDoneVerified {
 		ts.DoneVerified = false
 		ts.PersistedDoneVerified = false
 	}
 	// The trigger is the pane changing, not the newly observed status differing - a ship whose first
 	// probe reads the status the scout last held raises no transition at all - and not a restamped
 	// timestamp, too eager (a resume reseeds the dwell) and too blunt (same-second restamps vanish).
-	if t.Herdr.PaneID == ts.PersistedPaneID {
+	if a.Herdr.PaneID == ts.PersistedPaneID {
 		return
 	}
-	ts.PersistedPaneID = t.Herdr.PaneID
-	seed := statusChangeSeed(t, ts.Status, now)
+	ts.PersistedPaneID = a.Herdr.PaneID
+	seed := statusChangeSeed(t, a, ts.Status, now)
 	ts.ChangedAt = seed
 	ts.PersistedChangedAt = seed
-	ts.PersistedChangedFor = t.StatusChangedFor
+	ts.PersistedChangedFor = a.StatusChangedFor
 	// Reset after the seed above, which asks what status the cached dwell describes. StatusUnknown
 	// matches neither the working nor the blocked branch, so a ship's first probe reads as the
 	// baseline a first sighting always is rather than as a transition out of the scout's status.
@@ -373,10 +383,10 @@ func forgetPaneScopedCache(ts *TaskState, t state.Task, now time.Time) {
 	ts.LimitProbed = false
 	// Re-read from the promoted row rather than zeroed alongside the rest, so the columns get written
 	// clear here in the one case hand promote did not already clear them itself.
-	ts.PersistedLimitRetryAt = limitRetrySeed(t)
-	ts.PersistedLimitAttempts = t.UsageLimitAttempts
-	ts.LastReportState = t.LastReportState
-	ts.LastReportNote = t.LastReportNote
+	ts.PersistedLimitRetryAt = limitRetrySeed(a)
+	ts.PersistedLimitAttempts = a.UsageLimitAttempts
+	ts.LastReportState = a.LastReportState
+	ts.LastReportNote = a.LastReportNote
 }
 
 // Classifies whatever report lines have arrived since ts.ReportCursor, before ClassifyStatus runs
@@ -413,13 +423,14 @@ func tailReport(ctx context.Context, cfg Config, ts *TaskState, t state.Task, ou
 
 // Answers how long a task has already been dwelling in status, so a restart does not reset a dwell
 // that has been real all along.
-func statusChangeSeed(t state.Task, status herdr.Status, now time.Time) time.Time {
+
+func statusChangeSeed(t state.Task, a state.Attempt, status herdr.Status, now time.Time) time.Time {
 	// StatusChangedAt is only evidence about the status it was stamped for.
-	if t.StatusChangedAt != "" {
-		if t.StatusChangedFor != string(status) {
+	if a.StatusChangedAt != "" {
+		if a.StatusChangedFor != string(status) {
 			return now
 		}
-		if parsed, err := time.Parse(time.RFC3339, t.StatusChangedAt); err == nil {
+		if parsed, err := time.Parse(time.RFC3339, a.StatusChangedAt); err == nil {
 			return parsed
 		}
 	}
@@ -433,8 +444,8 @@ func statusChangeSeed(t state.Task, status herdr.Status, now time.Time) time.Tim
 // Floors the report file's mtime at the instant the task's current pane started, because hand
 // promote leaves the scout's report file - and so its mtime - untouched while clearing the
 // last-report state that had the scout's silence under the long done/failed bound.
-func reportEvidenceTime(home string, t state.Task) (time.Time, error) {
-	started, err := paneStartTime(t)
+func reportEvidenceTime(home string, t state.Task, a state.Attempt) (time.Time, error) {
+	started, err := paneStartTime(t, a)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -456,8 +467,8 @@ func reportEvidenceTime(home string, t state.Task) (time.Time, error) {
 // When the task's current pane started, as spawn and hand promote each recorded it. Deliberately no
 // longer StatusChangedAt, which the outage-dwell clock restamps for a pane it could not even reach,
 // sliding this floor forward by up to a full bound of real report silence.
-func paneStartTime(t state.Task) (time.Time, error) {
-	stamp, field := t.PaneStartedAt, "pane_started_at"
+func paneStartTime(t state.Task, a state.Attempt) (time.Time, error) {
+	stamp, field := a.PaneStartedAt, "pane_started_at"
 	// The schema migration and the legacy import both backfill the column, so an empty stamp means a
 	// row nothing in hand wrote, and CreatedAt is the honest floor for it.
 	if stamp == "" {
@@ -615,16 +626,15 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 		_, _ = fmt.Fprintf(errOut, "watch: read task %s failed: %v\n", id, err)
 		return
 	}
-	// A promote may have landed since this tick's state.List. Writing the cached values back would
-	// erase its restamp and leave the disk value matching what this watcher persisted, so no later
-	// tick would find anything to forget either.
-	forgetPaneScopedCache(ts, t, now)
-
 	active, err := state.ActiveAttempt(home, id)
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: read active attempt %s failed: %v\n", id, err)
 		return
 	}
+	// A promote may have landed since this tick's state.List. Writing the cached values back would
+	// erase its restamp and leave the disk value matching what this watcher persisted, so no later
+	// tick would find anything to forget either.
+	forgetPaneScopedCache(ts, t, active, now)
 	t.ReportOffset = ts.ReportCursor.Offset
 	t.ReportDigest = ts.ReportCursor.Digest
 	t.MergeAnnounced = t.MergeAnnounced || ts.PRMerged

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1636,6 +1636,53 @@ func TestSyncTaskStateDropsCachePromoteInvalidatedMidTick(t *testing.T) {
 	}
 }
 
+// The report cursor is task-owned, so a task terminalized between this tick's read and its write-back
+// must not lose it: a surviving report log replayed from offset 0 re-raises resolved decisions and can
+// auto-record a stale PR URL onto the id's next attempt.
+func TestSyncTaskStateKeepsTheReportCursorWhenTheAttemptIsGone(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: now.UTC().Format(time.RFC3339)},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if err := state.TransitionAttempt(home, attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionTask(home, "task-1", state.TaskOpen, state.TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := &TaskState{
+		Status:          herdr.StatusWorking,
+		Probed:          true,
+		ChangedAt:       now,
+		PersistedPaneID: "p1",
+		ReportCursor:    state.ReportCursor{Offset: 128, Digest: "consumed-digest"},
+	}
+
+	var errBuf bytes.Buffer
+	syncTaskState(home, "task-1", ts, now, &errBuf)
+	if !strings.Contains(errBuf.String(), "read active attempt task-1 failed") {
+		t.Fatalf("errOut = %q, want the missing attempt named", errBuf.String())
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.ReportOffset != 128 || history.Task.ReportDigest != "consumed-digest" {
+		t.Fatalf("report cursor = %d/%q, want the consumed cursor persisted", history.Task.ReportOffset, history.Task.ReportDigest)
+	}
+	if ts.PersistedCursor != ts.ReportCursor {
+		t.Fatalf("ts.PersistedCursor = %+v, want the write it just made mirrored", ts.PersistedCursor)
+	}
+}
+
 // Matches want as a whole output line, so "reported-done <id>" and "done <id>" - one a substring of
 // the other - cannot be confused.
 func hasEventLine(out, want string) bool {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1455,6 +1455,7 @@ func TestForgetPaneScopedCacheGivesTheShipsFirstProbeFailureADwell(t *testing.T)
 func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 	before := TaskState{
 		CreatedAt:               "created-marker",
+		AttemptID:               99,
 		Status:                  herdr.Status("scout-status"),
 		Probed:                  true,
 		ChangedAt:               time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1494,6 +1494,7 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 	// the parked latch, keyed to the report mtime not the pane. Persisted* entries mirror those facts.
 	carried := map[string]bool{
 		"CreatedAt":               true,
+		"AttemptID":               true,
 		"PRMerged":                true,
 		"ReportCursor":            true,
 		"PersistedCursor":         true,

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -127,7 +127,31 @@ func waitForPaneGets(t *testing.T, callLog string, want int) {
 	t.Fatalf("timed out waiting for %d pane get calls", want)
 }
 
-func setupWatcherHome(t *testing.T, taskOpts state.Task) (home string) {
+func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.Attempt) error {
+	t.Helper()
+	if err := state.CreateTask(home, task); err != nil {
+		return err
+	}
+	attempt.TaskID = task.ID
+	if _, err := state.CreateAttempt(home, attempt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readTaskAttempt(t *testing.T, home, id string) (state.Task, state.Attempt) {
+	t.Helper()
+	history, err := state.ReadHistory(home, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil {
+		t.Fatalf("task %q has no active attempt", id)
+	}
+	return history.Task, *history.ActiveAttempt
+}
+
+func setupWatcherHome(t *testing.T, taskOpts state.Task, attempts ...state.Attempt) (home string) {
 	t.Helper()
 	home = t.TempDir()
 	// hand init creates this; the project registry (data/projects.md) expects it
@@ -138,7 +162,11 @@ func setupWatcherHome(t *testing.T, taskOpts state.Task) (home string) {
 	if taskOpts.CreatedAt == "" {
 		taskOpts.CreatedAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	if err := state.Write(home, taskOpts); err != nil {
+	attempt := state.Attempt{Lifecycle: state.AttemptRunning}
+	if len(attempts) != 0 {
+		attempt = attempts[0]
+	}
+	if err := writeTaskAttempt(t, home, taskOpts, attempt); err != nil {
 		t.Fatal(err)
 	}
 	return home
@@ -152,7 +180,7 @@ func TestTickClassifiesNotBusyAsIdleUnreportedRegardlessOfHerdrSpelling(t *testi
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -181,12 +209,9 @@ func TestTickClassifiesNotBusyAsIdleUnreportedRegardlessOfHerdrSpelling(t *testi
 	// The task's own recorded report state stays empty rather than turning into
 	// "done": it is derived from what the worker wrote, and an idle pane is an
 	// observation about the harness, not a word the worker said.
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != "" {
-		t.Fatalf("LastReportState = %q, want no report state invented from an unexplained herdr transition", task.LastReportState)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != "" {
+		t.Fatalf("LastReportState = %q, want no report state invented from an unexplained herdr transition", attempt.LastReportState)
 	}
 
 	logData, err := os.ReadFile(filepath.Join(home, "state", "events.log"))
@@ -212,11 +237,9 @@ func TestTickRecordsVerifiedDoneOnlyOnceReportedDoneIsVerified(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip,
-		PR: "https://github.com/atqamz/hand/pull/1", MergeExecuted: true,
-		Herdr: state.Herdr{PaneID: "p1"},
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		PR: "https://github.com/atqamz/hand/pull/1", MergeExecuted: true}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}},
+	)
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -235,15 +258,12 @@ func TestTickRecordsVerifiedDoneOnlyOnceReportedDoneIsVerified(t *testing.T) {
 		t.Fatalf("output = %q, want a verified done event", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !task.DoneVerified {
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if !attempt.DoneVerified {
 		t.Fatal("task.DoneVerified = false, want the verified done persisted")
 	}
-	if task.LastReportState != state.ReportDone {
-		t.Fatalf("LastReportState = %q, want %q recorded", task.LastReportState, state.ReportDone)
+	if attempt.LastReportState != state.ReportDone {
+		t.Fatalf("LastReportState = %q, want %q recorded", attempt.LastReportState, state.ReportDone)
 	}
 }
 
@@ -255,7 +275,7 @@ func TestTickClassifiesBlockedWithoutInventingAPendingDecision(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -272,12 +292,9 @@ func TestTickClassifiesBlockedWithoutInventingAPendingDecision(t *testing.T) {
 		t.Fatalf("output = %q, want blocked task-1", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != "" {
-		t.Fatalf("LastReportState = %q, want nothing inferred from a pane the worker never explained", task.LastReportState)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != "" {
+		t.Fatalf("LastReportState = %q, want nothing inferred from a pane the worker never explained", attempt.LastReportState)
 	}
 }
 
@@ -287,7 +304,7 @@ func TestTickClassifiesPRMerged(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "MERGED")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://example.com/pr/1", Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -315,7 +332,7 @@ func TestTickFiresIdleUnreportedWhenPaneGoesNotBusyWithNoReport(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -334,12 +351,9 @@ func TestTickFiresIdleUnreportedWhenPaneGoesNotBusyWithNoReport(t *testing.T) {
 		t.Fatalf("output = %q, want idle-unreported task-1 when nothing explained the stop", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != "" {
-		t.Fatalf("LastReportState = %q, want the idle pane raised as an event and not as a decision the worker never asked for", task.LastReportState)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != "" {
+		t.Fatalf("LastReportState = %q, want the idle pane raised as an event and not as a decision the worker never asked for", attempt.LastReportState)
 	}
 }
 
@@ -348,7 +362,7 @@ func TestTickAbsorbsNotBusyWhenReportExplainsTheStop(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -381,7 +395,7 @@ func TestTickAutoRecordsPRFromReportLine(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "OPEN")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -417,7 +431,7 @@ func TestTickDoesNotOverwriteAlreadyRecordedPR(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "OPEN")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -450,7 +464,7 @@ func TestTickRefusesToAutoRecordAForeignRepoPR(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "OPEN")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -498,7 +512,7 @@ func TestTickKeepsAWorkerQuestionWhenItsPRURLIsRefused(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "OPEN")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -519,12 +533,9 @@ func TestTickKeepsAWorkerQuestionWhenItsPRURLIsRefused(t *testing.T) {
 		t.Fatalf("out = %q, want the refusal still announced", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != state.ReportNeedsDecision || !strings.Contains(task.LastReportNote, "which base branch?") {
-		t.Fatalf("LastReportState/Note = %q/%q, want the worker's own question intact", task.LastReportState, task.LastReportNote)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != state.ReportNeedsDecision || !strings.Contains(attempt.LastReportNote, "which base branch?") {
+		t.Fatalf("LastReportState/Note = %q/%q, want the worker's own question intact", attempt.LastReportState, attempt.LastReportNote)
 	}
 }
 
@@ -537,7 +548,7 @@ func TestTickSurfacesAContendedAutoRecordInsteadOfWaiting(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "OPEN")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -597,7 +608,7 @@ func TestTickStaysSilentWhenTheLockHolderRecordedTheSamePR(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	url := "https://github.com/atqamz/hand/pull/7"
@@ -651,14 +662,22 @@ func TestTickStaysSilentWhenTheLockHolderRecordedTheSamePR(t *testing.T) {
 // the whole database and copying it is the whole substitution.
 func taskSnapshotWithPR(t *testing.T, home, id, pr string) string {
 	t.Helper()
-	task, err := state.Read(home, id)
+	history, err := state.ReadHistory(home, id)
 	if err != nil {
 		t.Fatal(err)
 	}
+	task := history.Task
 	task.PR = pr
+	task.ActiveAttemptID = 0
 	scratch := t.TempDir()
-	if err := state.Write(scratch, task); err != nil {
+	if err := state.CreateTask(scratch, task); err != nil {
 		t.Fatal(err)
+	}
+	for _, attempt := range history.Attempts {
+		attempt.ID = 0
+		if _, err := state.CreateAttempt(scratch, attempt); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return store.Path(scratch)
 }
@@ -671,7 +690,7 @@ func TestTickReportsAnUnreadableTaskWhenTheLockIsContended(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	url := "https://github.com/atqamz/hand/pull/7"
@@ -722,7 +741,7 @@ func TestTickAnnouncesPRMergedBeforePersistingIt(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "MERGED")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -776,7 +795,7 @@ func TestTickDoesNotReannounceAPollObservedMergeAfterRestart(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGh(t, "MERGED")
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1", Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, PR: "https://github.com/atqamz/hand/pull/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -809,7 +828,7 @@ func TestTickReportsAnUnreadableReport(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	if err := os.MkdirAll(state.ReportPath(home, "task-1"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -832,7 +851,7 @@ func TestTickResumesReportTailAfterRestart(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -881,7 +900,7 @@ func TestTickAnnouncesADoneRewrittenToTheSameLengthAcrossARestart(t *testing.T) 
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -914,14 +933,12 @@ func TestTickAnnouncesADoneRewrittenToTheSameLengthAcrossARestart(t *testing.T) 
 		t.Fatalf("out = %q, want the same-length done rewrite announced", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != state.ReportDone {
-		t.Fatalf("LastReportState = %q, want the done rewrite recorded so the deferred verification can fire", task.LastReportState)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != state.ReportDone {
+		t.Fatalf("LastReportState = %q, want the done rewrite recorded so the deferred verification can fire", attempt.LastReportState)
 	}
 
+	task, _ := readTaskAttempt(t, home, "task-1")
 	task.MergeExecuted = true
 	if err := state.Write(home, task); err != nil {
 		t.Fatal(err)
@@ -941,10 +958,9 @@ func TestTickFiresParkedOnFirstResumedTickWhenTheSilenceAlreadyExceedsTheBound(t
 	// Created before the silence it is about to be blamed for: reportEvidenceTime
 	// floors the mtime at the pane's start, so a task younger than its own report
 	// file could not accumulate this silence in the first place.
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}},
+	)
 	reportPath := state.ReportPath(home, "task-1")
 	if err := os.WriteFile(reportPath, []byte("working: still on the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -987,11 +1003,11 @@ func TestTickDoesNotRefireParkedForADoneTaskAcrossARestart(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 
 	started := time.Now().Add(-2 * time.Hour)
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt:     started.UTC().Format(time.RFC3339),
-		PaneStartedAt: started.UTC().Format(time.RFC3339),
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: started.UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+
+		PaneStartedAt: started.UTC().Format(time.RFC3339)},
+	)
 	reportPath := state.ReportPath(home, "task-1")
 	if err := os.WriteFile(reportPath, []byte("done: shipped the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -1034,14 +1050,13 @@ func TestReportEvidenceTimeFloorsOnThePaneStartNotTheOutageStamp(t *testing.T) {
 	now := time.Now()
 	home := t.TempDir()
 	paneStart := now.Add(-3 * time.Hour)
-	task := state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt:        now.Add(-4 * time.Hour).UTC().Format(time.RFC3339),
+	task := state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: now.Add(-4 * time.Hour).UTC().Format(time.RFC3339)}
+	attempt := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
 		PaneStartedAt:    paneStart.UTC().Format(time.RFC3339),
 		StatusChangedAt:  now.Add(-time.Minute).UTC().Format(time.RFC3339),
-		StatusChangedFor: string(herdr.StatusUnknown),
-	}
-	if err := state.Write(home, task); err != nil {
+		StatusChangedFor: string(herdr.StatusUnknown)}
+	if err := writeTaskAttempt(t, home, task, attempt); err != nil {
 		t.Fatal(err)
 	}
 	reportPath := state.ReportPath(home, "task-1")
@@ -1053,7 +1068,7 @@ func TestReportEvidenceTimeFloorsOnThePaneStartNotTheOutageStamp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := reportEvidenceTime(home, task)
+	got, err := reportEvidenceTime(home, task, attempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1062,8 +1077,9 @@ func TestReportEvidenceTimeFloorsOnThePaneStartNotTheOutageStamp(t *testing.T) {
 	}
 
 	promoted := task
-	promoted.PaneStartedAt = now.Add(-time.Minute).UTC().Format(time.RFC3339)
-	got, err = reportEvidenceTime(home, promoted)
+	promotedAttempt := attempt
+	promotedAttempt.PaneStartedAt = now.Add(-time.Minute).UTC().Format(time.RFC3339)
+	got, err = reportEvidenceTime(home, promoted, promotedAttempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1079,11 +1095,10 @@ func TestTickTiesTheStaleDwellToDurableEvidenceAcrossARestart(t *testing.T) {
 
 	home := t.TempDir()
 	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
-	task := state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt: dwelling, StatusChangedAt: dwelling, StatusChangedFor: "working",
-	}
-	if err := state.Write(home, task); err != nil {
+	task := state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, CreatedAt: dwelling}
+	attempt := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		StatusChangedAt: dwelling, StatusChangedFor: "working"}
+	if err := writeTaskAttempt(t, home, task, attempt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1112,10 +1127,10 @@ func TestTickRefusesADurableDwellStampedForADifferentStatus(t *testing.T) {
 
 	home := t.TempDir()
 	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt: dwelling, StatusChangedAt: dwelling, StatusChangedFor: "blocked",
-	}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: dwelling}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		StatusChangedAt: dwelling, StatusChangedFor: "blocked"},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1132,12 +1147,9 @@ func TestTickRefusesADurableDwellStampedForADifferentStatus(t *testing.T) {
 		t.Fatalf("output = %q, want no stale: the 30m stamp was recorded for blocked, so it says nothing about how long working has been held", buf.String())
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.StatusChangedFor != "working" || got.StatusChangedAt == dwelling {
-		t.Fatalf("status_changed_at/for = %q/%q, want the dwell restamped for the status actually observed", got.StatusChangedAt, got.StatusChangedFor)
+	_, gotAttempt := readTaskAttempt(t, home, "task-1")
+	if gotAttempt.StatusChangedFor != "working" || gotAttempt.StatusChangedAt == dwelling {
+		t.Fatalf("status_changed_at/for = %q/%q, want the dwell restamped for the status actually observed", gotAttempt.StatusChangedAt, gotAttempt.StatusChangedFor)
 	}
 }
 
@@ -1149,7 +1161,7 @@ func TestTickAnnouncesAVerifiedDoneAfterARestartThatMissedTheEvidence(t *testing
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -1170,11 +1182,8 @@ func TestTickAnnouncesAVerifiedDoneAfterARestartThatMissedTheEvidence(t *testing
 
 	// hand merge, with the watcher stopped: it writes merged, leaving the
 	// verified announcement to whichever watcher restarts and rereads the evidence.
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.DoneVerified {
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.DoneVerified {
 		t.Fatal("task.DoneVerified = true, want the unverified report to leave the marker unset")
 	}
 	task.MergeExecuted = true
@@ -1190,15 +1199,12 @@ func TestTickAnnouncesAVerifiedDoneAfterARestartThatMissedTheEvidence(t *testing
 		t.Fatalf("out = %q, want the verified done announced by the restarted watcher", buf.String())
 	}
 
-	task, err = state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, attempt = readTaskAttempt(t, home, "task-1")
 	// Without the announcement the recorded state stays stuck where the unverified report left it.
-	if task.LastReportState != state.ReportDone {
-		t.Fatalf("LastReportState = %q, want the task's own recorded state moved to done", task.LastReportState)
+	if attempt.LastReportState != state.ReportDone {
+		t.Fatalf("LastReportState = %q, want the task's own recorded state moved to done", attempt.LastReportState)
 	}
-	if !task.DoneVerified {
+	if !attempt.DoneVerified {
 		t.Fatal("task.DoneVerified = false, want the announcement persisted after the fact")
 	}
 
@@ -1218,7 +1224,7 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -1244,11 +1250,8 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	if !hasEventLine(buf.String(), "done task-1: scout findings") {
 		t.Fatalf("out = %q, want the scout's verified done", buf.String())
 	}
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !task.DoneVerified {
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	if !attempt.DoneVerified {
 		t.Fatal("task.DoneVerified = false, want the scout's announcement persisted")
 	}
 
@@ -1256,9 +1259,12 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	// CreatedAt and the report channel do not - with the DoneVerified reset this
 	// test exists to cover.
 	task.Kind = state.KindShip
-	task.Herdr.PaneID = "p2"
-	task.DoneVerified = false
+	attempt.Herdr.PaneID = "p2"
+	attempt.DoneVerified = false
 	if err := state.Write(home, task); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.UpdateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1281,15 +1287,16 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	if !hasEventLine(buf.String(), "reported-done task-1: ship work") {
 		t.Fatalf("out = %q, want an unverified reported-done - the ship has not merged yet", buf.String())
 	}
-	task, err = state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.DoneVerified {
+	_, attempt = readTaskAttempt(t, home, "task-1")
+	if attempt.DoneVerified {
 		t.Fatal("task.DoneVerified = true, want promote's reset not resurrected by the cached copy")
 	}
 
 	// hand merge lands the evidence the ship's own done needs.
+	task, err = state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	task.MergeExecuted = true
 	if err := state.Write(home, task); err != nil {
 		t.Fatal(err)
@@ -1312,10 +1319,10 @@ func TestTickDropsTheCachedDwellWhenPromoteMovesTheTaskToANewPane(t *testing.T) 
 
 	home := t.TempDir()
 	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindScout, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt: dwelling, StatusChangedAt: dwelling, StatusChangedFor: "working",
-	}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout,
+		CreatedAt: dwelling}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		StatusChangedAt: dwelling, StatusChangedFor: "working"},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1327,15 +1334,15 @@ func TestTickDropsTheCachedDwellWhenPromoteMovesTheTaskToANewPane(t *testing.T) 
 	var buf bytes.Buffer
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 
-	promoted, err := state.Read(home, "task-1")
-	if err != nil {
+	promoted, attempt := readTaskAttempt(t, home, "task-1")
+	promoted.Kind = state.KindShip
+	attempt.Herdr.PaneID = "p2"
+	attempt.StatusChangedAt = time.Now().UTC().Format(time.RFC3339)
+	attempt.StatusChangedFor = ""
+	if err := state.Write(home, promoted); err != nil {
 		t.Fatal(err)
 	}
-	promoted.Kind = state.KindShip
-	promoted.Herdr.PaneID = "p2"
-	promoted.StatusChangedAt = time.Now().UTC().Format(time.RFC3339)
-	promoted.StatusChangedFor = ""
-	if err := state.Write(home, promoted); err != nil {
+	if err := state.UpdateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1350,26 +1357,23 @@ func TestTickDropsTheCachedDwellWhenPromoteMovesTheTaskToANewPane(t *testing.T) 
 		t.Fatalf("out = %q, want no stale: the ship's dwell starts at the promotion, not at the scout's last observed transition", buf.String())
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.StatusChangedAt == dwelling {
+	_, gotAttempt := readTaskAttempt(t, home, "task-1")
+	if gotAttempt.StatusChangedAt == dwelling {
 		t.Fatal("status_changed_at = the scout's stamp, want the cached scout dwell not written back over promote's restamp")
 	}
-	stamped, err := time.Parse(time.RFC3339, got.StatusChangedAt)
+	stamped, err := time.Parse(time.RFC3339, gotAttempt.StatusChangedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	restamped, err := time.Parse(time.RFC3339, promoted.StatusChangedAt)
+	restamped, err := time.Parse(time.RFC3339, attempt.StatusChangedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stamped.Before(restamped) {
-		t.Fatalf("status_changed_at = %q, want no earlier than promote's restamp %q", got.StatusChangedAt, promoted.StatusChangedAt)
+		t.Fatalf("status_changed_at = %q, want no earlier than promote's restamp %q", gotAttempt.StatusChangedAt, attempt.StatusChangedAt)
 	}
-	if got.StatusChangedFor != "working" {
-		t.Fatalf("status_changed_for = %q, want the status the ship's dwell was stamped for", got.StatusChangedFor)
+	if gotAttempt.StatusChangedFor != "working" {
+		t.Fatalf("status_changed_for = %q, want the status the ship's dwell was stamped for", gotAttempt.StatusChangedFor)
 	}
 }
 
@@ -1393,12 +1397,9 @@ func TestForgetPaneScopedCacheClearsEveryPaneAnchoredLatch(t *testing.T) {
 		LastReportNote:        "scout findings",
 	}
 
-	promoted := state.Task{
-		ID: "task-1", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p2"},
-		CreatedAt:       scoutDwell.UTC().Format(time.RFC3339),
-		StatusChangedAt: now.UTC().Format(time.RFC3339),
-	}
-	forgetPaneScopedCache(ts, promoted, now)
+	promoted := state.Task{ID: "task-1", Kind: state.KindShip, CreatedAt: scoutDwell.UTC().Format(time.RFC3339)}
+	promotedAttempt := state.Attempt{Herdr: state.Herdr{PaneID: "p2"}, StatusChangedAt: now.UTC().Format(time.RFC3339)}
+	forgetPaneScopedCache(ts, promoted, promotedAttempt, now)
 
 	if ts.Stale || ts.Blocked {
 		t.Fatalf("Stale = %v, Blocked = %v, want both latches cleared for the ship's new pane", ts.Stale, ts.Blocked)
@@ -1435,7 +1436,7 @@ func TestForgetPaneScopedCacheGivesTheShipsFirstProbeFailureADwell(t *testing.T)
 		PersistedPaneID: "p1",
 	}
 
-	forgetPaneScopedCache(ts, promotedTask(now), now)
+	forgetPaneScopedCache(ts, promotedTask(now), promotedAttempt(now), now)
 
 	if e := ClassifyStatus(ts, "task-1", "", errors.New("pane not found"), now); e != nil {
 		t.Fatalf("event = %+v, want none: a blink on the ship's first probe is not a failure", e)
@@ -1481,13 +1482,10 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 		LimitProbed:             true,
 		UnreachableFired:        true,
 	}
-	promoted := state.Task{
-		Herdr:            state.Herdr{PaneID: "ship-pane"},
-		DoneVerified:     false,
-		CreatedAt:        "2020-01-01T00:00:00Z",
-		StatusChangedFor: "",
-		LastReportState:  "ship-report-state",
-		LastReportNote:   "ship-report-note",
+	promoted := state.Task{CreatedAt: "2020-01-01T00:00:00Z"}
+	promotedAttempt := state.Attempt{
+		Herdr: state.Herdr{PaneID: "ship-pane"}, LastReportState: "ship-report-state",
+		LastReportNote: "ship-report-note",
 	}
 
 	// Every field the PR body's field-by-field table classifies as pane-independent, so
@@ -1505,7 +1503,7 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 	}
 
 	ts := before
-	forgetPaneScopedCache(&ts, promoted, time.Now())
+	forgetPaneScopedCache(&ts, promoted, promotedAttempt, time.Now())
 
 	// Walking every field by reflection: one neither reset/re-derived nor named in the carried map fails
 	// automatically by staying equal to its deliberately-stale "before" value. Which of the two fixes it
@@ -1533,10 +1531,13 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 
 func promotedTask(now time.Time) state.Task {
 	return state.Task{
-		ID: "task-1", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p2"},
-		CreatedAt:       now.Add(-30 * time.Minute).UTC().Format(time.RFC3339),
-		StatusChangedAt: now.UTC().Format(time.RFC3339),
+		ID: "task-1", Kind: state.KindShip,
+		CreatedAt: now.Add(-30 * time.Minute).UTC().Format(time.RFC3339),
 	}
+}
+
+func promotedAttempt(now time.Time) state.Attempt {
+	return state.Attempt{Herdr: state.Herdr{PaneID: "p2"}, StatusChangedAt: now.UTC().Format(time.RFC3339)}
 }
 
 // The scout's status is the baseline the ship's first probe would be diffed
@@ -1552,7 +1553,7 @@ func TestForgetPaneScopedCacheStopsIdleUnreportedForAStatusTheShipNeverHeld(t *t
 		LastReportNote:  "scout findings",
 	}
 
-	forgetPaneScopedCache(ts, promotedTask(now), now)
+	forgetPaneScopedCache(ts, promotedTask(now), promotedAttempt(now), now)
 
 	if e := ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, now.Add(time.Second)); e != nil {
 		t.Fatalf("event = %+v, want none: the ship was never observed working, so its first probe cannot be an unexplained stop", e)
@@ -1571,7 +1572,7 @@ func TestForgetPaneScopedCacheLetsTheShipsOwnBlockedFireAfterABlockedScout(t *te
 		PersistedPaneID: "p1",
 	}
 
-	forgetPaneScopedCache(ts, promotedTask(now), now)
+	forgetPaneScopedCache(ts, promotedTask(now), promotedAttempt(now), now)
 
 	e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(time.Second))
 	if e == nil || e.Kind != KindBlocked {
@@ -1601,12 +1602,13 @@ func TestSyncTaskStateDropsCachePromoteInvalidatedMidTick(t *testing.T) {
 		ReportCursor:          state.ReportCursor{Offset: 42, Digest: "cached-digest"},
 	}
 
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p2"},
-		CreatedAt:       scoutDwell.UTC().Format(time.RFC3339),
-		StatusChangedAt: now.UTC().Format(time.RFC3339),
-		ReportOffset:    42,
-	}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: scoutDwell.UTC().Format(time.RFC3339),
+
+		ReportOffset: 42}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p2"},
+
+		StatusChangedAt: now.UTC().Format(time.RFC3339)},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1616,21 +1618,18 @@ func TestSyncTaskStateDropsCachePromoteInvalidatedMidTick(t *testing.T) {
 		t.Fatalf("errOut = %q, want a clean write", errBuf.String())
 	}
 
-	got, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.StatusChangedAt == scoutDwell.UTC().Format(time.RFC3339) {
+	_, gotAttempt := readTaskAttempt(t, home, "task-1")
+	if gotAttempt.StatusChangedAt == scoutDwell.UTC().Format(time.RFC3339) {
 		t.Fatal("status_changed_at = the scout's stamp, want promote's restamp not overwritten")
 	}
-	if got.StatusChangedFor != string(herdr.StatusUnknown) {
-		t.Fatalf("status_changed_for = %q, want the restamped dwell to belong to no observed status: this tick probed the scout's pane", got.StatusChangedFor)
+	if gotAttempt.StatusChangedFor != string(herdr.StatusUnknown) {
+		t.Fatalf("status_changed_for = %q, want the restamped dwell to belong to no observed status: this tick probed the scout's pane", gotAttempt.StatusChangedFor)
 	}
-	if got.DoneVerified {
+	if gotAttempt.DoneVerified {
 		t.Fatal("done_verified = true, want the scout's marker not resurrected by the cached copy")
 	}
-	if got.LastReportState != "" || got.LastReportNote != "" {
-		t.Fatalf("last_report_state/note = %q/%q, want the scout's report evidence not written back", got.LastReportState, got.LastReportNote)
+	if gotAttempt.LastReportState != "" || gotAttempt.LastReportNote != "" {
+		t.Fatalf("last_report_state/note = %q/%q, want the scout's report evidence not written back", gotAttempt.LastReportState, gotAttempt.LastReportNote)
 	}
 	if ts.Stale {
 		t.Fatal("ts.Stale = true, want the cached stale latch cleared for the ship's pane")
@@ -1657,7 +1656,7 @@ func TestTickKeepsAMultiLineAutoRecordFailureOnOneLine(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	writeFakeGhFailingMultiline(t)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	registerProject(t, home, "nsr", "https://github.com/atqamz/hand.git")
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -1722,7 +1721,7 @@ func TestTickForgetsTornDownTasks(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -1919,7 +1918,7 @@ func TestRunExitsWhenPaneProbeIsCanceled(t *testing.T) {
 		Hang:       []string{"pane get"},
 		Log:        callLog, LogCommands: []string{"pane get"},
 	}.Install(t, faketool.Bin(t))
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1948,7 +1947,7 @@ func TestRunUntilEventTakesTheStartupStateAsBaseline(t *testing.T) {
 	setStatus(t, statusFile, "done")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR checks green\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -1979,7 +1978,7 @@ func TestRunUntilEventDeliversTheFirstTransitionAndReturns(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	callLog := logPaneGets(t)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
 
 	var out bytes.Buffer
@@ -2013,7 +2012,7 @@ func TestRunUntilEventFiltersWakesToTheRequestedKinds(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 	callLog := logPaneGets(t)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{
 		Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second,
 		EventFilter: NewEventFilter([]string{KindBlocked}),
@@ -2061,7 +2060,7 @@ func TestRunUntilEventDeliversIdleUnreportedForAWorkerThatWentQuiet(t *testing.T
 	writeFakeHerdr(t, statusFile)
 	callLog := logPaneGets(t)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("working: still on the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -2092,7 +2091,7 @@ func TestRunUntilEventReportsNoEventOnTimeout(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 100 * time.Millisecond}
 
 	var out bytes.Buffer
@@ -2118,7 +2117,7 @@ func TestRunUntilEventReportsNoEventOnContextCancel(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2178,7 +2177,7 @@ func TestRunUntilEventReportsNoEventWhenTheArmProbeHangs(t *testing.T) {
 		Hang:       []string{"pane get"},
 	}.Install(t, faketool.Bin(t))
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 100 * time.Millisecond}
 
 	start := time.Now()
@@ -2200,7 +2199,7 @@ func TestRunUntilEventFailsToArmWhenATaskCannotBeProbed(t *testing.T) {
 	setStatus(t, statusFile, paneGoneStatus)
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: time.Second}
 
 	err := RunUntilEvent(context.Background(), cfg, &bytes.Buffer{}, io.Discard)
@@ -2223,7 +2222,7 @@ func TestTickResumesTheLastStateAfterATrailingMalformedLine(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	ctx := context.Background()
@@ -2252,12 +2251,9 @@ func TestTickResumesTheLastStateAfterATrailingMalformedLine(t *testing.T) {
 		t.Fatalf("output = %q, want the stop still explained by the needs-decision the malformed line followed", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != state.ReportNeedsDecision || !strings.Contains(task.LastReportNote, "which base branch?") {
-		t.Fatalf("LastReportState/Note = %q/%q, want the worker's own question left intact", task.LastReportState, task.LastReportNote)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != state.ReportNeedsDecision || !strings.Contains(attempt.LastReportNote, "which base branch?") {
+		t.Fatalf("LastReportState/Note = %q/%q, want the worker's own question left intact", attempt.LastReportState, attempt.LastReportNote)
 	}
 }
 
@@ -2269,7 +2265,7 @@ func TestTickReseedsARespawnedTaskID(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	reportMD := filepath.Join(home, "data", "task-1", "report.md")
 	if err := os.MkdirAll(filepath.Dir(reportMD), 0o755); err != nil {
 		t.Fatal(err)
@@ -2302,9 +2298,10 @@ func TestTickReseedsARespawnedTaskID(t *testing.T) {
 	if err := os.Remove(reportMD); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout,
-		Herdr:     state.Herdr{PaneID: "p1"},
-		CreatedAt: time.Now().UTC().Add(time.Minute).Format(time.RFC3339)}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout,
+
+		CreatedAt: time.Now().UTC().Add(time.Minute).Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2318,11 +2315,8 @@ func TestTickReseedsARespawnedTaskID(t *testing.T) {
 		t.Fatalf("output = %q, want the respawned task's own done report read from offset 0", buf.String())
 	}
 
-	respawned, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if respawned.DoneVerified {
+	_, respawnedAttempt := readTaskAttempt(t, home, "task-1")
+	if respawnedAttempt.DoneVerified {
 		t.Fatal("done_verified inherited by a respawned ID, want the previous run's announcement not carried over")
 	}
 
@@ -2344,7 +2338,7 @@ func TestTickSetsTheStateColumnOnAReportedStop(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -2369,12 +2363,9 @@ func TestTickSetsTheStateColumnOnAReportedStop(t *testing.T) {
 		}
 		tick(ctx, cfg, client, states, &bytes.Buffer{}, io.Discard)
 
-		task, err := state.Read(home, "task-1")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if task.LastReportState != tc.wantState {
-			t.Fatalf("LastReportState = %q after %q, want state %s", task.LastReportState, tc.line, tc.wantState)
+		_, attempt := readTaskAttempt(t, home, "task-1")
+		if attempt.LastReportState != tc.wantState {
+			t.Fatalf("LastReportState = %q after %q, want state %s", attempt.LastReportState, tc.line, tc.wantState)
 		}
 	}
 }
@@ -2387,7 +2378,7 @@ func TestTickStaysSilentOnABlinkAtFirstSighting(t *testing.T) {
 	setStatus(t, statusFile, paneGoneStatus)
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -2417,7 +2408,7 @@ func TestTickAnnouncesATaskUnreachableAtFirstSightingOnceTheDwellMatures(t *test
 	setStatus(t, statusFile, paneGoneStatus)
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: 20 * time.Minute}
 	client := herdr.NewClient()
 	states := make(map[string]*TaskState)
@@ -2454,10 +2445,10 @@ func TestTickResumesAnUnreachableDwellAcrossARestart(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 
 	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
-	home := setupWatcherHome(t, state.Task{
-		ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"},
-		CreatedAt: dwelling, StatusChangedAt: dwelling, StatusChangedFor: "unknown",
-	})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: dwelling}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		StatusChangedAt: dwelling, StatusChangedFor: "unknown"},
+	)
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: 20 * time.Minute}
 	client := herdr.NewClient()
@@ -2485,7 +2476,7 @@ func TestTickKeepsAPendingQuestionWhenThePaneProbeFails(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, Herdr: state.Herdr{PaneID: "p1"}})
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 	client := herdr.NewClient()
@@ -2507,11 +2498,8 @@ func TestTickKeepsAPendingQuestionWhenThePaneProbeFails(t *testing.T) {
 		t.Fatalf("output = %q, want the failed event", buf.String())
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != state.ReportNeedsDecision || !strings.Contains(task.LastReportNote, "which base branch?") {
-		t.Fatalf("LastReportState/Note = %q/%q, want the worker's question left standing", task.LastReportState, task.LastReportNote)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != state.ReportNeedsDecision || !strings.Contains(attempt.LastReportNote, "which base branch?") {
+		t.Fatalf("LastReportState/Note = %q/%q, want the worker's question left standing", attempt.LastReportState, attempt.LastReportNote)
 	}
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -70,12 +70,10 @@ func Return(worktreePath string, force bool) error {
 // CheckCollision cross-checks a freshly acquired lease against every other task's recorded one,
 // returning the ID of the conflicting task or "" for no collision.
 func CheckCollision(homeDir string, lease Lease, excludeID string) (string, error) {
-	tasks, err := state.List(homeDir)
+	tasks, err := state.ListOpen(homeDir)
 	if err != nil {
 		return "", err
 	}
-	// Done and failed rows are compared too, because a task holds its lease until teardown
-	// returns it.
 	for _, t := range tasks {
 		if t.ID == excludeID {
 			continue

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -70,27 +70,28 @@ func Return(worktreePath string, force bool) error {
 // CheckCollision cross-checks a freshly acquired lease against every other task's recorded one,
 // returning the ID of the conflicting task or "" for no collision.
 func CheckCollision(homeDir string, lease Lease, excludeID string) (string, error) {
-	tasks, err := state.ListOpen(homeDir)
+	histories, err := state.ListOpenHistories(homeDir)
 	if err != nil {
 		return "", err
 	}
-	for _, t := range tasks {
-		if t.ID == excludeID {
+	for _, history := range histories {
+		if history.Task.ID == excludeID || history.ActiveAttempt == nil {
 			continue
 		}
-		if lease.ID != "" && t.LeaseID != "" {
+		attempt := history.ActiveAttempt
+		if lease.ID != "" && attempt.LeaseID != "" {
 			// Identity rather than path: a pool slot path is recycled across leases while an
 			// identity never is, so a row a failed teardown left behind still names a path
 			// treehouse has freed, and path equality refused the next spawn over that.
-			if t.LeaseID == lease.ID {
-				return t.ID, nil
+			if attempt.LeaseID == lease.ID {
+				return history.Task.ID, nil
 			}
 			continue
 		}
 		// Fallback whenever either side has no identity, which is any row written before the
 		// lease_id column existed.
-		if t.Worktree == lease.Path {
-			return t.ID, nil
+		if attempt.Worktree == lease.Path {
+			return history.Task.ID, nil
 		}
 	}
 	return "", nil

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -16,6 +16,16 @@ func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
 }
 
+func writeCollisionTask(t *testing.T, home, id, path, leaseID string) {
+	t.Helper()
+	if err := state.CreateTask(home, state.Task{ID: id}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: id, Lifecycle: state.AttemptRunning, Worktree: path, LeaseID: leaseID}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGetParsesLeasePathAndIdentity(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1","lease_id":"5fe5412a4aabdeb85a148d6d73eb42d8"}`})
 	got, err := Get(t.TempDir(), "hand:task-1")
@@ -133,9 +143,7 @@ func TestReturnFailsWhenAnUnforcedDirtyReturnAborts(t *testing.T) {
 
 func TestCheckCollisionDetectsAConflictOnLeaseIdentity(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
-		t.Fatal(err)
-	}
+	writeCollisionTask(t, home, "other-task", "/tmp/wt-shared", "lease-1")
 
 	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-1"}, "new-task")
 	if err != nil {
@@ -151,9 +159,7 @@ func TestCheckCollisionDetectsAConflictOnLeaseIdentity(t *testing.T) {
 // is not a collision, and refusing the spawn over it was the bug.
 func TestCheckCollisionAllowsAReusedPathUnderAFreshLease(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "stale-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
-		t.Fatal(err)
-	}
+	writeCollisionTask(t, home, "stale-task", "/tmp/wt-shared", "lease-1")
 
 	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-2"}, "new-task")
 	if err != nil {
@@ -168,9 +174,7 @@ func TestCheckCollisionAllowsAReusedPathUnderAFreshLease(t *testing.T) {
 // so it keeps being checked by path until its task is torn down and respawned.
 func TestCheckCollisionFallsBackToPathForARowWithNoIdentity(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "legacy-task", Worktree: "/tmp/wt-shared"}); err != nil {
-		t.Fatal(err)
-	}
+	writeCollisionTask(t, home, "legacy-task", "/tmp/wt-shared", "")
 
 	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-2"}, "new-task")
 	if err != nil {
@@ -185,9 +189,7 @@ func TestCheckCollisionFallsBackToPathForARowWithNoIdentity(t *testing.T) {
 // rows that have one are compared by path.
 func TestCheckCollisionFallsBackToPathForALeaseWithNoIdentity(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
-		t.Fatal(err)
-	}
+	writeCollisionTask(t, home, "other-task", "/tmp/wt-shared", "lease-1")
 
 	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared"}, "new-task")
 	if err != nil {
@@ -200,9 +202,7 @@ func TestCheckCollisionFallsBackToPathForALeaseWithNoIdentity(t *testing.T) {
 
 func TestCheckCollisionExcludesOwnTask(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "same-task", Worktree: "/tmp/wt-shared", LeaseID: "lease-1"}); err != nil {
-		t.Fatal(err)
-	}
+	writeCollisionTask(t, home, "same-task", "/tmp/wt-shared", "lease-1")
 
 	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-1"}, "same-task")
 	if err != nil {
@@ -215,9 +215,7 @@ func TestCheckCollisionExcludesOwnTask(t *testing.T) {
 
 func TestCheckCollisionNoConflict(t *testing.T) {
 	home := t.TempDir()
-	if err := state.Write(home, state.Task{ID: "other-task", Worktree: "/tmp/wt-other", LeaseID: "lease-1"}); err != nil {
-		t.Fatal(err)
-	}
+	writeCollisionTask(t, home, "other-task", "/tmp/wt-other", "lease-1")
 
 	conflict, err := CheckCollision(home, Lease{Path: "/tmp/wt-shared", ID: "lease-2"}, "new-task")
 	if err != nil {

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -125,14 +125,11 @@ func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 				t.Fatalf("spawn under claude warned about effort: %q", spawned.stderr)
 			}
 
-			task, err := state.Read(home, tc.id)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Logf("persisted tier: model=%q effort=%q", task.Model, task.Effort)
-			if task.Model != tc.wantModel || task.Effort != tc.wantEffort {
+			_, attempt := readTaskAttempt(t, home, tc.id)
+			t.Logf("persisted tier: model=%q effort=%q", attempt.Model, attempt.Effort)
+			if attempt.Model != tc.wantModel || attempt.Effort != tc.wantEffort {
 				t.Fatalf("persisted tier = model %q effort %q, want model %q effort %q",
-					task.Model, task.Effort, tc.wantModel, tc.wantEffort)
+					attempt.Model, attempt.Effort, tc.wantModel, tc.wantEffort)
 			}
 
 			lines := readLaunchLog(t, launchLog)
@@ -164,15 +161,11 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(home, "projects", "demo"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindScout,
-		Worktree:  filepath.Join(home, "wt-scout-old"),
-		Herdr:     state.Herdr{WorkspaceID: "ws-old", TabID: "tab-old", PaneID: "pane-old"},
-		Model:     "claude-sonnet-5",
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-scout-old"),
+		Herdr: state.Herdr{WorkspaceID: "ws-old", TabID: "tab-old", PaneID: "pane-old"}, Model: "claude-sonnet-5"})
 
 	// The scout already holds a pool slot and a tab in the project's workspace, so
 	// promote reuses that workspace for the ship task rather than opening a second
@@ -196,13 +189,10 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 		t.Fatalf("promote: exit %d, stderr %q", promoted.code, promoted.stderr)
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("persisted tier: model=%q effort=%q", task.Model, task.Effort)
-	if task.Model != "claude-opus-5" || task.Effort != "max" {
-		t.Fatalf("persisted tier = model %q effort %q, want claude-opus-5/max from the brief", task.Model, task.Effort)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	t.Logf("persisted tier: model=%q effort=%q", attempt.Model, attempt.Effort)
+	if attempt.Model != "claude-opus-5" || attempt.Effort != "max" {
+		t.Fatalf("persisted tier = model %q effort %q, want claude-opus-5/max from the brief", attempt.Model, attempt.Effort)
 	}
 
 	launch := readLaunchLog(t, launchLog)[0]

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -56,12 +56,9 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 	if exists, err := state.Exists(home, "task-2"); err != nil || exists {
 		t.Fatalf("state.Exists(task-2) = %v, %v, want the collision to leave no task-2 state", exists, err)
 	}
-	task1, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatalf("task-1 state should be untouched by task-2's collision: %v", err)
-	}
-	if task1.Worktree != sharedWorktree {
-		t.Fatalf("task-1 worktree = %q, want %q (collision handling must not mutate the winner)", task1.Worktree, sharedWorktree)
+	task1, attempt1 := readTaskAttempt(t, home, "task-1")
+	if attempt1.Worktree != sharedWorktree {
+		t.Fatalf("task-1 worktree = %q, want %q (collision handling must not mutate the winner; task=%+v)", attempt1.Worktree, sharedWorktree, task1)
 	}
 }
 
@@ -86,18 +83,12 @@ func TestSpawnAllowsARecycledWorktreePathUnderAFreshLease(t *testing.T) {
 		t.Fatalf("spawn task-2: exit %d, stderr %q, want the recycled path to be accepted", second.code, second.stderr)
 	}
 
-	task1, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
+	_, attempt1 := readTaskAttempt(t, home, "task-1")
+	_, attempt2 := readTaskAttempt(t, home, "task-2")
+	if attempt1.LeaseID == "" || attempt2.LeaseID == "" {
+		t.Fatalf("lease identities not recorded: task-1 %q, task-2 %q", attempt1.LeaseID, attempt2.LeaseID)
 	}
-	task2, err := state.Read(home, "task-2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task1.LeaseID == "" || task2.LeaseID == "" {
-		t.Fatalf("lease identities not recorded: task-1 %q, task-2 %q", task1.LeaseID, task2.LeaseID)
-	}
-	if task1.LeaseID == task2.LeaseID {
-		t.Fatalf("both tasks recorded lease %q, so this proved nothing about identity keying", task1.LeaseID)
+	if attempt1.LeaseID == attempt2.LeaseID {
+		t.Fatalf("both tasks recorded lease %q, so this proved nothing about identity keying", attempt1.LeaseID)
 	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -557,9 +557,7 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			name: "project remove with active task",
 			setup: func(t *testing.T, home string) {
 				registerProject(t, home, "demo", "direct-pr")
-				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}); err != nil {
-					t.Fatal(err)
-				}
+				writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning})
 			},
 			args:       []string{"project", "remove", "demo"},
 			wantStderr: `project "demo" has active tasks referencing it`,
@@ -568,9 +566,7 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			name: "teardown scout without report",
 			setup: func(t *testing.T, home string) {
 				registerProject(t, home, "demo", "direct-pr")
-				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout}); err != nil {
-					t.Fatal(err)
-				}
+				writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning})
 			},
 			args:       []string{"teardown", "task-1"},
 			wantStderr: "report not found at data/task-1/report.md",
@@ -581,9 +577,7 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 				registerProject(t, home, "demo", "direct-pr")
 				worktree := filepath.Join(home, "wt")
 				initGitRepo(t, worktree)
-				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Worktree: worktree}); err != nil {
-					t.Fatal(err)
-				}
+				writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree})
 			},
 			args:       []string{"teardown", "task-1"},
 			wantStderr: "no PR recorded for task-1",
@@ -592,9 +586,7 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			name: "promote a task that is not a scout",
 			setup: func(t *testing.T, home string) {
 				registerProject(t, home, "demo", "direct-pr")
-				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}); err != nil {
-					t.Fatal(err)
-				}
+				writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning})
 			},
 			args:       []string{"promote", "task-1"},
 			wantStderr: `task "task-1" is not a scout`,
@@ -603,9 +595,7 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			name: "merge an already merged task",
 			setup: func(t *testing.T, home string) {
 				registerProject(t, home, "demo", "direct-pr")
-				if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, MergeExecuted: true}); err != nil {
-					t.Fatal(err)
-				}
+				writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, MergeExecuted: true}, state.Attempt{Lifecycle: state.AttemptRunning})
 			},
 			args:       []string{"merge", "task-1"},
 			wantStderr: "task task-1 already merged",

--- a/tests/e2e/hold_test.go
+++ b/tests/e2e/hold_test.go
@@ -127,8 +127,8 @@ func TestHoldLifecycle(t *testing.T) {
 	if got := runHand(t, home, "teardown", "fix-login"); got.code != 0 {
 		t.Fatalf("teardown: exit %d, stderr %q", got.code, got.stderr)
 	}
-	if exists, err := state.Exists(home, "fix-login"); err != nil || exists {
-		t.Fatalf("state.Exists after teardown = %v, %v, want the task row gone", exists, err)
+	if exists, err := state.Exists(home, "fix-login"); err != nil || !exists {
+		t.Fatalf("state.Exists after teardown = %v, %v, want the task row preserved", exists, err)
 	}
 
 	survived := runHand(t, home, "status")

--- a/tests/e2e/hold_test.go
+++ b/tests/e2e/hold_test.go
@@ -118,8 +118,8 @@ func TestHoldLifecycle(t *testing.T) {
 		t.Fatalf("fleet JSON holds = %+v, want both holds", all.Holds)
 	}
 
-	// The motivating case: teardown deletes the task row, and the hold set on
-	// that id has to outlive it.
+	// The motivating case: the hold set on this id has to outlive the work it was
+	// raised against, which teardown leaves terminal rather than removing.
 	runGitIn(t, worktree, "commit", "--allow-empty", "-q", "-m", "wip")
 	if got := runHand(t, home, "merge", "fix-login", "--local"); got.code != 0 {
 		t.Fatalf("merge --local: exit %d, stderr %q", got.code, got.stderr)

--- a/tests/e2e/hold_test.go
+++ b/tests/e2e/hold_test.go
@@ -136,12 +136,12 @@ func TestHoldLifecycle(t *testing.T) {
 		t.Fatalf("status after teardown = %q, want the torn-down task's hold still listed", survived.stdout)
 	}
 
-	// Reusing the id would reattach that still-open question to unrelated work.
+	// A terminal id is never reused by spawn, even while its old hold remains open.
 	writeBrief(t, home, "fix-login")
 	respawn := runHand(t, home, "spawn", "fix-login", "demo")
-	assertInvocation(t, respawn, 3, `id "fix-login" has an open hold`)
-	if !strings.Contains(respawn.stderr, "hand hold clear fix-login") {
-		t.Fatalf("spawn stderr = %q, want it to name the remedy", respawn.stderr)
+	assertInvocation(t, respawn, 3, "hand reopen fix-login")
+	if strings.Contains(respawn.stderr, "open hold") {
+		t.Fatalf("spawn stderr = %q, want terminal-task refusal before hold check", respawn.stderr)
 	}
 
 	cleared := runHand(t, home, "hold", "clear", "fix-login")

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -21,12 +21,8 @@ func TestMergePR(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, PR: "1", CreatedAt: now}); err != nil {
-		t.Fatal(err)
-	}
-	if err := state.Write(home, state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, PR: "2", CreatedAt: now}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, PR: "1", CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning})
+	writeTaskAttempt(t, home, state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, PR: "2", CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning})
 
 	dir := binDir(t)
 	invocationLog := filepath.Join(t.TempDir(), "gh-invocations.log")

--- a/tests/e2e/pr_test.go
+++ b/tests/e2e/pr_test.go
@@ -28,9 +28,7 @@ func TestPRCommand(t *testing.T) {
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "e2e-fixture", Kind: state.KindShip, CreatedAt: now}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "e2e-fixture", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning})
 
 	invocationLog := filepath.Join(t.TempDir(), "gh-invocations.log")
 	writeFakeDispatch(t, dir, "gh", invocationLog, "$1 $2", `  "pr view") echo '{"state":"OPEN"}' ;;`)

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -34,16 +34,11 @@ func TestPromoteScoutToShip(t *testing.T) {
 	createdAt := time.Now().UTC().Format(time.RFC3339)
 	scoutPaneStart := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
 	oldWorktree := filepath.Join(home, "wt-scout-old")
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindScout,
-		Worktree:      oldWorktree,
-		LeaseID:       "lease-old",
-		Herdr:         state.Herdr{WorkspaceID: "ws-old", TabID: "tab-old", PaneID: "pane-old"},
-		CreatedAt:     createdAt,
-		PaneStartedAt: scoutPaneStart,
-	}); err != nil {
-		t.Fatal(err)
-	}
+		CreatedAt: createdAt,
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, LeaseID: "lease-old",
+		Herdr: state.Herdr{WorkspaceID: "ws-old", TabID: "tab-old", PaneID: "pane-old"}, PaneStartedAt: scoutPaneStart})
 
 	dir := binDir(t)
 	newWorktree := filepath.Join(home, "wt-ship-new")
@@ -84,33 +79,30 @@ func TestPromoteScoutToShip(t *testing.T) {
 		t.Fatalf("promote stdout = %q, want it to announce the scout->ship transition", promoted.stdout)
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
+	task, attempt := readTaskAttempt(t, home, "task-1")
 	if task.Kind != state.KindShip {
 		t.Fatalf("task.Kind = %q, want %q after promote", task.Kind, state.KindShip)
 	}
 	if task.Project != "demo" || task.CreatedAt != createdAt {
 		t.Fatalf("task identity changed: Project=%q CreatedAt=%q, want Project=demo CreatedAt=%q unchanged", task.Project, task.CreatedAt, createdAt)
 	}
-	if task.Worktree != newWorktree {
-		t.Fatalf("task.Worktree = %q, want the new worktree %q", task.Worktree, newWorktree)
+	if attempt.Worktree != newWorktree {
+		t.Fatalf("attempt.Worktree = %q, want the new worktree %q", attempt.Worktree, newWorktree)
 	}
-	if task.LeaseID != "lease-new" {
-		t.Fatalf("task.LeaseID = %q, want the new lease identity, not the scout's", task.LeaseID)
+	if attempt.LeaseID != "lease-new" {
+		t.Fatalf("attempt.LeaseID = %q, want the new lease identity, not the scout's", attempt.LeaseID)
 	}
-	if task.Herdr.WorkspaceID != "ws-new" || task.Herdr.TabID != "tab-new" || task.Herdr.PaneID != "pane-new" {
-		t.Fatalf("task.Herdr = %+v, want the new ws-new/tab-new/pane-new identifiers", task.Herdr)
+	if attempt.Herdr.WorkspaceID != "ws-new" || attempt.Herdr.TabID != "tab-new" || attempt.Herdr.PaneID != "pane-new" {
+		t.Fatalf("attempt.Herdr = %+v, want the new ws-new/tab-new/pane-new identifiers", attempt.Herdr)
 	}
-	if task.Herdr.Session != "default" {
-		t.Fatalf("task.Herdr.Session = %q, want %q", task.Herdr.Session, "default")
+	if attempt.Herdr.Session != "default" {
+		t.Fatalf("attempt.Herdr.Session = %q, want %q", attempt.Herdr.Session, "default")
 	}
-	if task.Harness != "claude" {
-		t.Fatalf("task.Harness = %q, want the default harness recorded", task.Harness)
+	if attempt.Harness != "claude" {
+		t.Fatalf("attempt.Harness = %q, want the default harness recorded", attempt.Harness)
 	}
-	if task.PaneStartedAt == "" || task.PaneStartedAt == scoutPaneStart {
-		t.Fatalf("task.PaneStartedAt = %q, want it restamped off the scout's %q: parked's silence floor is anchored to it", task.PaneStartedAt, scoutPaneStart)
+	if attempt.PaneStartedAt == "" || attempt.PaneStartedAt == scoutPaneStart {
+		t.Fatalf("attempt.PaneStartedAt = %q, want it restamped off the scout's %q: parked's silence floor is anchored to it", attempt.PaneStartedAt, scoutPaneStart)
 	}
 
 	logData, err := os.ReadFile(invocationLog)

--- a/tests/e2e/reopen_test.go
+++ b/tests/e2e/reopen_test.go
@@ -1,0 +1,147 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+type attemptView struct {
+	Ordinal   int    `json:"ordinal"`
+	Lifecycle string `json:"lifecycle"`
+	Harness   string `json:"harness"`
+	Worktree  string `json:"worktree"`
+}
+
+type detailStatus struct {
+	ID               string        `json:"id"`
+	Kind             string        `json:"kind"`
+	TaskLifecycle    string        `json:"task_lifecycle"`
+	AttemptOrdinal   int           `json:"attempt_ordinal"`
+	AttemptLifecycle string        `json:"attempt_lifecycle"`
+	Harness          string        `json:"harness"`
+	CreatedAt        string        `json:"created_at"`
+	Attempts         []attemptView `json:"attempts"`
+}
+
+type openFleet struct {
+	TaskCount int `json:"task_count"`
+	Tasks     []struct {
+		ID             string `json:"id"`
+		AttemptOrdinal int    `json:"attempt_ordinal"`
+	} `json:"tasks"`
+}
+
+// Drives the whole terminal-task round trip through the built binary: spawn, teardown, a refused second
+// spawn that names `hand reopen` as the way back, then the reopen itself. The task row and its durable
+// identity survive; the execution attempt does not, and the finished one stays on record beside the new.
+func TestReopenIsTheOnlyWayBackFromATerminalTask(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	writeBrief(t, home, "task-1")
+
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	worktree := filepath.Join(home, "wt-task-1")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
+
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, worktree)
+	// Two workspaces, because teardown closes the first attempt's: the reopened attempt is dispatched into
+	// herdr as freshly as the spawn was, not reattached to the pane the torn-down attempt left behind.
+	faketool.Herdr{
+		Creates: []faketool.HerdrWorkspace{
+			{ID: "ws-1", Label: "demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: "1", Pane: "pane-1"}}},
+			{ID: "ws-2", Label: "demo", Tabs: []faketool.HerdrTab{{ID: "tab-2", Label: "1", Pane: "pane-2"}}},
+		},
+		PaneAgent: "claude",
+	}.Install(t, dir)
+
+	if got := runHand(t, home, "spawn", "task-1", "demo"); got.code != 0 {
+		t.Fatalf("spawn: exit %d, stderr %q", got.code, got.stderr)
+	}
+	spawnedTask, spawnedAttempt := readTaskAttempt(t, home, "task-1")
+	if spawnedAttempt.Ordinal != 1 || spawnedAttempt.Herdr.PaneID != "pane-1" {
+		t.Fatalf("spawned attempt = %+v, want the first attempt in pane-1", spawnedAttempt)
+	}
+	running := runHand(t, home, "status", "task-1")
+	if running.code != 0 || !strings.Contains(running.stdout, "Attempt 1: running (claude") {
+		t.Fatalf("status after spawn = %q (exit %d), want attempt 1 running", running.stdout, running.code)
+	}
+
+	runGitIn(t, worktree, "commit", "--allow-empty", "-q", "-m", "wip")
+	if got := runHand(t, home, "merge", "task-1", "--local"); got.code != 0 {
+		t.Fatalf("merge --local: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if got := runHand(t, home, "teardown", "task-1"); got.code != 0 {
+		t.Fatalf("teardown: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	var torndown detailStatus
+	decodeJSON(t, runHand(t, home, "status", "task-1", "--json"), &torndown)
+	if torndown.TaskLifecycle != "terminal" || torndown.AttemptLifecycle != "completed" {
+		t.Fatalf("torn-down detail = %+v, want a terminal task whose attempt is completed", torndown)
+	}
+	var afterTeardown openFleet
+	decodeJSON(t, runHand(t, home, "status", "--json"), &afterTeardown)
+	if afterTeardown.TaskCount != 0 || len(afterTeardown.Tasks) != 0 {
+		t.Fatalf("fleet after teardown = %+v, want the terminal task out of the open fleet", afterTeardown)
+	}
+
+	// The one path back: spawn refuses the id outright and names the command that reopens it, so nothing
+	// but hand reopen can put a terminal task back to work.
+	assertInvocation(t, runHand(t, home, "spawn", "task-1", "demo"), 3, "use hand reopen task-1")
+
+	reopened := runHand(t, home, "reopen", "task-1")
+	if reopened.code != 0 {
+		t.Fatalf("reopen: exit %d, stderr %q", reopened.code, reopened.stderr)
+	}
+	for _, want := range []string{"result: reopened\n", "attempt: new\n", "project: demo\n", "kind: ship\n"} {
+		if !strings.Contains(reopened.stdout, want) {
+			t.Fatalf("reopen stdout = %q, want it to contain %q", reopened.stdout, want)
+		}
+	}
+
+	var detail detailStatus
+	decodeJSON(t, runHand(t, home, "status", "task-1", "--json"), &detail)
+	if detail.TaskLifecycle != "open" || detail.AttemptOrdinal != 2 || detail.AttemptLifecycle != "running" {
+		t.Fatalf("reopened detail = %+v, want an open task on a running second attempt", detail)
+	}
+	if detail.Kind != string(spawnedTask.Kind) || detail.CreatedAt != spawnedTask.CreatedAt {
+		t.Fatalf("reopened detail = %+v, want the task's durable identity (kind %q, created %q) preserved",
+			detail, spawnedTask.Kind, spawnedTask.CreatedAt)
+	}
+	if len(detail.Attempts) != 2 ||
+		detail.Attempts[0].Ordinal != 1 || detail.Attempts[0].Lifecycle != "completed" ||
+		detail.Attempts[1].Ordinal != 2 || detail.Attempts[1].Lifecycle != "running" {
+		t.Fatalf("attempt history = %+v, want the finished first attempt kept beside the running second", detail.Attempts)
+	}
+
+	text := runHand(t, home, "status", "task-1")
+	for _, want := range []string{"Attempt 1: completed (claude", "Attempt 2: running (claude"} {
+		if !strings.Contains(text.stdout, want) {
+			t.Fatalf("status after reopen = %q, want it to contain %q", text.stdout, want)
+		}
+	}
+
+	var afterReopen openFleet
+	decodeJSON(t, runHand(t, home, "status", "--json"), &afterReopen)
+	if afterReopen.TaskCount != 1 || len(afterReopen.Tasks) != 1 ||
+		afterReopen.Tasks[0].ID != "task-1" || afterReopen.Tasks[0].AttemptOrdinal != 2 {
+		t.Fatalf("fleet after reopen = %+v, want the task back in the open fleet on its second attempt", afterReopen)
+	}
+
+	reopenedTask, reopenedAttempt := readTaskAttempt(t, home, "task-1")
+	if reopenedAttempt.ID == spawnedAttempt.ID || reopenedAttempt.Herdr.PaneID != "pane-2" {
+		t.Fatalf("reopened attempt = %+v, want a new attempt row in pane-2, not the torn-down %+v", reopenedAttempt, spawnedAttempt)
+	}
+	// Task-owned delivery facts are not an execution detail: the merge recorded before teardown is still
+	// on the row the reopened attempt hangs off.
+	if !reopenedTask.MergeExecuted {
+		t.Fatalf("reopened task = %+v, want the merge recorded before teardown preserved", reopenedTask)
+	}
+}

--- a/tests/e2e/report_watch_test.go
+++ b/tests/e2e/report_watch_test.go
@@ -20,12 +20,8 @@ func TestWatchIdleAfterReportedNeedsDecisionIsNotDone(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, CreatedAt: now,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now},
+		state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")
@@ -68,12 +64,8 @@ func TestWatchIdleWithNoReportIsSupervisorActionable(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, CreatedAt: now,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now},
+		state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")
@@ -100,12 +92,9 @@ func TestWatchIdleWithNoReportIsSupervisorActionable(t *testing.T) {
 	if !strings.Contains(string(eventsLog), "idle-unreported task-1") {
 		t.Fatalf("events.log = %q, want the unreported idle on the log an operator reads", eventsLog)
 	}
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportState != "" {
-		t.Fatalf("LastReportState = %q, want nothing recorded for a worker that reported nothing", task.LastReportState)
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportState != "" {
+		t.Fatalf("LastReportState = %q, want nothing recorded for a worker that reported nothing", attempt.LastReportState)
 	}
 }
 
@@ -116,12 +105,8 @@ func TestWatchReportRewrittenInPlaceIsNotMalformed(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, CreatedAt: now,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now},
+		state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")
@@ -155,12 +140,9 @@ func TestWatchReportRewrittenInPlaceIsNotMalformed(t *testing.T) {
 		t.Fatalf("stdout = %q, want no malformed report for a report rewritten in place", stdout)
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.LastReportNote != notes[len(notes)-1] {
-		t.Fatalf("LastReportNote = %q, want %q", task.LastReportNote, notes[len(notes)-1])
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.LastReportNote != notes[len(notes)-1] {
+		t.Fatalf("LastReportNote = %q, want %q", attempt.LastReportNote, notes[len(notes)-1])
 	}
 }
 
@@ -172,12 +154,8 @@ func TestWatchDoneRewrittenToTheSameLengthReachesVerifiedDone(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
-		ID: "task-1", Project: "demo", Kind: state.KindScout,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, CreatedAt: now,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout, CreatedAt: now},
+		state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -101,12 +101,9 @@ func TestSendRecordsAnUndeliveredSteerAndExitsSix(t *testing.T) {
 	got := runHand(t, home, "send", "task-1", "stop and wait for review", "--wait", "400ms")
 	assertInvocation(t, got, 6, "composer still busy after 400ms, message recorded as undelivered")
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.SendUndeliveredMessage != "stop and wait for review" || task.SendUndeliveredAt == "" {
-		t.Fatalf("task row = %+v, want the abandoned message and a timestamp recorded", task)
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.SendUndeliveredMessage != "stop and wait for review" || attempt.SendUndeliveredAt == "" {
+		t.Fatalf("task = %+v attempt = %+v, want the abandoned message and a timestamp recorded", task, attempt)
 	}
 
 	setPaneStatus(t, statusDir, "pane-1", "idle")
@@ -116,22 +113,16 @@ func TestSendRecordsAnUndeliveredSteerAndExitsSix(t *testing.T) {
 			delivered.code, delivered.stdout, delivered.stderr)
 	}
 
-	task, err = state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if task.SendUndeliveredMessage != "" || task.SendUndeliveredAt != "" {
-		t.Fatalf("task row = %+v, want the undelivered trace cleared by a send that reached the pane", task)
+	_, attempt = readTaskAttempt(t, home, "task-1")
+	if attempt.SendUndeliveredMessage != "" || attempt.SendUndeliveredAt != "" {
+		t.Fatalf("attempt = %+v, want the undelivered trace cleared by a send that reached the pane", attempt)
 	}
 }
 
 func seedSendTask(t *testing.T, home string) {
 	t.Helper()
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 }

--- a/tests/e2e/slug_case_test.go
+++ b/tests/e2e/slug_case_test.go
@@ -147,8 +147,8 @@ func TestGateOpenedUpstreamPRFoundWhenOriginRemoteCasingDiffers(t *testing.T) {
 	if tornDown.code != 0 {
 		t.Fatalf("teardown: exit %d, stderr %q", tornDown.code, tornDown.stderr)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state.Exists after teardown = %v, %v, want the landed task removed", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state.Exists after teardown = %v, %v, want the landed task preserved", exists, err)
 	}
 }
 
@@ -180,7 +180,7 @@ func TestGateOpenedPRLandsWhenUpstreamDeclaresOwnRepoInOtherCasing(t *testing.T)
 	if tornDown.code != 0 {
 		t.Fatalf("teardown: exit %d, stderr %q", tornDown.code, tornDown.stderr)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state.Exists after teardown = %v, %v, want the landed task removed", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state.Exists after teardown = %v, %v, want the landed task preserved", exists, err)
 	}
 }

--- a/tests/e2e/slug_case_test.go
+++ b/tests/e2e/slug_case_test.go
@@ -89,9 +89,7 @@ func TestPRRecordAcceptsCanonicalCasingOfOwnRepoAndUpstream(t *testing.T) {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, id := range []string{"task-1", "task-2", "task-3"} {
-		if err := state.Write(home, state.Task{ID: id, Project: "No-Mistakes", Kind: state.KindShip, CreatedAt: now}); err != nil {
-			t.Fatal(err)
-		}
+		writeTaskAttempt(t, home, state.Task{ID: id, Project: "No-Mistakes", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning})
 	}
 
 	for _, tc := range []struct{ id, url string }{

--- a/tests/e2e/spawn_teardown_test.go
+++ b/tests/e2e/spawn_teardown_test.go
@@ -36,16 +36,13 @@ func TestSpawnTeardownCycle(t *testing.T) {
 		t.Fatalf("spawn: exit %d, stderr %q", spawned.code, spawned.stderr)
 	}
 
-	task, err := state.Read(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	if task.Project != "demo" || task.Kind != state.KindShip || attempt.Worktree != worktree ||
+		attempt.Harness == "" || attempt.Herdr.WorkspaceID != "ws-1" || attempt.Herdr.TabID != "tab-1" || attempt.Herdr.PaneID != "pane-1" {
+		t.Fatalf("spawned task state = %+v, attempt = %+v, want project=demo kind=ship worktree=%s herdr ids populated", task, attempt, worktree)
 	}
-	if task.Project != "demo" || task.Kind != state.KindShip || task.Worktree != worktree ||
-		task.Harness == "" || task.Herdr.WorkspaceID != "ws-1" || task.Herdr.TabID != "tab-1" || task.Herdr.PaneID != "pane-1" {
-		t.Fatalf("spawned task state = %+v, want project=demo kind=ship worktree=%s herdr ids populated", task, worktree)
-	}
-	if task.PaneStartedAt != task.CreatedAt || task.PaneStartedAt == "" {
-		t.Fatalf("spawned task PaneStartedAt = %q, CreatedAt = %q, want the spawn instant recorded as both: a task's first pane starts when it is created", task.PaneStartedAt, task.CreatedAt)
+	if attempt.PaneStartedAt != task.CreatedAt || attempt.PaneStartedAt == "" {
+		t.Fatalf("spawned attempt PaneStartedAt = %q, task CreatedAt = %q, want the spawn instant recorded as both", attempt.PaneStartedAt, task.CreatedAt)
 	}
 
 	// The regression this cycle exists to catch: a first spawn into a fresh workspace must reuse

--- a/tests/e2e/spawn_teardown_test.go
+++ b/tests/e2e/spawn_teardown_test.go
@@ -80,8 +80,8 @@ func TestSpawnTeardownCycle(t *testing.T) {
 		t.Fatalf("teardown: exit %d, stderr %q", done.code, done.stderr)
 	}
 
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state.Exists after teardown = %v, %v, want task removed", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state.Exists after teardown = %v, %v, want task preserved", exists, err)
 	}
 	records, err := completion.List(home)
 	if err != nil {

--- a/tests/e2e/state_helpers_test.go
+++ b/tests/e2e/state_helpers_test.go
@@ -1,0 +1,32 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/state"
+)
+
+func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.Attempt) {
+	t.Helper()
+	if err := state.CreateTask(home, task); err != nil {
+		t.Fatal(err)
+	}
+	attempt.TaskID = task.ID
+	if _, err := state.CreateAttempt(home, attempt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readTaskAttempt(t *testing.T, home, id string) (state.Task, state.Attempt) {
+	t.Helper()
+	history, err := state.ReadHistory(home, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil {
+		t.Fatalf("task %q has no active attempt", id)
+	}
+	return history.Task, *history.ActiveAttempt
+}

--- a/tests/e2e/teardown_return_test.go
+++ b/tests/e2e/teardown_return_test.go
@@ -66,8 +66,8 @@ func TestTeardownRefusesAnAbortedWorktreeReturn(t *testing.T) {
 	if forced.code != 0 {
 		t.Fatalf("teardown --force: exit %d, stderr %q", forced.code, forced.stderr)
 	}
-	if exists, err := state.Exists(home, "scout-1"); err != nil || exists {
-		t.Fatalf("state.Exists after the forced teardown = %v, %v, want the row removed", exists, err)
+	if exists, err := state.Exists(home, "scout-1"); err != nil || !exists {
+		t.Fatalf("state.Exists after the forced teardown = %v, %v, want the row preserved", exists, err)
 	}
 	if err := exec.Command("treehouse", "get", "--lease", "--json").Run(); err != nil {
 		t.Fatalf("pool still refuses a lease after the forced return: %v", err)

--- a/tests/e2e/teardown_return_test.go
+++ b/tests/e2e/teardown_return_test.go
@@ -35,11 +35,9 @@ func TestTeardownRefusesAnAbortedWorktreeReturn(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{ID: "scout-1", Project: "demo", Kind: state.KindScout,
-		Worktree: worktree, CreatedAt: now,
-		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "scout-1", Project: "demo", Kind: state.KindScout,
+		CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}})
 
 	dir := binDir(t)
 	invocationLog := filepath.Join(t.TempDir(), "invocations.log")

--- a/tests/e2e/upstream_deliver_test.go
+++ b/tests/e2e/upstream_deliver_test.go
@@ -75,8 +75,8 @@ func TestForkContributionDeliveredNotLanded(t *testing.T) {
 	if tornDown.code != 0 {
 		t.Fatalf("teardown of delivered work: exit %d, stderr %q", tornDown.code, tornDown.stderr)
 	}
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state.Exists after teardown = %v, %v, want the task removed", exists, err)
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state.Exists after teardown = %v, %v, want the task preserved", exists, err)
 	}
 
 	records, err := completion.List(home)

--- a/tests/e2e/watch_ownership_test.go
+++ b/tests/e2e/watch_ownership_test.go
@@ -93,11 +93,9 @@ func seedOneTaskHome(t *testing.T) string {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 
-	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
-		CreatedAt: time.Now().UTC().Format(time.RFC3339)}); err != nil {
-		t.Fatal(err)
-	}
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning,
+		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -19,13 +19,14 @@ func TestWatchEventStream(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	for _, task := range []state.Task{
-		{ID: "task-1", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, CreatedAt: now},
-		{ID: "task-2", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}, CreatedAt: now},
+	for _, tc := range []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}}},
+		{state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}}},
 	} {
-		if err := state.Write(home, task); err != nil {
-			t.Fatal(err)
-		}
+		writeTaskAttempt(t, home, tc.task, tc.attempt)
 	}
 
 	statusDir := t.TempDir()
@@ -96,13 +97,14 @@ func TestWatchUntilEventExitsOnTheFirstTransition(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	for _, task := range []state.Task{
-		{ID: "task-1", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, CreatedAt: now},
-		{ID: "task-2", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}, CreatedAt: now},
+	for _, tc := range []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}}},
+		{state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}}},
 	} {
-		if err := state.Write(home, task); err != nil {
-			t.Fatal(err)
-		}
+		writeTaskAttempt(t, home, tc.task, tc.attempt)
 	}
 	// A terminal report line nobody consumed: report_offset is still 0, so the
 	// poll loop classifies it as new. The baseline has to absorb it silently.
@@ -152,13 +154,10 @@ func TestWatchUntilEventTimesOutWithADistinctCode(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")
@@ -185,13 +184,10 @@ func TestWatchUntilEventFailsToArmWithADistinctCode(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	writeFakeHerdrUnprobeablePanes(t, binDir(t))
 
@@ -215,13 +211,10 @@ func TestWatchUntilEventDeliversParkedWhenTheReportChannelGoesSilent(t *testing.
 	registerProject(t, home, "demo", "direct-pr")
 	writeConfig(t, home, "parked-other-bound", "2")
 
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "slow-migration", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 	// Written now so the bound is crossed while the poll loop runs, not before it.
 	if err := os.WriteFile(state.ReportPath(home, "slow-migration"), []byte("working: still on the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -248,13 +241,10 @@ func TestWatchParksADoneWorkerUnderItsOwnBound(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 	writeConfig(t, home, "parked-done-bound", "2")
 
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "shipped-task", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 	// Written now so the bound is crossed while the poll loop runs, not before it.
 	if err := os.WriteFile(state.ReportPath(home, "shipped-task"), []byte("done: shipped the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -292,13 +282,10 @@ func TestWatchDoesNotRefireParkedForADoneTaskAcrossARestart(t *testing.T) {
 	writeConfig(t, home, "parked-done-bound", "6")
 
 	spawnedAt := time.Now().UTC().Format(time.RFC3339)
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "shipped-task", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
-		CreatedAt: spawnedAt, PaneStartedAt: spawnedAt,
-	}); err != nil {
-		t.Fatal(err)
-	}
+		CreatedAt: spawnedAt,
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, PaneStartedAt: spawnedAt})
 	if err := os.WriteFile(state.ReportPath(home, "shipped-task"), []byte("done: shipped the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -349,13 +336,10 @@ func TestWatchUntilEventWakesOnlyOnTheFilteredKind(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 	writeConfig(t, home, "parked-done-bound", "2")
 
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "shipped-task", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 	if err := os.WriteFile(state.ReportPath(home, "shipped-task"), []byte("done: shipped the migration\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -395,13 +379,10 @@ func TestWatchNotifiesInProcessForABlockedEvent(t *testing.T) {
 	marker := filepath.Join(home, "notify-marker.txt")
 	writeConfig(t, home, "notify", "printf '%s' \"$HAND_MESSAGE\" > "+marker)
 
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
 
 	statusDir := t.TempDir()
 	setPaneStatus(t, statusDir, "pane-1", "working")
@@ -448,13 +429,10 @@ func TestWatchTracksATaskFirstSightedUnreachable(t *testing.T) {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	setPaneStatus(t, statusDir, "pane-anchor", "working")
-	if err := state.Write(home, state.Task{
+	writeTaskAttempt(t, home, state.Task{
 		ID: "anchor-task", Project: "demo", Kind: state.KindShip,
-		Worktree: filepath.Join(home, "wt-anchor"), Herdr: state.Herdr{PaneID: "pane-anchor"},
 		CreatedAt: now,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-anchor"), Herdr: state.Herdr{PaneID: "pane-anchor"}})
 
 	watch := startHandBackground(t, home, "watch", "--poll", "30ms")
 	waitForInvocation(t, herdrLog, "herdr pane get pane-anchor", 5*time.Second)
@@ -464,13 +442,14 @@ func TestWatchTracksATaskFirstSightedUnreachable(t *testing.T) {
 	setPaneStatus(t, statusDir, "pane-dark", "unreachable")
 	setPaneStatus(t, statusDir, "pane-blink", "unreachable")
 	sighted := time.Now().UTC().Format(time.RFC3339)
-	for _, task := range []state.Task{
-		{ID: "dark-task", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-dark"), Herdr: state.Herdr{PaneID: "pane-dark"}, CreatedAt: sighted},
-		{ID: "blink-task", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-blink"), Herdr: state.Herdr{PaneID: "pane-blink"}, CreatedAt: sighted},
+	for _, tc := range []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{state.Task{ID: "dark-task", Project: "demo", Kind: state.KindShip, CreatedAt: sighted}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-dark"), Herdr: state.Herdr{PaneID: "pane-dark"}}},
+		{state.Task{ID: "blink-task", Project: "demo", Kind: state.KindShip, CreatedAt: sighted}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-blink"), Herdr: state.Herdr{PaneID: "pane-blink"}}},
 	} {
-		if err := state.Write(home, task); err != nil {
-			t.Fatal(err)
-		}
+		writeTaskAttempt(t, home, tc.task, tc.attempt)
 	}
 
 	// Three failing probes at a 30ms poll is well inside the 2s dwell, so silence
@@ -500,13 +479,14 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	for _, task := range []state.Task{
-		{ID: "limited", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-limited"), Herdr: state.Herdr{PaneID: "pane-limited"}, CreatedAt: now},
-		{ID: "plain", Project: "demo", Kind: state.KindShip, Worktree: filepath.Join(home, "wt-plain"), Herdr: state.Herdr{PaneID: "pane-plain"}, CreatedAt: now},
+	for _, tc := range []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{state.Task{ID: "limited", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-limited"), Herdr: state.Herdr{PaneID: "pane-limited"}}},
+		{state.Task{ID: "plain", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-plain"), Herdr: state.Herdr{PaneID: "pane-plain"}}},
 	} {
-		if err := state.Write(home, task); err != nil {
-			t.Fatal(err)
-		}
+		writeTaskAttempt(t, home, tc.task, tc.attempt)
 	}
 
 	statusDir := t.TempDir()
@@ -547,19 +527,13 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 		t.Fatalf("ReadHold(plain) = %v, %v, want no hold for a worker that stopped for another reason", found, err)
 	}
 
-	limited, err := state.Read(home, "limited")
-	if err != nil {
-		t.Fatal(err)
+	_, limitedAttempt := readTaskAttempt(t, home, "limited")
+	if limitedAttempt.UsageLimitRetryAt == "" {
+		t.Fatalf("limited attempt = %+v, want a durable retry stamp", limitedAttempt)
 	}
-	if limited.UsageLimitRetryAt == "" {
-		t.Fatalf("limited task = %+v, want a durable retry stamp", limited)
-	}
-	plain, err := state.Read(home, "plain")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if plain.UsageLimitRetryAt != "" || plain.UsageLimitAttempts != 0 {
-		t.Fatalf("plain task = %+v, want no usage-limit schedule", plain)
+	_, plainAttempt := readTaskAttempt(t, home, "plain")
+	if plainAttempt.UsageLimitRetryAt != "" || plainAttempt.UsageLimitAttempts != 0 {
+		t.Fatalf("plain attempt = %+v, want no usage-limit schedule", plainAttempt)
 	}
 
 	if result := watch.stop(t, 3*time.Second); result.code != 0 {
@@ -574,8 +548,8 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 	// The restart: the stamp the first run wrote moved into the past, which is the one thing that makes an
 	// attempt due without waiting out the ten-minute floor. It covers the durability too - a watcher that
 	// came up fresh still knows this worker is limited and when it may be poked.
-	limited.UsageLimitRetryAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
-	if err := state.Write(home, limited); err != nil {
+	limitedAttempt.UsageLimitRetryAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	if err := state.UpdateAttempt(home, limitedAttempt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -593,12 +567,17 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 	if _, found, err := state.ReadHold(home, "limited"); found || err != nil {
 		t.Fatalf("ReadHold(limited) after resume = %v, %v, want the hold released", found, err)
 	}
-	after, err := state.Read(home, "limited")
-	if err != nil {
-		t.Fatal(err)
+	deadline := time.Now().Add(5 * time.Second)
+	var afterAttempt state.Attempt
+	for time.Now().Before(deadline) {
+		_, afterAttempt = readTaskAttempt(t, home, "limited")
+		if afterAttempt.UsageLimitRetryAt == "" && afterAttempt.UsageLimitAttempts == 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
-	if after.UsageLimitRetryAt != "" || after.UsageLimitAttempts != 0 {
-		t.Fatalf("limited task after resume = %+v, want the schedule cleared", after)
+	if afterAttempt.UsageLimitRetryAt != "" || afterAttempt.UsageLimitAttempts != 0 {
+		t.Fatalf("limited attempt after resume = %+v, want the schedule cleared", afterAttempt)
 	}
 
 	if result := resumed.stop(t, 3*time.Second); result.code != 0 {


### PR DESCRIPTION
## Intent

Address atqamz/hand#219 review follow-up for issue #193 without broadening into #194/#195/#215: make explicit hand reopen the only terminal Task reopening path; remove writable execution compatibility fields and alternate Task-to-Attempt mutation paths; propagate durable Attempt-history read errors in status; restore existing-ID terminal spawn refusal before hold checks; preserve the Task/Attempt storage invariant, migration, lifecycle, status, watcher, send, worktree, and #192 contracts; verify the full repository matrix; push fixes to the existing draft PR #219 without merging.

## What Changed

- Storage now separates logical work from execution: schema migration v8 rewrites `task` (id, lifecycle, active-attempt relation, PR/merge/report cursor) and adds `attempt` (ordinal, lifecycle, harness/model/effort, worktree, lease, herdr identity, pane bookkeeping, usage-limit state) with a partial unique index allowing at most one provisioning/running attempt per task; legacy JSON import and unstamped already-split homes are detected and backfilled with attempt 1 rather than re-migrated.
- Lifecycle commands were rewired onto that split: spawn creates the task plus attempt 1 and refuses an existing terminal id by pointing at reopen, promote keeps the scout attempt and starts the next one, teardown terminalizes the task and attempt instead of deleting rows, and the new `hand reopen <id>` is the only path that returns a terminal task to open; send, watcher, and worktree read execution identity from the active attempt through `internal/state`'s task/attempt history API.
- `hand status` gained `task_lifecycle`, attempt ordinal/lifecycle, model/effort, and a bounded five-entry attempt history in both JSON and text views, propagates single-task history read errors instead of silently degrading, and limits the fleet view to open tasks; adds an ADR plus README notes and new store, migration, reopen, and e2e coverage.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>⚠️ **Test** - 1 info</summary>
</details>
<details>
<summary>⚠️ **Document** - 2 infos</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>

Fixes atqamz/hand#193