### PR TITLE
refactor(state): make lifecycle transitions atomic

### DIFF
--- a/cmd/deliver.go
+++ b/cmd/deliver.go
@@ -47,11 +47,12 @@ func newDeliverCmd() *cobra.Command {
 			// Re-running with a new reason is a correction, not a conflict: nothing
 			// downstream has consumed the mark until teardown reads it, and the last
 			// word on what was delivered is the one worth keeping.
-			t.DeliveredAt = time.Now().UTC().Format(time.RFC3339)
-			t.DeliveredReason = reason
-			if err := state.UpdateTask(home, t); err != nil {
+			deliveredAt := time.Now().UTC().Format(time.RFC3339)
+			if err := state.SetTaskDelivery(home, t.ID, deliveredAt, reason); err != nil {
 				return fmt.Errorf("write task state: %w", err)
 			}
+			t.DeliveredAt = deliveredAt
+			t.DeliveredReason = reason
 
 			var doc axi.Doc
 			doc.Field("id", id)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -125,11 +125,12 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 		return fmt.Errorf("gh pr merge failed: %s", strings.TrimSpace(string(out)))
 	}
 
-	t.MergeExecuted = true
-	t.MergeExecutedAt = time.Now().UTC().Format(time.RFC3339)
-	if err := state.UpdateTask(home, t); err != nil {
+	mergedAt := time.Now().UTC().Format(time.RFC3339)
+	if err := state.SetTaskMerge(home, t.ID, mergedAt); err != nil {
 		return fmt.Errorf("write task state: %w", err)
 	}
+	t.MergeExecuted = true
+	t.MergeExecutedAt = mergedAt
 
 	if proj, exists, err := project.Find(home, t.Project); err != nil {
 		return err
@@ -196,11 +197,12 @@ func runLocalMerge(cmd *cobra.Command, home string, t state.Task, active state.A
 		return &ExitError{Err: fmt.Errorf("fast-forward not possible: %s", strings.TrimSpace(string(out))), Code: 3}
 	}
 
-	t.MergeExecuted = true
-	t.MergeExecutedAt = time.Now().UTC().Format(time.RFC3339)
-	if err := state.UpdateTask(home, t); err != nil {
+	mergedAt := time.Now().UTC().Format(time.RFC3339)
+	if err := state.SetTaskMerge(home, t.ID, mergedAt); err != nil {
 		return fmt.Errorf("write task state: %w", err)
 	}
+	t.MergeExecuted = true
+	t.MergeExecutedAt = mergedAt
 
 	var doc axi.Doc
 	doc.Field("id", t.ID)

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -96,9 +96,9 @@ func recordPR(ctx context.Context, home string, t state.Task, url string) (state
 		return t, false, &ExitError{Err: err, Code: 3}
 	}
 
-	t.PR = url
-	if err := state.UpdateTask(home, t); err != nil {
+	if err := state.SetTaskPR(home, t.ID, url); err != nil {
 		return t, false, fmt.Errorf("write task state: %w", err)
 	}
+	t.PR = url
 	return t, false, nil
 }

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -13,6 +13,8 @@ import (
 var preconditionSentinels = []error{
 	state.ErrTaskNotFound,
 	state.ErrTaskActive,
+	state.ErrLifecycleConflict,
+	state.ErrOwnershipConflict,
 	state.ErrHoldNotFound,
 	project.ErrNotFound,
 	home.ErrNotFound,

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -119,6 +119,17 @@ func newPromoteCmd() *cobra.Command {
 			oldWorktree := active.Worktree
 			oldWorkspaceID := active.Herdr.WorkspaceID
 			oldTabID := active.Herdr.TabID
+			// The scout Attempt is terminal from the promotion above, so its tab and worktree are this
+			// command's to release however the ship Attempt ends: leaving them to the success path leaks
+			// a leased slot and a pane that nothing points at on every later failure.
+			defer func() {
+				if closeErr := closeTaskTab(client, oldWorkspaceID, oldTabID); closeErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: herdr tab close failed: %v\n", closeErr)
+				}
+				if returnErr := worktree.Return(oldWorktree, true); returnErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: return scout worktree failed: %v\n", returnErr)
+				}
+			}()
 
 			lease, err := worktree.Get(clonePath, "hand:"+id)
 			if err != nil {
@@ -191,17 +202,6 @@ func newPromoteCmd() *cobra.Command {
 			promoted = true
 			if err := state.ClearHoldIfKind(home, id, state.HoldKindLimit); err != nil {
 				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: clear usage-limit hold failed: %v\n", err); printErr != nil {
-					return printErr
-				}
-			}
-
-			if err := closeTaskTab(client, oldWorkspaceID, oldTabID); err != nil {
-				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: herdr tab close failed: %v\n", err); printErr != nil {
-					return printErr
-				}
-			}
-			if err := worktree.Return(oldWorktree, true); err != nil {
-				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: return scout worktree failed: %v\n", err); printErr != nil {
 					return printErr
 				}
 			}

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -141,33 +141,39 @@ func newPromoteCmd() *cobra.Command {
 			}
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 			defer releaseWorktree()
 
 			if conflict, err := worktree.CheckCollision(home, lease, id); err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			} else if conflict != "" {
-				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
+				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 
 			ws, tab, pane, rollback, err := acquireTaskWorkspace(client, wt, id, proj.Name)
 			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 			promoted := false
+			herdrRecorded := false
 			defer func() {
 				if promoted {
 					return
 				}
 				if closeErr := rollback(); closeErr != nil {
 					err = reportSpawnCleanup(err, closeErr)
+				} else if herdrRecorded {
+					if clearErr := state.ClearAttemptHerdr(home, id, shipAttempt.ID); clearErr != nil {
+						err = reportSpawnCleanup(err, clearErr)
+					}
 				}
 			}()
 			paneStartedAt := time.Now().UTC().Format(time.RFC3339)
 			if err := state.RecordAttemptHerdr(home, id, shipAttempt.ID, state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, paneStartedAt); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
+			herdrRecorded = true
 
 			// Provisioning evidence is durable before launch; rollback still releases resources when
 			// this call fails, while the partial Attempt remains truthful for later inspection.
@@ -180,24 +186,24 @@ func newPromoteCmd() *cobra.Command {
 				BriefHasFrontMatter: briefHasFrontMatter,
 			})
 			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 			if err := state.MarkLaunchSubmitted(home, id, shipAttempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 
 			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 			if err := state.MarkLaunchConfirmed(home, id, shipAttempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 			if err := state.MarkAttemptRunning(home, id, shipAttempt.ID); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), returnProvisioningWorktree(home, id, shipAttempt.ID, wt))
 			}
 			promoted = true
 			if err := state.ClearHoldIfKind(home, id, state.HoldKindLimit); err != nil {

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -101,6 +101,14 @@ func newPromoteCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			promotedAt := time.Now().UTC().Format(time.RFC3339)
+			shipAttempt, err := state.PromoteTask(home, id, active.ID, active.Lifecycle, state.Attempt{
+				TaskID: id, Lifecycle: state.AttemptProvisioning, Harness: harnessName, Model: model, Effort: effort,
+				CreatedAt: promotedAt,
+			})
+			if err != nil {
+				return asPrecondition(fmt.Errorf("write promoted provisioning state: %w", err))
+			}
 
 			releaseProject, err := state.Lock(home, "project:"+proj.Name)
 			if err != nil {
@@ -117,6 +125,9 @@ func newPromoteCmd() *cobra.Command {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
 			}
 			wt := lease.Path
+			if err := state.RecordAttemptWorktree(home, id, shipAttempt.ID, wt, lease.ID); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record worktree ownership: %w", err), worktree.Return(wt, true))
+			}
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
 				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
@@ -133,10 +144,6 @@ func newPromoteCmd() *cobra.Command {
 			if err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
-
-			// Same rollback contract as hand spawn: until state records the promotion,
-			// this call owns the new workspace or tab and must undo it on any failure; after
-			// that the promoted task owns them and later warnings must not tear them down.
 			promoted := false
 			defer func() {
 				if promoted {
@@ -146,7 +153,13 @@ func newPromoteCmd() *cobra.Command {
 					err = reportSpawnCleanup(err, closeErr)
 				}
 			}()
+			paneStartedAt := time.Now().UTC().Format(time.RFC3339)
+			if err := state.RecordAttemptHerdr(home, id, shipAttempt.ID, state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, paneStartedAt); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), worktree.Return(wt, true))
+			}
 
+			// Provisioning evidence is durable before launch; rollback still releases resources when
+			// this call fails, while the partial Attempt remains truthful for later inspection.
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree:            wt,
 				Brief:               briefAbs,
@@ -162,31 +175,18 @@ func newPromoteCmd() *cobra.Command {
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
+			if err := state.MarkLaunchSubmitted(home, id, shipAttempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), worktree.Return(wt, true))
+			}
 
 			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
-
-			promotedAt := time.Now().UTC().Format(time.RFC3339)
-			if err := state.TransitionAttempt(home, active.ID, active.Lifecycle, state.AttemptCompleted); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record scout attempt completion: %w", err), worktree.Return(wt, true))
+			if err := state.MarkLaunchConfirmed(home, id, shipAttempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), worktree.Return(wt, true))
 			}
-			t.Kind = state.KindShip
-			t.DeliveredAt = ""
-			t.DeliveredReason = ""
-			if err := state.UpdateTask(home, t); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
-			}
-			if _, err := state.CreateAttempt(home, state.Attempt{
-				TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort,
-				Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID},
-				CreatedAt: promotedAt, PaneStartedAt: promotedAt, StatusChangedAt: promotedAt,
-			}); err != nil {
-				persistErr := state.TransitionTask(home, id, state.TaskOpen, state.TaskTerminal)
-				if persistErr != nil {
-					return reportSpawnCleanup(fmt.Errorf("write ship attempt state: %w; terminalize task: %v", err, persistErr), worktree.Return(wt, true))
-				}
-				return reportSpawnCleanup(fmt.Errorf("write ship attempt state: %w; task is terminal, use hand reopen %s", err, id), worktree.Return(wt, true))
+			if err := state.MarkAttemptRunning(home, id, shipAttempt.ID); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), worktree.Return(wt, true))
 			}
 			promoted = true
 			if err := state.ClearHoldIfKind(home, id, state.HoldKindLimit); err != nil {

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -405,8 +405,8 @@ func TestPromoteFailureClosesWorkspaceItCreated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Task.Kind != state.KindShip || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != newWt || got.ActiveAttempt.Herdr.PaneID != "wA:pNew" {
-		t.Fatalf("provisioning evidence after launch failure = %+v, want ship ownership preserved", got)
+	if got.Task.Kind != state.KindShip || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != "" || got.ActiveAttempt.LeaseID != "" || got.ActiveAttempt.Herdr.PaneID != "" {
+		t.Fatalf("provisioning evidence after launch failure = %+v, want ship identity with released resources cleared", got)
 	}
 }
 
@@ -470,8 +470,8 @@ func TestPromoteReturnsScoutResourcesWhenTheShipLaunchFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if history.ActiveAttempt == nil || history.ActiveAttempt.Worktree != newWt {
-		t.Fatalf("history after launch failure = %+v, want the ship attempt keeping its own worktree", history)
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Worktree != "" || history.ActiveAttempt.Herdr.PaneID != "" {
+		t.Fatalf("history after launch failure = %+v, want the ship attempt without released resource evidence", history)
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -401,12 +401,12 @@ func TestPromoteFailureClosesWorkspaceItCreated(t *testing.T) {
 	if !strings.Contains(string(calls), "workspace close wA") {
 		t.Fatalf("calls = %q, want the workspace hand created to be closed", calls)
 	}
-	got, err := state.Read(home, "task-1")
+	got, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Kind != state.KindScout {
-		t.Fatalf("kind = %q, want the task left as a scout", got.Kind)
+	if got.Task.Kind != state.KindShip || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != newWt || got.ActiveAttempt.Herdr.PaneID != "wA:pNew" {
+		t.Fatalf("provisioning evidence after launch failure = %+v, want ship ownership preserved", got)
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -59,7 +59,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 	t.Setenv("HERDR_CALL_LOG", callLog)
 	herdr.Log = callLog
 	herdr.Install(t, bin)
-	faketool.Treehouse{Slots: []string{newWorktree, oldWorktree}}.Install(t, bin)
+	faketool.Treehouse{Slots: []string{newWorktree, oldWorktree}, Log: callLog}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	return home
@@ -436,6 +436,42 @@ func TestPromoteKeepsShipAfterScoutCleanupFailure(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "result: promoted\n") {
 		t.Fatalf("output = %q, want promotion success after cleanup warning", out.String())
+	}
+}
+
+// The promotion terminalizes the scout Attempt before any ship resource exists, so from that line on
+// nothing else will ever point at the scout's slot and pane. A launch failure after it must still hand
+// them back, or they stay leased with no state left to find them from (atqamz/hand#194).
+func TestPromoteReturnsScoutResourcesWhenTheShipLaunchFails(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	home := setupPromoteHome(t, oldWt, newWt, promoteLeakHerdr(true))
+	callLog := setupSpawnLeakEnv(t, true)
+
+	var errOut strings.Builder
+	cmd := newPromoteCmd()
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected promote to fail")
+	}
+
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "treehouse return "+oldWt) {
+		t.Fatalf("calls = %q, want the scout worktree returned", calls)
+	}
+	if !strings.Contains(string(calls), "tab close wA:tOld") {
+		t.Fatalf("calls = %q, want the scout tab closed", calls)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Worktree != newWt {
+		t.Fatalf("history after launch failure = %+v, want the ship attempt keeping its own worktree", history)
 	}
 }
 

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -111,52 +111,58 @@ func newReopenCmd() *cobra.Command {
 			}
 			releaseWorktree, err := state.Lock(homeDir, "worktree:"+wt)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			defer releaseWorktree()
 			if conflict, err := worktree.CheckCollision(homeDir, lease, id); err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			} else if conflict != "" {
-				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
+				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 
 			client := herdr.NewClient()
 			ws, tab, pane, rollback, err := acquireTaskWorkspace(client, wt, id, proj.Name)
 			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			started := false
+			herdrRecorded := false
 			defer func() {
 				if started {
 					return
 				}
 				if closeErr := rollback(); closeErr != nil {
 					err = reportSpawnCleanup(err, closeErr)
+				} else if herdrRecorded {
+					if clearErr := state.ClearAttemptHerdr(homeDir, id, attempt.ID); clearErr != nil {
+						err = reportSpawnCleanup(err, clearErr)
+					}
 				}
 			}()
 			paneStartedAt := time.Now().UTC().Format(time.RFC3339)
 			if err := state.RecordAttemptHerdr(homeDir, id, attempt.ID, state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, paneStartedAt); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
+			herdrRecorded = true
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{Worktree: wt, Brief: briefAbs, FleetHome: homeDir, Model: model, Effort: effort, BriefHasFrontMatter: briefHasFrontMatter})
 			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			if err := state.MarkLaunchSubmitted(homeDir, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			if err := state.MarkLaunchConfirmed(homeDir, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			if err := state.MarkAttemptRunning(homeDir, id, attempt.ID); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), returnProvisioningWorktree(homeDir, id, attempt.ID, wt))
 			}
 			started = true
 

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -87,6 +87,14 @@ func newReopenCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			startedAt := time.Now().UTC().Format(time.RFC3339)
+			attempt, err := state.ReopenTask(homeDir, state.Attempt{
+				TaskID: id, Lifecycle: state.AttemptProvisioning, Harness: harnessName, Model: model, Effort: effort,
+				CreatedAt: startedAt,
+			})
+			if err != nil {
+				return asPrecondition(fmt.Errorf("write reopened provisioning state: %w", err))
+			}
 
 			releaseProject, err := state.Lock(homeDir, "project:"+proj.Name)
 			if err != nil {
@@ -98,6 +106,9 @@ func newReopenCmd() *cobra.Command {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
 			}
 			wt := lease.Path
+			if err := state.RecordAttemptWorktree(homeDir, id, attempt.ID, wt, lease.ID); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record worktree ownership: %w", err), worktree.Return(wt, true))
+			}
 			releaseWorktree, err := state.Lock(homeDir, "worktree:"+wt)
 			if err != nil {
 				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
@@ -123,6 +134,10 @@ func newReopenCmd() *cobra.Command {
 					err = reportSpawnCleanup(err, closeErr)
 				}
 			}()
+			paneStartedAt := time.Now().UTC().Format(time.RFC3339)
+			if err := state.RecordAttemptHerdr(homeDir, id, attempt.ID, state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, paneStartedAt); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), worktree.Return(wt, true))
+			}
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{Worktree: wt, Brief: briefAbs, FleetHome: homeDir, Model: model, Effort: effort, BriefHasFrontMatter: briefHasFrontMatter})
 			if err != nil {
@@ -131,13 +146,17 @@ func newReopenCmd() *cobra.Command {
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
+			if err := state.MarkLaunchSubmitted(homeDir, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), worktree.Return(wt, true))
+			}
 			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
-
-			startedAt := time.Now().UTC().Format(time.RFC3339)
-			if _, err := state.ReopenTask(homeDir, state.Attempt{TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort, Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, CreatedAt: startedAt, PaneStartedAt: startedAt}); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write reopened attempt: %w", err), worktree.Return(wt, true))
+			if err := state.MarkLaunchConfirmed(homeDir, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), worktree.Return(wt, true))
+			}
+			if err := state.MarkAttemptRunning(homeDir, id, attempt.ID); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), worktree.Return(wt, true))
 			}
 			started = true
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -106,6 +106,24 @@ func newSendCmd() *cobra.Command {
 				}
 			}
 
+			// The composer wait can overlap promote or teardown. Take the task lock only for the short
+			// external send boundary, then verify the exact Attempt snapshot still owns the task.
+			releaseTask, err := state.TryLock(home, "task:"+id)
+			if err != nil {
+				if errors.Is(err, state.ErrLockBusy) {
+					return asPrecondition(fmt.Errorf("%w: task %q changed while sending; retry", state.ErrOwnershipConflict, id))
+				}
+				return fmt.Errorf("lock task %q before send: %w", id, err)
+			}
+			defer releaseTask()
+			current, err := state.ActiveAttempt(home, id)
+			if err != nil {
+				return asPrecondition(fmt.Errorf("re-read active attempt for task %q before send: %w", id, err))
+			}
+			if current.ID != active.ID || current.TaskID != active.TaskID || current.Lifecycle != active.Lifecycle || current.Herdr.PaneID != active.Herdr.PaneID {
+				return asPrecondition(fmt.Errorf("%w: task %q changed while sending; retry", state.ErrOwnershipConflict, id))
+			}
+
 			// Both delivery failures leave the steer undemonstrated in the pane -
 			// text that never left, and text sitting unsubmitted in the composer -
 			// so both owe the operator the same durable trace the wait bound does.

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -59,14 +59,9 @@ func newSendCmd() *cobra.Command {
 				return usageValue(waitFromFlag, fmt.Errorf("invalid wait duration %q: %w", wait, err))
 			}
 
-			// Task ownership covers the whole external interaction, so promote and teardown cannot replace
-			// the Attempt after this command resolves it. The nested send lock keeps explicit sends and
-			// watcher resume serialized with the same task -> send ordering.
-			releaseTask, err := state.Lock(home, "task:"+id)
-			if err != nil {
-				return fmt.Errorf("lock task %q: %w", id, err)
-			}
-			defer releaseTask()
+			// Send holds send only, never a task lock under it: the composer wait runs for the whole
+			// --wait bound, and blocking promote and teardown for that long is worse than the write
+			// they may race, which the store rejects on its own preconditions anyway.
 			releaseSend, err := state.Lock(home, "send:"+id)
 			if err != nil {
 				return fmt.Errorf("lock send %q: %w", id, err)
@@ -83,7 +78,7 @@ func newSendCmd() *cobra.Command {
 				}
 				return fmt.Errorf("read active attempt for task %q: %w", id, err)
 			}
