### PR TITLE
fix(watcher): harden takeover and cancellation lifecycle

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -246,9 +246,9 @@ func errorHelp(code int, path string) []string {
 	case 7:
 		return []string{"Terminal submission is uncertain; do not blindly retry because the message may already be in the pane"}
 	case 8:
-		return []string{"The watcher was interrupted before it was replaced: nothing was taken over, so an existing watcher still holds the fleet home"}
+		return []string{"The watcher stopped because of a generic interruption; it emitted no fleet event, releases ownership as the command exits, and may be re-armed by a supervisor"}
 	case 9:
-		return []string{"An explicit takeover replaced this watcher: launch another `hand watch` and it will become the owner"}
+		return []string{"This watcher was explicitly displaced by another Hand watcher; it emitted no fleet event, and the takeover successor acquires ownership after release"}
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -220,6 +220,8 @@ var errorKinds = map[int]string{
 	5: "arm-failed",
 	6: "send-not-submitted",
 	7: "send-uncertain",
+	8: "watch-interrupted",
+	9: "watch-replaced",
 }
 
 func errorKind(code int) string {
@@ -243,6 +245,10 @@ func errorHelp(code int, path string) []string {
 		return []string{"No terminal submission occurred; retry after the underlying precondition is ready"}
 	case 7:
 		return []string{"Terminal submission is uncertain; do not blindly retry because the message may already be in the pane"}
+	case 8:
+		return []string{"The watcher was interrupted before it was replaced: nothing was taken over, so an existing watcher still holds the fleet home"}
+	case 9:
+		return []string{"An explicit takeover replaced this watcher: launch another `hand watch` and it will become the owner"}
 	}
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -300,6 +300,28 @@ func TestUsageErrorHelpNamesTheCommandThatRefused(t *testing.T) {
 	}
 }
 
+func TestLifecycleHelpDescribesInterruptionAndReplacementFacts(t *testing.T) {
+	interrupted := strings.Join(errorHelp(8, "hand watch"), " ")
+	for _, want := range []string{"generic interruption", "no fleet event", "releases ownership", "re-armed"} {
+		if !strings.Contains(interrupted, want) {
+			t.Fatalf("exit 8 help = %q, want %q", interrupted, want)
+		}
+	}
+	if strings.Contains(interrupted, "nothing was taken over") || strings.Contains(interrupted, "still holds") {
+		t.Fatalf("exit 8 help = %q, contains an obsolete ownership claim", interrupted)
+	}
+
+	replaced := strings.Join(errorHelp(9, "hand watch"), " ")
+	for _, want := range []string{"explicitly displaced", "no fleet event", "takeover successor", "acquires ownership"} {
+		if !strings.Contains(replaced, want) {
+			t.Fatalf("exit 9 help = %q, want %q", replaced, want)
+		}
+	}
+	if strings.Contains(replaced, "launch another") {
+		t.Fatalf("exit 9 help = %q, tells the displaced operator to launch another successor", replaced)
+	}
+}
+
 // A general error is the one code with no recovery a caller can be told in
 // advance, so it gets no help block rather than a line saying nothing.
 func TestGeneralErrorCarriesNoHelpBlock(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -248,6 +248,8 @@ func TestErrorDocumentNamesTheKindBehindEveryExitCode(t *testing.T) {
 		{5, "arm-failed"},
 		{6, "send-not-submitted"},
 		{7, "send-uncertain"},
+		{8, "watch-interrupted"},
+		{9, "watch-replaced"},
 	} {
 		t.Run(tc.kind, func(t *testing.T) {
 			var out strings.Builder

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -182,7 +182,7 @@ func sessionNextAction(cfg workerConfig, projectCount int, backlog backlogSummar
 		return "Read `data/backlog.md` and prepare the queued task; dispatch it with `hand spawn <id> <project>` when its brief is ready"
 	}
 	if len(views) > 0 {
-		return "Run `hand watch --until-event` as a background task and re-arm it after each event"
+		return "Run `hand watch --until-event` as a background task; re-arm it after an event or when intentionally resuming after interruption or takeover"
 	}
 	return "The fleet is ready and idle"
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -86,8 +86,6 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			// After every validation above, so a usage error still exits 2 without
-			// having disturbed a running watcher's ownership.
 			ownership, err := watcher.Acquire(home, takeover)
 			if err != nil {
 				if errors.Is(err, watcher.ErrAttached) {
@@ -97,9 +95,11 @@ func newWatchCmd() *cobra.Command {
 			}
 			defer ownership.Release()
 
-			signalCtx, stopSignals := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
-			defer stopSignals()
-			ctx, cancel := contextWithTakeover(signalCtx, ownership.TakeoverRequested())
+			sig := make(chan os.Signal, 1)
+			signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+			defer signal.Stop(sig)
+
+			ctx, cancel := watchContext(cmd.Context(), sig, ownership.TakeoverRequested())
 			defer cancel()
 
 			cfg := watcher.Config{
@@ -115,22 +115,13 @@ func newWatchCmd() *cobra.Command {
 				EventFilter: watcher.NewEventFilter(events),
 			}
 			if !untilEvent {
-				return watcher.Run(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr())
+				return mapWatchResult(watcher.Run(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr()))
 			}
 
 			// The exit code is the delivery, so a watcher that stopped without an
 			// event must not exit 0: a caller re-arming on 0 would read it as fleet
 			// news, and one distinguishing it from a crash needs its own code.
-			if err := watcher.RunUntilEvent(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
-				if errors.Is(err, watcher.ErrNoEvent) {
-					return &ExitError{Err: err, Code: 4}
-				}
-				if errors.Is(err, watcher.ErrArmFailed) {
-					return &ExitError{Err: err, Code: 5}
-				}
-				return err
-			}
-			return nil
+			return mapWatchResult(watcher.RunUntilEvent(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr()))
 		},
 	}
 
@@ -138,6 +129,22 @@ func newWatchCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&untilEvent, "until-event", false, "block until the first event, print it, and exit 0")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "with --until-event, give up after this long and exit 4 (default: no timeout)")
 	cmd.Flags().StringSliceVar(&events, "event", nil, "with --until-event, wake only on these event kinds (default: any); repeatable or comma-separated")
-	cmd.Flags().BoolVar(&takeover, "takeover", false, "replace the watcher already attached to this fleet home, signaling it to stop first")
+	cmd.Flags().BoolVar(&takeover, "takeover", false, "request the current watcher to stop, then wait to acquire ownership")
 	return cmd
+}
+
+// Converts a watcher termination error into the application exit taxonomy,
+// resolved through errors.Is so wrapping preserves classification.
+func mapWatchResult(err error) error {
+	switch {
+	case errors.Is(err, watcher.ErrReplaced):
+		return &ExitError{Err: err, Code: 9}
+	case errors.Is(err, watcher.ErrInterrupted):
+		return &ExitError{Err: err, Code: 8}
+	case errors.Is(err, watcher.ErrNoEvent):
+		return &ExitError{Err: err, Code: 4}
+	case errors.Is(err, watcher.ErrArmFailed):
+		return &ExitError{Err: err, Code: 5}
+	}
+	return err
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -20,9 +21,9 @@ const defaultParkedDoneBound = 5400 * time.Second
 const defaultParkedOtherBound = 1200 * time.Second
 
 var (
-	acquireWatcher    = watcher.Acquire
-	notifyWatchSignal = signal.Notify
-	stopWatchSignal   = signal.Stop
+	acquireWatcher    func(context.Context, string, bool) (*watcher.Ownership, error) = watcher.AcquireContext
+	notifyWatchSignal                                                                 = signal.Notify
+	stopWatchSignal                                                                   = signal.Stop
 )
 
 func newWatchCmd() *cobra.Command {
@@ -96,16 +97,25 @@ func newWatchCmd() *cobra.Command {
 			notifyWatchSignal(sig, os.Interrupt, syscall.SIGTERM)
 			defer stopWatchSignal(sig)
 
-			ownership, err := acquireWatcher(home, takeover)
+			acquireCtx, stopAcquire := watchContext(cmd.Context(), sig, nil)
+			defer stopAcquire()
+
+			ownership, err := acquireWatcher(acquireCtx, home, takeover)
 			if err != nil {
 				if errors.Is(err, watcher.ErrAttached) {
 					return &ExitError{Err: err, Code: 3}
+				}
+				if errors.Is(err, watcher.ErrReplaced) {
+					return &ExitError{Err: err, Code: 9}
+				}
+				if errors.Is(err, watcher.ErrInterrupted) {
+					return &ExitError{Err: err, Code: 8}
 				}
 				return err
 			}
 			defer ownership.Release()
 
-			ctx, cancel := watchContext(cmd.Context(), sig, ownership.TakeoverRequested())
+			ctx, cancel := watchContext(acquireCtx, sig, ownership.TakeoverRequested())
 			defer cancel()
 
 			cfg := watcher.Config{

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -19,6 +19,12 @@ const defaultParkedPausedBound = 3600 * time.Second
 const defaultParkedDoneBound = 5400 * time.Second
 const defaultParkedOtherBound = 1200 * time.Second
 
+var (
+	acquireWatcher    = watcher.Acquire
+	notifyWatchSignal = signal.Notify
+	stopWatchSignal   = signal.Stop
+)
+
 func newWatchCmd() *cobra.Command {
 	var poll string
 	var untilEvent bool
@@ -86,7 +92,11 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 
-			ownership, err := watcher.Acquire(home, takeover)
+			sig := make(chan os.Signal, 1)
+			notifyWatchSignal(sig, os.Interrupt, syscall.SIGTERM)
+			defer stopWatchSignal(sig)
+
+			ownership, err := acquireWatcher(home, takeover)
 			if err != nil {
 				if errors.Is(err, watcher.ErrAttached) {
 					return &ExitError{Err: err, Code: 3}
@@ -94,10 +104,6 @@ func newWatchCmd() *cobra.Command {
 				return err
 			}
 			defer ownership.Release()
-
-			sig := make(chan os.Signal, 1)
-			signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
-			defer signal.Stop(sig)
 
 			ctx, cancel := watchContext(cmd.Context(), sig, ownership.TakeoverRequested())
 			defer cancel()

--- a/cmd/watch_context.go
+++ b/cmd/watch_context.go
@@ -26,30 +26,18 @@ func watchContext(parent context.Context, sig <-chan os.Signal, requested <-chan
 			return
 		}
 		if parent.Err() != nil {
-			if takeoverReady(requested) {
-				cancel(watcher.ErrReplaced)
-			} else {
-				cancel(watcher.ErrInterrupted)
-			}
+			cancelWithTakeoverPriority(cancel, requested)
 			return
 		}
 		select {
 		case <-requested:
 			cancel(watcher.ErrReplaced)
 		case <-sig:
-			if takeoverReady(requested) {
-				cancel(watcher.ErrReplaced)
-				return
-			}
-			cancel(watcher.ErrInterrupted)
+			cancelWithTakeoverPriority(cancel, requested)
 		case <-ctx.Done():
 			return
 		case <-parent.Done():
-			if takeoverReady(requested) {
-				cancel(watcher.ErrReplaced)
-			} else {
-				cancel(watcher.ErrInterrupted)
-			}
+			cancelWithTakeoverPriority(cancel, requested)
 		}
 	}()
 	return ctx, func() {
@@ -67,5 +55,16 @@ func takeoverReady(requested <-chan struct{}) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func cancelWithTakeoverPriority(cancel context.CancelCauseFunc, requested <-chan struct{}) {
+	// This select is the cancellation boundary: a later request belongs to the
+	// next lifecycle, while an already-observable request wins this one.
+	select {
+	case <-requested:
+		cancel(watcher.ErrReplaced)
+	default:
+		cancel(watcher.ErrInterrupted)
 	}
 }

--- a/cmd/watch_context.go
+++ b/cmd/watch_context.go
@@ -1,18 +1,33 @@
 package cmd
 
-import "context"
+import (
+	"context"
+	"os"
 
-func contextWithTakeover(parent context.Context, requested <-chan struct{}) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(parent)
-	if requested == nil {
-		return ctx, cancel
-	}
+	"github.com/atqamz/hand/internal/watcher"
+)
+
+// Wires parent context, the OS signal channel, and the ownership takeover
+// request into one context whose cancellation cause survives into watcher: a
+// takeover is ErrReplaced, an external signal or parent cancel is ErrInterrupted.
+func watchContext(parent context.Context, sig <-chan os.Signal, requested <-chan struct{}) (context.Context, func()) {
+	ctx, cancel := context.WithCancelCause(parent)
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
+		if ctx.Err() != nil {
+			return
+		}
 		select {
+		case <-sig:
+			cancel(watcher.ErrInterrupted)
 		case <-requested:
-			cancel()
+			cancel(watcher.ErrReplaced)
 		case <-ctx.Done():
 		}
 	}()
-	return ctx, cancel
+	return ctx, func() {
+		cancel(watcher.ErrInterrupted)
+		<-stopped
+	}
 }

--- a/cmd/watch_context.go
+++ b/cmd/watch_context.go
@@ -17,7 +17,7 @@ func watchContext(parent context.Context, sig <-chan os.Signal, requested <-chan
 		return ctx, func() {}
 	}
 
-	ctx, cancel := context.WithCancelCause(parent)
+	ctx, cancel := context.WithCancelCause(context.Background())
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
@@ -25,7 +25,12 @@ func watchContext(parent context.Context, sig <-chan os.Signal, requested <-chan
 			cancel(watcher.ErrReplaced)
 			return
 		}
-		if ctx.Err() != nil {
+		if parent.Err() != nil {
+			if takeoverReady(requested) {
+				cancel(watcher.ErrReplaced)
+			} else {
+				cancel(watcher.ErrInterrupted)
+			}
 			return
 		}
 		select {
@@ -38,8 +43,12 @@ func watchContext(parent context.Context, sig <-chan os.Signal, requested <-chan
 			}
 			cancel(watcher.ErrInterrupted)
 		case <-ctx.Done():
+			return
+		case <-parent.Done():
 			if takeoverReady(requested) {
 				cancel(watcher.ErrReplaced)
+			} else {
+				cancel(watcher.ErrInterrupted)
 			}
 		}
 	}()

--- a/cmd/watch_context.go
+++ b/cmd/watch_context.go
@@ -11,23 +11,52 @@ import (
 // request into one context whose cancellation cause survives into watcher: a
 // takeover is ErrReplaced, an external signal or parent cancel is ErrInterrupted.
 func watchContext(parent context.Context, sig <-chan os.Signal, requested <-chan struct{}) (context.Context, func()) {
+	if takeoverReady(requested) {
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(watcher.ErrReplaced)
+		return ctx, func() {}
+	}
+
 	ctx, cancel := context.WithCancelCause(parent)
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
+		if takeoverReady(requested) {
+			cancel(watcher.ErrReplaced)
+			return
+		}
 		if ctx.Err() != nil {
 			return
 		}
 		select {
-		case <-sig:
-			cancel(watcher.ErrInterrupted)
 		case <-requested:
 			cancel(watcher.ErrReplaced)
+		case <-sig:
+			if takeoverReady(requested) {
+				cancel(watcher.ErrReplaced)
+				return
+			}
+			cancel(watcher.ErrInterrupted)
 		case <-ctx.Done():
+			if takeoverReady(requested) {
+				cancel(watcher.ErrReplaced)
+			}
 		}
 	}()
 	return ctx, func() {
 		cancel(watcher.ErrInterrupted)
 		<-stopped
+	}
+}
+
+func takeoverReady(requested <-chan struct{}) bool {
+	if requested == nil {
+		return false
+	}
+	select {
+	case <-requested:
+		return true
+	default:
+		return false
 	}
 }

--- a/cmd/watch_context_test.go
+++ b/cmd/watch_context_test.go
@@ -74,6 +74,22 @@ func TestWatchContextPrefersObservableTakeoverOverBufferedSignal(t *testing.T) {
 	}
 }
 
+func TestWatchContextPrefersTakeoverAtEveryReadyCancellationBoundary(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		sig := make(chan os.Signal, 1)
+		sig <- os.Interrupt
+		requested := make(chan struct{})
+		close(requested)
+
+		ctx, cancel := watchContext(context.Background(), sig, requested)
+		if !errors.Is(context.Cause(ctx), watcher.ErrReplaced) {
+			cancel()
+			t.Fatalf("iteration %d cause = %v, want ErrReplaced", i, context.Cause(ctx))
+		}
+		cancel()
+	}
+}
+
 func TestWatchContextPrefersTakeoverOverAlreadyCanceledParent(t *testing.T) {
 	parent, cancelParent := context.WithCancel(context.Background())
 	cancelParent()

--- a/cmd/watch_context_test.go
+++ b/cmd/watch_context_test.go
@@ -2,31 +2,60 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/atqamz/hand/internal/watcher"
 )
 
-func TestContextWithTakeoverCancelsWhenRequested(t *testing.T) {
+func TestWatchContextCancelsWithReplacementCauseOnTakeover(t *testing.T) {
+	sig := make(chan os.Signal)
 	requested := make(chan struct{})
-	ctx, cancel := contextWithTakeover(context.Background(), requested)
+	ctx, cancel := watchContext(context.Background(), sig, requested)
 	defer cancel()
 
 	close(requested)
 	select {
 	case <-ctx.Done():
+		if !errors.Is(context.Cause(ctx), watcher.ErrReplaced) {
+			t.Fatalf("cause = %v, want ErrReplaced", context.Cause(ctx))
+		}
 	case <-time.After(time.Second):
 		t.Fatal("context did not cancel after takeover request")
 	}
 }
 
-func TestContextWithTakeoverFollowsParentCancellation(t *testing.T) {
+func TestWatchContextCancelsWithInterruptionCauseOnSignal(t *testing.T) {
+	sig := make(chan os.Signal, 1)
+	ctx, cancel := watchContext(context.Background(), sig, make(chan struct{}))
+	defer cancel()
+
+	sig <- os.Interrupt
+	select {
+	case <-ctx.Done():
+		if !errors.Is(context.Cause(ctx), watcher.ErrInterrupted) {
+			t.Fatalf("cause = %v, want ErrInterrupted", context.Cause(ctx))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("context did not cancel on an ordinary signal")
+	}
+}
+
+func TestWatchContextFollowsParentCancellation(t *testing.T) {
 	parent, cancelParent := context.WithCancel(context.Background())
-	ctx, cancel := contextWithTakeover(parent, make(chan struct{}))
+	ctx, cancel := watchContext(parent, make(chan os.Signal), make(chan struct{}))
 	defer cancel()
 
 	cancelParent()
 	select {
 	case <-ctx.Done():
+		// Parent cancellation is generic: it must not read as a takeover, leaving
+		// the distinction to the watcher layer, which maps it to ErrInterrupted.
+		if errors.Is(context.Cause(ctx), watcher.ErrReplaced) {
+			t.Fatal("parent cancellation surfaced as a takeover replacement cause")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("context did not cancel with its parent")
 	}

--- a/cmd/watch_context_test.go
+++ b/cmd/watch_context_test.go
@@ -60,3 +60,29 @@ func TestWatchContextFollowsParentCancellation(t *testing.T) {
 		t.Fatal("context did not cancel with its parent")
 	}
 }
+
+func TestWatchContextPrefersObservableTakeoverOverBufferedSignal(t *testing.T) {
+	sig := make(chan os.Signal, 1)
+	sig <- os.Interrupt
+	requested := make(chan struct{})
+	close(requested)
+
+	ctx, cancel := watchContext(context.Background(), sig, requested)
+	defer cancel()
+	if !errors.Is(context.Cause(ctx), watcher.ErrReplaced) {
+		t.Fatalf("cause = %v, want ErrReplaced when takeover and signal are both ready", context.Cause(ctx))
+	}
+}
+
+func TestWatchContextPrefersTakeoverOverAlreadyCanceledParent(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+	requested := make(chan struct{})
+	close(requested)
+
+	ctx, cancel := watchContext(parent, make(chan os.Signal), requested)
+	defer cancel()
+	if !errors.Is(context.Cause(ctx), watcher.ErrReplaced) {
+		t.Fatalf("cause = %v, want ErrReplaced when takeover is ready at the boundary", context.Cause(ctx))
+	}
+}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,7 +152,7 @@ func TestWatchRejectsUnknownEventKind(t *testing.T) {
 	}
 }
 
-func TestWatchExitsCleanlyOnContextCancel(t *testing.T) {
+func TestWatchMapsContextCancelToInterruption(t *testing.T) {
 	setupWatchHome(t)
 
 	cmd := newWatchCmd()
@@ -177,8 +179,14 @@ func TestWatchExitsCleanlyOnContextCancel(t *testing.T) {
 
 	select {
 	case err := <-done:
-		if err != nil {
-			t.Fatalf("watch returned %v, want nil", err)
+		if err == nil {
+			t.Fatal("watch returned nil after interruption, want exit 8")
+		}
+		if code := exitCodeFor(t, err); code != 8 {
+			t.Fatalf("code = %d, want 8 (watch-interrupted), err = %v", code, err)
+		}
+		if !errors.Is(err, watcher.ErrInterrupted) {
+			t.Fatalf("err = %v, want it to wrap ErrInterrupted", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("watch did not exit after context cancellation")
@@ -226,5 +234,37 @@ func TestWatchRejectsAUsageErrorWithoutContendingForOwnership(t *testing.T) {
 	}
 	if code := exitCodeFor(t, err); code != 2 {
 		t.Fatalf("code = %d, want 2 (err = %v)", code, err)
+	}
+}
+
+func TestMapWatchResultClassifiesLifecycleResults(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"replacement", watcher.ErrReplaced, 9},
+		{"interruption", watcher.ErrInterrupted, 8},
+		{"no event", watcher.ErrNoEvent, 4},
+		{"arm failed", watcher.ErrArmFailed, 5},
+		{"general error stays general", errors.New("boom"), 1},
+		{"nil stays nil", nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapWatchResult(tc.err)
+			if code := exitCodeFor(t, got); code != tc.code {
+				t.Fatalf("code = %d, want %d (err = %v)", code, tc.code, got)
+			}
+		})
+	}
+}
+
+// Wrapping must not defeat classification: the exit taxonomy resolves through
+// errors.Is.
+func TestMapWatchResultSurvivesWrapping(t *testing.T) {
+	got := mapWatchResult(fmt.Errorf("exit early: %w", watcher.ErrReplaced))
+	if code := exitCodeFor(t, got); code != 9 {
+		t.Fatalf("code = %d, want 9 through a wrapped replacement error", code)
 	}
 }

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -193,6 +193,55 @@ func TestWatchMapsContextCancelToInterruption(t *testing.T) {
 	}
 }
 
+func TestWatchRegistersSignalsBeforePublishingOwnership(t *testing.T) {
+	setupWatchHome(t)
+
+	oldAcquire := acquireWatcher
+	oldNotify := notifyWatchSignal
+	oldStop := stopWatchSignal
+	t.Cleanup(func() {
+		acquireWatcher = oldAcquire
+		notifyWatchSignal = oldNotify
+		stopWatchSignal = oldStop
+	})
+
+	registered := make(chan chan<- os.Signal, 1)
+	notifyWatchSignal = func(sig chan<- os.Signal, _ ...os.Signal) {
+		registered <- sig
+	}
+	stopWatchSignal = func(chan<- os.Signal) {}
+	acquireWatcher = func(home string, takeover bool) (*watcher.Ownership, error) {
+		var sig chan<- os.Signal
+		select {
+		case sig = <-registered:
+		default:
+			return nil, errors.New("watcher acquisition ran before signal registration")
+		}
+		sig <- os.Interrupt
+		return watcher.Acquire(home, takeover)
+	}
+
+	cmd := newWatchCmd()
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--poll", "1h"})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	err := cmd.Execute()
+	if err == nil || exitCodeFor(t, err) != 8 {
+		t.Fatalf("watch returned %v, want exit 8 after an interruption buffered before ownership publication", err)
+	}
+	if !errors.Is(err, watcher.ErrInterrupted) {
+		t.Fatalf("err = %v, want ErrInterrupted", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want no lifecycle pseudo-event", out.String())
+	}
+	if strings.Contains(errOut.String(), "watch-replaced") {
+		t.Fatalf("stderr = %q, want generic interruption rather than replacement", errOut.String())
+	}
+}
+
 func TestWatchRefusesWhenAWatcherIsAlreadyAttached(t *testing.T) {
 	home := setupWatchHome(t)
 

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -210,7 +210,7 @@ func TestWatchRegistersSignalsBeforePublishingOwnership(t *testing.T) {
 		registered <- sig
 	}
 	stopWatchSignal = func(chan<- os.Signal) {}
-	acquireWatcher = func(home string, takeover bool) (*watcher.Ownership, error) {
+	acquireWatcher = func(_ context.Context, home string, takeover bool) (*watcher.Ownership, error) {
 		var sig chan<- os.Signal
 		select {
 		case sig = <-registered:
@@ -239,6 +239,59 @@ func TestWatchRegistersSignalsBeforePublishingOwnership(t *testing.T) {
 	}
 	if strings.Contains(errOut.String(), "watch-replaced") {
 		t.Fatalf("stderr = %q, want generic interruption rather than replacement", errOut.String())
+	}
+}
+
+func TestWatchInterruptsWhileOwnershipAcquisitionIsWaiting(t *testing.T) {
+	setupWatchHome(t)
+
+	oldAcquire := acquireWatcher
+	oldNotify := notifyWatchSignal
+	oldStop := stopWatchSignal
+	t.Cleanup(func() {
+		acquireWatcher = oldAcquire
+		notifyWatchSignal = oldNotify
+		stopWatchSignal = oldStop
+	})
+
+	registered := make(chan chan<- os.Signal, 1)
+	started := make(chan struct{})
+	notifyWatchSignal = func(sig chan<- os.Signal, _ ...os.Signal) {
+		registered <- sig
+	}
+	stopWatchSignal = func(chan<- os.Signal) {}
+	acquireWatcher = func(ctx context.Context, _ string, _ bool) (*watcher.Ownership, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, watcher.ErrInterrupted
+	}
+
+	cmd := newWatchCmd()
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--takeover", "--poll", "1h"})
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute() }()
+
+	var sig chan<- os.Signal
+	select {
+	case sig = <-registered:
+	case <-time.After(time.Second):
+		t.Fatal("watch did not register its signal channel")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("watch did not enter ownership acquisition")
+	}
+	sig <- os.Interrupt
+
+	select {
+	case err := <-done:
+		if err == nil || exitCodeFor(t, err) != 8 || !errors.Is(err, watcher.ErrInterrupted) {
+			t.Fatalf("watch returned %v, want exit 8/ErrInterrupted while acquisition was waiting", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watch did not stop its interrupted ownership acquisition")
 	}
 }
 

--- a/docs/adr/watcher-takeover-is-generation-attributed.md
+++ b/docs/adr/watcher-takeover-is-generation-attributed.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-16
 - Status: accepted
 - Issues: atqamz/hand#222
-- PRs: none
+- PRs: atqamz/hand#231
 
 ## Context
 

--- a/docs/adr/watcher-takeover-is-generation-attributed.md
+++ b/docs/adr/watcher-takeover-is-generation-attributed.md
@@ -1,0 +1,74 @@
+# Watcher takeover is generation-attributed
+
+- Date: 2026-08-16
+- Status: accepted
+- Issues: atqamz/hand#222
+- PRs: none
+
+## Context
+
+A single per-home watcher is authoritative, but the takeover path used to prove
+replacement by signaling a pid read from `watch.pid`. Two failures followed.
+
+A watcher crashes, a stale pid remains, a new watcher takes the kernel lock, and
+before a takeover contender can even observe the new owner, it reads the stale
+pid and - on Unix - sends that process SIGTERM. The pid may now belong to an
+innocent unrelated process. A liveness check does not fix this: a pid that is
+reused by an innocent process is as alive as the intended incumbent was.
+
+The incumbent also cannot tell an explicit Hand takeover from an ordinary
+external SIGTERM: both arrived as the same signal, so a displaced watcher could
+not report whether it was replaced or just interrupted.
+
+## Decision
+
+The kernel-backed `watch.pid.lock` remains the only ownership authority. `watch.pid`
+stays advisory pid metadata. A second routing file `watch.owner` carries a
+versioned, random ownership generation that correlates takeover routing, nothing
+more.
+
+A fresh owner, while holding the authoritative lock, removes any stale routing
+record, generates a fresh generation, creates the generation-bound platform
+takeover endpoint, publishes the advisory pid, and only then publishes the
+complete `watch.owner` record - so a valid live record implies a ready endpoint.
+On release it unpublishes the record and closes the endpoint while still holding
+the lock, then clears the pid, then releases the lock last.
+
+Unix onboarding coordinates a successor through a generation-bound
+Unix-domain-socket endpoint derived from fleet-home identity and generation.
+Windows preserves its named-event takeover, re-keyed from home identity and
+generation instead of pid. A stale generation can never reach the current
+generation's endpoint, so a stale or reused pid can never become a takeover
+target.
+
+A successor becomes owner only by acquiring the kernel lock; endpoint request
+success alone never grants ownership. Malformed, partial, or wrong-version
+routing metadata is non-actionable - no pid fallback exists.
+
+Replacement and generic interruption are distinct results:
+`watch interrupted` (exit 8) for ctrl-C / external SIGTERM / parent cancellation,
+and `watch replaced by explicit takeover` (exit 9) for a valid generation-bound
+request. Event delivery stays exit 0, a quiet window exit 4, arm failure exit 5.
+
+## Rejected alternatives
+
+- Signaling the advisory pid (with or without a liveness pre-check): pid
+  liveness cannot prove ownership and can misid an innocent reused process.
+- Treating SIGTERM as proof of takeover: an external operator cannot be told
+  apart from an explicit Hand request, collapsing two distinct lifecycle exits.
+- A resolvable endpoint path rooted in fleet home alone: opens the takeover
+  target to arbitrary-path injection and exceeds macOS socket-path limits.
+- Timestamp or process-registry authority: only the kernel lock is authority.
+
+## Consequences
+
+No takeover operation targets a process by pid. Stale, reused, or malformed
+metadata is safe by construction: routing is generation-bound and authority is
+the kernel lock. A hard crash needs no manual `watch.pid` or `watch.owner`
+cleanup. The exit taxonomy distinguishes replacement from interruption so a
+supervisory agent re-arms only when it should.
+
+`state/events.log` remains the fleet/worker event channel: a watcher's own
+termination is neither a fleet event nor logged there. It surfaces through the
+typed error, the AXI error kind, and the exit code, so a lifecycle log or fake
+replaced/interrupted event is never needed.

--- a/docs/adr/windows-watch-takeover-via-named-event.md
+++ b/docs/adr/windows-watch-takeover-via-named-event.md
@@ -1,7 +1,7 @@
 # Windows watch takeover uses a named event
 
 - Date: 2026-08-12
-- Status: accepted
+- Status: superseded by [Watcher takeover is generation-attributed](watcher-takeover-is-generation-attributed.md)
 - Issues: atqamz/hand#201
 - PRs: none
 

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -66,7 +66,7 @@ var supervisorInstructions = []string{
 	"Edit `data/backlog.md` to record the task with a unique ID.",
 	"Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.",
 	"`hand status <id>` shows a worker's reported state. Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.",
-	"Run `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event; exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. Re-arm it after acting on an event or when intentionally resuming monitoring.",
+	"Run `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event; exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. A supervisor should re-arm it after acting on an event or when intentionally resuming monitoring.",
 	"Never merge without explicit authorization.",
 	"Run `hand teardown <id>` after work is landed. Work that is handed off but whose landing is someone else's call is recorded with `hand deliver <id> --reason <text>` first.",
 	"Never edit files under `projects/`. Workers do that in worktrees.",

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -66,7 +66,7 @@ var supervisorInstructions = []string{
 	"Edit `data/backlog.md` to record the task with a unique ID.",
 	"Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.",
 	"`hand status <id>` shows a worker's reported state. Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.",
-	"Run `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event and that exit is what reaches you, so re-arm it every time you act on one.",
+	"Run `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event; exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. Re-arm it after acting on an event or when intentionally resuming monitoring.",
 	"Never merge without explicit authorization.",
 	"Run `hand teardown <id>` after work is landed. Work that is handed off but whose landing is someone else's call is recorded with `hand deliver <id> --reason <text>` first.",
 	"Never edit files under `projects/`. Workers do that in worktrees.",

--- a/internal/watcher/owner_record.go
+++ b/internal/watcher/owner_record.go
@@ -1,0 +1,120 @@
+package watcher
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+)
+
+// The only record layout the current hand understands. Any other version is
+// untrusted routing input: no takeover action may be attempted against it.
+const ownerRecordVersion = 1
+
+// OwnerRecord is the versioned, generation-bound ownership record that routes
+// an explicit takeover request to the current watcher. It is routing metadata
+// only: authority is the kernel-backed watch.pid.lock, never this file.
+type OwnerRecord struct {
+	Version    int    `json:"version"`
+	Generation string `json:"generation"`
+	PID        int    `json:"pid"`
+}
+
+// Fresh 128 random bits encoded as 32 lowercase hex characters, tying this
+// watcher's takeover endpoint to this incumbent alone.
+func newGeneration() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate ownership generation: %w", err)
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+// Strictly decodes an untrusted advisory record. Anything malformed, partial,
+// truncated, wrong-version, or structurally invalid is rejected: no takeover
+// may fall back to reading watch.pid and signaling a process.
+func parseOwnerRecord(data []byte) (OwnerRecord, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var rec OwnerRecord
+	if err := dec.Decode(&rec); err != nil {
+		return OwnerRecord{}, fmt.Errorf("parse owner record: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return OwnerRecord{}, fmt.Errorf("parse owner record: unexpected trailing data")
+	}
+	if err := validateOwnerRecord(rec); err != nil {
+		return OwnerRecord{}, err
+	}
+	return rec, nil
+}
+
+func validateOwnerRecord(rec OwnerRecord) error {
+	if rec.Version != ownerRecordVersion {
+		return fmt.Errorf("owner record: unsupported version %d", rec.Version)
+	}
+	if len(rec.Generation) != ownerGenerationLen {
+		return fmt.Errorf("owner record: generation must be %d lowercase hex characters, got %q", ownerGenerationLen, rec.Generation)
+	}
+	for _, c := range rec.Generation {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		default:
+			return fmt.Errorf("owner record: generation %q is not lowercase hex", rec.Generation)
+		}
+	}
+	if rec.PID <= 0 {
+		return fmt.Errorf("owner record: pid must be a positive integer, got %d", rec.PID)
+	}
+	return nil
+}
+
+const ownerGenerationLen = 32
+
+// OwnerRecordPath names the routing record that ties an explicit takeover to a
+// specific generation, alongside the advisory PID file OwnerPath names.
+func OwnerRecordPath(homeDir string) string {
+	return filepath.Join(stateDir(homeDir), "watch.owner")
+}
+
+// A short stable identity for a fleet home, used to derive platform-owned
+// takeover endpoint identities without embedding arbitrary filesystem paths in
+// a socket or named-event name.
+func homeID(homeDir string) string {
+	home := canonicalHome(homeDir)
+	sum := sha256.Sum256([]byte(home))
+	return hex.EncodeToString(sum[:8])
+}
+
+// Folds ordinary references to the same fleet home into one endpoint identity:
+// clean, absolute, and symlink-resolved.
+func canonicalHome(homeDir string) string {
+	home := filepath.Clean(homeDir)
+	if abs, err := filepath.Abs(home); err == nil {
+		home = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(home); err == nil {
+		home = resolved
+	}
+	return home
+}
+
+// Atomically replaces watch.owner. This is the final step of acquisition, so a
+// valid live record implies a ready takeover endpoint.
+func publishOwnerRecord(homeDir string, rec OwnerRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal owner record: %w", err)
+	}
+	if err := atomicfileWrite(OwnerRecordPath(homeDir), data); err != nil {
+		return fmt.Errorf("publish owner record: %w", err)
+	}
+	return nil
+}

--- a/internal/watcher/owner_record.go
+++ b/internal/watcher/owner_record.go
@@ -3,7 +3,6 @@ package watcher
 import (
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -82,15 +81,6 @@ const ownerGenerationLen = 32
 // specific generation, alongside the advisory PID file OwnerPath names.
 func OwnerRecordPath(homeDir string) string {
 	return filepath.Join(stateDir(homeDir), "watch.owner")
-}
-
-// A short stable identity for a fleet home, used to derive platform-owned
-// takeover endpoint identities without embedding arbitrary filesystem paths in
-// a socket or named-event name.
-func homeID(homeDir string) string {
-	home := canonicalHome(homeDir)
-	sum := sha256.Sum256([]byte(home))
-	return hex.EncodeToString(sum[:8])
 }
 
 // Folds ordinary references to the same fleet home into one endpoint identity:

--- a/internal/watcher/owner_record_test.go
+++ b/internal/watcher/owner_record_test.go
@@ -6,7 +6,11 @@ import (
 	"testing"
 )
 
-const testGen = "0123456789abcdef0123456789abcdef"
+const (
+	testGen = "0123456789abcdef0123456789abcdef"
+	genA    = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	genB    = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
 
 func validRecord() OwnerRecord {
 	return OwnerRecord{Version: ownerRecordVersion, Generation: testGen, PID: 12345}

--- a/internal/watcher/owner_record_test.go
+++ b/internal/watcher/owner_record_test.go
@@ -1,0 +1,83 @@
+package watcher
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const testGen = "0123456789abcdef0123456789abcdef"
+
+func validRecord() OwnerRecord {
+	return OwnerRecord{Version: ownerRecordVersion, Generation: testGen, PID: 12345}
+}
+
+func TestOwnerRecordRoundTrips(t *testing.T) {
+	data, err := json.Marshal(validRecord())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseOwnerRecord(data)
+	if err != nil {
+		t.Fatalf("parseOwnerRecord: %v", err)
+	}
+	if got != validRecord() {
+		t.Fatalf("got %+v, want %+v", got, validRecord())
+	}
+}
+
+func TestNewGenerationIsLowercaseHex(t *testing.T) {
+	for range 20 {
+		gen, err := newGeneration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := validRecord()
+		rec.Generation = gen
+		if _, err := parseOwnerRecord(mustMarshal(t, rec)); err != nil {
+			t.Fatalf("fresh generation %q rejected: %v", gen, err)
+		}
+	}
+}
+
+func mustMarshal(t *testing.T, rec OwnerRecord) []byte {
+	t.Helper()
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// Every invalid record is non-actionable routing metadata: parseOwnerRecord must
+// reject it so no takeover path can ever target a process or generation from it.
+func TestParseOwnerRecordRejectsInvalidRecords(t *testing.T) {
+	gen := testGen
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty file", ""},
+		{"partial json", `{"version":1`},
+		{"malformed json", `{oops`},
+		{"trailing garbage", `{"version":1,"generation":"` + gen + `","pid":1} \n extra`},
+		{"wrong version", `{"version":2,"generation":"` + gen + `","pid":1}`},
+		{"missing generation", `{"version":1,"pid":5}`},
+		{"empty generation", `{"version":1,"generation":"","pid":5}`},
+		{"short generation", `{"version":1,"generation":"abcd","pid":5}`},
+		{"uppercase generation", `{"version":1,"generation":"` + strings.ToUpper(gen) + `","pid":5}`},
+		{"nonhex generation", `{"version":1,"generation":"gggggggggggggggggggggggggggggggg","pid":5}`},
+		{"missing pid", `{"version":1,"generation":"` + gen + `"}`},
+		{"zero pid", `{"version":1,"generation":"` + gen + `","pid":0}`},
+		{"negative pid", `{"version":1,"generation":"` + gen + `","pid":-3}`},
+		{"noninteger pid", `{"version":1,"generation":"` + gen + `","pid":"abc"}`},
+		{"unknown field", `{"version":1,"generation":"` + gen + `","pid":1,"evil":2}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseOwnerRecord([]byte(tc.input)); err == nil {
+				t.Fatalf("parseOwnerRecord(%q) succeeded, want rejection", tc.input)
+			}
+		})
+	}
+}

--- a/internal/watcher/ownership.go
+++ b/internal/watcher/ownership.go
@@ -187,12 +187,12 @@ func (o *Ownership) PID() int {
 	return o.record.PID
 }
 
-// Handles lock contention. Without --takeover it refuses immediately, naming
-// the coherent incumbent. With --takeover it requests each observed generation
-// once and waits for the kernel lock, never targeting a process by pid.
+// Handles lock contention. Without --takeover it refuses immediately. With
+// --takeover it requests each observed generation once after delivery succeeds
+// and waits for the kernel lock, never targeting a process by pid.
 func contend(lockFile *os.File, home string, takeover bool) error {
 	if !takeover {
-		return fmt.Errorf("%w (pid %s) - stop it, or re-run with --takeover to replace it", ErrAttached, incumbentLabel(home))
+		return fmt.Errorf("%w - a watcher already holds the fleet-home lock; stop it through its owning session, or use --takeover for cooperative replacement", ErrAttached)
 	}
 
 	deadline := time.Now().Add(takeoverGrace)
@@ -209,8 +209,8 @@ func contend(lockFile *os.File, home string, takeover bool) error {
 		}
 		requestCurrent(home, requested)
 		if time.Now().After(deadline) {
-			return fmt.Errorf("%w (pid %s) and it still holds %s %s after --takeover - stop it and retry",
-				ErrAttached, incumbentLabel(home), lockFile.Name(), takeoverGrace)
+			return fmt.Errorf("%w - the fleet-home lock did not release within %s after --takeover; stop the watcher through its owning session and retry",
+				ErrAttached, takeoverGrace)
 		}
 		time.Sleep(takeoverPoll)
 	}
@@ -227,12 +227,12 @@ func requestCurrent(home string, requested map[string]bool) {
 	if rec.PID == os.Getpid() || requested[rec.Generation] {
 		return
 	}
-	requested[rec.Generation] = true
 	if rErr := requestTakeover(home, rec.Generation); rErr != nil {
 		// Endpoint-gone or stale-generation here is not proof of ownership: the
 		// contender keeps waiting on the kernel lock, which is the only authority.
 		return
 	}
+	requested[rec.Generation] = true
 }
 
 // Returns the coherent current routing record, or an error for any malformed,
@@ -243,17 +243,6 @@ func readOwnerRecord(home string) (OwnerRecord, error) {
 		return OwnerRecord{}, err
 	}
 	return parseOwnerRecord(data)
-}
-
-// Names the attached watcher from a valid coherent owner record when one is
-// published, falling back to unknown rather than presenting a stale advisory pid
-// as current truth.
-func incumbentLabel(home string) string {
-	rec, err := readOwnerRecord(home)
-	if err != nil {
-		return "unknown"
-	}
-	return strconv.Itoa(rec.PID)
 }
 
 func lockOwner(file *os.File) error {

--- a/internal/watcher/ownership.go
+++ b/internal/watcher/ownership.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/atqamz/hand/internal/atomicfile"
 	"github.com/atqamz/hand/internal/filelock"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -18,82 +18,151 @@ import (
 // precondition failure rather than a general error.
 var ErrAttached = errors.New("a watcher is already attached to this fleet home")
 
-// How long Acquire waits for a signaled incumbent to release before reporting
-// that it did not, and how often it re-tries the lock in the meantime.
-const (
+// How long Acquire --takeover waits for a cooperatively-requested incumbent to
+// release before failing, and how often it re-tries the lock. Variables so a
+// test can shrink the wait without sleeping out the default grace.
+var (
 	takeoverGrace = 5 * time.Second
 	takeoverPoll  = 50 * time.Millisecond
 )
 
-// OwnerPath names the file that records the owning watcher's pid.
+// OwnerPath names the advisory file that records the owning watcher's pid.
+// Backward-compatible with what operators already read; OwnerRecordPath is the
+// coherent routing record #222 routes takeover through, and neither is authority.
 func OwnerPath(homeDir string) string {
 	return filepath.Join(state.Dir(homeDir), "watch.pid")
 }
 
+func stateDir(homeDir string) string {
+	return state.Dir(homeDir)
+}
+
+func atomicfileWrite(path string, data []byte) error {
+	return atomicfile.Write(path, ".atomic-", data, 0o644)
+}
+
 // Ownership keeps the files and endpoint that make a watcher the fleet-home owner.
 type Ownership struct {
-	ownerFile *os.File
-	lockFile  *os.File
-	endpoint  *takeoverEndpoint
-	once      sync.Once
+	home     string
+	lockFile *os.File
+	endpoint *takeoverEndpoint
+	record   OwnerRecord
+	once     sync.Once
 }
 
 // Acquire makes hand watch a singleton per fleet home. The kernel drops the lock when the holder dies.
 func Acquire(homeDir string, takeover bool) (*Ownership, error) {
-	path := OwnerPath(homeDir)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	home := canonicalHome(homeDir)
+	if err := os.MkdirAll(stateDir(home), 0o755); err != nil {
 		return nil, fmt.Errorf("create state directory: %w", err)
 	}
-	lockFile, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	lockPath := OwnerPath(home) + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("open %s.lock: %w", path, err)
+		return nil, fmt.Errorf("open %s: %w", lockPath, err)
 	}
 
 	if err := lockOwner(lockFile); err != nil {
 		if !errors.Is(err, filelock.ErrBusy) {
 			_ = lockFile.Close()
-			return nil, fmt.Errorf("lock %s: %w", path, err)
+			return nil, fmt.Errorf("lock %s: %w", lockPath, err)
 		}
-		if err := contend(lockFile, path, takeover); err != nil {
+		if err := contend(lockFile, home, takeover); err != nil {
 			_ = lockFile.Close()
 			return nil, err
 		}
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
-	if err != nil {
-		releaseLock(lockFile)
-		return nil, fmt.Errorf("open %s: %w", path, err)
-	}
 
-	endpoint, err := newTakeoverEndpoint(os.Getpid())
+	ownership, err := publishNewOwner(home, lockFile)
 	if err != nil {
-		_ = file.Close()
-		releaseLock(lockFile)
+		_ = lockFile.Close()
 		return nil, err
 	}
-
-	// The pid is recorded inside the lock only so a refusal can name the incumbent and takeover can
-	// request it to stop.
-	if err := recordOwner(file); err != nil {
-		releaseOwner(file, lockFile)
-		endpoint.Close()
-		return nil, err
-	}
-	return &Ownership{ownerFile: file, lockFile: lockFile, endpoint: endpoint}, nil
+	return ownership, nil
 }
 
-// Release clears the recorded pid, releases the lock, and stops the endpoint listener.
+// Runs the new-owner publication protocol once while holding the authoritative
+// lock: stale record out, fresh generation, endpoint ready, advisory pid, then
+// the coherent watch.owner record LAST as the readiness barrier.
+func publishNewOwner(home string, lockFile *os.File) (*Ownership, error) {
+	if err := clearRoutingRecord(home); err != nil {
+		releaseLock(lockFile)
+		return nil, err
+	}
+
+	gen, err := newGeneration()
+	if err != nil {
+		releaseLock(lockFile)
+		return nil, err
+	}
+
+	endpoint, err := newTakeoverEndpoint(home, gen)
+	if err != nil {
+		releaseLock(lockFile)
+		return nil, err
+	}
+
+	if err := publishPID(home, os.Getpid()); err != nil {
+		endpoint.Close()
+		releaseLock(lockFile)
+		return nil, err
+	}
+
+	record := OwnerRecord{Version: ownerRecordVersion, Generation: gen, PID: os.Getpid()}
+	if err := publishOwnerRecord(home, record); err != nil {
+		endpoint.Close()
+		_ = clearPID(home)
+		releaseLock(lockFile)
+		return nil, err
+	}
+
+	return &Ownership{home: home, lockFile: lockFile, endpoint: endpoint, record: record}, nil
+}
+
+func publishPID(home string, pid int) error {
+	data := []byte(strconv.Itoa(pid) + "\n")
+	if err := atomicfileWrite(OwnerPath(home), data); err != nil {
+		return fmt.Errorf("record watcher pid in %s: %w", OwnerPath(home), err)
+	}
+	return nil
+}
+
+// Leaves the advisory pid file present but empty, so an operator reading it on
+// an unwatched home finds nothing rather than a dead process's number.
+func clearPID(home string) error {
+	if err := atomicfileWrite(OwnerPath(home), nil); err != nil {
+		return fmt.Errorf("clear %s: %w", OwnerPath(home), err)
+	}
+	return nil
+}
+
+// Removes any old watch.owner publication while holding the authoritative lock,
+// so a stale generation cannot route a takeover at a stale incumbent during the
+// publication window.
+func clearRoutingRecord(home string) error {
+	if err := os.Remove(OwnerRecordPath(home)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale owner record: %w", err)
+	}
+	return nil
+}
+
+// Release shuts ownership down in the order that keeps stale routing metadata
+// non-destructive: routing record unpublished and endpoint closed while the
+// authoritative lock is still held, pid cleared, then the lock released last.
 func (o *Ownership) Release() {
 	if o == nil {
 		return
 	}
 	o.once.Do(func() {
-		releaseOwner(o.ownerFile, o.lockFile)
+		_ = clearRoutingRecord(o.home)
 		o.endpoint.Close()
+		_ = clearPID(o.home)
+		releaseLock(o.lockFile)
 	})
 }
 
-// TakeoverRequested returns the one-shot incumbent shutdown notification.
+// TakeoverRequested returns the one-shot incumbent shutdown notification, set
+// only by a valid current-generation request through the handmade endpoint.
 func (o *Ownership) TakeoverRequested() <-chan struct{} {
 	if o == nil || o.endpoint == nil {
 		return nil
@@ -101,23 +170,35 @@ func (o *Ownership) TakeoverRequested() <-chan struct{} {
 	return o.endpoint.Requested()
 }
 
-// Decides what a lock another live watcher holds means. The pid is read after the lock attempt
-// failed, so it belongs to a process that still held the lock a moment ago rather than to some
-// long-dead predecessor.
-func contend(lockFile *os.File, ownerPath string, takeover bool) error {
-	pid := readOwner(ownerPath)
-	if !takeover {
-		return fmt.Errorf("%w (pid %s) - stop it, or re-run with --takeover to replace it", ErrAttached, ownerLabel(pid))
+// Generation is the ownership generation this watcher published, for
+// diagnostics and tests.
+func (o *Ownership) Generation() string {
+	if o == nil {
+		return ""
 	}
-	// Never this process: in production a watcher acquires once, but an
-	// in-process caller that acquired already would otherwise request itself.
-	if pid > 0 && pid != os.Getpid() {
-		if err := requestTakeover(pid); err != nil {
-			return fmt.Errorf("request takeover from watcher pid %d: %w", pid, err)
-		}
+	return o.record.Generation
+}
+
+// PID is the advisory pid published for operator diagnostics, never authority.
+func (o *Ownership) PID() int {
+	if o == nil {
+		return 0
+	}
+	return o.record.PID
+}
+
+// Handles lock contention. Without --takeover it refuses immediately, naming
+// the coherent incumbent. With --takeover it requests each observed generation
+// once and waits for the kernel lock, never targeting a process by pid.
+func contend(lockFile *os.File, home string, takeover bool) error {
+	if !takeover {
+		return fmt.Errorf("%w (pid %s) - stop it, or re-run with --takeover to replace it", ErrAttached, incumbentLabel(home))
 	}
 
 	deadline := time.Now().Add(takeoverGrace)
+	requested := make(map[string]bool)
+	requestCurrent(home, requested)
+
 	for {
 		err := lockOwner(lockFile)
 		if err == nil {
@@ -126,67 +207,60 @@ func contend(lockFile *os.File, ownerPath string, takeover bool) error {
 		if !errors.Is(err, filelock.ErrBusy) {
 			return fmt.Errorf("lock %s: %w", lockFile.Name(), err)
 		}
+		requestCurrent(home, requested)
 		if time.Now().After(deadline) {
-			// The pid may have been unreadable, in which case there was nothing to request and the
-			// honest remedy is the same either way.
-			return fmt.Errorf("%w (pid %s) and it still holds %s %s after --takeover - kill it and retry",
-				ErrAttached, ownerLabel(pid), lockFile.Name(), takeoverGrace)
+			return fmt.Errorf("%w (pid %s) and it still holds %s %s after --takeover - stop it and retry",
+				ErrAttached, incumbentLabel(home), lockFile.Name(), takeoverGrace)
 		}
 		time.Sleep(takeoverPoll)
 	}
+}
+
+// Asks the currently-published owner generation to step aside, exactly once per
+// observed generation. A malformed or absent record performs no action; there is
+// never a pid-based fallback.
+func requestCurrent(home string, requested map[string]bool) {
+	rec, err := readOwnerRecord(home)
+	if err != nil {
+		return
+	}
+	if rec.PID == os.Getpid() || requested[rec.Generation] {
+		return
+	}
+	requested[rec.Generation] = true
+	if rErr := requestTakeover(home, rec.Generation); rErr != nil {
+		// Endpoint-gone or stale-generation here is not proof of ownership: the
+		// contender keeps waiting on the kernel lock, which is the only authority.
+		return
+	}
+}
+
+// Returns the coherent current routing record, or an error for any malformed,
+// partial, or unsupported value - none of which is actionable.
+func readOwnerRecord(home string) (OwnerRecord, error) {
+	data, err := os.ReadFile(OwnerRecordPath(home))
+	if err != nil {
+		return OwnerRecord{}, err
+	}
+	return parseOwnerRecord(data)
+}
+
+// Names the attached watcher from a valid coherent owner record when one is
+// published, falling back to unknown rather than presenting a stale advisory pid
+// as current truth.
+func incumbentLabel(home string) string {
+	rec, err := readOwnerRecord(home)
+	if err != nil {
+		return "unknown"
+	}
+	return strconv.Itoa(rec.PID)
 }
 
 func lockOwner(file *os.File) error {
 	return filelock.Lock(file, false)
 }
 
-// Clears the pid before dropping the lock, so an operator reading state/watch.pid on an unwatched
-// home finds nothing rather than the number of a process that has exited.
-func releaseOwner(file, lockFile *os.File) {
-	_ = file.Truncate(0)
-	_ = file.Close()
-	releaseLock(lockFile)
-}
-
 func releaseLock(file *os.File) {
 	_ = filelock.Unlock(file)
 	_ = file.Close()
-}
-
-func recordOwner(file *os.File) error {
-	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("clear %s: %w", file.Name(), err)
-	}
-	if _, err := file.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0); err != nil {
-		return fmt.Errorf("record watcher pid in %s: %w", file.Name(), err)
-	}
-	return nil
-}
-
-// Reports the recorded pid, or 0 for anything it cannot read as one - a wrong pid here would be
-// used to request takeover from the wrong process.
-func readOwner(path string) int {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return 0
-	}
-	line, _, terminated := strings.Cut(string(data), "\n")
-	// The terminating newline is required: the incumbent truncates before it writes, so a read racing
-	// that write sees an empty or partial value, and only a terminated line proves the whole pid
-	// reached disk.
-	if !terminated {
-		return 0
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(line))
-	if err != nil || pid <= 0 {
-		return 0
-	}
-	return pid
-}
-
-func ownerLabel(pid int) string {
-	if pid <= 0 {
-		return "unknown"
-	}
-	return strconv.Itoa(pid)
 }

--- a/internal/watcher/ownership.go
+++ b/internal/watcher/ownership.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -22,8 +23,9 @@ var ErrAttached = errors.New("a watcher is already attached to this fleet home")
 // release before failing, and how often it re-tries the lock. Variables so a
 // test can shrink the wait without sleeping out the default grace.
 var (
-	takeoverGrace = 5 * time.Second
-	takeoverPoll  = 50 * time.Millisecond
+	takeoverGrace     = 5 * time.Second
+	takeoverPoll      = 50 * time.Millisecond
+	afterLockAcquired = func() {}
 )
 
 // OwnerPath names the advisory file that records the owning watcher's pid.
@@ -52,6 +54,14 @@ type Ownership struct {
 
 // Acquire makes hand watch a singleton per fleet home. The kernel drops the lock when the holder dies.
 func Acquire(homeDir string, takeover bool) (*Ownership, error) {
+	return AcquireContext(context.Background(), homeDir, takeover)
+}
+
+// Context-aware acquisition stops a takeover wait without changing lock authority.
+func AcquireContext(ctx context.Context, homeDir string, takeover bool) (*Ownership, error) {
+	if err := acquisitionContextError(ctx); err != nil {
+		return nil, err
+	}
 	home := canonicalHome(homeDir)
 	if err := os.MkdirAll(stateDir(home), 0o755); err != nil {
 		return nil, fmt.Errorf("create state directory: %w", err)
@@ -67,15 +77,20 @@ func Acquire(homeDir string, takeover bool) (*Ownership, error) {
 			_ = lockFile.Close()
 			return nil, fmt.Errorf("lock %s: %w", lockPath, err)
 		}
-		if err := contend(lockFile, home, takeover); err != nil {
+		if err := contend(ctx, lockFile, home, takeover); err != nil {
 			_ = lockFile.Close()
 			return nil, err
 		}
 	}
 
+	afterLockAcquired()
 	ownership, err := publishNewOwner(home, lockFile)
 	if err != nil {
 		_ = lockFile.Close()
+		return nil, err
+	}
+	if err := acquisitionContextError(ctx); err != nil {
+		ownership.Release()
 		return nil, err
 	}
 	return ownership, nil
@@ -190,7 +205,10 @@ func (o *Ownership) PID() int {
 // Handles lock contention. Without --takeover it refuses immediately. With
 // --takeover it requests each observed generation once after delivery succeeds
 // and waits for the kernel lock, never targeting a process by pid.
-func contend(lockFile *os.File, home string, takeover bool) error {
+func contend(ctx context.Context, lockFile *os.File, home string, takeover bool) error {
+	if err := acquisitionContextError(ctx); err != nil {
+		return err
+	}
 	if !takeover {
 		return fmt.Errorf("%w - a watcher already holds the fleet-home lock; stop it through its owning session, or use --takeover for cooperative replacement", ErrAttached)
 	}
@@ -200,6 +218,9 @@ func contend(lockFile *os.File, home string, takeover bool) error {
 	requestCurrent(home, requested)
 
 	for {
+		if err := acquisitionContextError(ctx); err != nil {
+			return err
+		}
 		err := lockOwner(lockFile)
 		if err == nil {
 			return nil
@@ -212,8 +233,23 @@ func contend(lockFile *os.File, home string, takeover bool) error {
 			return fmt.Errorf("%w - the fleet-home lock did not release within %s after --takeover; stop the watcher through its owning session and retry",
 				ErrAttached, takeoverGrace)
 		}
-		time.Sleep(takeoverPoll)
+		timer := time.NewTimer(takeoverPoll)
+		select {
+		case <-ctx.Done():
+			if err := acquisitionContextError(ctx); err != nil {
+				_ = timer.Stop()
+				return err
+			}
+		case <-timer.C:
+		}
 	}
+}
+
+func acquisitionContextError(ctx context.Context) error {
+	if ctx == nil || ctx.Err() == nil {
+		return nil
+	}
+	return cancellationError(ctx)
 }
 
 // Asks the currently-published owner generation to step aside, exactly once per

--- a/internal/watcher/ownership_test.go
+++ b/internal/watcher/ownership_test.go
@@ -219,20 +219,25 @@ func TestContenderWithMalformedRecordWaitsForTheLock(t *testing.T) {
 	restoreTakeoverClocks(t)
 	takeoverGrace, takeoverPoll = 3*time.Second, 20*time.Millisecond
 
-	done := make(chan error, 1)
-	go func() { _, e := Acquire(home, true); done <- e }()
+	type outcome struct {
+		ownership *Ownership
+		err       error
+	}
+	done := make(chan outcome, 1)
+	go func() { o, e := Acquire(home, true); done <- outcome{o, e} }()
 	select {
-	case err := <-done:
-		t.Fatalf("contender returned early while the lock was held: %v", err)
+	case r := <-done:
+		t.Fatalf("contender returned early while the lock was held: %v", r.err)
 	case <-time.After(100 * time.Millisecond):
 	}
 	holder.Release()
 
 	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("contender Acquire after release: %v", err)
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("contender Acquire after release: %v", r.err)
 		}
+		r.ownership.Release()
 	case <-time.After(3 * time.Second):
 		t.Fatal("contender did not acquire once the holder released the lock")
 	}

--- a/internal/watcher/ownership_test.go
+++ b/internal/watcher/ownership_test.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -201,6 +202,76 @@ func TestContenderWithNoRecordWaitsForTheLock(t *testing.T) {
 		r.ownership.Release()
 	case <-time.After(3 * time.Second):
 		t.Fatal("contender did not acquire once the holder released the lock")
+	}
+}
+
+func TestContenderCannotActBetweenLockAcquisitionAndOwnerPublication(t *testing.T) {
+	home := t.TempDir()
+	incumbent, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := incumbent.Generation()
+	incumbent.endpoint.Close()
+	releaseLock(incumbent.lockFile)
+	if err := publishOwnerRecord(home, OwnerRecord{Version: ownerRecordVersion, Generation: generation, PID: 424242}); err != nil {
+		t.Fatal(err)
+	}
+
+	publicationReached := make(chan struct{})
+	publicationContinue := make(chan struct{})
+	oldAfterLockAcquired := afterLockAcquired
+	afterLockAcquired = func() {
+		close(publicationReached)
+		<-publicationContinue
+	}
+	t.Cleanup(func() {
+		afterLockAcquired = oldAfterLockAcquired
+		select {
+		case <-publicationContinue:
+		default:
+			close(publicationContinue)
+		}
+	})
+
+	type outcome struct {
+		ownership *Ownership
+		err       error
+	}
+	successorDone := make(chan outcome, 1)
+	go func() {
+		ownership, acquireErr := Acquire(home, false)
+		successorDone <- outcome{ownership: ownership, err: acquireErr}
+	}()
+	select {
+	case <-publicationReached:
+	case <-time.After(time.Second):
+		t.Fatal("successor did not acquire the kernel lock before publication")
+	}
+
+	if _, err := os.Stat(OwnerRecordPath(home)); err != nil {
+		t.Fatalf("stale owner record disappeared before the successor reached publication: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	contender, err := AcquireContext(ctx, home, true)
+	cancel()
+	if contender != nil {
+		contender.Release()
+		t.Fatal("takeover contender became owner while the successor held the kernel lock")
+	}
+	if !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("takeover contender = %v, want interruption while the lock remains held", err)
+	}
+
+	close(publicationContinue)
+	select {
+	case result := <-successorDone:
+		if result.err != nil {
+			t.Fatalf("successor Acquire: %v", result.err)
+		}
+		result.ownership.Release()
+	case <-time.After(time.Second):
+		t.Fatal("successor did not finish owner publication")
 	}
 }
 

--- a/internal/watcher/ownership_test.go
+++ b/internal/watcher/ownership_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -131,6 +132,9 @@ func readOwnerFile(t *testing.T, home string) string {
 // A stale advisory pid that happens to be a live innocent process must never be
 // attacked: when the kernel lock is free, Acquire ignores it entirely.
 func TestAcquireReplacesStaleLivePIDAndLeavesTheInnocentProcessAlone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support the signal-zero liveness probe")
+	}
 	home := t.TempDir()
 	innocent := exec.Command("sleep", "3600")
 	if err := innocent.Start(); err != nil {

--- a/internal/watcher/ownership_test.go
+++ b/internal/watcher/ownership_test.go
@@ -1,12 +1,15 @@
 package watcher
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestAcquireRefusesASecondWatcherAndNamesTheIncumbent(t *testing.T) {
@@ -123,4 +126,142 @@ func readOwnerFile(t *testing.T, home string) string {
 		t.Fatal(err)
 	}
 	return string(data)
+}
+
+// A stale advisory pid that happens to be a live innocent process must never be
+// attacked: when the kernel lock is free, Acquire ignores it entirely.
+func TestAcquireReplacesStaleLivePIDAndLeavesTheInnocentProcessAlone(t *testing.T) {
+	home := t.TempDir()
+	innocent := exec.Command("sleep", "3600")
+	if err := innocent.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = innocent.Process.Kill()
+		_ = innocent.Wait()
+	}()
+	writeOwnerFile(t, home, strconv.Itoa(innocent.Process.Pid)+"\n")
+
+	ownership, err := Acquire(home, false)
+	if err != nil {
+		t.Fatalf("Acquire over a stale live pid: %v", err)
+	}
+	ownership.Release()
+
+	// A zero signal is a liveness probe, never a delivered signal; it proves the
+	// innocent process was not terminated by any takeover handling.
+	if err := innocent.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("innocent process no longer exists after stale-pid handling: %v", err)
+	}
+	if got := readOwnerFile(t, home); got != "" {
+		t.Fatalf("owner file = %q after release, want it clear - not the innocent process's pid", got)
+	}
+}
+
+// Simulates a holder that has not (or no longer) published a coherent routing
+// record: a --takeover contender must perform no destructive action and simply
+// wait for the authoritative lock.
+func TestContenderWithNoRecordWaitsForTheLock(t *testing.T) {
+	home := t.TempDir()
+	holder, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(OwnerRecordPath(home)); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreTakeoverClocks(t)
+	takeoverGrace, takeoverPoll = 3*time.Second, 20*time.Millisecond
+
+	type outcome struct {
+		ownership *Ownership
+		err       error
+	}
+	done := make(chan outcome, 1)
+	go func() { o, e := Acquire(home, true); done <- outcome{o, e} }()
+
+	// Held, no record: contender waits, does nothing destructive, is not yet owner.
+	select {
+	case r := <-done:
+		t.Fatalf("contender returned early while the lock was held: %v / %v", r.ownership, r.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	holder.Release()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("contender Acquire after release: %v", r.err)
+		}
+		r.ownership.Release()
+	case <-time.After(3 * time.Second):
+		t.Fatal("contender did not acquire once the holder released the lock")
+	}
+}
+
+// Same expectation with a malformed record: no destructive action, Safe keeps
+// waiting, and the lock alone decides ownership.
+func TestContenderWithMalformedRecordWaitsForTheLock(t *testing.T) {
+	home := t.TempDir()
+	holder, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(OwnerRecordPath(home), []byte(`{truncated`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreTakeoverClocks(t)
+	takeoverGrace, takeoverPoll = 3*time.Second, 20*time.Millisecond
+
+	done := make(chan error, 1)
+	go func() { _, e := Acquire(home, true); done <- e }()
+	select {
+	case err := <-done:
+		t.Fatalf("contender returned early while the lock was held: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	holder.Release()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("contender Acquire after release: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("contender did not acquire once the holder released the lock")
+	}
+}
+
+// If safe takeover cannot complete before the grace bound because the lock
+// never releases, the contender fails and the incumbent stays the sole owner -
+// there are never two owners.
+func TestContenderFailsWithinGraceWithoutCreatingASecondOwner(t *testing.T) {
+	home := t.TempDir()
+	holder, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Release()
+
+	restoreTakeoverClocks(t)
+	takeoverGrace, takeoverPoll = 200*time.Millisecond, 20*time.Millisecond
+
+	_, err = Acquire(home, true)
+	if !errors.Is(err, ErrAttached) {
+		t.Fatalf("takeover contender = %v, want ErrAttached when the lock never releases", err)
+	}
+	// The holder still owns the single lock.
+	if _, err := Acquire(home, true); !errors.Is(err, ErrAttached) {
+		t.Fatalf("after a failed contender the holder was displaced: %v", err)
+	}
+}
+
+func restoreTakeoverClocks(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		takeoverGrace = 5 * time.Second
+		takeoverPoll = 50 * time.Millisecond
+	})
 }

--- a/internal/watcher/ownership_test.go
+++ b/internal/watcher/ownership_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func TestAcquireRefusesASecondWatcherAndNamesTheIncumbent(t *testing.T) {
+func TestAcquireRefusesASecondWatcherWithoutTrustingAdvisoryPID(t *testing.T) {
 	home := t.TempDir()
 
 	ownership, err := Acquire(home, false)
@@ -31,8 +31,8 @@ func TestAcquireRefusesASecondWatcherAndNamesTheIncumbent(t *testing.T) {
 	if !strings.Contains(err.Error(), ErrAttached.Error()) {
 		t.Fatalf("got %v, want it to wrap ErrAttached", err)
 	}
-	if !strings.Contains(err.Error(), "pid "+strconv.Itoa(os.Getpid())) {
-		t.Fatalf("got %v, want the refusal to name the incumbent pid %d", err, os.Getpid())
+	if strings.Contains(err.Error(), "pid ") || !strings.Contains(err.Error(), "owning session") {
+		t.Fatalf("got %v, want no operator instruction based on advisory PID", err)
 	}
 	if !strings.Contains(err.Error(), "--takeover") {
 		t.Fatalf("got %v, want the refusal to name the remedy", err)

--- a/internal/watcher/takeover_unix.go
+++ b/internal/watcher/takeover_unix.go
@@ -16,6 +16,7 @@ import (
 )
 
 const sockaddrUnLimit = 104
+const takeoverSocketDir = "/tmp"
 
 // Derives the generation-bound Unix socket location from the fleet-home
 // identity and ownership generation, not watch.pid. A short hashed name stays
@@ -23,12 +24,7 @@ const sockaddrUnLimit = 104
 func takeoverSocketPath(home, gen string) string {
 	sum := sha256.Sum256([]byte(canonicalHome(home) + "\x00" + gen))
 	name := fmt.Sprintf("hw-%s.sock", hex.EncodeToString(sum[:])[:24])
-	dir := os.TempDir()
-	path := filepath.Join(dir, name)
-	if len(path) >= sockaddrUnLimit {
-		return filepath.Join("/tmp", name)
-	}
-	return path
+	return filepath.Join(takeoverSocketDir, name)
 }
 
 // Owns the generation-bound Unix socket that lets a takeover contender ask the

--- a/internal/watcher/takeover_unix.go
+++ b/internal/watcher/takeover_unix.go
@@ -4,6 +4,8 @@ package watcher
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -15,10 +17,11 @@ import (
 )
 
 // Derives the generation-bound Unix socket location from the fleet-home
-// identity and ownership generation, not watch.pid. A short name avoids macOS
-// sockaddr_un length failures and trusts no arbitrary path from metadata.
+// identity and ownership generation, not watch.pid. A short hashed name stays
+// under macOS's sockaddr_un path limit, trusting no arbitrary path from metadata.
 func takeoverSocketPath(home, gen string) string {
-	name := fmt.Sprintf("hw-%s-%s.sock", homeID(home), gen)
+	sum := sha256.Sum256([]byte(canonicalHome(home) + "\x00" + gen))
+	name := fmt.Sprintf("hw-%s.sock", hex.EncodeToString(sum[:])[:24])
 	return filepath.Join(os.TempDir(), name)
 }
 

--- a/internal/watcher/takeover_unix.go
+++ b/internal/watcher/takeover_unix.go
@@ -15,13 +15,20 @@ import (
 	"time"
 )
 
+const sockaddrUnLimit = 104
+
 // Derives the generation-bound Unix socket location from the fleet-home
 // identity and ownership generation, not watch.pid. A short hashed name stays
 // under macOS's sockaddr_un path limit, trusting no arbitrary path from metadata.
 func takeoverSocketPath(home, gen string) string {
 	sum := sha256.Sum256([]byte(canonicalHome(home) + "\x00" + gen))
 	name := fmt.Sprintf("hw-%s.sock", hex.EncodeToString(sum[:])[:24])
-	return filepath.Join(os.TempDir(), name)
+	dir := os.TempDir()
+	path := filepath.Join(dir, name)
+	if len(path) >= sockaddrUnLimit {
+		return filepath.Join("/tmp", name)
+	}
+	return path
 }
 
 // Owns the generation-bound Unix socket that lets a takeover contender ask the

--- a/internal/watcher/takeover_unix.go
+++ b/internal/watcher/takeover_unix.go
@@ -3,25 +3,114 @@
 package watcher
 
 import (
+	"bufio"
 	"errors"
-	"syscall"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 )
 
-type takeoverEndpoint struct{}
+// Derives the generation-bound Unix socket location from the fleet-home
+// identity and ownership generation, not watch.pid. A short name avoids macOS
+// sockaddr_un length failures and trusts no arbitrary path from metadata.
+func takeoverSocketPath(home, gen string) string {
+	name := fmt.Sprintf("hw-%s-%s.sock", homeID(home), gen)
+	return filepath.Join(os.TempDir(), name)
+}
 
-func newTakeoverEndpoint(_ int) (*takeoverEndpoint, error) {
-	return &takeoverEndpoint{}, nil
+// Owns the generation-bound Unix socket that lets a takeover contender ask the
+// incumbent to step aside. The path derives from home identity + generation, so
+// a stale or reused pid can never be the target of a takeover.
+type takeoverEndpoint struct {
+	listener   net.Listener
+	requested  chan struct{}
+	signalOnce sync.Once
+	closeOnce  sync.Once
+	done       chan struct{}
+	sockPath   string
+}
+
+func newTakeoverEndpoint(home, gen string) (*takeoverEndpoint, error) {
+	sockPath := takeoverSocketPath(home, gen)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen on takeover socket: %w", err)
+	}
+	// Restrictive permissions so only the owning fleet user can request a takeover.
+	_ = os.Chmod(sockPath, 0o600)
+
+	e := &takeoverEndpoint{
+		listener:  ln,
+		requested: make(chan struct{}),
+		done:      make(chan struct{}),
+		sockPath:  sockPath,
+	}
+	go e.accept(gen)
+	return e, nil
 }
 
 func (e *takeoverEndpoint) Requested() <-chan struct{} {
-	return nil
+	if e == nil {
+		return nil
+	}
+	return e.requested
 }
 
-func (e *takeoverEndpoint) Close() {}
+func (e *takeoverEndpoint) Close() {
+	if e == nil {
+		return
+	}
+	e.closeOnce.Do(func() {
+		_ = e.listener.Close()
+		<-e.done
+		_ = os.Remove(e.sockPath)
+	})
+}
 
-func requestTakeover(pid int) error {
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+func (e *takeoverEndpoint) accept(gen string) {
+	defer close(e.done)
+	for {
+		conn, err := e.listener.Accept()
+		if err != nil {
+			// Listener closed: normal teardown, never a takeover signal.
+			return
+		}
+		go e.handle(conn, gen)
+	}
+}
+
+func (e *takeoverEndpoint) handle(conn net.Conn, gen string) {
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil || strings.TrimSuffix(string(line), "\n") != gen {
+		// Wrong generation or a malformed request must not trigger replacement.
+		return
+	}
+	e.signalOnce.Do(func() { close(e.requested) })
+	_, _ = conn.Write([]byte("ok\n"))
+}
+
+// Asks the incumbent that published gen to step aside by reaching its
+// generation-bound socket. Dialing that socket is the proof: a stale or absent
+// record can never target an unrelated process, nor fall back to pid.
+func requestTakeover(home, gen string) error {
+	conn, err := net.DialTimeout("unix", takeoverSocketPath(home, gen), time.Second)
+	if err != nil {
 		return err
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	if _, err := fmt.Fprintf(conn, "%s\n", gen); err != nil {
+		return err
+	}
+	reply, _ := bufio.NewReader(conn).ReadString('\n')
+	if strings.TrimSpace(reply) == "stale" {
+		return errors.New("stale takeover generation")
 	}
 	return nil
 }

--- a/internal/watcher/takeover_unix.go
+++ b/internal/watcher/takeover_unix.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -33,6 +32,7 @@ type takeoverEndpoint struct {
 	requested  chan struct{}
 	signalOnce sync.Once
 	closeOnce  sync.Once
+	handlers   sync.WaitGroup
 	done       chan struct{}
 	sockPath   string
 }
@@ -43,8 +43,11 @@ func newTakeoverEndpoint(home, gen string) (*takeoverEndpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listen on takeover socket: %w", err)
 	}
-	// Restrictive permissions so only the owning fleet user can request a takeover.
-	_ = os.Chmod(sockPath, 0o600)
+	if err := os.Chmod(sockPath, 0o600); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
+		return nil, fmt.Errorf("set takeover socket permissions: %w", err)
+	}
 
 	e := &takeoverEndpoint{
 		listener:  ln,
@@ -70,6 +73,7 @@ func (e *takeoverEndpoint) Close() {
 	e.closeOnce.Do(func() {
 		_ = e.listener.Close()
 		<-e.done
+		e.handlers.Wait()
 		_ = os.Remove(e.sockPath)
 	})
 }
@@ -82,11 +86,13 @@ func (e *takeoverEndpoint) accept(gen string) {
 			// Listener closed: normal teardown, never a takeover signal.
 			return
 		}
+		e.handlers.Add(1)
 		go e.handle(conn, gen)
 	}
 }
 
 func (e *takeoverEndpoint) handle(conn net.Conn, gen string) {
+	defer e.handlers.Done()
 	defer func() { _ = conn.Close() }()
 	_ = conn.SetDeadline(time.Now().Add(time.Second))
 	line, err := bufio.NewReader(conn).ReadBytes('\n')
@@ -111,9 +117,12 @@ func requestTakeover(home, gen string) error {
 	if _, err := fmt.Fprintf(conn, "%s\n", gen); err != nil {
 		return err
 	}
-	reply, _ := bufio.NewReader(conn).ReadString('\n')
-	if strings.TrimSpace(reply) == "stale" {
-		return errors.New("stale takeover generation")
+	reply, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read takeover acknowledgment: %w", err)
+	}
+	if reply != "ok\n" {
+		return fmt.Errorf("unexpected takeover acknowledgment %q", reply)
 	}
 	return nil
 }

--- a/internal/watcher/takeover_unix_test.go
+++ b/internal/watcher/takeover_unix_test.go
@@ -10,9 +10,6 @@ import (
 	"time"
 )
 
-const genA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-const genB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-
 // The deterministic core proof for the publication race: a stale generation-A
 // request must never wake the current generation-B endpoint, because each
 // generation owns a distinct socket derived from home identity + generation.
@@ -106,5 +103,16 @@ func TestUnixStaleSocketFailsSafely(t *testing.T) {
 	home := t.TempDir()
 	if err := requestTakeover(home, strings.Repeat("c", 32)); err == nil {
 		t.Fatal("dialing a non-existent socket succeeded, want a safe failure")
+	}
+}
+
+// macOS bounds sockaddr_un sun_path to 104 bytes; os.TempDir() alone is often
+// most of that, so the derived filename has to be compact. Rising over the
+// limit here is a bind: invalid argument failure on mac CI, so pin it.
+func TestUnixSocketPathStaysWithinSockaddrUnLimit(t *testing.T) {
+	const sockaddrUnLimit = 104
+	home := t.TempDir()
+	if path := takeoverSocketPath(home, "deadbeef"+strings.Repeat("a", 24)); len(path) >= sockaddrUnLimit {
+		t.Fatalf("takeover socket path %q is %d bytes, want < %d (macOS bind limit)", path, len(path), sockaddrUnLimit)
 	}
 }

--- a/internal/watcher/takeover_unix_test.go
+++ b/internal/watcher/takeover_unix_test.go
@@ -200,9 +200,8 @@ func TestUnixStaleSocketFailsSafely(t *testing.T) {
 	}
 }
 
-// macOS bounds sockaddr_un sun_path to 104 bytes; os.TempDir() alone is often
-// most of that, so the derived filename has to be compact. Rising over the
-// limit here is a bind: invalid argument failure on mac CI, so pin it.
+// macOS bounds sockaddr_un sun_path to 104 bytes; the fixed short directory and
+// compact derived filename keep binding valid regardless of TMPDIR.
 func TestUnixSocketPathStaysWithinSockaddrUnLimit(t *testing.T) {
 	home := t.TempDir()
 	if path := takeoverSocketPath(home, "deadbeef"+strings.Repeat("a", 24)); len(path) >= sockaddrUnLimit {
@@ -210,15 +209,16 @@ func TestUnixSocketPathStaysWithinSockaddrUnLimit(t *testing.T) {
 	}
 }
 
-func TestUnixSocketPathFallsBackFromAnOverlongTempDir(t *testing.T) {
+func TestUnixSocketPathDoesNotDependOnTempDir(t *testing.T) {
 	home := t.TempDir()
+	want := takeoverSocketPath(home, genB)
 	t.Setenv("TMPDIR", filepath.Join(string(filepath.Separator), strings.Repeat("t", 120)))
 	path := takeoverSocketPath(home, genB)
 	if len(path) >= sockaddrUnLimit {
 		t.Fatalf("takeover socket path %q is %d bytes, want < %d", path, len(path), sockaddrUnLimit)
 	}
-	if !strings.HasPrefix(path, string(filepath.Separator)+"tmp"+string(filepath.Separator)) {
-		t.Fatalf("takeover socket path %q did not use the short fallback directory", path)
+	if path != want {
+		t.Fatalf("takeover socket path changed with TMPDIR: before %q, after %q", want, path)
 	}
 }
 

--- a/internal/watcher/takeover_unix_test.go
+++ b/internal/watcher/takeover_unix_test.go
@@ -1,0 +1,110 @@
+//go:build !windows
+
+package watcher
+
+import (
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const genA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const genB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+// The deterministic core proof for the publication race: a stale generation-A
+// request must never wake the current generation-B endpoint, because each
+// generation owns a distinct socket derived from home identity + generation.
+func TestUnixStaleGenerationCannotWakeCurrentGeneration(t *testing.T) {
+	home := t.TempDir()
+	e, err := newTakeoverEndpoint(home, genB)
+	if err != nil {
+		t.Fatalf("newTakeoverEndpoint(genB): %v", err)
+	}
+	defer e.Close()
+
+	if err := requestTakeover(home, genA); err == nil {
+		t.Fatal("requestTakeover(genA) reached genB's socket, want a safe failure")
+	}
+	select {
+	case <-e.Requested():
+		t.Fatal("a stale generation signaled the current generation's takeover channel")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestUnixTakeoverValidGenerationClosesRequested(t *testing.T) {
+	home := t.TempDir()
+	e, err := newTakeoverEndpoint(home, genB)
+	if err != nil {
+		t.Fatalf("newTakeoverEndpoint: %v", err)
+	}
+	defer e.Close()
+
+	if err := requestTakeover(home, genB); err != nil {
+		t.Fatalf("requestTakeover(genB): %v", err)
+	}
+	select {
+	case <-e.Requested():
+	case <-time.After(2 * time.Second):
+		t.Fatal("a valid generation request did not close the takeover channel")
+	}
+}
+
+func TestUnixTakeoverMalformedRequestDoesNotWake(t *testing.T) {
+	home := t.TempDir()
+	e, err := newTakeoverEndpoint(home, genB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	conn, err := net.Dial("unix", takeoverSocketPath(home, genB))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("not-the-generation\n")); err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+
+	select {
+	case <-e.Requested():
+		t.Fatal("a malformed request closed the takeover channel")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// Closing the endpoint is teardown, never a takeover: the channel must stay
+// open and the socket must be removed.
+func TestUnixEndpointCloseDoesNotMasqueradeAsTakeover(t *testing.T) {
+	home := t.TempDir()
+	e, err := newTakeoverEndpoint(home, genB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sock := takeoverSocketPath(home, genB)
+	e.Close()
+
+	select {
+	case <-e.Requested():
+		t.Fatal("endpoint teardown closed the takeover channel")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("takeover socket %s still present after Close (stat err %v)", sock, err)
+	}
+	if err := requestTakeover(home, genB); err == nil {
+		t.Fatal("requestTakeover to a closed endpoint should fail safely")
+	}
+}
+
+// A socket that never existed (stale generation, crashed predecessor) fails
+// safely, with no fallback to pid-based targeting.
+func TestUnixStaleSocketFailsSafely(t *testing.T) {
+	home := t.TempDir()
+	if err := requestTakeover(home, strings.Repeat("c", 32)); err == nil {
+		t.Fatal("dialing a non-existent socket succeeded, want a safe failure")
+	}
+}

--- a/internal/watcher/takeover_unix_test.go
+++ b/internal/watcher/takeover_unix_test.go
@@ -3,8 +3,10 @@
 package watcher
 
 import (
+	"bufio"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +75,98 @@ func TestUnixTakeoverMalformedRequestDoesNotWake(t *testing.T) {
 	}
 }
 
+func TestUnixTakeoverRequiresPositiveAcknowledgment(t *testing.T) {
+	home := t.TempDir()
+	sock := takeoverSocketPath(home, genB)
+	listener, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = listener.Close()
+		_ = os.Remove(sock)
+	}()
+
+	served := make(chan struct{})
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_ = conn.SetDeadline(time.Now().Add(time.Second))
+			_, _ = bufio.NewReader(conn).ReadString('\n')
+			_, _ = conn.Write([]byte("not-ok\n"))
+			_ = conn.Close()
+		}
+		close(served)
+	}()
+
+	if err := requestTakeover(home, genB); err == nil {
+		t.Fatal("requestTakeover accepted an invalid acknowledgment")
+	}
+	select {
+	case <-served:
+	case <-time.After(time.Second):
+		t.Fatal("test endpoint did not receive the request")
+	}
+}
+
+func TestRequestCurrentRetriesAfterFailedAcknowledgment(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(OwnerRecordPath(home)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishOwnerRecord(home, OwnerRecord{Version: ownerRecordVersion, Generation: genB, PID: os.Getpid() + 1}); err != nil {
+		t.Fatal(err)
+	}
+	sock := takeoverSocketPath(home, genB)
+	listener, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serve := func(reply string) <-chan error {
+		done := make(chan error, 1)
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				done <- acceptErr
+				return
+			}
+			_ = conn.SetDeadline(time.Now().Add(time.Second))
+			_, _ = bufio.NewReader(conn).ReadString('\n')
+			_, _ = conn.Write([]byte(reply))
+			_ = conn.Close()
+			done <- nil
+		}()
+		return done
+	}
+
+	requested := make(map[string]bool)
+	serverDone := serve("not-ok\n")
+	requestCurrent(home, requested)
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+	if requested[genB] {
+		t.Fatal("failed acknowledgment marked the generation as requested")
+	}
+	_ = listener.Close()
+	_ = os.Remove(sock)
+
+	endpoint, err := newTakeoverEndpoint(home, genB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer endpoint.Close()
+	requestCurrent(home, requested)
+	if !requested[genB] {
+		t.Fatal("successful acknowledgment did not mark the generation as requested")
+	}
+	select {
+	case <-endpoint.Requested():
+	case <-time.After(time.Second):
+		t.Fatal("retry did not reach the generation endpoint")
+	}
+}
+
 // Closing the endpoint is teardown, never a takeover: the channel must stay
 // open and the socket must be removed.
 func TestUnixEndpointCloseDoesNotMasqueradeAsTakeover(t *testing.T) {
@@ -114,5 +208,24 @@ func TestUnixSocketPathStaysWithinSockaddrUnLimit(t *testing.T) {
 	home := t.TempDir()
 	if path := takeoverSocketPath(home, "deadbeef"+strings.Repeat("a", 24)); len(path) >= sockaddrUnLimit {
 		t.Fatalf("takeover socket path %q is %d bytes, want < %d (macOS bind limit)", path, len(path), sockaddrUnLimit)
+	}
+}
+
+func TestUnixSocketPathCanonicalizesEquivalentHomeAliases(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "fleet")
+	if err := os.Mkdir(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := t.TempDir()
+	alias := filepath.Join(aliasRoot, "alias")
+	if err := os.Symlink(home, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, equivalent := range []string{filepath.Join(home, "."), alias} {
+		if got, want := takeoverSocketPath(equivalent, genB), takeoverSocketPath(home, genB); got != want {
+			t.Fatalf("takeoverSocketPath(%q) = %q, want canonical identity %q", equivalent, got, want)
+		}
 	}
 }

--- a/internal/watcher/takeover_unix_test.go
+++ b/internal/watcher/takeover_unix_test.go
@@ -204,10 +204,21 @@ func TestUnixStaleSocketFailsSafely(t *testing.T) {
 // most of that, so the derived filename has to be compact. Rising over the
 // limit here is a bind: invalid argument failure on mac CI, so pin it.
 func TestUnixSocketPathStaysWithinSockaddrUnLimit(t *testing.T) {
-	const sockaddrUnLimit = 104
 	home := t.TempDir()
 	if path := takeoverSocketPath(home, "deadbeef"+strings.Repeat("a", 24)); len(path) >= sockaddrUnLimit {
 		t.Fatalf("takeover socket path %q is %d bytes, want < %d (macOS bind limit)", path, len(path), sockaddrUnLimit)
+	}
+}
+
+func TestUnixSocketPathFallsBackFromAnOverlongTempDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TMPDIR", filepath.Join(string(filepath.Separator), strings.Repeat("t", 120)))
+	path := takeoverSocketPath(home, genB)
+	if len(path) >= sockaddrUnLimit {
+		t.Fatalf("takeover socket path %q is %d bytes, want < %d", path, len(path), sockaddrUnLimit)
+	}
+	if !strings.HasPrefix(path, string(filepath.Separator)+"tmp"+string(filepath.Separator)) {
+		t.Fatalf("takeover socket path %q did not use the short fallback directory", path)
 	}
 }
 

--- a/internal/watcher/takeover_windows.go
+++ b/internal/watcher/takeover_windows.go
@@ -3,6 +3,8 @@
 package watcher
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -11,6 +13,13 @@ import (
 )
 
 const takeoverEventPrefix = "Global\\hand-watch-takeover-"
+
+// A short stable identity for a fleet home used to namespace the Windows named
+// event without embedding an arbitrary filesystem path in the event name.
+func homeID(homeDir string) string {
+	sum := sha256.Sum256([]byte(canonicalHome(homeDir)))
+	return hex.EncodeToString(sum[:8])
+}
 
 // Derives the generation-bound named event identity from the fleet-home identity
 // and ownership generation, never watch.pid.

--- a/internal/watcher/takeover_windows.go
+++ b/internal/watcher/takeover_windows.go
@@ -14,6 +14,8 @@ import (
 
 const takeoverEventPrefix = "Global\\hand-watch-takeover-"
 
+var errTakeoverEndpointMissing = errors.New("takeover endpoint missing")
+
 // A short stable identity for a fleet home used to namespace the Windows named
 // event without embedding an arbitrary filesystem path in the event name.
 func homeID(homeDir string) string {
@@ -103,7 +105,7 @@ func requestTakeover(home, gen string) error {
 	}
 	event, err := windows.OpenEvent(windows.EVENT_MODIFY_STATE, false, name)
 	if errors.Is(err, windows.ERROR_FILE_NOT_FOUND) {
-		return nil
+		return fmt.Errorf("%w: %w", errTakeoverEndpointMissing, err)
 	}
 	if err != nil {
 		return fmt.Errorf("open takeover event: %w", err)

--- a/internal/watcher/takeover_windows.go
+++ b/internal/watcher/takeover_windows.go
@@ -12,6 +12,15 @@ import (
 
 const takeoverEventPrefix = "Global\\hand-watch-takeover-"
 
+// Derives the generation-bound named event identity from the fleet-home identity
+// and ownership generation, never watch.pid.
+func takeoverEventName(home, gen string) string {
+	return fmt.Sprintf("%s%s-%s", takeoverEventPrefix, homeID(home), gen)
+}
+
+// Owns the generation-bound Windows named event that lets a takeover contender
+// ask the incumbent to step aside, plus a private local stop event that wakes
+// the listener during teardown.
 type takeoverEndpoint struct {
 	takeover  windows.Handle
 	stop      windows.Handle
@@ -20,8 +29,8 @@ type takeoverEndpoint struct {
 	closeOnce sync.Once
 }
 
-func newTakeoverEndpoint(pid int) (*takeoverEndpoint, error) {
-	name, err := windows.UTF16PtrFromString(takeoverEventName(pid))
+func newTakeoverEndpoint(home, gen string) (*takeoverEndpoint, error) {
+	name, err := windows.UTF16PtrFromString(takeoverEventName(home, gen))
 	if err != nil {
 		return nil, fmt.Errorf("encode takeover event name: %w", err)
 	}
@@ -75,8 +84,11 @@ func (e *takeoverEndpoint) listen() {
 	}
 }
 
-func requestTakeover(pid int) error {
-	name, err := windows.UTF16PtrFromString(takeoverEventName(pid))
+// Asks the incumbent that published gen to step aside through its
+// generation-bound named event. A missing event is a disappeared or stale
+// incumbent and is harmless; there is no pid-based fallback.
+func requestTakeover(home, gen string) error {
+	name, err := windows.UTF16PtrFromString(takeoverEventName(home, gen))
 	if err != nil {
 		return fmt.Errorf("encode takeover event name: %w", err)
 	}
@@ -92,8 +104,4 @@ func requestTakeover(pid int) error {
 		return fmt.Errorf("set takeover event: %w", err)
 	}
 	return nil
-}
-
-func takeoverEventName(pid int) string {
-	return fmt.Sprintf("%s%d", takeoverEventPrefix, pid)
 }

--- a/internal/watcher/takeover_windows_test.go
+++ b/internal/watcher/takeover_windows_test.go
@@ -3,19 +3,19 @@
 package watcher
 
 import (
-	"os"
 	"testing"
 	"time"
 )
 
 func TestTakeoverEventIsDelivered(t *testing.T) {
-	endpoint, err := newTakeoverEndpoint(os.Getpid())
+	home := t.TempDir()
+	endpoint, err := newTakeoverEndpoint(home, testGen)
 	if err != nil {
 		t.Fatalf("newTakeoverEndpoint: %v", err)
 	}
 	defer endpoint.Close()
 
-	if err := requestTakeover(os.Getpid()); err != nil {
+	if err := requestTakeover(home, testGen); err != nil {
 		t.Fatalf("requestTakeover: %v", err)
 	}
 
@@ -27,14 +27,40 @@ func TestTakeoverEventIsDelivered(t *testing.T) {
 }
 
 func TestRequestTakeoverIgnoresMissingEvent(t *testing.T) {
-	if err := requestTakeover(deadPid(t)); err != nil {
-		t.Fatalf("requestTakeover for a missing event: %v", err)
+	home := t.TempDir()
+	if err := requestTakeover(home, testGen); err != nil {
+		t.Fatalf("requestTakeover for a missing generation event: %v", err)
+	}
+}
+
+// A stale generation's event is a different name entirely, so it cannot wake
+// the current generation's handler.
+func TestTakeoverStaleGenerationCannotWakeCurrentGeneration(t *testing.T) {
+	home := t.TempDir()
+	endpoint, err := newTakeoverEndpoint(home, genB)
+	if err != nil {
+		t.Fatalf("newTakeoverEndpoint(genB): %v", err)
+	}
+	defer endpoint.Close()
+
+	if err := requestTakeover(home, genA); err != nil {
+		t.Fatalf("requesting a missing stale event should be harmless, got %v", err)
+	}
+	select {
+	case <-endpoint.Requested():
+		t.Fatal("a stale generation signaled the current generation's takeover channel")
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 
 func TestTakeoverEndpointCloseStopsListener(t *testing.T) {
+	home := t.TempDir()
 	for range 10 {
-		endpoint, err := newTakeoverEndpoint(os.Getpid())
+		gen, err := newGeneration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		endpoint, err := newTakeoverEndpoint(home, gen)
 		if err != nil {
 			t.Fatalf("newTakeoverEndpoint: %v", err)
 		}

--- a/internal/watcher/takeover_windows_test.go
+++ b/internal/watcher/takeover_windows_test.go
@@ -3,6 +3,10 @@
 package watcher
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -26,10 +30,10 @@ func TestTakeoverEventIsDelivered(t *testing.T) {
 	}
 }
 
-func TestRequestTakeoverIgnoresMissingEvent(t *testing.T) {
+func TestRequestTakeoverReportsMissingEventWithoutTreatingItAsDelivered(t *testing.T) {
 	home := t.TempDir()
-	if err := requestTakeover(home, testGen); err != nil {
-		t.Fatalf("requestTakeover for a missing generation event: %v", err)
+	if err := requestTakeover(home, testGen); !errors.Is(err, errTakeoverEndpointMissing) {
+		t.Fatalf("requestTakeover for a missing generation event = %v, want errTakeoverEndpointMissing", err)
 	}
 }
 
@@ -43,13 +47,52 @@ func TestTakeoverStaleGenerationCannotWakeCurrentGeneration(t *testing.T) {
 	}
 	defer endpoint.Close()
 
-	if err := requestTakeover(home, genA); err != nil {
-		t.Fatalf("requesting a missing stale event should be harmless, got %v", err)
+	if err := requestTakeover(home, genA); !errors.Is(err, errTakeoverEndpointMissing) {
+		t.Fatalf("requesting a missing stale event = %v, want errTakeoverEndpointMissing", err)
 	}
 	select {
 	case <-endpoint.Requested():
 		t.Fatal("a stale generation signaled the current generation's takeover channel")
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestTakeoverEventNameCanonicalizesEquivalentHomePaths(t *testing.T) {
+	home := t.TempDir()
+	for _, equivalent := range []string{filepath.Join(home, "."), filepath.Clean(home), strings.ToUpper(home)} {
+		if got, want := takeoverEventName(equivalent, testGen), takeoverEventName(home, testGen); got != want {
+			t.Fatalf("takeoverEventName(%q) = %q, want canonical identity %q", equivalent, got, want)
+		}
+	}
+}
+
+func TestRequestCurrentRetriesAfterMissingEvent(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(OwnerRecordPath(home)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishOwnerRecord(home, OwnerRecord{Version: ownerRecordVersion, Generation: testGen, PID: os.Getpid() + 1}); err != nil {
+		t.Fatal(err)
+	}
+	requested := make(map[string]bool)
+	requestCurrent(home, requested)
+	if requested[testGen] {
+		t.Fatal("missing event marked the generation as requested")
+	}
+
+	endpoint, err := newTakeoverEndpoint(home, testGen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer endpoint.Close()
+	requestCurrent(home, requested)
+	if !requested[testGen] {
+		t.Fatal("successful event delivery did not mark the generation as requested")
+	}
+	select {
+	case <-endpoint.Requested():
+	case <-time.After(time.Second):
+		t.Fatal("retry did not reach the generation event")
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -43,6 +43,26 @@ var ErrNoEvent = errors.New("no event")
 // an exit from RunUntilEvent always means the whole fleet was actually watched.
 var ErrArmFailed = errors.New("could not arm")
 
+// ErrInterrupted is the typed result for a graceful watcher interruption that
+// is not proven to be an explicit Hand takeover - ctrl-C, an externally
+// delivered SIGTERM, or parent/command context cancellation. It maps to exit 8.
+var ErrInterrupted = errors.New("watch interrupted")
+
+// ErrReplaced is the typed result for an incumbent that received a valid explicit
+// Hand takeover request through its generation-bound endpoint. A plain signal
+// must never produce it. It maps to exit 9.
+var ErrReplaced = errors.New("watch replaced by explicit takeover")
+
+// Classifies a canceled context into the one typed lifecycle result that fits:
+// explicit replacement beats generic interruption. A context deadline is not an
+// interruption and belongs to ErrNoEvent, decided by callers before here.
+func cancellationError(ctx context.Context) error {
+	if errors.Is(context.Cause(ctx), ErrReplaced) {
+		return ErrReplaced
+	}
+	return ErrInterrupted
+}
+
 // Run blocks, polling herdr agent states at cfg.PollInterval until ctx is canceled, returning nil on
 // clean cancellation or an error if herdr is unreachable at startup. out receives the actionable
 // event stream, while errOut receives internal diagnostics.
@@ -50,7 +70,7 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	client, err := connect(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil
+			return cancellationError(ctx)
 		}
 		return err
 	}
@@ -63,7 +83,7 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return cancellationError(ctx)
 		case <-ticker.C:
 			tick(ctx, cfg, client, states, out, errOut)
 		}
@@ -107,7 +127,7 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return fmt.Errorf("%w within %s", ErrNoEvent, cfg.Timeout)
 			}
-			return fmt.Errorf("%w: interrupted", ErrNoEvent)
+			return fmt.Errorf("%w", cancellationError(ctx))
 		case <-ticker.C:
 			var events bytes.Buffer
 			tick(ctx, cfg, client, states, &events, errOut)
@@ -133,7 +153,7 @@ func connect(ctx context.Context) (*herdr.Client, error) {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return nil, fmt.Errorf("%w: timed out reaching herdr", ErrNoEvent)
 		}
-		return nil, fmt.Errorf("%w: interrupted while reaching herdr", ErrNoEvent)
+		return nil, fmt.Errorf("while reaching herdr: %w", cancellationError(ctx))
 	case err := <-done:
 		if err != nil {
 			return nil, fmt.Errorf("herdr unreachable: %w", err)
@@ -173,7 +193,7 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return fmt.Errorf("%w: timed out probing tasks before arming", ErrNoEvent)
 		}
-		return fmt.Errorf("%w: interrupted while probing tasks before arming", ErrNoEvent)
+		return fmt.Errorf("while probing tasks before arming: %w", cancellationError(ctx))
 	case err := <-done:
 		return err
 	}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -24,6 +24,8 @@ import (
 
 const maxEventLogLines = 200
 
+var afterWatchTick = func() {}
+
 type Config struct {
 	Home           string
 	PollInterval   time.Duration
@@ -134,14 +136,14 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 	for {
 		select {
 		case <-ctx.Done():
-			lifecycleErr := contextLifecycleError(ctx)
-			if errors.Is(lifecycleErr, ErrNoEvent) {
-				return fmt.Errorf("%w within %s", ErrNoEvent, cfg.Timeout)
-			}
-			return fmt.Errorf("%w", lifecycleErr)
+			return runUntilEventContextError(ctx, cfg.Timeout)
 		case <-ticker.C:
 			var events bytes.Buffer
 			tick(ctx, cfg, client, states, &events, errOut)
+			afterWatchTick()
+			if ctxErr := contextLifecycleError(ctx); ctxErr != nil {
+				return runUntilEventContextError(ctx, cfg.Timeout)
+			}
 			if events.Len() == 0 {
 				continue
 			}
@@ -230,6 +232,14 @@ func withWatchTimeout(parent context.Context, timeout time.Duration) (context.Co
 		timer.Stop()
 		cancel(nil)
 	}
+}
+
+func runUntilEventContextError(ctx context.Context, timeout time.Duration) error {
+	lifecycleErr := contextLifecycleError(ctx)
+	if errors.Is(lifecycleErr, ErrNoEvent) {
+		return fmt.Errorf("%w within %s", ErrNoEvent, timeout)
+	}
+	return fmt.Errorf("%w", lifecycleErr)
 }
 
 func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[string]*TaskState, out, errOut io.Writer) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -54,8 +54,8 @@ var ErrInterrupted = errors.New("watch interrupted")
 var ErrReplaced = errors.New("watch replaced by explicit takeover")
 
 // Classifies a canceled context into the one typed lifecycle result that fits:
-// explicit replacement beats generic interruption. A context deadline is not an
-// interruption and belongs to ErrNoEvent, decided by callers before here.
+// explicit replacement beats generic interruption. A context deadline belongs
+// to ErrNoEvent rather than either lifecycle cancellation result.
 func cancellationError(ctx context.Context) error {
 	if errors.Is(context.Cause(ctx), ErrReplaced) {
 		return ErrReplaced
@@ -63,14 +63,24 @@ func cancellationError(ctx context.Context) error {
 	return ErrInterrupted
 }
 
-// Run blocks, polling herdr agent states at cfg.PollInterval until ctx is canceled, returning nil on
-// clean cancellation or an error if herdr is unreachable at startup. out receives the actionable
-// event stream, while errOut receives internal diagnostics.
+func contextLifecycleError(ctx context.Context) error {
+	if ctx.Err() == nil {
+		return nil
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
+		return ErrNoEvent
+	}
+	return cancellationError(ctx)
+}
+
+// Run blocks, polling herdr agent states at cfg.PollInterval until ctx is canceled, returning a
+// typed lifecycle result for cancellation or an error if herdr is unreachable at startup. out
+// receives the actionable event stream, while errOut receives internal diagnostics.
 func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	client, err := connect(ctx)
 	if err != nil {
-		if ctx.Err() != nil {
-			return cancellationError(ctx)
+		if lifecycleErr := contextLifecycleError(ctx); lifecycleErr != nil {
+			return lifecycleErr
 		}
 		return err
 	}
@@ -83,7 +93,7 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return cancellationError(ctx)
+			return contextLifecycleError(ctx)
 		case <-ticker.C:
 			tick(ctx, cfg, client, states, out, errOut)
 		}
@@ -124,10 +134,11 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 	for {
 		select {
 		case <-ctx.Done():
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			lifecycleErr := contextLifecycleError(ctx)
+			if errors.Is(lifecycleErr, ErrNoEvent) {
 				return fmt.Errorf("%w within %s", ErrNoEvent, cfg.Timeout)
 			}
-			return fmt.Errorf("%w", cancellationError(ctx))
+			return fmt.Errorf("%w", lifecycleErr)
 		case <-ticker.C:
 			var events bytes.Buffer
 			tick(ctx, cfg, client, states, &events, errOut)
@@ -150,11 +161,11 @@ func connect(ctx context.Context) (*herdr.Client, error) {
 	// Losing the race is ErrNoEvent for the same reason probeAllTasks's is: the window closed during
 	// arming, which is exit 4 wherever in arming it happens.
 	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return nil, fmt.Errorf("%w: timed out reaching herdr", ErrNoEvent)
-		}
-		return nil, fmt.Errorf("while reaching herdr: %w", cancellationError(ctx))
+		return nil, connectContextError(ctx)
 	case err := <-done:
+		if ctxErr := contextLifecycleError(ctx); ctxErr != nil {
+			return nil, connectContextError(ctx)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("herdr unreachable: %w", err)
 		}
@@ -190,13 +201,27 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 	// ErrNoEvent, not ErrArmFailed: the window is simply over, and no single task can be named as the
 	// cause the way ErrArmFailed's exit promises.
 	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return fmt.Errorf("%w: timed out probing tasks before arming", ErrNoEvent)
-		}
-		return fmt.Errorf("while probing tasks before arming: %w", cancellationError(ctx))
+		return probeContextError(ctx)
 	case err := <-done:
+		if ctxErr := contextLifecycleError(ctx); ctxErr != nil {
+			return probeContextError(ctx)
+		}
 		return err
 	}
+}
+
+func connectContextError(ctx context.Context) error {
+	if errors.Is(contextLifecycleError(ctx), ErrNoEvent) {
+		return fmt.Errorf("%w: timed out reaching herdr", ErrNoEvent)
+	}
+	return fmt.Errorf("while reaching herdr: %w", cancellationError(ctx))
+}
+
+func probeContextError(ctx context.Context) error {
+	if errors.Is(contextLifecycleError(ctx), ErrNoEvent) {
+		return fmt.Errorf("%w: timed out probing tasks before arming", ErrNoEvent)
+	}
+	return fmt.Errorf("while probing tasks before arming: %w", cancellationError(ctx))
 }
 
 func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[string]*TaskState, out, errOut io.Writer) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -158,8 +158,8 @@ func connect(ctx context.Context) (*herdr.Client, error) {
 	done := make(chan error, 1)
 	go func() { _, err := client.WorkspaceListContext(ctx); done <- err }()
 	select {
-	// Losing the race is ErrNoEvent for the same reason probeAllTasks's is: the window closed during
-	// arming, which is exit 4 wherever in arming it happens.
+	// Recheck lifecycle cause after the operation: a configured until-event timeout is ErrNoEvent,
+	// while generic cancellation and proven takeover retain their own typed results.
 	case <-ctx.Done():
 		return nil, connectContextError(ctx)
 	case err := <-done:
@@ -198,8 +198,7 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 		done <- nil
 	}()
 	select {
-	// ErrNoEvent, not ErrArmFailed: the window is simply over, and no single task can be named as the
-	// cause the way ErrArmFailed's exit promises.
+	// Recheck lifecycle cause after the operation so cancellation cannot be relabeled as an arm failure.
 	case <-ctx.Done():
 		return probeContextError(ctx)
 	case err := <-done:

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -53,10 +53,13 @@ var ErrInterrupted = errors.New("watch interrupted")
 // must never produce it. It maps to exit 9.
 var ErrReplaced = errors.New("watch replaced by explicit takeover")
 
-// Classifies a canceled context into the one typed lifecycle result that fits:
-// explicit replacement beats generic interruption. A context deadline belongs
-// to ErrNoEvent rather than either lifecycle cancellation result.
+// Classifies a canceled context into the one typed lifecycle result that fits.
+// Explicit replacement and the until-event timeout have distinct causes, while
+// every other parent or command cancellation is an interruption.
 func cancellationError(ctx context.Context) error {
+	if errors.Is(context.Cause(ctx), ErrNoEvent) {
+		return ErrNoEvent
+	}
 	if errors.Is(context.Cause(ctx), ErrReplaced) {
 		return ErrReplaced
 	}
@@ -66,9 +69,6 @@ func cancellationError(ctx context.Context) error {
 func contextLifecycleError(ctx context.Context) error {
 	if ctx.Err() == nil {
 		return nil
-	}
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
-		return ErrNoEvent
 	}
 	return cancellationError(ctx)
 }
@@ -106,13 +106,13 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, cfg.Timeout)
+		ctx, cancel = withWatchTimeout(ctx, cfg.Timeout)
 		defer cancel()
 	}
 
 	client, err := connect(ctx)
 	if err != nil {
-		if errors.Is(err, ErrNoEvent) && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		if errors.Is(err, ErrNoEvent) {
 			return fmt.Errorf("%w within %s: %w", ErrNoEvent, cfg.Timeout, err)
 		}
 		return err
@@ -222,6 +222,15 @@ func probeContextError(ctx context.Context) error {
 		return fmt.Errorf("%w: timed out probing tasks before arming", ErrNoEvent)
 	}
 	return fmt.Errorf("while probing tasks before arming: %w", cancellationError(ctx))
+}
+
+func withWatchTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancelCause(parent)
+	timer := time.AfterFunc(timeout, func() { cancel(ErrNoEvent) })
+	return ctx, func() {
+		timer.Stop()
+		cancel(nil)
+	}
 }
 
 func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[string]*TaskState, out, errOut io.Writer) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1943,7 +1943,7 @@ func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
 	}
 }
 
-func TestRunExitsCleanlyOnContextCancel(t *testing.T) {
+func TestRunReportsInterruptionOnContextCancel(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
@@ -1964,8 +1964,8 @@ func TestRunExitsCleanlyOnContextCancel(t *testing.T) {
 
 	select {
 	case err := <-done:
-		if err != nil {
-			t.Fatalf("Run returned %v, want nil", err)
+		if !errors.Is(err, ErrInterrupted) {
+			t.Fatalf("Run returned %v, want ErrInterrupted so a caller can tell interruption from a real event", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not exit after context cancellation")
@@ -1992,8 +1992,8 @@ func TestRunExitsWhenPaneProbeIsCanceled(t *testing.T) {
 
 	select {
 	case err := <-done:
-		if err != nil {
-			t.Fatalf("Run returned %v, want nil", err)
+		if !errors.Is(err, ErrInterrupted) {
+			t.Fatalf("Run returned %v, want ErrInterrupted", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not exit after canceling a pane probe")
@@ -2173,7 +2173,7 @@ func TestRunUntilEventReportsNoEventOnTimeout(t *testing.T) {
 	}
 }
 
-func TestRunUntilEventReportsNoEventOnContextCancel(t *testing.T) {
+func TestRunUntilEventReportsInterruptionOnContextCancel(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
@@ -2190,11 +2190,68 @@ func TestRunUntilEventReportsNoEventOnContextCancel(t *testing.T) {
 
 	select {
 	case err := <-done:
-		if !errors.Is(err, ErrNoEvent) {
-			t.Fatalf("RunUntilEvent = %v, want ErrNoEvent", err)
+		if !errors.Is(err, ErrInterrupted) {
+			t.Fatalf("RunUntilEvent = %v, want ErrInterrupted: a generic cancellation is not a no-event window", err)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("RunUntilEvent did not return after context cancellation")
+	}
+}
+
+// An explicit replacement cause (what ownership.TakeoverRequested() feeds the
+// watch context) must surface as ErrReplaced all the way out of the runner, not
+// as a generic interruption or a no-event result.
+func TestRunReportsReplacementOnTakeoverCause(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel(ErrReplaced)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrReplaced) {
+			t.Fatalf("Run returned %v, want ErrReplaced for an explicit takeover cause", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after a replacement cause")
+	}
+}
+
+func TestRunUntilEventReportsReplacementOnTakeoverCause(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunUntilEvent(ctx, cfg, &bytes.Buffer{}, io.Discard) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel(ErrReplaced)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrReplaced) {
+			t.Fatalf("RunUntilEvent = %v, want ErrReplaced for an explicit takeover cause", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunUntilEvent did not return after a replacement cause")
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -2292,6 +2292,37 @@ func TestRunUntilEventReportsReplacementOnTakeoverCause(t *testing.T) {
 	}
 }
 
+func TestRunUntilEventDoesNotDeliverAnEventAfterCancellationAtTheTickBoundary(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	oldAfterWatchTick := afterWatchTick
+	t.Cleanup(func() { afterWatchTick = oldAfterWatchTick })
+	ticks := 0
+	afterWatchTick = func() {
+		ticks++
+		if ticks == 2 {
+			setStatus(t, statusFile, "done")
+		}
+		if ticks == 3 {
+			cancel(ErrReplaced)
+		}
+	}
+
+	var out bytes.Buffer
+	err := RunUntilEvent(ctx, Config{Home: home, PollInterval: 10 * time.Millisecond, Timeout: 10 * time.Second}, &out, io.Discard)
+	if !errors.Is(err, ErrReplaced) {
+		t.Fatalf("RunUntilEvent = %v, want ErrReplaced when cancellation follows event collection", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("out = %q, want no event after cancellation at the tick boundary", out.String())
+	}
+}
+
 func TestRunUntilEventFailsWhenHerdrUnreachable(t *testing.T) {
 	faketool.Herdr{Unreachable: true}.Install(t, faketool.Bin(t))
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1982,6 +1982,21 @@ func TestRunReportsInterruptionOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestRunReportsAParentDeadlineAsInterruption(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := Run(ctx, Config{Home: t.TempDir(), PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
+	if !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("Run returned %v, want ErrInterrupted for a caller deadline", err)
+	}
+	if errors.Is(err, ErrNoEvent) {
+		t.Fatal("Run returned ErrNoEvent for a caller deadline; only the until-event timeout is a no-event window")
+	}
+}
+
 func TestRunExitsWhenPaneProbeIsCanceled(t *testing.T) {
 	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
 	faketool.Herdr{
@@ -2204,6 +2219,21 @@ func TestRunUntilEventReportsInterruptionOnContextCancel(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("RunUntilEvent did not return after context cancellation")
+	}
+}
+
+func TestRunUntilEventReportsAParentDeadlineAsInterruption(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := RunUntilEvent(ctx, Config{Home: t.TempDir(), PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
+	if !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("RunUntilEvent returned %v, want ErrInterrupted for a parent deadline", err)
+	}
+	if errors.Is(err, ErrNoEvent) {
+		t.Fatal("RunUntilEvent returned ErrNoEvent for a parent deadline without Config.Timeout")
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -112,19 +112,30 @@ func logPaneGets(t *testing.T) string {
 }
 
 func waitForPaneGets(t *testing.T, callLog string, want int) {
+	waitForHerdrCalls(t, callLog, "pane get", want)
+}
+
+func waitForHerdrCalls(t *testing.T, callLog, command string, want int) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	prefix := []byte("herdr " + command)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(callLog)
 		if err != nil && !os.IsNotExist(err) {
 			t.Fatal(err)
 		}
-		if bytes.Count(data, []byte("\n")) >= want {
+		calls := 0
+		for _, line := range bytes.Split(data, []byte("\n")) {
+			if bytes.HasPrefix(line, prefix) {
+				calls++
+			}
+		}
+		if calls >= want {
 			return
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for %d pane get calls", want)
+	t.Fatalf("timed out waiting for %d %s calls", want, command)
 }
 
 func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.Attempt) error {
@@ -1944,9 +1955,8 @@ func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
 }
 
 func TestRunReportsInterruptionOnContextCancel(t *testing.T) {
-	statusFile := filepath.Join(t.TempDir(), "status")
-	setStatus(t, statusFile, "working")
-	writeFakeHerdr(t, statusFile)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
 
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
@@ -1959,7 +1969,7 @@ func TestRunReportsInterruptionOnContextCancel(t *testing.T) {
 		done <- Run(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForHerdrCalls(t, callLog, "workspace list", 1)
 	cancel()
 
 	select {
@@ -2174,18 +2184,17 @@ func TestRunUntilEventReportsNoEventOnTimeout(t *testing.T) {
 }
 
 func TestRunUntilEventReportsInterruptionOnContextCancel(t *testing.T) {
-	statusFile := filepath.Join(t.TempDir(), "status")
-	setStatus(t, statusFile, "working")
-	writeFakeHerdr(t, statusFile)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	home := t.TempDir()
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- RunUntilEvent(ctx, cfg, &bytes.Buffer{}, io.Discard) }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForHerdrCalls(t, callLog, "workspace list", 1)
 	cancel()
 
 	select {
@@ -2202,9 +2211,8 @@ func TestRunUntilEventReportsInterruptionOnContextCancel(t *testing.T) {
 // watch context) must surface as ErrReplaced all the way out of the runner, not
 // as a generic interruption or a no-event result.
 func TestRunReportsReplacementOnTakeoverCause(t *testing.T) {
-	statusFile := filepath.Join(t.TempDir(), "status")
-	setStatus(t, statusFile, "working")
-	writeFakeHerdr(t, statusFile)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
 
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
@@ -2217,7 +2225,7 @@ func TestRunReportsReplacementOnTakeoverCause(t *testing.T) {
 		done <- Run(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForHerdrCalls(t, callLog, "workspace list", 1)
 	cancel(ErrReplaced)
 
 	select {
@@ -2231,18 +2239,17 @@ func TestRunReportsReplacementOnTakeoverCause(t *testing.T) {
 }
 
 func TestRunUntilEventReportsReplacementOnTakeoverCause(t *testing.T) {
-	statusFile := filepath.Join(t.TempDir(), "status")
-	setStatus(t, statusFile, "working")
-	writeFakeHerdr(t, statusFile)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	home := t.TempDir()
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
 
 	ctx, cancel := context.WithCancelCause(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- RunUntilEvent(ctx, cfg, &bytes.Buffer{}, io.Discard) }()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForHerdrCalls(t, callLog, "workspace list", 1)
 	cancel(ErrReplaced)
 
 	select {
@@ -2309,6 +2316,60 @@ func TestRunUntilEventReportsNoEventWhenTheArmProbeHangs(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("returned after %s, want --timeout to bound a hung pane probe", elapsed)
+	}
+}
+
+func TestRunUntilEventReportsInterruptionWhenTheArmProbeIsCanceled(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}},
+		Hang:      []string{"pane get"},
+		Log:       callLog, LogCommands: []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunUntilEvent(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}, &bytes.Buffer{}, io.Discard)
+	}()
+	waitForPaneGets(t, callLog, 1)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrInterrupted) || errors.Is(err, ErrArmFailed) {
+			t.Fatalf("RunUntilEvent = %v, want ErrInterrupted and not ErrArmFailed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunUntilEvent did not exit after canceling its arm probe")
+	}
+}
+
+func TestRunUntilEventReportsReplacementWhenTheArmProbeIsCanceled(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}},
+		Hang:      []string{"pane get"},
+		Log:       callLog, LogCommands: []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunUntilEvent(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}, &bytes.Buffer{}, io.Discard)
+	}()
+	waitForPaneGets(t, callLog, 1)
+	cancel(ErrReplaced)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrReplaced) || errors.Is(err, ErrArmFailed) {
+			t.Fatalf("RunUntilEvent = %v, want ErrReplaced and not ErrArmFailed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunUntilEvent did not exit after replacing its arm probe")
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -2153,7 +2153,7 @@ func TestRunUntilEventReportsNoEventOnTimeout(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
-	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 100 * time.Millisecond}
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: time.Second}
 
 	var out bytes.Buffer
 	start := time.Now()
@@ -2162,7 +2162,7 @@ func TestRunUntilEventReportsNoEventOnTimeout(t *testing.T) {
 	if !errors.Is(err, ErrNoEvent) {
 		t.Fatalf("RunUntilEvent = %v, want ErrNoEvent so a re-arm loop can tell a quiet window from an event", err)
 	}
-	if !strings.Contains(err.Error(), "100ms") {
+	if !strings.Contains(err.Error(), "1s") {
 		t.Fatalf("err = %v, want the elapsed timeout named", err)
 	}
 	if elapsed := time.Since(start); elapsed > 5*time.Second {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -223,9 +222,8 @@ func (s *syncBuffer) String() string {
 	return s.buf.String()
 }
 
-// Drives a long-running hand command (only `watch` today) so a test can observe its streaming output and
-// stop it with the same SIGTERM signal.NotifyContext listens for in cmd/watch.go, rather than waiting for
-// it to exit on its own.
+// Drives a long-running hand command (only `watch` today) so a test can observe
+// its streaming output and stop it through a platform-specific helper.
 type backgroundHand struct {
 	cmd     *exec.Cmd
 	args    []string
@@ -267,24 +265,6 @@ func (b *backgroundHand) waitForStdout(t *testing.T, substr string, timeout time
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %q on stdout; stdout=%q stderr=%q", substr, b.stdout.String(), b.stderr.String())
-}
-
-// Sends SIGTERM - the signal cmd/watch.go treats as generic external
-// interruption - and asserts the watcher exits 8 / watch-interrupted. After
-// the attributable-takeover contract, this is no longer a "clean exit".
-func (b *backgroundHand) interrupt(t *testing.T, timeout time.Duration) invocation {
-	t.Helper()
-	if err := b.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-		t.Fatalf("signal hand watch: %v", err)
-	}
-	got := b.waitForExit(t, timeout, "SIGTERM interruption")
-	if got.code != 8 {
-		t.Fatalf("interrupted watch exit = %d, want 8 watch-interrupted (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
-	}
-	if !strings.Contains(got.stderr, "watch-interrupted") {
-		t.Fatalf("interrupted watch stderr = %q, want the watch-interrupted kind", got.stderr)
-	}
-	return got
 }
 
 // Reaps a process expected to exit on its own, unlike stop: that exit is the whole delivery mechanism of

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -8,6 +8,7 @@ package e2e
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -268,14 +269,22 @@ func (b *backgroundHand) waitForStdout(t *testing.T, substr string, timeout time
 	t.Fatalf("timed out waiting for %q on stdout; stdout=%q stderr=%q", substr, b.stdout.String(), b.stderr.String())
 }
 
-// Sends SIGTERM (the signal cmd/watch.go's signal.NotifyContext listens for) and waits for a clean exit,
-// failing the test if the process doesn't exit within timeout.
-func (b *backgroundHand) stop(t *testing.T, timeout time.Duration) invocation {
+// Sends SIGTERM - the signal cmd/watch.go treats as generic external
+// interruption - and asserts the watcher exits 8 / watch-interrupted. After
+// the attributable-takeover contract, this is no longer a "clean exit".
+func (b *backgroundHand) interrupt(t *testing.T, timeout time.Duration) invocation {
 	t.Helper()
 	if err := b.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatalf("signal hand watch: %v", err)
 	}
-	return b.waitForExit(t, timeout, "SIGTERM")
+	got := b.waitForExit(t, timeout, "SIGTERM interruption")
+	if got.code != 8 {
+		t.Fatalf("interrupted watch exit = %d, want 8 watch-interrupted (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "watch-interrupted") {
+		t.Fatalf("interrupted watch stderr = %q, want the watch-interrupted kind", got.stderr)
+	}
+	return got
 }
 
 // Reaps a process expected to exit on its own, unlike stop: that exit is the whole delivery mechanism of
@@ -328,6 +337,49 @@ func waitForInvocations(t *testing.T, logPath, substr string, want int, timeout 
 	}
 	data, _ := os.ReadFile(logPath)
 	t.Fatalf("timed out waiting for %d occurrences of %q in invocation log; log=%q", want, substr, data)
+}
+
+// The routing record hand publishes last during acquisition. A complete valid
+// record implies the generation-bound takeover endpoint is already ready, so it
+// is a far stronger readiness barrier than merely seeing watch.pid.
+type ownerPublication struct {
+	Version    int    `json:"version"`
+	Generation string `json:"generation"`
+	PID        int    `json:"pid"`
+}
+
+func readOwnerPublication(t *testing.T, home string) (ownerPublication, error) {
+	t.Helper()
+	var rec ownerPublication
+	data, err := os.ReadFile(filepath.Join(state.Dir(home), "watch.owner"))
+	if err != nil {
+		return rec, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rec); err != nil {
+		return rec, err
+	}
+	return rec, nil
+}
+
+// Waits for the full coherent owner publication for pid: a valid version-1
+// record whose generation is 32 lowercase-hex chars and pid matches. Endpoint
+// readiness precedes this publication, so this is a deterministic barrier.
+func waitForCoherentOwner(t *testing.T, home string, pid int) ownerPublication {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		rec, err := readOwnerPublication(t, home)
+		if err == nil && rec.Version == 1 && rec.PID == pid && len(rec.Generation) == 32 {
+			return rec
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	pidData, _ := os.ReadFile(filepath.Join(state.Dir(home), "watch.pid"))
+	ownerData, _ := os.ReadFile(filepath.Join(state.Dir(home), "watch.owner"))
+	t.Fatalf("timed out waiting for coherent owner publication (pid %d); watch.pid=%q watch.owner=%q", pid, pidData, ownerData)
+	return ownerPublication{}
 }
 
 func newHome(t *testing.T) string {

--- a/tests/e2e/interrupt_unix_test.go
+++ b/tests/e2e/interrupt_unix_test.go
@@ -1,0 +1,25 @@
+//go:build e2e && !windows
+
+package e2e
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func (b *backgroundHand) interrupt(t *testing.T, timeout time.Duration) invocation {
+	t.Helper()
+	if err := b.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal hand watch: %v", err)
+	}
+	got := b.waitForExit(t, timeout, "SIGTERM interruption")
+	if got.code != 8 {
+		t.Fatalf("interrupted watch exit = %d, want 8 watch-interrupted (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "watch-interrupted") {
+		t.Fatalf("interrupted watch stderr = %q, want the watch-interrupted kind", got.stderr)
+	}
+	return got
+}

--- a/tests/e2e/interrupt_windows_test.go
+++ b/tests/e2e/interrupt_windows_test.go
@@ -1,0 +1,16 @@
+//go:build e2e && windows
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+func (b *backgroundHand) interrupt(t *testing.T, timeout time.Duration) invocation {
+	t.Helper()
+	if err := b.cmd.Process.Kill(); err != nil {
+		t.Fatalf("stop hand watch: %v", err)
+	}
+	return b.waitForExit(t, timeout, "portable Windows cleanup")
+}

--- a/tests/e2e/report_watch_test.go
+++ b/tests/e2e/report_watch_test.go
@@ -42,10 +42,7 @@ func TestWatchIdleAfterReportedNeedsDecisionIsNotDone(t *testing.T) {
 	setPaneStatus(t, statusDir, "pane-1", "done")
 	watch.waitForStdout(t, "needs-decision task-1: waiting on review", 5*time.Second)
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 
 	stdout := watch.stdout.String()
 	if strings.Contains(stdout, "done task-1") {
@@ -80,10 +77,7 @@ func TestWatchIdleWithNoReportIsSupervisorActionable(t *testing.T) {
 	setPaneStatus(t, statusDir, "pane-1", "done")
 	watch.waitForStdout(t, "idle-unreported task-1", 5*time.Second)
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 
 	eventsLog, err := os.ReadFile(filepath.Join(state.Dir(home), "events.log"))
 	if err != nil {
@@ -132,10 +126,7 @@ func TestWatchReportRewrittenInPlaceIsNotMalformed(t *testing.T) {
 		watch.waitForStdout(t, "working task-1: "+note, 5*time.Second)
 	}
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 	if stdout := watch.stdout.String(); strings.Contains(stdout, "malformed report") {
 		t.Fatalf("stdout = %q, want no malformed report for a report rewritten in place", stdout)
 	}
@@ -199,8 +190,5 @@ func TestWatchDoneRewrittenToTheSameLengthReachesVerifiedDone(t *testing.T) {
 	// what tells "done task-1" apart from "reported-done task-1".
 	watch.waitForStdout(t, "\ndone task-1: report.md written, findings in it", 5*time.Second)
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 }

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -206,7 +206,7 @@ func TestWatcherRestartAfterResumeSideEffectDoesNotResend(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	second.stop(t, 10*time.Second)
+	second.interrupt(t, 10*time.Second)
 	assertSendSideEffects(t, logPath, "Your previous turn stopped", 0)
 	sends, err := state.ListSends(home, "task-1")
 	if err != nil || len(sends) != 1 || sends[0].State != state.SendUncertain {

--- a/tests/e2e/watch_lifecycle_test.go
+++ b/tests/e2e/watch_lifecycle_test.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -43,6 +43,88 @@ func TestWatchUntilEventIncumbentIsReplacedByTakeover(t *testing.T) {
 	}
 
 	successor.interrupt(t, 10*time.Second)
+}
+
+func TestWatchConnectIsReplacedWhileHerdrIsBlocked(t *testing.T) {
+	home := newHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, binDir(t))
+
+	incumbent := startHandBackground(t, home, "watch", "--poll", "30ms")
+	waitForInvocation(t, callLog, "herdr workspace list", 10*time.Second)
+	successor := startHandBackground(t, home, "watch", "--poll", "30ms", "--takeover")
+
+	got := incumbent.waitForExit(t, 10*time.Second, "takeover during connect")
+	if got.code != 9 || !strings.Contains(got.stderr, "watch-replaced") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-connect incumbent: exit %d stdout %q stderr %q, want exit 9/watch-replaced and empty stdout", got.code, got.stdout, got.stderr)
+	}
+	waitForCoherentOwner(t, home, successor.cmd.Process.Pid)
+	successor.interrupt(t, 10*time.Second)
+}
+
+func TestWatchConnectInterruptionWhileHerdrIsBlocked(t *testing.T) {
+	home := newHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, binDir(t))
+
+	watch := startHandBackground(t, home, "watch", "--poll", "30ms")
+	waitForInvocation(t, callLog, "herdr workspace list", 10*time.Second)
+	got := watch.interrupt(t, 10*time.Second)
+	if got.code != 8 || !strings.Contains(got.stderr, "watch-interrupted") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-connect interruption: exit %d stdout %q stderr %q, want exit 8/watch-interrupted and empty stdout", got.code, got.stdout, got.stderr)
+	}
+}
+
+func TestWatchConnectTimeoutWhileHerdrIsBlocked(t *testing.T) {
+	home := newHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, binDir(t))
+
+	got := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "100ms")
+	if got.code != 4 || !strings.Contains(got.stderr, "no-event") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-connect timeout: exit %d stdout %q stderr %q, want exit 4/no-event and empty stdout", got.code, got.stdout, got.stderr)
+	}
+}
+
+func TestWatchArmProbeIsReplacedWhileHerdrIsBlocked(t *testing.T) {
+	home := seedOneTaskHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"pane get"}, Log: callLog, LogCommands: []string{"pane get"}, AllowUnknownPane: true}.Install(t, binDir(t))
+
+	incumbent := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s")
+	waitForInvocation(t, callLog, "herdr pane get", 10*time.Second)
+	successor := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s", "--takeover")
+
+	got := incumbent.waitForExit(t, 10*time.Second, "takeover during arm probe")
+	if got.code != 9 || strings.Contains(got.stderr, "arm-failed") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-arm incumbent: exit %d stdout %q stderr %q, want exit 9 without arm-failed or stdout", got.code, got.stdout, got.stderr)
+	}
+	waitForCoherentOwner(t, home, successor.cmd.Process.Pid)
+	successor.interrupt(t, 10*time.Second)
+}
+
+func TestWatchArmProbeInterruptionWhileHerdrIsBlocked(t *testing.T) {
+	home := seedOneTaskHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"pane get"}, Log: callLog, LogCommands: []string{"pane get"}, AllowUnknownPane: true}.Install(t, binDir(t))
+
+	watch := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s")
+	waitForInvocation(t, callLog, "herdr pane get", 10*time.Second)
+	got := watch.interrupt(t, 10*time.Second)
+	if got.code != 8 || strings.Contains(got.stderr, "arm-failed") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-arm interruption: exit %d stdout %q stderr %q, want exit 8 without arm-failed or stdout", got.code, got.stdout, got.stderr)
+	}
+}
+
+func TestWatchArmProbeTimeoutWhileHerdrIsBlocked(t *testing.T) {
+	home := seedOneTaskHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"pane get"}, Log: callLog, LogCommands: []string{"pane get"}, AllowUnknownPane: true}.Install(t, binDir(t))
+
+	got := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "100ms")
+	if got.code != 4 || strings.Contains(got.stderr, "arm-failed") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-arm timeout: exit %d stdout %q stderr %q, want exit 4 without arm-failed or stdout", got.code, got.stdout, got.stderr)
+	}
 }
 
 // Ordinary commands never enter watcher ownership: with a live streaming
@@ -136,9 +218,6 @@ func setupSendFakeHome(t *testing.T, home string) string {
 // watch is still refused with exit 3).
 func assertWatcherUnaffected(t *testing.T, home string, watcher *backgroundHand, rec ownerPublication) {
 	t.Helper()
-	if err := watcher.cmd.Process.Signal(syscall.Signal(0)); err != nil {
-		t.Fatalf("incumbent watcher no longer running after an ordinary command: %v", err)
-	}
 	now, err := readOwnerPublication(t, home)
 	if err != nil {
 		t.Fatalf("read owner publication after ordinary command: %v", err)
@@ -148,9 +227,9 @@ func assertWatcherUnaffected(t *testing.T, home string, watcher *backgroundHand,
 			rec.PID, rec.Generation, now.PID, now.Generation)
 	}
 	refused := runHand(t, home, "watch", "--poll", "30ms")
-	if refused.code != 3 || !strings.Contains(refused.stderr, "pid "+strconv.Itoa(rec.PID)) {
-		t.Fatalf("after an ordinary command the incumbent no longer refuses ownership: exit %d stderr %q (want 3 naming pid %d)",
-			refused.code, refused.stderr, rec.PID)
+	if refused.code != 3 || !strings.Contains(refused.stderr, "already attached") {
+		t.Fatalf("after an ordinary command the incumbent no longer refuses ownership: exit %d stderr %q (want lock contention)",
+			refused.code, refused.stderr)
 	}
 }
 

--- a/tests/e2e/watch_lifecycle_test.go
+++ b/tests/e2e/watch_lifecycle_test.go
@@ -62,19 +62,6 @@ func TestWatchConnectIsReplacedWhileHerdrIsBlocked(t *testing.T) {
 	successor.interrupt(t, 10*time.Second)
 }
 
-func TestWatchConnectInterruptionWhileHerdrIsBlocked(t *testing.T) {
-	home := newHome(t)
-	callLog := filepath.Join(t.TempDir(), "herdr-calls")
-	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, binDir(t))
-
-	watch := startHandBackground(t, home, "watch", "--poll", "30ms")
-	waitForInvocation(t, callLog, "herdr workspace list", 10*time.Second)
-	got := watch.interrupt(t, 10*time.Second)
-	if got.code != 8 || !strings.Contains(got.stderr, "watch-interrupted") || strings.TrimSpace(got.stdout) != "" {
-		t.Fatalf("blocked-connect interruption: exit %d stdout %q stderr %q, want exit 8/watch-interrupted and empty stdout", got.code, got.stdout, got.stderr)
-	}
-}
-
 func TestWatchConnectTimeoutWhileHerdrIsBlocked(t *testing.T) {
 	home := newHome(t)
 	callLog := filepath.Join(t.TempDir(), "herdr-calls")
@@ -101,19 +88,6 @@ func TestWatchArmProbeIsReplacedWhileHerdrIsBlocked(t *testing.T) {
 	}
 	waitForCoherentOwner(t, home, successor.cmd.Process.Pid)
 	successor.interrupt(t, 10*time.Second)
-}
-
-func TestWatchArmProbeInterruptionWhileHerdrIsBlocked(t *testing.T) {
-	home := seedOneTaskHome(t)
-	callLog := filepath.Join(t.TempDir(), "herdr-calls")
-	faketool.Herdr{Hang: []string{"pane get"}, Log: callLog, LogCommands: []string{"pane get"}, AllowUnknownPane: true}.Install(t, binDir(t))
-
-	watch := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s")
-	waitForInvocation(t, callLog, "herdr pane get", 10*time.Second)
-	got := watch.interrupt(t, 10*time.Second)
-	if got.code != 8 || strings.Contains(got.stderr, "arm-failed") || strings.TrimSpace(got.stdout) != "" {
-		t.Fatalf("blocked-arm interruption: exit %d stdout %q stderr %q, want exit 8 without arm-failed or stdout", got.code, got.stdout, got.stderr)
-	}
 }
 
 func TestWatchArmProbeTimeoutWhileHerdrIsBlocked(t *testing.T) {

--- a/tests/e2e/watch_lifecycle_test.go
+++ b/tests/e2e/watch_lifecycle_test.go
@@ -1,0 +1,189 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/state"
+)
+
+// An `--until-event` incumbent with no event due is taken over by an explicit
+// --takeover successor: the displaced watcher must exit 9 / watch-replaced with
+// no synthetic event on stdout, and the successor must become the published owner.
+func TestWatchUntilEventIncumbentIsReplacedByTakeover(t *testing.T) {
+	home := seedOneTaskHome(t) // task-1 pane stays "working": no transition, no timeout expiry below
+
+	incumbent := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s")
+	incumbentRec := waitForCoherentOwner(t, home, incumbent.cmd.Process.Pid)
+
+	successor := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s", "--takeover")
+
+	got := incumbent.waitForExit(t, 10*time.Second, "an explicit takeover")
+	if got.code != 9 {
+		t.Fatalf("displaced until-event watch: exit %d, want 9 watch-replaced (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "watch-replaced") {
+		t.Fatalf("stderr = %q, want kind watch-replaced", got.stderr)
+	}
+	if strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("stdout = %q, want it empty: a takeover must not synthesize a fake event for exit 0", got.stdout)
+	}
+
+	succRec := waitForCoherentOwner(t, home, successor.cmd.Process.Pid)
+	if succRec.Generation == incumbentRec.Generation {
+		t.Fatalf("successor published the incumbent's generation %q, want a fresh one", succRec.Generation)
+	}
+
+	successor.interrupt(t, 10*time.Second)
+}
+
+// Ordinary commands never enter watcher ownership: with a live streaming
+// incumbent, a successful status / session start / send / spawn must leave the
+// same watcher alive with the same ownership generation.
+func TestOrdinaryCommandsDoNotEvictTheWatcher(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		setup   func(t *testing.T, home string) string
+		command func(t *testing.T, home string)
+	}{
+		{"status", setupWatchFakeHome, func(t *testing.T, home string) {
+			assertInvocation(t, runHand(t, home, "status"), 0, "")
+		}},
+		{"session start", setupWatchFakeHome, func(t *testing.T, home string) {
+			assertInvocation(t, runHand(t, home, "session", "start"), 0, "")
+		}},
+		{"send", setupSendFakeHome, func(t *testing.T, home string) {
+			assertInvocation(t, runHand(t, home, "send", "task-1", "steer one"), 0, "")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := newHome(t)
+			registerProject(t, home, "demo", "direct-pr")
+			statusDir := tc.setup(t, home)
+
+			watcher := startHandBackground(t, home, "watch", "--poll", "30ms")
+			rec := waitForCoherentOwner(t, home, watcher.cmd.Process.Pid)
+			// Swallow any watcher events as real fleet traffic; only nudge the fixture for send.
+			if tc.name == "send" {
+				setPaneStatus(t, statusDir, "pane-1", "idle")
+			}
+
+			tc.command(t, home)
+			assertWatcherUnaffected(t, home, watcher, rec)
+			watcher.interrupt(t, 10*time.Second)
+		})
+	}
+
+	t.Run("spawn", func(t *testing.T) {
+		home := newHome(t)
+		registerProject(t, home, "demo", "local-only")
+		writeBrief(t, home, "task-1")
+
+		clonePath := filepath.Join(home, "projects", "demo")
+		initGitRepo(t, clonePath)
+		worktree := filepath.Join(home, "wt-task-1")
+		runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
+
+		dir := binDir(t)
+		invLog := filepath.Join(t.TempDir(), "invocations.log")
+		writeFakeTreehouse(t, dir, worktree)
+		writeFakeHerdrStaticLogged(t, dir, invLog, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+
+		watcher := startHandBackground(t, home, "watch", "--poll", "30ms")
+		rec := waitForCoherentOwner(t, home, watcher.cmd.Process.Pid)
+
+		spawned := runHand(t, home, "spawn", "task-1", "demo")
+		if spawned.code != 0 {
+			t.Fatalf("spawn did not run while a watcher was attached: exit %d, stderr %q", spawned.code, spawned.stderr)
+		}
+		assertWatcherUnaffected(t, home, watcher, rec)
+		watcher.interrupt(t, 10*time.Second)
+	})
+}
+
+func setupWatchFakeHome(t *testing.T, home string) string {
+	t.Helper()
+	statusDir := t.TempDir()
+	setPaneStatus(t, statusDir, "pane-1", "working")
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning,
+		Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
+	writeFakeHerdrWatch(t, binDir(t), statusDir, filepath.Join(t.TempDir(), "herdr-invocations.log"))
+	return statusDir
+}
+
+func setupSendFakeHome(t *testing.T, home string) string {
+	t.Helper()
+	seedSendTask(t, home)
+	statusDir := t.TempDir()
+	setPaneStatus(t, statusDir, "pane-1", "working")
+	// The watch fake doubles as a send fake: it answers workspace list (for the
+	// polling watcher's connect), pane get, and the send-text/send-keys voids.
+	writeFakeHerdrWatch(t, binDir(t), statusDir, filepath.Join(t.TempDir(), "herdr-invocations.log"))
+	return statusDir
+}
+
+// Proves the incumbent survives an ordinary command: still alive, still the same
+// published pid and generation, and still the sole owner (a plain non-takeover
+// watch is still refused with exit 3).
+func assertWatcherUnaffected(t *testing.T, home string, watcher *backgroundHand, rec ownerPublication) {
+	t.Helper()
+	if err := watcher.cmd.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("incumbent watcher no longer running after an ordinary command: %v", err)
+	}
+	now, err := readOwnerPublication(t, home)
+	if err != nil {
+		t.Fatalf("read owner publication after ordinary command: %v", err)
+	}
+	if now.PID != rec.PID || now.Generation != rec.Generation {
+		t.Fatalf("ownership changed after an ordinary command: was pid %d gen %s, now pid %d gen %s",
+			rec.PID, rec.Generation, now.PID, now.Generation)
+	}
+	refused := runHand(t, home, "watch", "--poll", "30ms")
+	if refused.code != 3 || !strings.Contains(refused.stderr, "pid "+strconv.Itoa(rec.PID)) {
+		t.Fatalf("after an ordinary command the incumbent no longer refuses ownership: exit %d stderr %q (want 3 naming pid %d)",
+			refused.code, refused.stderr, rec.PID)
+	}
+}
+
+// A stale routing record cannot block a new owner when the kernel lock is free,
+// and a malformed partial record is never a takeover target.
+func TestWatchStartsOverStaleAndMalformedRoutingMetadata(t *testing.T) {
+	home := seedOneTaskHome(t)
+
+	// A fully-published stale record from a crashed predecessor whose lock is free:
+	// the fresh watcher must acquire and publish its own generation.
+	ownerPath := filepath.Join(state.Dir(home), "watch.owner")
+	if err := os.WriteFile(ownerPath, []byte(fmt.Sprintf(`{"version":1,"generation":"%s","pid":%d}`, strings.Repeat("d", 32), 999999)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "100ms")
+	if got.code != 4 {
+		t.Fatalf("watch over a stale routing record (lock free): exit %d, want 4 no-event (stderr %q)", got.code, got.stderr)
+	}
+
+	// Same with malformed routing metadata: no destructive action, lock still decides.
+	if err := os.WriteFile(ownerPath, []byte(`{truncated`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeOwnerFileRaw(t, home, strconv.Itoa(os.Getpid())+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	got = runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "100ms")
+	if got.code != 4 {
+		t.Fatalf("watch over malformed routing metadata: exit %d, want 4 no-event (stderr %q)", got.code, got.stderr)
+	}
+}
+
+func writeOwnerFileRaw(t *testing.T, home, content string) error {
+	t.Helper()
+	return os.WriteFile(filepath.Join(state.Dir(home), "watch.pid"), []byte(content), 0o644)
+}

--- a/tests/e2e/watch_lifecycle_unix_test.go
+++ b/tests/e2e/watch_lifecycle_unix_test.go
@@ -1,0 +1,38 @@
+//go:build e2e && !windows
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func TestWatchConnectInterruptionWhileHerdrIsBlocked(t *testing.T) {
+	home := newHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"workspace list"}, Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, binDir(t))
+
+	watch := startHandBackground(t, home, "watch", "--poll", "30ms")
+	waitForInvocation(t, callLog, "herdr workspace list", 10*time.Second)
+	got := watch.interrupt(t, 10*time.Second)
+	if got.code != 8 || !strings.Contains(got.stderr, "watch-interrupted") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-connect interruption: exit %d stdout %q stderr %q, want exit 8/watch-interrupted and empty stdout", got.code, got.stdout, got.stderr)
+	}
+}
+
+func TestWatchArmProbeInterruptionWhileHerdrIsBlocked(t *testing.T) {
+	home := seedOneTaskHome(t)
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Hang: []string{"pane get"}, Log: callLog, LogCommands: []string{"pane get"}, AllowUnknownPane: true}.Install(t, binDir(t))
+
+	watch := startHandBackground(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "60s")
+	waitForInvocation(t, callLog, "herdr pane get", 10*time.Second)
+	got := watch.interrupt(t, 10*time.Second)
+	if got.code != 8 || strings.Contains(got.stderr, "arm-failed") || strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("blocked-arm interruption: exit %d stdout %q stderr %q, want exit 8 without arm-failed or stdout", got.code, got.stdout, got.stderr)
+	}
+}

--- a/tests/e2e/watch_ownership_test.go
+++ b/tests/e2e/watch_ownership_test.go
@@ -16,12 +16,12 @@ import (
 
 // Drives atqamz/hand#73 end to end with real processes, which is the only way to prove the contract
 // that matters: a second watcher is refused rather than added to the fleet's pool of pollers, and
-// --takeover replaces a genuinely live incumbent that has to be signaled and reaped.
+// --takeover replaces a genuinely live incumbent that has to be cooperatively requested and reaped.
 func TestWatchIsASingletonPerFleetHome(t *testing.T) {
 	home := seedOneTaskHome(t)
 
 	first := startHandBackground(t, home, "watch", "--poll", "30ms")
-	waitForOwner(t, home, first.cmd.Process.Pid)
+	firstRec := waitForCoherentOwner(t, home, first.cmd.Process.Pid)
 
 	refused := runHand(t, home, "watch", "--poll", "30ms")
 	if refused.code != 3 {
@@ -35,10 +35,15 @@ func TestWatchIsASingletonPerFleetHome(t *testing.T) {
 	}
 
 	second := startHandBackground(t, home, "watch", "--poll", "30ms", "--takeover")
-	if got := first.waitForExit(t, 10*time.Second, "--takeover by a second watcher"); got.code != 0 {
-		t.Fatalf("displaced watch: exit %d, want a clean 0 (stderr %q)", got.code, got.stderr)
+	// The displaced incumbent exits 9 / watch-replaced - an explicit Hand takeover,
+	// distinguishable from generic SIGTERM interruption (exit 8).
+	if got := first.waitForExit(t, 10*time.Second, "--takeover by a second watcher"); got.code != 9 {
+		t.Fatalf("displaced watch: exit %d, want 9 watch-replaced (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
 	}
-	waitForOwner(t, home, second.cmd.Process.Pid)
+	secondRec := waitForCoherentOwner(t, home, second.cmd.Process.Pid)
+	if secondRec.Generation == firstRec.Generation {
+		t.Fatalf("replacement published the incumbent's generation %q, want a fresh generation", secondRec.Generation)
+	}
 
 	// Ownership then belongs to the replacement, a full owner rather than a squatter: it refuses a third
 	// watcher exactly as the incumbent it displaced did.
@@ -47,7 +52,7 @@ func TestWatchIsASingletonPerFleetHome(t *testing.T) {
 		t.Fatalf("third watch: exit %d stderr %q, want 3 naming pid %d", third.code, third.stderr, second.cmd.Process.Pid)
 	}
 
-	second.stop(t, 10*time.Second)
+	second.interrupt(t, 10*time.Second)
 
 	// Ownership outlives no watcher: the lock has to be free again the moment the last one exits, or the next
 	// hand watch inherits a home it can never watch.
@@ -57,14 +62,14 @@ func TestWatchIsASingletonPerFleetHome(t *testing.T) {
 	}
 }
 
-// The strand test: a watcher killed with SIGKILL never runs its own release, so the pid file it leaves
-// behind holds a dead pid. The kernel drops its flock anyway, and the next watcher has to start with no
-// operator intervention at all - a lock that refuses forever after a crash is worse than no lock.
-func TestWatchStartsOverACrashedWatchersPidFile(t *testing.T) {
+// The strand test: a watcher killed with SIGKILL never runs its own release, so
+// the pid file and routing record it leaves behind are stale. The kernel drops
+// its flock anyway and the next watcher starts with no operator intervention.
+func TestWatchStartsOverACrashedWatchersStaleFiles(t *testing.T) {
 	home := seedOneTaskHome(t)
 
 	crashed := startHandBackground(t, home, "watch", "--poll", "30ms")
-	waitForOwner(t, home, crashed.cmd.Process.Pid)
+	waitForCoherentOwner(t, home, crashed.cmd.Process.Pid)
 
 	if err := crashed.cmd.Process.Kill(); err != nil {
 		t.Fatal(err)
@@ -82,12 +87,12 @@ func TestWatchStartsOverACrashedWatchersPidFile(t *testing.T) {
 
 	got := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "100ms")
 	if got.code != 4 {
-		t.Fatalf("watch after a SIGKILLed watcher: exit %d, want 4 (no event) - a leftover pid file must not lock this home out of watching itself (stderr %q)", got.code, got.stderr)
+		t.Fatalf("watch after a SIGKILLed watcher: exit %d, want 4 (no event) - leftover pid/routing files must not lock this home out of watching itself (stderr %q)", got.code, got.stderr)
 	}
 }
 
-// Gives the watcher one task to poll, so waitForOwner is waiting on a loop that has really started rather
-// than on a process that has merely been forked.
+// Gives the watcher one task to poll, so the coherent-owner wait is waiting on a loop that has really
+// started rather than on a process that has merely been forked.
 func seedOneTaskHome(t *testing.T) string {
 	t.Helper()
 	home := newHome(t)
@@ -101,20 +106,4 @@ func seedOneTaskHome(t *testing.T) string {
 	setPaneStatus(t, statusDir, "pane-1", "working")
 	writeFakeHerdrWatch(t, binDir(t), statusDir, filepath.Join(t.TempDir(), "herdr-invocations.log"))
 	return home
-}
-
-func waitForOwner(t *testing.T, home string, pid int) {
-	t.Helper()
-	path := watcher.OwnerPath(home)
-	want := strconv.Itoa(pid)
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(path)
-		if err == nil && strings.TrimSpace(string(data)) == want {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	data, _ := os.ReadFile(path)
-	t.Fatalf("timed out waiting for %s to name pid %d; it holds %q", path, pid, data)
 }

--- a/tests/e2e/watch_ownership_test.go
+++ b/tests/e2e/watch_ownership_test.go
@@ -30,9 +30,6 @@ func TestWatchIsASingletonPerFleetHome(t *testing.T) {
 	if !strings.Contains(refused.stderr, "already attached") {
 		t.Fatalf("second watch stderr %q, want it to say a watcher is already attached", refused.stderr)
 	}
-	if !strings.Contains(refused.stderr, "pid "+strconv.Itoa(first.cmd.Process.Pid)) {
-		t.Fatalf("second watch stderr %q, want it to name the incumbent pid %d", refused.stderr, first.cmd.Process.Pid)
-	}
 
 	second := startHandBackground(t, home, "watch", "--poll", "30ms", "--takeover")
 	// The displaced incumbent exits 9 / watch-replaced - an explicit Hand takeover,
@@ -48,8 +45,8 @@ func TestWatchIsASingletonPerFleetHome(t *testing.T) {
 	// Ownership then belongs to the replacement, a full owner rather than a squatter: it refuses a third
 	// watcher exactly as the incumbent it displaced did.
 	third := runHand(t, home, "watch", "--poll", "30ms")
-	if third.code != 3 || !strings.Contains(third.stderr, "pid "+strconv.Itoa(second.cmd.Process.Pid)) {
-		t.Fatalf("third watch: exit %d stderr %q, want 3 naming pid %d", third.code, third.stderr, second.cmd.Process.Pid)
+	if third.code != 3 || !strings.Contains(third.stderr, "already attached") {
+		t.Fatalf("third watch: exit %d stderr %q, want 3 lock contention", third.code, third.stderr)
 	}
 
 	second.interrupt(t, 10*time.Second)

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -72,10 +72,7 @@ func TestWatchEventStream(t *testing.T) {
 		t.Fatalf("events out of order in stdout: %q", stdout)
 	}
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 
 	// The log has to hold them durably too, so a consumer that starts reading only after the fact still sees
 	// everything a live stdout reader saw.
@@ -264,10 +261,7 @@ func TestWatchParksADoneWorkerUnderItsOwnBound(t *testing.T) {
 	watch.waitForStdout(t, "reported-done shipped-task: shipped the migration", 5*time.Second)
 	watch.waitForStdout(t, "parked shipped-task: done: shipped the migration (silent", 15*time.Second)
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 }
 
 // The bug atqamz/hand#127 tracks, exercised through a real restart rather than through the latch
@@ -409,10 +403,7 @@ func TestWatchNotifiesInProcessForABlockedEvent(t *testing.T) {
 		t.Fatalf("notify marker = %q, want the event text delivered by config/notify in-process", got)
 	}
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 }
 
 // A task first sighted with its pane already unreachable - a re-scan picking up a fresh spawn - has no
@@ -465,10 +456,7 @@ func TestWatchTracksATaskFirstSightedUnreachable(t *testing.T) {
 		t.Fatalf("a pane that blinked and came back raised failed: stdout=%q", watch.stdout.String())
 	}
 
-	result := watch.stop(t, 3*time.Second)
-	if result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 }
 
 // The full-stack half of internal/watcher's usage-limit tests: a real `hand watch` process, a real sqlite
@@ -536,9 +524,7 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 		t.Fatalf("plain attempt = %+v, want no usage-limit schedule", plainAttempt)
 	}
 
-	if result := watch.stop(t, 3*time.Second); result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	watch.interrupt(t, 3*time.Second)
 	if data, err := os.ReadFile(detectLog); err != nil {
 		t.Fatal(err)
 	} else if strings.Contains(string(data), "send-text") {
@@ -580,9 +566,7 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 		t.Fatalf("limited attempt after resume = %+v, want the schedule cleared", afterAttempt)
 	}
 
-	if result := resumed.stop(t, 3*time.Second); result.code != 0 {
-		t.Fatalf("hand watch exit = %d after SIGTERM, want 0 (stderr %q)", result.code, result.stderr)
-	}
+	resumed.interrupt(t, 3*time.Second)
 	if data, err := os.ReadFile(resumeLog); err != nil {
 		t.Fatal(err)
 	} else if strings.Contains(string(data), "send-text pane-plain") {


### PR DESCRIPTION
## Summary

- Attribute watcher cancellation deterministically to replacement, interruption, or timeout.
- Register signals before ownership publication and harden generation-bound Unix/Windows takeover delivery.
- Remove PID overclaims, add deterministic lifecycle coverage, and update lifecycle guidance.

Fixes atqamz/hand#222

## Test plan

- `git diff --check`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make lint`
- `make build`
- `make test`
- `make e2e`
- `make contract`
- `nix build .#default --no-link`
- `nix flake check --print-build-logs`
- Focused repeated watcher, command, and E2E runs.
- CI green: Lint, Ubuntu, macOS, Windows, E2E, and Nix.