### PR TITLE
fix(selfupdate): reconcile update notice cache

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -46,6 +46,19 @@ func newUpdateCmd(info selfupdate.BuildInfo) *cobra.Command {
 				return err
 			}
 
+			reconcileHome, reconcileErr := home.Resolve()
+			switch {
+			case reconcileErr == nil:
+				reconcileErr = selfupdate.ReconcileNotice(reconcileHome, target)
+			case errors.Is(reconcileErr, home.ErrNotFound):
+				reconcileErr = nil
+			}
+			if reconcileErr != nil {
+				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: reconcile the version notice cache: %v\n", reconcileErr); err != nil {
+					return err
+				}
+			}
+
 			if !newer || checkOnly {
 				doc := updateDoc(info, target, newer, false, "not-applicable", "not-applicable", nil)
 				if newer {

--- a/cmd/update_channel_test.go
+++ b/cmd/update_channel_test.go
@@ -2,15 +2,53 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/selfupdate"
 )
 
 const edgeCommandCommit = "0123456789abcdef0123456789abcdef01234567"
+const edgeCommandCommitA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+// Mirrors the unexported cache record selfupdate/notice.go reads and writes,
+// so a test can seed or inspect state/.version-check without exporting it.
+type versionCheckFixture struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Channel   string    `json:"channel,omitempty"`
+	Latest    string    `json:"latest"`
+	Commit    string    `json:"commit,omitempty"`
+}
+
+func writeVersionCheckFixture(t *testing.T, home string, cache versionCheckFixture) {
+	t.Helper()
+	data, err := json.Marshal(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "state", ".version-check"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readVersionCheckFixture(t *testing.T, home string) versionCheckFixture {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, "state", ".version-check"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cache versionCheckFixture
+	if err := json.Unmarshal(data, &cache); err != nil {
+		t.Fatal(err)
+	}
+	return cache
+}
 
 func writeFakeGHChannels(t *testing.T, stable, edge string) {
 	t.Helper()
@@ -25,6 +63,7 @@ func writeFakeGHEdgeUpdate(t *testing.T, commit, notes, fixtureDir string) {
 }
 
 func TestUpdateCheckFollowsEmbeddedEdgeChannel(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHChannels(t, "v0.5.0", edgeCommandCommit)
 
 	cmd := newUpdateCmd(selfupdate.BuildInfo{
@@ -56,6 +95,7 @@ func TestUpdateCheckFollowsEmbeddedEdgeChannel(t *testing.T) {
 }
 
 func TestUpdateCheckExplicitlySwitchesStableToEdge(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHChannels(t, "v0.5.0", edgeCommandCommit)
 
 	cmd := newUpdateCmd(selfupdate.BuildInfo{Version: "v0.9.0", Channel: selfupdate.ChannelStable})
@@ -71,6 +111,7 @@ func TestUpdateCheckExplicitlySwitchesStableToEdge(t *testing.T) {
 }
 
 func TestUpdateCheckEdgeWithMatchingCommitIsUpToDate(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHChannels(t, "v0.5.0", edgeCommandCommit)
 
 	cmd := newUpdateCmd(selfupdate.BuildInfo{
@@ -126,5 +167,157 @@ func TestUpdateRejectsInvalidChannelAsUsageError(t *testing.T) {
 	cmd.SetArgs([]string{"--check", "--channel", "nightly"})
 	if code := exitCodeFor(t, cmd.Execute()); code != 2 {
 		t.Fatalf("exit code = %d, want usage code 2", code)
+	}
+}
+
+func TestUpdateCheckReconcilesARolledBackEdgeCache(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeVersionCheckFixture(t, home, versionCheckFixture{
+		CheckedAt: time.Now(),
+		Channel:   selfupdate.ChannelEdge,
+		Latest:    "edge." + edgeCommandCommit[:12],
+		Commit:    edgeCommandCommit,
+	})
+	writeFakeGHChannels(t, "v0.5.0", edgeCommandCommitA)
+
+	cmd := newUpdateCmd(selfupdate.BuildInfo{
+		Version: "edge." + edgeCommandCommitA[:12],
+		Channel: selfupdate.ChannelEdge,
+		Commit:  edgeCommandCommitA,
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "update_available: false\n") {
+		t.Fatalf("output = %q, want no update available once the live target rolls back to the installed build", out.String())
+	}
+
+	cache := readVersionCheckFixture(t, home)
+	if cache.Commit != edgeCommandCommitA {
+		t.Fatalf("cache commit = %q, want the live target %q, not the withdrawn build", cache.Commit, edgeCommandCommitA)
+	}
+}
+
+func TestUpdateCheckReconcilesAForwardEdgeCache(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeVersionCheckFixture(t, home, versionCheckFixture{
+		CheckedAt: time.Now(),
+		Channel:   selfupdate.ChannelEdge,
+		Latest:    "edge." + edgeCommandCommitA[:12],
+		Commit:    edgeCommandCommitA,
+	})
+	writeFakeGHChannels(t, "v0.5.0", edgeCommandCommit)
+
+	cmd := newUpdateCmd(selfupdate.BuildInfo{
+		Version: "edge." + edgeCommandCommitA[:12],
+		Channel: selfupdate.ChannelEdge,
+		Commit:  edgeCommandCommitA,
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "update_available: true\n") {
+		t.Fatalf("output = %q, want an available update for the newer live edge build", out.String())
+	}
+
+	cache := readVersionCheckFixture(t, home)
+	if cache.Commit != edgeCommandCommit {
+		t.Fatalf("cache commit = %q, want the newer live target recorded", cache.Commit)
+	}
+}
+
+func TestUpdateCheckLeavesNoPositiveCacheClaimOnResolutionFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	t.Setenv("PATH", t.TempDir())
+
+	cmd := newUpdateCmd(selfupdate.BuildInfo{Version: "v0.1.0", Channel: selfupdate.ChannelStable})
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("want the existing error behavior when gh is unreachable")
+	}
+
+	if _, err := os.Stat(filepath.Join(home, "state", ".version-check")); !os.IsNotExist(err) {
+		t.Fatalf("got a version cache written after a failed live resolution, err=%v", err)
+	}
+}
+
+func TestUpdateCheckWarnsWhenTheCacheCannotBeWritten(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce directory write permissions the same way")
+	}
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeGHChannels(t, "v0.5.0", edgeCommandCommit)
+
+	stateDir := filepath.Join(home, "state")
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o755) })
+
+	cmd := newUpdateCmd(selfupdate.BuildInfo{
+		Version: "edge." + edgeCommandCommitA[:12],
+		Channel: selfupdate.ChannelEdge,
+		Commit:  edgeCommandCommitA,
+	})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want a successful check despite an unwritable cache", err)
+	}
+	if !strings.Contains(out.String(), "update_available: true\n") {
+		t.Fatalf("output = %q, want the check result unaffected by the cache failure", out.String())
+	}
+	if !strings.Contains(errOut.String(), "warning: reconcile the version notice cache:") {
+		t.Fatalf("got stderr %q, want a reconcile warning", errOut.String())
+	}
+}
+
+func TestUpdateApplyLeavesNoticeCoherentWithTheInstalledBuild(t *testing.T) {
+	setFakeExecutable(t)
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	fixture := buildUpdateFixture(t, []byte("new edge binary contents"))
+	writeFakeGHEdgeUpdate(t, edgeCommandCommit, "edge notes", fixture)
+
+	cmd := newUpdateCmd(selfupdate.BuildInfo{
+		Version: "edge." + edgeCommandCommitA[:12],
+		Channel: selfupdate.ChannelEdge,
+		Commit:  edgeCommandCommitA,
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := readVersionCheckFixture(t, home)
+	if cache.Channel != selfupdate.ChannelEdge || cache.Commit != edgeCommandCommit {
+		t.Fatalf("cache = %+v, want it to record the installed edge build", cache)
+	}
+
+	bin := faketool.Bin(t)
+	faketool.GH{}.Install(t, bin)
+	installed := selfupdate.BuildInfo{Version: "edge." + edgeCommandCommit[:12], Channel: selfupdate.ChannelEdge, Commit: edgeCommandCommit}
+	if notice := selfupdate.CheckNoticeForBuild(home, selfupdate.Repo, installed); notice != "" {
+		t.Fatalf("got %q, want no banner once notice state matches the installed build", notice)
 	}
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -542,6 +542,7 @@ func checkedUpdateDoc(current, latest string, available bool) string {
 }
 
 func TestUpdateCheckReportsAvailableUpdate(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHReleaseView(t, "v0.5.0")
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -560,6 +561,7 @@ func TestUpdateCheckReportsAvailableUpdate(t *testing.T) {
 // Up to date is an answer, not an absence: it renders the same schema as an
 // available update, differing only in the value of update_available.
 func TestUpdateCheckReportsUpToDate(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHReleaseView(t, "v0.1.0")
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -576,6 +578,7 @@ func TestUpdateCheckReportsUpToDate(t *testing.T) {
 }
 
 func TestUpdateWithoutCheckSkipsInstallWhenUpToDate(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHReleaseView(t, "v0.1.0")
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -592,6 +595,7 @@ func TestUpdateWithoutCheckSkipsInstallWhenUpToDate(t *testing.T) {
 }
 
 func TestUpdateCheckReportsAvailableUpdateForDevBuild(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
 	writeFakeGHReleaseView(t, "v0.5.0")
 
 	cmd := newUpdateCmd(devBuild("dev"))

--- a/internal/selfupdate/notice.go
+++ b/internal/selfupdate/notice.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/atqamz/hand/internal/atomicfile"
 )
 
 const cacheFile = ".version-check"
@@ -70,6 +72,23 @@ func CheckNoticeForBuild(home, repo string, info BuildInfo) string {
 	return fmt.Sprintf("A new version of hand is available: %s -> %s\nRun \"hand update\" to update", info.Version, target.Version)
 }
 
+// ReconcileNotice rewrites the notice cache for home from an authoritative live
+// resolution, so a startup notice can never keep advertising a target a live
+// check has already superseded.
+func ReconcileNotice(home string, target Target) error {
+	stateDir := filepath.Join(home, "state")
+	if _, err := os.Stat(stateDir); err != nil {
+		return nil
+	}
+	cachePath := filepath.Join(stateDir, cacheFile)
+	return writeCache(cachePath, versionCache{
+		CheckedAt: time.Now(),
+		Channel:   target.Channel,
+		Latest:    target.Version,
+		Commit:    target.Commit,
+	})
+}
+
 func cacheChannel(cache versionCache) string {
 	if cache.Channel == "" {
 		return ChannelStable
@@ -94,5 +113,5 @@ func writeCache(path string, cache versionCache) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return atomicfile.Write(path, ".version-check-", data, 0o644)
 }

--- a/internal/selfupdate/notice_test.go
+++ b/internal/selfupdate/notice_test.go
@@ -3,12 +3,15 @@ package selfupdate
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
 )
+
+const edgeTestCommitA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 func stableBuild(version string) BuildInfo {
 	return BuildInfo{Version: version, Channel: ChannelStable}
@@ -214,5 +217,141 @@ func TestCheckNoticeForBuildRefreshesCacheWhenChannelChanges(t *testing.T) {
 	}
 	if cache.Channel != ChannelEdge || cache.Commit != edgeTestCommit {
 		t.Fatalf("cache = %#v, want edge channel and commit", cache)
+	}
+}
+
+func TestReconcileNoticeReplacesARolledBackTarget(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCache(filepath.Join(home, "state", cacheFile), versionCache{
+		CheckedAt: time.Now(),
+		Channel:   ChannelEdge,
+		Latest:    "edge." + shortCommit(edgeTestCommit),
+		Commit:    edgeTestCommit,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	live := Target{Channel: ChannelEdge, Tag: ChannelEdge, Version: "edge." + shortCommit(edgeTestCommitA), Commit: edgeTestCommitA}
+	if err := ReconcileNotice(home, live); err != nil {
+		t.Fatal(err)
+	}
+
+	// A refusal fake: the reconciled cache must be fresh and match the
+	// installed build so no live gh call happens.
+	bin := faketool.Bin(t)
+	faketool.GH{}.Install(t, bin)
+	installed := BuildInfo{Version: "edge." + shortCommit(edgeTestCommitA), Channel: ChannelEdge, Commit: edgeTestCommitA}
+	if notice := CheckNoticeForBuild(home, "atqamz/hand", installed); notice != "" {
+		t.Fatalf("got %q, want no banner for the rolled-back build", notice)
+	}
+}
+
+func TestReconcileNoticeRecordsAForwardTarget(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCache(filepath.Join(home, "state", cacheFile), versionCache{
+		CheckedAt: time.Now(),
+		Channel:   ChannelEdge,
+		Latest:    "edge." + shortCommit(edgeTestCommitA),
+		Commit:    edgeTestCommitA,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	live := Target{Channel: ChannelEdge, Tag: ChannelEdge, Version: "edge." + shortCommit(edgeTestCommit), Commit: edgeTestCommit}
+	if err := ReconcileNotice(home, live); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := faketool.Bin(t)
+	faketool.GH{}.Install(t, bin)
+	installed := BuildInfo{Version: "edge." + shortCommit(edgeTestCommitA), Channel: ChannelEdge, Commit: edgeTestCommitA}
+	notice := CheckNoticeForBuild(home, "atqamz/hand", installed)
+	want := "A new edge build of hand is available: " + shortCommit(edgeTestCommitA) + " -> " + shortCommit(edgeTestCommit) + "\nRun \"hand update\" to update"
+	if notice != want {
+		t.Fatalf("got %q, want %q", notice, want)
+	}
+}
+
+func TestReconcileNoticeSkipsHomeWithoutStateDir(t *testing.T) {
+	home := t.TempDir()
+
+	if err := ReconcileNotice(home, Target{Channel: ChannelEdge, Version: "edge." + shortCommit(edgeTestCommit), Commit: edgeTestCommit}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "state")); !os.IsNotExist(err) {
+		t.Fatalf("got state dir created, want none, err=%v", err)
+	}
+}
+
+func TestReconcileNoticeKeepsStableAndEdgeCachesSeparate(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	live := Target{Channel: ChannelEdge, Tag: ChannelEdge, Version: "edge." + shortCommit(edgeTestCommit), Commit: edgeTestCommit}
+	if err := ReconcileNotice(home, live); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFakeGH(t, "v0.5.0", t.TempDir())
+	notice := CheckNoticeForBuild(home, "atqamz/hand", stableBuild("v0.1.0"))
+	want := "A new version of hand is available: v0.1.0 -> v0.5.0\nRun \"hand update\" to update"
+	if notice != want {
+		t.Fatalf("got %q, want %q, an edge cache must not answer for a stable build", notice, want)
+	}
+	cache, err := readCache(filepath.Join(home, "state", cacheFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cache.Channel != ChannelStable || cache.Latest != "v0.5.0" {
+		t.Fatalf("cache = %#v, want a stable record after the stable check", cache)
+	}
+}
+
+func TestReconcileNoticeWriteFailureLeavesAPreviousRecordIntact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce directory write permissions the same way")
+	}
+	home := t.TempDir()
+	stateDir := filepath.Join(home, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := versionCache{
+		CheckedAt: time.Now(),
+		Channel:   ChannelEdge,
+		Latest:    "edge." + shortCommit(edgeTestCommitA),
+		Commit:    edgeTestCommitA,
+	}
+	if err := writeCache(filepath.Join(stateDir, cacheFile), original); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o755) })
+
+	live := Target{Channel: ChannelEdge, Tag: ChannelEdge, Version: "edge." + shortCommit(edgeTestCommit), Commit: edgeTestCommit}
+	if err := ReconcileNotice(home, live); err == nil {
+		t.Fatal("want an error when state is not writable")
+	}
+
+	if err := os.Chmod(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cache, err := readCache(filepath.Join(stateDir, cacheFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cache.Channel != original.Channel || cache.Latest != original.Latest || cache.Commit != original.Commit {
+		t.Fatalf("cache = %#v, want the previous valid record unchanged: %#v", cache, original)
 	}
 }


### PR DESCRIPTION
## Intent

Fix atqamz/hand#223: one binary must not give two contradictory answers about whether an update is available. A live 'hand update --check' could report update_available: false while ordinary command startup kept advertising a withdrawn/rolled-back edge build from state/.version-check for up to 24 hours (the cache TTL), because the startup notice path trusts a fresh same-channel cache without a network call while 'hand update' does a live resolution but never wrote its result back to that cache.

Fix: add internal/selfupdate.ReconcileNotice(home string, target Target) error, which rewrites the notice cache (CheckedAt: now, Channel/Latest/Commit from the resolved target) using internal/atomicfile.Write (reusing the existing writeCache helper, no new atomic-write helper), keeping versionCache/cacheFile/the cache path unexported. It is a no-op (returns nil, writes nothing) when <home>/state does not exist.

Wired into cmd/update.go's RunE with exactly one call site: immediately after NeedsUpdate succeeds and before the '!newer || checkOnly' branch (covers both --check and real update, since real update takes that same path first). Fleet home is resolved via home.Resolve(); errors.Is(err, home.ErrNotFound) is treated as a no-op, mirroring the existing post-apply AGENTS.md refresh's switch-based pattern in the same file. Any other reconcile error is a stderr warning ('warning: reconcile the version notice cache: %v'), never a command failure - this was a deliberate correction from an earlier draft that hard-failed the command on a non-ErrNotFound home.Resolve() error (e.g. a misconfigured HAND_HOME), which contradicted the requirement that cache-write failure must never fail an otherwise-successful update check, and diverged from the established TestUpdateWarnsWhenHandHomeIsNotAFleetHome precedent. Deliberately only one call site - no second reconcile after Apply.

Behavioral invariants preserved: ordinary command startup stays bounded (checkTimeout) and non-fatal with no new network call; a successful live resolution always reconciles the cache before hand update returns; a cached target disagreeing with a successful live resolution is replaced; a failed live resolution invents nothing (no positive cache claim on failure); cache-write failure is a warning, not a command failure; stable and edge caches stay separated by channel; after a successful real update, the notice cache is coherent with the newly installed build; no new network call added anywhere.

Tests added: internal/selfupdate/notice_test.go gets TestReconcileNoticeReplacesARolledBackTarget, TestReconcileNoticeRecordsAForwardTarget, TestReconcileNoticeSkipsHomeWithoutStateDir, TestReconcileNoticeKeepsStableAndEdgeCachesSeparate, TestReconcileNoticeWriteFailureLeavesAPreviousRecordIntact (this one skips on Windows via runtime.GOOS check, matching the existing internal/watcher/ownership_test.go precedent, since POSIX chmod-based write-failure injection is unreliable on Windows). cmd/update_channel_test.go gets TestUpdateCheckReconcilesARolledBackEdgeCache, TestUpdateCheckReconcilesAForwardEdgeCache, TestUpdateCheckLeavesNoPositiveCacheClaimOnResolutionFailure, TestUpdateCheckWarnsWhenTheCacheCannotBeWritten (also Windows-skipped), TestUpdateApplyLeavesNoticeCoherentWithTheInstalledBuild. All 4 pre-existing notice-cache tests (TestCheckNoticeUsesFreshCacheWithoutCallingGH, TestCheckNoticeRefreshesStaleCache, TestCheckNoticeCachesFailedCheck, TestCheckNoticeForBuildRefreshesCacheWhenChannelChanges) verified not to regress.

Incidental but necessary fix: 7 pre-existing test functions in cmd/update_test.go and cmd/update_channel_test.go did not neutralize an ambient HAND_HOME (unlike the mkFleetDirs convention documented in cmd/fleethome_test.go). Since the new reconcile call site now calls home.Resolve() unconditionally on every hand update run, those tests risked silently writing to the developer's real fleet home's state/.version-check during . Added t.Setenv("HAND_HOME", "") as the first line of each of those 7 tests to neutralize this; verified via mtime comparison that the real fleet's cache file was untouched by a full test run both before and after this fix.

All verification commands passed: go vet ./..., go test ./..., go test -race ./..., nix develop -c make lint, nix develop -c make build, nix develop -c make contract (passed on 4th attempt - 3 prior failures were transient real-network GitHub API timeouts on unrelated tests, not related to this diff), nix develop -c make e2e, git diff --check, and NIX_CONFIG=... nix flake check --refresh --print-build-logs (all checks passed). No Windows/POSIX-only assumptions were introduced in shared code; the one platform-conditional test skip follows existing repo convention.

## What Changed

- Reconcile the version notice cache from live update targets during `hand update --check` and update flows, with non-fatal warnings for cache-write failures.
- Rewrite caches atomically, skip homes without a state directory, and preserve stable/edge channel separation.
- Add coverage for rollback, forward updates, resolution and write failures, and post-apply cache coherence.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves existing non-fatal flows, and reconciles the notice cache only after successful live resolution using the existing atomic write helper.

## Testing

Exercised rollback and forward cache replacement, failed resolution, unwritable-cache warnings, channel separation, and post-apply coherence. Normal and race-enabled targeted tests passed; no UI artifact applies.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c670a98d3bfd77df7b7031178194fddc552cfea0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Targeted self-update notice tests`
- `Targeted update command reconciliation tests`
- `Race-enabled versions of both test groups`
- `Verified clean worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
