### PR TITLE
fix(watcher): suppress false stale events for terminal or delivered tasks

### DIFF
--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -231,8 +231,13 @@ func ClassifyStatus(ts *TaskState, id string, status herdr.Status, probeErr erro
 	return nil
 }
 
-func ClassifyStale(ts *TaskState, id string, now time.Time, threshold time.Duration) *Event {
+func ClassifyStale(ts *TaskState, id, deliveredAt string, now time.Time, threshold time.Duration) *Event {
 	if !ts.Probed || ts.Stale {
+		return nil
+	}
+	// Silence is no longer an unattended condition after a terminal worker report or durable task
+	// delivery, so neither fact may consume the stale latch.
+	if state.TerminalReport(ts.LastReportState) || deliveredAt != "" {
 		return nil
 	}
 	if now.Sub(ts.ChangedAt) < threshold {

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -144,22 +144,77 @@ func TestClassifyStaleFiresOncePerWindow(t *testing.T) {
 	ts := NewTaskState(herdr.StatusWorking, now)
 	threshold := 5 * time.Minute
 
-	if e := ClassifyStale(ts, "task-1", now.Add(time.Minute), threshold); e != nil {
+	if e := ClassifyStale(ts, "task-1", "", now.Add(time.Minute), threshold); e != nil {
 		t.Fatalf("got %+v, want no stale event before threshold", e)
 	}
-	if e := ClassifyStale(ts, "task-1", now.Add(6*time.Minute), threshold); e == nil || e.Kind != KindStale {
+	if e := ClassifyStale(ts, "task-1", "", now.Add(6*time.Minute), threshold); e == nil || e.Kind != KindStale {
 		t.Fatalf("got %+v, want stale event", e)
 	}
-	if e := ClassifyStale(ts, "task-1", now.Add(10*time.Minute), threshold); e != nil {
+	if e := ClassifyStale(ts, "task-1", "", now.Add(10*time.Minute), threshold); e != nil {
 		t.Fatalf("stale event fired again in the same window: %+v", e)
 	}
 
 	ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, now.Add(11*time.Minute))
-	if e := ClassifyStale(ts, "task-1", now.Add(12*time.Minute), threshold); e != nil {
+	if e := ClassifyStale(ts, "task-1", "", now.Add(12*time.Minute), threshold); e != nil {
 		t.Fatalf("stale fired right after a status change reset the window: %+v", e)
 	}
-	if e := ClassifyStale(ts, "task-1", now.Add(17*time.Minute), threshold); e == nil || e.Kind != KindStale {
+	if e := ClassifyStale(ts, "task-1", "", now.Add(17*time.Minute), threshold); e == nil || e.Kind != KindStale {
 		t.Fatalf("got %+v, want stale again once the reset window elapsed: it is a wake trigger, so leaving and re-entering the condition is a second occurrence", e)
+	}
+}
+
+func TestClassifyStaleSuppressesTerminalWorkerReports(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	threshold := 5 * time.Minute
+
+	for _, reportState := range []string{state.ReportDone, state.ReportFailed} {
+		ts := NewTaskState(herdr.StatusWorking, now.Add(-threshold))
+		ts.LastReportState = reportState
+
+		if e := ClassifyStale(ts, "task-1", "", now, threshold); e != nil {
+			t.Fatalf("report state %q: got %+v, want no stale event", reportState, e)
+		}
+		if ts.Stale {
+			t.Fatalf("report state %q: stale latch changed without an event", reportState)
+		}
+	}
+}
+
+func TestClassifyStaleSuppressesDeliveredTaskWithoutTerminalReport(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	threshold := 5 * time.Minute
+	ts := NewTaskState(herdr.StatusWorking, now.Add(-threshold))
+	ts.LastReportState = state.ReportWorking
+
+	if e := ClassifyStale(ts, "task-1", "2026-08-17T00:00:00Z", now, threshold); e != nil {
+		t.Fatalf("got %+v, want no stale event for delivered work", e)
+	}
+	if ts.Stale {
+		t.Fatal("stale latch changed without an event for delivered work")
+	}
+}
+
+func TestClassifyStaleKeepsNonTerminalReportsEligible(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	threshold := 5 * time.Minute
+
+	for _, reportState := range []string{"", state.ReportWorking, state.ReportPaused, state.ReportBlocked, state.ReportNeedsDecision} {
+		ts := NewTaskState(herdr.StatusWorking, now.Add(-threshold))
+		ts.LastReportState = reportState
+
+		if e := ClassifyStale(ts, "task-1", "", now, threshold); e == nil || e.Kind != KindStale {
+			t.Fatalf("report state %q: got %+v, want stale event", reportState, e)
+		}
+	}
+}
+
+func TestClassifyStaleTreatsHerdrDoneAsNotBusyOnly(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	threshold := 5 * time.Minute
+	ts := NewTaskState(herdr.StatusDone, now.Add(-threshold))
+
+	if e := ClassifyStale(ts, "task-1", "", now, threshold); e == nil || e.Kind != KindStale {
+		t.Fatalf("got %+v, want stale event for unexplained herdr done", e)
 	}
 }
 
@@ -168,7 +223,7 @@ func TestClassifyStaleSkipsUnprobedTasks(t *testing.T) {
 	ts := NewTaskState(herdr.StatusWorking, now)
 	ClassifyStatus(ts, "task-1", "", errors.New("down"), now.Add(time.Second))
 
-	if e := ClassifyStale(ts, "task-1", now.Add(time.Hour), time.Minute); e != nil {
+	if e := ClassifyStale(ts, "task-1", "", now.Add(time.Hour), time.Minute); e != nil {
 		t.Fatalf("got %+v, want no stale event while probe is failing", e)
 	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -312,7 +312,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		if e := ClassifyUnreachable(ts, t.ID, now, cfg.StaleThreshold); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
-		if e := ClassifyStale(ts, t.ID, now, cfg.StaleThreshold); e != nil {
+		if e := ClassifyStale(ts, t.ID, t.DeliveredAt, now, cfg.StaleThreshold); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
 		if t.PR != "" && !ts.PRMerged {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -260,7 +260,7 @@ func TestTickClassifiesNotBusyAsIdleUnreportedRegardlessOfHerdrSpelling(t *testi
 
 func TestTickSuppressesStaleForTerminalAndDeliveredTasksUsingCurrentState(t *testing.T) {
 	writeFakeHerdrForPanes(t, "p1", "p2", "p3", "p4")
-	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	old := "2020-01-02T03:04:05Z"
 
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
@@ -347,7 +347,7 @@ func TestTickProcessesTerminalReportBeforeStale(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
-	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	old := "2020-01-02T03:04:05Z"
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Kind: state.KindShip, CreatedAt: old}, state.Attempt{
 		Lifecycle:        state.AttemptRunning,
@@ -380,7 +380,7 @@ func TestTickKeepsIdleUnreportedFactualAfterDelivery(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
-	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	old := "2020-01-02T03:04:05Z"
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Kind: state.KindShip, CreatedAt: old, DeliveredAt: old, DeliveredReason: "handed off"}, state.Attempt{
 		Lifecycle:        state.AttemptRunning,
@@ -2357,6 +2357,7 @@ func TestRunUntilEventSuppressesStaleAfterLiveTerminalAndDeliveryUpdates(t *test
 			"working", "working", "working",
 			"pane-gone", "pane-gone", "pane-gone",
 			"working", "working", "working",
+			"pane-gone", "pane-gone", "pane-gone",
 			"working", "working", "blocked",
 		},
 		Log: callLog, LogCommands: []string{"pane get"},
@@ -2389,13 +2390,14 @@ func TestRunUntilEventSuppressesStaleAfterLiveTerminalAndDeliveryUpdates(t *test
 		}, &out, io.Discard)
 	}()
 
-	waitForHerdrCalls(t, callLog, "pane get", 3)
+	waitForHerdrCalls(t, callLog, "pane get", 9)
 	if err := os.WriteFile(state.ReportPath(home, "terminal-task"), []byte("done: finished\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.SetTaskDelivery(home, "delivered-task", old, "handed off while watch was alive"); err != nil {
 		t.Fatal(err)
 	}
+	waitForHerdrCalls(t, callLog, "pane get", 15)
 	select {
 	case err := <-done:
 		if err != nil {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -2345,6 +2345,82 @@ func TestRunUntilEventDeliversIdleUnreportedForAWorkerThatWentQuiet(t *testing.T
 	}
 }
 
+func TestRunUntilEventSuppressesStaleAfterLiveTerminalAndDeliveryUpdates(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{
+			{ID: "wA:t1", Label: "terminal-task", Pane: "p1"},
+			{ID: "wA:t2", Label: "delivered-task", Pane: "p2"},
+			{ID: "wA:t3", Label: "live-task", Pane: "p3"},
+		}}},
+		PaneStatusSequence: []string{
+			"working", "working", "working",
+			"pane-gone", "pane-gone", "pane-gone",
+			"working", "working", "working",
+			"working", "working", "blocked",
+		},
+		Log: callLog, LogCommands: []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
+
+	old := "2020-01-02T03:04:05Z"
+	future := "2099-01-02T03:04:05Z"
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{state.Task{ID: "terminal-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}, StatusChangedAt: old}},
+		{state.Task{ID: "delivered-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p2"}, StatusChangedAt: old}},
+		{state.Task{ID: "live-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p3"}, StatusChangedAt: future}},
+	} {
+		if err := writeTaskAttempt(t, home, tc.task, tc.attempt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunUntilEvent(context.Background(), Config{
+			Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: 0, Timeout: 5 * time.Second,
+			EventFilter: NewEventFilter([]string{KindStale}),
+		}, &out, io.Discard)
+	}()
+
+	waitForHerdrCalls(t, callLog, "pane get", 3)
+	if err := os.WriteFile(state.ReportPath(home, "terminal-task"), []byte("done: finished\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskDelivery(home, "delivered-task", old, "handed off while watch was alive"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunUntilEvent = %v, want nil for the live stale event", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunUntilEvent did not return for the live stale event")
+	}
+	if got := out.String(); got != "stale live-task\n" {
+		t.Fatalf("out = %q, want only the live stale event", got)
+	}
+	logData, err := os.ReadFile(filepath.Join(state.Dir(home), "events.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"terminal-task", "delivered-task"} {
+		if strings.Contains(string(logData), "stale "+id) {
+			t.Fatalf("events.log = %q, contains false stale event for %s", string(logData), id)
+		}
+	}
+	if !strings.Contains(string(logData), "stale live-task") {
+		t.Fatalf("events.log = %q, want the live stale event", string(logData))
+	}
+}
+
 func TestRunUntilEventReportsNoEventOnTimeout(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -45,6 +46,23 @@ func writeFakeHerdr(t *testing.T, statusFile string) {
 		Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}},
 		Log:       callLog, LogCommands: []string{"pane get"},
 	}.Install(t, bin)
+}
+
+func writeFakeHerdrForPanes(t *testing.T, panes ...string) {
+	t.Helper()
+	tabs := make([]faketool.HerdrTab, 0, len(panes))
+	for i, pane := range panes {
+		tabs = append(tabs, faketool.HerdrTab{ID: fmt.Sprintf("wA:t%d", i+1), Label: fmt.Sprintf("task-%d", i+1), Pane: pane})
+	}
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	faketool.Herdr{
+		Workspaces:       []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: tabs}},
+		PaneStatus:       "working",
+		AllowUnknownPane: false,
+		Log:              callLog,
+		LogCommands:      []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
 }
 
 // Fakes `gh pr view --json state`, the only gh call a tick makes (watcher.go's ghutil.PRIsMerged),
@@ -237,6 +255,152 @@ func TestTickClassifiesNotBusyAsIdleUnreportedRegardlessOfHerdrSpelling(t *testi
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 	if buf.Len() != 0 {
 		t.Fatalf("repeated not-busy state fired again: %q", buf.String())
+	}
+}
+
+func TestTickSuppressesStaleForTerminalAndDeliveredTasksUsingCurrentState(t *testing.T) {
+	writeFakeHerdrForPanes(t, "p1", "p2", "p3", "p4")
+	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tasks := []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{
+			task: state.Task{ID: "terminal-task", Kind: state.KindShip, CreatedAt: old},
+			attempt: state.Attempt{
+				Lifecycle:        state.AttemptRunning,
+				Herdr:            state.Herdr{PaneID: "p1"},
+				StatusChangedAt:  old,
+				StatusChangedFor: string(herdr.StatusWorking),
+				LastReportState:  state.ReportDone,
+			},
+		},
+		{
+			task: state.Task{ID: "startup-delivered-task", Kind: state.KindShip, CreatedAt: old, DeliveredAt: old, DeliveredReason: "handed off"},
+			attempt: state.Attempt{
+				Lifecycle:        state.AttemptRunning,
+				Herdr:            state.Herdr{PaneID: "p2"},
+				StatusChangedAt:  old,
+				StatusChangedFor: string(herdr.StatusWorking),
+				LastReportState:  state.ReportWorking,
+			},
+		},
+		{
+			task: state.Task{ID: "live-delivery-task", Kind: state.KindShip, CreatedAt: old},
+			attempt: state.Attempt{
+				Lifecycle:        state.AttemptRunning,
+				Herdr:            state.Herdr{PaneID: "p3"},
+				StatusChangedAt:  old,
+				StatusChangedFor: string(herdr.StatusWorking),
+				LastReportState:  state.ReportWorking,
+			},
+		},
+		{
+			task: state.Task{ID: "live-task", Kind: state.KindShip, CreatedAt: old},
+			attempt: state.Attempt{
+				Lifecycle:        state.AttemptRunning,
+				Herdr:            state.Herdr{PaneID: "p4"},
+				StatusChangedAt:  old,
+				StatusChangedFor: string(herdr.StatusWorking),
+			},
+		},
+	}
+	for _, tc := range tasks {
+		if err := writeTaskAttempt(t, home, tc.task, tc.attempt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+	var out bytes.Buffer
+	tick(ctx, cfg, client, states, &out, io.Discard)
+
+	if err := state.SetTaskDelivery(home, "live-delivery-task", old, "handed off after watch started"); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	tick(ctx, cfg, client, states, &out, io.Discard)
+
+	if got := out.String(); got != "stale live-task\n" {
+		t.Fatalf("output = %q, want only the genuinely live task's stale event", got)
+	}
+	logData, err := os.ReadFile(filepath.Join(state.Dir(home), "events.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"terminal-task", "startup-delivered-task", "live-delivery-task"} {
+		if strings.Contains(string(logData), "stale "+id) {
+			t.Fatalf("events.log = %q, contains false stale event for %s", string(logData), id)
+		}
+	}
+}
+
+func TestTickProcessesTerminalReportBeforeStale(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Kind: state.KindShip, CreatedAt: old}, state.Attempt{
+		Lifecycle:        state.AttemptRunning,
+		Herdr:            state.Herdr{PaneID: "p1"},
+		StatusChangedAt:  old,
+		StatusChangedFor: string(herdr.StatusWorking),
+	})
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+	var out bytes.Buffer
+	tick(ctx, cfg, client, states, &out, io.Discard)
+
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: finished\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	tick(ctx, cfg, client, states, &out, io.Discard)
+
+	if !strings.Contains(out.String(), "reported-done task-1: finished") {
+		t.Fatalf("output = %q, want the terminal report event", out.String())
+	}
+	if strings.Contains(out.String(), "stale task-1") {
+		t.Fatalf("output = %q, want same-tick terminal report to suppress stale", out.String())
+	}
+}
+
+func TestTickKeepsIdleUnreportedFactualAfterDelivery(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+	old := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Kind: state.KindShip, CreatedAt: old, DeliveredAt: old, DeliveredReason: "handed off"}, state.Attempt{
+		Lifecycle:        state.AttemptRunning,
+		Herdr:            state.Herdr{PaneID: "p1"},
+		StatusChangedAt:  old,
+		StatusChangedFor: string(herdr.StatusWorking),
+	})
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+	var out bytes.Buffer
+	tick(ctx, cfg, client, states, &out, io.Discard)
+
+	setStatus(t, statusFile, "done")
+	out.Reset()
+	tick(ctx, cfg, client, states, &out, io.Discard)
+
+	if !strings.Contains(out.String(), "idle-unreported task-1") {
+		t.Fatalf("output = %q, want delivery to leave the factual unexplained stop visible", out.String())
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -2355,9 +2355,10 @@ func TestRunUntilEventSuppressesStaleAfterLiveTerminalAndDeliveryUpdates(t *test
 		}}},
 		PaneStatusSequence: []string{
 			"working", "working", "working",
-			"pane-gone", "pane-gone", "pane-gone",
 			"working", "working", "working",
-			"pane-gone", "pane-gone", "pane-gone",
+			"working", "working", "working",
+			"working", "working", "working",
+			"working", "working", "working",
 			"working", "working", "blocked",
 		},
 		Log: callLog, LogCommands: []string{"pane get"},
@@ -2373,9 +2374,9 @@ func TestRunUntilEventSuppressesStaleAfterLiveTerminalAndDeliveryUpdates(t *test
 		task    state.Task
 		attempt state.Attempt
 	}{
-		{state.Task{ID: "terminal-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}, StatusChangedAt: old}},
-		{state.Task{ID: "delivered-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p2"}, StatusChangedAt: old}},
-		{state.Task{ID: "live-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p3"}, StatusChangedAt: future}},
+		{state.Task{ID: "terminal-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}, StatusChangedAt: future, StatusChangedFor: string(herdr.StatusWorking)}},
+		{state.Task{ID: "delivered-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p2"}, StatusChangedAt: future, StatusChangedFor: string(herdr.StatusWorking)}},
+		{state.Task{ID: "live-task", Kind: state.KindShip, CreatedAt: old}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p3"}, StatusChangedAt: future, StatusChangedFor: string(herdr.StatusWorking)}},
 	} {
 		if err := writeTaskAttempt(t, home, tc.task, tc.attempt); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Summary

- Suppress false `stale` events for terminal worker reports (`done` and `failed`).
- Suppress false `stale` events for delivered Tasks using the current durable Task snapshot, including delivery recorded while a watcher remains alive.
- Preserve live stale detection, Herdr `done` liveness semantics, explicit event filtering, and single-shot watcher behavior.
- Equivalent-classifier audit covered `idle-unreported`, blocked, unreachable, parked, report, PR, usage-limit, and deferred-done paths; within #232's terminal/delivery stale-classifier scope, no other suppression was justified. A distinct teardown/observation race that can produce a false `failed` event is tracked separately in #235.

Fixes atqamz/hand#232

## Test plan

- Added deterministic classifier coverage for done, failed, delivered, non-terminal, Herdr-done, and stale-latch cases.
- Added real SQLite watcher coverage for startup delivery, live delivery updates, same-tick terminal reports, and delivery-only `idle-unreported`.
- Public-loop integration uses fixed timestamps and exact fake Herdr invocation barriers.
- Full local validation and Linux, macOS, Windows, E2E, Nix, and lint CI checks passed.

No schema migration, watcher actionable taxonomy, fake contract change, or adjacent roadmap scope was added.