### PR TITLE
feat(runtime): add deterministic reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ Workers run interactively inside [herdr](https://github.com/ogulcancelik/herdr),
 ### Durable fleet state
 
 Machine state lives in SQLite while operator context, briefs, reports, backlog history, and learnings remain plain files. The fleet survives the supervising agent's session, so a later session can pick up where the previous one stopped.
+SQLite is durable intent and history, while Git, treehouse, herdr, and worker processes are observed reality.
+`hand reconcile` compares those independently owned facts and applies only deterministic, ownership-proven convergence.
+An ambiguous or dirty resource becomes a durable `needs-repair` marker instead of being destroyed.
+Existing Attempts keep their persisted execution snapshot during recovery, so profile changes never reroute them and a missing running pane never causes a silent relaunch.
+`hand status` remains read-only and displays repair markers without attempting cleanup.
 
 ### Safe lifecycle boundaries
 
@@ -407,6 +412,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
+| `hand reconcile [id]` | Reconcile one Task or the bounded fleet candidate set with observed external reality. |
 | `hand watch` | Wait for actionable fleet events. |
 | `hand send` | Steer a running worker. |
 | `hand merge` | Merge completed work after authorization. |

--- a/README.md
+++ b/README.md
@@ -178,9 +178,8 @@ Workers run interactively inside [herdr](https://github.com/ogulcancelik/herdr),
 
 Machine state lives in SQLite while operator context, briefs, reports, backlog history, and learnings remain plain files. The fleet survives the supervising agent's session, so a later session can pick up where the previous one stopped.
 SQLite is durable intent and history, while Git, treehouse, herdr, and worker processes are observed reality.
-`hand reconcile` compares those independently owned facts and applies only deterministic, ownership-proven convergence.
-An ambiguous or dirty resource becomes a durable `needs-repair` marker instead of being destroyed.
-Existing Attempts keep their persisted execution snapshot during recovery, so profile changes never reroute them and a missing running pane never causes a silent relaunch.
+`hand reconcile` compares those independently owned facts and records `needs-repair` when safe convergence cannot be proven.
+The [deterministic reconciliation decision record](docs/adr/deterministic-reconciliation-observes-before-mutating.md) owns the recovery invariants.
 `hand status` remains read-only and displays repair markers without attempting cleanup.
 
 ### Safe lifecycle boundaries

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -13,47 +13,25 @@ func detectPR(ctx context.Context, home string, t state.Task, active state.Attem
 	return runtime.DetectPR(ctx, home, t, active, proj)
 }
 
-// detectPR made safe for a read command: it never fails the command, so a task with no branch, an
-// unregistered or local-only project, a lock held elsewhere, an ambiguous branch, or a failed gh call all
-// just leave t as read.
-func detectPRForStatus(ctx context.Context, home string, t state.Task) state.Task {
+func detectPRForStatus(ctx context.Context, home string, history state.TaskHistory) state.Task {
+	t := history.Task
 	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - and a torn-down task's
 	// completion record is already written, so both skip the lookup rather than pay a forge round trip for a
 	// PR recordPR would refuse. The scout half is the short-circuit checkLandedWork opens with.
 	if t.PR != "" || t.Kind == state.KindScout || t.Lifecycle == state.TaskTerminal {
 		return t
 	}
-	active, err := state.ActiveAttempt(home, t.ID)
-	if err != nil {
+	if history.ActiveAttempt == nil {
 		return t
 	}
-	proj, exists, err := project.Find(home, t.Project)
+	proj, exists, err := project.FindReadOnly(home, t.Project)
 	if err != nil || !exists || proj.Mode == project.ModeLocalOnly {
 		return t
 	}
 
-	// hand status holds no lock on the task, so it takes its own non-blocking one, mirroring the watcher's
-	// own recordAutoPR.
-	unlock, err := state.TryLock(home, "task:"+t.ID)
-	if err != nil {
-		return t
-	}
-	defer unlock()
-
-	// Re-read under the lock in case a concurrent hand pr or teardown recorded a PR first.
-	fresh, err := state.Read(home, t.ID)
-	if err != nil {
-		return t
-	}
-	if fresh.PR != "" {
-		return fresh
-	}
-
 	ghCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	// Unlike hand teardown's landed-work guard, nothing here is gated on the answer, so an ambiguous branch
-	// degrades like any other detection failure instead of refusing.
-	detected, err := detectPR(ghCtx, home, fresh, active, proj)
+	detected, err := runtime.DetectPRReadOnly(ghCtx, home, t, *history.ActiveAttempt, proj)
 	if err != nil {
 		return t
 	}

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/atqamz/hand/internal/axi"
@@ -29,13 +30,7 @@ func newReconcileCmd() *cobra.Command {
 			if err := renderReconcileReport(cmd, report, asJSON); err != nil {
 				return err
 			}
-			if repair := firstRepair(report); repair != nil {
-				return asPrecondition(runtime.Precondition(fmt.Errorf("task %q needs repair: %s", repair.ID, repair.RepairCode)))
-			}
-			if reconcileErr != nil {
-				return asPrecondition(reconcileErr)
-			}
-			return nil
+			return reconcileReportError(report, reconcileErr)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output JSON instead of TOON")
@@ -62,8 +57,35 @@ func renderReconcileReport(cmd *cobra.Command, report runtime.ReconcileReport, a
 			doc.Field("repair_code", result.RepairCode)
 			doc.Field("repair_reason", result.RepairReason)
 		}
+		if result.Error != "" {
+			doc.Field("error", result.Error)
+		}
+	}
+	if len(report.Anomalies) > 0 {
+		anomalies := make([]string, 0, len(report.Anomalies))
+		for _, anomaly := range report.Anomalies {
+			anomalies = append(anomalies, fmt.Sprintf("%s:%s/%s", anomaly.Kind, anomaly.WorkspaceID, anomaly.TabID))
+		}
+		doc.List("anomalies", anomalies)
+	}
+	if len(report.Errors) > 0 {
+		doc.List("errors", report.Errors)
 	}
 	return doc.Render(cmd.OutOrStdout())
+}
+
+func reconcileReportError(report runtime.ReconcileReport, reconcileErr error) error {
+	var errs []error
+	if repair := firstRepair(report); repair != nil {
+		errs = append(errs, runtime.Precondition(fmt.Errorf("task %q needs repair: %s", repair.ID, repair.RepairCode)))
+	}
+	if anomaly := firstAnomaly(report); anomaly != nil {
+		errs = append(errs, runtime.Precondition(fmt.Errorf("unattributed Herdr resource %s/%s", anomaly.WorkspaceID, anomaly.TabID)))
+	}
+	if reconcileErr != nil {
+		errs = append(errs, reconcileErr)
+	}
+	return asPrecondition(errors.Join(errs...))
 }
 
 func firstRepair(report runtime.ReconcileReport) *runtime.ReconcileResult {
@@ -73,4 +95,11 @@ func firstRepair(report runtime.ReconcileReport) *runtime.ReconcileResult {
 		}
 	}
 	return nil
+}
+
+func firstAnomaly(report runtime.ReconcileReport) *runtime.ReconcileAnomaly {
+	if len(report.Anomalies) == 0 {
+		return nil
+	}
+	return &report.Anomalies[0]
 }

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -84,7 +84,11 @@ func reconcileReportError(report runtime.ReconcileReport, reconcileErr error) er
 		errs = append(errs, runtime.Precondition(fmt.Errorf("task %q needs repair: %s", repair.ID, repair.RepairCode)))
 	}
 	if anomaly := firstAnomaly(report); anomaly != nil {
-		errs = append(errs, runtime.Precondition(fmt.Errorf("unattributed Herdr resource %s/%s", anomaly.WorkspaceID, anomaly.TabID)))
+		detail := fmt.Sprintf("Herdr anomaly %q at %s/%s", anomaly.Kind, anomaly.WorkspaceID, anomaly.TabID)
+		if anomaly.OwnerAttemptID != 0 {
+			detail += fmt.Sprintf(" (attempt %d)", anomaly.OwnerAttemptID)
+		}
+		errs = append(errs, runtime.Precondition(errors.New(detail)))
 	}
 	if reconcileErr != nil {
 		errs = append(errs, reconcileErr)

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -64,7 +64,11 @@ func renderReconcileReport(cmd *cobra.Command, report runtime.ReconcileReport, a
 	if len(report.Anomalies) > 0 {
 		anomalies := make([]string, 0, len(report.Anomalies))
 		for _, anomaly := range report.Anomalies {
-			anomalies = append(anomalies, fmt.Sprintf("%s:%s/%s", anomaly.Kind, anomaly.WorkspaceID, anomaly.TabID))
+			owner := "unattributed"
+			if anomaly.OwnerAttemptID != 0 {
+				owner = fmt.Sprintf("%d", anomaly.OwnerAttemptID)
+			}
+			anomalies = append(anomalies, fmt.Sprintf("%s:%s/%s owner_attempt=%s reason=%s", anomaly.Kind, anomaly.WorkspaceID, anomaly.TabID, owner, anomaly.Reason))
 		}
 		doc.List("anomalies", anomalies)
 	}

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/runtime"
+	"github.com/spf13/cobra"
+)
+
+func newReconcileCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "reconcile [id]",
+		Short: "Converge durable task state with observed external reality",
+		Args:  usageArgs(cobra.MaximumNArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			report, reconcileErr := runtime.New().Reconcile(runtime.ReconcileRequest{Context: cmd.Context(), Home: fleetHome, ID: id})
+			if err := renderReconcileReport(cmd, report, asJSON); err != nil {
+				return err
+			}
+			if repair := firstRepair(report); repair != nil {
+				return asPrecondition(runtime.Precondition(fmt.Errorf("task %q needs repair: %s", repair.ID, repair.RepairCode)))
+			}
+			if reconcileErr != nil {
+				return asPrecondition(reconcileErr)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output JSON instead of TOON")
+	return cmd
+}
+
+func renderReconcileReport(cmd *cobra.Command, report runtime.ReconcileReport, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	var doc axi.Doc
+	doc.Int("count", len(report.Results))
+	for _, result := range report.Results {
+		doc.Field("id", result.ID)
+		doc.Field("result", result.Outcome)
+		doc.Field("action", orNone(result.Action))
+		doc.Int("iterations", result.Iterations)
+		if result.AttemptID != 0 {
+			doc.Field("attempt", fmt.Sprintf("%d", result.AttemptID))
+		}
+		if result.RepairCode != "" {
+			doc.Field("repair_code", result.RepairCode)
+			doc.Field("repair_reason", result.RepairReason)
+		}
+	}
+	return doc.Render(cmd.OutOrStdout())
+}
+
+func firstRepair(report runtime.ReconcileReport) *runtime.ReconcileResult {
+	for i := range report.Results {
+		if report.Results[i].Outcome == "needs-repair" {
+			return &report.Results[i]
+		}
+	}
+	return nil
+}

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/runtime"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -55,5 +57,16 @@ func TestReconcileCommandRendersNeedsRepairAndReturnsPrecondition(t *testing.T) 
 	}
 	if !bytes.Contains(out.Bytes(), []byte("repair_code: running-pane-missing")) || !bytes.Contains(out.Bytes(), []byte("result: needs-repair")) {
 		t.Fatalf("reconcile output = %q, want repair result", out.String())
+	}
+}
+
+func TestReconcileCommandPreservesRepairAndObservationErrors(t *testing.T) {
+	report := runtime.ReconcileReport{Results: []runtime.ReconcileResult{
+		{ID: "task-a", Outcome: "needs-repair", RepairCode: "running-pane-missing"},
+		{ID: "task-b", Outcome: "blocked", Error: "Herdr service unavailable"},
+	}}
+	err := reconcileReportError(report, errors.New("task-b: Herdr service unavailable"))
+	if err == nil || !strings.Contains(err.Error(), "running-pane-missing") || !strings.Contains(err.Error(), "Herdr service unavailable") {
+		t.Fatalf("reconcile error = %v, want repair and observation diagnostics", err)
 	}
 }

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -81,6 +81,12 @@ func TestReconcileCommandPreservesRepairAndObservationErrors(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "running-pane-missing") || !strings.Contains(err.Error(), "Herdr service unavailable") {
 		t.Fatalf("reconcile error = %v, want repair and observation diagnostics", err)
 	}
+	if !strings.Contains(err.Error(), "released-herdr-resource") || !strings.Contains(err.Error(), "attempt 7") {
+		t.Fatalf("reconcile error = %v, want the attributed anomaly classification", err)
+	}
+	if strings.Contains(err.Error(), "unattributed Herdr resource") {
+		t.Fatalf("reconcile error = %v, must not misclassify an attributed anomaly", err)
+	}
 }
 
 func TestReconcileCommandReportsUnknownRepairAsFailure(t *testing.T) {

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -64,9 +64,47 @@ func TestReconcileCommandPreservesRepairAndObservationErrors(t *testing.T) {
 	report := runtime.ReconcileReport{Results: []runtime.ReconcileResult{
 		{ID: "task-a", Outcome: "needs-repair", RepairCode: "running-pane-missing"},
 		{ID: "task-b", Outcome: "blocked", Error: "Herdr service unavailable"},
-	}}
+	}, Anomalies: []runtime.ReconcileAnomaly{{Kind: "released-herdr-resource", WorkspaceID: "ws-1", TabID: "tab-1", OwnerAttemptID: 7, Reason: "refusing to close"}}}
+	var out bytes.Buffer
+	cmd := newReconcileCmd()
+	cmd.SetOut(&out)
+	if err := renderReconcileReport(cmd, report, false); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("error: Herdr service unavailable")) {
+		t.Fatalf("rendered report = %q, want per-result observation error", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("owner_attempt=7")) || !bytes.Contains(out.Bytes(), []byte("reason=refusing to close")) {
+		t.Fatalf("rendered report = %q, want attributed anomaly details", out.String())
+	}
 	err := reconcileReportError(report, errors.New("task-b: Herdr service unavailable"))
 	if err == nil || !strings.Contains(err.Error(), "running-pane-missing") || !strings.Contains(err.Error(), "Herdr service unavailable") {
 		t.Fatalf("reconcile error = %v, want repair and observation diagnostics", err)
+	}
+}
+
+func TestReconcileCommandReportsUnknownRepairAsFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Lifecycle: state.TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskRepair(home, "task-1", "operator-review-required", "unknown contradiction", 0, "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newReconcileCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("reconcile error = %v, want precondition exit 3", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("result: needs-repair")) || !bytes.Contains(out.Bytes(), []byte("repair_code: operator-review-required")) {
+		t.Fatalf("reconcile output = %q, want unknown repair result", out.String())
 	}
 }

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/state"
+)
+
+func TestReconcileCommandRendersHealthyTerminalTask(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Lifecycle: state.TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newReconcileCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); !bytes.Contains([]byte(got), []byte("result: healthy")) || !bytes.Contains([]byte(got), []byte("id: task-1")) {
+		t.Fatalf("reconcile output = %q, want healthy structured result", got)
+	}
+}
+
+func TestReconcileCommandRendersNeedsRepairAndReturnsPrecondition(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}}); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}}}.Install(t, faketool.Bin(t))
+	cmd := newReconcileCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("reconcile error = %v, want precondition exit 3", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("repair_code: running-pane-missing")) || !bytes.Contains(out.Bytes(), []byte("result: needs-repair")) {
+		t.Fatalf("reconcile output = %q, want repair result", out.String())
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.AddCommand(newProjectCmd())
 	root.AddCommand(newSpawnCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(newReconcileCmd())
 	root.AddCommand(newSessionCmd(info.Version))
 	root.AddCommand(newSendCmd())
 	root.AddCommand(newHoldCmd())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,9 @@ import (
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +25,13 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 			if fleetHome, err := home.Resolve(); err == nil {
 				startupOverview := cmd.Name() == "hand" || cmd.CommandPath() == "hand session start"
 				if cmd.Name() != "init" && !startupOverview {
+					if _, statErr := os.Stat(store.Path(fleetHome)); os.IsNotExist(statErr) {
+						if err := project.Migrate(fleetHome); err != nil {
+							return err
+						}
+					} else if statErr != nil {
+						return fmt.Errorf("check state/hand.db: %w", statErr)
+					}
 					if _, err := migrateWorkerSettings(fleetHome); err != nil {
 						return err
 					}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if fleetHome, err := home.Resolve(); err == nil {
 				startupOverview := cmd.Name() == "hand" || cmd.CommandPath() == "hand session start"
-				if cmd.Name() != "init" && !startupOverview {
+				if cmd.Name() != "init" && !startupOverview && cmd.Name() != "status" {
 					if _, statErr := os.Stat(store.Path(fleetHome)); os.IsNotExist(statErr) {
 						if err := project.Migrate(fleetHome); err != nil {
 							return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -147,6 +147,10 @@ type statusJSON struct {
 	ReportHistory    []string      `json:"report_history,omitempty"`
 	Held             *holdJSON     `json:"held,omitempty"`
 	GateRunIssue     string        `json:"gate_run_issue,omitempty"`
+	RepairCode       string        `json:"repair_code,omitempty"`
+	RepairReason     string        `json:"repair_reason,omitempty"`
+	RepairAttemptID  int64         `json:"repair_attempt,omitempty"`
+	RepairObservedAt string        `json:"repair_observed_at,omitempty"`
 	// Omitted when false so a consumer written before this field sees no change
 	// on the fleet it already understands.
 	Unacknowledged bool          `json:"unacknowledged,omitempty"`
@@ -336,11 +340,11 @@ func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, cols [
 }
 
 func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, error) {
-	listHistories := state.ListOpenHistories
+	listHistories := state.ListReconciliationHistories
 	listHolds := state.ListHolds
 	listProjects := project.List
 	if readOnly {
-		listHistories = state.ListOpenHistoriesReadOnly
+		listHistories = state.ListReconciliationHistoriesReadOnly
 		listHolds = state.ListHoldsReadOnly
 		listProjects = project.ListReadOnly
 	}
@@ -495,7 +499,7 @@ func (v taskView) json() statusJSON {
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt,
-		Reported: v.reported, GateRunIssue: v.gateIssue, Unacknowledged: v.unacked, Attempts: history,
+		Reported: v.reported, GateRunIssue: v.gateIssue, RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Attempts: history,
 	}
 }
 
@@ -573,6 +577,13 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	var doc axi.Doc
 	for _, c := range cols {
 		doc.Field(c.Name, c.Value(v))
+	}
+	if v.task.RepairCode != "" {
+		doc.Field("repair", "needs-repair")
+		doc.Field("repair_code", v.task.RepairCode)
+		doc.Field("repair_attempt", fmt.Sprintf("%d", v.task.RepairAttemptID))
+		doc.Field("repair_reason", v.task.RepairReason)
+		doc.Field("repair_observed_at", v.task.RepairObservedAt)
 	}
 	doc.List("report_history", historyBlock(v, tail, full))
 	doc.List("attempts", attemptHistoryBlock(v))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -521,7 +521,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	if err != nil {
 		return asPrecondition(err)
 	}
-	history.Task = detectPRForStatus(cmd.Context(), home, history.Task)
+	history.Task = detectPRForStatus(cmd.Context(), home, history)
 	t := history.Task
 
 	// An unreadable report degrades exactly as it does in the fleet view: the

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -290,7 +290,7 @@ func gateRunIssue(home string, t state.Task, reportedDone bool, p project.Projec
 }
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool, cols []axi.Column[taskView]) error {
-	views, holds, err := fleetViews(cmd, home, client, false)
+	views, holds, err := fleetViews(cmd, home, client, true)
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func reportedFrom(last state.ReportLine, ok bool, readErr error) *reportedJSON {
 }
 
 func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON, full bool, cols []axi.Column[taskView]) error {
-	history, err := state.ReadHistory(home, id)
+	history, err := state.ReadHistoryReadOnly(home, id)
 	if err != nil {
 		return asPrecondition(err)
 	}
@@ -530,7 +530,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	v, reportLines := buildTaskView(home, client, history, full)
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.
-	hold, held, err := state.ReadHold(home, id)
+	hold, held, err := state.ReadHoldReadOnly(home, id)
 	if err != nil {
 		return err
 	}
@@ -540,7 +540,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	// fail the command.
 	reportedDone := v.reportedState == state.ReportDone
 	if gateRunApplies(t, reportedDone) {
-		p, registered, err := project.Find(home, t.Project)
+		p, registered, err := project.FindReadOnly(home, t.Project)
 		// Propagated, not degraded: a single task's own project is the one fact this check is about, unlike
 		// the fleet view's best-effort lookup across every task's project at once.
 		if err != nil {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
@@ -245,6 +246,44 @@ func TestStatusRendersRepairWithoutMutatingIt(t *testing.T) {
 	}
 	if after.Task.RepairCode != before.Task.RepairCode || after.Task.RepairReason != before.Task.RepairReason || after.Task.RepairAttemptID != before.Task.RepairAttemptID || after.Task.RepairObservedAt != before.Task.RepairObservedAt {
 		t.Fatalf("status mutated repair marker: before=%+v after=%+v", before.Task, after.Task)
+	}
+}
+
+func TestStatusDoesNotImportLegacyState(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	legacy, err := json.Marshal(store.Task{ID: "task-1", Project: "myproj", Kind: store.KindShip, CreatedAt: "2026-08-15T00:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyPath := filepath.Join(home, "state", "task-1.json")
+	if err := os.WriteFile(legacyPath, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(home, "state", "hand.db")
+	dbBefore, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{nil, {"task-1"}} {
+		cmd := newStatusCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err == nil {
+			t.Fatalf("status %v succeeded, want missing current database error", args)
+		}
+		dbAfter, err := os.ReadFile(dbPath)
+		if err != nil {
+			t.Fatalf("status %v removed hand.db: %v", args, err)
+		}
+		if !bytes.Equal(dbAfter, dbBefore) {
+			t.Fatalf("status %v mutated hand.db", args)
+		}
+		if _, err := os.Stat(legacyPath); err != nil {
+			t.Fatalf("status %v consumed legacy state: %v", args, err)
+		}
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -214,6 +214,40 @@ func TestStatusSingleTaskDetail(t *testing.T) {
 	}
 }
 
+func TestStatusRendersRepairWithoutMutatingIt(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "working")
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskRepair(home, "task-1", "running-pane-missing", "persisted running Attempt has no matching Herdr pane", 1, "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	before, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "repair: needs-repair") || !strings.Contains(out.String(), "repair_code: running-pane-missing") || !strings.Contains(out.String(), "repair_attempt: 1") {
+		t.Fatalf("status = %q, want repair evidence", out.String())
+	}
+	after, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Task.RepairCode != before.Task.RepairCode || after.Task.RepairReason != before.Task.RepairReason || after.Task.RepairAttemptID != before.Task.RepairAttemptID || after.Task.RepairObservedAt != before.Task.RepairObservedAt {
+		t.Fatalf("status mutated repair marker: before=%+v after=%+v", before.Task, after.Task)
+	}
+}
+
 func TestStatusSingleTaskExecutionSnapshotSurvivesRoutingEdits(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -483,12 +483,12 @@ func TestStatusSingleTaskDetectsGateOpenedPR(t *testing.T) {
 		t.Fatalf("got %q, want the detected PR shown", out.String())
 	}
 
-	got, err := state.Read(home, "task-1")
+	got, err := state.ReadHistoryReadOnly(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.PR != "https://github.com/owner/repo/pull/9" {
-		t.Fatalf("task.PR = %q, want status to have recorded the detected PR", got.PR)
+	if got.Task.PR != "" {
+		t.Fatalf("task.PR = %q, want status to leave persisted state unchanged", got.Task.PR)
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -287,6 +287,38 @@ func TestStatusDoesNotImportLegacyState(t *testing.T) {
 	}
 }
 
+func TestRootStatusObservesLegacyStateWithoutCreatingDatabase(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	dbPath := filepath.Join(home, "state", "hand.db")
+	if err := os.Remove(dbPath); err != nil {
+		t.Fatal(err)
+	}
+	legacyPath := filepath.Join(home, "state", "task-1.json")
+	if err := os.WriteFile(legacyPath, []byte(`{"id":"task-1","project":"myproj","kind":"ship","created_at":"2026-08-15T00:00:00Z"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd(devBuild("test"))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"status", "task-1"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "task-1") {
+		t.Fatalf("status = %q, want the observed legacy task", out.String())
+	}
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("stat %s: %v, want status not to create it", dbPath, err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("stat %s: %v, want status to leave it untouched", legacyPath, err)
+	}
+}
+
 func TestStatusSingleTaskExecutionSnapshotSurvivesRoutingEdits(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -81,13 +81,16 @@ func taskFlags(v taskView) []string {
 	if v.gateIssue != "" {
 		flags = append(flags, "gate-"+strings.ReplaceAll(v.gateIssue, " ", "-"))
 	}
+	if v.task.RepairCode != "" {
+		flags = append(flags, "needs-repair")
+	}
 	return flags
 }
 
 // The predicate behind the fleet view's attention aggregate: a supervisor reading only the count knows
 // whether any row is asking for something without reading the rows.
 func needsAttention(v taskView) bool {
-	if v.unreadable || v.unacked || v.gateIssue != "" {
+	if v.unreadable || v.unacked || v.gateIssue != "" || v.task.RepairCode != "" {
 		return true
 	}
 	switch v.reportedState {
@@ -156,6 +159,21 @@ var taskFields = []axi.Column[taskView]{
 	{Name: "gate", Value: func(v taskView) string { return orNone(v.gateIssue) }},
 	{Name: "report_file", Value: func(v taskView) string { return orNone(v.reportFile) }},
 	{Name: "flags", Value: func(v taskView) string { return orNone(strings.Join(taskFlags(v), " ")) }},
+	{Name: "repair", Value: func(v taskView) string {
+		if v.task.RepairCode == "" {
+			return "none"
+		}
+		return "needs-repair"
+	}},
+	{Name: "repair_code", Value: func(v taskView) string { return orNone(v.task.RepairCode) }},
+	{Name: "repair_attempt", Value: func(v taskView) string {
+		if v.task.RepairAttemptID == 0 {
+			return "none"
+		}
+		return fmt.Sprintf("%d", v.task.RepairAttemptID)
+	}},
+	{Name: "repair_reason", Value: func(v taskView) string { return orNone(v.task.RepairReason) }},
+	{Name: "repair_observed_at", Value: func(v taskView) string { return orNone(v.task.RepairObservedAt) }},
 }
 
 // The fleet view answers "what is running and what wants me", so it defaults to

--- a/docs/adr/deterministic-reconciliation-observes-before-mutating.md
+++ b/docs/adr/deterministic-reconciliation-observes-before-mutating.md
@@ -1,0 +1,48 @@
+# Deterministic reconciliation observes before mutating
+
+- Date: 2026-08-15
+- Status: accepted
+- Issues: atqamz/hand#196
+- PRs: none single
+
+## Context
+
+Hand crosses SQLite, Git, treehouse, herdr, and worker-process boundaries without a distributed transaction.
+A crash can leave durable lifecycle evidence ahead of, behind, or contradictory to external reality.
+Re-running an external command blindly can launch duplicate workers, return a reused worktree lease, or close an unrelated herdr resource.
+
+## Decision
+
+SQLite is durable intent and history.
+Git, treehouse, herdr, and processes are observed evidence.
+Reconciliation compares those independently owned facts through a bounded observe, decide, apply-one-action, and re-observe loop.
+The decision table is deterministic, and repeated reconciliation against unchanged reality converges.
+
+Repair metadata is Task-addressed and orthogonal to Attempt lifecycle.
+It stores a stable machine-readable code, bounded reason, relevant Attempt ID, and observation timestamp.
+The marker remains until the same contradiction is proven gone or a safe lifecycle transition resolves it.
+Observation failures never become contradiction evidence and do not clear an existing marker.
+
+An existing Attempt is never rerouted during reconciliation.
+Its persisted harness, model, effort, execution class, planned-against commit, requested profile, and routing source remain the only execution identity.
+There is no automatic worker, harness, model, or profile fallback.
+
+Automatic resource cleanup requires exact ownership proof and a clean worktree.
+Dirty worktrees, incomplete or reused identities, missing running workers, and ambiguous launch evidence become `needs-repair`.
+The reconciler does not run as a daemon and does not implement the send protocol.
+
+The detailed recovery matrix belongs in the reconciliation decision and observation tests under `internal/runtime`.
+Command rendering stays in Cobra, and status remains read-only.
+
+## Rejected alternatives
+
+- Treating SQLite as a complete model of external reality would make stale rows authorize destructive actions.
+- Treating every external error as absence would turn service outages into false repair decisions.
+- Re-routing or relaunching an existing Attempt would create a second execution identity and duplicate side effects.
+- A daemon or generic controller would add lifecycle ownership and scheduling scope that this explicit CLI use-case does not need.
+
+## Consequences
+
+`hand reconcile [id]` is the explicit mutation boundary for recovery.
+The command can safely progress through several durable checkpoints in one invocation while the iteration guard prevents a logic loop.
+Operators must resolve ambiguous ownership and dirty work manually, and a worker that disappears while running is not silently replaced.

--- a/docs/adr/deterministic-reconciliation-observes-before-mutating.md
+++ b/docs/adr/deterministic-reconciliation-observes-before-mutating.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-15
 - Status: accepted
 - Issues: atqamz/hand#196
-- PRs: none single
+- PRs: atqamz/hand#229
 
 ## Context
 
@@ -22,6 +22,7 @@ Repair metadata is Task-addressed and orthogonal to Attempt lifecycle.
 It stores a stable machine-readable code, bounded reason, relevant Attempt ID, and observation timestamp.
 The marker remains until the same contradiction is proven gone or a safe lifecycle transition resolves it.
 Observation failures never become contradiction evidence and do not clear an existing marker.
+Unknown Herdr failures follow the same rule, including when a running Attempt's worktree is dirty.
 
 An existing Attempt is never rerouted during reconciliation.
 Its persisted harness, model, effort, execution class, planned-against commit, requested profile, and routing source remain the only execution identity.
@@ -29,6 +30,7 @@ There is no automatic worker, harness, model, or profile fallback.
 
 Automatic resource cleanup requires exact ownership proof and a clean worktree.
 Dirty worktrees, incomplete or reused identities, missing running workers, and ambiguous launch evidence become `needs-repair`.
+Released historical Herdr resources remain attributed anomalies when matching live identities are observed; reconciliation reports them without closing the resource.
 The reconciler does not run as a daemon and does not implement the send protocol.
 
 The detailed recovery matrix belongs in the reconciliation decision and observation tests under `internal/runtime`.

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -48,6 +48,26 @@ type envelope struct {
 	Error  *errorBody      `json:"error"`
 }
 
+var ErrNotFound = errors.New("herdr resource not found")
+
+type APIError struct {
+	Operation string
+	Code      string
+	Message   string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("herdr %s: %s: %s", e.Operation, e.Code, e.Message)
+}
+
+func (e *APIError) Unwrap() error {
+	code := strings.ToLower(e.Code)
+	if code == "not_found" || strings.HasSuffix(code, "_not_found") {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // Execs herdr and returns its trimmed stdout and trimmed stderr alongside the process error,
 // letting call and callVoid share one invocation path.
 func (c *Client) run(args ...string) ([]byte, string, error) {
@@ -92,7 +112,7 @@ func (c *Client) callContext(ctx context.Context, args ...string) (json.RawMessa
 		return nil, err
 	}
 	if env.Error != nil {
-		return nil, fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), env.Error.Code, env.Error.Message)
+		return nil, &APIError{Operation: strings.Join(args, " "), Code: env.Error.Code, Message: env.Error.Message}
 	}
 	if runErr != nil {
 		return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
@@ -128,7 +148,7 @@ func (c *Client) callVoid(args ...string) error {
 		return err
 	}
 	if env.Error != nil {
-		return fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), env.Error.Code, env.Error.Message)
+		return &APIError{Operation: strings.Join(args, " "), Code: env.Error.Code, Message: env.Error.Message}
 	}
 	if runErr != nil {
 		return fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -188,6 +188,21 @@ func TestCallReturnsErrorOnEnvelopeError(t *testing.T) {
 	}
 }
 
+func TestCallClassifiesStructuredNotFoundWithoutClassifyingProcessText(t *testing.T) {
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"error\":{\"code\":\"pane_not_found\",\"message\":\"pane missing\"}}", Exit: 1})
+	c := NewClient()
+	_, err := c.PaneGet("wA:pB")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("structured pane_not_found error = %v, want ErrNotFound", err)
+	}
+
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stderr: "binary reported not found\n", Exit: 1})
+	_, err = c.PaneGet("wA:pB")
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("process failure was classified as ErrNotFound: %v", err)
+	}
+}
+
 func TestCallFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stderr: "binary crashed\n", Exit: 1})
 	c := NewClient()

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -60,7 +60,19 @@ func ListReadOnly(homeDir string) ([]Project, error) {
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
-	return db.ListProjects()
+	projects, err := db.ListProjects()
+	if err != nil {
+		return nil, err
+	}
+	done, err := db.Migrated(legacyRegistryKey)
+	if err != nil || done {
+		return projects, err
+	}
+	legacy, err := parseRegistryFile(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	return append(projects, legacy...), nil
 }
 
 // Runs schema, legacy task, and legacy registry migrations through their existing

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -12,19 +12,7 @@ import (
 )
 
 func DetectPR(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, error) {
-	branch, err := currentBranch(active.Worktree)
-	if err != nil {
-		return task, err
-	}
-	repoSlug, err := project.RepoSlug(homeDir, projectInfo)
-	if err != nil {
-		return task, err
-	}
-	targets := []ghutil.PRSearchTarget{{Repo: repoSlug}}
-	if projectInfo.Upstream != "" && !strings.EqualFold(projectInfo.Upstream, repoSlug) {
-		targets = append(targets, ghutil.PRSearchTarget{Repo: projectInfo.Upstream, HeadRepo: repoSlug})
-	}
-	url, merged, found, err := ghutil.FindPRByBranch(ctx, branch, targets...)
+	url, merged, found, err := findPR(ctx, homeDir, active, projectInfo)
 	if err != nil {
 		return task, err
 	}
@@ -39,6 +27,37 @@ func DetectPR(ctx context.Context, homeDir string, task state.Task, active state
 		return task, err
 	}
 	return updated, nil
+}
+
+func DetectPRReadOnly(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, error) {
+	url, merged, found, err := findPR(ctx, homeDir, active, projectInfo)
+	if err != nil {
+		return task, err
+	}
+	if !found {
+		return task, nil
+	}
+	task.PR = url
+	if merged {
+		task.MergeAnnounced = true
+	}
+	return task, nil
+}
+
+func findPR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) (string, bool, bool, error) {
+	branch, err := currentBranch(active.Worktree)
+	if err != nil {
+		return "", false, false, err
+	}
+	repoSlug, err := project.RepoSlug(homeDir, projectInfo)
+	if err != nil {
+		return "", false, false, err
+	}
+	targets := []ghutil.PRSearchTarget{{Repo: repoSlug}}
+	if projectInfo.Upstream != "" && !strings.EqualFold(projectInfo.Upstream, repoSlug) {
+		targets = append(targets, ghutil.PRSearchTarget{Repo: projectInfo.Upstream, HeadRepo: repoSlug})
+	}
+	return ghutil.FindPRByBranch(ctx, branch, targets...)
 }
 
 func RecordPR(ctx context.Context, homeDir string, task state.Task, url string) (state.Task, bool, error) {

--- a/internal/runtime/promote_test.go
+++ b/internal/runtime/promote_test.go
@@ -165,6 +165,6 @@ func TestPromotePersistsPartialOldScoutCleanupWithoutMovingOwnership(t *testing.
 func scoutAttempt(worktreePath, workspaceID, tabID string) state.Attempt {
 	return state.Attempt{
 		TaskID: "task-1", Lifecycle: state.AttemptCompleted, Worktree: worktreePath,
-		Herdr: state.Herdr{WorkspaceID: workspaceID, TabID: tabID},
+		Herdr: state.Herdr{WorkspaceID: workspaceID, TabID: tabID, PaneID: "old-pane"},
 	}
 }

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -48,6 +48,7 @@ type dependencies struct {
 	confirmLaunch     func(herdrClient, string, string) error
 	appendCompletion  func(string, completion.Record) error
 	prMerged          func(context.Context, string) (bool, error)
+	branchMerged      func(string, string) (bool, error)
 	phase             func(lifecyclePhase) error
 }
 
@@ -65,6 +66,7 @@ func defaultDependencies() dependencies {
 		confirmLaunch:     confirmLaunch,
 		appendCompletion:  completion.Append,
 		prMerged:          ghutil.PRIsMerged,
+		branchMerged:      branchIsMerged,
 		phase:             func(lifecyclePhase) error { return nil },
 	}
 }

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
@@ -29,6 +30,8 @@ const (
 
 type worktreeDependencies struct {
 	get            func(string, string) (worktree.Lease, error)
+	observeLease   func(string, string) (worktree.LeaseObservation, error)
+	observeClean   func(string) (worktree.Cleanliness, error)
 	headCommit     func(string) (string, error)
 	returnWorktree func(string, bool) error
 	returnWithID   func(string, string, bool) error
@@ -44,6 +47,7 @@ type dependencies struct {
 	buildHarness      func(string, harness.Options) (string, error)
 	confirmLaunch     func(herdrClient, string, string) error
 	appendCompletion  func(string, completion.Record) error
+	prMerged          func(context.Context, string) (bool, error)
 	phase             func(lifecyclePhase) error
 }
 
@@ -55,11 +59,12 @@ func defaultDependencies() dependencies {
 	return dependencies{
 		now:               func() time.Time { return time.Now().UTC() },
 		herdr:             newHerdrClient,
-		worktree:          worktreeDependencies{get: worktree.Get, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision, verifyLease: worktree.VerifyLease},
+		worktree:          worktreeDependencies{get: worktree.Get, observeLease: worktree.ObserveLease, observeClean: worktree.ObserveCleanliness, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision, verifyLease: worktree.VerifyLease},
 		projectBaseCommit: projectBaseCommit,
 		buildHarness:      harness.Build,
 		confirmLaunch:     confirmLaunch,
 		appendCompletion:  completion.Append,
+		prMerged:          ghutil.PRIsMerged,
 		phase:             func(lifecyclePhase) error { return nil },
 	}
 }
@@ -70,6 +75,7 @@ type provisioningRequest struct {
 	clonePath           string
 	briefPath           string
 	briefHasFrontMatter bool
+	resumeExisting      bool
 	attempt             state.Attempt
 }
 
@@ -84,13 +90,19 @@ func (r *Runtime) provision(ctx context.Context, req provisioningRequest) (strin
 
 func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) (string, error) {
 	_ = ctx
-	lease, err := r.deps.worktree.get(req.clonePath, "hand:"+req.attempt.TaskID)
-	if err != nil {
-		return "", fmt.Errorf("acquire treehouse worktree: %w", err)
+	lease := worktree.Lease{Path: req.attempt.Worktree, ID: req.attempt.LeaseID}
+	var err error
+	if lease.Path == "" {
+		lease, err = r.deps.worktree.get(req.clonePath, "hand:"+req.attempt.TaskID)
+		if err != nil {
+			return "", fmt.Errorf("acquire treehouse worktree: %w", err)
+		}
 	}
 	worktreePath := lease.Path
-	if err := state.RecordAttemptWorktree(req.home, req.attempt.TaskID, req.attempt.ID, worktreePath, lease.ID); err != nil {
-		return "", reportCleanup(fmt.Errorf("record worktree ownership: %w", err), r.deps.worktree.returnLease(lease, true))
+	if req.attempt.Worktree == "" {
+		if err := state.RecordAttemptWorktree(req.home, req.attempt.TaskID, req.attempt.ID, worktreePath, lease.ID); err != nil {
+			return "", reportCleanup(fmt.Errorf("record worktree ownership: %w", err), r.deps.worktree.returnLease(lease, true))
+		}
 	}
 	var releaseWorktree func()
 	if brief.ExecutionClass(req.attempt.ExecutionClass) == brief.ExecutionClassMechanical {
@@ -194,7 +206,7 @@ func (r *Runtime) failProvision(req provisioningRequest, lease worktree.Lease, r
 			}
 		}
 	}
-	if lease.Path != "" {
+	if lease.Path != "" && !req.resumeExisting {
 		if err := r.returnProvisioningWorktree(req.home, req.attempt.TaskID, req.attempt.ID, lease); err != nil {
 			cleanup = append(cleanup, err)
 		}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -141,6 +141,19 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		err := Precondition(fmt.Errorf("worktree collision: %s already holds %s", conflict, worktreePath))
 		return "", r.failProvision(req, lease, nil, false, err)
 	}
+	if req.resumeExisting {
+		observeLease := r.deps.worktree.observeLease
+		if observeLease == nil {
+			observeLease = worktree.ObserveLease
+		}
+		observation, err := observeLease(worktreePath, lease.ID)
+		if err != nil {
+			return "", r.failProvision(req, lease, nil, false, Precondition(fmt.Errorf("verify resumed worktree lease: %w; refusing to launch", err)))
+		}
+		if observation.State != worktree.LeaseExact {
+			return "", r.failProvision(req, lease, nil, false, Precondition(fmt.Errorf("resumed worktree lease is %s; refusing to launch", observation.State)))
+		}
+	}
 
 	client := r.deps.herdr()
 	workspace, tab, pane, rollback, err := acquireTaskWorkspace(client, worktreePath, req.attempt.TaskID, req.projectName)

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -68,6 +68,31 @@ func TestProvisionFailureAfterWorktreeRecordClearsOnlyReturnedEvidence(t *testin
 	}
 }
 
+func TestProvisionResumeRefusesChangedLeaseBeforeHerdrCreation(t *testing.T) {
+	home, attempt := provisioningFixture(t)
+	attempt.Worktree = "/tmp/hand-wt"
+	attempt.LeaseID = "lease-old"
+	fake := &provisionHerdr{}
+	runtime := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
+	runtime.deps.worktree.observeLease = func(path, leaseID string) (worktree.LeaseObservation, error) {
+		if path != attempt.Worktree || leaseID != attempt.LeaseID {
+			t.Fatalf("observeLease(%q, %q), want persisted lease", path, leaseID)
+		}
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-new"}, nil
+	}
+
+	_, err := runtime.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt, resumeExisting: true,
+	})
+	if err == nil {
+		t.Fatal("provision() succeeded through changed resumed lease")
+	}
+	if fake.createdWorkspace {
+		t.Fatal("provision() created a Herdr workspace after lease mismatch")
+	}
+}
+
 func TestProvisionFailurePreservesWorktreeEvidenceWhenReturnFails(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	phaseErr := errors.New("stop after worktree phase")
@@ -199,11 +224,12 @@ func TestProvisionFailureAfterLaunchConfirmationKeepsConfirmationEvidence(t *tes
 }
 
 type provisionHerdr struct {
-	closedWorkspace string
-	closedTab       string
-	tabCloseErr     error
-	tabs            []herdr.Tab
-	paneStatus      herdr.Status
+	closedWorkspace  string
+	createdWorkspace bool
+	closedTab        string
+	tabCloseErr      error
+	tabs             []herdr.Tab
+	paneStatus       herdr.Status
 }
 
 func (f *provisionHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
@@ -213,6 +239,7 @@ func (f *provisionHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, er
 func (f *provisionHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
 
 func (f *provisionHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+	f.createdWorkspace = true
 	return herdr.Workspace{WorkspaceID: "ws-1"}, herdr.Tab{TabID: "tab-1"}, herdr.Pane{PaneID: "pane-1"}, nil
 }
 
@@ -257,6 +284,9 @@ func testProvisionRuntime(client herdrClient, phase func(lifecyclePhase) error) 
 		worktree: worktreeDependencies{
 			get: func(path, holder string) (worktree.Lease, error) {
 				return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
+			},
+			observeLease: func(string, string) (worktree.LeaseObservation, error) {
+				return worktree.LeaseObservation{State: worktree.LeaseExact}, nil
 			},
 			returnWorktree: func(string, bool) error { return nil },
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -210,6 +210,8 @@ func (f *provisionHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, er
 	return herdr.Workspace{WorkspaceID: "ws-1"}, true, nil
 }
 
+func (f *provisionHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
+
 func (f *provisionHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
 	return herdr.Workspace{WorkspaceID: "ws-1"}, herdr.Tab{TabID: "tab-1"}, herdr.Pane{PaneID: "pane-1"}, nil
 }

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -527,10 +527,6 @@ func (r *Runtime) classifyHerdrTab(home string, client herdrClient, workspace he
 			release()
 			return nil, nil
 		}
-		if state.ValidateID(freshTab.Label) != nil {
-			release()
-			return unattributedHerdrAnomaly(workspace, freshTab), nil
-		}
 		anomaly, matched, err := classifyLockedHerdrHistory(client, workspace, freshTab, history)
 		release()
 		if err != nil {
@@ -898,7 +894,7 @@ func terminalRepairEvidenceResolved(code string, attempt state.Attempt) bool {
 
 func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attempt) (reconciliationObservation, error) {
 	observation := reconciliationObservation{}
-	skipHerdrObservation := attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == ""
+	skipHerdrObservation := attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.WorkspaceID != "" && attempt.Herdr.TabID != "" && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == ""
 	if attempt.Worktree != "" {
 		observeLease := r.deps.worktree.observeLease
 		if observeLease == nil {
@@ -921,7 +917,7 @@ func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attemp
 			observation.Worktree.State = worktreeState(clean)
 		}
 	}
-	if attempt.Herdr.PaneID != "" && !skipHerdrObservation {
+	if hasHerdrIdentity(attempt.Herdr) && !skipHerdrObservation {
 		var err error
 		observation.Herdr, err = observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
@@ -1052,10 +1048,8 @@ func decideReconciliation(_ state.Task, attempt state.Attempt, observation recon
 }
 
 func decideProvisioning(attempt state.Attempt, observation reconciliationObservation, decision reconciliationDecision) reconciliationDecision {
-	if attempt.Herdr.WorkspaceID != "" || attempt.Herdr.TabID != "" {
-		if attempt.Herdr.PaneID == "" {
-			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "persisted Herdr workspace or tab identity has no pane identity")
-		}
+	if hasHerdrIdentity(attempt.Herdr) && incompleteHerdrOwnership(attempt.Herdr) != nil {
+		return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "persisted Herdr ownership identity is incomplete")
 	}
 	if attempt.Herdr.PaneID != "" {
 		if attempt.LaunchSubmittedAt == "" {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -854,10 +854,7 @@ func clearResolvedTerminalRepair(home string, history state.TaskHistory) (bool, 
 	if attempt == nil || attempt.Lifecycle == state.AttemptProvisioning || attempt.Lifecycle == state.AttemptRunning {
 		return false, nil
 	}
-	if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
-		return false, nil
-	}
-	if attempt.Worktree != "" && attempt.TeardownWorktreeState != state.TeardownResourceReleased {
+	if !terminalRepairEvidenceResolved(task.RepairCode, *attempt) {
 		return false, nil
 	}
 	if attempt.TeardownCompletionState != state.TeardownCompletionAppended {
@@ -879,9 +876,21 @@ func terminalRepairCanBeResolved(code string) bool {
 	case repairCodeProvisioningLaunchAmbiguous, repairCodeProvisioningPaneMissing, repairCodeLaunchSubmittedPaneMissing,
 		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
 		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeWorktreeDirty,
-		repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeTeardownResourceAmbiguous,
-		repairCodeCompletionEvidenceMismatch:
+		repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeTeardownResourceAmbiguous:
 		return true
+	default:
+		return false
+	}
+}
+
+func terminalRepairEvidenceResolved(code string, attempt state.Attempt) bool {
+	switch code {
+	case repairCodeProvisioningLaunchAmbiguous, repairCodeProvisioningPaneMissing, repairCodeLaunchSubmittedPaneMissing,
+		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
+		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeTeardownResourceAmbiguous:
+		return !hasHerdrIdentity(attempt.Herdr) || attempt.TeardownHerdrState == state.TeardownResourceReleased
+	case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable:
+		return attempt.Worktree == "" || attempt.TeardownWorktreeState == state.TeardownResourceReleased
 	default:
 		return false
 	}

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
@@ -270,6 +271,9 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 			continue
 		}
 		if history.ActiveAttempt == nil {
+			if reportExistingRepair(&result, history.Task) {
+				return result, nil
+			}
 			result.Outcome = reconcileOutcomeHealthy
 			return result, nil
 		}
@@ -322,12 +326,18 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 			result.Outcome = reconcileOutcomeRecovered
 			continue
 		}
+		if reportExistingRepair(&result, history.Task) {
+			return result, nil
+		}
 		if decision.Action == reconciliationActionKeep {
 			result.Outcome = reconcileOutcomeHealthy
 			return result, nil
 		}
 		fingerprint := fmt.Sprintf("%d:%s:%s:%s:%s:%s", attempt.ID, attempt.Lifecycle, attempt.Worktree, attempt.Herdr.PaneID, attempt.LaunchSubmittedAt, attempt.LaunchConfirmedAt)
 		if fingerprint == previousFingerprint {
+			if reportExistingRepair(&result, history.Task) {
+				return result, nil
+			}
 			result.Outcome = reconcileOutcomeNoProgress
 			return result, nil
 		}
@@ -339,6 +349,16 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 	}
 	result.Outcome = reconcileOutcomeNoProgress
 	return result, nil
+}
+
+func reportExistingRepair(result *ReconcileResult, task state.Task) bool {
+	if task.RepairCode == "" {
+		return false
+	}
+	result.Outcome = reconcileOutcomeRepair
+	result.RepairCode = task.RepairCode
+	result.RepairReason = task.RepairReason
+	return true
 }
 
 func (r *Runtime) observeMerge(ctx context.Context, home string, history state.TaskHistory) (bool, bool, string, error) {
@@ -367,30 +387,63 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 	if projectInfo.Mode != project.ModeLocalOnly {
 		return false, false, "local-git", fmt.Errorf("observe local merge for task %q: project mode %q has no local merge evidence", task.ID, projectInfo.Mode)
 	}
-	worktreePath := ""
-	if history.ActiveAttempt != nil {
-		worktreePath = history.ActiveAttempt.Worktree
+	releaseProject, err := state.Lock(home, "project:"+task.Project)
+	if err != nil {
+		return false, false, "local-git", fmt.Errorf("lock project %q for local merge observation: %w", task.Project, err)
 	}
-	if worktreePath == "" {
-		for i := len(history.Attempts) - 1; i >= 0; i-- {
-			if history.Attempts[i].Worktree != "" {
-				worktreePath = history.Attempts[i].Worktree
-				break
-			}
-		}
+	defer releaseProject()
+	attempt, err := mergeWorktreeAttempt(history)
+	if err != nil {
+		return false, false, "local-git", err
 	}
-	if worktreePath == "" {
-		return false, false, "local-git", fmt.Errorf("observe local merge for task %q: no Attempt worktree is available", task.ID)
+	releaseWorktree, err := state.Lock(home, "worktree:"+attempt.Worktree)
+	if err != nil {
+		return false, false, "local-git", fmt.Errorf("lock worktree %q for local merge observation: %w", attempt.Worktree, err)
+	}
+	defer releaseWorktree()
+	observeLease := r.deps.worktree.observeLease
+	if observeLease == nil {
+		observeLease = worktree.ObserveLease
+	}
+	lease, err := observeLease(attempt.Worktree, attempt.LeaseID)
+	if err != nil {
+		return false, false, "local-git", fmt.Errorf("observe local merge lease for task %q Attempt %d: %w", task.ID, attempt.ID, err)
+	}
+	if lease.State != worktree.LeaseExact {
+		return false, false, "local-git", fmt.Errorf("observe local merge for task %q Attempt %d: exact Treehouse lease ownership was not proven", task.ID, attempt.ID)
 	}
 	branchMerged := r.deps.branchMerged
 	if branchMerged == nil {
 		branchMerged = branchIsMerged
 	}
-	merged, err := branchMerged(filepath.Join(home, "projects", task.Project), worktreePath)
+	merged, err := branchMerged(filepath.Join(home, "projects", task.Project), attempt.Worktree)
 	if err != nil {
 		return false, false, "local-git", fmt.Errorf("observe local merged branch for task %q: %w", task.ID, err)
 	}
 	return merged, !merged, "local-git", nil
+}
+
+func mergeWorktreeAttempt(history state.TaskHistory) (*state.Attempt, error) {
+	task := history.Task
+	var attempt *state.Attempt
+	if history.ActiveAttempt != nil {
+		attempt = history.ActiveAttempt
+	} else {
+		for i := len(history.Attempts) - 1; i >= 0; i-- {
+			candidate := &history.Attempts[i]
+			if candidate.Worktree != "" && candidate.TeardownWorktreeState != state.TeardownResourceReleased {
+				attempt = candidate
+				break
+			}
+		}
+	}
+	if attempt == nil || attempt.Worktree == "" {
+		return nil, fmt.Errorf("observe local merge for task %q: no Attempt worktree with current ownership is available", task.ID)
+	}
+	if attempt.LeaseID == "" {
+		return nil, fmt.Errorf("observe local merge for task %q: Attempt %d has no exact Treehouse lease identity", task.ID, attempt.ID)
+	}
+	return attempt, nil
 }
 
 func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
@@ -399,10 +452,13 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 	if err != nil {
 		return nil, err
 	}
-	ownedTabs := make(map[string]struct{}, len(ownerships))
+	ownershipCandidates := make(map[string][]string, len(ownerships))
 	for _, ownership := range ownerships {
 		if ownership.WorkspaceID != "" && ownership.TabID != "" {
-			ownedTabs[ownership.WorkspaceID+"\x00"+ownership.TabID] = struct{}{}
+			key := ownership.WorkspaceID + "\x00" + ownership.TabID
+			if !containsString(ownershipCandidates[key], ownership.TaskID) {
+				ownershipCandidates[key] = append(ownershipCandidates[key], ownership.TaskID)
+			}
 		}
 	}
 	workspaces, err := client.WorkspaceList()
@@ -431,16 +487,156 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 			return tabs[i].Label < tabs[j].Label
 		})
 		for _, tab := range tabs {
-			if _, owned := ownedTabs[workspace.WorkspaceID+"\x00"+tab.TabID]; owned {
-				continue
+			anomaly, err := r.classifyHerdrTab(home, client, workspace, tab, ownershipCandidates)
+			if err != nil {
+				return nil, err
 			}
-			anomalies = append(anomalies, ReconcileAnomaly{
-				Kind: "unattributed-herdr-tab", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
-				TabID: tab.TabID, TabLabel: tab.Label, Reason: "Hand namespace tab has no exact durable Attempt owner",
-			})
+			if anomaly != nil {
+				anomalies = append(anomalies, *anomaly)
+			}
 		}
 	}
 	return anomalies, nil
+}
+
+func (r *Runtime) classifyHerdrTab(home string, client herdrClient, workspace herdr.Workspace, tab herdr.Tab, ownershipCandidates map[string][]string) (*ReconcileAnomaly, error) {
+	candidates := append([]string(nil), ownershipCandidates[workspace.WorkspaceID+"\x00"+tab.TabID]...)
+	if state.ValidateID(tab.Label) == nil && !containsString(candidates, tab.Label) {
+		candidates = append(candidates, tab.Label)
+	}
+	sort.Strings(candidates)
+	for _, taskID := range candidates {
+		release, err := state.Lock(home, "task:"+taskID)
+		if err != nil {
+			return nil, fmt.Errorf("lock Herdr candidate task %q: %w", taskID, err)
+		}
+		history, err := state.ReadHistory(home, taskID)
+		if err != nil {
+			release()
+			if errors.Is(err, state.ErrTaskNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		freshTab, found, err := findHerdrTab(client, workspace.WorkspaceID, tab.TabID)
+		if err != nil {
+			release()
+			return nil, err
+		}
+		if !found {
+			release()
+			return nil, nil
+		}
+		if state.ValidateID(freshTab.Label) != nil {
+			release()
+			return unattributedHerdrAnomaly(workspace, freshTab), nil
+		}
+		anomaly, matched, err := classifyLockedHerdrHistory(client, workspace, freshTab, history)
+		release()
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			return anomaly, nil
+		}
+	}
+	return unattributedHerdrAnomaly(workspace, tab), nil
+}
+
+func findHerdrTab(client herdrClient, workspaceID, tabID string) (herdr.Tab, bool, error) {
+	tabs, err := client.TabList(workspaceID)
+	if err != nil {
+		return herdr.Tab{}, false, fmt.Errorf("re-observe Herdr tabs for workspace %s: %w", workspaceID, err)
+	}
+	for _, tab := range tabs {
+		if tab.TabID == tabID {
+			return tab, true, nil
+		}
+	}
+	return herdr.Tab{}, false, nil
+}
+
+func classifyLockedHerdrHistory(client herdrClient, workspace herdr.Workspace, tab herdr.Tab, history state.TaskHistory) (*ReconcileAnomaly, bool, error) {
+	var matches []state.Attempt
+	for _, attempt := range history.Attempts {
+		if attempt.Herdr.WorkspaceID == workspace.WorkspaceID && attempt.Herdr.TabID == tab.TabID {
+			matches = append(matches, attempt)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		iActive := matches[i].Lifecycle == state.AttemptProvisioning || matches[i].Lifecycle == state.AttemptRunning
+		jActive := matches[j].Lifecycle == state.AttemptProvisioning || matches[j].Lifecycle == state.AttemptRunning
+		if iActive != jActive {
+			return iActive
+		}
+		return matches[i].ID > matches[j].ID
+	})
+	if len(matches) == 0 {
+		return nil, false, nil
+	}
+	for _, attempt := range matches {
+		if attempt.TeardownHerdrState == state.TeardownResourceReleased {
+			return &ReconcileAnomaly{
+				Kind: "released-herdr-resource", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
+				TabID: tab.TabID, TabLabel: tab.Label, OwnerAttemptID: attempt.ID,
+				Reason: "live Herdr tab matches an Attempt whose Herdr teardown is durably released; possible recreation or ID reuse; refusing to close",
+			}, true, nil
+		}
+	}
+	attempt := matches[0]
+	if attempt.Lifecycle != state.AttemptProvisioning && attempt.Lifecycle != state.AttemptRunning {
+		return classifyTerminalHerdrMatch(client, workspace, tab, history, attempt)
+	}
+	observation, err := observeHerdrOwnership(client, attempt.Herdr, history.Task.ID, history.Task.Project)
+	if err != nil {
+		return nil, false, err
+	}
+	if observation.State == herdrOwnershipExact {
+		return nil, true, nil
+	}
+	return &ReconcileAnomaly{
+		Kind: "herdr-ownership-inconsistency", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
+		TabID: tab.TabID, TabLabel: tab.Label, OwnerAttemptID: attempt.ID,
+		Reason: "live Herdr tab matches durable workspace/tab identity but current pane ownership is not exact; refusing to close",
+	}, true, nil
+}
+
+func classifyTerminalHerdrMatch(client herdrClient, workspace herdr.Workspace, tab herdr.Tab, history state.TaskHistory, attempt state.Attempt) (*ReconcileAnomaly, bool, error) {
+	if !hasHerdrIdentity(attempt.Herdr) {
+		return &ReconcileAnomaly{
+			Kind: "herdr-ownership-inconsistency", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
+			TabID: tab.TabID, TabLabel: tab.Label, OwnerAttemptID: attempt.ID,
+			Reason: "live Herdr tab matches a terminal Attempt with incomplete durable identity; refusing to close",
+		}, true, nil
+	}
+	observation, err := observeHerdrOwnership(client, attempt.Herdr, history.Task.ID, history.Task.Project)
+	if err != nil {
+		return nil, false, err
+	}
+	if observation.State == herdrOwnershipExact {
+		return nil, true, nil
+	}
+	return &ReconcileAnomaly{
+		Kind: "herdr-ownership-inconsistency", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
+		TabID: tab.TabID, TabLabel: tab.Label, OwnerAttemptID: attempt.ID,
+		Reason: "live Herdr tab matches a terminal Attempt but current ownership is not exact; refusing to close",
+	}, true, nil
+}
+
+func unattributedHerdrAnomaly(workspace herdr.Workspace, tab herdr.Tab) *ReconcileAnomaly {
+	return &ReconcileAnomaly{
+		Kind: "unattributed-herdr-tab", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
+		TabID: tab.TabID, TabLabel: tab.Label, Reason: "Hand namespace tab has no exact durable Attempt owner",
+	}
+}
+
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) (*state.Attempt, error) {
@@ -785,10 +981,12 @@ func shouldClearRepair(task state.Task, attempt state.Attempt, observation recon
 			return true
 		}
 	}
-	if observation.Treehouse.State == treehouseLeaseExact && observation.Worktree.State == worktreeClean {
+	if observation.Treehouse.State == treehouseLeaseExact {
 		switch task.RepairCode {
-		case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch:
-			return true
+		case repairCodeWorktreeOwnershipMismatch:
+			return attempt.Lifecycle == state.AttemptRunning || observation.Worktree.State == worktreeClean
+		case repairCodeWorktreeDirty:
+			return observation.Worktree.State == worktreeClean
 		}
 	}
 	return false

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/atqamz/hand/internal/brief"
@@ -68,6 +70,9 @@ const (
 	repairCodeWorktreeDirty               = "worktree-dirty"
 	repairCodeWorktreeOwnershipMismatch   = "worktree-ownership-mismatch"
 	repairCodeLegacyWorktreeUnprovable    = "legacy-worktree-ownership-unprovable"
+	repairCodeTeardownResourceAmbiguous   = "teardown-resource-ambiguous"
+	repairCodeCompletionEvidenceMismatch  = "completion-evidence-mismatch"
+	repairCodeMergeFactMismatch           = "merge-fact-mismatch"
 )
 
 type treehouseObservation struct {
@@ -124,10 +129,23 @@ type ReconcileResult struct {
 	Profile        string `json:"profile,omitempty"`
 	PlannedAgainst string `json:"planned_against,omitempty"`
 	RoutingSource  string `json:"routing_source,omitempty"`
+	Error          string `json:"error,omitempty"`
+}
+
+type ReconcileAnomaly struct {
+	Kind           string `json:"kind"`
+	WorkspaceID    string `json:"workspace_id"`
+	WorkspaceLabel string `json:"workspace_label"`
+	TabID          string `json:"tab_id"`
+	TabLabel       string `json:"tab_label"`
+	OwnerAttemptID int64  `json:"owner_attempt,omitempty"`
+	Reason         string `json:"reason"`
 }
 
 type ReconcileReport struct {
-	Results []ReconcileResult `json:"results"`
+	Results   []ReconcileResult  `json:"results"`
+	Anomalies []ReconcileAnomaly `json:"anomalies,omitempty"`
+	Errors    []string           `json:"errors,omitempty"`
 }
 
 const (
@@ -147,6 +165,9 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	}
 	if req.ID != "" {
 		result, err := r.reconcileTask(ctx, req.Home, req.ID)
+		if err != nil {
+			result.Error = err.Error()
+		}
 		return ReconcileReport{Results: []ReconcileResult{result}}, err
 	}
 	histories, err := state.ListReconciliationHistories(req.Home)
@@ -157,10 +178,20 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	var errs []error
 	for _, history := range histories {
 		result, err := r.reconcileTask(ctx, req.Home, history.Task.ID)
+		if err != nil {
+			result.Error = err.Error()
+		}
 		report.Results = append(report.Results, result)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("task %q: %w", history.Task.ID, err))
 		}
+	}
+	anomalies, err := r.observeHerdrOrphans(req.Home)
+	if err != nil {
+		report.Errors = append(report.Errors, err.Error())
+		errs = append(errs, fmt.Errorf("observe Herdr inventory: %w", err))
+	} else {
+		report.Anomalies = anomalies
 	}
 	return report, errors.Join(errs...)
 }
@@ -180,13 +211,17 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 		if err != nil {
 			return result, err
 		}
-		mergeObserved, mergeMismatch, err := r.observeMerge(ctx, history.Task)
+		mergeObserved, mergeMismatch, mergeSource, err := r.observeMerge(ctx, home, history)
 		if err != nil {
 			result.Outcome = reconcileOutcomeBlocked
 			return result, err
 		}
 		if mergeMismatch {
-			decision := repairDecision(reconciliationDecision{}, "merge-fact-mismatch", "durable state claims a merged PR but authoritative GitHub evidence says it is not merged")
+			reason := "durable state claims a merged PR but authoritative GitHub evidence says it is not merged"
+			if mergeSource == "local-git" {
+				reason = "durable state claims a merged branch but authoritative local Git evidence says it is not merged"
+			}
+			decision := repairDecision(reconciliationDecision{}, repairCodeMergeFactMismatch, reason)
 			attemptID := int64(0)
 			if history.ActiveAttempt != nil {
 				attemptID = history.ActiveAttempt.ID
@@ -197,7 +232,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 			result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
 			return result, nil
 		}
-		if mergeObserved && history.Task.RepairCode == "merge-fact-mismatch" {
+		if mergeObserved && history.Task.RepairCode == repairCodeMergeFactMismatch {
 			if err := state.ClearTaskRepair(home, id, history.Task.RepairCode); err != nil {
 				return result, err
 			}
@@ -227,6 +262,12 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 				result.Outcome = reconcileOutcomeRecovered
 				continue
 			}
+		}
+		if cleared, err := clearResolvedTerminalRepair(home, history); err != nil {
+			return result, err
+		} else if cleared {
+			result.Outcome = reconcileOutcomeRecovered
+			continue
 		}
 		if history.ActiveAttempt == nil {
 			result.Outcome = reconcileOutcomeHealthy
@@ -300,19 +341,106 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 	return result, nil
 }
 
-func (r *Runtime) observeMerge(ctx context.Context, task state.Task) (bool, bool, error) {
-	if task.PR == "" || (!task.MergeExecuted && !task.MergeAnnounced) {
-		return false, false, nil
+func (r *Runtime) observeMerge(ctx context.Context, home string, history state.TaskHistory) (bool, bool, string, error) {
+	task := history.Task
+	if !task.MergeExecuted && !task.MergeAnnounced {
+		return false, false, "", nil
 	}
-	prMerged := r.deps.prMerged
-	if prMerged == nil {
-		prMerged = ghutil.PRIsMerged
+	if task.PR != "" {
+		prMerged := r.deps.prMerged
+		if prMerged == nil {
+			prMerged = ghutil.PRIsMerged
+		}
+		merged, err := prMerged(ctx, task.PR)
+		if err != nil {
+			return false, false, "github-pr", fmt.Errorf("observe merged PR %s: %w", task.PR, err)
+		}
+		return merged, !merged, "github-pr", nil
 	}
-	merged, err := prMerged(ctx, task.PR)
+	projectInfo, found, err := project.FindReadOnly(home, task.Project)
 	if err != nil {
-		return false, false, fmt.Errorf("observe merged PR %s: %w", task.PR, err)
+		return false, false, "local-git", fmt.Errorf("observe local merge project %q: %w", task.Project, err)
 	}
-	return merged, !merged, nil
+	if !found {
+		return false, false, "local-git", fmt.Errorf("observe local merge project %q: project is not registered", task.Project)
+	}
+	if projectInfo.Mode != project.ModeLocalOnly {
+		return false, false, "local-git", fmt.Errorf("observe local merge for task %q: project mode %q has no local merge evidence", task.ID, projectInfo.Mode)
+	}
+	worktreePath := ""
+	if history.ActiveAttempt != nil {
+		worktreePath = history.ActiveAttempt.Worktree
+	}
+	if worktreePath == "" {
+		for i := len(history.Attempts) - 1; i >= 0; i-- {
+			if history.Attempts[i].Worktree != "" {
+				worktreePath = history.Attempts[i].Worktree
+				break
+			}
+		}
+	}
+	if worktreePath == "" {
+		return false, false, "local-git", fmt.Errorf("observe local merge for task %q: no Attempt worktree is available", task.ID)
+	}
+	branchMerged := r.deps.branchMerged
+	if branchMerged == nil {
+		branchMerged = branchIsMerged
+	}
+	merged, err := branchMerged(filepath.Join(home, "projects", task.Project), worktreePath)
+	if err != nil {
+		return false, false, "local-git", fmt.Errorf("observe local merged branch for task %q: %w", task.ID, err)
+	}
+	return merged, !merged, "local-git", nil
+}
+
+func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
+	client := r.deps.herdr()
+	ownerships, err := state.ListHerdrOwnerships(home)
+	if err != nil {
+		return nil, err
+	}
+	ownedTabs := make(map[string]struct{}, len(ownerships))
+	for _, ownership := range ownerships {
+		if ownership.WorkspaceID != "" && ownership.TabID != "" {
+			ownedTabs[ownership.WorkspaceID+"\x00"+ownership.TabID] = struct{}{}
+		}
+	}
+	workspaces, err := client.WorkspaceList()
+	if err != nil {
+		return nil, fmt.Errorf("list Herdr workspaces: %w", err)
+	}
+	sort.Slice(workspaces, func(i, j int) bool {
+		if workspaces[i].Label != workspaces[j].Label {
+			return workspaces[i].Label < workspaces[j].Label
+		}
+		return workspaces[i].WorkspaceID < workspaces[j].WorkspaceID
+	})
+	var anomalies []ReconcileAnomaly
+	for _, workspace := range workspaces {
+		if !strings.HasPrefix(workspace.Label, "hand:") {
+			continue
+		}
+		tabs, err := client.TabList(workspace.WorkspaceID)
+		if err != nil {
+			return nil, fmt.Errorf("list Herdr tabs for workspace %s: %w", workspace.WorkspaceID, err)
+		}
+		sort.Slice(tabs, func(i, j int) bool {
+			if tabs[i].TabID != tabs[j].TabID {
+				return tabs[i].TabID < tabs[j].TabID
+			}
+			return tabs[i].Label < tabs[j].Label
+		})
+		for _, tab := range tabs {
+			if _, owned := ownedTabs[workspace.WorkspaceID+"\x00"+tab.TabID]; owned {
+				continue
+			}
+			anomalies = append(anomalies, ReconcileAnomaly{
+				Kind: "unattributed-herdr-tab", WorkspaceID: workspace.WorkspaceID, WorkspaceLabel: workspace.Label,
+				TabID: tab.TabID, TabLabel: tab.Label, Reason: "Hand namespace tab has no exact durable Attempt owner",
+			})
+		}
+	}
+	return anomalies, nil
 }
 
 func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) (*state.Attempt, error) {
@@ -345,9 +473,9 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 		}
 		switch observation.State {
 		case herdrOwnershipIncomplete, herdrOwnershipMismatch:
-			return false, repairDecision(reconciliationDecision{}, "teardown-resource-ambiguous", "historical Herdr resource ownership cannot be proven safely"), nil
+			return false, repairDecision(reconciliationDecision{}, repairCodeTeardownResourceAmbiguous, "historical Herdr resource ownership cannot be proven safely"), nil
 		case herdrOwnershipAbsent:
-			if cleared, err := clearHistoricalRepair(home, task, attempt, "teardown-resource-ambiguous", "herdr-ownership-mismatch"); err != nil {
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeTeardownResourceAmbiguous, repairCodeHerdrOwnershipMismatch); err != nil {
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
@@ -357,7 +485,7 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 			}
 			return true, reconciliationDecision{}, nil
 		case herdrOwnershipExact:
-			if cleared, err := clearHistoricalRepair(home, task, attempt, "teardown-resource-ambiguous", "herdr-ownership-mismatch"); err != nil {
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeTeardownResourceAmbiguous, repairCodeHerdrOwnershipMismatch); err != nil {
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
@@ -389,7 +517,7 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 		}
 		switch lease.State {
 		case worktree.LeaseUnprovable:
-			return false, repairDecision(reconciliationDecision{}, "legacy-worktree-ownership-unprovable", "historical worktree has no exact lease identity"), nil
+			return false, repairDecision(reconciliationDecision{}, repairCodeLegacyWorktreeUnprovable, "historical worktree has no exact lease identity"), nil
 		case worktree.LeaseMismatch:
 			if attempt.TeardownWorktreeState == state.TeardownResourceReleasing {
 				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
@@ -454,9 +582,9 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 			return false, reconciliationDecision{}, err
 		}
 		if !found {
-			return false, repairDecision(reconciliationDecision{}, "completion-evidence-mismatch", "durable completion state says appended but no exact completion record exists"), nil
+			return false, repairDecision(reconciliationDecision{}, repairCodeCompletionEvidenceMismatch, "durable completion state says appended but no exact completion record exists"), nil
 		}
-		if cleared, err := clearHistoricalRepair(home, task, attempt, "completion-evidence-mismatch"); err != nil {
+		if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeCompletionEvidenceMismatch); err != nil {
 			return false, reconciliationDecision{}, err
 		} else if cleared {
 			return true, reconciliationDecision{}, nil
@@ -515,11 +643,57 @@ func clearHistoricalRepair(home string, task state.Task, attempt state.Attempt, 
 	return false, nil
 }
 
+func clearResolvedTerminalRepair(home string, history state.TaskHistory) (bool, error) {
+	task := history.Task
+	if task.RepairCode == "" || task.RepairAttemptID == 0 || !terminalRepairCanBeResolved(task.RepairCode) {
+		return false, nil
+	}
+	var attempt *state.Attempt
+	for i := range history.Attempts {
+		if history.Attempts[i].ID == task.RepairAttemptID {
+			attempt = &history.Attempts[i]
+			break
+		}
+	}
+	if attempt == nil || attempt.Lifecycle == state.AttemptProvisioning || attempt.Lifecycle == state.AttemptRunning {
+		return false, nil
+	}
+	if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
+		return false, nil
+	}
+	if attempt.Worktree != "" && attempt.TeardownWorktreeState != state.TeardownResourceReleased {
+		return false, nil
+	}
+	if attempt.TeardownCompletionState != state.TeardownCompletionAppended {
+		return false, nil
+	}
+	if _, found, err := completion.FindAttempt(home, attempt.ID); err != nil {
+		return false, err
+	} else if !found {
+		return false, nil
+	}
+	if err := state.ClearTaskRepair(home, task.ID, task.RepairCode); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func terminalRepairCanBeResolved(code string) bool {
+	switch code {
+	case repairCodeProvisioningLaunchAmbiguous, repairCodeProvisioningPaneMissing, repairCodeLaunchSubmittedPaneMissing,
+		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
+		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeWorktreeDirty,
+		repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeTeardownResourceAmbiguous,
+		repairCodeCompletionEvidenceMismatch:
+		return true
+	default:
+		return false
+	}
+}
+
 func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attempt) (reconciliationObservation, error) {
 	observation := reconciliationObservation{}
-	if attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == "" {
-		return observation, nil
-	}
+	skipHerdrObservation := attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == ""
 	if attempt.Worktree != "" {
 		observeLease := r.deps.worktree.observeLease
 		if observeLease == nil {
@@ -542,7 +716,7 @@ func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attemp
 			observation.Worktree.State = worktreeState(clean)
 		}
 	}
-	if attempt.Herdr.PaneID != "" {
+	if attempt.Herdr.PaneID != "" && !skipHerdrObservation {
 		var err error
 		observation.Herdr, err = observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
@@ -629,6 +803,18 @@ func decideReconciliation(_ state.Task, attempt state.Attempt, observation recon
 	if observation.ObservationError {
 		decision.Action = reconciliationActionBlocked
 		return decision
+	}
+	if attempt.Worktree != "" {
+		switch observation.Treehouse.State {
+		case treehouseLeaseMismatch:
+			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded worktree path is leased under a different Treehouse lease ID")
+		case treehouseLeaseUnprovable:
+			return repairDecision(decision, repairCodeLegacyWorktreeUnprovable, "recorded worktree ownership has no provable Treehouse lease identity")
+		case treehouseLeaseAbsent:
+			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded Treehouse lease is absent")
+		case treehouseLeaseUnobserved:
+			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded Treehouse lease was not observed")
+		}
 	}
 
 	if attempt.Lifecycle == state.AttemptProvisioning {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1,0 +1,726 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/atqamz/hand/internal/brief"
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+type reconciliationAction string
+
+const (
+	reconciliationActionKeep                 reconciliationAction = "keep"
+	reconciliationActionContinueProvisioning reconciliationAction = "continue-provisioning"
+	reconciliationActionConfirmLaunch        reconciliationAction = "confirm-launch"
+	reconciliationActionMarkRunning          reconciliationAction = "mark-running"
+	reconciliationActionCleanupTerminal      reconciliationAction = "cleanup-terminal-resources"
+	reconciliationActionNeedsRepair          reconciliationAction = "needs-repair"
+	reconciliationActionBlocked              reconciliationAction = "blocked"
+)
+
+type treehouseLeaseState string
+
+const (
+	treehouseLeaseUnobserved treehouseLeaseState = "unobserved"
+	treehouseLeaseExact      treehouseLeaseState = "exact"
+	treehouseLeaseAbsent     treehouseLeaseState = "absent"
+	treehouseLeaseMismatch   treehouseLeaseState = "mismatch"
+	treehouseLeaseUnprovable treehouseLeaseState = "unprovable"
+)
+
+type worktreeState string
+
+const (
+	worktreeUnobserved worktreeState = "unobserved"
+	worktreeClean      worktreeState = "clean"
+	worktreeDirty      worktreeState = "dirty"
+	worktreeMissing    worktreeState = "missing"
+)
+
+type herdrOwnershipState string
+
+const (
+	herdrOwnershipUnobserved herdrOwnershipState = "unobserved"
+	herdrOwnershipExact      herdrOwnershipState = "exact"
+	herdrOwnershipAbsent     herdrOwnershipState = "absent"
+	herdrOwnershipMismatch   herdrOwnershipState = "mismatch"
+	herdrOwnershipIncomplete herdrOwnershipState = "incomplete"
+)
+
+const (
+	repairCodeProvisioningLaunchAmbiguous = "provisioning-launch-ambiguous"
+	repairCodeProvisioningPaneMissing     = "provisioning-pane-missing"
+	repairCodeLaunchSubmittedPaneMissing  = "launch-submitted-pane-missing"
+	repairCodeLaunchAgentMismatch         = "launch-agent-mismatch"
+	repairCodeRunningPaneMissing          = "running-pane-missing"
+	repairCodeRunningPaneIdentityMismatch = "running-pane-identity-mismatch"
+	repairCodeHerdrOwnershipIncomplete    = "herdr-ownership-incomplete"
+	repairCodeHerdrOwnershipMismatch      = "herdr-ownership-mismatch"
+	repairCodeWorktreeDirty               = "worktree-dirty"
+	repairCodeWorktreeOwnershipMismatch   = "worktree-ownership-mismatch"
+	repairCodeLegacyWorktreeUnprovable    = "legacy-worktree-ownership-unprovable"
+)
+
+type treehouseObservation struct {
+	State treehouseLeaseState
+}
+
+type worktreeObservation struct {
+	State worktreeState
+}
+
+type herdrObservation struct {
+	State herdrOwnershipState
+	Agent string
+}
+
+type reconciliationObservation struct {
+	Treehouse        treehouseObservation
+	Worktree         worktreeObservation
+	Herdr            herdrObservation
+	ObservationError bool
+}
+
+type reconciliationDecision struct {
+	Action         reconciliationAction
+	RepairCode     string
+	RepairReason   string
+	Harness        string
+	Model          string
+	Effort         string
+	ExecutionClass string
+	PlannedAgainst string
+	Profile        string
+	RoutingSource  string
+}
+
+type ReconcileRequest struct {
+	Context context.Context
+	Home    string
+	ID      string
+}
+
+type ReconcileResult struct {
+	ID             string `json:"id"`
+	Outcome        string `json:"result"`
+	Action         string `json:"action"`
+	Iterations     int    `json:"iterations"`
+	AttemptID      int64  `json:"attempt,omitempty"`
+	RepairCode     string `json:"repair_code,omitempty"`
+	RepairReason   string `json:"repair_reason,omitempty"`
+	Harness        string `json:"harness,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Effort         string `json:"effort,omitempty"`
+	ExecutionClass string `json:"execution_class,omitempty"`
+	Profile        string `json:"profile,omitempty"`
+	PlannedAgainst string `json:"planned_against,omitempty"`
+	RoutingSource  string `json:"routing_source,omitempty"`
+}
+
+type ReconcileReport struct {
+	Results []ReconcileResult `json:"results"`
+}
+
+const (
+	reconcileOutcomeHealthy    = "healthy"
+	reconcileOutcomeRecovered  = "recovered"
+	reconcileOutcomeRepair     = "needs-repair"
+	reconcileOutcomeBlocked    = "blocked"
+	reconcileOutcomeNoProgress = "no-progress"
+)
+
+const reconcileIterationLimit = 8
+
+func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
+	ctx := req.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if req.ID != "" {
+		result, err := r.reconcileTask(ctx, req.Home, req.ID)
+		return ReconcileReport{Results: []ReconcileResult{result}}, err
+	}
+	histories, err := state.ListReconciliationHistories(req.Home)
+	if err != nil {
+		return ReconcileReport{}, err
+	}
+	report := ReconcileReport{Results: make([]ReconcileResult, 0, len(histories))}
+	var errs []error
+	for _, history := range histories {
+		result, err := r.reconcileTask(ctx, req.Home, history.Task.ID)
+		report.Results = append(report.Results, result)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("task %q: %w", history.Task.ID, err))
+		}
+	}
+	return report, errors.Join(errs...)
+}
+
+func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (ReconcileResult, error) {
+	release, err := state.Lock(home, "task:"+id)
+	if err != nil {
+		return ReconcileResult{ID: id, Outcome: reconcileOutcomeBlocked}, fmt.Errorf("lock task %q: %w", id, err)
+	}
+	defer release()
+
+	result := ReconcileResult{ID: id}
+	previousFingerprint := ""
+	for iteration := 1; iteration <= reconcileIterationLimit; iteration++ {
+		result.Iterations = iteration
+		history, err := state.ReadHistory(home, id)
+		if err != nil {
+			return result, err
+		}
+		mergeObserved, mergeMismatch, err := r.observeMerge(ctx, history.Task)
+		if err != nil {
+			result.Outcome = reconcileOutcomeBlocked
+			return result, err
+		}
+		if mergeMismatch {
+			decision := repairDecision(reconciliationDecision{}, "merge-fact-mismatch", "durable state claims a merged PR but authoritative GitHub evidence says it is not merged")
+			attemptID := int64(0)
+			if history.ActiveAttempt != nil {
+				attemptID = history.ActiveAttempt.ID
+			}
+			if err := r.recordRepair(home, history.Task, state.Attempt{ID: attemptID}, decision); err != nil {
+				return result, err
+			}
+			result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
+			return result, nil
+		}
+		if mergeObserved && history.Task.RepairCode == "merge-fact-mismatch" {
+			if err := state.ClearTaskRepair(home, id, history.Task.RepairCode); err != nil {
+				return result, err
+			}
+			result.Outcome = reconcileOutcomeRecovered
+			continue
+		}
+		historical, err := r.pendingHistoricalAttempt(home, history)
+		if err != nil {
+			return result, err
+		}
+		if historical != nil {
+			result.AttemptID = historical.ID
+			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, *historical)
+			if err != nil {
+				result.Outcome = reconcileOutcomeBlocked
+				return result, err
+			}
+			if decision.Action == reconciliationActionNeedsRepair {
+				if err := r.recordRepair(home, history.Task, *historical, decision); err != nil {
+					return result, err
+				}
+				result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
+				return result, nil
+			}
+			if progress {
+				result.Action = string(reconciliationActionCleanupTerminal)
+				result.Outcome = reconcileOutcomeRecovered
+				continue
+			}
+		}
+		if history.ActiveAttempt == nil {
+			result.Outcome = reconcileOutcomeHealthy
+			return result, nil
+		}
+		attempt := *history.ActiveAttempt
+		result.AttemptID = attempt.ID
+		result.Harness, result.Model, result.Effort = attempt.Harness, attempt.Model, attempt.Effort
+		result.ExecutionClass, result.Profile = attempt.ExecutionClass, attempt.RequestedProfile
+		result.PlannedAgainst, result.RoutingSource = attempt.PlannedAgainst, attempt.RoutingSource
+		if attempt.TeardownTerminalAttempt != "" {
+			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, attempt)
+			if err != nil {
+				result.Outcome = reconcileOutcomeBlocked
+				return result, err
+			}
+			if decision.Action == reconciliationActionNeedsRepair {
+				if err := r.recordRepair(home, history.Task, attempt, decision); err != nil {
+					return result, err
+				}
+				result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
+				return result, nil
+			}
+			if progress {
+				result.Action = string(reconciliationActionCleanupTerminal)
+				result.Outcome = reconcileOutcomeRecovered
+				continue
+			}
+		}
+		observation, err := r.observeAttempt(home, history.Task, attempt)
+		if err != nil {
+			result.Outcome = reconcileOutcomeBlocked
+			return result, err
+		}
+		decision := decideReconciliation(history.Task, attempt, observation)
+		result.Action = string(decision.Action)
+		switch decision.Action {
+		case reconciliationActionNeedsRepair:
+			if err := r.recordRepair(home, history.Task, attempt, decision); err != nil {
+				return result, err
+			}
+			result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
+			return result, nil
+		case reconciliationActionBlocked:
+			result.Outcome = reconcileOutcomeBlocked
+			return result, fmt.Errorf("reconciliation observation was incomplete")
+		}
+		if shouldClearRepair(history.Task, attempt, observation) {
+			if err := state.ClearTaskRepair(home, id, history.Task.RepairCode); err != nil {
+				return result, err
+			}
+			result.Outcome = reconcileOutcomeRecovered
+			continue
+		}
+		if decision.Action == reconciliationActionKeep {
+			result.Outcome = reconcileOutcomeHealthy
+			return result, nil
+		}
+		fingerprint := fmt.Sprintf("%d:%s:%s:%s:%s:%s", attempt.ID, attempt.Lifecycle, attempt.Worktree, attempt.Herdr.PaneID, attempt.LaunchSubmittedAt, attempt.LaunchConfirmedAt)
+		if fingerprint == previousFingerprint {
+			result.Outcome = reconcileOutcomeNoProgress
+			return result, nil
+		}
+		previousFingerprint = fingerprint
+		if err := r.applyReconciliationAction(ctx, home, history.Task, attempt, decision); err != nil {
+			return result, err
+		}
+		result.Outcome = reconcileOutcomeRecovered
+	}
+	result.Outcome = reconcileOutcomeNoProgress
+	return result, nil
+}
+
+func (r *Runtime) observeMerge(ctx context.Context, task state.Task) (bool, bool, error) {
+	if task.PR == "" || (!task.MergeExecuted && !task.MergeAnnounced) {
+		return false, false, nil
+	}
+	prMerged := r.deps.prMerged
+	if prMerged == nil {
+		prMerged = ghutil.PRIsMerged
+	}
+	merged, err := prMerged(ctx, task.PR)
+	if err != nil {
+		return false, false, fmt.Errorf("observe merged PR %s: %w", task.PR, err)
+	}
+	return merged, !merged, nil
+}
+
+func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) (*state.Attempt, error) {
+	for i := range history.Attempts {
+		attempt := &history.Attempts[i]
+		if history.ActiveAttempt != nil && attempt.ID == history.ActiveAttempt.ID {
+			continue
+		}
+		if attempt.Lifecycle == state.AttemptProvisioning || attempt.Lifecycle == state.AttemptRunning {
+			continue
+		}
+		if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
+			return attempt, nil
+		}
+		if attempt.Worktree != "" && attempt.TeardownWorktreeState != state.TeardownResourceReleased {
+			return attempt, nil
+		}
+		if attempt.TeardownCompletionState != "" {
+			return attempt, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attempt state.Attempt) (bool, reconciliationDecision, error) {
+	if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
+		observation, err := observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
+		if err != nil {
+			return false, reconciliationDecision{}, err
+		}
+		switch observation.State {
+		case herdrOwnershipIncomplete, herdrOwnershipMismatch:
+			return false, repairDecision(reconciliationDecision{}, "teardown-resource-ambiguous", "historical Herdr resource ownership cannot be proven safely"), nil
+		case herdrOwnershipAbsent:
+			if cleared, err := clearHistoricalRepair(home, task, attempt, "teardown-resource-ambiguous", "herdr-ownership-mismatch"); err != nil {
+				return false, reconciliationDecision{}, err
+			} else if cleared {
+				return true, reconciliationDecision{}, nil
+			}
+			if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceReleased); err != nil {
+				return false, reconciliationDecision{}, err
+			}
+			return true, reconciliationDecision{}, nil
+		case herdrOwnershipExact:
+			if cleared, err := clearHistoricalRepair(home, task, attempt, "teardown-resource-ambiguous", "herdr-ownership-mismatch"); err != nil {
+				return false, reconciliationDecision{}, err
+			} else if cleared {
+				return true, reconciliationDecision{}, nil
+			}
+			if attempt.TeardownHerdrState == "" {
+				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceReleasing); err != nil {
+					return false, reconciliationDecision{}, err
+				}
+			}
+			if err := closeTaskTab(r.deps.herdr(), attempt.Herdr.WorkspaceID, attempt.Herdr.TabID); err != nil {
+				_ = state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceAmbiguous)
+				return false, reconciliationDecision{}, fmt.Errorf("close historical Herdr resource: %w", err)
+			}
+			if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceReleased); err != nil {
+				return false, reconciliationDecision{}, err
+			}
+			return true, reconciliationDecision{}, nil
+		}
+	}
+
+	if attempt.Worktree != "" && attempt.TeardownWorktreeState != state.TeardownResourceReleased {
+		observeLease := r.deps.worktree.observeLease
+		if observeLease == nil {
+			observeLease = worktree.ObserveLease
+		}
+		lease, err := observeLease(attempt.Worktree, attempt.LeaseID)
+		if err != nil {
+			return false, reconciliationDecision{}, fmt.Errorf("observe historical Treehouse lease: %w", err)
+		}
+		switch lease.State {
+		case worktree.LeaseUnprovable:
+			return false, repairDecision(reconciliationDecision{}, "legacy-worktree-ownership-unprovable", "historical worktree has no exact lease identity"), nil
+		case worktree.LeaseMismatch:
+			if attempt.TeardownWorktreeState == state.TeardownResourceReleasing {
+				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
+					return false, reconciliationDecision{}, err
+				}
+				return true, reconciliationDecision{}, nil
+			}
+			return false, repairDecision(reconciliationDecision{}, "worktree-ownership-mismatch", "historical worktree path is held by a different Treehouse lease"), nil
+		case worktree.LeaseAbsent:
+			if cleared, err := clearHistoricalRepair(home, task, attempt, "worktree-ownership-mismatch"); err != nil {
+				return false, reconciliationDecision{}, err
+			} else if cleared {
+				return true, reconciliationDecision{}, nil
+			}
+			if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
+				return false, reconciliationDecision{}, err
+			}
+			return true, reconciliationDecision{}, nil
+		case worktree.LeaseExact:
+			observeClean := r.deps.worktree.observeClean
+			if observeClean == nil {
+				observeClean = worktree.ObserveCleanliness
+			}
+			clean, err := observeClean(attempt.Worktree)
+			if err != nil {
+				return false, reconciliationDecision{}, fmt.Errorf("observe historical worktree cleanliness: %w", err)
+			}
+			if clean != worktree.Clean {
+				return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeDirty, "historical worktree is dirty; automatic reconciliation will not discard it"), nil
+			}
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeDirty, "worktree-ownership-mismatch"); err != nil {
+				return false, reconciliationDecision{}, err
+			} else if cleared {
+				return true, reconciliationDecision{}, nil
+			}
+			if attempt.TeardownWorktreeState == "" {
+				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleasing); err != nil {
+					return false, reconciliationDecision{}, err
+				}
+			}
+			returnLease := r.deps.worktree.returnWithID
+			if attempt.LeaseID == "" || returnLease == nil {
+				if r.deps.worktree.returnWorktree == nil {
+					return false, reconciliationDecision{}, fmt.Errorf("no worktree return operation configured")
+				}
+				if err := r.deps.worktree.returnWorktree(attempt.Worktree, false); err != nil {
+					return false, reconciliationDecision{}, fmt.Errorf("return historical worktree: %w", err)
+				}
+			} else if err := returnLease(attempt.Worktree, attempt.LeaseID, false); err != nil {
+				return false, reconciliationDecision{}, fmt.Errorf("return historical worktree lease: %w", err)
+			}
+			if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
+				return false, reconciliationDecision{}, err
+			}
+			return true, reconciliationDecision{}, nil
+		}
+	}
+
+	if attempt.TeardownCompletionState == state.TeardownCompletionAppended {
+		_, found, err := completion.FindAttempt(home, attempt.ID)
+		if err != nil {
+			return false, reconciliationDecision{}, err
+		}
+		if !found {
+			return false, repairDecision(reconciliationDecision{}, "completion-evidence-mismatch", "durable completion state says appended but no exact completion record exists"), nil
+		}
+		if cleared, err := clearHistoricalRepair(home, task, attempt, "completion-evidence-mismatch"); err != nil {
+			return false, reconciliationDecision{}, err
+		} else if cleared {
+			return true, reconciliationDecision{}, nil
+		}
+		if attempt.TeardownTerminalAttempt != "" {
+			if attempt.Lifecycle == attempt.TeardownTerminalAttempt {
+				return false, reconciliationDecision{}, nil
+			}
+			if err := state.TerminalizeTaskAndAttempt(home, task.ID, attempt.ID, attempt.Lifecycle, attempt.TeardownTerminalAttempt); err != nil {
+				return false, reconciliationDecision{}, fmt.Errorf("finish recovered teardown: %w", err)
+			}
+			return true, reconciliationDecision{}, nil
+		}
+		return false, reconciliationDecision{}, nil
+	}
+	if attempt.TeardownCompletionState == state.TeardownCompletionPending {
+		record, found, err := completion.FindAttempt(home, attempt.ID)
+		if err != nil {
+			return false, reconciliationDecision{}, err
+		}
+		if !found {
+			launched := attempt.LaunchSubmittedAt != "" || attempt.LaunchConfirmedAt != "" || attempt.Lifecycle != state.AttemptInterrupted
+			record = completionFor(task, attempt.TeardownDisposition, launched)
+			record.AttemptID, record.AttemptLifecycle = attempt.ID, string(attempt.TeardownTerminalAttempt)
+			record.TornDownAt = r.deps.now().Format(time.RFC3339)
+			if err := r.deps.appendCompletion(home, record); err != nil {
+				return false, reconciliationDecision{}, fmt.Errorf("append recovered completion: %w", err)
+			}
+		}
+		if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionAppended); err != nil {
+			return false, reconciliationDecision{}, err
+		}
+		return true, reconciliationDecision{}, nil
+	}
+	if attempt.TeardownTerminalAttempt != "" && attempt.TeardownCompletionState == "" {
+		if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionPending); err != nil {
+			return false, reconciliationDecision{}, err
+		}
+		return true, reconciliationDecision{}, nil
+	}
+	return false, reconciliationDecision{}, nil
+}
+
+func clearHistoricalRepair(home string, task state.Task, attempt state.Attempt, codes ...string) (bool, error) {
+	if task.RepairCode == "" || (task.RepairAttemptID != 0 && task.RepairAttemptID != attempt.ID) {
+		return false, nil
+	}
+	for _, code := range codes {
+		if task.RepairCode == code {
+			if err := state.ClearTaskRepair(home, task.ID, code); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attempt) (reconciliationObservation, error) {
+	observation := reconciliationObservation{}
+	if attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == "" {
+		return observation, nil
+	}
+	if attempt.Worktree != "" {
+		observeLease := r.deps.worktree.observeLease
+		if observeLease == nil {
+			observeLease = worktree.ObserveLease
+		}
+		lease, err := observeLease(attempt.Worktree, attempt.LeaseID)
+		if err != nil {
+			return observation, fmt.Errorf("observe Treehouse lease: %w", err)
+		}
+		observation.Treehouse.State = treehouseLeaseState(lease.State)
+		if lease.State == worktree.LeaseExact {
+			observeClean := r.deps.worktree.observeClean
+			if observeClean == nil {
+				observeClean = worktree.ObserveCleanliness
+			}
+			clean, err := observeClean(attempt.Worktree)
+			if err != nil {
+				return observation, fmt.Errorf("observe worktree cleanliness: %w", err)
+			}
+			observation.Worktree.State = worktreeState(clean)
+		}
+	}
+	if attempt.Herdr.PaneID != "" {
+		var err error
+		observation.Herdr, err = observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
+		if err != nil {
+			return observation, err
+		}
+		if observation.Herdr.State == herdrOwnershipUnobserved {
+			return observation, fmt.Errorf("observe Herdr ownership: no observation")
+		}
+		if observation.Herdr.State == herdrOwnershipIncomplete {
+			return observation, nil
+		}
+		if observation.Herdr.State == herdrOwnershipAbsent || observation.Herdr.State == herdrOwnershipMismatch {
+			return observation, nil
+		}
+	}
+	return observation, nil
+}
+
+func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
+	switch decision.Action {
+	case reconciliationActionContinueProvisioning:
+		projectInfo, found, err := project.FindReadOnly(home, task.Project)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return Precondition(fmt.Errorf("project %q not registered", task.Project))
+		}
+		briefPath := filepath.Join(home, task.Brief)
+		_, hasFrontMatter, err := brief.Parse(briefPath)
+		if err != nil {
+			return fmt.Errorf("parse persisted brief: %w", err)
+		}
+		_, err = r.provision(ctx, provisioningRequest{
+			home: home, projectName: projectInfo.Name, clonePath: filepath.Join(home, "projects", projectInfo.Name),
+			briefPath: briefPath, briefHasFrontMatter: hasFrontMatter, attempt: attempt,
+			resumeExisting: attempt.Worktree != "",
+		})
+		return err
+	case reconciliationActionConfirmLaunch:
+		if err := r.deps.confirmLaunch(r.deps.herdr(), attempt.Herdr.PaneID, attempt.Harness); err != nil {
+			return fmt.Errorf("confirm persisted launch: %w", err)
+		}
+		return state.MarkLaunchConfirmed(home, task.ID, attempt.ID, r.deps.now().Format(time.RFC3339))
+	case reconciliationActionMarkRunning:
+		return state.MarkAttemptRunning(home, task.ID, attempt.ID)
+	default:
+		return nil
+	}
+}
+
+func (r *Runtime) recordRepair(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
+	if task.RepairCode == decision.RepairCode && task.RepairReason == decision.RepairReason && task.RepairAttemptID == attempt.ID {
+		return nil
+	}
+	return state.SetTaskRepair(home, task.ID, decision.RepairCode, decision.RepairReason, attempt.ID, r.deps.now().Format(time.RFC3339))
+}
+
+func shouldClearRepair(task state.Task, attempt state.Attempt, observation reconciliationObservation) bool {
+	if task.RepairCode == "" || (task.RepairAttemptID != 0 && task.RepairAttemptID != attempt.ID) {
+		return false
+	}
+	if observation.Herdr.State == herdrOwnershipExact && observation.Herdr.Agent == attempt.Harness {
+		switch task.RepairCode {
+		case repairCodeProvisioningPaneMissing, repairCodeLaunchSubmittedPaneMissing, repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch, repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch:
+			return true
+		}
+	}
+	if observation.Treehouse.State == treehouseLeaseExact && observation.Worktree.State == worktreeClean {
+		switch task.RepairCode {
+		case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch:
+			return true
+		}
+	}
+	return false
+}
+
+func decideReconciliation(_ state.Task, attempt state.Attempt, observation reconciliationObservation) reconciliationDecision {
+	decision := reconciliationDecision{
+		Harness: attempt.Harness, Model: attempt.Model, Effort: attempt.Effort,
+		ExecutionClass: attempt.ExecutionClass, PlannedAgainst: attempt.PlannedAgainst,
+		Profile: attempt.RequestedProfile, RoutingSource: attempt.RoutingSource,
+	}
+	if observation.ObservationError {
+		decision.Action = reconciliationActionBlocked
+		return decision
+	}
+
+	if attempt.Lifecycle == state.AttemptProvisioning {
+		return decideProvisioning(attempt, observation, decision)
+	}
+	if attempt.Lifecycle == state.AttemptRunning {
+		if attempt.Herdr.PaneID == "" {
+			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "running Attempt has no persisted Herdr pane identity")
+		}
+		if observation.Herdr.State == herdrOwnershipExact && observation.Herdr.Agent == attempt.Harness {
+			decision.Action = reconciliationActionKeep
+			return decision
+		}
+		if observation.Herdr.State == herdrOwnershipAbsent {
+			return repairDecision(decision, repairCodeRunningPaneMissing, "persisted running Attempt has no matching Herdr pane")
+		}
+		if observation.Herdr.State == herdrOwnershipMismatch {
+			return repairDecision(decision, repairCodeRunningPaneIdentityMismatch, "persisted running Attempt points at a different Herdr resource")
+		}
+		if observation.Herdr.State == herdrOwnershipIncomplete {
+			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "running Attempt Herdr ownership cannot be proven")
+		}
+		if observation.Herdr.State == herdrOwnershipExact {
+			return repairDecision(decision, repairCodeLaunchAgentMismatch, "running Attempt pane does not prove the persisted harness is present")
+		}
+	}
+	return decision
+}
+
+func decideProvisioning(attempt state.Attempt, observation reconciliationObservation, decision reconciliationDecision) reconciliationDecision {
+	if attempt.Herdr.WorkspaceID != "" || attempt.Herdr.TabID != "" {
+		if attempt.Herdr.PaneID == "" {
+			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "persisted Herdr workspace or tab identity has no pane identity")
+		}
+	}
+	if attempt.Herdr.PaneID != "" {
+		if attempt.LaunchSubmittedAt == "" {
+			return repairDecision(decision, repairCodeProvisioningLaunchAmbiguous, "persisted Herdr pane exists but launch submission may have happened before the crash")
+		}
+		if observation.Herdr.State == herdrOwnershipAbsent {
+			return repairDecision(decision, repairCodeLaunchSubmittedPaneMissing, "launch was recorded but the expected Herdr pane is absent")
+		}
+		if observation.Herdr.State == herdrOwnershipMismatch {
+			return repairDecision(decision, repairCodeHerdrOwnershipMismatch, "launch was recorded but Herdr identity does not match the Attempt")
+		}
+		if observation.Herdr.State == herdrOwnershipIncomplete {
+			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "Herdr ownership for the recorded launch is incomplete")
+		}
+		if observation.Herdr.State != herdrOwnershipExact {
+			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "Herdr ownership for the recorded launch was not proven")
+		}
+		if observation.Herdr.Agent != attempt.Harness {
+			return repairDecision(decision, repairCodeLaunchAgentMismatch, "the expected persisted harness is not observed in the recorded pane")
+		}
+		if attempt.LaunchConfirmedAt != "" {
+			decision.Action = reconciliationActionMarkRunning
+			return decision
+		}
+		decision.Action = reconciliationActionConfirmLaunch
+		return decision
+	}
+	if attempt.LaunchSubmittedAt != "" || attempt.LaunchConfirmedAt != "" {
+		return repairDecision(decision, repairCodeProvisioningPaneMissing, "launch evidence exists but no Herdr pane identity was persisted")
+	}
+
+	if attempt.Worktree != "" {
+		switch observation.Treehouse.State {
+		case treehouseLeaseMismatch:
+			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded worktree path is leased under a different Treehouse lease ID")
+		case treehouseLeaseUnprovable:
+			return repairDecision(decision, repairCodeLegacyWorktreeUnprovable, "recorded worktree ownership has no provable Treehouse lease identity")
+		case treehouseLeaseAbsent:
+			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded Treehouse lease is absent")
+		case treehouseLeaseExact:
+			if observation.Worktree.State == worktreeDirty {
+				return repairDecision(decision, repairCodeWorktreeDirty, "recorded worktree is dirty; automatic reconciliation will not discard it")
+			}
+			if observation.Worktree.State == worktreeClean {
+				decision.Action = reconciliationActionContinueProvisioning
+				return decision
+			}
+		}
+		return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded worktree ownership or cleanliness was not proven")
+	}
+
+	decision.Action = reconciliationActionContinueProvisioning
+	return decision
+}
+
+func repairDecision(decision reconciliationDecision, code, reason string) reconciliationDecision {
+	decision.Action = reconciliationActionNeedsRepair
+	decision.RepairCode = code
+	decision.RepairReason = reason
+	return decision
+}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -114,6 +114,26 @@ func TestDecideReconciliationProvisioningMatrix(t *testing.T) {
 			wantAction:  reconciliationActionNeedsRepair,
 			wantCode:    repairCodeRunningPaneMissing,
 		},
