### PR TITLE
test: harden runtime durability coverage

### DIFF
--- a/internal/store/migration_v8_test.go
+++ b/internal/store/migration_v8_test.go
@@ -45,8 +45,8 @@ func TestMigrationV8ConvertsReal040Database(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("ReadTaskHistory = %v, %v", found, err)
 	}
-	if history.Task.Lifecycle != TaskOpen || history.Task.ActiveAttemptID == 0 {
-		t.Fatalf("task lifecycle/active attempt = %q/%d", history.Task.Lifecycle, history.Task.ActiveAttemptID)
+	if history.Task.ID != "legacy" || history.Task.Lifecycle != TaskOpen || history.Task.ActiveAttemptID == 0 {
+		t.Fatalf("task identity/lifecycle/active attempt = %q/%q/%d", history.Task.ID, history.Task.Lifecycle, history.Task.ActiveAttemptID)
 	}
 	if history.Task.Project != "nsr" || history.Task.Kind != "ship" || history.Task.Brief != "data/legacy/brief.md" || history.Task.ReportOffset != 41 || history.Task.ReportDigest != "digest-before-upgrade" || history.Task.PR != "https://github.com/o/nsr/pull/7" || !history.Task.MergeExecuted || history.Task.MergeExecutedAt != "2026-07-24T12:00:00Z" || !history.Task.MergeAnnounced || history.Task.DeliveredAt != "2026-07-24T13:00:00Z" || history.Task.DeliveredReason != "merged" || history.Task.CreatedAt != "2026-07-24T10:00:00Z" {
 		t.Fatalf("task-owned state was not preserved: %+v", history.Task)
@@ -55,7 +55,7 @@ func TestMigrationV8ConvertsReal040Database(t *testing.T) {
 		t.Fatalf("attempt count = %d, want 1", len(history.Attempts))
 	}
 	attempt := history.Attempts[0]
-	if attempt.Ordinal != 1 || attempt.Lifecycle != AttemptRunning || attempt.Harness != "claude" || attempt.Model != "opus" || attempt.Effort != "high" || attempt.Worktree != "/w/nsr" || attempt.LeaseID != "lease-7" || attempt.CreatedAt != "2026-07-24T10:00:00Z" || attempt.PaneStartedAt != "2026-07-24T10:30:00Z" || attempt.StatusChangedAt != "2026-07-24T11:00:00Z" || attempt.StatusChangedFor != "working" || !attempt.DoneVerified {
+	if attempt.ID == 0 || history.Task.ActiveAttemptID != attempt.ID || attempt.TaskID != "legacy" || attempt.Ordinal != 1 || attempt.Lifecycle != AttemptRunning || attempt.Harness != "claude" || attempt.Model != "opus" || attempt.Effort != "high" || attempt.Worktree != "/w/nsr" || attempt.LeaseID != "lease-7" || attempt.CreatedAt != "2026-07-24T10:00:00Z" || attempt.PaneStartedAt != "2026-07-24T10:30:00Z" || attempt.StatusChangedAt != "2026-07-24T11:00:00Z" || attempt.StatusChangedFor != "working" || !attempt.DoneVerified {
 		t.Fatalf("execution state was not preserved: %+v", attempt)
 	}
 	if attempt.Herdr.Session != "default" || attempt.Herdr.WorkspaceID != "wA" || attempt.Herdr.TabID != "wA:tB" || attempt.Herdr.PaneID != "wA:pC" || attempt.LastReportState != "working" || attempt.LastReportNote != "still working" || attempt.UsageLimitRetryAt != "2026-07-24T15:00:00Z" || attempt.UsageLimitAttempts != 2 || attempt.SendUndeliveredMessage != "stop" || attempt.SendUndeliveredAt != "2026-07-24T13:30:00Z" || attempt.ParkedFiredFor != "2026-07-24T11:30:00Z" {

--- a/internal/store/migration_v8_test.go
+++ b/internal/store/migration_v8_test.go
@@ -48,19 +48,24 @@ func TestMigrationV8ConvertsReal040Database(t *testing.T) {
 	if history.Task.Lifecycle != TaskOpen || history.Task.ActiveAttemptID == 0 {
 		t.Fatalf("task lifecycle/active attempt = %q/%d", history.Task.Lifecycle, history.Task.ActiveAttemptID)
 	}
-	if history.Task.ReportOffset != 41 || history.Task.ReportDigest != "digest-before-upgrade" || history.Task.PR != "https://github.com/o/nsr/pull/7" || history.Task.DeliveredAt != "2026-07-24T13:00:00Z" {
+	if history.Task.Project != "nsr" || history.Task.Kind != "ship" || history.Task.Brief != "data/legacy/brief.md" || history.Task.ReportOffset != 41 || history.Task.ReportDigest != "digest-before-upgrade" || history.Task.PR != "https://github.com/o/nsr/pull/7" || !history.Task.MergeExecuted || history.Task.MergeExecutedAt != "2026-07-24T12:00:00Z" || !history.Task.MergeAnnounced || history.Task.DeliveredAt != "2026-07-24T13:00:00Z" || history.Task.DeliveredReason != "merged" || history.Task.CreatedAt != "2026-07-24T10:00:00Z" {
 		t.Fatalf("task-owned state was not preserved: %+v", history.Task)
 	}
 	if len(history.Attempts) != 1 {
 		t.Fatalf("attempt count = %d, want 1", len(history.Attempts))
 	}
 	attempt := history.Attempts[0]
-	if attempt.Ordinal != 1 || attempt.Lifecycle != AttemptRunning || attempt.Harness != "claude" || attempt.Model != "opus" || attempt.Effort != "high" || attempt.Worktree != "/w/nsr" || attempt.LeaseID != "lease-7" {
+	if attempt.Ordinal != 1 || attempt.Lifecycle != AttemptRunning || attempt.Harness != "claude" || attempt.Model != "opus" || attempt.Effort != "high" || attempt.Worktree != "/w/nsr" || attempt.LeaseID != "lease-7" || attempt.CreatedAt != "2026-07-24T10:00:00Z" || attempt.PaneStartedAt != "2026-07-24T10:30:00Z" || attempt.StatusChangedAt != "2026-07-24T11:00:00Z" || attempt.StatusChangedFor != "working" || !attempt.DoneVerified {
 		t.Fatalf("execution state was not preserved: %+v", attempt)
 	}
-	if attempt.Herdr.PaneID != "wA:pC" || attempt.LastReportState != "working" || attempt.UsageLimitAttempts != 2 || attempt.SendUndeliveredMessage != "stop" {
+	if attempt.Herdr.Session != "default" || attempt.Herdr.WorkspaceID != "wA" || attempt.Herdr.TabID != "wA:tB" || attempt.Herdr.PaneID != "wA:pC" || attempt.LastReportState != "working" || attempt.LastReportNote != "still working" || attempt.UsageLimitRetryAt != "2026-07-24T15:00:00Z" || attempt.UsageLimitAttempts != 2 || attempt.SendUndeliveredMessage != "stop" || attempt.SendUndeliveredAt != "2026-07-24T13:30:00Z" || attempt.ParkedFiredFor != "2026-07-24T11:30:00Z" {
 		t.Fatalf("attempt bookkeeping was not preserved: %+v", attempt)
 	}
+	sends, err := migrated.ListSends("legacy")
+	if err != nil || len(sends) != 1 || sends[0].State != SendUncertain || sends[0].Message != "stop" || sends[0].Origin != SendOriginLegacyUndelivered {
+		t.Fatalf("migrated send history = %+v, err=%v, want one uncertain legacy send", sends, err)
+	}
+	wantTask, wantAttempt, wantSend := history.Task, attempt, sends[0]
 	var teardownColumns int
 	if err := migrated.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name IN ('teardown_terminal_attempt', 'teardown_disposition', 'teardown_herdr_state', 'teardown_worktree_state', 'teardown_completion_state')`).Scan(&teardownColumns); err != nil {
 		t.Fatal(err)
@@ -70,6 +75,25 @@ func TestMigrationV8ConvertsReal040Database(t *testing.T) {
 	}
 	if _, err := migrated.sql.Query(`SELECT harness FROM task`); err == nil {
 		t.Fatal("old execution columns remain authoritative on task")
+	}
+	if err := migrated.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(home)
+	if err != nil {
+		t.Fatalf("reopen migrated 0.4.0 database: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedHistory, found, err := reopened.ReadTaskHistory("legacy")
+	if err != nil || !found || len(reopenedHistory.Attempts) != 1 {
+		t.Fatalf("reopened history = %+v, found=%t, err=%v", reopenedHistory, found, err)
+	}
+	if reopenedHistory.Task != wantTask || reopenedHistory.Attempts[0] != wantAttempt {
+		t.Fatalf("reopened history changed: task=%+v attempt=%+v, want task=%+v attempt=%+v", reopenedHistory.Task, reopenedHistory.Attempts[0], wantTask, wantAttempt)
+	}
+	reopenedSends, err := reopened.ListSends("legacy")
+	if err != nil || len(reopenedSends) != 1 || reopenedSends[0] != wantSend {
+		t.Fatalf("reopened send history = %+v, err=%v, want %+v", reopenedSends, err, wantSend)
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -2032,18 +2032,27 @@ func TestRunUntilEventTakesTheStartupStateAsBaseline(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "done")
 	writeFakeHerdr(t, statusFile)
+	callLog := logPaneGets(t)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR checks green\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	var out bytes.Buffer
-	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 200 * time.Millisecond}
-	err := RunUntilEvent(context.Background(), cfg, &out, io.Discard)
+	done := make(chan error, 1)
+	go func() {
+		done <- RunUntilEvent(ctx, Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour}, &out, io.Discard)
+	}()
 
-	if !errors.Is(err, ErrNoEvent) {
-		t.Fatalf("RunUntilEvent = %v, want ErrNoEvent: nothing changed after it armed", err)
+	waitForPaneGets(t, callLog, 4)
+	cancel()
+	err := <-done
+
+	if !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("RunUntilEvent = %v, want ErrInterrupted after the baseline was observed", err)
 	}
 	if out.Len() != 0 {
 		t.Fatalf("out = %q, want the startup state delivered as nothing", out.String())

--- a/tests/e2e/runtime_hardening_test.go
+++ b/tests/e2e/runtime_hardening_test.go
@@ -1,0 +1,177 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/routing"
+	"github.com/atqamz/hand/internal/state"
+)
+
+func TestRuntimeRouteMatrixPersistsEveryCanonicalCell(t *testing.T) {
+	type routeCell struct {
+		kind  string
+		class string
+	}
+	cells := []routeCell{
+		{kind: "scout", class: "mechanical"},
+		{kind: "scout", class: "standard"},
+		{kind: "scout", class: "deep"},
+		{kind: "ship", class: "mechanical"},
+		{kind: "ship", class: "standard"},
+		{kind: "ship", class: "deep"},
+	}
+
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	plannedAgainst := strings.TrimSpace(runGitIn(t, clonePath, "rev-parse", "HEAD"))
+	worktrees := make([]string, 0, len(cells))
+	for i := range cells {
+		worktree := filepath.Join(home, fmt.Sprintf("wt-task-%d", i))
+		runGitIn(t, clonePath, "worktree", "add", "-q", "-b", fmt.Sprintf("task-%d-branch", i), worktree)
+		worktrees = append(worktrees, worktree)
+	}
+
+	dir := binDir(t)
+	writeFakeBin(t, dir, "claude", "exit 0\n")
+	faketool.Treehouse{Slots: worktrees}.Install(t, dir)
+	workspaces := make([]faketool.HerdrWorkspace, 0, len(cells))
+	for i := range cells {
+		workspaces = append(workspaces, faketool.HerdrWorkspace{
+			ID: fmt.Sprintf("workspace-%d", i), Label: "demo",
+			Tabs: []faketool.HerdrTab{{ID: fmt.Sprintf("tab-%d", i), Label: "1", Pane: fmt.Sprintf("pane-%d", i)}},
+		})
+	}
+	tabCreates := make([]faketool.HerdrTab, 0, len(cells)-1)
+	for i := 1; i < len(cells); i++ {
+		tabCreates = append(tabCreates, faketool.HerdrTab{ID: fmt.Sprintf("tab-extra-%d", i), Pane: fmt.Sprintf("pane-extra-%d", i)})
+	}
+	faketool.Herdr{Creates: workspaces, TabCreates: tabCreates, PaneAgent: "claude", PaneStatus: "working"}.Install(t, dir)
+
+	for i, cell := range cells {
+		profile := fmt.Sprintf("operator-%s-%d", cell.class, i)
+		if got := runHand(t, home, "config", "profile", "set", profile, "--harness", "claude", "--model", "model-"+cell.class, "--effort", "effort-"+cell.class); got.code != 0 {
+			t.Fatalf("profile %s: exit %d, stderr %q", profile, got.code, got.stderr)
+		}
+		if got := runHand(t, home, "config", "route", "set", cell.kind, cell.class, profile); got.code != 0 {
+			t.Fatalf("route %s.%s: exit %d, stderr %q", cell.kind, cell.class, got.code, got.stderr)
+		}
+	}
+
+	for i, cell := range cells {
+		id := fmt.Sprintf("task-%d", i)
+		writeBriefWith(t, home, id, executionBrief(cell.class, plannedAgainst))
+		args := []string{"spawn", id, "demo", "--skip-gate-check"}
+		if cell.kind == "scout" {
+			args = append(args, "--scout")
+		}
+		got := runHand(t, home, args...)
+		if got.code != 0 {
+			t.Fatalf("spawn %s.%s: exit %d, stderr %q", cell.kind, cell.class, got.code, got.stderr)
+		}
+		task, attempt := readTaskAttempt(t, home, id)
+		profile := fmt.Sprintf("operator-%s-%d", cell.class, i)
+		if task.Kind != cell.kind || attempt.ExecutionClass != cell.class || attempt.RequestedProfile != profile || attempt.Harness != "claude" || attempt.Model != "model-"+cell.class || attempt.Effort != "effort-"+cell.class || attempt.PlannedAgainst != plannedAgainst || attempt.RoutingSource != string(routing.RoutingSourceRoute) {
+			t.Fatalf("%s.%s task=%+v attempt=%+v, want immutable route snapshot for %s", cell.kind, cell.class, task, attempt, profile)
+		}
+	}
+}
+
+func TestReopenUsesCurrentRouteWithoutMutatingHistoricalAttempt(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	plannedAgainst := strings.TrimSpace(runGitIn(t, clonePath, "rev-parse", "HEAD"))
+	worktree := filepath.Join(home, "wt-task-1")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
+
+	dir := binDir(t)
+	writeFakeBin(t, dir, "claude", "exit 0\n")
+	faketool.Treehouse{Slots: []string{worktree}}.Install(t, dir)
+	faketool.Herdr{
+		Creates: []faketool.HerdrWorkspace{
+			{ID: "workspace-1", Label: "demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: "1", Pane: "pane-1"}}},
+			{ID: "workspace-2", Label: "demo", Tabs: []faketool.HerdrTab{{ID: "tab-2", Label: "1", Pane: "pane-2"}}},
+		},
+		PaneAgent: "claude", PaneStatus: "working",
+	}.Install(t, dir)
+
+	setExecutionProfile(t, home, "route-a", "claude", "model-a", "effort-a")
+	setHardeningRoute(t, home, "ship", "standard", "route-a")
+	writeBriefWith(t, home, "task-1", executionBrief("standard", plannedAgainst))
+	if got := runHand(t, home, "spawn", "task-1", "demo", "--skip-gate-check"); got.code != 0 {
+		t.Fatalf("spawn: exit %d, stderr %q", got.code, got.stderr)
+	}
+	_, first := readTaskAttempt(t, home, "task-1")
+	if first.RequestedProfile != "route-a" || first.Model != "model-a" || first.Effort != "effort-a" {
+		t.Fatalf("first Attempt = %+v, want route-a snapshot", first)
+	}
+
+	runGitIn(t, worktree, "commit", "--allow-empty", "-q", "-m", "finish first attempt")
+	if got := runHand(t, home, "merge", "task-1", "--local"); got.code != 0 {
+		t.Fatalf("merge --local: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if got := runHand(t, home, "teardown", "task-1"); got.code != 0 {
+		t.Fatalf("teardown: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	setExecutionProfile(t, home, "route-b", "claude", "model-b", "effort-b")
+	setHardeningRoute(t, home, "ship", "standard", "route-b")
+	if got := runHand(t, home, "reopen", "task-1", "--skip-gate-check"); got.code != 0 {
+		t.Fatalf("reopen: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 2 || history.ActiveAttempt == nil {
+		t.Fatalf("history = %+v, want two Attempts and one active replacement", history)
+	}
+	old, current := history.Attempts[0], *history.ActiveAttempt
+	if old.ID == current.ID || old.Lifecycle != state.AttemptCompleted {
+		t.Fatalf("old=%+v current=%+v, want distinct terminal historical Attempt", old, current)
+	}
+	if old.RequestedProfile != "route-a" || old.Model != "model-a" || old.Effort != "effort-a" || old.ExecutionClass != "standard" {
+		t.Fatalf("historical Attempt changed after route edit: %+v", old)
+	}
+	if current.RequestedProfile != "route-b" || current.Model != "model-b" || current.Effort != "effort-b" || current.ExecutionClass != "standard" {
+		t.Fatalf("reopened Attempt = %+v, want current route-b snapshot", current)
+	}
+}
+
+func TestSelectedProfileFailureDoesNotFallBackToAnotherProfile(t *testing.T) {
+	home, _, treehouseLog, herdrLog := setupClassifiedRoutingRefusal(t)
+	setExecutionProfile(t, home, "valid-alternative", "claude", "good-model", "high")
+	setExecutionProfile(t, home, "selected-incompatible", "grok", "", "")
+	setHardeningRoute(t, home, "ship", "standard", "selected-incompatible")
+	writeBriefWith(t, home, "task-1", executionBrief("standard", strings.Repeat("a", 40)))
+
+	got := runHand(t, home, "spawn", "task-1", "demo", "--skip-gate-check")
+	assertInvocation(t, got, 3, `harness "grok" is not installed on PATH`)
+	if exists, err := state.Exists(home, "task-1"); err != nil || exists {
+		t.Fatalf("state.Exists = %v, %v, want no Task or Attempt", exists, err)
+	}
+	if log := readOptionalLog(t, treehouseLog); log != "" {
+		t.Fatalf("treehouse log = %q, want no acquisition after selected Profile failure", log)
+	}
+	if log := readOptionalLog(t, herdrLog); log != "" {
+		t.Fatalf("herdr log = %q, want no resource creation after selected Profile failure", log)
+	}
+}
+
+func setHardeningRoute(t *testing.T, home, kind, class, profile string) {
+	t.Helper()
+	got := runHand(t, home, "config", "route", "set", kind, class, profile)
+	if got.code != 0 {
+		t.Fatalf("route %s.%s = profile %s: exit %d, stderr %q", kind, class, profile, got.code, got.stderr)
+	}
+}

--- a/tests/e2e/runtime_hardening_test.go
+++ b/tests/e2e/runtime_hardening_test.go
@@ -78,7 +78,14 @@ func TestRuntimeRouteMatrixPersistsEveryCanonicalCell(t *testing.T) {
 		}
 		task, attempt := readTaskAttempt(t, home, id)
 		profile := fmt.Sprintf("operator-%s-%d", cell.class, i)
-		if task.Kind != cell.kind || attempt.ExecutionClass != cell.class || attempt.RequestedProfile != profile || attempt.Harness != "claude" || attempt.Model != "model-"+cell.class || attempt.Effort != "effort-"+cell.class || attempt.PlannedAgainst != plannedAgainst || attempt.RoutingSource != string(routing.RoutingSourceRoute) {
+		wantWorkspace := "workspace-0"
+		wantTab := "tab-0"
+		wantPane := "pane-0"
+		if i > 0 {
+			wantTab = fmt.Sprintf("tab-extra-%d", i)
+			wantPane = fmt.Sprintf("pane-extra-%d", i)
+		}
+		if task.ID != id || task.ActiveAttemptID != attempt.ID || task.Kind != cell.kind || attempt.TaskID != id || attempt.ExecutionClass != cell.class || attempt.RequestedProfile != profile || attempt.Harness != "claude" || attempt.Model != "model-"+cell.class || attempt.Effort != "effort-"+cell.class || attempt.PlannedAgainst != plannedAgainst || attempt.RoutingSource != string(routing.RoutingSourceRoute) || attempt.Herdr.WorkspaceID != wantWorkspace || attempt.Herdr.TabID != wantTab || attempt.Herdr.PaneID != wantPane {
 			t.Fatalf("%s.%s task=%+v attempt=%+v, want immutable route snapshot for %s", cell.kind, cell.class, task, attempt, profile)
 		}
 	}
@@ -137,19 +144,21 @@ func TestReopenUsesCurrentRouteWithoutMutatingHistoricalAttempt(t *testing.T) {
 		t.Fatalf("history = %+v, want two Attempts and one active replacement", history)
 	}
 	old, current := history.Attempts[0], *history.ActiveAttempt
-	if old.ID == current.ID || old.Lifecycle != state.AttemptCompleted {
+	if history.Task.ID != "task-1" || history.Task.ActiveAttemptID != current.ID || old.ID == 0 || current.ID == 0 || old.ID == current.ID || old.TaskID != "task-1" || current.TaskID != "task-1" || old.Ordinal != 1 || current.Ordinal != 2 || old.Lifecycle != state.AttemptCompleted {
 		t.Fatalf("old=%+v current=%+v, want distinct terminal historical Attempt", old, current)
 	}
-	if old.RequestedProfile != "route-a" || old.Model != "model-a" || old.Effort != "effort-a" || old.ExecutionClass != "standard" {
+	if old.RequestedProfile != "route-a" || old.Model != "model-a" || old.Effort != "effort-a" || old.ExecutionClass != "standard" || old.PlannedAgainst != plannedAgainst {
 		t.Fatalf("historical Attempt changed after route edit: %+v", old)
 	}
-	if current.RequestedProfile != "route-b" || current.Model != "model-b" || current.Effort != "effort-b" || current.ExecutionClass != "standard" {
+	if current.RequestedProfile != "route-b" || current.Model != "model-b" || current.Effort != "effort-b" || current.ExecutionClass != "standard" || current.PlannedAgainst != plannedAgainst {
 		t.Fatalf("reopened Attempt = %+v, want current route-b snapshot", current)
 	}
 }
 
 func TestSelectedProfileFailureDoesNotFallBackToAnotherProfile(t *testing.T) {
-	home, _, treehouseLog, herdrLog := setupClassifiedRoutingRefusal(t)
+	home, bin, treehouseLog, herdrLog := setupClassifiedRoutingRefusal(t)
+	workerLog := filepath.Join(t.TempDir(), "worker.log")
+	writeFakeBin(t, bin, "claude", fmt.Sprintf("echo launch >> %s\nexit 0\n", shellSingleQuote(workerLog)))
 	setExecutionProfile(t, home, "valid-alternative", "claude", "good-model", "high")
 	setExecutionProfile(t, home, "selected-incompatible", "grok", "", "")
 	setHardeningRoute(t, home, "ship", "standard", "selected-incompatible")
@@ -165,6 +174,9 @@ func TestSelectedProfileFailureDoesNotFallBackToAnotherProfile(t *testing.T) {
 	}
 	if log := readOptionalLog(t, herdrLog); log != "" {
 		t.Fatalf("herdr log = %q, want no resource creation after selected Profile failure", log)
+	}
+	if log := readOptionalLog(t, workerLog); log != "" {
+		t.Fatalf("worker log = %q, want no launch after selected Profile failure", log)
 	}
 }
 

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -194,9 +194,10 @@ func TestWatcherRestartAfterResumeSideEffectDoesNotResend(t *testing.T) {
 	}
 	first.waitForExit(t, 10*time.Second, "watcher process death after resume Text side effect")
 
-	beforeRestart := countInvocations(t, logPath+".invocations", "pane get")
+	const paneGetInvocation = "herdr pane get pane-1"
+	beforeRestart := countInvocations(t, logPath+".invocations", paneGetInvocation)
 	second := startHandBackground(t, home, "watch", "--poll", "20ms")
-	waitForInvocations(t, logPath+".invocations", "pane get", beforeRestart+2, 10*time.Second)
+	waitForInvocations(t, logPath+".invocations", paneGetInvocation, beforeRestart+2, 10*time.Second)
 	second.interrupt(t, 10*time.Second)
 	assertSendSideEffects(t, logPath, "Your previous turn stopped", 0)
 	sends, err := state.ListSends(home, "task-1")
@@ -211,7 +212,13 @@ func countInvocations(t *testing.T, logPath, substr string) int {
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
-	return strings.Count(string(data), substr)
+	count := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == substr {
+			count++
+		}
+	}
+	return count
 }
 
 func installCrashSendHerdr(t *testing.T, dir, logPath, hang string) {

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -194,24 +194,24 @@ func TestWatcherRestartAfterResumeSideEffectDoesNotResend(t *testing.T) {
 	}
 	first.waitForExit(t, 10*time.Second, "watcher process death after resume Text side effect")
 
+	beforeRestart := countInvocations(t, logPath+".invocations", "pane get")
 	second := startHandBackground(t, home, "watch", "--poll", "20ms")
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(logPath)
-		if err != nil && !os.IsNotExist(err) {
-			t.Fatal(err)
-		}
-		if strings.Count(string(data), "Your previous turn stopped") > 1 {
-			t.Fatalf("watcher resent an unresolved resume after restart: %q", data)
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	waitForInvocations(t, logPath+".invocations", "pane get", beforeRestart+2, 10*time.Second)
 	second.interrupt(t, 10*time.Second)
 	assertSendSideEffects(t, logPath, "Your previous turn stopped", 0)
 	sends, err := state.ListSends(home, "task-1")
 	if err != nil || len(sends) != 1 || sends[0].State != state.SendUncertain {
 		t.Fatalf("sends=%+v err=%v, want one uncertain watcher send after restart", sends, err)
 	}
+}
+
+func countInvocations(t *testing.T, logPath, substr string) int {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return strings.Count(string(data), substr)
 }
 
 func installCrashSendHerdr(t *testing.T, dir, logPath, hang string) {


### PR DESCRIPTION
## Summary
- Add built-binary coverage for all six canonical route cells, immutable same-Task reopen snapshots, and selected Profile failure without fallback.
- Verify realistic 0.4.0 migration history remains stable across database reopen.
- Replace watcher restart timing and startup-baseline timing assertions with deterministic external-tool invocation barriers.

Fixes atqamz/hand#198

## Test plan
- go test ./...
- go test -race ./...
- go vet ./...
- make lint
- make build
- make test
- make e2e
- make contract
- nix build .#default --no-link
- nix flake check --print-build-logs
- Focused repeated race suites for runtime, store, watcher, steering, and E2E restart/routing coverage.
- CI: Lint, Ubuntu, macOS, Windows, E2E, and Nix all passed; Publish edge skipped by workflow policy.