### PR TITLE
fix(runtime): recover unobservable worktree ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
-| `hand reconcile [id]` | Reconcile one Task or the bounded fleet candidate set with observed external reality. |
+| `hand reconcile [id] [--abandon-worktree]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; explicitly relinquish an unobservable historical worktree lease when given a Task ID. |
 | `hand watch` | Wait for actionable fleet events. |
 | `hand send` | Steer a running worker. |
 | `hand merge` | Merge completed work after authorization. |

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -23,7 +23,9 @@ func newReconcileCmd() *cobra.Command {
 			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
 			"the worktree is left exactly as it is for the operator to reclaim through treehouse itself. The flag\n" +
 			"only adds this worktree attestation and leaves every other reconciliation action unchanged, including\n" +
-			"ordinary Herdr cleanup, which still requires proven ownership.",
+			"ordinary Herdr cleanup, which still requires proven ownership. Eligibility is a recorded teardown\n" +
+			"decision left by an interruption at the worktree step; an attempt without that decision is never\n" +
+			"abandoned.",
 		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -23,9 +23,12 @@ func newReconcileCmd() *cobra.Command {
 			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
 			"the worktree is left exactly as it is for the operator to reclaim through treehouse itself. The flag\n" +
 			"only adds this worktree attestation and leaves every other reconciliation action unchanged, including\n" +
-			"ordinary Herdr cleanup, which still requires proven ownership. Eligibility is a recorded teardown\n" +
-			"decision left by an interruption at the worktree step; an attempt without that decision is never\n" +
-			"abandoned.",
+			"ordinary Herdr cleanup, which still requires proven ownership. An attempt that is still active is\n" +
+			"reached only through a recorded teardown decision, the shape a teardown interrupted at the worktree\n" +
+			"step leaves behind, while an attempt whose lifecycle is already terminal is eligible on its own once\n" +
+			"its worktree resource is unsettled. No worktree of a live worker can be abandoned on either route,\n" +
+			"because a provisioning or running attempt is skipped and the active attempt is reachable only through\n" +
+			"that recorded decision.",
 		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -21,7 +21,9 @@ func newReconcileCmd() *cobra.Command {
 			"--abandon-worktree attests that Hand relinquishes a recorded Treehouse lease whose pool cannot be\n" +
 			"observed at all, for instance after the pool key moved. It needs an explicit task ID, it refuses any\n" +
 			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
-			"the worktree is left exactly as it is for the operator to reclaim through treehouse itself.",
+			"the worktree is left exactly as it is for the operator to reclaim through treehouse itself. The flag\n" +
+			"only adds this worktree attestation and leaves every other reconciliation action unchanged, including\n" +
+			"ordinary Herdr cleanup, which still requires proven ownership.",
 		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -13,10 +13,16 @@ import (
 
 func newReconcileCmd() *cobra.Command {
 	var asJSON bool
+	var abandonWorktree bool
 	cmd := &cobra.Command{
 		Use:   "reconcile [id]",
 		Short: "Converge durable task state with observed external reality",
-		Args:  usageArgs(cobra.MaximumNArgs(1)),
+		Long: "Converge durable task state with observed external reality.\n\n" +
+			"--abandon-worktree attests that Hand relinquishes a recorded Treehouse lease whose pool cannot be\n" +
+			"observed at all, for instance after the pool key moved. It needs an explicit task ID, it refuses any\n" +
+			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
+			"the worktree is left exactly as it is for the operator to reclaim through treehouse itself.",
+		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()
 			if err != nil {
@@ -26,7 +32,12 @@ func newReconcileCmd() *cobra.Command {
 			if len(args) == 1 {
 				id = args[0]
 			}
-			report, reconcileErr := runtime.New().Reconcile(runtime.ReconcileRequest{Context: cmd.Context(), Home: fleetHome, ID: id})
+			if abandonWorktree && id == "" {
+				return asPrecondition(runtime.Precondition(errors.New("--abandon-worktree needs an explicit task ID")))
+			}
+			report, reconcileErr := runtime.New().Reconcile(runtime.ReconcileRequest{
+				Context: cmd.Context(), Home: fleetHome, ID: id, AbandonWorktree: abandonWorktree,
+			})
 			if err := renderReconcileReport(cmd, report, asJSON); err != nil {
 				return err
 			}
@@ -34,6 +45,7 @@ func newReconcileCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output JSON instead of TOON")
+	cmd.Flags().BoolVar(&abandonWorktree, "abandon-worktree", false, "attest that Hand relinquishes an unobservable Treehouse lease without touching the worktree")
 	return cmd
 }
 
@@ -56,6 +68,9 @@ func renderReconcileReport(cmd *cobra.Command, report runtime.ReconcileReport, a
 		if result.RepairCode != "" {
 			doc.Field("repair_code", result.RepairCode)
 			doc.Field("repair_reason", result.RepairReason)
+		}
+		if result.Detail != "" {
+			doc.Field("detail", result.Detail)
 		}
 		if result.Error != "" {
 			doc.Field("error", result.Error)

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -89,6 +89,46 @@ func TestReconcileCommandPreservesRepairAndObservationErrors(t *testing.T) {
 	}
 }
 
+// An attestation names one lease. Without a task ID it would relinquish whatever the fleet-wide
+// sweep happened to find unobservable, so the flag is refused before anything is read.
+func TestReconcileCommandRefusesFleetWideAbandonment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Lifecycle: state.TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newReconcileCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--abandon-worktree"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("reconcile error = %v, want precondition exit 3", err)
+	}
+	if !strings.Contains(err.Error(), "explicit task ID") {
+		t.Fatalf("reconcile error = %v, want the missing task ID named", err)
+	}
+}
+
+func TestReconcileCommandRendersAbandonmentDetail(t *testing.T) {
+	report := runtime.ReconcileReport{Results: []runtime.ReconcileResult{
+		{ID: "task-a", Outcome: "healthy", Action: "abandon-worktree", Detail: "attempt 7 relinquished worktree /pool/1 on operator attestation"},
+	}}
+	var out bytes.Buffer
+	cmd := newReconcileCmd()
+	cmd.SetOut(&out)
+	if err := renderReconcileReport(cmd, report, false); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("action: abandon-worktree")) || !bytes.Contains(out.Bytes(), []byte("detail: attempt 7 relinquished")) {
+		t.Fatalf("rendered report = %q, want the abandonment recorded in the output", out.String())
+	}
+}
+
 func TestReconcileCommandReportsUnknownRepairAsFailure(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HAND_HOME", home)

--- a/docs/adr/deterministic-reconciliation-observes-before-mutating.md
+++ b/docs/adr/deterministic-reconciliation-observes-before-mutating.md
@@ -48,3 +48,4 @@ Command rendering stays in Cobra, and status remains read-only.
 `hand reconcile [id]` is the explicit mutation boundary for recovery.
 The command can safely progress through several durable checkpoints in one invocation while the iteration guard prevents a logic loop.
 Operators must resolve ambiguous ownership and dirty work manually, and a worker that disappears while running is not silently replaced.
+`unobservable-ownership-is-not-a-mismatch.md` adds the one supported gesture for a treehouse pool that can no longer be observed at all.

--- a/docs/adr/deterministic-reconciliation-observes-before-mutating.md
+++ b/docs/adr/deterministic-reconciliation-observes-before-mutating.md
@@ -47,5 +47,6 @@ Command rendering stays in Cobra, and status remains read-only.
 
 `hand reconcile [id]` is the explicit mutation boundary for recovery.
 The command can safely progress through several durable checkpoints in one invocation while the iteration guard prevents a logic loop.
-Operators must resolve ambiguous ownership and dirty work manually, and a worker that disappears while running is not silently replaced.
+Ambiguous ownership is resolved only by a fresh exact observation or an operator action explicitly supported by the owning resource decision, and dirty work remains manual.
+A worker that disappears while running is not silently replaced.
 `unobservable-ownership-is-not-a-mismatch.md` adds the one supported gesture for a treehouse pool that can no longer be observed at all.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -34,8 +34,10 @@ Teardown that cannot observe the pool refuses and writes no resource state, so t
 `ambiguous` remains reachable from provable contradiction, and it stops being a dead end: both teardown and reconciliation may leave it, but only behind a fresh `LeaseExact` observation of the same lease identity.
 
 For the permanently unobservable pool there is one explicit operator gesture, `hand reconcile <task> --abandon-worktree`.
-It requires a task ID, applies through `reconcileHistoricalAttempt` only when a recorded teardown decision makes the attempt eligible, and refuses any observed state other than `LeaseUnknown`.
-That decision is what a teardown interrupted at the worktree step leaves behind, so eligibility is not limited by the attempt's active lifecycle; an attempt without a recorded teardown decision is never abandoned.
+It requires an explicit task ID and refuses any observed state other than `LeaseUnknown`, on every route into it.
+An attempt that is still active is reached only through a recorded teardown decision, the shape a teardown interrupted at the worktree step leaves behind.
+An attempt whose lifecycle is already terminal is eligible on its own once its worktree resource is unsettled, with no recorded teardown decision required, so a crash before teardown stays recoverable.
+No worktree of a live worker can be abandoned on either route, because a provisioning or running attempt is skipped and the active attempt is reachable only through that recorded decision.
 The abandonment itself runs no treehouse command and records only the worktree resource state.
 It records the terminal resource state `abandoned`, which means Hand has relinquished its claim on a lease it can no longer observe, and reconciliation then converges the task through its ordinary path.
 The probe that justified the attestation is reported in the reconcile result rather than stored in a new column.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -28,7 +28,8 @@ An absent executable, a non-zero exit, unparsable output, an empty pool and a po
 Unproven ownership never authorizes a destructive command, and `--force` is not a way around that.
 `--force` still only chooses how a return whose ownership is already proven deals with dirty work.
 
-Nothing durable is recorded from an unprovable observation.
+No durable teardown resource state is recorded from an unprovable observation.
+The Task-addressed repair marker is recorded on purpose, names the failed probe, and is cleared when a later observation proves ownership or the resource settles, so it reports an unresolved condition rather than concluding one.
 Teardown that cannot observe the pool refuses and writes no resource state, so the next teardown with an observable pool proceeds normally.
 `ambiguous` remains reachable from provable contradiction, and it stops being a dead end: both teardown and reconciliation may leave it, but only behind a fresh `LeaseExact` observation of the same lease identity.
 

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -1,0 +1,56 @@
+# Unobservable ownership is not a mismatch
+
+- Date: 2026-08-17
+- Status: accepted
+- Issues: atqamz/hand#245
+- PRs: none pending
+
+## Context
+
+`deterministic-reconciliation-observes-before-mutating.md` already states that observation failures never become contradiction evidence.
+The treehouse observation path did not implement it.
+`worktree.ObserveLease` returned one flat set of states in which "the pool answered and this lease belongs to somebody else" and "the pool could not be observed at all" were the same value, and `VerifyLease` collapsed every non-exact state into `treehouse lease for <path> does not match expected lease <id>`.
+Teardown then recorded `teardown_worktree_state = ambiguous` from that single unobservable answer, the store's predecessor table forbade every transition out of `ambiguous`, and reconciliation only moved a worktree resource forward from the empty state.
+So one unobservable observation permanently refused teardown before `--force` was consulted, and no supported command converged the task.
+
+The unobservability is not always transient.
+Treehouse derives its pool key as `<clone directory basename>-<hash of the origin URL>`, so renaming a GitHub repository moves the key and orphans the pool the live leases were acquired from.
+That pool stays unobservable for as long as the remote URL stays changed, which is why a design whose only recovery is "observe again later" recovers nothing.
+
+## Decision
+
+A treehouse lease observation separates answers about the recorded lease from the absence of an answer.
+`LeaseExact`, `LeaseAbsent`, `LeaseMismatch` and `LeaseUnprovable` are all answers: the pool was observed and it either confirmed the identity, reported the slot available, named another identity, or offered no identity comparable with the recorded one.
+`LeaseUnknown` is the absence of an answer, and it travels to every caller as its own state in `worktree.LeaseObservation` together with the `worktree.LeaseProbe` that failed: the command run, the working directory that selected the pool, and the reason.
+`ObserveLease` therefore returns no error at all.
+An absent executable, a non-zero exit, unparsable output, an empty pool and a pool that describes other worktrees are all `LeaseUnknown`, because none of them disproves the recorded ownership.
+
+Unproven ownership never authorizes a destructive command, and `--force` is not a way around that.
+`--force` still only chooses how a return whose ownership is already proven deals with dirty work.
+
+Nothing durable is recorded from an unprovable observation.
+Teardown that cannot observe the pool refuses and writes no resource state, so the next teardown with an observable pool proceeds normally.
+`ambiguous` remains reachable from provable contradiction, and it stops being a dead end: both teardown and reconciliation may leave it, but only behind a fresh `LeaseExact` observation of the same lease identity.
+
+For the permanently unobservable pool there is one explicit operator gesture, `hand reconcile <task> --abandon-worktree`.
+It requires a task ID, it applies only through `reconcileHistoricalAttempt` so a running attempt's worktree can never be abandoned, it refuses any observed state other than `LeaseUnknown`, and it runs no treehouse command.
+It records the terminal resource state `abandoned`, which means Hand has relinquished its claim on a lease it can no longer observe, and reconciliation then converges the task through its ordinary path.
+The probe that justified the attestation is reported in the reconcile result rather than stored in a new column.
+
+The decision table, the refusal messages, and the convergence traces belong to the tests under `internal/runtime` and `internal/worktree`.
+The real command's pool-resolution contract belongs to `internal/faketool/FIDELITY.md` and is rechecked by `tests/contract`.
+
+## Rejected alternatives
+
+- Returning the worktree anyway, or letting `--force` stand in for ownership proof, would let an unobservable pool authorize destroying somebody else's work.
+- Retry alone, whether as a `retryable` state or an operator instruction to observe later, does not recover an orphaned pool, because nothing about the pool will change while the remote URL stays changed.
+- A separate `hand repair` command would add a second convergence engine beside the reconciler that already owns observe, decide, apply one action, and re-observe.
+- Recording operator evidence in a new schema column would add durable state that only the run that produced it can interpret, when the resource state plus the reported probe already say what was relinquished and why.
+- Changing treehouse's key derivation, or restoring the previous origin URL, would fix one fleet's accident outside Hand and leave Hand still unable to describe an unobservable pool.
+
+## Consequences
+
+A byte-identical lease identity is never accused of mismatching, and a diagnostic distinguishes "ownership could not be proven" from "ownership was disproven" in the structured result, not only in the rendered message.
+An operator who has independently established that a pool is gone has one supported, task-scoped gesture, and it is auditable in the reconcile output.
+Teardown of a lease whose pool is temporarily unobservable stays retryable forever without operator involvement, because it records nothing.
+Attempt lifecycle convergence after terminal worker completion stays with atqamz/hand#239; this record changes only how a worktree resource is observed and settled.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -20,7 +20,7 @@ That pool stays unobservable for as long as the remote URL stays changed, which 
 ## Decision
 
 A treehouse lease observation separates answers about the recorded lease from the absence of an answer.
-`LeaseExact`, `LeaseAbsent`, `LeaseMismatch` and `LeaseUnprovable` are all answers: the pool was observed and it either confirmed the identity, reported the slot available, named another identity, or offered no identity comparable with the recorded one.
+`LeaseExact`, `LeaseAbsent`, `LeaseMismatch` and `LeaseUnprovable` are all determinate answers: the worktree was confirmed owned by the expected lease, locally absent or absent from the observed pool, held by another identity, or offered no identity comparable with the recorded one.
 `LeaseUnknown` is the absence of an answer, and it travels to every caller as its own state in `worktree.LeaseObservation` together with the `worktree.LeaseProbe` that failed: the command run, the working directory that selected the pool, and the reason.
 `ObserveLease` therefore returns no error at all.
 An absent executable, a non-zero exit, unparsable output, an empty pool and a pool that describes other worktrees are all `LeaseUnknown`, because none of them disproves the recorded ownership.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -33,7 +33,8 @@ Teardown that cannot observe the pool refuses and writes no resource state, so t
 `ambiguous` remains reachable from provable contradiction, and it stops being a dead end: both teardown and reconciliation may leave it, but only behind a fresh `LeaseExact` observation of the same lease identity.
 
 For the permanently unobservable pool there is one explicit operator gesture, `hand reconcile <task> --abandon-worktree`.
-It requires a task ID, it applies only through `reconcileHistoricalAttempt` so a running attempt's worktree can never be abandoned, it refuses any observed state other than `LeaseUnknown`, and it runs no treehouse command.
+It requires a task ID, it applies only through `reconcileHistoricalAttempt` so a running attempt's worktree can never be abandoned, and it refuses any observed state other than `LeaseUnknown`.
+The abandonment itself runs no treehouse command and records only the worktree resource state.
 It records the terminal resource state `abandoned`, which means Hand has relinquished its claim on a lease it can no longer observe, and reconciliation then converges the task through its ordinary path.
 The probe that justified the attestation is reported in the reconcile result rather than stored in a new column.
 
@@ -52,5 +53,6 @@ The real command's pool-resolution contract belongs to `internal/faketool/FIDELI
 
 A byte-identical lease identity is never accused of mismatching, and a diagnostic distinguishes "ownership could not be proven" from "ownership was disproven" in the structured result, not only in the rendered message.
 An operator who has independently established that a pool is gone has one supported, task-scoped gesture, and it is auditable in the reconcile output.