+		{
+			name:    "running absent lease",
+			attempt: state.Attempt{Lifecycle: state.AttemptRunning, Worktree: "/pool/1", LeaseID: "lease-1", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{
+				Treehouse: treehouseObservation{State: treehouseLeaseAbsent},
+				Herdr:     herdrObservation{State: herdrOwnershipExact, Agent: "claude"},
+			},
+			wantAction: reconciliationActionNeedsRepair,
+			wantCode:   repairCodeWorktreeOwnershipMismatch,
+		},
+		{
+			name:    "running unprovable lease",
+			attempt: state.Attempt{Lifecycle: state.AttemptRunning, Worktree: "/pool/1", LeaseID: "lease-1", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{
+				Treehouse: treehouseObservation{State: treehouseLeaseUnprovable},
+				Herdr:     herdrObservation{State: herdrOwnershipExact, Agent: "claude"},
+			},
+			wantAction: reconciliationActionNeedsRepair,
+			wantCode:   repairCodeLegacyWorktreeUnprovable,
+		},
 	}
 
 	for _, tt := range tests {
@@ -186,6 +206,7 @@ func (f *reconcileHerdrClient) FindWorkspaceByLabel(string) (herdr.Workspace, bo
 	}
 	return f.workspace, f.workspace.WorkspaceID != "", nil
 }
+func (f *reconcileHerdrClient) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
 func (f *reconcileHerdrClient) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
 	return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, errors.New("unused")
 }