-			if active.Lifecycle != state.AttemptRunning || active.LaunchConfirmedAt == "" {
+			if active.Lifecycle != state.AttemptRunning {
 				return &ExitError{Err: fmt.Errorf("task %q has no confirmed running attempt", id), Code: 3}
 			}
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -59,9 +59,8 @@ func newSendCmd() *cobra.Command {
 				return usageValue(waitFromFlag, fmt.Errorf("invalid wait duration %q: %w", wait, err))
 			}
 
-			// Send holds send only, never a task lock under it: the composer wait runs for the whole
-			// --wait bound, and blocking promote and teardown for that long is worse than the write
-			// they may race, which the store rejects on its own preconditions anyway.
+			// Send holds send across the composer wait, then takes task only for the short external-send
+			// boundary. Blocking promote and teardown for the whole --wait bound is avoided.
 			releaseSend, err := state.Lock(home, "send:"+id)
 			if err != nil {
 				return fmt.Errorf("lock send %q: %w", id, err)

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -59,14 +59,19 @@ func newSendCmd() *cobra.Command {
 				return usageValue(waitFromFlag, fmt.Errorf("invalid wait duration %q: %w", wait, err))
 			}
 
-			// Serializes concurrent sends to the same task: two retry loops racing against the same busy
-			// composer is the exact hazard atqamz/hand#102 traced a lost steer to. A second send waits
-			// behind the first, its own --wait clock starting only once it holds this lock.
-			release, err := state.Lock(home, "send:"+id)
+			// Task ownership covers the whole external interaction, so promote and teardown cannot replace
+			// the Attempt after this command resolves it. The nested send lock keeps explicit sends and
+			// watcher resume serialized with the same task -> send ordering.
+			releaseTask, err := state.Lock(home, "task:"+id)
+			if err != nil {
+				return fmt.Errorf("lock task %q: %w", id, err)
+			}
+			defer releaseTask()
+			releaseSend, err := state.Lock(home, "send:"+id)
 			if err != nil {
 				return fmt.Errorf("lock send %q: %w", id, err)
 			}
-			defer release()
+			defer releaseSend()
 
 			active, err := state.ActiveAttempt(home, id)
 			if err != nil {
@@ -78,8 +83,8 @@ func newSendCmd() *cobra.Command {
 				}
 				return fmt.Errorf("read active attempt for task %q: %w", id, err)
 			}
-			if active.Lifecycle != state.AttemptProvisioning && active.Lifecycle != state.AttemptRunning {
-				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
+			if active.Lifecycle != state.AttemptRunning || active.LaunchConfirmedAt == "" {
+				return &ExitError{Err: fmt.Errorf("task %q has no confirmed running attempt", id), Code: 3}
 			}
 
 			client := herdr.NewClient()
@@ -96,7 +101,7 @@ func newSendCmd() *cobra.Command {
 					if !errors.Is(waitErr, herdr.ErrComposerBusyTimeout) {
 						return fmt.Errorf("herdr pane %s not found: %w", active.Herdr.PaneID, waitErr)
 					}
-					if err := recordUndeliveredSend(home, id, message); err != nil {
+					if err := recordUndeliveredSend(home, id, active.ID, active.Lifecycle, message); err != nil {
 						return fmt.Errorf("%w; record undelivered send: %w", waitErr, err)
 					}
 					// Code 6: the composer stayed busy for the whole --wait bound, so the message never reached
@@ -110,13 +115,13 @@ func newSendCmd() *cobra.Command {
 			// text that never left, and text sitting unsubmitted in the composer -
 			// so both owe the operator the same durable trace the wait bound does.
 			if err := client.PaneSendText(active.Herdr.PaneID, message); err != nil {
-				return withUndeliveredSend(home, id, message, fmt.Errorf("send message failed: %w", err))
+				return withUndeliveredSend(home, id, active.ID, active.Lifecycle, message, fmt.Errorf("send message failed: %w", err))
 			}
 			if err := client.PaneSendKeys(active.Herdr.PaneID, "Enter"); err != nil {
-				return withUndeliveredSend(home, id, message, fmt.Errorf("submit message failed: %w", err))
+				return withUndeliveredSend(home, id, active.ID, active.Lifecycle, message, fmt.Errorf("submit message failed: %w", err))
 			}
 
-			if err := clearUndeliveredSend(home, id); err != nil {
+			if err := clearUndeliveredSend(home, id, active.ID, active.Lifecycle); err != nil {
 				// The message is already in the pane, so failing here would invite a
 				// retry that double-sends the steer; a stale trace is the lesser harm.
 				if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: clear undelivered send trace: %v\n", err); printErr != nil {
@@ -140,8 +145,8 @@ func newSendCmd() *cobra.Command {
 
 // Records the trace alongside a delivery failure, keeping the cause as the returned error so the exit
 // code of the failing path is unchanged.
-func withUndeliveredSend(home, id, message string, cause error) error {
-	if err := recordUndeliveredSend(home, id, message); err != nil {
+func withUndeliveredSend(home, id string, attemptID int64, expected state.AttemptLifecycle, message string, cause error) error {
+	if err := recordUndeliveredSend(home, id, attemptID, expected, message); err != nil {
 		return fmt.Errorf("%w; record undelivered send: %w", cause, err)
 	}
 	return cause
@@ -149,33 +154,16 @@ func withUndeliveredSend(home, id, message string, cause error) error {
 
 // Durably records the message hand send could not demonstrably deliver, so an operator or worker learns
 // the steer never arrived instead of it vanishing with the process that attempted it.
-func recordUndeliveredSend(home, id, message string) error {
-	return setUndeliveredSend(home, id, message, time.Now().UTC().Format(time.RFC3339))
+func recordUndeliveredSend(home, id string, attemptID int64, expected state.AttemptLifecycle, message string) error {
+	return setUndeliveredSend(home, id, attemptID, expected, message, time.Now().UTC().Format(time.RFC3339))
 }
 
 // Runs after every send that actually reaches the pane, whatever message that send carries: the trace's
 // job is telling the operator their last attempt did not land, and any successful send moots it.
-func clearUndeliveredSend(home, id string) error {
-	return setUndeliveredSend(home, id, "", "")
+func clearUndeliveredSend(home, id string, attemptID int64, expected state.AttemptLifecycle) error {
+	return setUndeliveredSend(home, id, attemptID, expected, "", "")
 }
 
-func setUndeliveredSend(home, id, message, at string) error {
-	// A short-lived task-row lock, separate from the send lock the command holds across its whole wait,
-	// so a long busy wait never blocks an unrelated reader like hand watch or hand status.
-	release, err := state.Lock(home, "task:"+id)
-	if err != nil {
-		return fmt.Errorf("lock task %q: %w", id, err)
-	}
-	defer release()
-
-	active, err := state.ActiveAttempt(home, id)
-	if err != nil {
-		return err
-	}
-	if active.SendUndeliveredMessage == message && active.SendUndeliveredAt == at {
-		return nil
-	}
-	active.SendUndeliveredMessage = message
-	active.SendUndeliveredAt = at
-	return state.UpdateAttempt(home, active)
+func setUndeliveredSend(home, id string, attemptID int64, expected state.AttemptLifecycle, message, at string) error {
+	return state.SetAttemptSendTrace(home, id, attemptID, expected, message, at)
 }

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -135,6 +135,29 @@ func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 	}
 }
 
+func TestSendDoesNotSteerAnAttemptWhileTaskOwnershipIsChanging(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "sent.log")
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	release, err := state.TryLock(home, "task:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "do not send"})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "changed while sending") {
+		t.Fatalf("got err %v, want an ownership conflict before pane send", err)
+	}
+	if _, readErr := os.ReadFile(logPath); !errors.Is(readErr, os.ErrNotExist) {
+		t.Fatalf("sent log read error = %v, want no pane send", readErr)
+	}
+}
+
 func TestSendReadsMessageFromFile(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "sent.log")
 	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -50,6 +50,24 @@ func TestSendHappyPathWhenIdle(t *testing.T) {
 	}
 }
 
+func TestSendRefusesUnconfirmedProvisioningAttempt(t *testing.T) {
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "hello worker"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want exit code 3", err)
+	}
+	if !strings.Contains(err.Error(), "confirmed running attempt") {
+		t.Fatalf("got err %v, want unconfirmed-attempt refusal", err)
+	}
+}
+
 func TestSendFailsWhenPaneNotFound(t *testing.T) {
 	// "pane get" is a query command (call(), client.go); call() checks env.Error before runErr, so this fake
 	// would behave identically without the exit 1 - kept only because it is a plausible real exit status for

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -68,6 +68,38 @@ func TestSendRefusesUnconfirmedProvisioningAttempt(t *testing.T) {
 	}
 }
 
+func TestSendReachesRunningAttemptCarryingNoLaunchEvidence(t *testing.T) {
+	// What a pre-split row and a legacy JSON import both look like: running, with no launch stamps to
+	// read. The attempt is genuinely alive, so refusing it would strand every fleet migrated into this
+	// schema (atqamz/hand#194).
+	logPath := filepath.Join(t.TempDir(), "sent.log")
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readTaskAttempt(t, home, "task-1"); got.LaunchSubmittedAt != "" || got.LaunchConfirmedAt != "" {
+		t.Fatalf("attempt carries launch evidence %q/%q, so this is not the migrated case", got.LaunchSubmittedAt, got.LaunchConfirmedAt)
+	}
+
+	cmd := newSendCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "hello worker"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "result: sent\n") {
+		t.Fatalf("output = %q, want a sent result", out.String())
+	}
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimRight(string(got), "\n") != "hello worker" {
+		t.Fatalf("sent text = %q, want the message delivered to the pane", got)
+	}
+}
+
 func TestSendFailsWhenPaneNotFound(t *testing.T) {
 	// "pane get" is a query command (call(), client.go); call() checks env.Error before runErr, so this fake
 	// would behave identically without the exit 1 - kept only because it is a plausible real exit status for

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -123,34 +123,40 @@ func newSpawnCmd() *cobra.Command {
 			}
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
-				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 			defer releaseWorktree()
 
 			if conflict, err := worktree.CheckCollision(home, lease, id); err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(home, id, attempt.ID, wt))
 			} else if conflict != "" {
-				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, worktree.Return(wt, true))
+				return reportSpawnCleanup(&ExitError{Err: fmt.Errorf("worktree collision: %s already holds %s", conflict, wt), Code: 3}, returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 
 			client := herdr.NewClient()
 			ws, tab, pane, rollback, err := acquireTaskWorkspace(client, wt, id, proj.Name)
 			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 			spawned := false
+			herdrRecorded := false
 			defer func() {
 				if spawned {
 					return
 				}
 				if closeErr := rollback(); closeErr != nil {
 					err = reportSpawnCleanup(err, closeErr)
+				} else if herdrRecorded {
+					if clearErr := state.ClearAttemptHerdr(home, id, attempt.ID); clearErr != nil {
+						err = reportSpawnCleanup(err, clearErr)
+					}
 				}
 			}()
 			paneStartedAt := time.Now().UTC().Format(time.RFC3339)
 			if err := state.RecordAttemptHerdr(home, id, attempt.ID, state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, paneStartedAt); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
+			herdrRecorded = true
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree:            wt,
@@ -161,24 +167,24 @@ func newSpawnCmd() *cobra.Command {
 				BriefHasFrontMatter: briefHasFrontMatter,
 			})
 			if err != nil {
-				return reportSpawnCleanup(err, worktree.Return(wt, true))
+				return reportSpawnCleanup(err, returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 			if err := state.MarkLaunchSubmitted(home, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 
 			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 			if err := state.MarkLaunchConfirmed(home, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 			if err := state.MarkAttemptRunning(home, id, attempt.ID); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), worktree.Return(wt, true))
+				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), returnProvisioningWorktree(home, id, attempt.ID, wt))
 			}
 			spawned = true
 
@@ -201,6 +207,16 @@ func newSpawnCmd() *cobra.Command {
 	cmd.Flags().StringVar(&effort, "effort", "", "effort level for harnesses that support it")
 	cmd.Flags().BoolVar(&skipGateCheck, "skip-gate-check", false, "dispatch even if the no-mistakes gate is not initialized, the clone path is missing from disk, or that path is not a git repository")
 	return cmd
+}
+
+func returnProvisioningWorktree(home, taskID string, attemptID int64, path string) error {
+	if err := worktree.Return(path, true); err != nil {
+		return err
+	}
+	if err := state.ClearAttemptWorktree(home, taskID, attemptID); err != nil {
+		return fmt.Errorf("clear returned worktree evidence: %w", err)
+	}
+	return nil
 }
 
 // Refuses to dispatch into a no-mistakes project whose gate is not initialized, rather than letting

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -90,6 +90,23 @@ func newSpawnCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			kind := state.KindShip
+			if scout {
+				kind = state.KindScout
+			}
+			spawnedAt := time.Now().UTC().Format(time.RFC3339)
+			task := state.Task{
+				ID: id, Project: proj.Name, Kind: kind, Brief: briefRel,
+				Lifecycle: state.TaskOpen, CreatedAt: spawnedAt,
+			}
+			attempt, err := state.CreateTaskWithAttempt(home, task, state.Attempt{
+				TaskID: id, Lifecycle: state.AttemptProvisioning, Harness: harnessName, Model: model, Effort: effort,
+				CreatedAt: spawnedAt,
+			})
+			if err != nil {
+				return asPrecondition(fmt.Errorf("write provisioning state: %w", err))
+			}
 			releaseProject, err := state.Lock(home, "project:"+proj.Name)
 			if err != nil {
 				return fmt.Errorf("lock project %q: %w", proj.Name, err)
@@ -101,6 +118,9 @@ func newSpawnCmd() *cobra.Command {
 				return fmt.Errorf("acquire treehouse worktree: %w", err)
 			}
 			wt := lease.Path
+			if err := state.RecordAttemptWorktree(home, id, attempt.ID, wt, lease.ID); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record worktree ownership: %w", err), worktree.Return(wt, true))
+			}
 			releaseWorktree, err := state.Lock(home, "worktree:"+wt)
 			if err != nil {
 				return reportSpawnCleanup(fmt.Errorf("lock worktree %q: %w", wt, err), worktree.Return(wt, true))
@@ -118,9 +138,6 @@ func newSpawnCmd() *cobra.Command {
 			if err != nil {
 				return reportSpawnCleanup(err, worktree.Return(wt, true))
 			}
-
-			// Disarms the rollback below once state has durably recorded the task: from that point
-			// its workspace and tab are owned by the running task, not by this call.
 			spawned := false
 			defer func() {
 				if spawned {
@@ -130,6 +147,10 @@ func newSpawnCmd() *cobra.Command {
 					err = reportSpawnCleanup(err, closeErr)
 				}
 			}()
+			paneStartedAt := time.Now().UTC().Format(time.RFC3339)
+			if err := state.RecordAttemptHerdr(home, id, attempt.ID, state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID}, paneStartedAt); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record Herdr ownership: %w", err), worktree.Return(wt, true))
+			}
 
 			launchCmd, err := harness.Build(harnessName, harness.Options{
 				Worktree:            wt,
@@ -146,34 +167,18 @@ func newSpawnCmd() *cobra.Command {
 			if err := client.PaneRun(pane.PaneID, launchCmd); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("send launch command failed: %w", err), worktree.Return(wt, true))
 			}
+			if err := state.MarkLaunchSubmitted(home, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record launch submission: %w", err), worktree.Return(wt, true))
+			}
 
 			if err := confirmLaunch(client, pane.PaneID, harnessName); err != nil {
 				return reportSpawnCleanup(fmt.Errorf("confirm worker started: %w", err), worktree.Return(wt, true))
 			}
-
-			kind := state.KindShip
-			if scout {
-				kind = state.KindScout
+			if err := state.MarkLaunchConfirmed(home, id, attempt.ID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record launch confirmation: %w", err), worktree.Return(wt, true))
 			}
-
-			spawnedAt := time.Now().UTC().Format(time.RFC3339)
-			task := state.Task{
-				ID:        id,
-				Project:   proj.Name,
-				Kind:      kind,
-				Brief:     briefRel,
-				Lifecycle: state.TaskOpen,
-				CreatedAt: spawnedAt,
-			}
-			if err := state.CreateTask(home, task); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write task state: %w", err), worktree.Return(wt, true))
-			}
-			if _, err := state.CreateAttempt(home, state.Attempt{
-				TaskID: id, Lifecycle: state.AttemptRunning, Harness: harnessName, Model: model, Effort: effort,
-				Worktree: wt, LeaseID: lease.ID, Herdr: state.Herdr{Session: "default", WorkspaceID: ws.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID},
-				CreatedAt: spawnedAt, PaneStartedAt: spawnedAt,
-			}); err != nil {
-				return reportSpawnCleanup(fmt.Errorf("write attempt state: %w", err), worktree.Return(wt, true))
+			if err := state.MarkAttemptRunning(home, id, attempt.ID); err != nil {
+				return reportSpawnCleanup(fmt.Errorf("record running attempt: %w", err), worktree.Return(wt, true))
 			}
 			spawned = true
 

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -427,8 +427,8 @@ func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.
 	}
 
 	got, err := state.ReadHistory(home, "task-1")
-	if err != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt {
-		t.Fatalf("provisioning evidence after collision = %+v err=%v", got, err)
+	if err != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != "" || got.ActiveAttempt.LeaseID != "" {
+		t.Fatalf("provisioning evidence after collision = %+v err=%v, want returned resource ownership cleared", got, err)
 	}
 }
 
@@ -508,8 +508,8 @@ func TestSpawnRollsBackWhenWorkerNeverStarts(t *testing.T) {
 	}
 
 	got, readErr := state.ReadHistory(home, "task-1")
-	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt || got.ActiveAttempt.Herdr.PaneID != "wA:pC" || got.ActiveAttempt.LaunchSubmittedAt == "" || got.ActiveAttempt.LaunchConfirmedAt != "" {
-		t.Fatalf("provisioning evidence after confirmation failure = %+v err=%v", got, readErr)
+	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != "" || got.ActiveAttempt.LeaseID != "" || got.ActiveAttempt.Herdr.PaneID != "" || got.ActiveAttempt.LaunchSubmittedAt == "" || got.ActiveAttempt.LaunchConfirmedAt != "" {
+		t.Fatalf("provisioning evidence after confirmation failure = %+v err=%v, want launch evidence without released resources", got, readErr)
 	}
 	calls, readErr := os.ReadFile(callLog)
 	if readErr != nil {
@@ -556,8 +556,8 @@ func TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind(t *testing.T) {
 	}
 
 	got, readErr := state.ReadHistory(home, "task-1")
-	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt {
-		t.Fatalf("provisioning evidence after partial workspace response = %+v err=%v", got, readErr)
+	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != "" || got.ActiveAttempt.Herdr.PaneID != "" {
+		t.Fatalf("provisioning evidence after partial workspace response = %+v err=%v, want released resources cleared", got, readErr)
 	}
 	calls, readErr := os.ReadFile(callLog)
 	if readErr != nil {
@@ -587,8 +587,8 @@ func TestSpawnTabRenameFailureClosesWorkspaceItCreated(t *testing.T) {
 	}
 
 	got, readErr := state.ReadHistory(home, "task-1")
-	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt {
-		t.Fatalf("provisioning evidence after tab rename failure = %+v err=%v", got, readErr)
+	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != "" || got.ActiveAttempt.Herdr.PaneID != "" {
+		t.Fatalf("provisioning evidence after tab rename failure = %+v err=%v, want released resources cleared", got, readErr)
 	}
 	calls, readErr := os.ReadFile(callLog)
 	if readErr != nil {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -186,6 +186,9 @@ func TestSpawnHappyPath(t *testing.T) {
 	if active.LeaseID != "lease-1" {
 		t.Fatalf("got lease id %q, want the identity treehouse handed back", active.LeaseID)
 	}
+	if active.LaunchSubmittedAt == "" || active.LaunchConfirmedAt == "" || active.StatusChangedAt == "" {
+		t.Fatalf("launch evidence = %+v, want submitted, confirmed, and running timestamps", active)
+	}
 	for _, want := range []string{
 		"id: task-1\n",
 		"result: spawned\n",
@@ -423,8 +426,9 @@ func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.
 		t.Fatalf("got err %v, want collision", err)
 	}
 
-	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
-		t.Fatalf("state written after collision: exists=%v err=%v", exists, err)
+	got, err := state.ReadHistory(home, "task-1")
+	if err != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt {
+		t.Fatalf("provisioning evidence after collision = %+v err=%v", got, err)
 	}
 }
 
@@ -503,8 +507,9 @@ func TestSpawnRollsBackWhenWorkerNeverStarts(t *testing.T) {
 		t.Fatalf("got err %v, want the spawn to fail on launch confirmation", err)
 	}
 
-	if exists, existsErr := state.Exists(home, "task-1"); existsErr != nil || exists {
-		t.Fatalf("state written for a worker that never started: exists=%v err=%v", exists, existsErr)
+	got, readErr := state.ReadHistory(home, "task-1")
+	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt || got.ActiveAttempt.Herdr.PaneID != "wA:pC" || got.ActiveAttempt.LaunchSubmittedAt == "" || got.ActiveAttempt.LaunchConfirmedAt != "" {
+		t.Fatalf("provisioning evidence after confirmation failure = %+v err=%v", got, readErr)
 	}
 	calls, readErr := os.ReadFile(callLog)
 	if readErr != nil {
@@ -550,8 +555,9 @@ func TestSpawnPartialWorkspaceCreateLeavesNoWorkspaceBehind(t *testing.T) {
 		t.Fatalf("got err %v, want the partial workspace_created response rejected", err)
 	}
 
-	if exists, existsErr := state.Exists(home, "task-1"); existsErr != nil || exists {
-		t.Fatalf("state written for a partial workspace_created response: exists=%v err=%v", exists, existsErr)
+	got, readErr := state.ReadHistory(home, "task-1")
+	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt {
+		t.Fatalf("provisioning evidence after partial workspace response = %+v err=%v", got, readErr)
 	}
 	calls, readErr := os.ReadFile(callLog)
 	if readErr != nil {
@@ -580,8 +586,9 @@ func TestSpawnTabRenameFailureClosesWorkspaceItCreated(t *testing.T) {
 		t.Fatalf("got err %v, want the tab rename failure surfaced", err)
 	}
 
-	if exists, existsErr := state.Exists(home, "task-1"); existsErr != nil || exists {
-		t.Fatalf("state written for a failed tab rename: exists=%v err=%v", exists, existsErr)
+	got, readErr := state.ReadHistory(home, "task-1")
+	if readErr != nil || got.ActiveAttempt == nil || got.ActiveAttempt.Lifecycle != state.AttemptProvisioning || got.ActiveAttempt.Worktree != wt {
+		t.Fatalf("provisioning evidence after tab rename failure = %+v err=%v", got, readErr)
 	}
 	calls, readErr := os.ReadFile(callLog)
 	if readErr != nil {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -52,12 +52,15 @@ func newTeardownCmd() *cobra.Command {
 			originalTask := t
 			active := *history.ActiveAttempt
 
-			// An attempt still provisioning never ran an agent, so there is no landed work to check for
-			// and no completion to claim: it can only be torn down as interrupted.
-			launched := active.Lifecycle != state.AttemptProvisioning
+			// Provisioning remains durable through launch confirmation, so lifecycle alone cannot tell
+			// whether the worker ever ran. Launch evidence makes the ordinary landed-work check mandatory.
+			launched := active.Lifecycle != state.AttemptProvisioning || active.LaunchSubmittedAt != "" || active.LaunchConfirmedAt != ""
 
 			dirtWasSafe := false
 			if !force && launched {
+				if active.Lifecycle == state.AttemptProvisioning && active.Worktree == "" {
+					return &ExitError{Err: fmt.Errorf("task %q has launch evidence but no worktree to inspect; rerun with --force to interrupt it", id), Code: 3}
+				}
 				updated, safeDirt, err := checkLandedWork(cmd.Context(), home, t, active)
 				if err != nil {
 					return err
@@ -112,7 +115,7 @@ func newTeardownCmd() *cobra.Command {
 			}
 
 			terminalAttempt := state.AttemptCompleted
-			if force || !launched {
+			if force || !launched || active.Lifecycle == state.AttemptProvisioning {
 				terminalAttempt = state.AttemptInterrupted
 			}
 			if err := state.TerminalizeTaskAndAttempt(home, id, active.ID, active.Lifecycle, terminalAttempt); err != nil {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -49,6 +49,7 @@ func newTeardownCmd() *cobra.Command {
 				return &ExitError{Err: fmt.Errorf("task %q has no active attempt", id), Code: 3}
 			}
 			t := history.Task
+			originalTask := t
 			active := *history.ActiveAttempt
 
 			dirtWasSafe := false
@@ -86,8 +87,10 @@ func newTeardownCmd() *cobra.Command {
 			record := completionFor(t, force)
 			record.TornDownAt = time.Now().UTC().Format(time.RFC3339)
 
-			if err := state.UpdateTask(home, t); err != nil {
-				return fmt.Errorf("record task facts: %w", err)
+			if t.PR != originalTask.PR {
+				if err := state.SetTaskPR(home, id, t.PR); err != nil {
+					return fmt.Errorf("record task facts: %w", err)
+				}
 			}
 
 			if err := completion.Append(home, record); err != nil {
@@ -98,10 +101,7 @@ func newTeardownCmd() *cobra.Command {
 			if force {
 				terminalAttempt = state.AttemptInterrupted
 			}
-			if err := state.TransitionAttempt(home, active.ID, active.Lifecycle, terminalAttempt); err != nil {
-				return fmt.Errorf("record attempt completion: %w", err)
-			}
-			if err := state.TransitionTask(home, id, state.TaskOpen, state.TaskTerminal); err != nil {
+			if err := state.TerminalizeTaskAndAttempt(home, id, active.ID, active.Lifecycle, terminalAttempt); err != nil {
 				return fmt.Errorf("record task completion: %w", err)
 			}
 

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -96,6 +96,16 @@ func newTeardownCmd() *cobra.Command {
 					return fmt.Errorf("record task facts: %w", err)
 				}
 			}
+			if t.Kind != originalTask.Kind {
+				if err := state.SetTaskKind(home, id, string(t.Kind)); err != nil {
+					return fmt.Errorf("record task kind: %w", err)
+				}
+			}
+			if t.MergeAnnounced && !originalTask.MergeAnnounced {
+				if err := state.SetTaskMergeAnnounced(home, id); err != nil {
+					return fmt.Errorf("record merge announcement: %w", err)
+				}
+			}
 
 			if err := completion.Append(home, record); err != nil {
 				return fmt.Errorf("record completion: %w", err)

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -52,8 +52,12 @@ func newTeardownCmd() *cobra.Command {
 			originalTask := t
 			active := *history.ActiveAttempt
 
+			// An attempt still provisioning never ran an agent, so there is no landed work to check for
+			// and no completion to claim: it can only be torn down as interrupted.
+			launched := active.Lifecycle != state.AttemptProvisioning
+
 			dirtWasSafe := false
-			if !force {
+			if !force && launched {
 				updated, safeDirt, err := checkLandedWork(cmd.Context(), home, t, active)
 				if err != nil {
 					return err
@@ -84,7 +88,7 @@ func newTeardownCmd() *cobra.Command {
 			// Everything the record claims (landed work, a returned worktree) is already true by this
 			// line, --force or not, so a fault after it lands cannot make the record inaccurate, only
 			// late to terminalize its source.
-			record := completionFor(t, force)
+			record := completionFor(t, force, launched)
 			record.TornDownAt = time.Now().UTC().Format(time.RFC3339)
 
 			if t.PR != originalTask.PR {
@@ -98,7 +102,7 @@ func newTeardownCmd() *cobra.Command {
 			}
 
 			terminalAttempt := state.AttemptCompleted
-			if force {
+			if force || !launched {
 				terminalAttempt = state.AttemptInterrupted
 			}
 			if err := state.TerminalizeTaskAndAttempt(home, id, active.ID, active.Lifecycle, terminalAttempt); err != nil {
@@ -123,7 +127,11 @@ func newTeardownCmd() *cobra.Command {
 			doc.Field("kind", record.Kind)
 			doc.Field("outcome", record.Outcome)
 			doc.Field("detail", orNone(record.Detail))
-			doc.Field("worktree", "returned")
+			worktreeResult := "returned"
+			if active.Worktree == "" {
+				worktreeResult = "none"
+			}
+			doc.Field("worktree", worktreeResult)
 			doc.Help("This task remains inspectable with `hand status " + id + "`; use `hand reopen " + id + "` for another attempt")
 			return doc.Render(cmd.OutOrStdout())
 		},
@@ -133,12 +141,17 @@ func newTeardownCmd() *cobra.Command {
 	return cmd
 }
 
-func completionFor(t state.Task, forced bool) completion.Record {
+func completionFor(t state.Task, forced, launched bool) completion.Record {
 	c := completion.Record{ID: t.ID, Project: t.Project, Kind: t.Kind}
 	// The delivered case sits ahead of the merge cases below only while no merge is on the row: a
 	// delivery that then genuinely landed has the stronger fact to record, so an observed or executed
 	// merge outranks the mark.
 	switch {
+	// Ahead of every case below, including the forced one: none of them can be true of an attempt
+	// whose agent never started, and recording a merge or a delivery for it would be a false fact.
+	case !launched:
+		c.Outcome = "torn-down"
+		c.Detail = "attempt never launched"
 	case forced:
 		c.Outcome = "torn-down"
 		c.Detail = "forced (landed-work checks skipped)"
@@ -494,6 +507,10 @@ func currentBranch(worktreePath string) (string, error) {
 // workspace either way, so this says so rather than leaving it to a side effect
 // (internal/faketool/FIDELITY.md).
 func closeTaskTab(client *herdr.Client, workspaceID, tabID string) error {
+	// An attempt that never reached a pane has no tab to close.
+	if workspaceID == "" || tabID == "" {
+		return nil
+	}
 	tabs, err := client.TabList(workspaceID)
 	if err != nil {
 		return err

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -507,6 +507,116 @@ func TestTeardownReleasesAnAttemptThatNeverReachedItsResources(t *testing.T) {
 	}
 }
 
+func TestTeardownRefusesLaunchedProvisioningWithUnlandedWork(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	writeFakeGHPRState(t, "OPEN")
+	runGitIn(t, worktree, "checkout", "-q", "-b", "task-1-branch")
+	if err := os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("unlanded"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, worktree, "add", "feature.txt")
+	runGitIn(t, worktree, "commit", "-q", "-m", "feature")
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj", PR: teardownTestPR}, state.Attempt{
+		Lifecycle: state.AttemptProvisioning, Worktree: worktree, LaunchSubmittedAt: "2026-08-14T00:00:01Z",
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pB"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), "not merged") {
+		t.Fatalf("got err %v, want launched provisioning safety refusal", err)
+	}
+	if history, readErr := state.ReadHistory(home, "task-1"); readErr != nil || history.Task.Lifecycle != state.TaskOpen || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptProvisioning {
+		t.Fatalf("history after safety refusal = %+v, %v, want provisioning task preserved", history, readErr)
+	}
+	if invocations := readInvocations(t, worktree); len(invocations) != 0 {
+		t.Fatalf("external cleanup before landed-work refusal = %v, want no invocations", invocations)
+	}
+}
+
+func TestTeardownDoesNotCallConfirmedProvisioningNeverLaunched(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	writeFakeGHPRState(t, "MERGED")
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj", PR: teardownTestPR}, state.Attempt{
+		Lifecycle: state.AttemptProvisioning, Worktree: worktree,
+		LaunchSubmittedAt: "2026-08-14T00:00:01Z", LaunchConfirmedAt: "2026-08-14T00:00:02Z",
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pB"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("attempt after confirmed provisioning teardown = %+v, want interrupted without a running transition", history.Attempts[0])
+	}
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Detail == "attempt never launched" {
+		t.Fatalf("completions = %+v, want launched completion", records)
+	}
+}
+
+func TestTeardownRefusesLaunchedProvisioningWithoutWorktree(t *testing.T) {
+	home, _ := setupTeardownHome(t)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{
+		Lifecycle: state.AttemptProvisioning, LaunchConfirmedAt: "2026-08-14T00:00:02Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), "launch evidence but no worktree") {
+		t.Fatalf("got err %v, want missing-worktree safety refusal", err)
+	}
+}
+
+func TestTeardownForceInterruptsLaunchedProvisioning(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{
+		Lifecycle: state.AttemptProvisioning, Worktree: worktree, LaunchSubmittedAt: "2026-08-14T00:00:01Z",
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB", PaneID: "wA:pB"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("forced launched provisioning teardown = %+v, want interrupted", history.Attempts[0])
+	}
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Detail == "attempt never launched" {
+		t.Fatalf("forced completions = %+v, want launched forced completion", records)
+	}
+}
+
 // Teardown must survive a fault in its last step, which takes both halves of "retryable". Reverting
 // either half fails this test: the ordering leaves nothing to retry, the idempotency leaves the retry
 // dying on a tab herdr no longer lists.

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -878,6 +878,10 @@ func TestTeardownAcceptsAShipRowThatDeliveredAScoutReport(t *testing.T) {
 	if records[0].Kind != state.KindScout || records[0].Outcome != "done" {
 		t.Fatalf("completion = %+v, want kind scout outcome done", records[0])
 	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil || history.Task.Kind != state.KindScout {
+		t.Fatalf("task after teardown = %+v, want inferred scout kind persisted", history.Task)
+	}
 }
 
 // The half of atqamz/hand#129's fix that matters: the scout-deliverable path must not become "no PR

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -469,6 +469,44 @@ func TestTeardownShipSucceedsWhenPRMerged(t *testing.T) {
 	}
 }
 
+// A spawn that failed before it leased anything leaves exactly this Attempt: provisioning, with no
+// worktree and no pane. Teardown is the only way out of it, so it has to tolerate the missing
+// resources and terminalize through a transition provisioning actually allows (atqamz/hand#194).
+func TestTeardownReleasesAnAttemptThatNeverReachedItsResources(t *testing.T) {
+	home, _ := setupTeardownHome(t)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"},
+		state.Attempt{Lifecycle: state.AttemptProvisioning}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.Task.ActiveAttemptID != 0 ||
+		len(history.Attempts) != 1 || history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("unprovisioned teardown history = %+v", history)
+	}
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Outcome != "torn-down" || records[0].Detail != "attempt never launched" {
+		t.Fatalf("completions = %+v, want one never-launched record", records)
+	}
+	if !strings.Contains(out.String(), "worktree: none\n") {
+		t.Fatalf("output = %q, want no worktree claimed", out.String())
+	}
+}
+
 // Teardown must survive a fault in its last step, which takes both halves of "retryable". Reverting
 // either half fails this test: the ordering leaves nothing to retry, the idempotency leaves the retry
 // dying on a tab herdr no longer lists.

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -14,6 +14,10 @@ func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.
 		t.Fatal(err)
 	}
 	attempt.TaskID = task.ID
+	if attempt.Lifecycle == state.AttemptRunning && attempt.LaunchConfirmedAt == "" {
+		attempt.LaunchSubmittedAt = "test-submitted"
+		attempt.LaunchConfirmedAt = "test-confirmed"
+	}
 	if _, err := state.CreateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -14,10 +14,6 @@ func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.
 		t.Fatal(err)
 	}
 	attempt.TaskID = task.ID
-	if attempt.Lifecycle == state.AttemptRunning && attempt.LaunchConfirmedAt == "" {
-		attempt.LaunchSubmittedAt = "test-submitted"
-		attempt.LaunchConfirmedAt = "test-confirmed"
-	}
 	if _, err := state.CreateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/state/hold.go
+++ b/internal/state/hold.go
@@ -1,10 +1,6 @@
 package state
 
-import (
-	"errors"
-
-	"github.com/atqamz/hand/internal/store"
-)
+import "github.com/atqamz/hand/internal/store"
 
 // ErrHoldNotFound is wrapped into errors returned by ClearHold when no hold
 // row exists for the given ID, rendering as `hold "<id>" not found`.
@@ -43,31 +39,35 @@ func ClearHold(homeDir, id string) error {
 // whether it wrote. Set-side counterpart of ClearHoldIfKind: a machine-set hold overwriting an
 // operator's own would not merely hide their question - the later kind-matched clear deletes the row.
 func SetHoldIfNotOtherKind(homeDir string, h Hold) (bool, error) {
-	existing, exists, err := ReadHold(homeDir, h.ID)
+	if err := ValidateID(h.ID); err != nil {
+		return false, err
+	}
+	db, err := store.Open(homeDir)
 	if err != nil {
 		return false, err
 	}
-	if exists && existing.Kind != h.Kind {
-		return false, nil
-	}
-	if err := SetHold(homeDir, h); err != nil {
+	defer func() { _ = db.Close() }()
+	written, err := db.SetHoldIfNotOtherKind(h)
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return written, nil
 }
 
 // ClearHoldIfKind drops the hold on id only when it is of kind, so a caller that
 // invalidated one machine-set hold decides nothing about an operator's own hold on the
 // same id. A missing hold is the ordinary case, not a failure.
 func ClearHoldIfKind(homeDir, id, kind string) error {
-	h, exists, err := ReadHold(homeDir, id)
-	if err != nil || !exists || h.Kind != kind {
+	if err := ValidateID(id); err != nil {
 		return err
 	}
-	if err := ClearHold(homeDir, id); err != nil && !errors.Is(err, ErrHoldNotFound) {
+	db, err := store.Open(homeDir)
+	if err != nil {
 		return err
 	}
-	return nil
+	defer func() { _ = db.Close() }()
+	_, err = db.ClearHoldIfKind(id, kind)
+	return err
 }
 
 func ReadHold(homeDir, id string) (Hold, bool, error) {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -70,8 +70,8 @@ func Claim(homeDir, id string) (func(), error) {
 }
 
 func Lock(homeDir, name string) (func(), error) {
-	// Lifecycle commands acquire task, then project, then worktree. Send owns send only; its database
-	// bookkeeping is attempt-targeted so it never nests a task lock under send.
+	// Lifecycle commands acquire task, then project, then worktree. Send and watcher resume acquire send,
+	// then task only for the short external-send boundary; attempt writes remain ID-targeted.
 	return store.Lock(homeDir, name, false)
 }
 
@@ -302,6 +302,24 @@ func SetTaskPR(homeDir, id, pr string) error {
 	return db.SetTaskPR(id, pr)
 }
 
+func SetTaskKind(homeDir, id, kind string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskKind(id, kind)
+}
+
+func SetTaskMergeAnnounced(homeDir, id string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskMergeAnnounced(id)
+}
+
 func SetTaskDelivery(homeDir, id, deliveredAt, reason string) error {
 	db, err := store.Open(homeDir)
 	if err != nil {
@@ -338,6 +356,15 @@ func RecordAttemptWorktree(homeDir, taskID string, attemptID int64, worktree, le
 	return db.RecordAttemptWorktree(taskID, attemptID, worktree, leaseID)
 }
 
+func ClearAttemptWorktree(homeDir, taskID string, attemptID int64) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ClearAttemptWorktree(taskID, attemptID)
+}
+
 func RecordAttemptHerdr(homeDir, taskID string, attemptID int64, herdr Herdr, paneStartedAt string) error {
 	db, err := store.Open(homeDir)
 	if err != nil {
@@ -345,6 +372,15 @@ func RecordAttemptHerdr(homeDir, taskID string, attemptID int64, herdr Herdr, pa
 	}
 	defer func() { _ = db.Close() }()
 	return db.RecordAttemptHerdr(taskID, attemptID, herdr, paneStartedAt)
+}
+
+func ClearAttemptHerdr(homeDir, taskID string, attemptID int64) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ClearAttemptHerdr(taskID, attemptID)
 }
 
 func MarkLaunchSubmitted(homeDir, taskID string, attemptID int64, at string) error {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -70,6 +70,8 @@ func Claim(homeDir, id string) (func(), error) {
 }
 
 func Lock(homeDir, name string) (func(), error) {
+	// Lifecycle commands acquire task, then project, then worktree. Send owns send only; its database
+	// bookkeeping is attempt-targeted so it never nests a task lock under send.
 	return store.Lock(homeDir, name, false)
 }
 
@@ -159,6 +161,15 @@ func ActiveAttempt(homeDir, id string) (Attempt, error) {
 	return *history.ActiveAttempt, nil
 }
 
+func ReadAttempt(homeDir string, attemptID int64) (Attempt, bool, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Attempt{}, false, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ReadAttempt(attemptID)
+}
+
 func Write(homeDir string, t Task) error {
 	if err := ValidateID(t.ID); err != nil {
 		return err
@@ -190,6 +201,23 @@ func CreateTask(homeDir string, t Task) error {
 	return db.CreateTask(t)
 }
 
+func CreateTaskWithAttempt(homeDir string, t Task, a Attempt) (Attempt, error) {
+	if err := ValidateID(t.ID); err != nil {
+		return Attempt{}, err
+	}
+	if a.TaskID != "" {
+		if err := ValidateID(a.TaskID); err != nil {
+			return Attempt{}, err
+		}
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Attempt{}, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.CreateTaskWithAttempt(t, a)
+}
+
 func UpdateTask(homeDir string, t Task) error {
 	if err := ValidateID(t.ID); err != nil {
 		return err
@@ -212,6 +240,18 @@ func CreateAttempt(homeDir string, a Attempt) (Attempt, error) {
 	}
 	defer func() { _ = db.Close() }()
 	return db.CreateAttempt(a)
+}
+
+func CreateAttemptIfOpenAndInactive(homeDir string, a Attempt) (Attempt, error) {
+	if err := ValidateID(a.TaskID); err != nil {
+		return Attempt{}, err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Attempt{}, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.CreateAttemptIfOpenAndInactive(a)
 }
 
 func UpdateAttempt(homeDir string, a Attempt) error {
@@ -239,6 +279,129 @@ func TransitionTask(homeDir, id string, from, to TaskLifecycle) error {
 	}
 	defer func() { _ = db.Close() }()
 	return db.TransitionTask(id, from, to)
+}
+
+func PromoteTask(homeDir, id string, scoutAttemptID int64, scoutFrom AttemptLifecycle, ship Attempt) (Attempt, error) {
+	if err := ValidateID(id); err != nil {
+		return Attempt{}, err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return Attempt{}, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.PromoteTask(id, scoutAttemptID, scoutFrom, ship)
+}
+
+func TerminalizeTaskAndAttempt(homeDir, taskID string, attemptID int64, attemptFrom, attemptTo AttemptLifecycle) error {
+	if err := ValidateID(taskID); err != nil {
+		return err
+	}
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.TerminalizeTaskAndAttempt(taskID, attemptID, attemptFrom, attemptTo)
+}
+
+func SetTaskPR(homeDir, id, pr string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskPR(id, pr)
+}
+
+func SetTaskDelivery(homeDir, id, deliveredAt, reason string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskDelivery(id, deliveredAt, reason)
+}
+
+func SetTaskMerge(homeDir, id, mergedAt string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskMerge(id, mergedAt)
+}
+
+func SetTaskReportState(homeDir, id string, offset int64, digest string, mergeAnnounced bool) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskReportState(id, offset, digest, mergeAnnounced)
+}
+
+func RecordAttemptWorktree(homeDir, taskID string, attemptID int64, worktree, leaseID string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.RecordAttemptWorktree(taskID, attemptID, worktree, leaseID)
+}
+
+func RecordAttemptHerdr(homeDir, taskID string, attemptID int64, herdr Herdr, paneStartedAt string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.RecordAttemptHerdr(taskID, attemptID, herdr, paneStartedAt)
+}
+
+func MarkLaunchSubmitted(homeDir, taskID string, attemptID int64, at string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.MarkLaunchSubmitted(taskID, attemptID, at)
+}
+
+func MarkLaunchConfirmed(homeDir, taskID string, attemptID int64, at string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.MarkLaunchConfirmed(taskID, attemptID, at)
+}
+
+func MarkAttemptRunning(homeDir, taskID string, attemptID int64) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.MarkAttemptRunning(taskID, attemptID)
+}
+
+func SetAttemptSendTrace(homeDir, taskID string, attemptID int64, expected AttemptLifecycle, message, at string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetAttemptSendTrace(taskID, attemptID, expected, message, at)
+}
+
+func UpdateAttemptObservation(homeDir, taskID string, attemptID int64, expected AttemptLifecycle, statusChangedAt, statusChangedFor string, doneVerified bool, lastReportState, lastReportNote, parkedFiredFor, usageLimitRetryAt string, usageLimitAttempts int) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.UpdateAttemptObservation(taskID, attemptID, expected, statusChangedAt, statusChangedFor, doneVerified, lastReportState, lastReportNote, parkedFiredFor, usageLimitRetryAt, usageLimitAttempts)
 }
 
 func ReopenTask(homeDir string, a Attempt) (Attempt, error) {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -242,18 +242,6 @@ func CreateAttempt(homeDir string, a Attempt) (Attempt, error) {
 	return db.CreateAttempt(a)
 }
 
-func CreateAttemptIfOpenAndInactive(homeDir string, a Attempt) (Attempt, error) {
-	if err := ValidateID(a.TaskID); err != nil {
-		return Attempt{}, err
-	}
-	db, err := store.Open(homeDir)
-	if err != nil {
-		return Attempt{}, err
-	}
-	defer func() { _ = db.Close() }()
-	return db.CreateAttemptIfOpenAndInactive(a)
-}
-
 func UpdateAttempt(homeDir string, a Attempt) error {
 	db, err := store.Open(homeDir)
 	if err != nil {

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/atqamz/hand/internal/filelock"
 	"github.com/atqamz/hand/internal/store"
@@ -225,6 +226,32 @@ func TestTryLockReportsBusyInsteadOfWaiting(t *testing.T) {
 		t.Fatal(err)
 	}
 	second()
+}
+
+func TestAttemptSendBookkeepingDoesNotNestTaskLock(t *testing.T) {
+	dir := t.TempDir()
+	attempt, err := CreateTaskWithAttempt(dir, Task{ID: "task-1", Lifecycle: TaskOpen}, Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := Lock(dir, "task:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- SetAttemptSendTrace(dir, "task-1", attempt.ID, AttemptProvisioning, "message", "2026-08-14T00:00:00Z")
+	}()
+	select {
+	case err := <-result:
+		release()
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		release()
+		t.Fatal("attempt bookkeeping waited on the task lock")
+	}
 }
 
 func TestWriteOverwritesExisting(t *testing.T) {

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -28,6 +28,11 @@ type (
 	AttemptLifecycle = store.AttemptLifecycle
 )
 
+var (
+	ErrLifecycleConflict = store.ErrLifecycleConflict
+	ErrOwnershipConflict = store.ErrOwnershipConflict
+)
+
 const (
 	TaskOpen     = store.TaskOpen
 	TaskTerminal = store.TaskTerminal

--- a/internal/store/attempt_test.go
+++ b/internal/store/attempt_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"sync"
 	"testing"
 )
 
@@ -93,6 +94,9 @@ func TestTaskAndAttemptTransitionsRejectIllegalStates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err := db.sql.Exec(`UPDATE attempt SET launch_submitted_at = 'submitted', launch_confirmed_at = 'confirmed' WHERE id = ?`, attempt.ID); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.TransitionAttempt(attempt.ID, AttemptProvisioning, AttemptRunning); err != nil {
 		t.Fatal(err)
 	}
@@ -148,18 +152,332 @@ func TestReopenTaskCreatesANewAttemptWithoutResurrectingHistory(t *testing.T) {
 	if err := db.TransitionTask("task-1", TaskOpen, TaskTerminal); err != nil {
 		t.Fatal(err)
 	}
-	second, err := db.ReopenTask("task-1", Attempt{Lifecycle: AttemptRunning, Harness: "codex"})
+	second, err := db.ReopenTask("task-1", Attempt{Lifecycle: AttemptProvisioning, Harness: "codex"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second.Ordinal != 2 || second.Lifecycle != AttemptRunning || second.Harness != "codex" {
-		t.Fatalf("reopened attempt = %+v, want ordinal 2 running codex", second)
+	if second.Ordinal != 2 || second.Lifecycle != AttemptProvisioning || second.Harness != "codex" {
+		t.Fatalf("reopened attempt = %+v, want ordinal 2 provisioning codex", second)
 	}
 	history, found, err := db.ReadTaskHistory("task-1")
 	if err != nil || !found || history.Task.Lifecycle != TaskOpen || history.ActiveAttempt == nil || history.ActiveAttempt.ID != second.ID {
 		t.Fatalf("reopened history = %+v, %v, want task open with second active", history, err)
 	}
 	if len(history.Attempts) != 2 || history.Attempts[0].Lifecycle != AttemptCompleted {
-		t.Fatalf("attempt history = %+v, want completed first attempt and running second", history.Attempts)
+		t.Fatalf("attempt history = %+v, want completed first attempt and provisioning second", history.Attempts)
+	}
+}
+
+func TestProvisioningEvidenceIsIncrementalAndRequiredBeforeRunning(t *testing.T) {
+	db, _ := openTemp(t)
+	created, err := db.CreateTaskWithAttempt(Task{ID: "task-1", Lifecycle: TaskOpen}, Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := func() Attempt {
+		attempt, found, err := db.ReadAttempt(created.ID)
+		if err != nil || !found {
+			t.Fatalf("ReadAttempt = %+v, %v, %v", attempt, found, err)
+		}
+		return attempt
+	}
+	if got := read(); got.Worktree != "" || got.Herdr.PaneID != "" || got.LaunchSubmittedAt != "" || got.LaunchConfirmedAt != "" {
+		t.Fatalf("initial provisioning evidence = %+v, want empty boundaries", got)
+	}
+	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "lease-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.RecordAttemptHerdr("task-1", created.ID, Herdr{PaneID: "pane-1"}, "2026-08-14T00:00:01Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkLaunchSubmitted("task-1", created.ID, "2026-08-14T00:00:02Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkAttemptRunning("task-1", created.ID); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("running before confirmation = %v, want invalid transition", err)
+	}
+	if err := db.MarkLaunchConfirmed("task-1", created.ID, "2026-08-14T00:00:03Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkAttemptRunning("task-1", created.ID); err != nil {
+		t.Fatal(err)
+	}
+	got := read()
+	if got.Lifecycle != AttemptRunning || got.Worktree != "/tmp/wt" || got.LeaseID != "lease-1" || got.Herdr.PaneID != "pane-1" || got.LaunchSubmittedAt == "" || got.LaunchConfirmedAt == "" {
+		t.Fatalf("final provisioning evidence = %+v, want every boundary and running", got)
+	}
+}
+
+func TestTerminalTaskRejectsOrdinaryAttemptCreation(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateAttemptIfOpenAndInactive(Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning}); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("attempt on terminal task = %v, want invalid transition", err)
+	}
+}
+
+func TestStaleTaskTransitionLosesWithoutChangingNewerLifecycle(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionTask("task-1", TaskOpen, TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionTask("task-1", TaskOpen, TaskTerminal); !errors.Is(err, ErrLifecycleConflict) {
+		t.Fatalf("stale task transition = %v, want lifecycle conflict", err)
+	}
+	got, found, err := db.ReadTask("task-1")
+	if err != nil || !found || got.Lifecycle != TaskTerminal {
+		t.Fatalf("task after stale transition = %+v, %v, %v", got, found, err)
+	}
+}
+
+func TestConcurrentReopenHasOneWinnerAndOneFreshProvisioningAttempt(t *testing.T) {
+	db, home := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(first.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionTask("task-1", TaskOpen, TaskTerminal); err != nil {
+		t.Fatal(err)
+	}
+	other, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = other.Close() }()
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, writer := range []*DB{db, other} {
+		wg.Add(1)
+		go func(writer *DB) {
+			defer wg.Done()
+			<-start
+			_, err := writer.ReopenTask("task-1", Attempt{Lifecycle: AttemptProvisioning, Harness: "codex"})
+			results <- err
+		}(writer)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	winners := 0
+	for err := range results {
+		if err == nil {
+			winners++
+			continue
+		}
+		if !errors.Is(err, ErrLifecycleConflict) {
+			t.Fatalf("losing reopen error = %v, want lifecycle conflict", err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("reopen winners = %d, want 1", winners)
+	}
+	history, found, err := db.ReadTaskHistory("task-1")
+	if err != nil || !found || history.Task.Lifecycle != TaskOpen || history.ActiveAttempt == nil {
+		t.Fatalf("reopened history = %+v, %v, %v", history, found, err)
+	}
+	if len(history.Attempts) != 2 || history.ActiveAttempt.Ordinal != 2 || history.ActiveAttempt.Lifecycle != AttemptProvisioning {
+		t.Fatalf("reopened attempts = %+v, want one historical and one active provisioning", history.Attempts)
+	}
+}
+
+func TestPromotePreservesScoutAndAtomicallyOwnsShipProvisioningAttempt(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Kind: KindScout, Lifecycle: TaskOpen, DeliveredAt: "old", DeliveredReason: "old"}); err != nil {
+		t.Fatal(err)
+	}
+	scout, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning, Harness: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ship, err := db.PromoteTask("task-1", scout.ID, AttemptRunning, Attempt{Lifecycle: AttemptProvisioning, Harness: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, found, err := db.ReadTaskHistory("task-1")
+	if err != nil || !found || history.Task.Kind != KindShip || history.Task.ActiveAttemptID != ship.ID || history.ActiveAttempt == nil {
+		t.Fatalf("promoted history = %+v, %v, %v", history, found, err)
+	}
+	if history.ActiveAttempt.ID != ship.ID || history.ActiveAttempt.Lifecycle != AttemptProvisioning || history.ActiveAttempt.Harness != "codex" {
+		t.Fatalf("ship attempt = %+v, want fresh provisioning attempt", history.ActiveAttempt)
+	}
+	if history.Attempts[0].ID != scout.ID || history.Attempts[0].Lifecycle != AttemptCompleted {
+		t.Fatalf("scout history = %+v, want completed scout preserved", history.Attempts)
+	}
+	if history.Task.DeliveredAt != "" || history.Task.DeliveredReason != "" {
+		t.Fatalf("delivery facts = %q/%q, want cleared for ship", history.Task.DeliveredAt, history.Task.DeliveredReason)
+	}
+}
+
+func TestConcurrentActiveAttemptCreationHasOneWinnerAndOneActiveRelation(t *testing.T) {
+	db, home := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	other, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = other.Close() }()
+
+	start := make(chan struct{})
+	results := make(chan struct {
+		attempt Attempt
+		err     error
+	}, 2)
+	var wg sync.WaitGroup
+	for _, writer := range []*DB{db, other} {
+		wg.Add(1)
+		go func(writer *DB) {
+			defer wg.Done()
+			<-start
+			attempt, err := writer.CreateAttemptIfOpenAndInactive(Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning})
+			results <- struct {
+				attempt Attempt
+				err     error
+			}{attempt: attempt, err: err}
+		}(writer)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	winners := 0
+	for result := range results {
+		if result.err == nil {
+			winners++
+			continue
+		}
+		if !errors.Is(result.err, ErrLifecycleConflict) {
+			t.Fatalf("losing creation error = %v, want lifecycle conflict", result.err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("creation winners = %d, want 1", winners)
+	}
+	history, found, err := db.ReadTaskHistory("task-1")
+	if err != nil || !found || history.ActiveAttempt == nil {
+		t.Fatalf("final history = %+v, %v, %v", history, found, err)
+	}
+	if len(history.Attempts) != 1 || !isActiveAttempt(history.Attempts[0].Lifecycle) || history.Task.ActiveAttemptID != history.ActiveAttempt.ID {
+		t.Fatalf("final attempt ownership = %+v, task=%+v", history.Attempts, history.Task)
+	}
+}
+
+func TestStaleAttemptTransitionsLoseWithoutChangingNewerLifecycle(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE attempt SET launch_submitted_at = 'submitted', launch_confirmed_at = 'confirmed' WHERE id = ?`, attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptProvisioning, AttemptRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptProvisioning, AttemptFailed); !errors.Is(err, ErrLifecycleConflict) {
+		t.Fatalf("stale provisioning transition = %v, want lifecycle conflict", err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(attempt.ID, AttemptRunning, AttemptInterrupted); !errors.Is(err, ErrLifecycleConflict) {
+		t.Fatalf("stale running transition = %v, want lifecycle conflict", err)
+	}
+	got, found, err := db.ReadAttempt(attempt.ID)
+	if err != nil || !found || got.Lifecycle != AttemptCompleted {
+		t.Fatalf("attempt after stale transitions = %+v, %v, %v", got, found, err)
+	}
+}
+
+func TestAttemptBookkeepingRequiresCurrentActiveOwnership(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning, Worktree: "old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TransitionAttempt(first.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	second, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning, Worktree: "new"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.RecordAttemptWorktree("task-1", first.ID, "stale", "stale-lease"); !errors.Is(err, ErrOwnershipConflict) {
+		t.Fatalf("historical bookkeeping = %v, want ownership conflict", err)
+	}
+	got, found, err := db.ReadAttempt(second.ID)
+	if err != nil || !found || got.Worktree != "new" {
+		t.Fatalf("replacement attempt = %+v, %v, %v", got, found, err)
+	}
+	got, found, err = db.ReadAttempt(first.ID)
+	if err != nil || !found || got.Worktree != "old" {
+		t.Fatalf("historical attempt = %+v, %v, %v", got, found, err)
+	}
+}
+
+func TestTerminalizeTaskAndAttemptClearsOwnershipTogether(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TerminalizeTaskAndAttempt("task-1", attempt.ID, AttemptRunning, AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	history, found, err := db.ReadTaskHistory("task-1")
+	if err != nil || !found {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != TaskTerminal || history.Task.ActiveAttemptID != 0 || history.Attempts[0].Lifecycle != AttemptCompleted {
+		t.Fatalf("terminalized history = %+v, want coherent closure", history)
+	}
+}
+
+func TestTerminalizeTaskAndAttemptRollsBackOnStaleTask(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(Attempt{TaskID: "task-1", Lifecycle: AttemptRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE task SET lifecycle = 'terminal' WHERE id = 'task-1'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.TerminalizeTaskAndAttempt("task-1", attempt.ID, AttemptRunning, AttemptCompleted); !errors.Is(err, ErrLifecycleConflict) {
+		t.Fatalf("stale terminalization = %v, want lifecycle conflict", err)
+	}
+	gotAttempt, found, err := db.ReadAttempt(attempt.ID)
+	if err != nil || !found || gotAttempt.Lifecycle != AttemptRunning {
+		t.Fatalf("attempt after rollback = %+v, %v, %v", gotAttempt, found, err)
+	}
+	gotTask, found, err := db.ReadTask("task-1")
+	if err != nil || !found || gotTask.ActiveAttemptID != attempt.ID {
+		t.Fatalf("task after rollback = %+v, %v, %v", gotTask, found, err)
 	}
 }

--- a/internal/store/attempt_test.go
+++ b/internal/store/attempt_test.go
@@ -208,6 +208,33 @@ func TestProvisioningEvidenceIsIncrementalAndRequiredBeforeRunning(t *testing.T)
 	}
 }
 
+func TestReleasedProvisioningResourcesDoNotLeaveStaleOwnershipEvidence(t *testing.T) {
+	db, _ := openTemp(t)
+	created, err := db.CreateTaskWithAttempt(Task{ID: "task-1", Lifecycle: TaskOpen}, Attempt{TaskID: "task-1", Lifecycle: AttemptProvisioning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "lease-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.RecordAttemptHerdr("task-1", created.ID, Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "2026-08-14T00:00:01Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ClearAttemptWorktree("task-1", created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ClearAttemptHerdr("task-1", created.ID); err != nil {
+		t.Fatal(err)
+	}
+	got, found, err := db.ReadAttempt(created.ID)
+	if err != nil || !found {
+		t.Fatalf("ReadAttempt = %+v, %v, %v", got, found, err)
+	}
+	if got.Worktree != "" || got.LeaseID != "" || got.Herdr != (Herdr{}) || got.PaneStartedAt != "" {
+		t.Fatalf("released provisioning evidence = %+v, want no current resource ownership", got)
+	}
+}
+
 func TestTerminalTaskRejectsOrdinaryAttemptCreation(t *testing.T) {
 	db, _ := openTemp(t)
 	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskTerminal}); err != nil {

--- a/internal/store/hold_test.go
+++ b/internal/store/hold_test.go
@@ -150,3 +150,49 @@ func TestListHoldsSurfacesEveryRowRegardlessOfKind(t *testing.T) {
 		t.Fatalf("ListHolds = %+v, want the inconsistent row untouched", holds)
 	}
 }
+
+func TestConditionalMachineHoldCannotOverwriteOperatorHold(t *testing.T) {
+	db, _ := openTemp(t)
+	operator := sampleHold()
+	if err := db.SetHold(operator); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := db.SetHoldIfNotOtherKind(Hold{ID: operator.ID, Kind: HoldKindLimit, Reason: "quota"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written {
+		t.Fatal("SetHoldIfNotOtherKind = true, want operator hold to win")
+	}
+	got, found, err := db.ReadHold(operator.ID)
+	if err != nil || !found {
+		t.Fatalf("ReadHold = %+v, %v, want operator hold", got, err)
+	}
+	if got != operator {
+		t.Fatalf("hold = %+v, want %+v", got, operator)
+	}
+}
+
+func TestConditionalMachineClearCannotDeleteOperatorReplacement(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.SetHold(Hold{ID: "fix-login", Kind: HoldKindLimit, Reason: "quota"}); err != nil {
+		t.Fatal(err)
+	}
+	operator := sampleHold()
+	if err := db.SetHold(operator); err != nil {
+		t.Fatal(err)
+	}
+
+	cleared, err := db.ClearHoldIfKind(operator.ID, HoldKindLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleared {
+		t.Fatal("ClearHoldIfKind = true, want operator replacement to remain")
+	}
+	got, found, err := db.ReadHold(operator.ID)
+	if err != nil || !found || got != operator {
+		t.Fatalf("ReadHold = %+v, %v, want %+v", got, found, operator)
+	}
+}

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -99,11 +99,15 @@ var migrations = []string{
 	ALTER TABLE task_v8 RENAME TO task;
 	ALTER TABLE attempt_v8 RENAME TO attempt;
 	CREATE UNIQUE INDEX attempt_one_active ON attempt(task_id) WHERE lifecycle IN ('provisioning', 'running');`,
+	`ALTER TABLE attempt ADD COLUMN launch_submitted_at TEXT NOT NULL DEFAULT '';
+	ALTER TABLE attempt ADD COLUMN launch_confirmed_at TEXT NOT NULL DEFAULT '';`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
 // layout has every earlier migration folded into it, whatever user_version claims.
 const splitVersion = 8
+
+const launchEvidenceVersion = splitVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -114,6 +118,14 @@ func (db *DB) taskIsSplit() (bool, error) {
 		return false, fmt.Errorf("detect the split task layout: %w", err)
 	}
 	return count != 0, nil
+}
+
+func (db *DB) hasLaunchEvidenceColumns() (bool, error) {
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name IN ('launch_submitted_at', 'launch_confirmed_at')`).Scan(&count); err != nil {
+		return false, fmt.Errorf("detect launch evidence columns: %w", err)
+	}
+	return count == 2, nil
 }
 
 func (db *DB) schemaVersion() (int, error) {
@@ -188,16 +200,39 @@ func (db *DB) migrateSchema() error {
 			return err
 		}
 		if split {
-			if _, err := db.sql.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, splitVersion)); err != nil {
-				return fmt.Errorf("record schema version %d: %w", splitVersion, err)
+			stamp := splitVersion
+			complete, err := db.hasLaunchEvidenceColumns()
+			if err != nil {
+				return err
 			}
-			current = splitVersion
+			if complete && latest >= launchEvidenceVersion {
+				stamp = launchEvidenceVersion
+			}
+			if err := db.stampSchemaVersion(stamp); err != nil {
+				return err
+			}
+			current = stamp
 		}
 	}
 	for version := current; version < latest; version++ {
 		if err := db.applyMigration(version); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (db *DB) stampSchemaVersion(version int) error {
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin schema version stamp %d: %w", version, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := recordSchemaVersion(tx, version); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("record schema version %d: %w", version, err)
 	}
 	return nil
 }

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"sync"
 	"testing"
 )
 
@@ -130,4 +131,174 @@ func TestFreshDatabaseSkipsAMigrationTheSchemaAlreadyBuilds(t *testing.T) {
 		t.Fatalf("reopening a stamped fresh database: %v", err)
 	}
 	defer func() { _ = second.Close() }()
+}
+
+func TestFailedMigrationDoesNotAdvanceUserVersion(t *testing.T) {
+	home := t.TempDir()
+	restore := migrations
+	t.Cleanup(func() { migrations = restore })
+
+	migrations = nil
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrations = []string{`
+		ALTER TABLE project ADD COLUMN migration_marker TEXT NOT NULL DEFAULT '';
+		SELECT missing_migration_table.value FROM missing_migration_table;
+	`}
+	if _, err := Open(home); err == nil {
+		t.Fatal("Open succeeded for an intentionally failing migration")
+	}
+
+	migrations = nil
+	check, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = check.Close() }()
+	version, err := check.schemaVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 0 {
+		t.Fatalf("user_version = %d, want 0 after rollback", version)
+	}
+	var columns int
+	if err := check.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('project') WHERE name = 'migration_marker'`).Scan(&columns); err != nil {
+		t.Fatal(err)
+	}
+	if columns != 0 {
+		t.Fatal("failed migration left its schema change behind")
+	}
+}
+
+func TestConcurrentOpenersMigrateAReal040DatabaseOnce(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &DB{sql: sqlDB, home: home}
+	values := []any{
+		"legacy", "nsr", "ship", "data/legacy/brief.md", "", false, "", 0, "", false, "", "",
+		"claude", "opus", "high", "/w/nsr", "lease-7", "default", "wA", "wA:tB", "wA:pC",
+		"2026-07-24T10:00:00Z", "2026-07-24T10:30:00Z", "2026-07-24T11:00:00Z", "working", true,
+		"working", "still working", "", "", "", "", 0,
+	}
+	if _, err := db.sql.Exec(legacy040Schema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (
+		id, project, kind, brief, pr, merge_executed, merge_executed_at, report_offset, report_digest,
+		merge_announced, delivered_at, delivered_reason, harness, model, effort, worktree, lease_id,
+		herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id, created_at, pane_started_at,
+		status_changed_at, status_changed_for, done_verified, last_report_state, last_report_note,
+		send_undelivered_message, send_undelivered_at, parked_fired_for, usage_limit_retry_at,
+		usage_limit_attempts) VALUES (`+placeholders(len(values))+`)
+	`, values...); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = 7`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	const openers = 2
+	errs := make([]error, openers)
+	var wg sync.WaitGroup
+	for i := range openers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			opened, err := Open(home)
+			if err == nil {
+				err = opened.Close()
+			}
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("opener %d: %v", i, err)
+		}
+	}
+
+	check, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = check.Close() }()
+	version, err := check.schemaVersion()
+	if err != nil || version != len(migrations) {
+		t.Fatalf("schema version = %d, %v, want %d", version, err, len(migrations))
+	}
+	history, found, err := check.ReadTaskHistory("legacy")
+	if err != nil || !found || history.ActiveAttempt == nil {
+		t.Fatalf("migrated history = %+v, %v, %v", history, found, err)
+	}
+	if history.ActiveAttempt.Worktree != "/w/nsr" || history.ActiveAttempt.Herdr.PaneID != "wA:pC" {
+		t.Fatalf("migrated attempt lost execution evidence: %+v", history.ActiveAttempt)
+	}
+}
+
+func TestUnstampedSplitLayoutUsesTransactionalStampBeforeNextMigration(t *testing.T) {
+	home := t.TempDir()
+	restore := migrations
+	t.Cleanup(func() { migrations = restore })
+
+	migrations = restore[:8]
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &DB{sql: sqlDB, home: home}
+	if _, err := db.sql.Exec(legacy040Schema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = 7`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	split, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := split.sql.Exec(`PRAGMA user_version = 0`); err != nil {
+		_ = split.Close()
+		t.Fatal(err)
+	}
+	if err := split.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrations = restore
+	check, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = check.Close() }()
+	var evidenceColumns int
+	if err := check.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name IN ('launch_submitted_at', 'launch_confirmed_at')`).Scan(&evidenceColumns); err != nil {
+		t.Fatal(err)
+	}
+	if evidenceColumns != 2 {
+		t.Fatalf("launch evidence columns = %d, want 2", evidenceColumns)
+	}
+	version, err := check.schemaVersion()
+	if err != nil || version != len(migrations) {
+		t.Fatalf("schema version = %d, %v, want %d", version, err, len(migrations))
+	}
+	if version == 0 {
+		t.Fatal("unstamped split layout remained at version 0")
+	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,6 +40,10 @@ var ErrLifecycleConflict = errors.New("lifecycle conflict")
 
 var ErrOwnershipConflict = errors.New("attempt ownership conflict")
 
+// SQLITE_BUSY means the write lost the database lock rather than losing a lifecycle race, so the
+// caller may retry it instead of being told a precondition it never violated failed.
+var ErrContention = errors.New("database contention")
+
 // Wrapped by ClearHold, rendered by callers as `hold "<id>" not found`.
 var ErrHoldNotFound = errors.New("not found")
 
@@ -241,7 +245,7 @@ func open(path string) (*sql.DB, error) {
 	}
 	// The pragmas need a file: URI, and a URI means sqlite reads `%`, `#` and
 	// `?` in the fleet home's path as syntax rather than as filename.
-	uri := "file:" + (&url.URL{Path: path}).EscapedPath() + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)"
+	uri := "file:" + (&url.URL{Path: path}).EscapedPath() + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate"
 	db, err := sql.Open("sqlite", uri)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
@@ -525,7 +529,10 @@ func (db *DB) CreateTaskWithAttempt(t Task, a Attempt) (Attempt, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...); err != nil {
-		if isSQLiteConstraint(err) || isSQLiteBusy(err) {
+		if isSQLiteBusy(err) {
+			return Attempt{}, contention("create task", t.ID, err)
+		}
+		if isSQLiteConstraint(err) {
 			return Attempt{}, fmt.Errorf("%w: task %q already exists", ErrLifecycleConflict, t.ID)
 		}
 		return Attempt{}, fmt.Errorf("create task %q: %w", t.ID, err)
@@ -582,14 +589,12 @@ func (db *DB) createAttempt(a Attempt, requireInactive bool) (Attempt, error) {
 	if requireInactive && isActiveAttempt(a.Lifecycle) && activeID.Valid {
 		return Attempt{}, fmt.Errorf("%w: task %q already owns attempt %d", ErrLifecycleConflict, a.TaskID, activeID.Int64)
 	}
-	if a.Ordinal == 0 {
-		if err := tx.QueryRow(`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM attempt WHERE task_id = ?`, a.TaskID).Scan(&a.Ordinal); err != nil {
-			return Attempt{}, fmt.Errorf("next attempt ordinal for task %q: %w", a.TaskID, err)
-		}
-	}
 	created, err := insertAttemptTx(tx, a)
 	if err != nil {
-		if isSQLiteBusy(err) || isSQLiteConstraint(err) {
+		if isSQLiteBusy(err) {
+			return Attempt{}, contention("create attempt", a.TaskID, err)
+		}
+		if isSQLiteConstraint(err) {
 			if isActiveAttempt(a.Lifecycle) && activeAttemptExistsTx(tx, a.TaskID) {
 				return Attempt{}, fmt.Errorf("%w: task %q already owns an active attempt", ErrLifecycleConflict, a.TaskID)
 			}
@@ -647,6 +652,10 @@ func insertAttemptTx(tx *sql.Tx, a Attempt) (Attempt, error) {
 func activeAttemptExistsTx(tx *sql.Tx, taskID string) bool {
 	var one int
 	return tx.QueryRow(`SELECT 1 FROM attempt WHERE task_id = ? AND lifecycle IN ('provisioning', 'running') LIMIT 1`, taskID).Scan(&one) == nil
+}
+
+func contention(operation, taskID string, err error) error {
+	return fmt.Errorf("%w: %s for task %q lost the database write lock, retry it: %w", ErrContention, operation, taskID, err)
 }
 
 func isSQLiteBusy(err error) bool {
@@ -845,7 +854,10 @@ func (db *DB) ReopenTask(taskID string, a Attempt) (Attempt, error) {
 	}
 	result, err := insertAttemptTx(tx, a)
 	if err != nil {
-		if isSQLiteBusy(err) || isSQLiteConstraint(err) {
+		if isSQLiteBusy(err) {
+			return Attempt{}, contention("reopen task", taskID, err)
+		}
+		if isSQLiteConstraint(err) {
 			return Attempt{}, fmt.Errorf("%w: task %q is being reopened by another writer", ErrLifecycleConflict, taskID)
 		}
 		return Attempt{}, fmt.Errorf("create reopened attempt for task %q: %w", taskID, err)
@@ -903,7 +915,10 @@ func (db *DB) PromoteTask(taskID string, scoutAttemptID int64, scoutFrom Attempt
 	}
 	created, err := insertAttemptTx(tx, ship)
 	if err != nil {
-		if isSQLiteBusy(err) || isSQLiteConstraint(err) {
+		if isSQLiteBusy(err) {
+			return Attempt{}, contention("promote task", taskID, err)
+		}
+		if isSQLiteConstraint(err) {
 			return Attempt{}, fmt.Errorf("%w: task %q is being promoted by another writer", ErrLifecycleConflict, taskID)
 		}
 		return Attempt{}, fmt.Errorf("create ship attempt for task %q: %w", taskID, err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -523,7 +523,7 @@ func (db *DB) CreateTaskWithAttempt(t Task, a Attempt) (Attempt, error) {
 	}
 	t.ActiveAttemptID = 0
 	a.Ordinal = 0
-	tx, err := db.sql.Begin()
+	tx, err := db.beginLifecycleTx("create task", t.ID)
 	if err != nil {
 		return Attempt{}, fmt.Errorf("begin task creation: %w", err)
 	}
@@ -572,7 +572,7 @@ func (db *DB) createAttempt(a Attempt, requireInactive bool) (Attempt, error) {
 	if a.Lifecycle == "" {
 		a.Lifecycle = AttemptProvisioning
 	}
-	tx, err := db.sql.Begin()
+	tx, err := db.beginLifecycleTx("create attempt", a.TaskID)
 	if err != nil {
 		return Attempt{}, fmt.Errorf("begin attempt creation: %w", err)
 	}
@@ -658,6 +658,14 @@ func contention(operation, taskID string, err error) error {
 	return fmt.Errorf("%w: %s for task %q lost the database write lock, retry it: %w", ErrContention, operation, taskID, err)
 }
 
+func (db *DB) beginLifecycleTx(operation, taskID string) (*sql.Tx, error) {
+	tx, err := db.sql.Begin()
+	if isSQLiteBusy(err) {
+		return nil, contention(operation, taskID, err)
+	}
+	return tx, err
+}
+
 func isSQLiteBusy(err error) bool {
 	var sqliteErr *sqlite.Error
 	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_BUSY
@@ -721,7 +729,7 @@ func (db *DB) TransitionAttempt(id int64, from, to AttemptLifecycle) error {
 	if !validAttemptTransition(from, to) {
 		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, from, to)
 	}
-	tx, err := db.sql.Begin()
+	tx, err := db.beginLifecycleTx("transition attempt", fmt.Sprintf("attempt:%d", id))
 	if err != nil {
 		return fmt.Errorf("begin attempt transition: %w", err)
 	}
@@ -839,7 +847,7 @@ func (db *DB) ReopenTask(taskID string, a Attempt) (Attempt, error) {
 	a.TaskID = taskID
 	a.ID = 0
 	a.Ordinal = 0
-	tx, err := db.sql.Begin()
+	tx, err := db.beginLifecycleTx("reopen task", taskID)
 	if err != nil {
 		return Attempt{}, fmt.Errorf("begin task reopen: %w", err)
 	}
@@ -888,7 +896,7 @@ func (db *DB) PromoteTask(taskID string, scoutAttemptID int64, scoutFrom Attempt
 	ship.TaskID = taskID
 	ship.ID = 0
 	ship.Ordinal = 0
-	tx, err := db.sql.Begin()
+	tx, err := db.beginLifecycleTx("promote task", taskID)
 	if err != nil {
 		return Attempt{}, fmt.Errorf("begin task promotion: %w", err)
 	}
@@ -943,7 +951,7 @@ func (db *DB) TerminalizeTaskAndAttempt(taskID string, attemptID int64, attemptF
 	if !validAttemptTransition(attemptFrom, attemptTo) || isActiveAttempt(attemptTo) {
 		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, attemptFrom, attemptTo)
 	}
-	tx, err := db.sql.Begin()
+	tx, err := db.beginLifecycleTx("terminalize task", taskID)
 	if err != nil {
 		return fmt.Errorf("begin task terminalization: %w", err)
 	}
@@ -976,6 +984,16 @@ func (db *DB) TerminalizeTaskAndAttempt(taskID string, attemptID int64, attemptF
 func (db *DB) SetTaskPR(id, pr string) error {
 	result, err := db.sql.Exec(`UPDATE task SET pr = ? WHERE id = ?`, pr, id)
 	return updateTaskFact(result, err, "set PR", id)
+}
+
+func (db *DB) SetTaskKind(id, kind string) error {
+	result, err := db.sql.Exec(`UPDATE task SET kind = ? WHERE id = ? AND lifecycle = 'open'`, kind, id)
+	return updateTaskFact(result, err, "set kind", id)
+}
+
+func (db *DB) SetTaskMergeAnnounced(id string) error {
+	result, err := db.sql.Exec(`UPDATE task SET merge_announced = 1 WHERE id = ?`, id)
+	return updateTaskFact(result, err, "set merge announcement", id)
 }
 
 func (db *DB) SetTaskDelivery(id, deliveredAt, reason string) error {
@@ -1014,11 +1032,25 @@ func (db *DB) RecordAttemptWorktree(taskID string, attemptID int64, worktree, le
 	return updateAttemptOwnership(result, err, "record worktree", taskID, attemptID)
 }
 
+func (db *DB) ClearAttemptWorktree(taskID string, attemptID int64) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET worktree = '', lease_id = ''
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, attemptID, taskID, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "clear returned worktree", taskID, attemptID)
+}
+
 func (db *DB) RecordAttemptHerdr(taskID string, attemptID int64, herdr Herdr, paneStartedAt string) error {
 	result, err := db.sql.Exec(`UPDATE attempt SET herdr_session = ?, herdr_workspace_id = ?, herdr_tab_id = ?, herdr_pane_id = ?, pane_started_at = ?
 		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
 		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, herdr.Session, herdr.WorkspaceID, herdr.TabID, herdr.PaneID, paneStartedAt, attemptID, taskID, taskID, attemptID)
 	return updateAttemptOwnership(result, err, "record Herdr identity", taskID, attemptID)
+}
+
+func (db *DB) ClearAttemptHerdr(taskID string, attemptID int64) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET herdr_session = '', herdr_workspace_id = '', herdr_tab_id = '', herdr_pane_id = '', pane_started_at = ''
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, attemptID, taskID, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "clear released Herdr identity", taskID, attemptID)
 }
 
 func (db *DB) MarkLaunchSubmitted(taskID string, attemptID int64, at string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,8 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/shellquote"
-	_ "modernc.org/sqlite"
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 const (
@@ -34,6 +35,10 @@ const (
 var ErrTaskNotFound = errors.New("not found")
 
 var ErrInvalidTransition = errors.New("invalid lifecycle transition")
+
+var ErrLifecycleConflict = errors.New("lifecycle conflict")
+
+var ErrOwnershipConflict = errors.New("attempt ownership conflict")
 
 // Wrapped by ClearHold, rendered by callers as `hold "<id>" not found`.
 var ErrHoldNotFound = errors.New("not found")
@@ -97,6 +102,8 @@ type Attempt struct {
 	Herdr                  Herdr            `json:"herdr"`
 	CreatedAt              string           `json:"created_at"`
 	PaneStartedAt          string           `json:"pane_started_at"`
+	LaunchSubmittedAt      string           `json:"launch_submitted_at"`
+	LaunchConfirmedAt      string           `json:"launch_confirmed_at"`
 	StatusChangedAt        string           `json:"status_changed_at"`
 	StatusChangedFor       string           `json:"status_changed_for"`
 	DoneVerified           bool             `json:"done_verified"`
@@ -188,6 +195,8 @@ CREATE TABLE IF NOT EXISTS attempt (
 	herdr_pane_id          TEXT NOT NULL DEFAULT '',
 	created_at             TEXT NOT NULL DEFAULT '',
 	pane_started_at        TEXT NOT NULL DEFAULT '',
+	launch_submitted_at    TEXT NOT NULL DEFAULT '',
+	launch_confirmed_at    TEXT NOT NULL DEFAULT '',
 	status_changed_at      TEXT NOT NULL DEFAULT '',
 	status_changed_for     TEXT NOT NULL DEFAULT '',
 	done_verified          INTEGER NOT NULL DEFAULT 0,
@@ -326,6 +335,7 @@ var taskColumns = strings.Join(taskColumnNames, ", ")
 var attemptColumnNames = []string{
 	"id", "task_id", "ordinal", "lifecycle", "harness", "model", "effort", "worktree", "lease_id",
 	"herdr_session", "herdr_workspace_id", "herdr_tab_id", "herdr_pane_id", "created_at", "pane_started_at",
+	"launch_submitted_at", "launch_confirmed_at",
 	"status_changed_at", "status_changed_for", "done_verified", "last_report_state", "last_report_note",
 	"send_undelivered_message", "send_undelivered_at", "parked_fired_for", "usage_limit_retry_at", "usage_limit_attempts",
 }
@@ -367,6 +377,7 @@ func scanTask(row interface{ Scan(...any) error }) (Task, error) {
 func attemptValues(a Attempt) []any {
 	return []any{a.ID, a.TaskID, a.Ordinal, a.Lifecycle, a.Harness, a.Model, a.Effort, a.Worktree, a.LeaseID,
 		a.Herdr.Session, a.Herdr.WorkspaceID, a.Herdr.TabID, a.Herdr.PaneID, a.CreatedAt, a.PaneStartedAt,
+		a.LaunchSubmittedAt, a.LaunchConfirmedAt,
 		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
 		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts}
 }
@@ -375,6 +386,7 @@ func scanAttempt(row interface{ Scan(...any) error }) (Attempt, error) {
 	var a Attempt
 	err := row.Scan(&a.ID, &a.TaskID, &a.Ordinal, &a.Lifecycle, &a.Harness, &a.Model, &a.Effort, &a.Worktree, &a.LeaseID,
 		&a.Herdr.Session, &a.Herdr.WorkspaceID, &a.Herdr.TabID, &a.Herdr.PaneID, &a.CreatedAt, &a.PaneStartedAt,
+		&a.LaunchSubmittedAt, &a.LaunchConfirmedAt,
 		&a.StatusChangedAt, &a.StatusChangedFor, &a.DoneVerified, &a.LastReportState, &a.LastReportNote,
 		&a.SendUndeliveredMessage, &a.SendUndeliveredAt, &a.ParkedFiredFor, &a.UsageLimitRetryAt, &a.UsageLimitAttempts)
 	return a, err
@@ -495,7 +507,61 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	return histories, nil
 }
 
+func (db *DB) CreateTaskWithAttempt(t Task, a Attempt) (Attempt, error) {
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	if a.TaskID == "" {
+		a.TaskID = t.ID
+	}
+	if a.TaskID != t.ID || a.Lifecycle != AttemptProvisioning {
+		return Attempt{}, fmt.Errorf("%w: task creation requires a matching provisioning attempt", ErrInvalidTransition)
+	}
+	t.ActiveAttemptID = 0
+	a.Ordinal = 0
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return Attempt{}, fmt.Errorf("begin task creation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...); err != nil {
+		if isSQLiteConstraint(err) || isSQLiteBusy(err) {
+			return Attempt{}, fmt.Errorf("%w: task %q already exists", ErrLifecycleConflict, t.ID)
+		}
+		return Attempt{}, fmt.Errorf("create task %q: %w", t.ID, err)
+	}
+	created, err := insertAttemptTx(tx, a)
+	if err != nil {
+		return Attempt{}, fmt.Errorf("create initial attempt for task %q: %w", t.ID, err)
+	}
+	result, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ? AND lifecycle = 'open' AND active_attempt_id IS NULL`, created.ID, t.ID)
+	if err != nil {
+		return Attempt{}, fmt.Errorf("set initial active attempt %d: %w", created.ID, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return Attempt{}, fmt.Errorf("set initial active attempt %d: %w", created.ID, err)
+	} else if affected != 1 {
+		return Attempt{}, fmt.Errorf("%w: task %q did not accept initial attempt", ErrLifecycleConflict, t.ID)
+	}
+	if err := tx.Commit(); err != nil {
+		return Attempt{}, fmt.Errorf("create task %q: %w", t.ID, err)
+	}
+	return created, nil
+}
+
+func (db *DB) CreateAttemptIfOpenAndInactive(a Attempt) (Attempt, error) {
+	if a.Lifecycle != "" && a.Lifecycle != AttemptProvisioning {
+		return Attempt{}, fmt.Errorf("%w: new active attempts start provisioning", ErrInvalidTransition)
+	}
+	a.Ordinal = 0
+	return db.createAttempt(a, true)
+}
+
 func (db *DB) CreateAttempt(a Attempt) (Attempt, error) {
+	return db.createAttempt(a, false)
+}
+
+func (db *DB) createAttempt(a Attempt, requireInactive bool) (Attempt, error) {
 	if a.Lifecycle == "" {
 		a.Lifecycle = AttemptProvisioning
 	}
@@ -505,12 +571,52 @@ func (db *DB) CreateAttempt(a Attempt) (Attempt, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 	var lifecycle TaskLifecycle
-	if err := tx.QueryRow(`SELECT lifecycle FROM task WHERE id = ?`, a.TaskID).Scan(&lifecycle); errors.Is(err, sql.ErrNoRows) {
+	var activeID sql.NullInt64
+	if err := tx.QueryRow(`SELECT lifecycle, active_attempt_id FROM task WHERE id = ?`, a.TaskID).Scan(&lifecycle, &activeID); errors.Is(err, sql.ErrNoRows) {
 		return Attempt{}, fmt.Errorf("task %q %w", a.TaskID, ErrTaskNotFound)
 	} else if err != nil {
 		return Attempt{}, fmt.Errorf("read task %q for attempt: %w", a.TaskID, err)
 	} else if lifecycle != TaskOpen {
-		return Attempt{}, fmt.Errorf("task %q is terminal", a.TaskID)
+		return Attempt{}, fmt.Errorf("%w: task %q is terminal", ErrInvalidTransition, a.TaskID)
+	}
+	if requireInactive && isActiveAttempt(a.Lifecycle) && activeID.Valid {
+		return Attempt{}, fmt.Errorf("%w: task %q already owns attempt %d", ErrLifecycleConflict, a.TaskID, activeID.Int64)
+	}
+	if a.Ordinal == 0 {
+		if err := tx.QueryRow(`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM attempt WHERE task_id = ?`, a.TaskID).Scan(&a.Ordinal); err != nil {
+			return Attempt{}, fmt.Errorf("next attempt ordinal for task %q: %w", a.TaskID, err)
+		}
+	}
+	created, err := insertAttemptTx(tx, a)
+	if err != nil {
+		if isSQLiteBusy(err) || isSQLiteConstraint(err) {
+			if isActiveAttempt(a.Lifecycle) && activeAttemptExistsTx(tx, a.TaskID) {
+				return Attempt{}, fmt.Errorf("%w: task %q already owns an active attempt", ErrLifecycleConflict, a.TaskID)
+			}
+			return Attempt{}, fmt.Errorf("%w: attempt ordinal for task %q was claimed by another writer", ErrLifecycleConflict, a.TaskID)
+		}
+		return Attempt{}, fmt.Errorf("create attempt %d: %w", a.ID, err)
+	}
+	if isActiveAttempt(a.Lifecycle) {
+		result, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ? AND lifecycle = 'open' AND (active_attempt_id IS NULL OR active_attempt_id = ?)`, created.ID, created.TaskID, created.ID)
+		if err != nil {
+			return Attempt{}, fmt.Errorf("set active attempt %d: %w", created.ID, err)
+		}
+		if affected, err := result.RowsAffected(); err != nil {
+			return Attempt{}, fmt.Errorf("set active attempt %d: %w", created.ID, err)
+		} else if affected != 1 {
+			return Attempt{}, fmt.Errorf("%w: task %q did not accept attempt %d", ErrLifecycleConflict, created.TaskID, created.ID)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return Attempt{}, fmt.Errorf("create attempt for task %q: %w", a.TaskID, err)
+	}
+	return created, nil
+}
+
+func insertAttemptTx(tx *sql.Tx, a Attempt) (Attempt, error) {
+	if a.Lifecycle == "" {
+		a.Lifecycle = AttemptProvisioning
 	}
 	if a.Ordinal == 0 {
 		if err := tx.QueryRow(`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM attempt WHERE task_id = ?`, a.TaskID).Scan(&a.Ordinal); err != nil {
@@ -523,24 +629,34 @@ func (db *DB) CreateAttempt(a Attempt) (Attempt, error) {
 		query := `INSERT INTO attempt (` + strings.Join(attemptColumnNames[1:], ", ") + `) VALUES (` + placeholders(len(attemptColumnNames)-1) + `)`
 		result, err := tx.Exec(query, args...)
 		if err != nil {
-			return Attempt{}, fmt.Errorf("create attempt for task %q: %w", a.TaskID, err)
+			return Attempt{}, err
 		}
-		a.ID, err = result.LastInsertId()
+		id, err := result.LastInsertId()
 		if err != nil {
 			return Attempt{}, fmt.Errorf("read new attempt ID: %w", err)
 		}
-	} else if _, err := tx.Exec(`INSERT INTO attempt (`+attemptColumns+`) VALUES (`+placeholders(len(attemptColumnNames))+`)`, args...); err != nil {
-		return Attempt{}, fmt.Errorf("create attempt %d: %w", a.ID, err)
+		a.ID = id
+		return a, nil
 	}
-	if isActiveAttempt(a.Lifecycle) {
-		if _, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ?`, a.ID, a.TaskID); err != nil {
-			return Attempt{}, fmt.Errorf("set active attempt %d: %w", a.ID, err)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return Attempt{}, fmt.Errorf("create attempt for task %q: %w", a.TaskID, err)
+	if _, err := tx.Exec(`INSERT INTO attempt (`+attemptColumns+`) VALUES (`+placeholders(len(attemptColumnNames))+`)`, args...); err != nil {
+		return Attempt{}, err
 	}
 	return a, nil
+}
+
+func activeAttemptExistsTx(tx *sql.Tx, taskID string) bool {
+	var one int
+	return tx.QueryRow(`SELECT 1 FROM attempt WHERE task_id = ? AND lifecycle IN ('provisioning', 'running') LIMIT 1`, taskID).Scan(&one) == nil
+}
+
+func isSQLiteBusy(err error) bool {
+	var sqliteErr *sqlite.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_BUSY
+}
+
+func isSQLiteConstraint(err error) bool {
+	var sqliteErr *sqlite.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_CONSTRAINT
 }
 
 func (db *DB) ReadAttempt(id int64) (Attempt, bool, error) {
@@ -578,11 +694,12 @@ func (db *DB) ListAttempts(taskID string) ([]Attempt, error) {
 func (db *DB) UpdateAttempt(a Attempt) error {
 	_, err := db.sql.Exec(`UPDATE attempt SET task_id = ?, ordinal = ?, lifecycle = ?, harness = ?, model = ?, effort = ?,
 		worktree = ?, lease_id = ?, herdr_session = ?, herdr_workspace_id = ?, herdr_tab_id = ?, herdr_pane_id = ?,
-		created_at = ?, pane_started_at = ?, status_changed_at = ?, status_changed_for = ?, done_verified = ?,
+		created_at = ?, pane_started_at = ?, launch_submitted_at = ?, launch_confirmed_at = ?, status_changed_at = ?, status_changed_for = ?, done_verified = ?,
 		last_report_state = ?, last_report_note = ?, send_undelivered_message = ?, send_undelivered_at = ?,
 		parked_fired_for = ?, usage_limit_retry_at = ?, usage_limit_attempts = ? WHERE id = ?`,
 		a.TaskID, a.Ordinal, a.Lifecycle, a.Harness, a.Model, a.Effort, a.Worktree, a.LeaseID,
 		a.Herdr.Session, a.Herdr.WorkspaceID, a.Herdr.TabID, a.Herdr.PaneID, a.CreatedAt, a.PaneStartedAt,
+		a.LaunchSubmittedAt, a.LaunchConfirmedAt,
 		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
 		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts, a.ID)
 	if err != nil {
@@ -602,23 +719,47 @@ func (db *DB) TransitionAttempt(id int64, from, to AttemptLifecycle) error {
 	defer func() { _ = tx.Rollback() }()
 	var current AttemptLifecycle
 	var taskID string
-	if err := tx.QueryRow(`SELECT task_id, lifecycle FROM attempt WHERE id = ?`, id).Scan(&taskID, &current); errors.Is(err, sql.ErrNoRows) {
+	var launchConfirmedAt string
+	if err := tx.QueryRow(`SELECT task_id, lifecycle, launch_confirmed_at FROM attempt WHERE id = ?`, id).Scan(&taskID, &current, &launchConfirmedAt); errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("attempt %d %w", id, ErrTaskNotFound)
 	} else if err != nil {
 		return fmt.Errorf("read attempt %d: %w", id, err)
 	}
-	if current != from || !validAttemptTransition(current, to) {
-		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, current, to)
+	if current != from {
+		return fmt.Errorf("%w: attempt %d is already %s", ErrLifecycleConflict, id, current)
 	}
-	if _, err := tx.Exec(`UPDATE attempt SET lifecycle = ? WHERE id = ?`, to, id); err != nil {
+	if to == AttemptRunning && launchConfirmedAt == "" {
+		return fmt.Errorf("%w: attempt launch is not confirmed", ErrInvalidTransition)
+	}
+	result, err := tx.Exec(`UPDATE attempt SET lifecycle = ? WHERE id = ? AND task_id = ? AND lifecycle = ?`, to, id, taskID, from)
+	if err != nil {
 		return fmt.Errorf("transition attempt %d: %w", id, err)
 	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("transition attempt %d: %w", id, err)
+	} else if affected != 1 {
+		return fmt.Errorf("%w: attempt %d changed while transitioning", ErrLifecycleConflict, id)
+	}
 	if isActiveAttempt(to) {
-		if _, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ?`, id, taskID); err != nil {
+		result, err := tx.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ? AND lifecycle = 'open' AND (active_attempt_id IS NULL OR active_attempt_id = ?)`, id, taskID, id)
+		if err != nil {
 			return fmt.Errorf("set active attempt %d: %w", id, err)
 		}
-	} else if _, err := tx.Exec(`UPDATE task SET active_attempt_id = NULL WHERE id = ? AND active_attempt_id = ?`, taskID, id); err != nil {
-		return fmt.Errorf("clear active attempt %d: %w", id, err)
+		if affected, err := result.RowsAffected(); err != nil {
+			return fmt.Errorf("set active attempt %d: %w", id, err)
+		} else if affected != 1 {
+			return fmt.Errorf("%w: task %q no longer owns attempt %d", ErrOwnershipConflict, taskID, id)
+		}
+	} else {
+		result, err := tx.Exec(`UPDATE task SET active_attempt_id = NULL WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?`, taskID, id)
+		if err != nil {
+			return fmt.Errorf("clear active attempt %d: %w", id, err)
+		}
+		if affected, err := result.RowsAffected(); err != nil {
+			return fmt.Errorf("clear active attempt %d: %w", id, err)
+		} else if affected != 1 {
+			return fmt.Errorf("%w: task %q no longer owns attempt %d", ErrOwnershipConflict, taskID, id)
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("transition attempt %d: %w", id, err)
@@ -627,16 +768,26 @@ func (db *DB) TransitionAttempt(id int64, from, to AttemptLifecycle) error {
 }
 
 func (db *DB) SetActiveAttempt(taskID string, attemptID int64) error {
-	a, found, err := db.ReadAttempt(attemptID)
-	if err != nil {
-		return err
-	}
-	if !found || a.TaskID != taskID || !isActiveAttempt(a.Lifecycle) {
-		return fmt.Errorf("%w: attempt %d cannot be active", ErrInvalidTransition, attemptID)
-	}
-	_, err = db.sql.Exec(`UPDATE task SET active_attempt_id = ? WHERE id = ? AND lifecycle = 'open'`, attemptID, taskID)
+	result, err := db.sql.Exec(`UPDATE task SET active_attempt_id = ?
+		WHERE id = ? AND lifecycle = 'open' AND active_attempt_id IS NULL
+		AND EXISTS (SELECT 1 FROM attempt WHERE id = ? AND task_id = ? AND lifecycle IN ('provisioning', 'running'))`, attemptID, taskID, attemptID, taskID)
 	if err != nil {
 		return fmt.Errorf("set active attempt %d: %w", attemptID, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("set active attempt %d: %w", attemptID, err)
+	} else if affected != 1 {
+		var attemptTask string
+		var lifecycle AttemptLifecycle
+		if err := db.sql.QueryRow(`SELECT task_id, lifecycle FROM attempt WHERE id = ?`, attemptID).Scan(&attemptTask, &lifecycle); errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: attempt %d cannot be active for task %q", ErrInvalidTransition, attemptID, taskID)
+		} else if err != nil {
+			return fmt.Errorf("read attempt %d after active conflict: %w", attemptID, err)
+		}
+		if attemptTask != taskID || !isActiveAttempt(lifecycle) {
+			return fmt.Errorf("%w: attempt %d cannot be active for task %q", ErrInvalidTransition, attemptID, taskID)
+		}
+		return fmt.Errorf("%w: task %q already has another active attempt", ErrLifecycleConflict, taskID)
 	}
 	return nil
 }
@@ -645,19 +796,25 @@ func (db *DB) TransitionTask(id string, from, to TaskLifecycle) error {
 	if !validTaskTransition(from, to) {
 		return fmt.Errorf("%w: task %s -> %s", ErrInvalidTransition, from, to)
 	}
-	task, found, err := db.ReadTask(id)
-	if err != nil {
-		return err
-	}
-	if !found || task.Lifecycle != from {
-		return fmt.Errorf("%w: task %s -> %s", ErrInvalidTransition, task.Lifecycle, to)
-	}
-	if to == TaskTerminal && task.ActiveAttemptID != 0 {
-		return fmt.Errorf("%w: task has active attempt", ErrInvalidTransition)
-	}
-	_, err = db.sql.Exec(`UPDATE task SET lifecycle = ?, active_attempt_id = CASE WHEN ? = 'terminal' THEN NULL ELSE active_attempt_id END WHERE id = ?`, to, to, id)
+	result, err := db.sql.Exec(`UPDATE task SET lifecycle = ?, active_attempt_id = CASE WHEN ? = 'terminal' THEN NULL ELSE active_attempt_id END
+		WHERE id = ? AND lifecycle = ? AND active_attempt_id IS NULL`, to, to, id, from)
 	if err != nil {
 		return fmt.Errorf("transition task %q: %w", id, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("transition task %q: %w", id, err)
+	} else if affected != 1 {
+		var current TaskLifecycle
+		var activeID sql.NullInt64
+		if err := db.sql.QueryRow(`SELECT lifecycle, active_attempt_id FROM task WHERE id = ?`, id).Scan(&current, &activeID); errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("task %q %w", id, ErrTaskNotFound)
+		} else if err != nil {
+			return fmt.Errorf("read task %q after transition conflict: %w", id, err)
+		}
+		if current == from && !activeID.Valid {
+			return fmt.Errorf("%w: task %q changed while transitioning", ErrLifecycleConflict, id)
+		}
+		return fmt.Errorf("%w: task %q is %s", ErrLifecycleConflict, id, current)
 	}
 	return nil
 }
@@ -667,11 +824,12 @@ func validTaskTransition(from, to TaskLifecycle) bool {
 }
 
 func (db *DB) ReopenTask(taskID string, a Attempt) (Attempt, error) {
-	if !isActiveAttempt(a.Lifecycle) {
-		return Attempt{}, fmt.Errorf("%w: task reopen requires an active attempt", ErrInvalidTransition)
+	if a.Lifecycle != AttemptProvisioning {
+		return Attempt{}, fmt.Errorf("%w: task reopen requires a provisioning attempt", ErrInvalidTransition)
 	}
 	a.TaskID = taskID
 	a.ID = 0
+	a.Ordinal = 0
 	tx, err := db.sql.Begin()
 	if err != nil {
 		return Attempt{}, fmt.Errorf("begin task reopen: %w", err)
@@ -683,28 +841,247 @@ func (db *DB) ReopenTask(taskID string, a Attempt) (Attempt, error) {
 	} else if err != nil {
 		return Attempt{}, fmt.Errorf("read task %q for reopen: %w", taskID, err)
 	} else if lifecycle != TaskTerminal {
-		return Attempt{}, fmt.Errorf("%w: task %s -> open", ErrInvalidTransition, lifecycle)
+		return Attempt{}, fmt.Errorf("%w: task %q is %s", ErrLifecycleConflict, taskID, lifecycle)
 	}
-	if err := tx.QueryRow(`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM attempt WHERE task_id = ?`, taskID).Scan(&a.Ordinal); err != nil {
-		return Attempt{}, fmt.Errorf("next attempt ordinal for task %q: %w", taskID, err)
-	}
-	args := attemptValues(a)[1:]
-	query := `INSERT INTO attempt (` + strings.Join(attemptColumnNames[1:], ", ") + `) VALUES (` + placeholders(len(attemptColumnNames)-1) + `)`
-	result, err := tx.Exec(query, args...)
+	result, err := insertAttemptTx(tx, a)
 	if err != nil {
+		if isSQLiteBusy(err) || isSQLiteConstraint(err) {
+			return Attempt{}, fmt.Errorf("%w: task %q is being reopened by another writer", ErrLifecycleConflict, taskID)
+		}
 		return Attempt{}, fmt.Errorf("create reopened attempt for task %q: %w", taskID, err)
 	}
-	a.ID, err = result.LastInsertId()
+	a = result
+	updated, err := tx.Exec(`UPDATE task SET lifecycle = 'open', active_attempt_id = ? WHERE id = ? AND lifecycle = 'terminal'`, a.ID, taskID)
 	if err != nil {
-		return Attempt{}, fmt.Errorf("read reopened attempt ID: %w", err)
-	}
-	if _, err := tx.Exec(`UPDATE task SET lifecycle = 'open', active_attempt_id = ? WHERE id = ? AND lifecycle = 'terminal'`, a.ID, taskID); err != nil {
 		return Attempt{}, fmt.Errorf("reopen task %q: %w", taskID, err)
+	}
+	if affected, err := updated.RowsAffected(); err != nil {
+		return Attempt{}, fmt.Errorf("reopen task %q: %w", taskID, err)
+	} else if affected != 1 {
+		return Attempt{}, fmt.Errorf("%w: task %q changed while reopening", ErrLifecycleConflict, taskID)
 	}
 	if err := tx.Commit(); err != nil {
 		return Attempt{}, fmt.Errorf("reopen task %q: %w", taskID, err)
 	}
 	return a, nil
+}
+
+func (db *DB) PromoteTask(taskID string, scoutAttemptID int64, scoutFrom AttemptLifecycle, ship Attempt) (Attempt, error) {
+	if !validAttemptTransition(scoutFrom, AttemptCompleted) {
+		return Attempt{}, fmt.Errorf("%w: scout attempt %s cannot be completed", ErrInvalidTransition, scoutFrom)
+	}
+	if ship.Lifecycle != AttemptProvisioning {
+		return Attempt{}, fmt.Errorf("%w: promoted attempt must start provisioning", ErrInvalidTransition)
+	}
+	ship.TaskID = taskID
+	ship.ID = 0
+	ship.Ordinal = 0
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return Attempt{}, fmt.Errorf("begin task promotion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var lifecycle TaskLifecycle
+	var kind string
+	var activeID sql.NullInt64
+	if err := tx.QueryRow(`SELECT lifecycle, kind, active_attempt_id FROM task WHERE id = ?`, taskID).Scan(&lifecycle, &kind, &activeID); errors.Is(err, sql.ErrNoRows) {
+		return Attempt{}, fmt.Errorf("task %q %w", taskID, ErrTaskNotFound)
+	} else if err != nil {
+		return Attempt{}, fmt.Errorf("read task %q for promotion: %w", taskID, err)
+	}
+	if lifecycle != TaskOpen || kind != KindScout || !activeID.Valid || activeID.Int64 != scoutAttemptID {
+		return Attempt{}, fmt.Errorf("%w: task %q no longer owns scout attempt %d", ErrLifecycleConflict, taskID, scoutAttemptID)
+	}
+	result, err := tx.Exec(`UPDATE attempt SET lifecycle = 'completed' WHERE id = ? AND task_id = ? AND lifecycle = ?`, scoutAttemptID, taskID, scoutFrom)
+	if err != nil {
+		return Attempt{}, fmt.Errorf("complete scout attempt %d: %w", scoutAttemptID, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return Attempt{}, fmt.Errorf("complete scout attempt %d: %w", scoutAttemptID, err)
+	} else if affected != 1 {
+		return Attempt{}, fmt.Errorf("%w: scout attempt %d changed during promotion", ErrLifecycleConflict, scoutAttemptID)
+	}
+	created, err := insertAttemptTx(tx, ship)
+	if err != nil {
+		if isSQLiteBusy(err) || isSQLiteConstraint(err) {
+			return Attempt{}, fmt.Errorf("%w: task %q is being promoted by another writer", ErrLifecycleConflict, taskID)
+		}
+		return Attempt{}, fmt.Errorf("create ship attempt for task %q: %w", taskID, err)
+	}
+	result, err = tx.Exec(`UPDATE task SET kind = ?, delivered_at = '', delivered_reason = '', active_attempt_id = ?
+		WHERE id = ? AND lifecycle = 'open' AND kind = ? AND active_attempt_id = ?`, KindShip, created.ID, taskID, KindScout, scoutAttemptID)
+	if err != nil {
+		return Attempt{}, fmt.Errorf("take ship ownership for task %q: %w", taskID, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return Attempt{}, fmt.Errorf("take ship ownership for task %q: %w", taskID, err)
+	} else if affected != 1 {
+		return Attempt{}, fmt.Errorf("%w: task %q changed while promoting", ErrLifecycleConflict, taskID)
+	}
+	if err := tx.Commit(); err != nil {
+		return Attempt{}, fmt.Errorf("promote task %q: %w", taskID, err)
+	}
+	return created, nil
+}
+
+func (db *DB) TerminalizeTaskAndAttempt(taskID string, attemptID int64, attemptFrom, attemptTo AttemptLifecycle) error {
+	if !validAttemptTransition(attemptFrom, attemptTo) || isActiveAttempt(attemptTo) {
+		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, attemptFrom, attemptTo)
+	}
+	tx, err := db.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin task terminalization: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.Exec(`UPDATE attempt SET lifecycle = ? WHERE id = ? AND task_id = ? AND lifecycle = ?`, attemptTo, attemptID, taskID, attemptFrom)
+	if err != nil {
+		return fmt.Errorf("terminalize attempt %d: %w", attemptID, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("terminalize attempt %d: %w", attemptID, err)
+	} else if affected != 1 {
+		return fmt.Errorf("%w: attempt %d changed during terminalization", ErrLifecycleConflict, attemptID)
+	}
+	result, err = tx.Exec(`UPDATE task SET lifecycle = 'terminal', active_attempt_id = NULL
+		WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?`, taskID, attemptID)
+	if err != nil {
+		return fmt.Errorf("terminalize task %q: %w", taskID, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("terminalize task %q: %w", taskID, err)
+	} else if affected != 1 {
+		return fmt.Errorf("%w: task %q no longer owns attempt %d", ErrLifecycleConflict, taskID, attemptID)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("terminalize task %q: %w", taskID, err)
+	}
+	return nil
+}
+
+func (db *DB) SetTaskPR(id, pr string) error {
+	result, err := db.sql.Exec(`UPDATE task SET pr = ? WHERE id = ?`, pr, id)
+	return updateTaskFact(result, err, "set PR", id)
+}
+
+func (db *DB) SetTaskDelivery(id, deliveredAt, reason string) error {
+	result, err := db.sql.Exec(`UPDATE task SET delivered_at = ?, delivered_reason = ? WHERE id = ? AND lifecycle = 'open'`, deliveredAt, reason, id)
+	return updateTaskFact(result, err, "set delivery", id)
+}
+
+func (db *DB) SetTaskMerge(id, mergedAt string) error {
+	result, err := db.sql.Exec(`UPDATE task SET merge_executed = 1, merge_executed_at = ? WHERE id = ? AND lifecycle = 'open'`, mergedAt, id)
+	return updateTaskFact(result, err, "set merge", id)
+}
+
+func (db *DB) SetTaskReportState(id string, offset int64, digest string, mergeAnnounced bool) error {
+	result, err := db.sql.Exec(`UPDATE task SET report_offset = ?, report_digest = ?, merge_announced = merge_announced OR ? WHERE id = ?`, offset, digest, mergeAnnounced, id)
+	return updateTaskFact(result, err, "set report state", id)
+}
+
+func updateTaskFact(result sql.Result, err error, operation, id string) error {
+	if err != nil {
+		return fmt.Errorf("%s for task %q: %w", operation, id, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s for task %q: %w", operation, id, err)
+	}
+	if affected != 1 {
+		return fmt.Errorf("%w: task %q was not eligible for %s", ErrLifecycleConflict, id, operation)
+	}
+	return nil
+}
+
+func (db *DB) RecordAttemptWorktree(taskID string, attemptID int64, worktree, leaseID string) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET worktree = ?, lease_id = ?
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, worktree, leaseID, attemptID, taskID, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "record worktree", taskID, attemptID)
+}
+
+func (db *DB) RecordAttemptHerdr(taskID string, attemptID int64, herdr Herdr, paneStartedAt string) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET herdr_session = ?, herdr_workspace_id = ?, herdr_tab_id = ?, herdr_pane_id = ?, pane_started_at = ?
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, herdr.Session, herdr.WorkspaceID, herdr.TabID, herdr.PaneID, paneStartedAt, attemptID, taskID, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "record Herdr identity", taskID, attemptID)
+}
+
+func (db *DB) MarkLaunchSubmitted(taskID string, attemptID int64, at string) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET launch_submitted_at = CASE WHEN launch_submitted_at = '' THEN ? ELSE launch_submitted_at END
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, at, attemptID, taskID, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "record launch submission", taskID, attemptID)
+}
+
+func (db *DB) MarkLaunchConfirmed(taskID string, attemptID int64, at string) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET launch_confirmed_at = CASE WHEN launch_confirmed_at = '' THEN ? ELSE launch_confirmed_at END
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning' AND launch_submitted_at <> ''
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, at, attemptID, taskID, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "record launch confirmation", taskID, attemptID)
+}
+
+func (db *DB) MarkAttemptRunning(taskID string, attemptID int64) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET lifecycle = 'running', status_changed_at = CASE WHEN status_changed_at = '' THEN launch_confirmed_at ELSE status_changed_at END
+		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning' AND launch_confirmed_at <> ''
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, attemptID, taskID, taskID, attemptID)
+	if err != nil {
+		return fmt.Errorf("record running attempt for attempt %d: %w", attemptID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("record running attempt for attempt %d: %w", attemptID, err)
+	}
+	if affected == 1 {
+		return nil
+	}
+	var lifecycle AttemptLifecycle
+	var launchConfirmedAt string
+	var ownerLifecycle TaskLifecycle
+	var activeID sql.NullInt64
+	err = db.sql.QueryRow(`SELECT attempt.lifecycle, attempt.launch_confirmed_at, task.lifecycle, task.active_attempt_id
+		FROM attempt JOIN task ON task.id = attempt.task_id WHERE attempt.id = ? AND attempt.task_id = ?`, attemptID, taskID).Scan(&lifecycle, &launchConfirmedAt, &ownerLifecycle, &activeID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: task %q no longer owns active attempt %d", ErrOwnershipConflict, taskID, attemptID)
+	}
+	if err != nil {
+		return fmt.Errorf("read attempt %d after running conflict: %w", attemptID, err)
+	}
+	if ownerLifecycle != TaskOpen || !activeID.Valid || activeID.Int64 != attemptID {
+		return fmt.Errorf("%w: task %q no longer owns active attempt %d", ErrOwnershipConflict, taskID, attemptID)
+	}
+	if lifecycle == AttemptProvisioning && launchConfirmedAt == "" {
+		return fmt.Errorf("%w: attempt launch is not confirmed", ErrInvalidTransition)
+	}
+	return fmt.Errorf("%w: attempt %d is already %s", ErrLifecycleConflict, attemptID, lifecycle)
+}
+
+func (db *DB) SetAttemptSendTrace(taskID string, attemptID int64, expected AttemptLifecycle, message, at string) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET send_undelivered_message = ?, send_undelivered_at = ?
+		WHERE id = ? AND task_id = ? AND lifecycle = ?
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, message, at, attemptID, taskID, expected, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "record send trace", taskID, attemptID)
+}
+
+func (db *DB) UpdateAttemptObservation(taskID string, attemptID int64, expected AttemptLifecycle, statusChangedAt, statusChangedFor string, doneVerified bool, lastReportState, lastReportNote, parkedFiredFor, usageLimitRetryAt string, usageLimitAttempts int) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET status_changed_at = ?, status_changed_for = ?, done_verified = done_verified OR ?,
+		last_report_state = ?, last_report_note = ?, parked_fired_for = ?, usage_limit_retry_at = ?, usage_limit_attempts = ?
+		WHERE id = ? AND task_id = ? AND lifecycle = ?
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, statusChangedAt, statusChangedFor, doneVerified, lastReportState, lastReportNote, parkedFiredFor, usageLimitRetryAt, usageLimitAttempts, attemptID, taskID, expected, taskID, attemptID)
+	return updateAttemptOwnership(result, err, "record watcher observation", taskID, attemptID)
+}
+
+func updateAttemptOwnership(result sql.Result, err error, operation, taskID string, attemptID int64) error {
+	if err != nil {
+		return fmt.Errorf("%s for attempt %d: %w", operation, attemptID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s for attempt %d: %w", operation, attemptID, err)
+	}
+	if affected != 1 {
+		return fmt.Errorf("%w: task %q no longer owns active attempt %d for %s", ErrOwnershipConflict, taskID, attemptID, operation)
+	}
+	return nil
 }
 
 func validAttemptTransition(from, to AttemptLifecycle) bool {
@@ -847,6 +1224,23 @@ func (db *DB) SetHold(h Hold) error {
 	return nil
 }
 
+func (db *DB) SetHoldIfNotOtherKind(h Hold) (bool, error) {
+	result, err := db.sql.Exec(`INSERT INTO hold (`+holdColumns+`)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			kind = excluded.kind, reason = excluded.reason,
+			blocked_on = excluded.blocked_on, set_at = excluded.set_at
+		WHERE hold.kind = excluded.kind`, h.ID, h.Kind, h.Reason, h.BlockedOn, h.SetAt)
+	if err != nil {
+		return false, fmt.Errorf("write conditional hold %q: %w", h.ID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("write conditional hold %q: %w", h.ID, err)
+	}
+	return affected == 1, nil
+}
+
 func (db *DB) ReadHold(id string) (Hold, bool, error) {
 	row := db.sql.QueryRow(`SELECT `+holdColumns+` FROM hold WHERE id = ?`, id)
 	h, err := scanHold(row)
@@ -896,4 +1290,16 @@ func (db *DB) ClearHold(id string) error {
 		return fmt.Errorf("hold %q %w", id, ErrHoldNotFound)
 	}
 	return nil
+}
+
+func (db *DB) ClearHoldIfKind(id, kind string) (bool, error) {
+	result, err := db.sql.Exec(`DELETE FROM hold WHERE id = ? AND kind = ?`, id, kind)
+	if err != nil {
+		return false, fmt.Errorf("clear conditional hold %q: %w", id, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("clear conditional hold %q: %w", id, err)
+	}
+	return affected == 1, nil
 }

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -117,15 +117,16 @@ type TaskState struct {
 	// CreatedAt pairs with AttemptID as the tracked execution identity, not just a timestamp:
 	// the poll loop compares both against the task on disk so a reopened or promoted ID is
 	// re-seeded from scratch instead of inheriting this state.
-	CreatedAt    string
-	AttemptID    int64
-	Status       herdr.Status
-	Probed       bool
-	ChangedAt    time.Time
-	Blocked      bool
-	Stale        bool
-	PRMerged     bool
-	ReportCursor state.ReportCursor
+	CreatedAt        string
+	AttemptID        int64
+	AttemptLifecycle state.AttemptLifecycle
+	Status           herdr.Status
+	Probed           bool
+	ChangedAt        time.Time
+	Blocked          bool
+	Stale            bool
+	PRMerged         bool
+	ReportCursor     state.ReportCursor
 	// The Persisted* fields mirror what the task's durable state already carries,
 	// so a write skipped for lock contention is retried on the next tick instead
 	// of silently lost.

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -129,8 +129,8 @@ func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 // decides whether the limit is over - the next tick's clear check does that, by seeing whether the pane
 // started working.
 func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
-	// Follow foreground send's task -> send order, so promotion and teardown cannot replace the
-	// Attempt while this resume steers its pane. TryLock keeps the poll loop moving.
+	// Task before send, the documented order, so promotion and teardown cannot replace the Attempt
+	// while this resume steers its pane. TryLock keeps the poll loop moving.
 	releaseTask, err := state.TryLock(cfg.Home, "task:"+t.ID)
 	if err != nil {
 		if !errors.Is(err, state.ErrLockBusy) {

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -129,10 +129,17 @@ func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 // decides whether the limit is over - the next tick's clear check does that, by seeing whether the pane
 // started working.
 func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
-	// The same `send:<id>` lock hand send holds, because two writers racing one composer is the lost
-	// steer atqamz/hand#102 traced. TryLock, never Lock: a tick must not block behind an operator's
-	// whole --wait, and an operator send landing right now is itself the thing that ends the limit.
-	release, err := state.TryLock(cfg.Home, "send:"+t.ID)
+	// Follow foreground send's task -> send order, so promotion and teardown cannot replace the
+	// Attempt while this resume steers its pane. TryLock keeps the poll loop moving.
+	releaseTask, err := state.TryLock(cfg.Home, "task:"+t.ID)
+	if err != nil {
+		if !errors.Is(err, state.ErrLockBusy) {
+			_, _ = fmt.Fprintf(errOut, "watch: lock task %s failed: %v\n", t.ID, err)
+		}
+		return nil
+	}
+	defer releaseTask()
+	releaseSend, err := state.TryLock(cfg.Home, "send:"+t.ID)
 	if err != nil {
 		if !errors.Is(err, state.ErrLockBusy) {
 			_, _ = fmt.Fprintf(errOut, "watch: lock send %s failed: %v\n", t.ID, err)
@@ -140,7 +147,7 @@ func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t stat
 		// A busy lock spends no attempt: the schedule is left untouched, so the next tick finds it due.
 		return nil
 	}
-	defer release()
+	defer releaseSend()
 
 	// Read first: the freshest refusal on screen is the harness's own latest prediction of when its quota
 	// returns, and scheduling from it keeps a genuinely long limit off the backoff's much shorter clock.

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -98,7 +98,7 @@ func detectUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Task,
 
 	ts.LimitAttempts = 0
 	ts.LimitRetryAt = nextLimitRetry(reset, 0, now)
-	writeLimitHold(cfg.Home, t.ID, ts, errOut)
+	writeLimitHoldForAttempt(cfg, t, a, ts, errOut)
 	return &Event{
 		TaskID: t.ID,
 		Kind:   KindUsageLimit,
@@ -129,16 +129,8 @@ func continueUsageLimit(cfg Config, client limitPane, ts *TaskState, t state.Tas
 // decides whether the limit is over - the next tick's clear check does that, by seeing whether the pane
 // started working.
 func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t state.Task, a state.Attempt, pane herdr.Pane, now time.Time, errOut io.Writer) *Event {
-	// Task before send, the documented order, so promotion and teardown cannot replace the Attempt
-	// while this resume steers its pane. TryLock keeps the poll loop moving.
-	releaseTask, err := state.TryLock(cfg.Home, "task:"+t.ID)
-	if err != nil {
-		if !errors.Is(err, state.ErrLockBusy) {
-			_, _ = fmt.Fprintf(errOut, "watch: lock task %s failed: %v\n", t.ID, err)
-		}
-		return nil
-	}
-	defer releaseTask()
+	// Send before task is the shared order with hand send. The task lock is held only while the
+	// short external steer runs, so promotion and teardown cannot replace the Attempt mid-steer.
 	releaseSend, err := state.TryLock(cfg.Home, "send:"+t.ID)
 	if err != nil {
 		if !errors.Is(err, state.ErrLockBusy) {
@@ -148,6 +140,14 @@ func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t stat
 		return nil
 	}
 	defer releaseSend()
+	releaseTask, err := state.TryLock(cfg.Home, "task:"+t.ID)
+	if err != nil {
+		if !errors.Is(err, state.ErrLockBusy) {
+			_, _ = fmt.Fprintf(errOut, "watch: lock task %s failed: %v\n", t.ID, err)
+		}
+		return nil
+	}
+	defer releaseTask()
 
 	if !ownsAttempt(cfg.Home, t, a, errOut) {
 		return nil
@@ -310,4 +310,19 @@ func writeLimitHold(home, id string, ts *TaskState, errOut io.Writer) {
 	if !written {
 		_, _ = fmt.Fprintf(errOut, "watch: hold on %s is not of kind limit; usage-limit wait left unprojected: %s\n", id, limitReason(ts))
 	}
+}
+
+func writeLimitHoldForAttempt(cfg Config, t state.Task, a state.Attempt, ts *TaskState, errOut io.Writer) {
+	releaseTask, err := state.TryLock(cfg.Home, "task:"+t.ID)
+	if err != nil {
+		if !errors.Is(err, state.ErrLockBusy) {
+			_, _ = fmt.Fprintf(errOut, "watch: lock task %s failed: %v\n", t.ID, err)
+		}
+		return
+	}
+	defer releaseTask()
+	if !ownsAttempt(cfg.Home, t, a, errOut) {
+		return
+	}
+	writeLimitHold(cfg.Home, t.ID, ts, errOut)
 }

--- a/internal/watcher/usagelimit.go
+++ b/internal/watcher/usagelimit.go
@@ -149,6 +149,10 @@ func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t stat
 	}
 	defer releaseSend()
 
+	if !ownsAttempt(cfg.Home, t, a, errOut) {
+		return nil
+	}
+
 	// Read first: the freshest refusal on screen is the harness's own latest prediction of when its quota
 	// returns, and scheduling from it keeps a genuinely long limit off the backoff's much shorter clock.
 	reset := time.Time{}
@@ -178,6 +182,23 @@ func attemptUsageLimitResume(cfg Config, client limitPane, ts *TaskState, t stat
 		Text:   fmt.Sprintf("usage-limit-stuck %s: %s", t.ID, limitReason(ts)),
 		Reason: limitReason(ts),
 	}
+}
+
+// The Task and Attempt a tick carries were read before the locks above, so a teardown or promotion that
+// landed in between describes execution this fleet has moved past: steering it pokes a pane the run no
+// longer owns, and the hold write would put a limit hold back on an id nothing is waiting for.
+func ownsAttempt(home string, t state.Task, a state.Attempt, errOut io.Writer) bool {
+	history, err := state.ReadHistory(home, t.ID)
+	if err != nil {
+		if !errors.Is(err, state.ErrTaskNotFound) {
+			_, _ = fmt.Fprintf(errOut, "watch: re-read task %s failed: %v\n", t.ID, err)
+		}
+		return false
+	}
+	current := history.ActiveAttempt
+	return history.Task.ID == t.ID && history.Task.Lifecycle == state.TaskOpen &&
+		current != nil && current.ID == a.ID && current.TaskID == t.ID &&
+		current.Lifecycle == state.AttemptRunning && current.Herdr.PaneID == a.Herdr.PaneID
 }
 
 // Forgets the schedule and the operator-visible hold together, so the two cannot disagree about whether

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -400,11 +400,11 @@ func TestNextLimitRetryIsBounded(t *testing.T) {
 // A steer that never landed is one lost attempt, not a task that becomes due again on
 // every tick - which is the retry storm the whole mechanism is bounded to avoid.
 func TestAFailedSteerStillConsumesItsAttempt(t *testing.T) {
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	ts := &TaskState{LimitRetryAt: time.Now().Add(-time.Minute)}
 	client := &steerFailingPane{}
-	cfg := Config{Home: t.TempDir()}
-	task := state.Task{ID: "task-1"}
-	attempt := state.Attempt{Herdr: state.Herdr{PaneID: "p1"}}
+	cfg := Config{Home: home}
+	task, attempt := readTaskAttempt(t, home, "task-1")
 	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
 	var errBuf bytes.Buffer
 
@@ -462,6 +462,37 @@ func TestAnAttemptYieldsToASendHoldingTheLock(t *testing.T) {
 	}
 	if !ts.LimitRetryAt.Equal(due) {
 		t.Fatalf("LimitRetryAt = %s, want it left due at %s", ts.LimitRetryAt, due)
+	}
+}
+
+// A tick reads its Task and Attempt before it takes either lock, so `hand teardown` can terminalize both
+// in between. The steer would then reach a pane the fleet has taken back, and the hold write would put a
+// limit hold on a terminal id, which refuses `hand reopen` and `hand spawn` until it is cleared by hand.
+func TestAnAttemptYieldsWhenTeardownReplacedTheOwnershipItRead(t *testing.T) {
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+
+	due := time.Now().Add(-time.Minute)
+	ts := &TaskState{LimitRetryAt: due}
+	client := &countingPane{}
+	cfg := Config{Home: home}
+	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
+	var errBuf bytes.Buffer
+
+	if e := classifyUsageLimit(cfg, client, ts, task, attempt, pane, herdr.StatusDone, nil, false, time.Now(), &errBuf); e != nil {
+		t.Fatalf("event = %+v, want none", e)
+	}
+	if client.reads != 0 || client.steers != 0 {
+		t.Fatalf("reads = %d, steers = %d, want neither: the attempt this tick read is no longer the fleet's", client.reads, client.steers)
+	}
+	if ts.LimitAttempts != 0 || !ts.LimitRetryAt.Equal(due) {
+		t.Fatalf("LimitAttempts = %d, LimitRetryAt = %s, want the schedule left alone", ts.LimitAttempts, ts.LimitRetryAt)
+	}
+	if h, exists := limitHold(t, home, "task-1"); exists {
+		t.Fatalf("hold = %+v, want none: a limit hold on a terminal task blocks hand reopen and hand spawn", h)
 	}
 }
 

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -465,6 +465,30 @@ func TestAnAttemptYieldsToASendHoldingTheLock(t *testing.T) {
 	}
 }
 
+func TestAnAttemptYieldsToTaskOwnershipChangeAfterSendLock(t *testing.T) {
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	release, err := state.TryLock(home, "task:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	due := time.Now().Add(-time.Minute)
+	ts := &TaskState{LimitRetryAt: due}
+	client := &countingPane{}
+	cfg := Config{Home: home}
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
+	var errBuf bytes.Buffer
+
+	if e := classifyUsageLimit(cfg, client, ts, task, attempt, pane, herdr.StatusDone, nil, false, time.Now(), &errBuf); e != nil {
+		t.Fatalf("event = %+v, want none", e)
+	}
+	if client.reads != 0 || client.steers != 0 {
+		t.Fatalf("reads = %d, steers = %d, want neither while task ownership changes", client.reads, client.steers)
+	}
+}
+
 // A tick reads its Task and Attempt before it takes either lock, so `hand teardown` can terminalize both
 // in between. The steer would then reach a pane the fleet has taken back, and the hold write would put a
 // limit hold on a terminal id, which refuses `hand reopen` and `hand spawn` until it is cleared by hand.
@@ -512,8 +536,7 @@ func TestALimitLeavesAnOperatorHoldOnTheSameIDStanding(t *testing.T) {
 	ts := &TaskState{}
 	client := &countingPane{}
 	cfg := Config{Home: home}
-	task := state.Task{ID: "task-1"}
-	attempt := state.Attempt{Herdr: state.Herdr{PaneID: "p1"}}
+	task, attempt := readTaskAttempt(t, home, "task-1")
 	pane := herdr.Pane{PaneID: "p1", Agent: limitedPaneAgent}
 	var errBuf bytes.Buffer
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -139,8 +139,8 @@ func connect(ctx context.Context) (*herdr.Client, error) {
 	}
 }
 
-// Confirms every active task's pane answers before RunUntilEvent arms, since an unprobed task would
-// otherwise wait out the timeout with no distinguishing signal.
+// Confirms every running task's pane answers before RunUntilEvent arms; provisioning has no pane
+// contract yet and is intentionally left for a later tick after launch confirmation.
 func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error {
 	histories, err := state.ListOpenHistories(home)
 	if err != nil {
@@ -152,6 +152,9 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 			if history.ActiveAttempt == nil {
 				done <- fmt.Errorf("%w: %s has no active attempt", ErrArmFailed, history.Task.ID)
 				return
+			}
+			if history.ActiveAttempt.Lifecycle == state.AttemptProvisioning {
+				continue
 			}
 			if _, err := client.PaneGetContext(ctx, history.ActiveAttempt.Herdr.PaneID); err != nil {
 				done <- fmt.Errorf("%w: %s: %v", ErrArmFailed, history.Task.ID, err)
@@ -193,6 +196,9 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		}
 		attempt := *history.ActiveAttempt
 		seen[t.ID] = true
+		if attempt.Lifecycle == state.AttemptProvisioning {
+			continue
+		}
 		pane, probeErr := client.PaneGetContext(ctx, attempt.Herdr.PaneID)
 		if ctx.Err() != nil {
 			return
@@ -206,7 +212,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		// Inheriting the previous run's TaskState would suppress the new task's verified done forever -
 		// syncTaskState writes that inherited done_verified onto the fresh row, making the suppression
 		// durable - and absorb its first unexplained stop.
-		if tracked && (ts.CreatedAt != t.CreatedAt || ts.AttemptID != t.ActiveAttemptID) {
+		if tracked && (ts.CreatedAt != t.CreatedAt || ts.AttemptID != t.ActiveAttemptID || ts.AttemptLifecycle != attempt.Lifecycle) {
 			tracked = false
 		}
 		if !tracked {
@@ -284,6 +290,7 @@ func resumeTaskState(t state.Task, a state.Attempt, status herdr.Status, now tim
 	ts.PersistedPaneID = a.Herdr.PaneID
 	ts.CreatedAt = t.CreatedAt
 	ts.AttemptID = t.ActiveAttemptID
+	ts.AttemptLifecycle = a.Lifecycle
 	ts.ReportCursor = state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest}
 	ts.PersistedCursor = ts.ReportCursor
 	ts.PRMerged = t.MergeAnnounced
@@ -569,8 +576,7 @@ func recordAutoPR(home, id, url string) error {
 	if t.PR != "" {
 		return nil
 	}
-	t.PR = url
-	if err := state.UpdateTask(home, t); err != nil {
+	if err := state.SetTaskPR(home, id, url); err != nil {
 		return fmt.Errorf("write task %s: %w", id, err)
 	}
 	return nil
@@ -626,37 +632,33 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 		_, _ = fmt.Fprintf(errOut, "watch: read task %s failed: %v\n", id, err)
 		return
 	}
-	t.ReportOffset = ts.ReportCursor.Offset
-	t.ReportDigest = ts.ReportCursor.Digest
-	t.MergeAnnounced = t.MergeAnnounced || ts.PRMerged
 	// The report cursor is task-owned and lands before the attempt is resolved: dropping it because a
 	// task terminalized mid-tick would replay lines this watcher already consumed, which re-raises
 	// resolved decisions and can auto-record a stale PR URL.
-	if err := state.UpdateTask(home, t); err != nil {
+	if err := state.SetTaskReportState(home, id, ts.ReportCursor.Offset, ts.ReportCursor.Digest, ts.PRMerged); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: persist task %s failed: %v\n", id, err)
 		return
 	}
 	ts.PersistedCursor = ts.ReportCursor
 	ts.PersistedPRMerged = ts.PRMerged
 
-	active, err := state.ActiveAttempt(home, id)
+	active, found, err := state.ReadAttempt(home, ts.AttemptID)
 	if err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: read active attempt %s failed: %v\n", id, err)
+		return
+	}
+	if !found || active.TaskID != id || t.ActiveAttemptID != ts.AttemptID || active.Lifecycle != ts.AttemptLifecycle {
+		_, _ = fmt.Fprintf(errOut, "watch: read active attempt %s failed: attempt ownership changed\n", id)
 		return
 	}
 	// A promote may have landed since this tick's state.List. Writing the cached values back would
 	// erase its restamp and leave the disk value matching what this watcher persisted, so no later
 	// tick would find anything to forget either.
 	forgetPaneScopedCache(ts, t, active, now)
-	active.DoneVerified = active.DoneVerified || ts.DoneVerified
-	active.StatusChangedAt = ts.ChangedAt.UTC().Format(time.RFC3339)
-	active.StatusChangedFor = string(ts.Status)
-	active.LastReportState = ts.LastReportState
-	active.LastReportNote = ts.LastReportNote
-	active.ParkedFiredFor = parkedFiredStamp(ts.ParkedFiredFor)
-	active.UsageLimitRetryAt = limitRetryStamp(ts.LimitRetryAt)
-	active.UsageLimitAttempts = ts.LimitAttempts
-	if err := state.UpdateAttempt(home, active); err != nil {
+	if err := state.UpdateAttemptObservation(home, id, ts.AttemptID, ts.AttemptLifecycle,
+		ts.ChangedAt.UTC().Format(time.RFC3339), string(ts.Status), ts.DoneVerified,
+		ts.LastReportState, ts.LastReportNote, parkedFiredStamp(ts.ParkedFiredFor),
+		limitRetryStamp(ts.LimitRetryAt), ts.LimitAttempts); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: persist attempt %s failed: %v\n", id, err)
 		return
 	}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1457,6 +1457,7 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 	before := TaskState{
 		CreatedAt:               "created-marker",
 		AttemptID:               99,
+		AttemptLifecycle:        state.AttemptRunning,
 		Status:                  herdr.Status("scout-status"),
 		Probed:                  true,
 		ChangedAt:               time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -1494,6 +1495,7 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 	carried := map[string]bool{
 		"CreatedAt":               true,
 		"AttemptID":               true,
+		"AttemptLifecycle":        true,
 		"PRMerged":                true,
 		"ReportCursor":            true,
 		"PersistedCursor":         true,
@@ -1612,6 +1614,10 @@ func TestSyncTaskStateDropsCachePromoteInvalidatedMidTick(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, observed := readTaskAttempt(t, home, "task-1")
+	ts.AttemptID = observed.ID
+	ts.AttemptLifecycle = observed.Lifecycle
+
 	var errBuf bytes.Buffer
 	syncTaskState(home, "task-1", ts, now, &errBuf)
 	if errBuf.Len() != 0 {
@@ -1658,11 +1664,13 @@ func TestSyncTaskStateKeepsTheReportCursorWhenTheAttemptIsGone(t *testing.T) {
 	}
 
 	ts := &TaskState{
-		Status:          herdr.StatusWorking,
-		Probed:          true,
-		ChangedAt:       now,
-		PersistedPaneID: "p1",
-		ReportCursor:    state.ReportCursor{Offset: 128, Digest: "consumed-digest"},
+		Status:           herdr.StatusWorking,
+		AttemptID:        attempt.ID,
+		AttemptLifecycle: attempt.Lifecycle,
+		Probed:           true,
+		ChangedAt:        now,
+		PersistedPaneID:  "p1",
+		ReportCursor:     state.ReportCursor{Offset: 128, Digest: "consumed-digest"},
 	}
 
 	var errBuf bytes.Buffer

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -53,6 +53,10 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 // no-op success; an aborted one exits 0 with the slot still leased, so the exit
 // status alone cannot say a return happened. See internal/faketool/FIDELITY.md.
 func Return(worktreePath string, force bool) error {
+	// An attempt that never reached a lease has no slot to release.
+	if worktreePath == "" {
+		return nil
+	}
 	args := []string{"return", worktreePath}
 	if force {
 		args = append(args, "--force")

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -32,7 +32,7 @@ func setupCollisionHome(t *testing.T) (string, string) {
 
 // Proves worktree.CheckCollision is actually wired into the built spawn command, not just unit-tested in
 // isolation: a second spawn onto a slot a surviving task row still names must be refused before it ever
-// reaches herdr, and must leave no trace of task-2.
+// reaches herdr, while its provisioning attempt preserves the failed boundary.
 func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 	home, dir := setupCollisionHome(t)
 
@@ -53,8 +53,12 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 		t.Fatalf("collision stderr = %q, want it to name the conflicting task task-1", second.stderr)
 	}
 
-	if exists, err := state.Exists(home, "task-2"); err != nil || exists {
-		t.Fatalf("state.Exists(task-2) = %v, %v, want the collision to leave no task-2 state", exists, err)
+	if exists, err := state.Exists(home, "task-2"); err != nil || !exists {
+		t.Fatalf("state.Exists(task-2) = %v, %v, want the provisioning attempt preserved", exists, err)
+	}
+	task2, attempt2 := readTaskAttempt(t, home, "task-2")
+	if task2.Lifecycle != state.TaskOpen || attempt2.Lifecycle != state.AttemptProvisioning || attempt2.Worktree != sharedWorktree {
+		t.Fatalf("task-2 state = %+v / %+v, want the acquired worktree preserved on the provisioning attempt", task2, attempt2)
 	}
 	task1, attempt1 := readTaskAttempt(t, home, "task-1")
 	if attempt1.Worktree != sharedWorktree {

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -57,8 +57,8 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 		t.Fatalf("state.Exists(task-2) = %v, %v, want the provisioning attempt preserved", exists, err)
 	}
 	task2, attempt2 := readTaskAttempt(t, home, "task-2")
-	if task2.Lifecycle != state.TaskOpen || attempt2.Lifecycle != state.AttemptProvisioning || attempt2.Worktree != sharedWorktree {
-		t.Fatalf("task-2 state = %+v / %+v, want the acquired worktree preserved on the provisioning attempt", task2, attempt2)
+	if task2.Lifecycle != state.TaskOpen || attempt2.Lifecycle != state.AttemptProvisioning || attempt2.Worktree != "" || attempt2.LeaseID != "" {
+		t.Fatalf("task-2 state = %+v / %+v, want returned resource ownership cleared on the provisioning attempt", task2, attempt2)
 	}
 	task1, attempt1 := readTaskAttempt(t, home, "task-1")
 	if attempt1.Worktree != sharedWorktree {

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -124,5 +124,11 @@ func seedSendTask(t *testing.T, home string) {
 	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindShip,
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
+	}, state.Attempt{
+		Lifecycle:         state.AttemptRunning,
+		Worktree:          filepath.Join(home, "wt-1"),
+		Herdr:             state.Herdr{PaneID: "pane-1"},
+		LaunchSubmittedAt: time.Now().UTC().Format(time.RFC3339),
+		LaunchConfirmedAt: time.Now().UTC().Format(time.RFC3339),
+	})
 }


### PR DESCRIPTION
## Summary
- Make Task/Attempt ownership transitions and terminalization conditional and transactional inside SQLite.
- Persist provisioning ownership and launch evidence incrementally, with attempt-targeted watcher/send writes and race-safe holds.
- Preserve migration rollback and unstamped split-layout version stamping guarantees.

Fixes atqamz/hand#194

## Test plan
- nix develop --command go test ./... -count=1
- nix develop --command go test -race ./...
- nix develop --command go vet ./...
- nix develop --command make lint
- nix develop --command make build
- nix develop --command make contract
- nix develop --command make e2e
- nix flake check --print-build-logs