+`--abandon-worktree` adds the worktree attestation without narrowing reconciliation to a single action.
 Teardown of a lease whose pool is temporarily unobservable stays retryable forever without operator involvement, because it records nothing.
 Attempt lifecycle convergence after terminal worker completion stays with atqamz/hand#239; this record changes only how a worktree resource is observed and settled.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-17
 - Status: accepted
 - Issues: atqamz/hand#245
-- PRs: none pending
+- PRs: atqamz/hand#248
 
 ## Context
 

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -34,7 +34,8 @@ Teardown that cannot observe the pool refuses and writes no resource state, so t
 `ambiguous` remains reachable from provable contradiction, and it stops being a dead end: both teardown and reconciliation may leave it, but only behind a fresh `LeaseExact` observation of the same lease identity.
 
 For the permanently unobservable pool there is one explicit operator gesture, `hand reconcile <task> --abandon-worktree`.
-It requires a task ID, it applies only through `reconcileHistoricalAttempt` so a running attempt's worktree can never be abandoned, and it refuses any observed state other than `LeaseUnknown`.
+It requires a task ID, applies through `reconcileHistoricalAttempt` only when a recorded teardown decision makes the attempt eligible, and refuses any observed state other than `LeaseUnknown`.
+That decision is what a teardown interrupted at the worktree step leaves behind, so eligibility is not limited by the attempt's active lifecycle; an attempt without a recorded teardown decision is never abandoned.
 The abandonment itself runs no treehouse command and records only the worktree resource state.
 It records the terminal resource state `abandoned`, which means Hand has relinquished its claim on a lease it can no longer observe, and reconciliation then converges the task through its ordinary path.
 The probe that justified the attestation is reported in the reconcile result rather than stored in a new column.

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -11,6 +11,7 @@ Versions probed: `treehouse v2.1.0`, `herdr 0.7.5`, `gh 2.97.0`.
 
 `tests/contract` re-runs these calls against the real tools under the `contract` build tag, skipping where a binary is absent, so a record that has gone stale against a newer tool is discoverable by running them.
 It covers no call that would change anything an operator owns: a scratch treehouse pool and a scratch herdr workspace are created and destroyed, and every `gh` call is read-only.
+The one `git remote set-url` it runs is on a throwaway clone inside the test's own temp directory, whose `origin` points at a bare repository created for that test.
 
 Decorative glyphs appear in several stderr lines below and are omitted from the transcripts.
 No matcher may depend on one.
@@ -58,6 +59,19 @@ The command requires a git repository as its working directory.
 
 State left behind: the command only observes the current pool state.
 The lease identity is durable for the current acquisition and changes when a returned slot is handed out again.
+
+A leased entry may also carry a `processes` array of the `pid` and `name` of what is running in the slot, which nothing in `hand` reads.
+
+The working directory does not merely have to be a repository, it selects which pool is reported.
+Treehouse derives the pool key from the repository the working directory belongs to, as `<clone directory basename>-<hash of the origin URL>`, hashing the remote URL and not the clone path.
+So the answer is scoped to one pool, and the pool the working directory resolves to now is the only one `status --json` describes.
+
+Changing a repository's `origin` URL therefore moves the pool key and orphans the pool the existing leases live in.
+Run from a worktree of the orphaned pool, `status --json` still exits 0, and it reports the entries of the **new** pool: an array that describes other worktrees entirely and names nothing at the working directory it was run from, while the orphaned pool's own `treehouse-state.json` still records that worktree's lease as held.
+An empty `[]` with exit 0 is the same class of answer, seen when the pool the key now names has no slots yet, and `TestTreehouseStatusFollowsTheOriginURLAndOrphansARenamedPool` reproduces exactly that against the real binary.
+`worktree.ObserveLease` classifies both as an unobservable pool and never as an absent or mismatched lease: nothing about the recorded ownership was observed, so nothing about it was disproven.
+An orphaned pool stays orphaned for as long as the remote URL stays changed, which is why recovery cannot be "observe again later".
+`Treehouse{Slots: []string{other}}` reproduces the reported-another-pool shape and `Treehouse{}` the empty one, since the fake encodes an empty pool as `[]` rather than `null`.
 
 ### `treehouse get` with every slot leased or dirty
 

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -54,6 +54,13 @@ func Bin(t *testing.T) string {
 	return dir
 }
 