@@ -397,6 +418,171 @@ func TestReconcileRunningMissingPaneRecordsRepairWithoutReplacement(t *testing.T
 	}
 	if history.Task.RepairCode != repairCodeRunningPaneMissing || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
 		t.Fatalf("history=%+v, want running Attempt and repair marker", history)
+	}
+}
+
+func TestReconcileRunningWorktreeLeaseMismatchWinsOverHealthyPane(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "old-lease",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeLease = func(string, string) (worktree.LeaseObservation, error) {
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}, nil
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeOwnershipMismatch || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history = %+v, want lease repair and unchanged running Attempt", history)
+	}
+}
+
+func TestDecideRunningKeepsDirtyWorktreeWhenLeaseAndPaneAreExact(t *testing.T) {
+	decision := decideReconciliation(state.Task{ID: "task-1"}, state.Attempt{
+		Lifecycle: state.AttemptRunning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	}, reconciliationObservation{
+		Treehouse: treehouseObservation{State: treehouseLeaseExact},
+		Worktree:  worktreeObservation{State: worktreeDirty},
+		Herdr:     herdrObservation{State: herdrOwnershipExact, Agent: "claude"},
+	})
+	if decision.Action != reconciliationActionKeep {
+		t.Fatalf("decision = %+v, want keep despite worker edits", decision)
+	}
+}
+
+func TestReconcileClearsRepairAfterTeardownAndReopenResolvesOldAttempt(t *testing.T) {
+	home := reconcileFixture(t)
+	oldAttempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+		Herdr:             state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", oldAttempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil || history.Task.RepairCode != repairCodeRunningPaneMissing {
+		t.Fatalf("repair history = %+v, err=%v", history, err)
+	}
+
+	if err := state.SetAttemptTeardownDecision(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, state.TeardownDispositionForced); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", oldAttempt.ID, state.AttemptRunning, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", oldAttempt.ID, state.AttemptRunning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleased); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, state.TeardownCompletionPending); err != nil {
+		t.Fatal(err)
+	}
+	if err := completion.Append(home, completion.Record{ID: "task-1", Project: "demo", Outcome: "torn-down", Detail: "forced", AttemptID: oldAttempt.ID, AttemptLifecycle: string(state.AttemptInterrupted)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, state.TeardownCompletionAppended); err != nil {
+		t.Fatal(err)
+	}
+
+	newAttempt, err := state.ReopenTask(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newWorktree := filepath.Join(home, "reopened-worktree")
+	if err := state.RecordAttemptWorktree(home, "task-1", newAttempt.ID, newWorktree, "lease-new"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.RecordAttemptHerdr(home, "task-1", newAttempt.ID, state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "2026-08-15T00:00:02Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkLaunchSubmitted(home, "task-1", newAttempt.ID, "2026-08-15T00:00:03Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkLaunchConfirmed(home, "task-1", newAttempt.ID, "2026-08-15T00:00:04Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", newAttempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "" || history.Task.RepairAttemptID != 0 {
+		t.Fatalf("stale repair marker after resolved teardown and reopen: %+v", history.Task)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != newAttempt.ID {
+		t.Fatalf("active attempt = %+v, want reopened attempt %d", history.ActiveAttempt, newAttempt.ID)
+	}
+}
+
+func TestReconcileDoesNotClearUnknownRepairAfterTerminalTeardown(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownDispositionForced); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, state.AttemptProvisioning, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleased); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownCompletionPending); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownCompletionAppended); err != nil {
+		t.Fatal(err)
+	}
+	if err := completion.Append(home, completion.Record{ID: "task-1", Project: "demo", Outcome: "torn-down", Detail: "forced", AttemptID: attempt.ID, AttemptLifecycle: string(state.AttemptInterrupted)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskRepair(home, "task-1", "operator-review-required", "unknown contradiction", attempt.ID, "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "operator-review-required" {
+		t.Fatalf("repair code = %q, want unknown marker retained", history.Task.RepairCode)
 	}
 }
 
@@ -739,6 +925,55 @@ func TestReconcileMergeObservationFailureLeavesRepairMarkerUnchanged(t *testing.
 	}
 }
 
+func TestReconcileLocalMergeMismatchNeedsRepairWithoutRewritingHistory(t *testing.T) {
+	home := reconcileFixture(t)
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.branchMerged = func(string, string) (bool, error) { return false, nil }
+	result, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Results[0].Outcome != reconcileOutcomeRepair || history.Task.RepairCode != "merge-fact-mismatch" || !history.Task.MergeExecuted {
+		t.Fatalf("result=%+v task=%+v, want local merge contradiction repair", result, history.Task)
+	}
+}
+
+func TestReconcileLocalMergeObservationFailureDoesNotCreateRepair(t *testing.T) {
+	home := reconcileFixture(t)
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.branchMerged = func(string, string) (bool, error) { return false, errors.New("git unavailable") }
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err == nil {
+		t.Fatal("Reconcile succeeded through local Git observation failure")
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "" {
+		t.Fatalf("local Git observation failure created repair marker: %+v", history.Task)
+	}
+}
+
 func TestReconcileResumesPartialTeardownWithoutChangingDisposition(t *testing.T) {
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
@@ -769,6 +1004,23 @@ func TestReconcileResumesPartialTeardownWithoutChangingDisposition(t *testing.T)
 	}
 	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil || history.Attempts[0].TeardownDisposition != state.TeardownDispositionCompleted || history.Attempts[0].TeardownHerdrState != state.TeardownResourceReleased || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Attempts[0].TeardownCompletionState != state.TeardownCompletionAppended || returns != 1 || client.closed != 1 {
 		t.Fatalf("history=%+v returns=%d closes=%d, want resumed terminal teardown", history, returns, client.closed)
+	}
+}
+
+func TestReconcileFleetReportsUnattributedHandTabWithoutClaimingOwnership(t *testing.T) {
+	home := reconcileFixture(t)
+	client := &inventoryReconcileHerdr{}
+	r := reconcileRuntime(client, nil)
+	report, err := r.Reconcile(ReconcileRequest{Home: home})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Anomalies) != 1 {
+		t.Fatalf("anomalies = %+v, want one unattributed Herdr tab", report.Anomalies)
+	}
+	anomaly := report.Anomalies[0]
+	if anomaly.Kind != "unattributed-herdr-tab" || anomaly.WorkspaceID != "ws-orphan" || anomaly.TabID != "tab-orphan" || anomaly.OwnerAttemptID != 0 {
+		t.Fatalf("anomaly = %+v, want unattributed identity without owner", anomaly)
 	}
 }
 
@@ -825,6 +1077,16 @@ type healthyReconcileHerdr struct {
 
 type missingReconcileHerdr struct{ healthyReconcileHerdr }
 
+type inventoryReconcileHerdr struct{ healthyReconcileHerdr }
+
+func (*inventoryReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) {
+	return []herdr.Workspace{{WorkspaceID: "ws-orphan", Label: "hand:demo"}}, nil
+}
+
+func (*inventoryReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
+	return []herdr.Tab{{TabID: "tab-orphan", WorkspaceID: "ws-orphan", Label: "orphan-task"}}, nil
+}
+
 func (*missingReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
 	return herdr.Workspace{}, false, nil
 }
@@ -832,6 +1094,7 @@ func (*missingReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, boo
 func (f *healthyReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
 	return herdr.Workspace{WorkspaceID: "ws-1", Label: "hand:demo"}, true, nil
 }
+func (f *healthyReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
 func (f *healthyReconcileHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
 	return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, errors.New("unused")
 }

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -588,6 +588,83 @@ func TestReconcileDoesNotClearUnknownRepairAfterTerminalTeardown(t *testing.T) {
 	}
 }
 
+func TestClearResolvedTerminalRepairRequiresRepairEvidenceResolution(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		code       string
+		attempt    state.Attempt
+		completion bool
+	}{
+		{
+			name: "herdr repair retains recorded identity",
+			code: repairCodeRunningPaneMissing,
+			attempt: state.Attempt{Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{
+				WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1",
+			}},
+			completion: true,
+		},
+		{
+			name:       "worktree repair retains recorded ownership",
+			code:       repairCodeWorktreeDirty,
+			attempt:    state.Attempt{Lifecycle: state.AttemptProvisioning, Worktree: "/pool/1", LeaseID: "lease-1"},
+			completion: true,
+		},
+		{
+			name:       "completion mismatch never clears here",
+			code:       repairCodeCompletionEvidenceMismatch,
+			attempt:    state.Attempt{Lifecycle: state.AttemptProvisioning},
+			completion: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := reconcileFixture(t)
+			test.attempt.TaskID = "task-1"
+			attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, test.attempt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownDispositionForced); err != nil {
+				t.Fatal(err)
+			}
+			if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+				t.Fatal(err)
+			}
+			if test.completion {
+				if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownCompletionPending); err != nil {
+					t.Fatal(err)
+				}
+				if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownCompletionAppended); err != nil {
+					t.Fatal(err)
+				}
+				if err := completion.Append(home, completion.Record{ID: "task-1", Project: "demo", Outcome: "torn-down", AttemptID: attempt.ID, AttemptLifecycle: string(state.AttemptInterrupted)}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := state.SetTaskRepair(home, "task-1", test.code, "unresolved evidence", attempt.ID, "2026-08-15T00:00:00Z"); err != nil {
+				t.Fatal(err)
+			}
+			history, err := state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleared, err := clearResolvedTerminalRepair(home, history)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cleared {
+				t.Fatal("clearResolvedTerminalRepair cleared unresolved repair evidence")
+			}
+			history, err = state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Task.RepairCode != test.code {
+				t.Fatalf("repair code = %q, want %q retained", history.Task.RepairCode, test.code)
+			}
+		})
+	}
+}
+
 func TestReconcileRunningOwnershipRepairClearsWithDirtyExactLease(t *testing.T) {
 	task := state.Task{ID: "task-1", RepairCode: repairCodeWorktreeOwnershipMismatch, RepairAttemptID: 7}
 	attempt := state.Attempt{ID: 7, Lifecycle: state.AttemptRunning, Worktree: "/pool/1", LeaseID: "lease-1"}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -574,15 +575,58 @@ func TestReconcileDoesNotClearUnknownRepairAfterTerminalTeardown(t *testing.T) {
 	if err := state.SetTaskRepair(home, "task-1", "operator-review-required", "unknown contradiction", attempt.ID, "2026-08-15T00:00:00Z"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+	report, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
 		t.Fatal(err)
 	}
 	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if history.Task.RepairCode != "operator-review-required" {
+	if len(report.Results) != 1 || report.Results[0].Outcome != reconcileOutcomeRepair || report.Results[0].RepairCode != "operator-review-required" || history.Task.RepairCode != "operator-review-required" {
 		t.Fatalf("repair code = %q, want unknown marker retained", history.Task.RepairCode)
+	}
+}
+
+func TestReconcileRunningOwnershipRepairClearsWithDirtyExactLease(t *testing.T) {
+	task := state.Task{ID: "task-1", RepairCode: repairCodeWorktreeOwnershipMismatch, RepairAttemptID: 7}
+	attempt := state.Attempt{ID: 7, Lifecycle: state.AttemptRunning, Worktree: "/pool/1", LeaseID: "lease-1"}
+	observation := reconciliationObservation{
+		Treehouse: treehouseObservation{State: treehouseLeaseExact},
+		Worktree:  worktreeObservation{State: worktreeDirty},
+	}
+	if !shouldClearRepair(task, attempt, observation) {
+		t.Fatal("shouldClearRepair() = false, want exact running lease to clear ownership-only repair despite dirt")
+	}
+}
+
+func TestReconcileClearsRunningOwnershipRepairWithDirtyWorktree(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskRepair(home, "task-1", repairCodeWorktreeOwnershipMismatch, "previous lease observation was mismatched", attempt.ID, "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Outcome != reconcileOutcomeHealthy || history.Task.RepairCode != "" || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("report=%+v history=%+v, want healthy running Attempt with ownership repair cleared", report, history)
 	}
 }
 
@@ -974,6 +1018,77 @@ func TestReconcileLocalMergeObservationFailureDoesNotCreateRepair(t *testing.T) 
 	}
 }
 
