### PR TITLE
feat(cmd): report fleet health from doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Optional:
 - [no-mistakes](https://github.com/kunchenguid/no-mistakes) - required only by projects using `no-mistakes` mode
 - [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
 
-`hand init` reports checked tools it cannot find on `PATH`. `hand doctor` checks the fleet home's generated agent instructions and related drift.
+`hand init` reports checked tools it cannot find on `PATH`. `hand doctor` reports fleet health: generated agent-instruction drift, project no-mistakes gate failures, routing configuration drift, and effective routing decisions.
 
 Building from source additionally requires Go 1.26.5 or newer.
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -134,6 +134,9 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 	}
 	for _, problem := range snapshot.Config.Problems {
 		findings = append(findings, doctorFinding{Severity: doctorWarning, Text: routingProblemFinding(problem)})
+		if problem.Kind != "" && problem.ExecutionClass != "" {
+			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: routingDecisionProblem(problem)})
+		}
 	}
 	if len(snapshot.Config.Profiles) == 0 && len(snapshot.Config.Routes) == 0 {
 		return append(findings, doctorFinding{Severity: doctorWarning, Text: legacyRoutingFinding(snapshot.Legacy, "routing effective fallback after configuration problems")}), nil
@@ -185,6 +188,11 @@ func profileDetails(profile routing.Profile) string {
 		details = append(details, fmt.Sprintf("effort %q", profile.Effort))
 	}
 	return strings.Join(details, ", ")
+}
+
+func routingDecisionProblem(problem routing.ConfigProblem) string {
+	details := strings.TrimPrefix(problem.Message, "route ")
+	return fmt.Sprintf("routing decision: %s.%s -> unavailable (%s)", problem.Kind, problem.ExecutionClass, details)
 }
 
 func routingProblemFinding(problem routing.ConfigProblem) string {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -123,19 +123,68 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(snapshot.Config.Profiles) == 0 && len(snapshot.Config.Routes) == 0 {
+	if len(snapshot.Config.Profiles) == 0 && len(snapshot.Config.Routes) == 0 && onlyMissingRoutes(snapshot.Config.Problems) {
 		severity := doctorWarning
-		text := "routing falls back to legacy defaults without explicit intent"
+		text := legacyRoutingFinding(snapshot.Legacy, "routing falls back to legacy defaults without explicit intent")
 		if snapshot.Legacy.ConfiguredHarness != "" {
 			severity = doctorInfo
-			text = "routing resolves through explicit legacy defaults"
+			text = legacyRoutingFinding(snapshot.Legacy, "routing resolves through explicit legacy defaults")
 		}
 		return append(findings, doctorFinding{Severity: severity, Text: text}), nil
 	}
 	for _, problem := range snapshot.Config.Problems {
 		findings = append(findings, doctorFinding{Severity: doctorWarning, Text: routingProblemFinding(problem)})
 	}
-	return append(findings, doctorFinding{Severity: doctorInfo, Text: "routing resolves through configured profiles"}), nil
+	if len(snapshot.Config.Profiles) == 0 && len(snapshot.Config.Routes) == 0 {
+		return append(findings, doctorFinding{Severity: doctorWarning, Text: legacyRoutingFinding(snapshot.Legacy, "routing effective fallback after configuration problems")}), nil
+	}
+	for _, route := range snapshot.Config.Routes {
+		profile, found := profileByName(snapshot.Config.Profiles, route.Profile)
+		if found {
+			findings = append(findings, doctorFinding{Severity: doctorInfo, Text: fmt.Sprintf("routing decision: %s.%s -> profile %q -> %s", route.Kind, route.ExecutionClass, profile.Name, profileDetails(profile))})
+		}
+	}
+	return findings, nil
+}
+
+func onlyMissingRoutes(problems []routing.ConfigProblem) bool {
+	for _, problem := range problems {
+		if problem.Code != routing.ConfigProblemMissingRoute {
+			return false
+		}
+	}
+	return true
+}
+
+func legacyRoutingFinding(defaults routing.LegacyDefaults, prefix string) string {
+	details := []string{fmt.Sprintf("harness %q", defaults.Harness)}
+	if model := defaults.Models[defaults.Harness]; model != "" {
+		details = append(details, fmt.Sprintf("model %q", model))
+	}
+	if effort := defaults.Efforts[defaults.Harness]; effort != "" {
+		details = append(details, fmt.Sprintf("effort %q", effort))
+	}
+	return prefix + ": " + strings.Join(details, ", ")
+}
+
+func profileByName(profiles []routing.Profile, name string) (routing.Profile, bool) {
+	for _, profile := range profiles {
+		if profile.Name == name {
+			return profile, true
+		}
+	}
+	return routing.Profile{}, false
+}
+
+func profileDetails(profile routing.Profile) string {
+	details := []string{fmt.Sprintf("harness %q", profile.Harness)}
+	if profile.Model != "" {
+		details = append(details, fmt.Sprintf("model %q", profile.Model))
+	}
+	if profile.Effort != "" {
+		details = append(details, fmt.Sprintf("effort %q", profile.Effort))
+	}
+	return strings.Join(details, ", ")
 }
 
 func routingProblemFinding(problem routing.ConfigProblem) string {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,29 +4,40 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/routing"
 	"github.com/spf13/cobra"
 )
 
-// A whole-file finding has no line to anchor to, and a 0 there would read as
-// one rather than as its absence.
-var doctorFields = []axi.Column[agentsmd.Violation]{
-	{Name: "line", Value: func(v agentsmd.Violation) string {
-		if v.Line == 0 {
+type doctorSeverity string
+
+const (
+	doctorError   doctorSeverity = "error"
+	doctorWarning doctorSeverity = "warning"
+	doctorInfo    doctorSeverity = "info"
+)
+
+type doctorFinding struct {
+	Line     int
+	Severity doctorSeverity
+	Text     string
+}
+
+var doctorFields = []axi.Column[doctorFinding]{
+	{Name: "line", Value: func(f doctorFinding) string {
+		if f.Line == 0 {
 			return "none"
 		}
-		return strconv.Itoa(v.Line)
+		return strconv.Itoa(f.Line)
 	}},
-	{Name: "severity", Value: func(v agentsmd.Violation) string {
-		if v.Severity == agentsmd.SeverityInfo {
-			return "info"
-		}
-		return "violation"
-	}},
-	{Name: "finding", Value: func(v agentsmd.Violation) string { return v.Text }},
+	{Name: "severity", Value: func(f doctorFinding) string { return string(f.Severity) }},
+	{Name: "finding", Value: func(f doctorFinding) string { return f.Text }},
 }
 
 var doctorDefaultFields = []string{"line", "severity", "finding"}
@@ -36,14 +47,14 @@ func newDoctorCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Check the fleet home's AGENTS.md for perishable content and generated-block drift",
+		Short: "Check fleet health, including AGENTS.md, project gates, and routing",
 		Args:  usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()
 			if err != nil {
 				return asPrecondition(err)
 			}
-			violations, err := agentsmd.Check(fleetHome)
+			findings, err := doctorFindings(fleetHome)
 			if err != nil {
 				return err
 			}
@@ -54,18 +65,18 @@ func newDoctorCmd() *cobra.Command {
 
 			path := filepath.Join(fleetHome, "AGENTS.md")
 			failing := 0
-			for _, v := range violations {
-				if v.Severity != agentsmd.SeverityInfo {
+			for _, finding := range findings {
+				if finding.Severity == doctorError {
 					failing++
 				}
 			}
 
 			var doc axi.Doc
 			doc.Field("file", path)
-			doc.Int("count", len(violations))
+			doc.Int("count", len(findings))
 			doc.Int("violations", failing)
-			axi.Table(&doc, "findings", violations, cols)
-			doc.Help(doctorHelp(len(violations), failing)...)
+			axi.Table(&doc, "findings", findings, cols)
+			doc.Help(doctorHelp(len(findings), failing)...)
 			if err := doc.Render(cmd.OutOrStdout()); err != nil {
 				return err
 			}
@@ -80,6 +91,63 @@ func newDoctorCmd() *cobra.Command {
 	return cmd
 }
 
+func doctorFindings(fleetHome string) ([]doctorFinding, error) {
+	violations, err := agentsmd.Check(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	findings := make([]doctorFinding, 0, len(violations))
+	for _, violation := range violations {
+		severity := doctorError
+		if violation.Severity == agentsmd.SeverityInfo {
+			severity = doctorInfo
+		}
+		findings = append(findings, doctorFinding{Line: violation.Line, Severity: severity, Text: violation.Text})
+	}
+
+	projects, err := project.ListReadOnly(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projects {
+		if issue := gateIssue(fleetHome, p); issue != "" {
+			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q no-mistakes gate is %s", p.Name, issue)})
+		}
+	}
+
+	detection, err := harness.DetectCurrent()
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := routing.LoadExecutionSnapshot(fleetHome, detection.Name, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(snapshot.Config.Profiles) == 0 && len(snapshot.Config.Routes) == 0 {
+		severity := doctorWarning
+		text := "routing falls back to legacy defaults without explicit intent"
+		if snapshot.Legacy.ConfiguredHarness != "" {
+			severity = doctorInfo
+			text = "routing resolves through explicit legacy defaults"
+		}
+		return append(findings, doctorFinding{Severity: severity, Text: text}), nil
+	}
+	for _, problem := range snapshot.Config.Problems {
+		findings = append(findings, doctorFinding{Severity: doctorWarning, Text: routingProblemFinding(problem)})
+	}
+	return append(findings, doctorFinding{Severity: doctorInfo, Text: "routing resolves through configured profiles"}), nil
+}
+
+func routingProblemFinding(problem routing.ConfigProblem) string {
+	if problem.Kind != "" && problem.ExecutionClass != "" {
+		return fmt.Sprintf("routing drift: route %s.%s %s", problem.Kind, problem.ExecutionClass, strings.TrimPrefix(problem.Message, "route "))
+	}
+	if problem.Profile != "" {
+		return fmt.Sprintf("routing drift: profile %q %s", problem.Profile, problem.Message)
+	}
+	return "routing drift: " + problem.Message
+}
+
 // hand doctor fixes nothing, so what it owes a reader is which findings are
 // theirs to edit and which one command repairs on its own.
 func doctorHelp(count, failing int) []string {
@@ -87,10 +155,10 @@ func doctorHelp(count, failing int) []string {
 		return nil
 	}
 	if failing == 0 {
-		return []string{"Every finding here is informational, so this run passed; nothing has to change"}
+		return []string{"No error findings, so this run passed; inspect warnings and info before the next dispatch"}
 	}
 	return []string{
-		"Edit AGENTS.md to resolve each finding; hand doctor reports and never rewrites",
-		"Run `hand update` if the finding is generated-block drift, since that block is refreshed rather than hand-edited",
+		"Resolve every error finding; hand doctor reports and never rewrites",
+		"Run `hand update` for generated-block drift, or inspect project gates and routing configuration for fleet health findings",
 	}
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -10,17 +10,160 @@ import (
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/routing"
 )
 
-// A clean file is the one answer silence used to be indistinguishable from a
-// checker that never ran, so it states its zero rather than printing nothing.
-func TestDoctorCleanFleetHomeStatesItsZeroCount(t *testing.T) {
+func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string)
+		want  []doctorFinding
+	}{
+		{
+			name: "clean fleet",
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				mustConfigSet(t, settingHarness, harness.Claude)
+			},
+			want: []doctorFinding{{Severity: doctorInfo, Text: "routing resolves through explicit legacy defaults"}},
+		},
+		{
+			name: "unreachable gate",
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("PATH", t.TempDir())
+			},
+			want: []doctorFinding{{Severity: doctorError, Text: `project "gated" no-mistakes gate is unreachable`}},
+		},
+		{
+			name: "uninitialized gate",
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("PATH", fakeNoMistakesPath(t, "repo not initialized"))
+			},
+			want: []doctorFinding{{Severity: doctorError, Text: `project "gated" no-mistakes gate is not initialized`}},
+		},
+		{
+			name: "explicit legacy intent",
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				mustConfigSet(t, settingHarness, harness.Claude)
+			},
+			want: []doctorFinding{{Severity: doctorInfo, Text: "routing resolves through explicit legacy defaults"}},
+		},
+		{
+			name: "unstated legacy fallback",
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []doctorFinding{{Severity: doctorWarning, Text: "routing falls back to legacy defaults without explicit intent"}},
+		},
+		{
+			name: "partial routing config",
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				if err := routing.WriteProfile(home, routing.Profile{Name: "daily", Harness: harness.Claude}); err != nil {
+					t.Fatal(err)
+				}
+				if err := routing.WriteRoute(home, routing.Route{Kind: routing.TaskKindScout, ExecutionClass: routing.ExecutionClassStandard, Profile: "daily"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []doctorFinding{{Severity: doctorWarning, Text: "routing drift: route scout.mechanical is not configured"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Chdir(home)
+			mkFleetDirs(t, home)
+			t.Setenv("HAND_HARNESS", harness.Claude)
+			tt.setup(t, home)
+
+			findings, err := doctorFindings(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tt.want {
+				if !hasDoctorFinding(findings, want) {
+					t.Fatalf("findings = %#v, want %#v", findings, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorIncludesProjectListGateFinding(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDoctorFinding(findings, doctorFinding{Severity: doctorError, Text: `project "gated" no-mistakes gate is unreachable`}) {
+		t.Fatalf("findings = %#v, want project list gate finding", findings)
+	}
+}
+
+func hasDoctorFinding(findings []doctorFinding, want doctorFinding) bool {
+	for _, finding := range findings {
+		if finding.Severity == want.Severity && finding.Text == want.Text {
+			return true
+		}
+	}
+	return false
+}
+
+// A clean fleet still reports its effective routing decision rather than making
+// an operator infer it from a lack of findings.
+func TestDoctorCleanFleetReportsEffectiveRouting(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
 
 	var out bytes.Buffer
 	cmd := newDoctorCmd()
@@ -30,9 +173,12 @@ func TestDoctorCleanFleetHomeStatesItsZeroCount(t *testing.T) {
 		t.Fatalf("got error %v, want nil for a clean AGENTS.md", err)
 	}
 	want := "file: " + axi.Value(filepath.Join(home, "AGENTS.md")) + "\n" +
-		"count: 0\n" +
+		"count: 1\n" +
 		"violations: 0\n" +
-		"findings[0]{line,severity,finding}:\n"
+		"findings[1]{line,severity,finding}:\n" +
+		"  none,info,routing resolves through explicit legacy defaults\n" +
+		"help[1]:\n" +
+		"  - No error findings, so this run passed; inspect warnings and info before the next dispatch\n"
 	if out.String() != want {
 		t.Fatalf("stdout = %q, want %q", out.String(), want)
 	}
@@ -69,8 +215,8 @@ func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
 	if !strings.Contains(out.String(), want) {
 		t.Fatalf("stdout = %q, want the findings anchored at the resolved home's absolute path %q", out.String(), want)
 	}
-	if !strings.Contains(out.String(), "violations: 1\n") || !strings.Contains(out.String(), ",violation,") {
-		t.Fatalf("stdout = %q, want one finding counted and marked at violation severity", out.String())
+	if !strings.Contains(out.String(), "violations: 1\n") || !strings.Contains(out.String(), ",error,") {
+		t.Fatalf("stdout = %q, want one finding counted and marked at error severity", out.String())
 	}
 }
 
@@ -96,10 +242,10 @@ func TestDoctorTreatsMissingManagedMarkersAsViolation(t *testing.T) {
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("got nil error, want missing managed markers to fail doctor")
 	}
-	if !strings.Contains(out.String(), "count: 1\n") || !strings.Contains(out.String(), "violations: 1\n") {
+	if !strings.Contains(out.String(), "violations: 1\n") {
 		t.Fatalf("stdout = %q, want the missing markers counted as a violation", out.String())
 	}
-	if !strings.Contains(out.String(), "  none,violation,") {
+	if !strings.Contains(out.String(), "  none,error,") {
 		t.Fatalf("stdout = %q, want a whole-file finding to carry no line number", out.String())
 	}
 }
@@ -158,9 +304,9 @@ func TestDoctorReportsMalformedMarkersWithLineNumbers(t *testing.T) {
 		content string
 		want    string
 	}{
-		{"unpaired", "# Rules\n<!-- hand:generated:start -->\n", "  2,violation,\"unpaired hand:generated start marker\""},
-		{"duplicate", "<!-- hand:generated:start -->\n<!-- hand:generated:start -->\n<!-- hand:generated:end -->\n", "  2,violation,\"duplicate hand:generated start marker\""},
-		{"reversed", "<!-- hand:generated:end -->\n<!-- hand:generated:start -->\n", "  1,violation,\"hand:generated end marker appears before start marker\""},
+		{"unpaired", "# Rules\n<!-- hand:generated:start -->\n", "  2,error,\"unpaired hand:generated start marker\""},
+		{"duplicate", "<!-- hand:generated:start -->\n<!-- hand:generated:start -->\n<!-- hand:generated:end -->\n", "  2,error,\"duplicate hand:generated start marker\""},
+		{"reversed", "<!-- hand:generated:end -->\n<!-- hand:generated:start -->\n", "  1,error,\"hand:generated end marker appears before start marker\""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -209,6 +209,31 @@ func TestDoctorReportsConfiguredRoutingDecision(t *testing.T) {
 	}
 }
 
+func TestDoctorReportsUnresolvedConfiguredRoutingDecision(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "config", "routes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "routes", "ship.deep"), []byte("missing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HAND_HARNESS", harness.Claude)
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := doctorFinding{Severity: doctorWarning, Text: `routing decision: ship.deep -> unavailable (profile "missing" does not exist or is invalid)`}
+	if !hasDoctorFinding(findings, want) {
+		t.Fatalf("findings = %#v, want %q", findings, want.Text)
+	}
+}
+
 func TestDoctorReportsMalformedRoutingBeforeEffectiveFallback(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -30,7 +30,7 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 				}
 				mustConfigSet(t, settingHarness, harness.Claude)
 			},
-			want: []doctorFinding{{Severity: doctorInfo, Text: "routing resolves through explicit legacy defaults"}},
+			want: []doctorFinding{{Severity: doctorInfo, Text: `routing resolves through explicit legacy defaults: harness "claude"`}},
 		},
 		{
 			name: "unreachable gate",
@@ -72,7 +72,7 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 				}
 				mustConfigSet(t, settingHarness, harness.Claude)
 			},
-			want: []doctorFinding{{Severity: doctorInfo, Text: "routing resolves through explicit legacy defaults"}},
+			want: []doctorFinding{{Severity: doctorInfo, Text: `routing resolves through explicit legacy defaults: harness "claude"`}},
 		},
 		{
 			name: "unstated legacy fallback",
@@ -82,7 +82,7 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			want: []doctorFinding{{Severity: doctorWarning, Text: "routing falls back to legacy defaults without explicit intent"}},
+			want: []doctorFinding{{Severity: doctorWarning, Text: `routing falls back to legacy defaults without explicit intent: harness "claude"`}},
 		},
 		{
 			name: "partial routing config",
@@ -176,11 +176,71 @@ func TestDoctorCleanFleetReportsEffectiveRouting(t *testing.T) {
 		"count: 1\n" +
 		"violations: 0\n" +
 		"findings[1]{line,severity,finding}:\n" +
-		"  none,info,routing resolves through explicit legacy defaults\n" +
+		"  none,info," + axi.Value(`routing resolves through explicit legacy defaults: harness "claude"`) + "\n" +
 		"help[1]:\n" +
 		"  - No error findings, so this run passed; inspect warnings and info before the next dispatch\n"
 	if out.String() != want {
 		t.Fatalf("stdout = %q, want %q", out.String(), want)
+	}
+}
+
+func TestDoctorReportsConfiguredRoutingDecision(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if err := routing.WriteProfile(home, routing.Profile{Name: "daily", Harness: harness.Claude, Model: "opus", Effort: "high"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := routing.WriteRoute(home, routing.Route{Kind: routing.TaskKindScout, ExecutionClass: routing.ExecutionClassMechanical, Profile: "daily"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HAND_HARNESS", harness.Claude)
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := doctorFinding{Severity: doctorInfo, Text: `routing decision: scout.mechanical -> profile "daily" -> harness "claude", model "opus", effort "high"`}
+	if !hasDoctorFinding(findings, want) {
+		t.Fatalf("findings = %#v, want %q", findings, want.Text)
+	}
+}
+
+func TestDoctorReportsMalformedRoutingBeforeEffectiveFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	profileDir := filepath.Join(home, "config", "profiles", "broken")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profileDir, "current"), []byte("missing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profileIndex := -1
+	fallbackIndex := -1
+	for i, finding := range findings {
+		if strings.HasPrefix(finding.Text, "routing drift: profile") {
+			profileIndex = i
+		}
+		if strings.HasPrefix(finding.Text, "routing effective fallback after configuration problems: harness") {
+			fallbackIndex = i
+		}
+	}
+	if profileIndex < 0 || fallbackIndex < 0 || profileIndex >= fallbackIndex {
+		t.Fatalf("findings = %#v, want malformed profile before fallback", findings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `hand doctor` now reports AGENTS.md drift, registered no-mistakes gate health, routing configuration drift, and effective routing decisions.
- A configured legacy harness with no profiles or routes is intentional legacy and reports as `info`; unstated legacy fallback and partial or ineffective routing report as `warning`; unreachable or uninitialised project gates report as `error`. These derive from existing routing and legacy settings, so no persisted intent key was added.
- Kept the change outside the parallel runtime lifecycle and contract-hermeticity lanes.

Closes atqamz/hand#242

## Test plan

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `nix develop -c make lint`
- `nix develop -c make build`
- `nix develop -c make contract`
- `nix develop -c make e2e`
- `nix flake check --print-build-logs`
- `git diff --check`
- no-mistakes pipeline review, focused tests, documentation, lint, push, PR, and CI