+// Replaces PATH with an empty directory for the rest of the test, so no tool at all - fake or real
+// - can be found. It is how a suite exercises an external executable that is not installed.
+func NoTools(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
 type commandConfig struct {
 	Name       string
 	Args       bool

--- a/internal/runtime/promote.go
+++ b/internal/runtime/promote.go
@@ -197,7 +197,7 @@ func (r *Runtime) cleanupScout(homeDir, taskID string, scout state.Attempt) ([]s
 		warnings = append(warnings, "warning: return scout worktree failed: no owned worktree path")
 	} else {
 		switch scout.TeardownWorktreeState {
-		case state.TeardownResourceReleased:
+		case state.TeardownResourceReleased, state.TeardownResourceAbandoned:
 		case state.TeardownResourceReleasing, state.TeardownResourceAmbiguous:
 			warnings = append(warnings, fmt.Sprintf("warning: worktree ownership for attempt %d is ambiguous; refusing destructive retry", scout.ID))
 		default:

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -30,13 +30,12 @@ const (
 
 type worktreeDependencies struct {
 	get            func(string, string) (worktree.Lease, error)
-	observeLease   func(string, string) (worktree.LeaseObservation, error)
+	observeLease   func(string, string) worktree.LeaseObservation
 	observeClean   func(string) (worktree.Cleanliness, error)
 	headCommit     func(string) (string, error)
 	returnWorktree func(string, bool) error
 	returnWithID   func(string, string, bool) error
 	checkCollision func(string, worktree.Lease, string) (string, error)
-	verifyLease    func(string, string) error
 }
 
 type dependencies struct {
@@ -60,7 +59,7 @@ func defaultDependencies() dependencies {
 	return dependencies{
 		now:               func() time.Time { return time.Now().UTC() },
 		herdr:             newHerdrClient,
-		worktree:          worktreeDependencies{get: worktree.Get, observeLease: worktree.ObserveLease, observeClean: worktree.ObserveCleanliness, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision, verifyLease: worktree.VerifyLease},
+		worktree:          worktreeDependencies{get: worktree.Get, observeLease: worktree.ObserveLease, observeClean: worktree.ObserveCleanliness, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision},
 		projectBaseCommit: projectBaseCommit,
 		buildHarness:      harness.Build,
 		confirmLaunch:     confirmLaunch,
@@ -143,16 +142,10 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		return "", r.failProvision(req, lease, nil, false, err)
 	}
 	if req.resumeExisting {
-		observeLease := r.deps.worktree.observeLease
-		if observeLease == nil {
-			observeLease = worktree.ObserveLease
-		}
-		observation, err := observeLease(worktreePath, lease.ID)
-		if err != nil {
-			return "", r.failProvision(req, lease, nil, false, Precondition(fmt.Errorf("verify resumed worktree lease: %w; refusing to launch", err)))
-		}
+		observation := r.observeWorktreeLease(worktreePath, lease.ID)
 		if observation.State != worktree.LeaseExact {
-			return "", r.failProvision(req, lease, nil, false, Precondition(fmt.Errorf("resumed worktree lease is %s; refusing to launch", observation.State)))
+			unproven := &worktree.UnprovenLeaseError{WorktreePath: worktreePath, ExpectedLeaseID: lease.ID, Observation: observation}
+			return "", r.failProvision(req, lease, nil, false, Precondition(fmt.Errorf("resumed worktree lease is %s: %w; refusing to launch", observation.State, unproven)))
 		}
 	}
 

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -74,11 +74,11 @@ func TestProvisionResumeRefusesChangedLeaseBeforeHerdrCreation(t *testing.T) {
 	attempt.LeaseID = "lease-old"
 	fake := &provisionHerdr{}
 	runtime := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
-	runtime.deps.worktree.observeLease = func(path, leaseID string) (worktree.LeaseObservation, error) {
+	runtime.deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
 		if path != attempt.Worktree || leaseID != attempt.LeaseID {
 			t.Fatalf("observeLease(%q, %q), want persisted lease", path, leaseID)
 		}
-		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-new"}, nil
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-new"}
 	}
 
 	_, err := runtime.provision(context.Background(), provisioningRequest{
@@ -285,8 +285,8 @@ func testProvisionRuntime(client herdrClient, phase func(lifecyclePhase) error) 
 			get: func(path, holder string) (worktree.Lease, error) {
 				return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
 			},
-			observeLease: func(string, string) (worktree.LeaseObservation, error) {
-				return worktree.LeaseObservation{State: worktree.LeaseExact}, nil
+			observeLease: func(string, string) worktree.LeaseObservation {
+				return worktree.LeaseObservation{State: worktree.LeaseExact}
 			},
 			returnWorktree: func(string, bool) error { return nil },
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1148,10 +1148,10 @@ func leaseOrNone(leaseID string) string {
 func unobservableWorktreeReason(attempt state.Attempt, probe worktree.LeaseProbe) string {
 	lease := leaseOrNone(attempt.LeaseID)
 	if probe.Command == "" {
-		return fmt.Sprintf("recorded worktree %s could not be observed, so recorded lease %s is neither proven nor disproven", attempt.Worktree, lease)
+		return fmt.Sprintf("recorded worktree %s could not be observed, so recorded lease %s is neither proven nor disproven; destructive cleanup refused because ownership could not be proven, not because a lease mismatched", attempt.Worktree, lease)
 	}
 	return fmt.Sprintf(
-		"recorded worktree ownership could not be observed: %s; observed by running %q with working directory %s, which is what selects the pool; recorded lease %s is neither proven nor disproven",
+		"recorded worktree ownership could not be observed: %s; observed by running %q with working directory %s, which is what selects the pool; recorded lease %s is neither proven nor disproven; destructive cleanup refused because ownership could not be proven, not because a lease mismatched",
 		probe.Reason, probe.Command, probe.WorkingDir, lease)
 }
 

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -26,6 +26,7 @@ const (
 	reconciliationActionConfirmLaunch        reconciliationAction = "confirm-launch"
 	reconciliationActionMarkRunning          reconciliationAction = "mark-running"
 	reconciliationActionCleanupTerminal      reconciliationAction = "cleanup-terminal-resources"
+	reconciliationActionAbandonWorktree      reconciliationAction = "abandon-worktree"
 	reconciliationActionNeedsRepair          reconciliationAction = "needs-repair"
 	reconciliationActionBlocked              reconciliationAction = "blocked"
 )
@@ -38,6 +39,7 @@ const (
 	treehouseLeaseAbsent     treehouseLeaseState = "absent"
 	treehouseLeaseMismatch   treehouseLeaseState = "mismatch"
 	treehouseLeaseUnprovable treehouseLeaseState = "unprovable"
+	treehouseLeaseUnknown    treehouseLeaseState = "unknown"
 )
 
 type worktreeState string
@@ -71,6 +73,7 @@ const (
 	repairCodeWorktreeDirty               = "worktree-dirty"
 	repairCodeWorktreeOwnershipMismatch   = "worktree-ownership-mismatch"
 	repairCodeLegacyWorktreeUnprovable    = "legacy-worktree-ownership-unprovable"
+	repairCodeWorktreeUnobservable        = "worktree-ownership-unobservable"
 	repairCodeTeardownResourceAmbiguous   = "teardown-resource-ambiguous"
 	repairCodeCompletionEvidenceMismatch  = "completion-evidence-mismatch"
 	repairCodeMergeFactMismatch           = "merge-fact-mismatch"
@@ -78,6 +81,7 @@ const (
 
 type treehouseObservation struct {
 	State treehouseLeaseState
+	Probe worktree.LeaseProbe
 }
 
 type worktreeObservation struct {
@@ -107,12 +111,16 @@ type reconciliationDecision struct {
 	PlannedAgainst string
 	Profile        string
 	RoutingSource  string
+	Detail         string
 }
 
+// AbandonWorktree carries an operator attestation and demands an explicit ID, so it can never
+// relinquish more than the one recorded lease the operator named.
 type ReconcileRequest struct {
-	Context context.Context
-	Home    string
-	ID      string
+	Context         context.Context
+	Home            string
+	ID              string
+	AbandonWorktree bool
 }
 
 type ReconcileResult struct {
@@ -130,6 +138,7 @@ type ReconcileResult struct {
 	Profile        string `json:"profile,omitempty"`
 	PlannedAgainst string `json:"planned_against,omitempty"`
 	RoutingSource  string `json:"routing_source,omitempty"`
+	Detail         string `json:"detail,omitempty"`
 	Error          string `json:"error,omitempty"`
 }
 
@@ -165,11 +174,14 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 		ctx = context.Background()
 	}
 	if req.ID != "" {
-		result, err := r.reconcileTask(ctx, req.Home, req.ID)
+		result, err := r.reconcileTask(ctx, req.Home, req.ID, req.AbandonWorktree)
 		if err != nil {
 			result.Error = err.Error()
 		}
 		return ReconcileReport{Results: []ReconcileResult{result}}, err
+	}
+	if req.AbandonWorktree {
+		return ReconcileReport{}, Precondition(fmt.Errorf("abandoning a worktree lease needs an explicit task ID"))
 	}
 	histories, err := state.ListReconciliationHistories(req.Home)
 	if err != nil {
@@ -178,7 +190,7 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	report := ReconcileReport{Results: make([]ReconcileResult, 0, len(histories))}
 	var errs []error
 	for _, history := range histories {
-		result, err := r.reconcileTask(ctx, req.Home, history.Task.ID)
+		result, err := r.reconcileTask(ctx, req.Home, history.Task.ID, false)
 		if err != nil {
 			result.Error = err.Error()
 		}
@@ -197,7 +209,7 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	return report, errors.Join(errs...)
 }
 
-func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (ReconcileResult, error) {
+func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWorktree bool) (ReconcileResult, error) {
 	release, err := state.Lock(home, "task:"+id)
 	if err != nil {
 		return ReconcileResult{ID: id, Outcome: reconcileOutcomeBlocked}, fmt.Errorf("lock task %q: %w", id, err)
@@ -249,7 +261,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 		}
 		if historical != nil {
 			result.AttemptID = historical.ID
-			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, *historical)
+			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, *historical, abandonWorktree)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
 				return result, err
@@ -262,8 +274,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 				return result, nil
 			}
 			if progress {
-				result.Action = string(reconciliationActionCleanupTerminal)
-				result.Outcome = reconcileOutcomeRecovered
+				recordHistoricalProgress(&result, decision)
 				continue
 			}
 		}
@@ -286,7 +297,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 		result.ExecutionClass, result.Profile = attempt.ExecutionClass, attempt.RequestedProfile
 		result.PlannedAgainst, result.RoutingSource = attempt.PlannedAgainst, attempt.RoutingSource
 		if attempt.TeardownTerminalAttempt != "" {
-			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, attempt)
+			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, attempt, abandonWorktree)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
 				return result, err
@@ -299,8 +310,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 				return result, nil
 			}
 			if progress {
-				result.Action = string(reconciliationActionCleanupTerminal)
-				result.Outcome = reconcileOutcomeRecovered
+				recordHistoricalProgress(&result, decision)
 				continue
 			}
 		}
@@ -354,6 +364,17 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string) (Reconcile
 	return result, nil
 }
 
+func recordHistoricalProgress(result *ReconcileResult, decision reconciliationDecision) {
+	result.Action = string(reconciliationActionCleanupTerminal)
+	if decision.Action != "" {
+		result.Action = string(decision.Action)
+	}
+	if decision.Detail != "" {
+		result.Detail = decision.Detail
+	}
+	result.Outcome = reconcileOutcomeRecovered
+}
+
 func reportExistingRepair(result *ReconcileResult, task state.Task) bool {
 	if task.RepairCode == "" {
 		return false
@@ -404,16 +425,10 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 		return false, false, "local-git", fmt.Errorf("lock worktree %q for local merge observation: %w", attempt.Worktree, err)
 	}
 	defer releaseWorktree()
-	observeLease := r.deps.worktree.observeLease
-	if observeLease == nil {
-		observeLease = worktree.ObserveLease
-	}
-	lease, err := observeLease(attempt.Worktree, attempt.LeaseID)
-	if err != nil {
-		return false, false, "local-git", fmt.Errorf("observe local merge lease for task %q Attempt %d: %w", task.ID, attempt.ID, err)
-	}
+	lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
 	if lease.State != worktree.LeaseExact {
-		return false, false, "local-git", fmt.Errorf("observe local merge for task %q Attempt %d: exact Treehouse lease ownership was not proven", task.ID, attempt.ID)
+		unproven := &worktree.UnprovenLeaseError{WorktreePath: attempt.Worktree, ExpectedLeaseID: attempt.LeaseID, Observation: lease}
+		return false, false, "local-git", fmt.Errorf("observe local merge for task %q Attempt %d: %w", task.ID, attempt.ID, unproven)
 	}
 	branchMerged := r.deps.branchMerged
 	if branchMerged == nil {
@@ -434,7 +449,7 @@ func mergeWorktreeAttempt(history state.TaskHistory) (*state.Attempt, error) {
 	} else {
 		for i := len(history.Attempts) - 1; i >= 0; i-- {
 			candidate := &history.Attempts[i]
-			if candidate.Worktree != "" && candidate.TeardownWorktreeState != state.TeardownResourceReleased {
+			if candidate.Worktree != "" && !worktreeCleanupSettled(candidate.TeardownWorktreeState) {
 				attempt = candidate
 				break
 			}
@@ -650,7 +665,7 @@ func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) 
 		if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
 			return attempt, nil
 		}
-		if attempt.Worktree != "" && attempt.TeardownWorktreeState != state.TeardownResourceReleased {
+		if attempt.Worktree != "" && !worktreeCleanupSettled(attempt.TeardownWorktreeState) {
 			return attempt, nil
 		}
 		if attempt.TeardownCompletionState != "" {
@@ -660,7 +675,7 @@ func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) 
 	return nil, nil
 }
 
-func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attempt state.Attempt) (bool, reconciliationDecision, error) {
+func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attempt state.Attempt, abandonWorktree bool) (bool, reconciliationDecision, error) {
 	if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
 		observation, err := observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
@@ -701,16 +716,14 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 		}
 	}
 
-	if attempt.Worktree != "" && attempt.TeardownWorktreeState != state.TeardownResourceReleased {
-		observeLease := r.deps.worktree.observeLease
-		if observeLease == nil {
-			observeLease = worktree.ObserveLease
-		}
-		lease, err := observeLease(attempt.Worktree, attempt.LeaseID)
-		if err != nil {
-			return false, reconciliationDecision{}, fmt.Errorf("observe historical Treehouse lease: %w", err)
-		}
+	if attempt.Worktree != "" && !worktreeCleanupSettled(attempt.TeardownWorktreeState) {
+		lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
 		switch lease.State {
+		case worktree.LeaseUnknown:
+			if abandonWorktree {
+				return r.abandonHistoricalWorktree(home, task, attempt, lease)
+			}
+			return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeUnobservable, unobservableWorktreeReason(attempt, lease.Probe)), nil
 		case worktree.LeaseUnprovable:
 			return false, repairDecision(reconciliationDecision{}, repairCodeLegacyWorktreeUnprovable, "historical worktree has no exact lease identity"), nil
 		case worktree.LeaseMismatch:
@@ -720,9 +733,9 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 				}
 				return true, reconciliationDecision{}, nil
 			}
-			return false, repairDecision(reconciliationDecision{}, "worktree-ownership-mismatch", "historical worktree path is held by a different Treehouse lease"), nil
+			return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeOwnershipMismatch, "historical worktree path is held by a different Treehouse lease"), nil
 		case worktree.LeaseAbsent:
-			if cleared, err := clearHistoricalRepair(home, task, attempt, "worktree-ownership-mismatch"); err != nil {
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable); err != nil {
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
@@ -743,12 +756,14 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 			if clean != worktree.Clean {
 				return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeDirty, "historical worktree is dirty; automatic reconciliation will not discard it"), nil
 			}
-			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeDirty, "worktree-ownership-mismatch"); err != nil {
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeLegacyWorktreeUnprovable); err != nil {
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
 			}
-			if attempt.TeardownWorktreeState == "" {
+			// Proven ownership is what clears the ambiguous latch: the same observation that would
+			// have refused the release is the one allowed to resume it.
+			if attempt.TeardownWorktreeState == "" || attempt.TeardownWorktreeState == state.TeardownResourceAmbiguous {
 				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleasing); err != nil {
 					return false, reconciliationDecision{}, err
 				}
@@ -823,6 +838,19 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 	return false, reconciliationDecision{}, nil
 }
 
+// Records an operator's attestation that Hand relinquishes a lease no observation can reach. It
+// runs no destructive command and refuses any state an observation could still prove or disprove.
+func (r *Runtime) abandonHistoricalWorktree(home string, task state.Task, attempt state.Attempt, lease worktree.LeaseObservation) (bool, reconciliationDecision, error) {
+	if lease.State != worktree.LeaseUnknown {
+		return false, reconciliationDecision{}, Precondition(fmt.Errorf("refusing to abandon worktree %s of attempt %d: ownership observed as %s, which is provable evidence; abandonment is only for an unobservable pool", attempt.Worktree, attempt.ID, lease.State))
+	}
+	if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAbandoned); err != nil {
+		return false, reconciliationDecision{}, fmt.Errorf("record abandoned worktree ownership: %w", err)
+	}
+	detail := fmt.Sprintf("attempt %d relinquished worktree %s with recorded lease %s on operator attestation; %s", attempt.ID, attempt.Worktree, leaseOrNone(attempt.LeaseID), unobservableWorktreeReason(attempt, lease.Probe))
+	return true, reconciliationDecision{Action: reconciliationActionAbandonWorktree, Detail: detail}, nil
+}
+
 func clearHistoricalRepair(home string, task state.Task, attempt state.Attempt, codes ...string) (bool, error) {
 	if task.RepairCode == "" || (task.RepairAttemptID != 0 && task.RepairAttemptID != attempt.ID) {
 		return false, nil
@@ -875,7 +903,8 @@ func terminalRepairCanBeResolved(code string) bool {
 	case repairCodeProvisioningLaunchAmbiguous, repairCodeProvisioningPaneMissing, repairCodeLaunchSubmittedPaneMissing,
 		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
 		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeWorktreeDirty,
-		repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeTeardownResourceAmbiguous:
+		repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeUnobservable,
+		repairCodeTeardownResourceAmbiguous:
 		return true
 	default:
 		return false
@@ -888,8 +917,8 @@ func terminalRepairEvidenceResolved(code string, attempt state.Attempt) bool {
 		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
 		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeTeardownResourceAmbiguous:
 		return !hasHerdrIdentity(attempt.Herdr) || attempt.TeardownHerdrState == state.TeardownResourceReleased
-	case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable:
-		return attempt.Worktree == "" || attempt.TeardownWorktreeState == state.TeardownResourceReleased
+	case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeUnobservable:
+		return attempt.Worktree == "" || worktreeCleanupSettled(attempt.TeardownWorktreeState)
 	default:
 		return false
 	}
@@ -899,15 +928,9 @@ func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attemp
 	observation := reconciliationObservation{}
 	skipHerdrObservation := attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.WorkspaceID != "" && attempt.Herdr.TabID != "" && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == ""
 	if attempt.Worktree != "" {
-		observeLease := r.deps.worktree.observeLease
-		if observeLease == nil {
-			observeLease = worktree.ObserveLease
-		}
-		lease, err := observeLease(attempt.Worktree, attempt.LeaseID)
-		if err != nil {
-			return observation, fmt.Errorf("observe Treehouse lease: %w", err)
-		}
+		lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
 		observation.Treehouse.State = treehouseLeaseState(lease.State)
+		observation.Treehouse.Probe = lease.Probe
 		if lease.State == worktree.LeaseExact {
 			observeClean := r.deps.worktree.observeClean
 			if observeClean == nil {
@@ -991,11 +1014,14 @@ func shouldClearRepair(task state.Task, attempt state.Attempt, observation recon
 	}
 	if observation.Treehouse.State == treehouseLeaseExact {
 		switch task.RepairCode {
-		case repairCodeWorktreeOwnershipMismatch:
+		case repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeLegacyWorktreeUnprovable:
 			return attempt.Lifecycle == state.AttemptRunning || observation.Worktree.State == worktreeClean
 		case repairCodeWorktreeDirty:
 			return observation.Worktree.State == worktreeClean
 		}
+	}
+	if task.RepairCode == repairCodeWorktreeUnobservable && worktreeCleanupSettled(attempt.TeardownWorktreeState) {
+		return true
 	}
 	return false
 }
@@ -1014,12 +1040,14 @@ func decideReconciliation(_ state.Task, attempt state.Attempt, observation recon
 		switch observation.Treehouse.State {
 		case treehouseLeaseMismatch:
 			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded worktree path is leased under a different Treehouse lease ID")
+		case treehouseLeaseUnknown:
+			return repairDecision(decision, repairCodeWorktreeUnobservable, unobservableWorktreeReason(attempt, observation.Treehouse.Probe))
 		case treehouseLeaseUnprovable:
 			return repairDecision(decision, repairCodeLegacyWorktreeUnprovable, "recorded worktree ownership has no provable Treehouse lease identity")
 		case treehouseLeaseAbsent:
 			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded Treehouse lease is absent")
 		case treehouseLeaseUnobserved:
-			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded Treehouse lease was not observed")
+			return repairDecision(decision, repairCodeWorktreeUnobservable, "recorded Treehouse lease was not observed")
 		}
 	}
 
@@ -1088,6 +1116,8 @@ func decideProvisioning(attempt state.Attempt, observation reconciliationObserva
 		switch observation.Treehouse.State {
 		case treehouseLeaseMismatch:
 			return repairDecision(decision, repairCodeWorktreeOwnershipMismatch, "recorded worktree path is leased under a different Treehouse lease ID")
+		case treehouseLeaseUnknown:
+			return repairDecision(decision, repairCodeWorktreeUnobservable, unobservableWorktreeReason(attempt, observation.Treehouse.Probe))
 		case treehouseLeaseUnprovable:
 			return repairDecision(decision, repairCodeLegacyWorktreeUnprovable, "recorded worktree ownership has no provable Treehouse lease identity")
 		case treehouseLeaseAbsent:
@@ -1106,6 +1136,23 @@ func decideProvisioning(attempt state.Attempt, observation reconciliationObserva
 
 	decision.Action = reconciliationActionContinueProvisioning
 	return decision
+}
+
+func leaseOrNone(leaseID string) string {
+	if leaseID == "" {
+		return "(none recorded)"
+	}
+	return leaseID
+}
+
+func unobservableWorktreeReason(attempt state.Attempt, probe worktree.LeaseProbe) string {
+	lease := leaseOrNone(attempt.LeaseID)
+	if probe.Command == "" {
+		return fmt.Sprintf("recorded worktree %s could not be observed, so recorded lease %s is neither proven nor disproven", attempt.Worktree, lease)
+	}
+	return fmt.Sprintf(
+		"recorded worktree ownership could not be observed: %s; observed by running %q with working directory %s, which is what selects the pool; recorded lease %s is neither proven nor disproven",
+		probe.Reason, probe.Command, probe.WorkingDir, lease)
 }
 
 func repairDecision(decision reconciliationDecision, code, reason string) reconciliationDecision {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -114,8 +114,6 @@ type reconciliationDecision struct {
 	Detail         string
 }
 
-// AbandonWorktree carries an operator attestation and demands an explicit ID, so it can never
-// relinquish more than the one recorded lease the operator named.
 type ReconcileRequest struct {
 	Context         context.Context
 	Home            string
@@ -761,8 +759,6 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
 			}
-			// Proven ownership is what clears the ambiguous latch: the same observation that would
-			// have refused the release is the one allowed to resume it.
 			if attempt.TeardownWorktreeState == "" || attempt.TeardownWorktreeState == state.TeardownResourceAmbiguous {
 				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleasing); err != nil {
 					return false, reconciliationDecision{}, err
@@ -838,8 +834,6 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 	return false, reconciliationDecision{}, nil
 }
 
-// Records an operator's attestation that Hand relinquishes a lease no observation can reach. It
-// runs no destructive command and refuses any state an observation could still prove or disprove.
 func (r *Runtime) abandonHistoricalWorktree(home string, task state.Task, attempt state.Attempt, lease worktree.LeaseObservation) (bool, reconciliationDecision, error) {
 	if lease.State != worktree.LeaseUnknown {
 		return false, reconciliationDecision{}, Precondition(fmt.Errorf("refusing to abandon worktree %s of attempt %d: ownership observed as %s, which is provable evidence; abandonment is only for an unobservable pool", attempt.Worktree, attempt.ID, lease.State))

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -931,6 +931,13 @@ func TestReconcileUnobservableWorktreeNeedsRepairInsteadOfMismatch(t *testing.T)
 // that Hand relinquishes the recorded lease, and the task finishes its teardown from there.
 func TestReconcileAbandonWorktreeConvergesAnUnobservableLease(t *testing.T) {
 	home, attempt := unobservableTeardownFixture(t, state.TeardownResourceAmbiguous)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != attempt.ID || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.ActiveAttempt.TeardownTerminalAttempt != state.AttemptCompleted {
+		t.Fatalf("eligible attempt = %+v, want an active attempt with a recorded teardown decision", history.ActiveAttempt)
+	}
 	returns := 0
 	r := unobservableReconcileRuntime(t, &returns)
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
@@ -952,7 +959,7 @@ func TestReconcileAbandonWorktreeConvergesAnUnobservableLease(t *testing.T) {
 	if returns != 0 {
 		t.Fatalf("worktree return count = %d, want abandonment to run no destructive command", returns)
 	}
-	history, err := state.ReadHistory(home, "task-1")
+	history, err = state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1070,7 +1077,7 @@ func TestReconcileAbandonWorktreeNeverTouchesARunningAttempt(t *testing.T) {
 	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
 		t.Fatalf("attempt after abandonment attempt = %+v, want the running worker untouched", history.ActiveAttempt)
 	}
-	if history.ActiveAttempt.TeardownWorktreeState != "" || returns != 0 {
+	if history.ActiveAttempt.TeardownTerminalAttempt != "" || history.ActiveAttempt.TeardownWorktreeState != "" || returns != 0 {
 		t.Fatalf("worktree state = %q returns = %d, want no teardown of a running attempt", history.ActiveAttempt.TeardownWorktreeState, returns)
 	}
 	if history.Task.RepairCode != repairCodeWorktreeUnobservable {

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -907,7 +907,7 @@ func TestReconcileUnobservableWorktreeNeedsRepairInsteadOfMismatch(t *testing.T)
 		t.Fatalf("repair code = %q, want %q", report.Results[0].RepairCode, repairCodeWorktreeUnobservable)
 	}
 	reason := report.Results[0].RepairReason
-	for _, want := range []string{"could not be observed", "treehouse status --json", "/pool/1", "lease-1", "neither proven nor disproven"} {
+	for _, want := range []string{"could not be observed", "treehouse status --json", "/pool/1", "lease-1", "neither proven nor disproven", "destructive cleanup refused because ownership could not be proven, not because a lease mismatched"} {
 		if !strings.Contains(reason, want) {
 			t.Fatalf("repair reason = %q, want it to contain %q", reason, want)
 		}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -1085,6 +1085,49 @@ func TestReconcileAbandonWorktreeNeverTouchesARunningAttempt(t *testing.T) {
 	}
 }
 
+func TestReconcileAbandonWorktreeSettlesATerminalAttemptWithoutATeardownDecision(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt != nil || history.Attempts[0].Lifecycle != state.AttemptCompleted {
+		t.Fatalf("eligible attempt = %+v, want a terminal attempt that is no longer active", history.Attempts[0])
+	}
+	if history.Attempts[0].TeardownTerminalAttempt != "" || history.Attempts[0].TeardownWorktreeState != "" {
+		t.Fatalf("eligible attempt = %+v, want an unsettled worktree and no recorded teardown decision", history.Attempts[0])
+	}
+	returns := 0
+	r := unobservableReconcileRuntime(t, &returns)
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AbandonWorktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Results) != 1 || report.Results[0].RepairCode != "" {
+		t.Fatalf("report = %+v, want one result that needs no repair", report)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceAbandoned || returns != 0 {
+		t.Fatalf("worktree state = %q returns = %d, want abandonment without a destructive command", history.Attempts[0].TeardownWorktreeState, returns)
+	}
+}
+
 // A latch is a refusal to guess, not a verdict: the observation that would have refused the release
 // is the one that resumes it once the pool answers again.
 func TestReconcileConvergesALatchedWorktreeOnceOwnershipIsProven(t *testing.T) {

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -454,8 +455,8 @@ func TestReconcileRunningWorktreeLeaseMismatchWinsOverHealthyPane(t *testing.T) 
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.worktree.observeLease = func(string, string) (worktree.LeaseObservation, error) {
-		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}, nil
+	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}
 	}
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
@@ -835,8 +836,8 @@ func TestReconcileReusedTerminalLeaseDoesNotReturnNewOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.worktree.observeLease = func(string, string) (worktree.LeaseObservation, error) {
-		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}, nil
+	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}
 	}
 	returns := 0
 	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
@@ -849,6 +850,261 @@ func TestReconcileReusedTerminalLeaseDoesNotReturnNewOwner(t *testing.T) {
 	}
 	if history.Task.RepairCode != "worktree-ownership-mismatch" || returns != 0 {
 		t.Fatalf("history=%+v returns=%d, want mismatch repair without touching new lease", history, returns)
+	}
+}
+
+// The shape atqamz/hand#245 reports: a teardown decision is recorded, the worktree is still owned,
+// and the pool the lease was acquired from can no longer be observed from that worktree.
+func unobservableTeardownFixture(t *testing.T, latch string) (string, state.Attempt) {
+	t.Helper()
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptCompleted, state.TeardownDispositionCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if latch != "" {
+		if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, state.AttemptRunning, "worktree", latch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home, attempt
+}
+
+func unobservableReconcileRuntime(t *testing.T, returns *int) *Runtime {
+	t.Helper()
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseUnknown, Probe: worktree.LeaseProbe{
+			Command: "treehouse status --json", WorkingDir: path, Reason: "treehouse reported no pool entries",
+		}}
+	}
+	r.deps.worktree.returnWithID = func(string, string, bool) error { *returns++; return nil }
+	r.deps.worktree.returnWorktree = func(string, bool) error { *returns++; return nil }
+	return r
+}
+
+func TestReconcileUnobservableWorktreeNeedsRepairInsteadOfMismatch(t *testing.T) {
+	home, _ := unobservableTeardownFixture(t, state.TeardownResourceAmbiguous)
+	returns := 0
+	r := unobservableReconcileRuntime(t, &returns)
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Results) != 1 || report.Results[0].Outcome != reconcileOutcomeRepair {
+		t.Fatalf("report = %+v, want one needs-repair result", report)
+	}
+	if report.Results[0].RepairCode != repairCodeWorktreeUnobservable {
+		t.Fatalf("repair code = %q, want %q", report.Results[0].RepairCode, repairCodeWorktreeUnobservable)
+	}
+	reason := report.Results[0].RepairReason
+	for _, want := range []string{"could not be observed", "treehouse status --json", "/pool/1", "lease-1", "neither proven nor disproven"} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("repair reason = %q, want it to contain %q", reason, want)
+		}
+	}
+	if strings.Contains(reason, "held by a different Treehouse lease") || strings.Contains(reason, "no exact lease identity") {
+		t.Fatalf("repair reason = %q, want no claim about a different or missing identity", reason)
+	}
+	if returns != 0 {
+		t.Fatalf("worktree return count = %d, want no destructive cleanup", returns)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.TeardownWorktreeState != state.TeardownResourceAmbiguous {
+		t.Fatalf("worktree state = %+v, want the latch unchanged by an observation that failed", history.ActiveAttempt)
+	}
+}
+
+// The supported convergence path for a pool that can never be observed again: an operator attests
+// that Hand relinquishes the recorded lease, and the task finishes its teardown from there.
+func TestReconcileAbandonWorktreeConvergesAnUnobservableLease(t *testing.T) {
+	home, attempt := unobservableTeardownFixture(t, state.TeardownResourceAmbiguous)
+	returns := 0
+	r := unobservableReconcileRuntime(t, &returns)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AbandonWorktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Results) != 1 || report.Results[0].Outcome != reconcileOutcomeHealthy {
+		t.Fatalf("report = %+v, want one converged result", report)
+	}
+	detail := report.Results[0].Detail
+	for _, want := range []string{"operator attestation", "/pool/1", "lease-1", "treehouse status --json"} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("detail = %q, want it to contain %q", detail, want)
+		}
+	}
+	if returns != 0 {
+		t.Fatalf("worktree return count = %d, want abandonment to run no destructive command", returns)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil {
+		t.Fatalf("task after abandonment = %+v, want a converged terminal task", history.Task)
+	}
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceAbandoned {
+		t.Fatalf("worktree state = %q, want abandoned", history.Attempts[0].TeardownWorktreeState)
+	}
+	if history.Task.RepairCode != "" {
+		t.Fatalf("repair code = %q, want the unobservable repair cleared", history.Task.RepairCode)
+	}
+	if _, found, err := completion.FindAttempt(home, attempt.ID); err != nil || !found {
+		t.Fatalf("completion for attempt %d found=%t err=%v, want the teardown finished", attempt.ID, found, err)
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("reconcile after convergence = %v, want a healthy no-op", err)
+	}
+}
+
+// Abandonment is only for what cannot be observed. A lease held by another owner and a lease proven
+// to be ours both keep their ordinary handling even when the operator passes the attestation.
+func TestReconcileAbandonWorktreeRefusesProvableOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		observation worktree.LeaseObservation
+		wantState   string
+		wantReturns int
+		wantRepair  string
+	}{
+		{
+			name:        "another owner",
+			observation: worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-2"},
+			wantState:   state.TeardownResourceAmbiguous,
+			wantRepair:  repairCodeWorktreeOwnershipMismatch,
+		},
+		{
+			name:        "proven ours",
+			observation: worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"},
+			wantState:   state.TeardownResourceReleased,
+			wantReturns: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home, _ := unobservableTeardownFixture(t, state.TeardownResourceAmbiguous)
+			returns := 0
+			r := unobservableReconcileRuntime(t, &returns)
+			r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return test.observation }
+			if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AbandonWorktree: true}); err != nil {
+				t.Fatal(err)
+			}
+			history, err := state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Attempts[0].TeardownWorktreeState != test.wantState {
+				t.Fatalf("worktree state = %q, want %q", history.Attempts[0].TeardownWorktreeState, test.wantState)
+			}
+			if returns != test.wantReturns {
+				t.Fatalf("worktree return count = %d, want %d", returns, test.wantReturns)
+			}
+			if history.Task.RepairCode != test.wantRepair {
+				t.Fatalf("repair code = %q, want %q", history.Task.RepairCode, test.wantRepair)
+			}
+		})
+	}
+}
+
+func TestAbandonHistoricalWorktreeRefusesAnyObservedOwnership(t *testing.T) {
+	home, attempt := unobservableTeardownFixture(t, "")
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	task := state.Task{ID: "task-1"}
+	for _, observed := range []worktree.LeaseObservationState{worktree.LeaseExact, worktree.LeaseMismatch, worktree.LeaseAbsent, worktree.LeaseUnprovable} {
+		_, _, err := r.abandonHistoricalWorktree(home, task, attempt, worktree.LeaseObservation{State: observed})
+		if err == nil {
+			t.Fatalf("abandonHistoricalWorktree() accepted a %s observation", observed)
+		}
+		var classified *Error
+		if !errors.As(err, &classified) || classified.Kind != ErrorPrecondition {
+			t.Fatalf("abandonHistoricalWorktree() = %v, want a precondition refusal", err)
+		}
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.TeardownWorktreeState != "" {
+		t.Fatalf("worktree state = %+v, want nothing recorded by a refused abandonment", history.ActiveAttempt)
+	}
+}
+
+// Abandonment relinquishes a lease nothing is still using; a worker's live worktree is never that,
+// so the attestation cannot reach an attempt that has not decided its teardown.
+func TestReconcileAbandonWorktreeNeverTouchesARunningAttempt(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	returns := 0
+	r := unobservableReconcileRuntime(t, &returns)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AbandonWorktree: true}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("attempt after abandonment attempt = %+v, want the running worker untouched", history.ActiveAttempt)
+	}
+	if history.ActiveAttempt.TeardownWorktreeState != "" || returns != 0 {
+		t.Fatalf("worktree state = %q returns = %d, want no teardown of a running attempt", history.ActiveAttempt.TeardownWorktreeState, returns)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeUnobservable {
+		t.Fatalf("repair code = %q, want %q", history.Task.RepairCode, repairCodeWorktreeUnobservable)
+	}
+}
+
+// A latch is a refusal to guess, not a verdict: the observation that would have refused the release
+// is the one that resumes it once the pool answers again.
+func TestReconcileConvergesALatchedWorktreeOnceOwnershipIsProven(t *testing.T) {
+	home, _ := unobservableTeardownFixture(t, state.TeardownResourceAmbiguous)
+	returns := 0
+	r := unobservableReconcileRuntime(t, &returns)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil {
+		t.Fatalf("task after proven ownership = %+v, want a converged terminal task", history.Task)
+	}
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || returns != 1 {
+		t.Fatalf("worktree state = %q returns = %d, want one proven return", history.Attempts[0].TeardownWorktreeState, returns)
+	}
+	if history.Task.RepairCode != "" {
+		t.Fatalf("repair code = %q, want the unobservable repair cleared", history.Task.RepairCode)
 	}
 }
 
@@ -1132,12 +1388,12 @@ func TestReconcileLocalMergeDoesNotInspectReusedTreehousePath(t *testing.T) {
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
 	observed := 0
-	r.deps.worktree.observeLease = func(path, leaseID string) (worktree.LeaseObservation, error) {
+	r.deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
 		observed++
 		if path != "/pool/shared" || leaseID != "lease-a" {
 			t.Fatalf("observeLease(%q, %q), want Task 1 lease", path, leaseID)
 		}
-		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-b"}, nil
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-b"}
 	}
 	branchChecks := 0
 	r.deps.branchMerged = func(string, string) (bool, error) {
@@ -1371,8 +1627,8 @@ func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lea
 		herdr: func() herdrClient { return client },
 		worktree: worktreeDependencies{
 			get: get,
-			observeLease: func(string, string) (worktree.LeaseObservation, error) {
-				return worktree.LeaseObservation{State: worktree.LeaseExact}, nil
+			observeLease: func(string, string) worktree.LeaseObservation {
+				return worktree.LeaseObservation{State: worktree.LeaseExact}
 			},
 			observeClean: func(path string) (worktree.Cleanliness, error) {
 				return worktree.Clean, nil

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -108,8 +108,6 @@ func (r *Runtime) observeWorktreeLease(worktreePath, leaseID string) worktree.Le
 	return observe(worktreePath, leaseID)
 }
 
-// Reports whether nothing further is owed on the worktree: either it was returned with proven
-// ownership, or an operator attested that Hand relinquishes the recorded lease.
 func worktreeCleanupSettled(teardownWorktreeState string) bool {
 	return teardownWorktreeState == state.TeardownResourceReleased || teardownWorktreeState == state.TeardownResourceAbandoned
 }

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
 )
 
 type herdrClient interface {
@@ -97,6 +98,20 @@ func closeTaskTab(client herdrClient, workspaceID, tabID string) error {
 		return client.WorkspaceClose(workspaceID)
 	}
 	return client.TabClose(tabID)
+}
+
+func (r *Runtime) observeWorktreeLease(worktreePath, leaseID string) worktree.LeaseObservation {
+	observe := r.deps.worktree.observeLease
+	if observe == nil {
+		observe = worktree.ObserveLease
+	}
+	return observe(worktreePath, leaseID)
+}
+
+// Reports whether nothing further is owed on the worktree: either it was returned with proven
+// ownership, or an operator attested that Hand relinquishes the recorded lease.
+func worktreeCleanupSettled(teardownWorktreeState string) bool {
+	return teardownWorktreeState == state.TeardownResourceReleased || teardownWorktreeState == state.TeardownResourceAbandoned
 }
 
 func incompleteHerdrOwnership(ownership state.Herdr) error {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -206,35 +206,41 @@ func (r *Runtime) releaseWorktree(home, taskID string, attempt state.Attempt, fo
 	if attempt.Worktree == "" {
 		return nil
 	}
-	verifyLease := r.deps.worktree.verifyLease
-	if verifyLease == nil {
-		verifyLease = worktree.VerifyLease
-	}
-	verifyOwnership := func(action string) error {
-		if err := verifyLease(attempt.Worktree, attempt.LeaseID); err != nil {
-			if stateErr := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAmbiguous); stateErr != nil {
-				return fmt.Errorf("record unverified worktree ownership: %w", stateErr)
-			}
-			return fmt.Errorf("verify worktree ownership before %s: %w", action, err)
+	proveOwnership := func(action string) error {
+		observation := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
+		if observation.State == worktree.LeaseExact {
+			return nil
 		}
-		return nil
+		unproven := &worktree.UnprovenLeaseError{WorktreePath: attempt.Worktree, ExpectedLeaseID: attempt.LeaseID, Observation: observation}
+		// An observation that could not be made is not evidence about ownership, so it records
+		// nothing durable: latching on it is what made one unobservable pool permanent.
+		if observation.State != worktree.LeaseUnknown {
+			if stateErr := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAmbiguous); stateErr != nil {
+				return fmt.Errorf("record unproven worktree ownership: %w", stateErr)
+			}
+		}
+		return fmt.Errorf("prove worktree ownership before %s: %w", action, unproven)
 	}
 	switch attempt.TeardownWorktreeState {
-	case state.TeardownResourceReleased:
+	case state.TeardownResourceReleased, state.TeardownResourceAbandoned:
 		return nil
-	case state.TeardownResourceReleasing, state.TeardownResourceAmbiguous:
+	case state.TeardownResourceReleasing:
 		return fmt.Errorf("worktree ownership for attempt %d is ambiguous; refusing destructive retry", attempt.ID)
+	case state.TeardownResourceAmbiguous:
+		if err := proveOwnership("clearing ambiguous worktree ownership"); err != nil {
+			return err
+		}
 	case state.TeardownResourceRetryable:
 		if !force {
 			return fmt.Errorf("worktree for attempt %d remains leased; retry with --force", attempt.ID)
 		}
-		if err := verifyOwnership("forced retry"); err != nil {
+		if err := proveOwnership("forced retry"); err != nil {
 			return err
 		}
 	}
 	// Legacy attempts without a persisted lease ID retain pre-migration path-only behavior.
 	if attempt.TeardownWorktreeState == "" && attempt.LeaseID != "" {
-		if err := verifyOwnership("return"); err != nil {
+		if err := proveOwnership("return"); err != nil {
 			return err
 		}
 	}

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -397,24 +397,16 @@ func TestTeardownRetrySkipsReleasedWorktreeAfterLeaseReused(t *testing.T) {
 }
 
 func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
-	home, worktreePath := teardownFixture(t, true)
-	history, err := state.ReadHistory(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	history.ActiveAttempt.LeaseID = "lease-1"
-	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
+	home, worktreePath, _ := leasedTeardownFixture(t)
 	returns := 0
-	verified := 0
+	observed := 0
 	deps := defaultDependencies()
-	deps.worktree.verifyLease = func(path, leaseID string) error {
+	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "lease-1" {
-			t.Fatalf("verifyLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
+			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
-		verified++
-		return nil
+		observed++
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
 	deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
 		if path != worktreePath {
@@ -433,7 +425,7 @@ func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
 	if _, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); !errors.Is(err, worktree.ErrReturnAborted) {
 		t.Fatalf("first Teardown() = %v, want aborted-return error", err)
 	}
-	history, err = state.ReadHistory(home, "task-1")
+	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,8 +436,8 @@ func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if returns != 2 || verified != 2 || result.Detail != "report "+filepath.Join("data", "task-1", "report.md") {
-		t.Fatalf("retry returns=%d verified=%d result=%+v, want verified forced retry and unchanged detail", returns, verified, result)
+	if returns != 2 || observed != 2 || result.Detail != "report "+filepath.Join("data", "task-1", "report.md") {
+		t.Fatalf("retry returns=%d observed=%d result=%+v, want a proven forced retry and unchanged detail", returns, observed, result)
 	}
 	history, err = state.ReadHistory(home, "task-1")
 	if err != nil {
@@ -457,22 +449,14 @@ func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
 }
 
 func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
-	home, worktreePath := teardownFixture(t, true)
-	history, err := state.ReadHistory(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	history.ActiveAttempt.LeaseID = "lease-1"
-	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
+	home, worktreePath, attempt := leasedTeardownFixture(t)
 	called := false
 	deps := defaultDependencies()
-	deps.worktree.verifyLease = func(path, leaseID string) error {
+	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "lease-1" {
-			t.Fatalf("verifyLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
+			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
-		return nil
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
 	deps.worktree.returnWorktree = func(string, bool) error {
 		t.Fatal("teardown used path-only return for a known lease")
@@ -486,7 +470,7 @@ func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 		return nil
 	}
 
-	if err := (&Runtime{deps: deps}).releaseWorktree(home, "task-1", *history.ActiveAttempt, false); err != nil {
+	if err := (&Runtime{deps: deps}).releaseWorktree(home, "task-1", attempt, false); err != nil {
 		t.Fatal(err)
 	}
 	if !called {
@@ -495,41 +479,36 @@ func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 }
 
 func TestTeardownRefusesARecycledWorktreeLeaseOnFirstReturn(t *testing.T) {
-	home, worktreePath := teardownFixture(t, true)
-	history, err := state.ReadHistory(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	history.ActiveAttempt.LeaseID = "lease-1"
-	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
-	verified := 0
+	home, worktreePath, _ := leasedTeardownFixture(t)
+	observed := 0
 	returns := 0
 	deps := defaultDependencies()
-	deps.worktree.verifyLease = func(path, leaseID string) error {
+	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "lease-1" {
-			t.Fatalf("verifyLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
+			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
-		verified++
-		return errors.New("treehouse lease is lease-2")
+		observed++
+		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-2"}
 	}
 	deps.worktree.returnWorktree = func(string, bool) error {
 		returns++
 		return nil
 	}
 
-	_, err = (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
-	if err == nil || !strings.Contains(err.Error(), "verify worktree ownership") {
-		t.Fatalf("Teardown() = %v, want lease verification refusal", err)
+	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
+	if err == nil || !strings.Contains(err.Error(), "prove worktree ownership") {
+		t.Fatalf("Teardown() = %v, want an unproven-ownership refusal", err)
 	}
-	if verified != 1 {
-		t.Fatalf("lease verification count = %d, want one", verified)
+	if !strings.Contains(err.Error(), "belongs to another owner") {
+		t.Fatalf("Teardown() = %v, want the mismatch named as another owner's lease", err)
+	}
+	if observed != 1 {
+		t.Fatalf("lease observation count = %d, want one", observed)
 	}
 	if returns != 0 {
 		t.Fatalf("worktree return count = %d, want no destructive return", returns)
 	}
-	history, err = state.ReadHistory(home, "task-1")
+	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -546,17 +525,181 @@ func TestTeardownRefusesARecycledWorktreeLeaseOnFirstReturn(t *testing.T) {
 	}
 }
 
+func leasedTeardownFixture(t *testing.T) (string, string, state.Attempt) {
+	t.Helper()
+	home, worktreePath := teardownFixture(t, true)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	history.ActiveAttempt.LeaseID = "lease-1"
+	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
+		t.Fatal(err)
+	}
+	return home, worktreePath, *history.ActiveAttempt
+}
+
+func unobservablePool(worktreePath string) worktree.LeaseObservation {
+	return worktree.LeaseObservation{State: worktree.LeaseUnknown, Probe: worktree.LeaseProbe{
+		Command: "treehouse status --json", WorkingDir: worktreePath, Reason: "treehouse reported no pool entries",
+	}}
+}
+
+// The defect of atqamz/hand#245: one pool that could not be observed used to latch teardown
+// permanently. It must record nothing durable and leave a later observation free to prove ownership.
+func TestTeardownDoesNotLatchOnAnUnobservablePool(t *testing.T) {
+	home, worktreePath, _ := leasedTeardownFixture(t)
+	returns := 0
+	observation := unobservablePool(worktreePath)
+	deps := defaultDependencies()
+	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return observation }
+	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	runtime := &Runtime{deps: deps}
+
+	_, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
+	if err == nil {
+		t.Fatal("Teardown() released a worktree whose ownership could not be observed")
+	}
+	for _, want := range []string{"could not be observed", "treehouse status --json", worktreePath, "could not be proven, not because a lease mismatched"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Teardown() = %v, want the diagnostic to contain %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "does not match") || strings.Contains(err.Error(), "belongs to another owner") {
+		t.Fatalf("Teardown() = %v, want no mismatch claimed about a byte-identical lease", err)
+	}
+	if returns != 0 {
+		t.Fatalf("worktree return count = %d, want no destructive return", returns)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.TeardownWorktreeState != "" {
+		t.Fatalf("worktree state after an unobservable pool = %+v, want no durable conclusion", history.ActiveAttempt)
+	}
+
+	observation = worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	if _, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("retry after the pool became observable = %v, want release", err)
+	}
+	if returns != 1 {
+		t.Fatalf("worktree return count = %d, want exactly one proven return", returns)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased {
+		t.Fatalf("worktree state after a proven return = %q, want released", history.Attempts[0].TeardownWorktreeState)
+	}
+}
+
+// --force retries a return that aborted; it never substitutes for proof of ownership, and the
+// retryable knowledge the earlier abort produced survives the refusal.
+func TestTeardownForceCannotDestroyAnUnobservableWorktree(t *testing.T) {
+	home, worktreePath, _ := leasedTeardownFixture(t)
+	returns := 0
+	observation := worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	deps := defaultDependencies()
+	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return observation }
+	deps.worktree.returnWithID = func(_, _ string, force bool) error {
+		returns++
+		if !force {
+			return worktree.ErrReturnAborted
+		}
+		return nil
+	}
+	runtime := &Runtime{deps: deps}
+	if _, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); !errors.Is(err, worktree.ErrReturnAborted) {
+		t.Fatalf("first Teardown() = %v, want the known abort", err)
+	}
+
+	observation = unobservablePool(worktreePath)
+	_, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: true})
+	if err == nil || !strings.Contains(err.Error(), "could not be observed") {
+		t.Fatalf("forced retry = %v, want a refusal naming the unobservable pool", err)
+	}
+	if returns != 1 {
+		t.Fatalf("worktree return count = %d, want no forced destructive retry", returns)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.TeardownWorktreeState != state.TeardownResourceRetryable {
+		t.Fatalf("worktree state after a refused forced retry = %+v, want the retryable evidence kept", history.ActiveAttempt)
+	}
+}
+
+// The observation that would have refused the release is the one allowed to resume it, so a latch an
+// earlier failure left behind converges instead of standing forever.
+func TestTeardownConvergesALatchedWorktreeOnceOwnershipIsProven(t *testing.T) {
+	home, _, attempt := leasedTeardownFixture(t)
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAmbiguous); err != nil {
+		t.Fatal(err)
+	}
+	returns := 0
+	deps := defaultDependencies()
+	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	}
+	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+
+	if _, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("Teardown() on a latched attempt = %v, want release once ownership is proven", err)
+	}
+	if returns != 1 {
+		t.Fatalf("worktree return count = %d, want one proven return", returns)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased {
+		t.Fatalf("worktree state after clearing the latch = %q, want released", history.Attempts[0].TeardownWorktreeState)
+	}
+}
+
+// A latch is not a bypass: proof is still required to clear it, so an unobservable pool leaves the
+// latch exactly where it was rather than being released or reclassified.
+func TestTeardownKeepsALatchedWorktreeWhenOwnershipStaysUnobservable(t *testing.T) {
+	home, worktreePath, attempt := leasedTeardownFixture(t)
+	if err := state.SetAttemptTeardownResourceState(home, "task-1", attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAmbiguous); err != nil {
+		t.Fatal(err)
+	}
+	returns := 0
+	deps := defaultDependencies()
+	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return unobservablePool(worktreePath) }
+	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+
+	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: true})
+	if err == nil || !strings.Contains(err.Error(), "could not be observed") {
+		t.Fatalf("Teardown() = %v, want a refusal naming the unobservable pool", err)
+	}
+	if returns != 0 {
+		t.Fatalf("worktree return count = %d, want no destructive return", returns)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.TeardownWorktreeState != state.TeardownResourceAmbiguous {
+		t.Fatalf("worktree state = %+v, want the latch unchanged", history.ActiveAttempt)
+	}
+}
+
 func TestTeardownRetryRefusesWorktreeWithoutLeaseIdentity(t *testing.T) {
 	home, worktreePath := teardownFixture(t, true)
 	returns := 0
-	verified := 0
+	observed := 0
 	deps := defaultDependencies()
-	deps.worktree.verifyLease = func(path, leaseID string) error {
+	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "" {
-			t.Fatalf("verifyLease(%q, %q), want (%q, empty)", path, leaseID, worktreePath)
+			t.Fatalf("observeLease(%q, %q), want (%q, empty)", path, leaseID, worktreePath)
 		}
-		verified++
-		return errors.New("missing lease identity")
+		observed++
+		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
 	}
 	deps.worktree.returnWorktree = func(string, bool) error {
 		returns++
@@ -569,8 +712,8 @@ func TestTeardownRetryRefusesWorktreeWithoutLeaseIdentity(t *testing.T) {
 	if _, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: true}); err == nil {
 		t.Fatal("forced retry succeeded without a lease identity")
 	}
-	if returns != 1 || verified != 1 {
-		t.Fatalf("retry returns=%d verified=%d, want one initial return and one failed verification", returns, verified)
+	if returns != 1 || observed != 1 {
+		t.Fatalf("retry returns=%d observed=%d, want one initial return and one unproven observation", returns, observed)
 	}
 }
 

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -131,6 +131,46 @@ func TestListHerdrOwnershipsIncludesLifecycleAndTeardownMetadata(t *testing.T) {
 	}
 }
 
+// A latch has to be leavable in both directions: forward to a release once ownership is proven, and
+// sideways to abandonment when an operator attests. Only the worktree can be abandoned.
+func TestSetAttemptTeardownResourceStateLeavesAmbiguousBothWays(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		resource string
+		next     string
+		wantErr  error
+	}{
+		{name: "worktree resumes releasing", resource: "worktree", next: TeardownResourceReleasing},
+		{name: "worktree is abandonable", resource: "worktree", next: TeardownResourceAbandoned},
+		{name: "worktree cannot skip to released", resource: "worktree", next: TeardownResourceReleased, wantErr: store.ErrLifecycleConflict},
+		{name: "herdr resumes releasing", resource: "herdr", next: TeardownResourceReleasing},
+		{name: "herdr is not abandonable", resource: "herdr", next: TeardownResourceAbandoned, wantErr: store.ErrInvalidTransition},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			attempt, err := CreateTaskWithAttempt(home, Task{ID: "task-1", Project: "demo", Kind: KindShip, Brief: "data/task-1/brief.md"}, Attempt{
+				TaskID: "task-1", Lifecycle: AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := SetAttemptTeardownResourceState(home, "task-1", attempt.ID, AttemptProvisioning, test.resource, TeardownResourceAmbiguous); err != nil {
+				t.Fatal(err)
+			}
+			err = SetAttemptTeardownResourceState(home, "task-1", attempt.ID, AttemptProvisioning, test.resource, test.next)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("SetAttemptTeardownResourceState() = %v, want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SetAttemptTeardownResourceState() = %v, want the latch left behind", err)
+			}
+		})
+	}
+}
+
 func TestReadHistoryReadOnlySupportsSchemaV10(t *testing.T) {
 	home := t.TempDir()
 	if _, err := CreateTaskWithAttempt(home, Task{ID: "task-1", Project: "demo", Kind: KindShip, Brief: "data/task-1/brief.md"}, Attempt{

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -74,6 +74,7 @@ const (
 	TeardownResourceReleased                = store.TeardownResourceReleased
 	TeardownResourceAmbiguous               = store.TeardownResourceAmbiguous
 	TeardownResourceRetryable               = store.TeardownResourceRetryable
+	TeardownResourceAbandoned               = store.TeardownResourceAbandoned
 	TeardownCompletionPending               = store.TeardownCompletionPending
 	TeardownCompletionAppended              = store.TeardownCompletionAppended
 	TeardownDispositionCompleted            = store.TeardownDispositionCompleted

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -119,6 +119,7 @@ const (
 	TeardownResourceReleased                = "released"
 	TeardownResourceAmbiguous               = "ambiguous"
 	TeardownResourceRetryable               = "retryable"
+	TeardownResourceAbandoned               = "abandoned"
 	TeardownCompletionPending               = "pending"
 	TeardownCompletionAppended              = "appended"
 	TeardownDispositionCompleted            = "completed"
@@ -970,7 +971,7 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 		WHERE attempt.task_id = task.id
 		AND attempt.lifecycle NOT IN ('provisioning', 'running')
 		AND (
-			(attempt.worktree <> '' AND attempt.teardown_worktree_state <> 'released')
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
 			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
 			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
 		)
@@ -1030,7 +1031,7 @@ func (db *DB) listReconciliationHistoriesBeforeSend() ([]TaskHistory, error) {
 		WHERE attempt.task_id = task.id
 		AND attempt.lifecycle NOT IN ('provisioning', 'running')
 		AND (
-			(attempt.worktree <> '' AND attempt.teardown_worktree_state <> 'released')
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
 			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
 			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
 		)
@@ -2115,17 +2116,24 @@ func (db *DB) SetAttemptTeardownResourceState(taskID string, attemptID int64, ex
 	default:
 		return fmt.Errorf("%w: unknown teardown resource %q", ErrInvalidTransition, resource)
 	}
-	if next != TeardownResourceReleasing && next != TeardownResourceReleased && next != TeardownResourceAmbiguous && next != TeardownResourceRetryable {
+	if next != TeardownResourceReleasing && next != TeardownResourceReleased && next != TeardownResourceAmbiguous && next != TeardownResourceRetryable && next != TeardownResourceAbandoned {
 		return fmt.Errorf("%w: unknown teardown resource state %q", ErrInvalidTransition, next)
+	}
+	if next == TeardownResourceAbandoned && resource != "worktree" {
+		return fmt.Errorf("%w: teardown resource %q cannot be abandoned", ErrInvalidTransition, resource)
 	}
 	currentAllowed := "''"
 	switch next {
+	// 'ambiguous' is a predecessor of 'releasing' so that a later proof of ownership can clear the
+	// latch an unobservable pool leaves behind; the proof is the caller's job, not this table's.
 	case TeardownResourceReleasing:
-		currentAllowed = "'', 'retryable'"
+		currentAllowed = "'', 'retryable', 'ambiguous'"
 	case TeardownResourceReleased, TeardownResourceRetryable:
 		currentAllowed = "'releasing'"
 	case TeardownResourceAmbiguous:
 		currentAllowed = "'releasing', 'retryable', ''"
+	case TeardownResourceAbandoned:
+		currentAllowed = "'ambiguous', 'retryable', ''"
 	}
 	query := `UPDATE attempt SET ` + column + ` = ? WHERE id = ? AND task_id = ? AND lifecycle = ? AND ` + column + ` IN (` + currentAllowed + `)`
 	result, err := db.sql.Exec(query, next, attemptID, taskID, expected)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -44,11 +44,52 @@ const (
 	LeaseAbsent     LeaseObservationState = "absent"
 	LeaseMismatch   LeaseObservationState = "mismatch"
 	LeaseUnprovable LeaseObservationState = "unprovable"
+	LeaseUnknown    LeaseObservationState = "unknown"
 )
+
+// LeaseProbe records how an unobservable pool was probed. WorkingDir is load-bearing evidence:
+// treehouse resolves the pool from it, so a pool key that moved reports nothing from a worktree
+// whose lease is still held in the pool it was acquired from.
+type LeaseProbe struct {
+	Command    string
+	WorkingDir string
+	Reason     string
+}
 
 type LeaseObservation struct {
 	State   LeaseObservationState
 	LeaseID string
+	Probe   LeaseProbe
+}
+
+const statusCommand = "treehouse status --json"
+
+// UnprovenLeaseError refuses an action that requires proven ownership. Observation carries the
+// classification, so a caller can tell an unobservable pool from a lease that belongs elsewhere.
+type UnprovenLeaseError struct {
+	WorktreePath    string
+	ExpectedLeaseID string
+	Observation     LeaseObservation
+}
+
+func (e *UnprovenLeaseError) Error() string {
+	expected := e.ExpectedLeaseID
+	if expected == "" {
+		expected = "(none recorded)"
+	}
+	switch e.Observation.State {
+	case LeaseUnknown:
+		return fmt.Sprintf(
+			"treehouse lease for %s could not be observed: %s; observed by running %q with working directory %s, which is what selects the pool; expected lease %s; destructive cleanup refused because ownership could not be proven, not because a lease mismatched",
+			e.WorktreePath, e.Observation.Probe.Reason, e.Observation.Probe.Command, e.Observation.Probe.WorkingDir, expected)
+	case LeaseMismatch:
+		return fmt.Sprintf("treehouse lease for %s is held as %s, not the expected %s; the worktree belongs to another owner", e.WorktreePath, e.Observation.LeaseID, expected)
+	case LeaseAbsent:
+		return fmt.Sprintf("treehouse reports no lease held on %s; expected lease %s", e.WorktreePath, expected)
+	case LeaseUnprovable:
+		return fmt.Sprintf("treehouse lease for %s has no comparable identity; expected lease %s; destructive cleanup refused because ownership could not be proven, not because a lease mismatched", e.WorktreePath, expected)
+	}
+	return fmt.Sprintf("treehouse lease for %s is %s, which does not prove ownership of expected lease %s", e.WorktreePath, e.Observation.State, expected)
 }
 
 type Cleanliness string
@@ -58,41 +99,46 @@ const (
 	Dirty Cleanliness = "dirty"
 )
 
-func ObserveLease(worktreePath, expectedLeaseID string) (LeaseObservation, error) {
+// ObserveLease classifies recorded worktree ownership and never fails: every cause that stops the
+// pool from being observed is reported as LeaseUnknown carrying its probe, because an observation
+// that could not be made is not evidence that ownership changed.
+func ObserveLease(worktreePath, expectedLeaseID string) LeaseObservation {
 	if worktreePath == "" {
-		return LeaseObservation{State: LeaseAbsent}, nil
+		return LeaseObservation{State: LeaseAbsent}
 	}
 	if _, err := os.Stat(worktreePath); err != nil {
 		if os.IsNotExist(err) {
-			return LeaseObservation{State: LeaseAbsent}, nil
+			return LeaseObservation{State: LeaseAbsent}
 		}
-		return LeaseObservation{}, fmt.Errorf("inspect worktree path: %w", err)
+		return unknownLease(worktreePath, fmt.Sprintf("inspect worktree path: %v", err))
 	}
-	entries, err := treehouseStatus(worktreePath)
-	if err != nil {
-		return LeaseObservation{}, err
+	entries, reason := treehouseStatus(worktreePath)
+	if reason != "" {
+		return unknownLease(worktreePath, reason)
 	}
 	for _, entry := range entries {
 		if entry.Path != worktreePath {
 			continue
 		}
 		if entry.Status != "leased" {
-			return LeaseObservation{State: LeaseAbsent, LeaseID: entry.LeaseID}, nil
+			return LeaseObservation{State: LeaseAbsent, LeaseID: entry.LeaseID}
 		}
 		if expectedLeaseID == "" || entry.LeaseID == "" {
-			return LeaseObservation{State: LeaseUnprovable, LeaseID: entry.LeaseID}, nil
+			return LeaseObservation{State: LeaseUnprovable, LeaseID: entry.LeaseID}
 		}
 		if entry.LeaseID == expectedLeaseID {
-			return LeaseObservation{State: LeaseExact, LeaseID: entry.LeaseID}, nil
+			return LeaseObservation{State: LeaseExact, LeaseID: entry.LeaseID}
 		}
-		return LeaseObservation{State: LeaseMismatch, LeaseID: entry.LeaseID}, nil
+		return LeaseObservation{State: LeaseMismatch, LeaseID: entry.LeaseID}
 	}
-	if _, err := os.Stat(worktreePath); err == nil {
-		return LeaseObservation{State: LeaseUnprovable}, nil
-	} else if !os.IsNotExist(err) {
-		return LeaseObservation{}, fmt.Errorf("inspect worktree path: %w", err)
+	if len(entries) == 0 {
+		return unknownLease(worktreePath, "treehouse reported no pool entries")
 	}
-	return LeaseObservation{State: LeaseAbsent}, nil
+	return unknownLease(worktreePath, fmt.Sprintf("treehouse reported %d pool entries and none names this worktree; the first is %s", len(entries), entries[0].Path))
+}
+
+func unknownLease(worktreePath, reason string) LeaseObservation {
+	return LeaseObservation{State: LeaseUnknown, Probe: LeaseProbe{Command: statusCommand, WorkingDir: worktreePath, Reason: reason}}
 }
 
 func ObserveCleanliness(worktreePath string) (Cleanliness, error) {
@@ -192,32 +238,29 @@ func returnTreehouse(worktreePath string, args []string, force bool) error {
 	return nil
 }
 
-func VerifyLease(worktreePath, expectedLeaseID string) error {
-	if worktreePath == "" || expectedLeaseID == "" {
-		return fmt.Errorf("cannot verify treehouse lease without path and lease ID")
-	}
-	observation, err := ObserveLease(worktreePath, expectedLeaseID)
-	if err != nil {
-		return err
-	}
-	if observation.State == LeaseExact {
-		return nil
-	}
-	return fmt.Errorf("treehouse lease for %s does not match expected lease %s", worktreePath, expectedLeaseID)
-}
-
-func treehouseStatus(worktreePath string) ([]statusEntry, error) {
+// Reports the pool entries, or the reason the pool could not be observed. A missing executable, a
+// non-zero exit and unparsable output are all unobservability, never absence and never a mismatch.
+func treehouseStatus(worktreePath string) ([]statusEntry, string) {
 	cmd := exec.Command("treehouse", "status", "--json")
 	cmd.Dir = worktreePath
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("treehouse status failed: %w", err)
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Sprintf("treehouse is not executable: %v", err)
+		}
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			return nil, fmt.Sprintf("treehouse status failed: %v", err)
+		}
+		return nil, fmt.Sprintf("treehouse status failed: %v: %s", err, detail)
 	}
 	var entries []statusEntry
 	if err := json.Unmarshal(out, &entries); err != nil {
-		return nil, fmt.Errorf("parse treehouse status output: %w", err)
+		return nil, fmt.Sprintf("treehouse status output is not a JSON array: %v", err)
 	}
-	return entries, nil
+	return entries, ""
 }
 
 // CheckCollision cross-checks a freshly acquired lease against every other task's recorded one,

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -97,15 +97,6 @@ func TestGetFailsOnMissingPath(t *testing.T) {
 	}
 }
 
-func TestVerifyLeaseRequiresAnExactLeasedIdentity(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "wt-1")
-	faketool.InitRepo(t, path)
-	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
-	if err := VerifyLease(path, "lease-1"); err != nil {
-		t.Fatalf("VerifyLease() = %v, want exact lease match", err)
-	}
-}
-
 func TestObserveLeaseDistinguishesExactMissingReusedAndLegacyOwnership(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
@@ -120,12 +111,12 @@ func TestObserveLeaseDistinguishesExactMissingReusedAndLegacyOwnership(t *testin
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
-			got, err := ObserveLease(path, test.leaseID)
-			if err != nil {
-				t.Fatal(err)
-			}
+			got := ObserveLease(path, test.leaseID)
 			if got.State != test.want {
 				t.Fatalf("ObserveLease() = %+v, want %s", got, test.want)
+			}
+			if got.Probe != (LeaseProbe{}) {
+				t.Fatalf("ObserveLease() probe = %+v, want no probe on an observed pool", got.Probe)
 			}
 		})
 	}
@@ -138,22 +129,128 @@ func TestObserveLeaseReportsAbsentAfterReturn(t *testing.T) {
 	if err := ReturnLease(path, "lease-1", true); err != nil {
 		t.Fatal(err)
 	}
-	got, err := ObserveLease(path, "lease-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.State != LeaseAbsent {
+	if got := ObserveLease(path, "lease-1"); got.State != LeaseAbsent {
 		t.Fatalf("ObserveLease() = %+v, want absent", got)
 	}
 }
 
 func TestObserveLeaseReportsAbsentWhenTheRecordedPathIsGone(t *testing.T) {
-	got, err := ObserveLease(filepath.Join(t.TempDir(), "gone"), "lease-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.State != LeaseAbsent {
+	if got := ObserveLease(filepath.Join(t.TempDir(), "gone"), "lease-1"); got.State != LeaseAbsent {
 		t.Fatalf("ObserveLease() = %+v, want absent", got)
+	}
+}
+
+// Every cause that stops the pool from being observed is one classification, never absence and
+// never a mismatch: the orphaned pool of atqamz/hand#245 is the first case here.
+func TestObserveLeaseReportsUnknownForEveryUnobservablePool(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		install    func(t *testing.T, path string)
+		wantReason string
+	}{
+		{
+			name: "pool has no entries",
+			install: func(t *testing.T, path string) {
+				faketool.Treehouse{}.Install(t, faketool.Bin(t))
+			},
+			wantReason: "no pool entries",
+		},
+		{
+			name: "pool names other worktrees only",
+			install: func(t *testing.T, path string) {
+				other := filepath.Join(filepath.Dir(path), "wt-other")
+				faketool.Treehouse{Slots: []string{other}}.Install(t, faketool.Bin(t))
+			},
+			wantReason: "none names this worktree",
+		},
+		{
+			name: "status exits non-zero",
+			install: func(t *testing.T, path string) {
+				writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "status", Stderr: "pool lock is held\n", Exit: 1})
+			},
+			wantReason: "pool lock is held",
+		},
+		{
+			name: "treehouse is not installed",
+			install: func(t *testing.T, path string) {
+				faketool.NoTools(t)
+			},
+			wantReason: "not executable",
+		},
+		{
+			name: "status prints malformed JSON",
+			install: func(t *testing.T, path string) {
+				writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "status", Stdout: "{not json"})
+			},
+			wantReason: "not a JSON array",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "wt-1")
+			faketool.InitRepo(t, path)
+			test.install(t, path)
+			got := ObserveLease(path, "lease-1")
+			if got.State != LeaseUnknown {
+				t.Fatalf("ObserveLease() = %+v, want %s", got, LeaseUnknown)
+			}
+			if got.Probe.Command != "treehouse status --json" || got.Probe.WorkingDir != path {
+				t.Fatalf("ObserveLease() probe = %+v, want the command and working directory that selected the pool", got.Probe)
+			}
+			if !strings.Contains(got.Probe.Reason, test.wantReason) {
+				t.Fatalf("ObserveLease() probe reason = %q, want it to contain %q", got.Probe.Reason, test.wantReason)
+			}
+		})
+	}
+}
+
+// An unobservable pool and a lease held by somebody else are different facts, and a caller has to
+// be able to tell them apart without reading a message.
+func TestUnknownAndMismatchAreDistinguishableWithoutReadingAMessage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wt-1")
+	faketool.InitRepo(t, path)
+	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-2"}}.Install(t, faketool.Bin(t))
+	mismatch := ObserveLease(path, "lease-1")
+	if mismatch.State != LeaseMismatch || mismatch.LeaseID != "lease-2" {
+		t.Fatalf("ObserveLease() = %+v, want a mismatch naming the observed lease", mismatch)
+	}
+
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "status", Stdout: "[]"})
+	unknown := ObserveLease(path, "lease-1")
+	if unknown.State != LeaseUnknown {
+		t.Fatalf("ObserveLease() = %+v, want %s", unknown, LeaseUnknown)
+	}
+	if unknown.State == mismatch.State {
+		t.Fatal("an unobservable pool is reported with the same state as a lease held by another owner")
+	}
+	if unknown.LeaseID != "" {
+		t.Fatalf("ObserveLease() = %+v, want no observed lease identity when nothing was observed", unknown)
+	}
+
+	message := (&UnprovenLeaseError{WorktreePath: path, ExpectedLeaseID: "lease-1", Observation: unknown}).Error()
+	for _, forbidden := range []string{"does not match", "belongs to another owner", "is held as"} {
+		if strings.Contains(message, forbidden) {
+			t.Fatalf("unobservable diagnostic = %q, want no claim of %q", message, forbidden)
+		}
+	}
+	for _, want := range []string{"could not be observed", "treehouse status --json", path, "could not be proven, not because a lease mismatched"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("unobservable diagnostic = %q, want it to contain %q", message, want)
+		}
+	}
+}
+
+// The same recorded ownership that could not be observed once is proven on a later observation,
+// with no durable trace of the failed attempt.
+func TestObserveLeaseProvesOwnershipAfterATransientUnobservablePool(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wt-1")
+	faketool.InitRepo(t, path)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "status", Stderr: "connection reset\n", Exit: 1})
+	if got := ObserveLease(path, "lease-1"); got.State != LeaseUnknown {
+		t.Fatalf("ObserveLease() = %+v, want %s", got, LeaseUnknown)
+	}
+	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
+	if got := ObserveLease(path, "lease-1"); got.State != LeaseExact {
+		t.Fatalf("ObserveLease() = %+v, want %s once the pool answers again", got, LeaseExact)
 	}
 }
 
@@ -173,7 +270,7 @@ func TestObserveCleanlinessIncludesUntrackedFiles(t *testing.T) {
 	}
 }
 
-func TestVerifyLeaseRunsStatusFromTheWorktreeRepository(t *testing.T) {
+func TestObserveLeaseRunsStatusFromTheWorktreeRepository(t *testing.T) {
 	worktreePath := filepath.Join(t.TempDir(), "worktree")
 	faketool.InitRepo(t, worktreePath)
 	faketool.Treehouse{Slots: []string{worktreePath}}.Install(t, faketool.Bin(t))
@@ -182,29 +279,29 @@ func TestVerifyLeaseRunsStatusFromTheWorktreeRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := VerifyLease(worktreePath, lease.ID); err != nil {
-		t.Fatalf("VerifyLease() = %v, want the lease visible from the worktree repository", err)
+	if got := ObserveLease(worktreePath, lease.ID); got.State != LeaseExact {
+		t.Fatalf("ObserveLease() = %+v, want the lease visible from the worktree repository", got)
 	}
 }
 
-func TestVerifyLeaseRejectsARecycledOrMissingIdentity(t *testing.T) {
+func TestObserveLeaseRejectsARecycledOrMissingIdentity(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-2"}}.Install(t, faketool.Bin(t))
-	if err := VerifyLease(path, "lease-1"); err == nil {
-		t.Fatal("VerifyLease() accepted a recycled lease identity")
+	if got := ObserveLease(path, "lease-1"); got.State != LeaseMismatch {
+		t.Fatalf("ObserveLease() = %+v, want a recycled lease identity reported as %s", got, LeaseMismatch)
 	}
-	if err := VerifyLease(path, ""); err == nil {
-		t.Fatal("VerifyLease() accepted an empty expected lease identity")
+	if got := ObserveLease(path, ""); got.State != LeaseUnprovable {
+		t.Fatalf("ObserveLease() = %+v, want an empty expected identity reported as %s", got, LeaseUnprovable)
 	}
 }
 
-func TestVerifyLeaseRejectsAnAvailableStatus(t *testing.T) {
+func TestObserveLeaseRejectsAnAvailableStatus(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}}.Install(t, faketool.Bin(t))
-	if err := VerifyLease(path, "lease-1"); err == nil {
-		t.Fatal("VerifyLease() accepted an available entry")
+	if got := ObserveLease(path, "lease-1"); got.State != LeaseAbsent {
+		t.Fatalf("ObserveLease() = %+v, want an available entry reported as %s", got, LeaseAbsent)
 	}
 }
 

--- a/tests/contract/treehouse_test.go
+++ b/tests/contract/treehouse_test.go
@@ -164,6 +164,55 @@ func TestTreehouseStatusReportsTheCurrentLeaseIdentity(t *testing.T) {
 	run(t, dir, "treehouse", "return", lease.Path).requireCode(t, 0)
 }
 
+// atqamz/hand#245: the pool key is the hash of the origin URL, so changing that URL moves the key
+// and orphans the pool the lease lives in. status --json keeps exiting 0 and answers for the pool the
+// key now names, which is why an unobservable pool is a property of the answer, not of the exit code.
+func TestTreehouseStatusFollowsTheOriginURLAndOrphansARenamedPool(t *testing.T) {
+	requireBin(t, "treehouse")
+	root := t.TempDir()
+	clone := newRepo(t)
+	before := filepath.Join(t.TempDir(), "before.git")
+	after := filepath.Join(t.TempDir(), "after.git")
+	for _, remote := range []string{before, after} {
+		run(t, root, "git", "init", "--bare", "-q", remote).requireCode(t, 0)
+	}
+	run(t, clone, "git", "remote", "add", "origin", before).requireCode(t, 0)
+	run(t, clone, "git", "push", "-q", "-u", "origin", "main").requireCode(t, 0)
+	config := fmt.Sprintf("max_trees = 1\nroot = %q\n", root)
+	if err := os.WriteFile(filepath.Join(clone, "treehouse.toml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	leased := acquire(t, clone, "hand:contract-orphan")
+	orphaned := filepath.Dir(filepath.Dir(leased.Path))
+	if !strings.HasPrefix(filepath.Base(orphaned), filepath.Base(clone)+"-") {
+		t.Fatalf("pool directory %q, want a <clone basename>-<hash of origin URL> key", orphaned)
+	}
+
+	run(t, clone, "git", "remote", "set-url", "origin", after).requireCode(t, 0)
+
+	for _, dir := range []string{clone, leased.Path} {
+		status := run(t, dir, "treehouse", "status", "--json").requireCode(t, 0).stdout
+		var entries []statusEntry
+		if err := json.Unmarshal([]byte(status), &entries); err != nil {
+			t.Fatalf("parse status %q from %s: %v", status, dir, err)
+		}
+		for _, entry := range entries {
+			if entry.Path == leased.Path {
+				t.Fatalf("status from %s still reports the orphaned lease %+v", dir, entry)
+			}
+		}
+	}
+
+	recorded, err := os.ReadFile(filepath.Join(orphaned, "treehouse-state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(recorded), leased.LeaseID) {
+		t.Fatalf("orphaned pool state %q no longer records lease %q as held", recorded, leased.LeaseID)
+	}
+}
+
 func TestTreehouseRefusesAnUnmanagedPath(t *testing.T) {
 	requireBin(t, "treehouse")
 	dir := newPool(t, 1)


### PR DESCRIPTION
## Summary

- Split treehouse lease observation into determinate answers and the absence of an answer: `LeaseUnknown` is its own typed state carrying a `LeaseProbe` with the command, the working directory that selected the pool, and the reason, so an unobservable pool is never reported as an absent or mismatched lease. `ObserveLease` no longer returns an error at all and `VerifyLease`, which collapsed every non-exact state into one mismatch message, is deleted.
- Ended the permanent latch: teardown records no durable resource state from an observation it could not make, and `teardown_worktree_state = ambiguous` stops being a dead end because both teardown and reconciliation may leave it, but only behind a fresh exact observation of the same lease identity.
- Added one supported recovery gesture, `hand reconcile <task> --abandon-worktree`, for a pool that is permanently unobservable because its key moved. It needs an explicit task ID, refuses every observed state other than unknown, runs no treehouse command, and records the terminal resource state `abandoned`.

Ownership safety is unchanged. Destructive cleanup still requires proven ownership, `--force` still only chooses how a return whose ownership is already proven deals with dirty work, and no worktree of a live worker can be abandoned on either route into abandonment.

Closes atqamz/hand#245

## Root cause

Treehouse derives its pool key as `<clone directory basename>-<hash of the origin URL>`, hashing the remote URL rather than the clone path. Renaming the repository moved the key and orphaned the pool the live leases were acquired from. Run from a worktree of the orphaned pool, `treehouse status --json` still exits 0 and answers for the pool the key now names, describing other worktrees and naming nothing at the working directory it was run from. The old code classified that as unprovable or mismatched ownership, teardown latched `ambiguous` from it, the store's predecessor table forbade every transition out of `ambiguous`, and no supported command converged the task. The unobservability is permanent while the remote URL stays changed, so a design whose only recovery is retry-later recovers nothing.

`tests/contract/treehouse_test.go:TestTreehouseStatusFollowsTheOriginURLAndOrphansARenamedPool` reproduces this against the real treehouse binary in a fully isolated scratch pool, so the pool-key contract in `internal/faketool/FIDELITY.md` is machine-checked rather than asserted.

## Boundary

Attempt lifecycle convergence after terminal worker completion stays with atqamz/hand#239. Treehouse's key derivation is out of scope, and restoring the previous origin URL is rejected as both a fix and an experiment.

## Test plan

- `go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race -count=1 ./...`
- `make lint`, `make build`, `make e2e`, `make contract`, `nix flake check`, `git diff --check`
- Focused worktree tests at `-race -count=5`; teardown, reconcile, repair, abandonment and lease tests at `-race -count=3`
- Required cases covered: exact lease; another owner is a mismatch; empty `status --json`, non-zero exit, absent executable and malformed JSON all unknown; transient unobservable then exact; a latched attempt converging once ownership is proven; `--force` unable to destroy unproven ownership; ordinary exact-lease teardown end to end; restart and retry equivalence; and a structural assertion that unknown and mismatch are distinguishable without reading a message.
- Both abandonment routes are pinned: `TestReconcileAbandonWorktreeNeverTouchesARunningAttempt` and `TestReconcileAbandonWorktreeSettlesATerminalAttemptWithoutATeardownDecision`.

## Pipeline


<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4a3b94cdd4c9ad01925d12eed3ec9b351baf7d8a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>- info: **intent** - passed</summary>

- info: No issues found.

</details>

<details>
<summary>- info: **Rebase** - passed</summary>

- info: No issues found.

</details>

<details>
<summary>- warning: **Review** - medium risk</summary>

- info: No issues found.

</details>

<details>
<summary>- info: **Test** - passed</summary>

- info: No issues found.
- `nix develop --command go test -race -count=1 ./internal/worktree -run 'TestObserveLeaseDistinguishesExactMissingReusedAndLegacyOwnership|TestObserveLeaseReportsUnknownForEveryUnobservablePool|TestUnknownAndMismatchAreDistinguishableWithoutReadingAMessage|TestObserveLeaseProvesOwnershipAfterATransientUnobservablePool|TestReturnLease.*'`
- `nix develop --command go test -race -count=1 ./internal/runtime -run 'TestReconcileUnobservableWorktreeNeedsRepairInsteadOfMismatch|TestReconcileAbandonWorktree.*|TestReconcileConvergesALatchedWorktreeOnceOwnershipIsProven|TestTeardown.*UnobservablePool|TestTeardown.*LatchedWorktree.*|TestTeardownRetry.*'`
- `nix develop --command go test -race -count=1 ./cmd -run 'TestReconcileCommand.*'`
- `nix develop --command go test -race -tags=contract -count=1 -timeout=10m ./tests/contract -run 'TestTreehouseStatusFollowsTheOriginURLAndOrphansARenamedPool|TestTreehouseConditionalReturnProtectsAReusedLease|TestTreehouseStatusReportsTheCurrentLeaseIdentity'`
- `git status --short`

</details>

<details>
<summary>- info: **Document** - passed</summary>

- info: No issues found.

</details>

<details>
<summary>- info: **Lint** - passed</summary>

- info: No issues found.

</details>

<details>
<summary>- info: **Push** - passed</summary>

- info: No issues found.

</details>