+func TestReconcileLocalMergeDoesNotInspectReusedTreehousePath(t *testing.T) {
+	home := reconcileFixture(t)
+	_, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/shared", LeaseID: "lease-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, Brief: "data/task-2/brief.md"}, state.Attempt{
+		TaskID: "task-2", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/shared", LeaseID: "lease-b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	observed := 0
+	r.deps.worktree.observeLease = func(path, leaseID string) (worktree.LeaseObservation, error) {
+		observed++
+		if path != "/pool/shared" || leaseID != "lease-a" {
+			t.Fatalf("observeLease(%q, %q), want Task 1 lease", path, leaseID)
+		}
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-b"}, nil
+	}
+	branchChecks := 0
+	r.deps.branchMerged = func(string, string) (bool, error) {
+		branchChecks++
+		return false, nil
+	}
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err == nil {
+		t.Fatal("Reconcile succeeded without proving the historical lease")
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed != 1 || branchChecks != 0 || history.Task.RepairCode == repairCodeMergeFactMismatch || report.Results[0].Outcome != reconcileOutcomeBlocked {
+		t.Fatalf("report=%+v history=%+v observed=%d branchChecks=%d, want blocked ABA-safe observation", report, history.Task, observed, branchChecks)
+	}
+}
+
+func TestReconcileLocalMergeHoldsProjectAndWorktreeLocks(t *testing.T) {
+	home := reconcileFixture(t)
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/shared", LeaseID: "lease-a",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.branchMerged = func(string, string) (bool, error) {
+		for _, lockName := range []string{"project:demo", "worktree:/pool/shared"} {
+			release, err := state.TryLock(home, lockName)
+			if release != nil {
+				release()
+			}
+			if !errors.Is(err, state.ErrLockBusy) {
+				return false, fmt.Errorf("%s was not held during local Git observation", lockName)
+			}
+		}
+		return true, nil
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestReconcileResumesPartialTeardownWithoutChangingDisposition(t *testing.T) {
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
@@ -1021,6 +1136,91 @@ func TestReconcileFleetReportsUnattributedHandTabWithoutClaimingOwnership(t *tes
 	anomaly := report.Anomalies[0]
 	if anomaly.Kind != "unattributed-herdr-tab" || anomaly.WorkspaceID != "ws-orphan" || anomaly.TabID != "tab-orphan" || anomaly.OwnerAttemptID != 0 {
 		t.Fatalf("anomaly = %+v, want unattributed identity without owner", anomaly)
+	}
+}
+
+func TestObserveHerdrOrphansRechecksOwnershipAfterTaskLock(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &inventoryRaceReconcileHerdr{}
+	client.beforeWorkspaceList = func() error {
+		release, err := state.Lock(home, "task:task-1")
+		if err != nil {
+			return err
+		}
+		defer release()
+		return state.RecordAttemptHerdr(home, "task-1", attempt.ID, state.Herdr{Session: "default", WorkspaceID: "ws-race", TabID: "tab-race", PaneID: "pane-race"}, "2026-08-15T00:00:00Z")
+	}
+	r := reconcileRuntime(client, nil)
+	anomalies, err := r.observeHerdrOrphans(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.beforeWorkspaceListCalls != 1 || client.tabListCalls < 2 || len(anomalies) != 0 {
+		t.Fatalf("calls=%d tabs=%d anomalies=%+v, want locked fresh ownership with no anomaly", client.beforeWorkspaceListCalls, client.tabListCalls, anomalies)
+	}
+}
+
+func TestObserveHerdrOrphansReportsReleasedHistoricalResource(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Herdr: state.Herdr{Session: "default", WorkspaceID: "ws-released", TabID: "tab-released", PaneID: "pane-released"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleased); err != nil {
+		t.Fatal(err)
+	}
+	client := &releasedInventoryReconcileHerdr{}
+	anomalies, err := reconcileRuntime(client, nil).observeHerdrOrphans(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(anomalies) != 1 || anomalies[0].Kind != "released-herdr-resource" || anomalies[0].OwnerAttemptID != attempt.ID {
+		t.Fatalf("anomalies=%+v, want attributed released-resource anomaly for Attempt %d", anomalies, attempt.ID)
+	}
+}
+
+func TestObserveHerdrOrphansReportsReleasedIdentityAlongsideReopenedAttempt(t *testing.T) {
+	home := reconcileFixture(t)
+	identity := state.Herdr{Session: "default", WorkspaceID: "ws-reused", TabID: "tab-reused", PaneID: "pane-reused"}
+	oldAttempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Herdr: identity,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", oldAttempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleased); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.ReopenTask(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Herdr: identity}); err != nil {
+		t.Fatal(err)
+	}
+	client := &releasedReopenInventoryReconcileHerdr{}
+	anomalies, err := reconcileRuntime(client, nil).observeHerdrOrphans(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(anomalies) != 1 || anomalies[0].Kind != "released-herdr-resource" || anomalies[0].OwnerAttemptID != oldAttempt.ID {
+		t.Fatalf("anomalies=%+v, want released historical Attempt %d anomaly despite active reuse", anomalies, oldAttempt.ID)
 	}
 }
 
@@ -1079,12 +1279,71 @@ type missingReconcileHerdr struct{ healthyReconcileHerdr }
 
 type inventoryReconcileHerdr struct{ healthyReconcileHerdr }
 
+type inventoryRaceReconcileHerdr struct {
+	healthyReconcileHerdr
+	beforeWorkspaceList      func() error
+	beforeWorkspaceListCalls int
+	tabListCalls             int
+}
+
+type releasedInventoryReconcileHerdr struct{ healthyReconcileHerdr }
+
+type releasedReopenInventoryReconcileHerdr struct{ healthyReconcileHerdr }
+
 func (*inventoryReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) {
 	return []herdr.Workspace{{WorkspaceID: "ws-orphan", Label: "hand:demo"}}, nil
 }
 
 func (*inventoryReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
 	return []herdr.Tab{{TabID: "tab-orphan", WorkspaceID: "ws-orphan", Label: "orphan-task"}}, nil
+}
+
+func (f *inventoryRaceReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) {
+	f.beforeWorkspaceListCalls++
+	if f.beforeWorkspaceList != nil {
+		if err := f.beforeWorkspaceList(); err != nil {
+			return nil, err
+		}
+		f.beforeWorkspaceList = nil
+	}
+	return []herdr.Workspace{{WorkspaceID: "ws-race", Label: "hand:demo"}}, nil
+}
+
+func (f *inventoryRaceReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
+	f.tabListCalls++
+	return []herdr.Tab{{TabID: "tab-race", WorkspaceID: "ws-race", Label: "task-1"}}, nil
+}
+
+func (f *inventoryRaceReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
+	return herdr.Workspace{WorkspaceID: "ws-race", Label: "hand:demo"}, true, nil
+}
+
+func (f *inventoryRaceReconcileHerdr) PaneGet(string) (herdr.Pane, error) {
+	return herdr.Pane{PaneID: "pane-race", TabID: "tab-race", WorkspaceID: "ws-race", Agent: "claude"}, nil
+}
+
+func (*releasedInventoryReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) {
+	return []herdr.Workspace{{WorkspaceID: "ws-released", Label: "hand:demo"}}, nil
+}
+
+func (*releasedInventoryReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
+	return []herdr.Tab{{TabID: "tab-released", WorkspaceID: "ws-released", Label: "task-1"}}, nil
+}
+
+func (*releasedInventoryReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
+	return herdr.Workspace{WorkspaceID: "ws-released", Label: "hand:demo"}, true, nil
+}
+
+func (*releasedInventoryReconcileHerdr) PaneGet(string) (herdr.Pane, error) {
+	return herdr.Pane{PaneID: "pane-released", TabID: "tab-released", WorkspaceID: "ws-released", Agent: "claude"}, nil
+}
+
+func (*releasedReopenInventoryReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) {
+	return []herdr.Workspace{{WorkspaceID: "ws-reused", Label: "hand:demo"}}, nil
+}
+
+func (*releasedReopenInventoryReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
+	return []herdr.Tab{{TabID: "tab-reused", WorkspaceID: "ws-reused", Label: "task-1"}}, nil
 }
 
 func (*missingReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -1,0 +1,852 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/brief"
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/routing"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+func TestDecideReconciliationUsesPersistedAttemptIdentity(t *testing.T) {
+	attempt := state.Attempt{
+		ID: 17, TaskID: "task-1", Lifecycle: state.AttemptProvisioning,
+		Harness: "claude", Model: "opus", Effort: "high",
+		ExecutionClass: "mechanical", PlannedAgainst: "base-1",
+		RequestedProfile: "profile-a", RoutingSource: "route-a",
+		LaunchConfirmedAt: "2026-08-15T00:00:00Z",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z",
+		Herdr:             state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"},
+	}
+	decision := decideReconciliation(state.Task{ID: "task-1"}, attempt, reconciliationObservation{
+		Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"},
+	})
+	if decision.Action != reconciliationActionMarkRunning {
+		t.Fatalf("action = %q, want %q", decision.Action, reconciliationActionMarkRunning)
+	}
+	if decision.Harness != attempt.Harness || decision.Model != attempt.Model || decision.Effort != attempt.Effort || decision.Profile != attempt.RequestedProfile || decision.PlannedAgainst != attempt.PlannedAgainst {
+		t.Fatalf("decision identity = %+v, want persisted attempt identity", decision)
+	}
+}
+
+func TestDecideReconciliationProvisioningMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		attempt     state.Attempt
+		observation reconciliationObservation
+		wantAction  reconciliationAction
+		wantCode    string
+	}{
+		{
+			name:       "attempt created",
+			attempt:    state.Attempt{Lifecycle: state.AttemptProvisioning},
+			wantAction: reconciliationActionContinueProvisioning,
+		},
+		{
+			name:    "worktree recorded clean exact lease",
+			attempt: state.Attempt{Lifecycle: state.AttemptProvisioning, Worktree: "/pool/1", LeaseID: "lease-1"},
+			observation: reconciliationObservation{
+				Treehouse: treehouseObservation{State: treehouseLeaseExact},
+				Worktree:  worktreeObservation{State: worktreeClean},
+			},
+			wantAction: reconciliationActionContinueProvisioning,
+		},
+		{
+			name:    "worktree recorded dirty",
+			attempt: state.Attempt{Lifecycle: state.AttemptProvisioning, Worktree: "/pool/1", LeaseID: "lease-1"},
+			observation: reconciliationObservation{
+				Treehouse: treehouseObservation{State: treehouseLeaseExact},
+				Worktree:  worktreeObservation{State: worktreeDirty},
+			},
+			wantAction: reconciliationActionNeedsRepair,
+			wantCode:   repairCodeWorktreeDirty,
+		},
+		{
+			name:    "worktree lease mismatch",
+			attempt: state.Attempt{Lifecycle: state.AttemptProvisioning, Worktree: "/pool/1", LeaseID: "lease-1"},
+			observation: reconciliationObservation{
+				Treehouse: treehouseObservation{State: treehouseLeaseMismatch},
+				Worktree:  worktreeObservation{State: worktreeClean},
+			},
+			wantAction: reconciliationActionNeedsRepair,
+			wantCode:   repairCodeWorktreeOwnershipMismatch,
+		},
+		{
+			name:        "pane recorded without launch evidence",
+			attempt:     state.Attempt{Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}},
+			wantAction:  reconciliationActionNeedsRepair,
+			wantCode:    repairCodeProvisioningLaunchAmbiguous,
+		},
+		{
+			name:        "submitted pane healthy",
+			attempt:     state.Attempt{Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}},
+			wantAction:  reconciliationActionConfirmLaunch,
+		},
+		{
+			name:        "submitted pane missing",
+			attempt:     state.Attempt{Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}},
+			wantAction:  reconciliationActionNeedsRepair,
+			wantCode:    repairCodeLaunchSubmittedPaneMissing,
+		},
+		{
+			name:        "confirmed pane healthy",
+			attempt:     state.Attempt{Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}},
+			wantAction:  reconciliationActionMarkRunning,
+		},
+		{
+			name:        "running pane missing",
+			attempt:     state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"}},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}},
+			wantAction:  reconciliationActionNeedsRepair,
+			wantCode:    repairCodeRunningPaneMissing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := decideReconciliation(state.Task{ID: "task-1"}, tt.attempt, tt.observation)
+			if decision.Action != tt.wantAction {
+				t.Fatalf("action = %q, want %q (%+v)", decision.Action, tt.wantAction, decision)
+			}
+			if decision.RepairCode != tt.wantCode {
+				t.Fatalf("repair code = %q, want %q", decision.RepairCode, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestDecideReconciliationObservationFailureDoesNotBecomeRepair(t *testing.T) {
+	decision := decideReconciliation(state.Task{ID: "task-1"}, state.Attempt{
+		Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws", TabID: "tab", PaneID: "pane"},
+	}, reconciliationObservation{ObservationError: true})
+	if decision.Action != reconciliationActionBlocked {
+		t.Fatalf("action = %q, want blocked", decision.Action)
+	}
+	if decision.RepairCode != "" {
+		t.Fatalf("repair code = %q, want empty on observation failure", decision.RepairCode)
+	}
+}
+
+func TestObserveHerdrOwnershipRequiresAllDurableIdentityEdges(t *testing.T) {
+	client := &reconcileHerdrClient{
+		workspace: herdr.Workspace{WorkspaceID: "ws-1", Label: "hand:demo"},
+		tabs:      []herdr.Tab{{TabID: "tab-1", WorkspaceID: "ws-1", Label: "task-1"}},
+		pane:      herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1", Agent: "claude"},
+	}
+	observation, err := observeHerdrOwnership(client, state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "task-1", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.State != herdrOwnershipExact || observation.Agent != "claude" {
+		t.Fatalf("observation = %+v, want exact claude ownership", observation)
+	}
+
+	client.pane.PaneID = "pane-new"
+	observation, err = observeHerdrOwnership(client, state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "task-1", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.State != herdrOwnershipMismatch {
+		t.Fatalf("reused pane observation = %+v, want mismatch", observation)
+	}
+}
+
+func TestObserveHerdrOwnershipPreservesObservationFailures(t *testing.T) {
+	client := &reconcileHerdrClient{err: errors.New("herdr service unavailable")}
+	_, err := observeHerdrOwnership(client, state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "task-1", "demo")
+	if err == nil || err.Error() != "find Herdr workspace: herdr service unavailable" {
+		t.Fatalf("observeHerdrOwnership() = %v, want service error", err)
+	}
+}
+
+type reconcileHerdrClient struct {
+	workspace herdr.Workspace
+	tabs      []herdr.Tab
+	pane      herdr.Pane
+	err       error
+}
+
+func (f *reconcileHerdrClient) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
+	if f.err != nil {
+		return herdr.Workspace{}, false, f.err
+	}
+	return f.workspace, f.workspace.WorkspaceID != "", nil
+}
+func (f *reconcileHerdrClient) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+	return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, errors.New("unused")
+}
+func (f *reconcileHerdrClient) WorkspaceClose(string) error         { return errors.New("unused") }
+func (f *reconcileHerdrClient) TabList(string) ([]herdr.Tab, error) { return f.tabs, nil }
+func (f *reconcileHerdrClient) TabCreate(string, string, string) (herdr.Tab, herdr.Pane, error) {
+	return herdr.Tab{}, herdr.Pane{}, errors.New("unused")
+}
+func (f *reconcileHerdrClient) TabRename(string, string) error       { return errors.New("unused") }
+func (f *reconcileHerdrClient) TabClose(string) error                { return errors.New("unused") }
+func (f *reconcileHerdrClient) PaneGet(string) (herdr.Pane, error)   { return f.pane, nil }
+func (f *reconcileHerdrClient) PaneRun(string, string) error         { return errors.New("unused") }
+func (f *reconcileHerdrClient) PaneSendKeys(string, ...string) error { return errors.New("unused") }
+func (f *reconcileHerdrClient) PaneRead(string, int) (string, error) { return "", errors.New("unused") }
+
+func TestReconcileAttemptCreatedContinuesTheSameAttempt(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Model: "opus", Effort: "high",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &healthyReconcileHerdr{}
+	gets := 0
+	r := reconcileRuntime(client, func(path, holder string) (worktree.Lease, error) {
+		gets++
+		return worktree.Lease{Path: filepath.Join(home, "leased"), ID: "lease-1"}, nil
+	})
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != attempt.ID || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history after reconcile = %+v, want same running Attempt %d", history, attempt.ID)
+	}
+	if gets != 1 || client.runs != 1 || len(report.Results) != 1 || report.Results[0].Outcome != reconcileOutcomeHealthy {
+		t.Fatalf("reconcile effects = gets %d runs %d report %+v", gets, client.runs, report)
+	}
+	second, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Results[0].Outcome != reconcileOutcomeHealthy || gets != 1 || client.runs != 1 {
+		t.Fatalf("second reconcile = %+v, gets=%d runs=%d, want no new effects", second, gets, client.runs)
+	}
+}
+
+func TestReconcileNeverReroutesAnExistingAttempt(t *testing.T) {
+	home := reconcileFixture(t)
+	if err := routing.WriteProfile(home, routing.Profile{Name: "profile-a", Harness: "claude", Model: "model-a", Effort: "low"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := routing.WriteProfile(home, routing.Profile{Name: "profile-b", Harness: "codex", Model: "model-b", Effort: "high"}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Model: "model-a", Effort: "low", ExecutionClass: "deep", PlannedAgainst: "base-a", RequestedProfile: "profile-a", RoutingSource: "route-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := routing.WriteRoute(home, routing.Route{Kind: routing.TaskKindShip, ExecutionClass: routing.ExecutionClassDeep, Profile: "profile-b"}); err != nil {
+		t.Fatal(err)
+	}
+	var gotHarness string
+	var got harness.Options
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.buildHarness = func(name string, options harness.Options) (string, error) {
+		gotHarness, got = name, options
+		return "launch", nil
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != attempt.ID || gotHarness != "claude" || got.Model != "model-a" || got.Effort != "low" || got.ExecutionClass != brief.ExecutionClass("deep") {
+		t.Fatalf("history=%+v launch=%q %+v, want persisted profile-a execution", history, gotHarness, got)
+	}
+}
+
+func TestReconcileRecordedWorktreeNeverAcquiresAnotherLease(t *testing.T) {
+	home := reconcileFixture(t)
+	path := filepath.Join(home, "leased")
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: path, LeaseID: "lease-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gets := 0
+	r := reconcileRuntime(&healthyReconcileHerdr{}, func(string, string) (worktree.Lease, error) {
+		gets++
+		return worktree.Lease{}, errors.New("unexpected second treehouse get")
+	})
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != attempt.ID || gets != 0 {
+		t.Fatalf("history=%+v gets=%d, want same Attempt and no get", history, gets)
+	}
+	if report.Results[0].Outcome != reconcileOutcomeHealthy {
+		t.Fatalf("report = %+v, want healthy", report)
+	}
+}
+
+func TestReconcileDirtyWorktreeRecordsRepairWithoutTouchingIt(t *testing.T) {
+	home := reconcileFixture(t)
+	path := filepath.Join(home, "leased")
+	if err := os.WriteFile(path, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: path, LeaseID: "lease-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+	result, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeDirty || result.Results[0].Outcome != reconcileOutcomeRepair {
+		t.Fatalf("repair result = %+v history=%+v", result, history.Task)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != "keep" {
+		t.Fatalf("dirty worktree changed: %q %v", got, err)
+	}
+}
+
+func TestReconcileRecordedPaneWithoutLaunchEvidenceRefusesToRelaunch(t *testing.T) {
+	home := reconcileFixture(t)
+	client := &healthyReconcileHerdr{}
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(client, nil)
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Outcome != reconcileOutcomeRepair || history.Task.RepairCode != repairCodeProvisioningLaunchAmbiguous || client.runs != 0 {
+		t.Fatalf("result=%+v history=%+v runs=%d, want durable ambiguity and no relaunch", report, history.Task, client.runs)
+	}
+}
+
+func TestReconcileSubmittedLaunchConfirmsExistingPaneWithoutRelaunch(t *testing.T) {
+	home := reconcileFixture(t)
+	client := &healthyReconcileHerdr{}
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(client, nil)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.ActiveAttempt.LaunchConfirmedAt == "" || client.runs != 0 {
+		t.Fatalf("history=%+v runs=%d, want confirmed same Attempt without PaneRun", history, client.runs)
+	}
+}
+
+func TestReconcileRunningMissingPaneRecordsRepairWithoutReplacement(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeRunningPaneMissing || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history=%+v, want running Attempt and repair marker", history)
+	}
+}
+
+func TestReconcileTerminalOwnedResourcesCleansEachResourceOnce(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	client := &healthyReconcileHerdr{}
+	r := reconcileRuntime(client, nil)
+	returns := 0
+	r.deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+		returns++
+		if path != "/pool/1" || leaseID != "lease-1" || force {
+			t.Fatalf("returnWithID(%q, %q, %t), want exact clean lease", path, leaseID, force)
+		}
+		return nil
+	}
+	first, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Results[0].Outcome != reconcileOutcomeHealthy || returns != 1 || client.closed != 1 || history.Attempts[0].TeardownHerdrState != state.TeardownResourceReleased || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased {
+		t.Fatalf("first=%+v returns=%d closes=%d attempt=%+v", first, returns, client.closed, history.Attempts[0])
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if returns != 1 || client.closed != 1 {
+		t.Fatalf("second reconcile repeated cleanup: returns=%d closes=%d", returns, client.closed)
+	}
+}
+
+func TestReconcileTerminalDirtyWorktreeRefusesCleanup(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Worktree: "/pool/1", LeaseID: "lease-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err == nil {
+		t.Fatal("MarkAttemptRunning succeeded without launch evidence")
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	returns := 0
+	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeDirty || returns != 0 || history.Attempts[0].TeardownWorktreeState == state.TeardownResourceReleased {
+		t.Fatalf("history=%+v returns=%d, want dirty repair without return", history, returns)
+	}
+}
+
+func TestReconcileTerminalIncompleteHerdrIdentityNeedsRepair(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{WorkspaceID: "ws-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "teardown-resource-ambiguous" {
+		t.Fatalf("repair code = %q, want incomplete Herdr ownership repair", history.Task.RepairCode)
+	}
+}
+
+func TestReconcileReusedTerminalLeaseDoesNotReturnNewOwner(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Worktree: "/pool/1", LeaseID: "old-lease",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeLease = func(string, string) (worktree.LeaseObservation, error) {
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}, nil
+	}
+	returns := 0
+	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "worktree-ownership-mismatch" || returns != 0 {
+		t.Fatalf("history=%+v returns=%d, want mismatch repair without touching new lease", history, returns)
+	}
+}
+
+func TestReconcilePromotionCrashCleansScoutBeforeShipLaunch(t *testing.T) {
+	home := reconcileFixture(t)
+	scout, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/scout", LeaseID: "scout-lease", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", scout.ID); err != nil {
+		t.Fatal(err)
+	}
+	ship, err := state.PromoteTask(home, "task-1", scout.ID, state.AttemptRunning, state.Attempt{
+		Lifecycle: state.AttemptProvisioning, Harness: "codex", Model: "gpt-5.6-codex", Effort: "high", ExecutionClass: "deep", PlannedAgainst: "base-2", RequestedProfile: "ship-profile", RoutingSource: "route",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &healthyReconcileHerdr{}
+	r := reconcileRuntime(client, nil)
+	returns := 0
+	r.deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+		returns++
+		if path != "/scout" || leaseID != "scout-lease" || force {
+			t.Fatalf("scout return = %q %q %t", path, leaseID, force)
+		}
+		return nil
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != ship.ID || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.Attempts[0].TeardownHerdrState != state.TeardownResourceReleased || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || returns != 1 || client.runs != 1 {
+		t.Fatalf("history=%+v returns=%d runs=%d, want cleaned scout and running same ship Attempt %d", history, returns, client.runs, ship.ID)
+	}
+	if history.ActiveAttempt.Harness != "codex" || history.ActiveAttempt.Model != "gpt-5.6-codex" || history.ActiveAttempt.RequestedProfile != "ship-profile" {
+		t.Fatalf("ship routing changed during recovery: %+v", history.ActiveAttempt)
+	}
+}
+
+func TestReconcilePromotionDirtyScoutBlocksShipLaunch(t *testing.T) {
+	home := reconcileFixture(t)
+	scout, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/scout", LeaseID: "scout-lease", LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", scout.ID); err != nil {
+		t.Fatal(err)
+	}
+	ship, err := state.PromoteTask(home, "task-1", scout.ID, state.AttemptRunning, state.Attempt{Lifecycle: state.AttemptProvisioning, Harness: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeDirty || history.ActiveAttempt == nil || history.ActiveAttempt.ID != ship.ID || history.ActiveAttempt.Lifecycle != state.AttemptProvisioning {
+		t.Fatalf("history=%+v, want scout repair and unlaunched ship Attempt %d", history, ship.ID)
+	}
+}
+
+func TestReconcilePendingTeardownCompletionResumesDurableDecision(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownDispositionForced); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownCompletionPending); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].TeardownDisposition != state.TeardownDispositionForced || history.Attempts[0].TeardownCompletionState != state.TeardownCompletionAppended {
+		t.Fatalf("teardown journal changed: %+v", history.Attempts[0])
+	}
+	record, found, err := completion.FindAttempt(home, attempt.ID)
+	if err != nil || !found || record.Detail != "attempt never launched" {
+		t.Fatalf("completion = %+v found=%t err=%v", record, found, err)
+	}
+	before, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("second reconcile appended completion: before=%d after=%d", len(before), len(after))
+	}
+}
+
+func TestReconcileCompletionStateWithoutRecordNeedsRepair(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptProvisioning, state.TeardownCompletionPending); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownCompletionAppended); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "completion-evidence-mismatch" {
+		t.Fatalf("repair code = %q, want completion mismatch", history.Task.RepairCode)
+	}
+}
+
+func TestReconcileMergeMismatchNeedsRepairWithoutRewritingHistory(t *testing.T) {
+	home := reconcileFixture(t)
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return false, nil }
+	first, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := history.Task.RepairObservedAt
+	if first.Results[0].Outcome != reconcileOutcomeRepair || history.Task.RepairCode != "merge-fact-mismatch" || !history.Task.MergeExecuted {
+		t.Fatalf("first=%+v task=%+v, want repair without history rewrite", first, history.Task)
+	}
+	second, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Results[0].Outcome != reconcileOutcomeRepair || history.Task.RepairObservedAt != observedAt {
+		t.Fatalf("repair marker churned: first=%+v second=%+v task=%+v", first, second, history.Task)
+	}
+}
+
+func TestReconcileMergeObservationFailureLeavesRepairMarkerUnchanged(t *testing.T) {
+	home := reconcileFixture(t)
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskRepair(home, "task-1", "old-code", "old reason", 1, "old-time"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return false, errors.New("GitHub unavailable") }
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err == nil {
+		t.Fatal("Reconcile succeeded through GitHub observation failure")
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "old-code" || history.Task.RepairReason != "old reason" || history.Task.RepairObservedAt != "old-time" {
+		t.Fatalf("observation failure changed repair marker: %+v", history.Task)
+	}
+}
+
+func TestReconcileResumesPartialTeardownWithoutChangingDisposition(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptCompleted, state.TeardownDispositionCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, state.AttemptRunning, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	client := &healthyReconcileHerdr{}
+	r := reconcileRuntime(client, nil)
+	returns := 0
+	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil || history.Attempts[0].TeardownDisposition != state.TeardownDispositionCompleted || history.Attempts[0].TeardownHerdrState != state.TeardownResourceReleased || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Attempts[0].TeardownCompletionState != state.TeardownCompletionAppended || returns != 1 || client.closed != 1 {
+		t.Fatalf("history=%+v returns=%d closes=%d, want resumed terminal teardown", history, returns, client.closed)
+	}
+}
+
+func reconcileFixture(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "brief.md"), []byte("brief\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://example.com/demo.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lease, error)) *Runtime {
+	if get == nil {
+		get = func(path, holder string) (worktree.Lease, error) {
+			return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
+		}
+	}
+	return &Runtime{deps: dependencies{
+		now:   func() time.Time { return time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC) },
+		herdr: func() herdrClient { return client },
+		worktree: worktreeDependencies{
+			get: get,
+			observeLease: func(string, string) (worktree.LeaseObservation, error) {
+				return worktree.LeaseObservation{State: worktree.LeaseExact}, nil
+			},
+			observeClean: func(path string) (worktree.Cleanliness, error) {
+				return worktree.Clean, nil
+			},
+			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },
+			returnWorktree: func(string, bool) error { return nil },
+			returnWithID:   func(string, string, bool) error { return nil },
+		},
+		buildHarness:     func(string, harness.Options) (string, error) { return "launch", nil },
+		confirmLaunch:    func(herdrClient, string, string) error { return nil },
+		appendCompletion: completion.Append,
+		phase:            func(lifecyclePhase) error { return nil },
+	}}
+}
+
+type healthyReconcileHerdr struct {
+	runs   int
+	closed int
+}
+
+type missingReconcileHerdr struct{ healthyReconcileHerdr }
+
+func (*missingReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
+	return herdr.Workspace{}, false, nil
+}
+
+func (f *healthyReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
+	return herdr.Workspace{WorkspaceID: "ws-1", Label: "hand:demo"}, true, nil
+}
+func (f *healthyReconcileHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+	return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, errors.New("unused")
+}
+func (f *healthyReconcileHerdr) WorkspaceClose(string) error { f.closed++; return nil }
+func (f *healthyReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
+	return []herdr.Tab{{TabID: "tab-1", WorkspaceID: "ws-1", Label: "task-1"}}, nil
+}
+func (f *healthyReconcileHerdr) TabCreate(string, string, string) (herdr.Tab, herdr.Pane, error) {
+	return herdr.Tab{TabID: "tab-1", WorkspaceID: "ws-1", Label: "task-1"}, herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1"}, nil
+}
+func (f *healthyReconcileHerdr) TabRename(string, string) error { return nil }
+func (f *healthyReconcileHerdr) TabClose(string) error          { return nil }
+func (f *healthyReconcileHerdr) PaneGet(string) (herdr.Pane, error) {
+	return herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1", Agent: "claude"}, nil
+}
+func (f *healthyReconcileHerdr) PaneRun(string, string) error         { f.runs++; return nil }
+func (f *healthyReconcileHerdr) PaneSendKeys(string, ...string) error { return nil }
+func (f *healthyReconcileHerdr) PaneRead(string, int) (string, error) { return "ready", nil }

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -186,6 +186,25 @@ func TestObserveHerdrOwnershipRequiresAllDurableIdentityEdges(t *testing.T) {
 	}
 }
 
+func TestObserveHerdrOwnershipRejectsEachIncompleteIdentity(t *testing.T) {
+	client := &reconcileHerdrClient{}
+	for name, ownership := range map[string]state.Herdr{
+		"missing workspace": {TabID: "tab-1", PaneID: "pane-1"},
+		"missing tab":       {WorkspaceID: "ws-1", PaneID: "pane-1"},
+		"missing pane":      {WorkspaceID: "ws-1", TabID: "tab-1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			observation, err := observeHerdrOwnership(client, ownership, "task-1", "demo")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if observation.State != herdrOwnershipIncomplete {
+				t.Fatalf("observation = %+v, want incomplete ownership", observation)
+			}
+		})
+	}
+}
+
 func TestObserveHerdrOwnershipPreservesObservationFailures(t *testing.T) {
 	client := &reconcileHerdrClient{err: errors.New("herdr service unavailable")}
 	_, err := observeHerdrOwnership(client, state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "task-1", "demo")
@@ -1404,7 +1423,7 @@ func (*releasedInventoryReconcileHerdr) WorkspaceList() ([]herdr.Workspace, erro
 }
 
 func (*releasedInventoryReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
-	return []herdr.Tab{{TabID: "tab-released", WorkspaceID: "ws-released", Label: "task-1"}}, nil
+	return []herdr.Tab{{TabID: "tab-released", WorkspaceID: "ws-released", Label: "malformed label"}}, nil
 }
 
 func (*releasedInventoryReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
@@ -11,6 +10,7 @@ import (
 
 type herdrClient interface {
 	FindWorkspaceByLabel(string) (herdr.Workspace, bool, error)
+	WorkspaceList() ([]herdr.Workspace, error)
 	WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error)
 	WorkspaceClose(string) error
 	TabList(string) ([]herdr.Tab, error)
@@ -163,8 +163,7 @@ func observeHerdrOwnership(client herdrClient, expected state.Herdr, taskID, pro
 }
 
 func isHerdrNotFound(err error) bool {
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "not_found") || strings.Contains(message, "not found")
+	return errors.Is(err, herdr.ErrNotFound)
 }
 
 // CloseTaskTab closes a task-owned tab without touching unrelated tabs.

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -103,8 +103,8 @@ func incompleteHerdrOwnership(ownership state.Herdr) error {
 	if ownership.WorkspaceID == "" && ownership.TabID == "" && ownership.PaneID == "" {
 		return nil
 	}
-	if ownership.WorkspaceID == "" || ownership.TabID == "" {
-		return fmt.Errorf("workspace and tab identity are incomplete (workspace=%q, tab=%q, pane=%q)", ownership.WorkspaceID, ownership.TabID, ownership.PaneID)
+	if ownership.WorkspaceID == "" || ownership.TabID == "" || ownership.PaneID == "" {
+		return fmt.Errorf("workspace, tab, and pane identity are incomplete (workspace=%q, tab=%q, pane=%q)", ownership.WorkspaceID, ownership.TabID, ownership.PaneID)
 	}
 	return nil
 }

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
@@ -106,6 +107,64 @@ func incompleteHerdrOwnership(ownership state.Herdr) error {
 		return fmt.Errorf("workspace and tab identity are incomplete (workspace=%q, tab=%q, pane=%q)", ownership.WorkspaceID, ownership.TabID, ownership.PaneID)
 	}
 	return nil
+}
+
+func hasHerdrIdentity(ownership state.Herdr) bool {
+	return ownership.WorkspaceID != "" || ownership.TabID != "" || ownership.PaneID != ""
+}
+
+func observeHerdrOwnership(client herdrClient, expected state.Herdr, taskID, projectName string) (herdrObservation, error) {
+	if err := incompleteHerdrOwnership(expected); err != nil {
+		return herdrObservation{State: herdrOwnershipIncomplete}, nil
+	}
+	if expected.WorkspaceID == "" && expected.TabID == "" && expected.PaneID == "" {
+		return herdrObservation{State: herdrOwnershipUnobserved}, nil
+	}
+	workspace, found, err := client.FindWorkspaceByLabel(herdrWorkspaceLabel(projectName))
+	if err != nil {
+		return herdrObservation{}, fmt.Errorf("find Herdr workspace: %w", err)
+	}
+	if !found {
+		return herdrObservation{State: herdrOwnershipAbsent}, nil
+	}
+	if workspace.WorkspaceID != expected.WorkspaceID || workspace.Label != herdrWorkspaceLabel(projectName) {
+		return herdrObservation{State: herdrOwnershipMismatch}, nil
+	}
+	tabs, err := client.TabList(workspace.WorkspaceID)
+	if err != nil {
+		return herdrObservation{}, fmt.Errorf("list Herdr tabs: %w", err)
+	}
+	var tab herdr.Tab
+	foundTab := false
+	for _, candidate := range tabs {
+		if candidate.TabID == expected.TabID {
+			tab = candidate
+			foundTab = true
+			break
+		}
+	}
+	if !foundTab {
+		return herdrObservation{State: herdrOwnershipAbsent}, nil
+	}
+	if tab.WorkspaceID != expected.WorkspaceID || tab.Label != taskID {
+		return herdrObservation{State: herdrOwnershipMismatch}, nil
+	}
+	pane, err := client.PaneGet(expected.PaneID)
+	if err != nil {
+		if isHerdrNotFound(err) {
+			return herdrObservation{State: herdrOwnershipAbsent}, nil
+		}
+		return herdrObservation{}, fmt.Errorf("read Herdr pane: %w", err)
+	}
+	if pane.PaneID != expected.PaneID || pane.TabID != expected.TabID || pane.WorkspaceID != expected.WorkspaceID {
+		return herdrObservation{State: herdrOwnershipMismatch}, nil
+	}
+	return herdrObservation{State: herdrOwnershipExact, Agent: pane.Agent}, nil
+}
+
+func isHerdrNotFound(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not_found") || strings.Contains(message, "not found")
 }
 
 // CloseTaskTab closes a task-owned tab without touching unrelated tabs.

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -390,8 +390,8 @@ func TestReopenSchemaV10MigratesOnlyAfterValidRouting(t *testing.T) {
 	if _, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatalf("Reopen() = %v, want schema v10 upgrade after route validation", err)
 	}
-	if got := runtimeStoreSchemaVersion(t, home); got != 11 {
-		t.Fatalf("schema version after valid Reopen = %d, want 11", got)
+	if got := runtimeStoreSchemaVersion(t, home); got != 12 {
+		t.Fatalf("schema version after valid Reopen = %d, want 12", got)
 	}
 }
 
@@ -414,8 +414,8 @@ func TestPromoteSchemaV10MigratesOnlyAfterValidRouting(t *testing.T) {
 	if _, err := r.Promote(context.Background(), PromoteRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatalf("Promote() = %v, want schema v10 upgrade after route validation", err)
 	}
-	if got := runtimeStoreSchemaVersion(t, home); got != 11 {
-		t.Fatalf("schema version after valid Promote = %d, want 11", got)
+	if got := runtimeStoreSchemaVersion(t, home); got != 12 {
+		t.Fatalf("schema version after valid Promote = %d, want 12", got)
 	}
 }
 
@@ -519,6 +519,11 @@ func downgradeRuntimeStoreToV10(t *testing.T, home string) {
 	defer func() { _ = db.Close() }()
 	for _, column := range []string{"execution_class", "planned_against", "requested_profile", "routing_source"} {
 		if _, err := db.Exec("ALTER TABLE attempt DROP COLUMN " + column); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, column := range []string{"repair_code", "repair_reason", "repair_attempt_id", "repair_observed_at"} {
+		if _, err := db.Exec("ALTER TABLE task DROP COLUMN " + column); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -354,6 +354,24 @@ func SetTaskReportState(homeDir, id string, offset int64, digest string, mergeAn
 	return db.SetTaskReportState(id, offset, digest, mergeAnnounced)
 }
 
+func SetTaskRepair(homeDir, id, code, reason string, attemptID int64, observedAt string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskRepair(id, code, reason, attemptID, observedAt)
+}
+
+func ClearTaskRepair(homeDir, id, expectedCode string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ClearTaskRepair(id, expectedCode)
+}
+
 func RecordAttemptWorktree(homeDir, taskID string, attemptID int64, worktree, leaseID string) error {
 	db, err := store.Open(homeDir)
 	if err != nil {
@@ -502,6 +520,24 @@ func ListOpenHistories(homeDir string) ([]TaskHistory, error) {
 	}
 	defer func() { _ = db.Close() }()
 	return db.ListOpenTaskHistories()
+}
+
+func ListReconciliationHistories(homeDir string) ([]TaskHistory, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ListReconciliationHistories()
+}
+
+func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) {
+	db, err := store.OpenReadOnly(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ListReconciliationHistories()
 }
 
 // ListOpenHistoriesReadOnly is ListOpenHistories for a presentation reader: same open-only fleet, off

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -540,6 +540,15 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	return db.ListReconciliationHistories()
 }
 
+func ListHerdrOwnerships(homeDir string) ([]Herdr, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+	return db.ListHerdrOwnerships()
+}
+
 // ListOpenHistoriesReadOnly is ListOpenHistories for a presentation reader: same open-only fleet, off
 // a handle that cannot create schema or import legacy state. A torn-down task is history, not fleet.
 func ListOpenHistoriesReadOnly(homeDir string) ([]TaskHistory, error) {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -540,7 +540,7 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	return db.ListReconciliationHistories()
 }
 
-func ListHerdrOwnerships(homeDir string) ([]Herdr, error) {
+func ListHerdrOwnerships(homeDir string) ([]HerdrOwnership, error) {
 	db, err := store.Open(homeDir)
 	if err != nil {
 		return nil, err

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -43,6 +43,59 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRepairMarkerRequiresMatchingEvidenceToClear(t *testing.T) {
+	home := t.TempDir()
+	if _, err := CreateTaskWithAttempt(home, Task{ID: "task-1", Project: "demo", Kind: KindShip, Brief: "data/task-1/brief.md"}, Attempt{
+		TaskID: "task-1", Lifecycle: AttemptProvisioning, Harness: "claude",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetTaskRepair(home, "task-1", "running-pane-missing", "persisted running Attempt has no matching Herdr pane", 1, "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClearTaskRepair(home, "task-1", "different-code"); err == nil {
+		t.Fatal("ClearTaskRepair with stale code succeeded")
+	}
+	history, err := ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "running-pane-missing" || history.Task.RepairAttemptID != 1 {
+		t.Fatalf("stale clear changed repair marker: %+v", history.Task)
+	}
+	if err := ClearTaskRepair(home, "task-1", "running-pane-missing"); err != nil {
+		t.Fatal(err)
+	}
+	history, err = ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "" || history.Task.RepairReason != "" || history.Task.RepairAttemptID != 0 || history.Task.RepairObservedAt != "" {
+		t.Fatalf("matching clear left repair marker: %+v", history.Task)
+	}
+}
+
+func TestListReconciliationHistoriesIsSortedAndIncludesRepairTasks(t *testing.T) {
+	home := t.TempDir()
+	for _, id := range []string{"zebra", "apple"} {
+		if _, err := CreateTaskWithAttempt(home, Task{ID: id, Project: "demo", Kind: KindShip, Brief: "data/" + id + "/brief.md"}, Attempt{
+			TaskID: id, Lifecycle: AttemptProvisioning, Harness: "claude",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := SetTaskRepair(home, "zebra", "worktree-dirty", "worktree is dirty", 2, "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	histories, err := ListReconciliationHistories(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(histories) != 2 || histories[0].Task.ID != "apple" || histories[1].Task.ID != "zebra" {
+		t.Fatalf("candidate order = %+v", histories)
+	}
+}
+
 func TestReadHistoryReadOnlySupportsSchemaV10(t *testing.T) {
 	home := t.TempDir()
 	if _, err := CreateTaskWithAttempt(home, Task{ID: "task-1", Project: "demo", Kind: KindShip, Brief: "data/task-1/brief.md"}, Attempt{

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -96,6 +96,36 @@ func TestListReconciliationHistoriesIsSortedAndIncludesRepairTasks(t *testing.T)
 	}
 }
 
+func TestListHerdrOwnershipsIncludesLifecycleAndTeardownMetadata(t *testing.T) {
+	home := t.TempDir()
+	attempt, err := CreateTaskWithAttempt(home, Task{ID: "task-1", Project: "demo", Kind: KindShip, Brief: "data/task-1/brief.md"}, Attempt{
+		TaskID: "task-1", Lifecycle: AttemptProvisioning, Harness: "claude", Herdr: Herdr{Session: "default", WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, AttemptProvisioning, AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetAttemptTeardownResourceState(home, "task-1", attempt.ID, AttemptInterrupted, "herdr", TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetAttemptTeardownResourceState(home, "task-1", attempt.ID, AttemptInterrupted, "herdr", TeardownResourceReleased); err != nil {
+		t.Fatal(err)
+	}
+	ownerships, err := ListHerdrOwnerships(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ownerships) != 1 {
+		t.Fatalf("ownerships = %+v, want one row", ownerships)
+	}
+	got := ownerships[0]
+	if got.AttemptID != attempt.ID || got.TaskID != "task-1" || got.Lifecycle != AttemptInterrupted || got.TeardownHerdrState != TeardownResourceReleased || got.WorkspaceID != "ws-1" || got.TabID != "tab-1" || got.PaneID != "pane-1" {
+		t.Fatalf("ownership = %+v, want durable lifecycle and teardown metadata", got)
+	}
+}
+
 func TestReadHistoryReadOnlySupportsSchemaV10(t *testing.T) {
 	home := t.TempDir()
 	if _, err := CreateTaskWithAttempt(home, Task{ID: "task-1", Project: "demo", Kind: KindShip, Brief: "data/task-1/brief.md"}, Attempt{

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -20,6 +20,7 @@ const (
 // to, and a second definition would be one more place to forget a field.
 type (
 	Herdr            = store.Herdr
+	HerdrOwnership   = store.HerdrOwnership
 	Task             = store.Task
 	Attempt          = store.Attempt
 	TaskHistory      = store.TaskHistory

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -174,6 +174,9 @@ func readLegacyTask(path, id string) (legacyTask, error) {
 // import: a source that stays on disk afterwards cannot use its own absence as
 // the done marker.
 func (db *DB) Migrated(key string) (bool, error) {
+	if db.empty {
+		return false, nil
+	}
 	value, err := db.meta("migrated:" + key)
 	return value != "", err
 }

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -35,18 +35,21 @@ func legacyTaskFiles(homeDir string) ([]string, error) {
 // Reading the JSON directly is the point: recovering an existing fleet must
 // not depend on the binary that wrote it still working. A second run is a
 // no-op, because it finds no JSON left to import.
-func (db *DB) migrateLegacy() error {
+func (db *DB) migrateLegacy(archive bool) error {
 	names, err := legacyTaskFiles(db.home)
 	if err != nil || len(names) == 0 {
 		return err
 	}
 	// Unlocked, a process that parsed a file before another one imported it and
 	// deleted the row lands its own insert afterwards and resurrects the task.
-	unlock, err := Lock(db.home, MigrationLock, false)
-	if err != nil {
-		return fmt.Errorf("lock migration: %w", err)
+	var unlock func()
+	if archive {
+		unlock, err = Lock(db.home, MigrationLock, false)
+		if err != nil {
+			return fmt.Errorf("lock migration: %w", err)
+		}
+		defer unlock()
 	}
-	defer unlock()
 
 	names, err = legacyTaskFiles(db.home)
 	if err != nil || len(names) == 0 {
@@ -99,6 +102,9 @@ func (db *DB) migrateLegacy() error {
 		}
 	}
 
+	if !archive {
+		return nil
+	}
 	if err := os.MkdirAll(LegacyDir(db.home), 0o755); err != nil {
 		return fmt.Errorf("create migrated directory: %w", err)
 	}

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -110,6 +110,10 @@ var migrations = []string{
 	ALTER TABLE attempt ADD COLUMN planned_against TEXT NOT NULL DEFAULT '';
 	ALTER TABLE attempt ADD COLUMN requested_profile TEXT NOT NULL DEFAULT '';
 	ALTER TABLE attempt ADD COLUMN routing_source TEXT NOT NULL DEFAULT '';`,
+	`ALTER TABLE task ADD COLUMN repair_code TEXT NOT NULL DEFAULT '';
+	ALTER TABLE task ADD COLUMN repair_reason TEXT NOT NULL DEFAULT '';
+	ALTER TABLE task ADD COLUMN repair_attempt_id INTEGER NOT NULL DEFAULT 0;
+	ALTER TABLE task ADD COLUMN repair_observed_at TEXT NOT NULL DEFAULT '';`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -121,6 +125,8 @@ const launchEvidenceVersion = splitVersion + 1
 const teardownEvidenceVersion = launchEvidenceVersion + 1
 
 const routingProvenanceVersion = teardownEvidenceVersion + 1
+
+const repairMetadataVersion = routingProvenanceVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -153,6 +159,14 @@ func (db *DB) hasRoutingProvenanceColumns() (bool, error) {
 	var count int
 	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name IN ('execution_class', 'planned_against', 'requested_profile', 'routing_source')`).Scan(&count); err != nil {
 		return false, fmt.Errorf("detect routing provenance columns: %w", err)
+	}
+	return count == 4, nil
+}
+
+func (db *DB) hasRepairMetadataColumns() (bool, error) {
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name IN ('repair_code', 'repair_reason', 'repair_attempt_id', 'repair_observed_at')`).Scan(&count); err != nil {
+		return false, fmt.Errorf("detect repair metadata columns: %w", err)
 	}
 	return count == 4, nil
 }
@@ -248,6 +262,13 @@ func (db *DB) migrateSchema() error {
 					}
 					if routingComplete && latest >= routingProvenanceVersion {
 						stamp = routingProvenanceVersion
+						repairComplete, err := db.hasRepairMetadataColumns()
+						if err != nil {
+							return err
+						}
+						if repairComplete && latest >= repairMetadataVersion {
+							stamp = repairMetadataVersion
+						}
 					}
 				}
 			}

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -40,6 +40,69 @@ func TestFreshSchemaIncludesAttemptRoutingProvenance(t *testing.T) {
 	}
 }
 
+func TestFreshSchemaIncludesTaskRepairMetadata(t *testing.T) {
+	db, _ := openTemp(t)
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name IN ('repair_code', 'repair_reason', 'repair_attempt_id', 'repair_observed_at')`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 4 {
+		t.Fatalf("task repair columns = %d, want 4", count)
+	}
+}
+
+func TestMigrationV12AddsEmptyTaskRepairMetadata(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &DB{sql: sqlDB, home: home}
+	preV12Schema := strings.NewReplacer(
+		"\tcreated_at        TEXT NOT NULL DEFAULT '',\n", "\tcreated_at        TEXT NOT NULL DEFAULT ''\n",
+		"\trepair_code       TEXT NOT NULL DEFAULT '',\n", "",
+		"\trepair_reason     TEXT NOT NULL DEFAULT '',\n", "",
+		"\trepair_attempt_id INTEGER NOT NULL DEFAULT 0,\n\trepair_observed_at TEXT NOT NULL DEFAULT ''\n", "",
+	).Replace(schema)
+	if _, err := db.sql.Exec(preV12Schema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle, created_at) VALUES ('legacy', 'demo', 'ship', 'open', '2026-08-15T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle, harness, model, effort, execution_class, planned_against, requested_profile, routing_source) VALUES ('legacy', 1, 'running', 'claude', 'opus', 'high', 'deep', 'base', 'brain', 'route')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE task SET active_attempt_id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = 11`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = migrated.Close() }()
+	if version, err := migrated.schemaVersion(); err != nil || version != 12 {
+		t.Fatalf("schemaVersion = %d, %v, want 12", version, err)
+	}
+	history, found, err := migrated.ReadTaskHistory("legacy")
+	if err != nil || !found || history.ActiveAttempt == nil {
+		t.Fatalf("ReadTaskHistory = %+v, %v, %v", history, found, err)
+	}
+	if history.Task.RepairCode != "" || history.Task.RepairReason != "" || history.Task.RepairAttemptID != 0 || history.Task.RepairObservedAt != "" {
+		t.Fatalf("migration invented repair state: %+v", history.Task)
+	}
+	if got := history.ActiveAttempt; got.Harness != "claude" || got.Model != "opus" || got.Effort != "high" || got.ExecutionClass != "deep" || got.PlannedAgainst != "base" || got.RequestedProfile != "brain" || got.RoutingSource != "route" {
+		t.Fatalf("migration lost Attempt execution identity: %+v", got)
+	}
+}
+
 func TestMigrationV11AddsEmptyAttemptRoutingProvenance(t *testing.T) {
 	home := t.TempDir()
 	sqlDB, err := open(Path(home))
@@ -48,10 +111,14 @@ func TestMigrationV11AddsEmptyAttemptRoutingProvenance(t *testing.T) {
 	}
 	db := &DB{sql: sqlDB, home: home}
 	preV11Schema := strings.NewReplacer(
+		"\tcreated_at        TEXT NOT NULL DEFAULT '',\n", "\tcreated_at        TEXT NOT NULL DEFAULT ''\n",
 		"\texecution_class        TEXT NOT NULL DEFAULT '',\n", "",
 		"\tplanned_against        TEXT NOT NULL DEFAULT '',\n", "",
 		"\trequested_profile      TEXT NOT NULL DEFAULT '',\n", "",
 		"\trouting_source        TEXT NOT NULL DEFAULT '',\n", "",
+		"\trepair_code       TEXT NOT NULL DEFAULT '',\n", "",
+		"\trepair_reason     TEXT NOT NULL DEFAULT '',\n", "",
+		"\trepair_attempt_id INTEGER NOT NULL DEFAULT 0,\n\trepair_observed_at TEXT NOT NULL DEFAULT ''\n", "",
 	).Replace(schema)
 	if _, err := db.sql.Exec(preV11Schema); err != nil {
 		t.Fatal(err)
@@ -74,8 +141,8 @@ func TestMigrationV11AddsEmptyAttemptRoutingProvenance(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = migrated.Close() }()
-	if version, err := migrated.schemaVersion(); err != nil || version != 11 {
-		t.Fatalf("schemaVersion = %d, %v, want 11", version, err)
+	if version, err := migrated.schemaVersion(); err != nil || version != 12 {
+		t.Fatalf("schemaVersion = %d, %v, want 12", version, err)
 	}
 	history, found, err := migrated.ReadTaskHistory("legacy")
 	if err != nil || !found || len(history.Attempts) != 1 {
@@ -90,7 +157,7 @@ func TestMigrationV11AddsEmptyAttemptRoutingProvenance(t *testing.T) {
 	}
 }
 
-func TestUnstampedCurrentSchemaDetectsRoutingProvenance(t *testing.T) {
+func TestUnstampedCurrentSchemaDetectsLatestLayout(t *testing.T) {
 	home := t.TempDir()
 	db, err := Open(home)
 	if err != nil {
@@ -108,8 +175,8 @@ func TestUnstampedCurrentSchemaDetectsRoutingProvenance(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = reopened.Close() }()
-	if version, err := reopened.schemaVersion(); err != nil || version != routingProvenanceVersion {
-		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, routingProvenanceVersion)
+	if version, err := reopened.schemaVersion(); err != nil || version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, len(migrations))
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -196,8 +196,9 @@ func Path(homeDir string) string {
 }
 
 type DB struct {
-	sql  *sql.DB
-	home string
+	sql   *sql.DB
+	home  string
+	empty bool
 }
 
 // The version-0 baseline plus every registered migration folded in: a column
@@ -350,6 +351,26 @@ func OpenReadOnly(homeDir string) (*DB, error) {
 		return nil, err
 	}
 	latest := len(migrations)
+	empty, err := db.isNewDatabase()
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if empty {
+		entries, err := os.ReadDir(Dir(homeDir))
+		if err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+		for _, entry := range entries {
+			if filepath.Ext(entry.Name()) == ".json" {
+				_ = db.Close()
+				return nil, fmt.Errorf("state/hand.db is schema version %d, older than this build of hand requires (version %d) - run `hand init %s` before opening it read-only", current, latest, shellquote.Quote(homeDir))
+			}
+		}
+		db.empty = true
+		return db, nil
+	}
 	if err := schemaVersionError(current, latest); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -375,6 +396,15 @@ func openReadOnlyForLifecycle(homeDir string) (*DB, int, error) {
 	if err := schemaVersionError(current, latest); err != nil {
 		_ = db.Close()
 		return nil, 0, err
+	}
+	empty, err := db.isNewDatabase()
+	if err != nil {
+		_ = db.Close()
+		return nil, 0, err
+	}
+	if empty {
+		db.empty = true
+		return db, current, nil
 	}
 	if current < teardownEvidenceVersion {
 		_ = db.Close()
@@ -598,6 +628,9 @@ func (db *DB) ListTasks() ([]Task, error) {
 }
 
 func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
 	task, found, err := db.ReadTask(id)
 	if err != nil || !found {
 		return TaskHistory{}, found, err
@@ -614,12 +647,15 @@ func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
 		}
 	}
 	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
-		return TaskHistory{}, false, fmt.Errorf("task %q active attempt %d not found", id, task.ActiveAttemptID)
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
 	}
 	return history, true, nil
 }
 
 func (db *DB) readTaskHistoryBeforeRouting(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
 	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeRepair+` FROM task WHERE id = ?`, id)
 	task, err := scanTaskBeforeRepair(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -632,6 +668,9 @@ func (db *DB) readTaskHistoryBeforeRouting(id string) (TaskHistory, bool, error)
 }
 
 func (db *DB) readTaskHistoryBeforeRepair(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
 	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeRepair+` FROM task WHERE id = ?`, id)
 	task, err := scanTaskBeforeRepair(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -661,7 +700,7 @@ func (db *DB) readTaskHistoryBeforeRepair(id string) (TaskHistory, bool, error) 
 		}
 	}
 	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
-		return TaskHistory{}, false, fmt.Errorf("task %q active attempt %d not found", id, task.ActiveAttemptID)
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
 	}
 	return history, true, nil
 }
@@ -691,12 +730,15 @@ func (db *DB) readTaskHistoryBeforeRoutingWithTask(task Task) (TaskHistory, bool
 		}
 	}
 	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
-		return TaskHistory{}, false, fmt.Errorf("task %q active attempt %d not found", task.ID, task.ActiveAttemptID)
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", task.ID, task.ActiveAttemptID)
 	}
 	return history, true, nil
 }
 
 func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
 	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("list open tasks: %w", err)
@@ -733,6 +775,9 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 }
 
 func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
 	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
 		SELECT 1 FROM attempt
 		WHERE attempt.task_id = task.id
@@ -1588,6 +1633,9 @@ func (db *DB) DeleteTask(id string) error {
 }
 
 func (db *DB) ListProjects() ([]Project, error) {
+	if db.empty {
+		return nil, nil
+	}
 	rows, err := db.sql.Query(`SELECT name, url, mode, upstream FROM project ORDER BY position, name`)
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
@@ -1703,6 +1751,9 @@ func (db *DB) SetHoldIfNotOtherKind(h Hold) (bool, error) {
 }
 
 func (db *DB) ReadHold(id string) (Hold, bool, error) {
+	if db.empty {
+		return Hold{}, false, nil
+	}
 	row := db.sql.QueryRow(`SELECT `+holdColumns+` FROM hold WHERE id = ?`, id)
 	h, err := scanHold(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1718,6 +1769,9 @@ func (db *DB) ReadHold(id string) (Hold, bool, error) {
 // being consistent with kind, would let a row an external write left inconsistent disappear
 // from "what is held" instead of being reported as a hold that needs attention.
 func (db *DB) ListHolds() ([]Hold, error) {
+	if db.empty {
+		return nil, nil
+	}
 	rows, err := db.sql.Query(`SELECT ` + holdColumns + ` FROM hold ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("list holds: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -320,7 +320,7 @@ func Open(homeDir string) (*DB, error) {
 		_ = sqlDB.Close()
 		return nil, err
 	}
-	if err := db.migrateLegacy(); err != nil {
+	if err := db.migrateLegacy(true); err != nil {
 		_ = sqlDB.Close()
 		return nil, err
 	}
@@ -341,6 +341,30 @@ func openReadOnly(homeDir string) (*DB, error) {
 // Presentation readers use an existing-file handle so SELECTs cannot create schema or
 // import legacy state. An older layout has to cross an explicit migration boundary first.
 func OpenReadOnly(homeDir string) (*DB, error) {
+	if _, err := os.Stat(Path(homeDir)); os.IsNotExist(err) {
+		sqlDB, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			return nil, fmt.Errorf("open read-only state: %w", err)
+		}
+		sqlDB.SetMaxOpenConns(1)
+		db := &DB{sql: sqlDB, home: homeDir, empty: true}
+		if err := db.createSchema(true, len(migrations)); err != nil {
+			_ = sqlDB.Close()
+			return nil, err
+		}
+		if err := db.migrateLegacy(false); err != nil {
+			_ = sqlDB.Close()
+			return nil, err
+		}
+		db.empty = false
+		if _, err := sqlDB.Exec("PRAGMA query_only = 1"); err != nil {
+			_ = sqlDB.Close()
+			return nil, fmt.Errorf("set read-only state: %w", err)
+		}
+		return db, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("check %s: %w", Path(homeDir), err)
+	}
 	db, err := openReadOnly(homeDir)
 	if err != nil {
 		return nil, err
@@ -383,6 +407,15 @@ func OpenReadOnly(homeDir string) (*DB, error) {
 }
 
 func openReadOnlyForLifecycle(homeDir string) (*DB, int, error) {
+	if _, err := os.Stat(Path(homeDir)); os.IsNotExist(err) {
+		db, err := OpenReadOnly(homeDir)
+		if err != nil {
+			return nil, 0, err
+		}
+		return db, len(migrations), nil
+	} else if err != nil {
+		return nil, 0, fmt.Errorf("check %s: %w", Path(homeDir), err)
+	}
 	db, err := openReadOnly(homeDir)
 	if err != nil {
 		return nil, 0, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -90,21 +90,25 @@ const (
 )
 
 type Task struct {
-	ID              string        `json:"id"`
-	Project         string        `json:"project"`
-	Kind            string        `json:"kind"`
-	Brief           string        `json:"brief"`
-	Lifecycle       TaskLifecycle `json:"lifecycle"`
-	ActiveAttemptID int64         `json:"active_attempt_id"`
-	PR              string        `json:"pr"`
-	MergeExecuted   bool          `json:"merged"`
-	MergeExecutedAt string        `json:"merged_at"`
-	ReportOffset    int64         `json:"report_offset"`
-	ReportDigest    string        `json:"report_digest"`
-	MergeAnnounced  bool          `json:"pr_merged_observed"`
-	DeliveredAt     string        `json:"delivered_at"`
-	DeliveredReason string        `json:"delivered_reason"`
-	CreatedAt       string        `json:"created_at"`
+	ID               string        `json:"id"`
+	Project          string        `json:"project"`
+	Kind             string        `json:"kind"`
+	Brief            string        `json:"brief"`
+	Lifecycle        TaskLifecycle `json:"lifecycle"`
+	ActiveAttemptID  int64         `json:"active_attempt_id"`
+	PR               string        `json:"pr"`
+	MergeExecuted    bool          `json:"merged"`
+	MergeExecutedAt  string        `json:"merged_at"`
+	ReportOffset     int64         `json:"report_offset"`
+	ReportDigest     string        `json:"report_digest"`
+	MergeAnnounced   bool          `json:"pr_merged_observed"`
+	DeliveredAt      string        `json:"delivered_at"`
+	DeliveredReason  string        `json:"delivered_reason"`
+	CreatedAt        string        `json:"created_at"`
+	RepairCode       string        `json:"repair_code"`
+	RepairReason     string        `json:"repair_reason"`
+	RepairAttemptID  int64         `json:"repair_attempt_id"`
+	RepairObservedAt string        `json:"repair_observed_at"`
 }
 
 type Attempt struct {
@@ -204,7 +208,11 @@ CREATE TABLE IF NOT EXISTS task (
 	delivered_reason  TEXT NOT NULL DEFAULT '',
 	report_offset     INTEGER NOT NULL DEFAULT 0,
 	report_digest     TEXT NOT NULL DEFAULT '',
-	created_at        TEXT NOT NULL DEFAULT ''
+	created_at        TEXT NOT NULL DEFAULT '',
+	repair_code       TEXT NOT NULL DEFAULT '',
+	repair_reason     TEXT NOT NULL DEFAULT '',
+	repair_attempt_id INTEGER NOT NULL DEFAULT 0,
+	repair_observed_at TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS attempt (
 	id                     INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -375,6 +383,9 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
+	if current == repairMetadataVersion-1 {
+		return db.readTaskHistoryBeforeRepair(id)
+	}
 	return db.readTaskHistoryBeforeRouting(id)
 }
 
@@ -417,10 +428,12 @@ func (db *DB) setMeta(key, value string) error {
 var taskColumnNames = []string{
 	"id", "project", "kind", "brief", "lifecycle", "active_attempt_id", "pr",
 	"merge_executed", "merge_executed_at", "merge_announced", "delivered_at", "delivered_reason",
-	"report_offset", "report_digest", "created_at",
+	"report_offset", "report_digest", "created_at", "repair_code", "repair_reason", "repair_attempt_id", "repair_observed_at",
 }
 
 var taskColumns = strings.Join(taskColumnNames, ", ")
+
+var taskColumnsBeforeRepair = strings.Join(taskColumnNames[:len(taskColumnNames)-4], ", ")
 
 var attemptColumnNames = []string{
 	"id", "task_id", "ordinal", "lifecycle", "harness", "model", "effort",
@@ -443,7 +456,7 @@ func placeholders(count int) string {
 func taskValues(t Task) []any {
 	return []any{t.ID, t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
-		t.ReportOffset, t.ReportDigest, t.CreatedAt}
+		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt}
 }
 
 func nullableAttemptID(id int64) any {
@@ -454,6 +467,21 @@ func nullableAttemptID(id int64) any {
 }
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
+	var t Task
+	var activeID sql.NullInt64
+	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
+		&t.MergeExecuted, &t.MergeExecutedAt, &t.MergeAnnounced, &t.DeliveredAt, &t.DeliveredReason,
+		&t.ReportOffset, &t.ReportDigest, &t.CreatedAt, &t.RepairCode, &t.RepairReason, &t.RepairAttemptID, &t.RepairObservedAt)
+	if activeID.Valid {
+		t.ActiveAttemptID = activeID.Int64
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	return t, err
+}
+
+func scanTaskBeforeRepair(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
 	var activeID sql.NullInt64
 	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
@@ -527,10 +555,10 @@ func (db *DB) CreateTask(t Task) error {
 func (db *DB) UpdateTask(t Task) error {
 	_, err := db.sql.Exec(`UPDATE task SET project = ?, kind = ?, brief = ?,
 		pr = ?, merge_executed = ?, merge_executed_at = ?, merge_announced = ?, delivered_at = ?, delivered_reason = ?,
-		report_offset = ?, report_digest = ?, created_at = ? WHERE id = ?`,
+		report_offset = ?, report_digest = ?, created_at = ?, repair_code = ?, repair_reason = ?, repair_attempt_id = ?, repair_observed_at = ? WHERE id = ?`,
 		t.Project, t.Kind, t.Brief, t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
-		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.ID)
+		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt, t.ID)
 	if err != nil {
 		return fmt.Errorf("update task %q: %w", t.ID, err)
 	}
@@ -581,18 +609,31 @@ func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
 }
 
 func (db *DB) readTaskHistoryBeforeRouting(id string) (TaskHistory, bool, error) {
-	task, found, err := db.ReadTask(id)
-	if err != nil || !found {
-		return TaskHistory{}, found, err
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeRepair+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeRepair(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
 	}
-	rows, err := db.sql.Query(`SELECT `+attemptColumnsBeforeRouting+` FROM attempt WHERE task_id = ? ORDER BY ordinal`, id)
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
+	}
+	return db.readTaskHistoryBeforeRoutingWithTask(task)
+}
+
+func (db *DB) readTaskHistoryBeforeRepair(id string) (TaskHistory, bool, error) {
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeRepair+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeRepair(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	rows, err := db.sql.Query(`SELECT `+attemptColumns+` FROM attempt WHERE task_id = ? ORDER BY ordinal`, id)
 	if err != nil {
 		return TaskHistory{}, false, fmt.Errorf("list attempts for task %q: %w", id, err)
 	}
 	defer func() { _ = rows.Close() }()
 	var attempts []Attempt
 	for rows.Next() {
-		attempt, err := scanAttemptBeforeRouting(rows)
+		attempt, err := scanAttempt(rows)
 		if err != nil {
 			return TaskHistory{}, false, fmt.Errorf("list attempts for task %q: %w", id, err)
 		}
@@ -614,6 +655,36 @@ func (db *DB) readTaskHistoryBeforeRouting(id string) (TaskHistory, bool, error)
 	return history, true, nil
 }
 
+func (db *DB) readTaskHistoryBeforeRoutingWithTask(task Task) (TaskHistory, bool, error) {
+	rows, err := db.sql.Query(`SELECT `+attemptColumnsBeforeRouting+` FROM attempt WHERE task_id = ? ORDER BY ordinal`, task.ID)
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("list attempts for task %q: %w", task.ID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var attempts []Attempt
+	for rows.Next() {
+		attempt, err := scanAttemptBeforeRouting(rows)
+		if err != nil {
+			return TaskHistory{}, false, fmt.Errorf("list attempts for task %q: %w", task.ID, err)
+		}
+		attempts = append(attempts, attempt)
+	}
+	if err := rows.Err(); err != nil {
+		return TaskHistory{}, false, fmt.Errorf("list attempts for task %q: %w", task.ID, err)
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("task %q active attempt %d not found", task.ID, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
 func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' ORDER BY id`)
 	if err != nil {
@@ -630,6 +701,51 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("list open tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.ListAttempts(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("task %q active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
+}
+
+func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
+	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state <> 'released')
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list reconciliation tasks: %w", err)
 	}
 	for i := range histories {
 		attempts, err := db.ListAttempts(histories[i].Task.ID)
@@ -1150,6 +1266,30 @@ func (db *DB) SetTaskMerge(id, mergedAt string) error {
 func (db *DB) SetTaskReportState(id string, offset int64, digest string, mergeAnnounced bool) error {
 	result, err := db.sql.Exec(`UPDATE task SET report_offset = ?, report_digest = ?, merge_announced = merge_announced OR ? WHERE id = ?`, offset, digest, mergeAnnounced, id)
 	return updateTaskFact(result, err, "set report state", id)
+}
+
+func (db *DB) SetTaskRepair(id, code, reason string, attemptID int64, observedAt string) error {
+	result, err := db.sql.Exec(`UPDATE task SET repair_code = ?, repair_reason = ?, repair_attempt_id = ?, repair_observed_at = ? WHERE id = ?`, code, reason, attemptID, observedAt, id)
+	return updateTaskFact(result, err, "set repair", id)
+}
+
+func (db *DB) ClearTaskRepair(id, expectedCode string) error {
+	result, err := db.sql.Exec(`UPDATE task SET repair_code = '', repair_reason = '', repair_attempt_id = 0, repair_observed_at = '' WHERE id = ? AND repair_code = ?`, id, expectedCode)
+	if err != nil {
+		return fmt.Errorf("clear repair for task %q: %w", id, err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf("clear repair for task %q: %w", id, err)
+	} else if affected == 1 {
+		return nil
+	}
+	var current string
+	if err := db.sql.QueryRow(`SELECT repair_code FROM task WHERE id = ?`, id).Scan(&current); errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("task %q %w", id, ErrTaskNotFound)
+	} else if err != nil {
+		return fmt.Errorf("read repair for task %q: %w", id, err)
+	}
+	return fmt.Errorf("%w: task %q repair code is %q, expected %q", ErrLifecycleConflict, id, current, expectedCode)
 }
 
 func updateTaskFact(result sql.Result, err error, operation, id string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -58,6 +58,17 @@ type Herdr struct {
 	PaneID      string `json:"pane_id"`
 }
 
+type HerdrOwnership struct {
+	AttemptID          int64            `json:"attempt_id"`
+	TaskID             string           `json:"task_id"`
+	Lifecycle          AttemptLifecycle `json:"lifecycle"`
+	TeardownHerdrState string           `json:"teardown_herdr_state,omitempty"`
+	Session            string           `json:"session"`
+	WorkspaceID        string           `json:"workspace_id"`
+	TabID              string           `json:"tab_id"`
+	PaneID             string           `json:"pane_id"`
+}
+
 type TaskLifecycle string
 
 const (
@@ -766,16 +777,16 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 	return histories, nil
 }
 
-func (db *DB) ListHerdrOwnerships() ([]Herdr, error) {
-	rows, err := db.sql.Query(`SELECT herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id FROM attempt WHERE herdr_workspace_id <> '' OR herdr_tab_id <> '' OR herdr_pane_id <> '' ORDER BY id`)
+func (db *DB) ListHerdrOwnerships() ([]HerdrOwnership, error) {
+	rows, err := db.sql.Query(`SELECT id, task_id, lifecycle, teardown_herdr_state, herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id FROM attempt WHERE herdr_workspace_id <> '' OR herdr_tab_id <> '' OR herdr_pane_id <> '' ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("list Herdr ownerships: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
-	var ownerships []Herdr
+	var ownerships []HerdrOwnership
 	for rows.Next() {
-		var ownership Herdr
-		if err := rows.Scan(&ownership.Session, &ownership.WorkspaceID, &ownership.TabID, &ownership.PaneID); err != nil {
+		var ownership HerdrOwnership
+		if err := rows.Scan(&ownership.AttemptID, &ownership.TaskID, &ownership.Lifecycle, &ownership.TeardownHerdrState, &ownership.Session, &ownership.WorkspaceID, &ownership.TabID, &ownership.PaneID); err != nil {
 			return nil, fmt.Errorf("list Herdr ownerships: %w", err)
 		}
 		ownerships = append(ownerships, ownership)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -766,6 +766,26 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 	return histories, nil
 }
 
+func (db *DB) ListHerdrOwnerships() ([]Herdr, error) {
+	rows, err := db.sql.Query(`SELECT herdr_session, herdr_workspace_id, herdr_tab_id, herdr_pane_id FROM attempt WHERE herdr_workspace_id <> '' OR herdr_tab_id <> '' OR herdr_pane_id <> '' ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list Herdr ownerships: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ownerships []Herdr
+	for rows.Next() {
+		var ownership Herdr
+		if err := rows.Scan(&ownership.Session, &ownership.WorkspaceID, &ownership.TabID, &ownership.PaneID); err != nil {
+			return nil, fmt.Errorf("list Herdr ownerships: %w", err)
+		}
+		ownerships = append(ownerships, ownership)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list Herdr ownerships: %w", err)
+	}
+	return ownerships, nil
+}
+
 func (db *DB) CreateTaskWithAttempt(t Task, a Attempt) (Attempt, error) {
 	if t.Lifecycle == "" {
 		t.Lifecycle = TaskOpen

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -646,14 +646,21 @@ func TestOpenReadOnlyMissingDatabaseDoesNotCreateState(t *testing.T) {
 	home := t.TempDir()
 	before := snapshotStoreTree(t, home)
 	db, err := OpenReadOnly(home)
-	if db != nil {
-		_ = db.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err == nil {
-		t.Fatal("OpenReadOnly created or opened a missing database")
+	tasks, err := db.ListTasks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("OpenReadOnly missing database returned tasks: %+v", tasks)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
 	}
 	if after := snapshotStoreTree(t, home); !slices.Equal(after, before) {
-		t.Fatalf("missing-database open changed the fleet:\nbefore: %v\nafter:  %v", before, after)
+		t.Fatalf("missing-database open changed the fleet:\nbefore: %v\nafter: %v", before, after)
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -82,6 +82,9 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 
 	client, err := connect(ctx)
 	if err != nil {
+		if errors.Is(err, ErrNoEvent) && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("%w within %s: %w", ErrNoEvent, cfg.Timeout, err)
+		}
 		return err
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -34,6 +35,70 @@ type statusEntry struct {
 	Path    string `json:"path"`
 	Status  string `json:"status"`
 	LeaseID string `json:"lease_id"`
+}
+
+type LeaseObservationState string
+
+const (
+	LeaseExact      LeaseObservationState = "exact"
+	LeaseAbsent     LeaseObservationState = "absent"
+	LeaseMismatch   LeaseObservationState = "mismatch"
+	LeaseUnprovable LeaseObservationState = "unprovable"
+)
+
+type LeaseObservation struct {
+	State   LeaseObservationState
+	LeaseID string
+}
+
+type Cleanliness string
+
+const (
+	Clean Cleanliness = "clean"
+	Dirty Cleanliness = "dirty"
+)
+
+func ObserveLease(worktreePath, expectedLeaseID string) (LeaseObservation, error) {
+	if worktreePath == "" {
+		return LeaseObservation{State: LeaseAbsent}, nil
+	}
+	entries, err := treehouseStatus(worktreePath)
+	if err != nil {
+		return LeaseObservation{}, err
+	}
+	for _, entry := range entries {
+		if entry.Path != worktreePath {
+			continue
+		}
+		if entry.Status != "leased" {
+			return LeaseObservation{State: LeaseAbsent, LeaseID: entry.LeaseID}, nil
+		}
+		if expectedLeaseID == "" || entry.LeaseID == "" {
+			return LeaseObservation{State: LeaseUnprovable, LeaseID: entry.LeaseID}, nil
+		}
+		if entry.LeaseID == expectedLeaseID {
+			return LeaseObservation{State: LeaseExact, LeaseID: entry.LeaseID}, nil
+		}
+		return LeaseObservation{State: LeaseMismatch, LeaseID: entry.LeaseID}, nil
+	}
+	if _, err := os.Stat(worktreePath); err == nil {
+		return LeaseObservation{State: LeaseUnprovable}, nil
+	} else if !os.IsNotExist(err) {
+		return LeaseObservation{}, fmt.Errorf("inspect worktree path: %w", err)
+	}
+	return LeaseObservation{State: LeaseAbsent}, nil
+}
+
+func ObserveCleanliness(worktreePath string) (Cleanliness, error) {
+	cmd := exec.Command("git", "-C", worktreePath, "status", "--porcelain", "--untracked-files=all")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git worktree status failed: %w", err)
+	}
+	if len(out) != 0 {
+		return Dirty, nil
+	}
+	return Clean, nil
 }
 
 // Get acquires a worktree from the project clone's treehouse pool. clonePath must be the project
@@ -125,22 +190,28 @@ func VerifyLease(worktreePath, expectedLeaseID string) error {
 	if worktreePath == "" || expectedLeaseID == "" {
 		return fmt.Errorf("cannot verify treehouse lease without path and lease ID")
 	}
+	observation, err := ObserveLease(worktreePath, expectedLeaseID)
+	if err != nil {
+		return err
+	}
+	if observation.State == LeaseExact {
+		return nil
+	}
+	return fmt.Errorf("treehouse lease for %s does not match expected lease %s", worktreePath, expectedLeaseID)
+}
+
+func treehouseStatus(worktreePath string) ([]statusEntry, error) {
 	cmd := exec.Command("treehouse", "status", "--json")
 	cmd.Dir = worktreePath
 	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("treehouse status failed: %w", err)
+		return nil, fmt.Errorf("treehouse status failed: %w", err)
 	}
 	var entries []statusEntry
 	if err := json.Unmarshal(out, &entries); err != nil {
-		return fmt.Errorf("parse treehouse status output: %w", err)
+		return nil, fmt.Errorf("parse treehouse status output: %w", err)
 	}
-	for _, entry := range entries {
-		if entry.Path == worktreePath && entry.Status == "leased" && entry.LeaseID == expectedLeaseID {
-			return nil
-		}
-	}
-	return fmt.Errorf("treehouse lease for %s does not match expected lease %s", worktreePath, expectedLeaseID)
+	return entries, nil
 }
 
 // CheckCollision cross-checks a freshly acquired lease against every other task's recorded one,

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -62,6 +62,12 @@ func ObserveLease(worktreePath, expectedLeaseID string) (LeaseObservation, error
 	if worktreePath == "" {
 		return LeaseObservation{State: LeaseAbsent}, nil
 	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		if os.IsNotExist(err) {
+			return LeaseObservation{State: LeaseAbsent}, nil
+		}
+		return LeaseObservation{}, fmt.Errorf("inspect worktree path: %w", err)
+	}
 	entries, err := treehouseStatus(worktreePath)
 	if err != nil {
 		return LeaseObservation{}, err

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -147,6 +147,16 @@ func TestObserveLeaseReportsAbsentAfterReturn(t *testing.T) {
 	}
 }
 
+func TestObserveLeaseReportsAbsentWhenTheRecordedPathIsGone(t *testing.T) {
+	got, err := ObserveLease(filepath.Join(t.TempDir(), "gone"), "lease-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != LeaseAbsent {
+		t.Fatalf("ObserveLease() = %+v, want absent", got)
+	}
+}
+
 func TestObserveCleanlinessIncludesUntrackedFiles(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -106,6 +106,63 @@ func TestVerifyLeaseRequiresAnExactLeasedIdentity(t *testing.T) {
 	}
 }
 
+func TestObserveLeaseDistinguishesExactMissingReusedAndLegacyOwnership(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wt-1")
+	faketool.InitRepo(t, path)
+	for _, test := range []struct {
+		name    string
+		leaseID string
+		want    LeaseObservationState
+	}{
+		{name: "exact", leaseID: "lease-1", want: LeaseExact},
+		{name: "reused", leaseID: "lease-old", want: LeaseMismatch},
+		{name: "legacy", leaseID: "", want: LeaseUnprovable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
+			got, err := ObserveLease(path, test.leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.State != test.want {
+				t.Fatalf("ObserveLease() = %+v, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestObserveLeaseReportsAbsentAfterReturn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wt-1")
+	faketool.InitRepo(t, path)
+	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
+	if err := ReturnLease(path, "lease-1", true); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ObserveLease(path, "lease-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != LeaseAbsent {
+		t.Fatalf("ObserveLease() = %+v, want absent", got)
+	}
+}
+
+func TestObserveCleanlinessIncludesUntrackedFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wt-1")
+	faketool.InitRepo(t, path)
+	got, err := ObserveCleanliness(path)
+	if err != nil || got != Clean {
+		t.Fatalf("clean worktree = %q, %v", got, err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "untracked"), []byte("dirty"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ObserveCleanliness(path)
+	if err != nil || got != Dirty {
+		t.Fatalf("dirty worktree = %q, %v", got, err)
+	}
+}
+
 func TestVerifyLeaseRunsStatusFromTheWorktreeRepository(t *testing.T) {
 	worktreePath := filepath.Join(t.TempDir(), "worktree")
 	faketool.InitRepo(t, worktreePath)

--- a/tests/e2e/migrate_test.go
+++ b/tests/e2e/migrate_test.go
@@ -59,20 +59,26 @@ func TestMigrationImportsALegacyHomeAndIsIdempotent(t *testing.T) {
 		}
 	}
 
-	if _, err := os.Stat(filepath.Join(home, "state", "task-1.json")); !os.IsNotExist(err) {
-		t.Fatalf("stat state/task-1.json: %v, want the imported file moved aside", err)
+	if _, err := os.Stat(filepath.Join(home, "state", "task-1.json")); err != nil {
+		t.Fatalf("stat state/task-1.json: %v, want status to leave the legacy file untouched", err)
 	}
 	archived := filepath.Join(store.LegacyDir(home), "task-1.json")
-	if _, err := os.Stat(archived); err != nil {
-		t.Fatalf("stat %s: %v, want the imported file kept for the operator", archived, err)
+	if _, err := os.Stat(archived); !os.IsNotExist(err) {
+		t.Fatalf("stat %s: %v, want status not to archive the legacy file", archived, err)
 	}
-	if _, err := os.Stat(store.Path(home)); err != nil {
-		t.Fatalf("stat machine state database: %v", err)
+	if _, err := os.Stat(store.Path(home)); !os.IsNotExist(err) {
+		t.Fatalf("stat machine state database: %v, want status not to create it", err)
 	}
 
 	projects := runHand(t, home, "project", "list")
 	if projects.code != 0 || !strings.Contains(projects.stdout, "demo") {
 		t.Fatalf("project list: exit %d, stdout %q, want the registry imported from prose", projects.code, projects.stdout)
+	}
+	if _, err := os.Stat(archived); err != nil {
+		t.Fatalf("stat %s: %v, want the later mutating command to archive the legacy file", archived, err)
+	}
+	if _, err := os.Stat(store.Path(home)); err != nil {
+		t.Fatalf("stat machine state database: %v, want the later mutating command to create it", err)
 	}
 
 	second := runHand(t, home, "status")

--- a/tests/e2e/migrate_test.go
+++ b/tests/e2e/migrate_test.go
@@ -102,6 +102,12 @@ func TestMigrationDoesNotLetARestoredLegacyFileOverwriteNewerState(t *testing.T)
 	if got := runHand(t, home, "status", "task-1"); got.code != 0 {
 		t.Fatalf("status after migration: exit %d, stderr %q", got.code, got.stderr)
 	}
+	if _, err := os.Stat(filepath.Join(home, "state", "task-1.json")); err != nil {
+		t.Fatalf("stat state/task-1.json: %v, want status to leave the legacy file untouched", err)
+	}
+	if got := runHand(t, home, "project", "list"); got.code != 0 {
+		t.Fatalf("project list after read-only status: exit %d, stderr %q", got.code, got.stderr)
+	}
 
 	restored, err := os.ReadFile(filepath.Join(store.LegacyDir(home), "task-1.json"))
 	if err != nil {

--- a/tests/e2e/reconcile_test.go
+++ b/tests/e2e/reconcile_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/state"
+)
+
+func TestReconcileReportsReleasedHerdrResourceThroughStatefulFake(t *testing.T) {
+	home := newHome(t)
+	oldAttempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+		Herdr: state.Herdr{Session: "default", WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", oldAttempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, "herdr", state.TeardownResourceReleased); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Herdr{Workspaces: []faketool.HerdrWorkspace{{ID: "ws-1", Label: "hand:demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: "task-1", Pane: "pane-1"}}}}}.Install(t, binDir(t))
+
+	got := runHand(t, home, "reconcile")
+	if got.code != 3 {
+		t.Fatalf("reconcile: exit %d, stdout %q, stderr %q, want precondition anomaly", got.code, got.stdout, got.stderr)
+	}
+	for _, want := range []string{"released-herdr-resource", fmt.Sprintf("owner_attempt=%d", oldAttempt.ID), "refusing to close"} {
+		if !strings.Contains(got.stdout, want) {
+			t.Fatalf("reconcile stdout = %q, want %q", got.stdout, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds deterministic crash reconciliation for durable Task and Attempt state against observed Git, Treehouse, Herdr, and completion reality.
- Preserves immutable Attempt execution snapshots during recovery, requires exact ownership before cleanup, and records ambiguity as task-level `needs-repair`.
- Includes the approved additive repair-marker schema migration required by #196; this final CLI diagnostic fix adds no schema change.

Fixes atqamz/hand#196

## Test plan

- `git diff --check`
- `nix develop --command go test ./...`
- `nix develop --command go test -race ./...`
- `nix develop --command go vet ./...`
- `nix develop --command make lint`
- `nix develop --command make build`
- `nix develop --command make contract`
- `nix develop --command make e2e`
- `nix flake check --print-build-logs`
- PR CI passed on Linux, macOS, Windows, Nix build, lint, and E2E.
- Final CLI regression preserves anomaly kind and attempt attribution, including `released-herdr-resource` with `attempt 7`.

## Scope

- `hand status` remains read-only.
- Existing Attempts are never rerouted, relaunched, or given automatic model or harness fallback.
- Dirty or ambiguous resources are never auto-destroyed.
- The #197 send protocol and #198 broad hardening remain out of scope.
- No daemon, controller, or plugin framework was introduced.