### PR TITLE
test(contract): make default contract suite hermetic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,17 @@ jobs:
       - name: End-to-end
         run: go test -tags=e2e -timeout=10m ./tests/e2e/...
 
+  contract:
+    name: Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Contract
+        run: make contract
+
   nix-build:
     name: Nix build (x86_64-linux)
     runs-on: ubuntu-latest
@@ -77,7 +88,7 @@ jobs:
 
   edge:
     name: Publish edge
-    needs: [lint, test, e2e, nix-build]
+    needs: [lint, test, e2e, contract, nix-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This checkout is the tool's own source, not a fleet home itself - there is no `s
 - Comments obey two rules `make lint` enforces through `tools/commentlint`: a comment may not open with the identifier it documents, and a comment block may not exceed three lines. CONTRIBUTING.md's "Comments" section owns the bar, exemptions, and reasoning.
 - Command output goes through `internal/axi` as TOON and every failure through `cmd/root.go`'s error document; `hand watch`'s event stream is the exception. Package and command tests own these shapes.
 - Harness/herdr syntax, exit enforcement, watch's stdout/errOut split, and first-run prompt handling are owned by their implementations and closest tests under `internal/harness`, `internal/herdr`, `internal/watcher`, and `cmd`.
-- `herdr`, `treehouse` and `gh` are faked once in `internal/faketool` for every suite. `internal/faketool/FIDELITY.md` records observed external behavior and `tests/contract` (`make contract`) rechecks it. Extend the shared fake, never hand-write another.
+- `herdr`, `treehouse` and `gh` are faked once in `internal/faketool` for every suite. `internal/faketool/FIDELITY.md` records observed external behavior, `tests/contract` (`make contract`) rechecks it hermetically, and `make contract-live` separately probes reversible calls against installed tools. Extend the shared fake, never hand-write another.
 - Test, release, and write conventions live as doc comments: `tests/e2e` (`fakes_test.go`, `e2e_test.go`), GitHub access via `gh` (`internal/ghutil`), AGENTS.md refresh (`internal/agentsmd`), atomic writes (`internal/atomicfile`).
 - Dev environment is Nix-based (`flake.nix`, `CONTRIBUTING.md`); `make lint`, `go build ./...`, and `go test -race ./...` verify inside `nix develop`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ An installed edge release is the preferred path for dogfooding the newest CI-ver
 3. Make changes.
 4. make lint && make test
 5. make e2e if you changed CLI behavior (end-to-end suite, excluded from make test).
-6. make contract if you changed how hand calls herdr, treehouse or gh, and you have those installed. It checks the records in internal/faketool/FIDELITY.md against the real tools, skipping whichever is absent, so CI never runs it.
+6. make contract if you changed how hand calls herdr, treehouse or gh. It checks hermetic shared-tool fixtures against the records in internal/faketool/FIDELITY.md, so CI runs it on every change. Run make contract-live separately to smoke-test reversible calls against installed tools and the live GitHub API.
 7. nix build .#default if you changed Go dependencies (CI builds the flake, and a stale vendorHash in flake.nix fails it).
 8. Open a PR whose body carries a closing keyword (Closes, Fixes, or Resolves) directly preceding a fully qualified atqamz/hand#N, on its own line. A bare #N links but reads ambiguously outside the repo, and a reference without the keyword links the issue without ever closing it.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt lint e2e contract install clean
+.PHONY: build test fmt lint e2e contract contract-live install clean
 
 VERSION ?= dev
 CHANNEL ?= dev
@@ -23,9 +23,11 @@ lint:
 e2e:
 	go test -tags=e2e -timeout=10m ./tests/e2e/...
 
-# Runs against the real herdr, treehouse and gh, skipping whichever is absent.
 contract:
 	go test -tags=contract -count=1 -timeout=10m ./tests/contract/...
+
+contract-live:
+	go test -tags=contract,contractlive -count=1 -timeout=10m ./tests/contract/...
 
 install: build
 	cp hand $(GOPATH)/bin/ 2>/dev/null || cp hand ~/.local/bin/

--- a/docs/adr/mechanical-plans-verify-acquired-head.md
+++ b/docs/adr/mechanical-plans-verify-acquired-head.md
@@ -28,4 +28,4 @@ Relying only on the project-base check would allow Treehouse's own fetch/reset t
 ## Consequences
 
 Mechanical dispatch can briefly acquire a lease when Treehouse advances the base during acquisition, but it never launches a worker from that lease unless the exact revision is verified.
-The shared fake and contract suite model and verify this external-tool behavior.
+The shared fake and hermetic contract suite model this external-tool behavior; the explicit live lane verifies the reversible call against the real binary.

--- a/docs/adr/one-stateful-fake-per-external-tool.md
+++ b/docs/adr/one-stateful-fake-per-external-tool.md
@@ -11,7 +11,7 @@ Per-test scripts can return expected text without representing the state changed
 
 ## Decision
 
-[`internal/faketool`](../../internal/faketool) provides one stateful fake for each external CLI used by the suites. [`internal/faketool/FIDELITY.md`](../../internal/faketool/FIDELITY.md) records observed behavior, and [`tests/contract`](../../tests/contract) checks reversible calls against installed real tools.
+[`internal/faketool`](../../internal/faketool) provides one stateful fake for each external CLI used by the suites. [`internal/faketool/FIDELITY.md`](../../internal/faketool/FIDELITY.md) records observed behavior, [`tests/contract`](../../tests/contract) checks it hermetically through shared fixtures, and `make contract-live` checks reversible calls against installed real tools.
 
 ## Rejected alternatives
 

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -43,7 +43,7 @@ It records the terminal resource state `abandoned`, which means Hand has relinqu
 The probe that justified the attestation is reported in the reconcile result rather than stored in a new column.
 
 The decision table, the refusal messages, and the convergence traces belong to the tests under `internal/runtime` and `internal/worktree`.
-The real command's pool-resolution contract belongs to `internal/faketool/FIDELITY.md` and is rechecked by `tests/contract`.
+The real command's pool-resolution contract belongs to `internal/faketool/FIDELITY.md`, is rechecked hermetically by `make contract`, and is probed against the real command by `make contract-live`.
 
 ## Rejected alternatives
 

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -47,7 +47,7 @@ Mechanical dispatch verifies that `HEAD` still equals `planned_against` immediat
 
 Conditional return accepts `--if-lease-id <id>` and refuses a return when the slot's current lease identity differs, leaving that lease held.
 Hand uses this form whenever acquisition returned an identity, so a stale cleanup cannot release an L2 lease on a reused path.
-The shared fake models the identity check and the contract suite verifies the ABA protection against the real binary.
+The shared fake models the identity check, and `make contract-live` verifies the ABA protection against the real binary.
 
 ### `treehouse status --json`
 

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -9,8 +9,9 @@ A behaviour no test exercises does not belong here.
 Every entry was observed by running the real binary, not read off its documentation.
 Versions probed: `treehouse v2.1.0`, `herdr 0.7.5`, `gh 2.97.0`.
 
-`tests/contract` re-runs these calls against the real tools under the `contract` build tag, skipping where a binary is absent, so a record that has gone stale against a newer tool is discoverable by running them.
-It covers no call that would change anything an operator owns: a scratch treehouse pool and a scratch herdr workspace are created and destroyed, and every `gh` call is read-only.
+`make contract-live` re-runs reversible calls against the real tools under the `contractlive` build tag, skipping where a binary is absent, so a record that has gone stale against a newer tool is discoverable without making the default suite depend on installed tools or the network.
+`make contract` exercises shared fake fixtures only.
+The live lane covers no call that would change anything an operator owns: a scratch treehouse pool and a scratch herdr workspace are created and destroyed, and every `gh` call is read-only.
 The one `git remote set-url` it runs is on a throwaway clone inside the test's own temp directory, whose `origin` points at a bare repository created for that test.
 
 Decorative glyphs appear in several stderr lines below and are omitted from the transcripts.
@@ -42,7 +43,7 @@ State left behind: the slot is leased and is not handed out again until it is re
 When `origin` is configured, acquisition can fetch the remote and reset the leased worktree to the farther-ahead default-branch tip even while the registered clone's local default branch remains behind.
 The acquired worktree's `HEAD` is therefore load-bearing state, not an incidental property of the returned path.
 Mechanical dispatch verifies that `HEAD` still equals `planned_against` immediately after acquisition and returns a mismatched lease before any Herdr or worker launch.
-`Treehouse.AcquireHeads` models this reset in the shared fake, and `tests/contract` verifies the behavior against the real binary.
+`Treehouse.AcquireHeads` models this reset in the shared fake, and `make contract-live` verifies the behavior against the real binary.
 
 Conditional return accepts `--if-lease-id <id>` and refuses a return when the slot's current lease identity differs, leaving that lease held.
 Hand uses this form whenever acquisition returned an identity, so a stale cleanup cannot release an L2 lease on a reused path.
@@ -236,6 +237,13 @@ Text `pane run` typed into the pane appears in a later read, so a read reflects 
 
 Driven by `internal/ghutil`, and through it by teardown's landed-work check and the gate's PR detection.
 
+### Transport and service failures
+
+GitHub transport and service failures exit nonzero and put their diagnostic on stderr, not stdout.
+The fleet has observed HTTP 503, DNS lookup failure and request dial timeout failures against `api.github.com`.
+`GHResponse` preserves the configured stdout, stderr and exit code verbatim so focused tests can express each failure without a network call.
+An empty successful result remains distinct: `gh pr list` exits 0 and writes `[]` to stdout.
+
 ### `gh pr list --repo <slug> --head <branch> --state all --limit 200 --json number,url,state,headRepository`
 
 Exit 0 with a JSON array on stdout, `[]` when nothing matches - an empty result is not an error.
@@ -274,7 +282,7 @@ This is the transition `hand merge` and `hand teardown` are sequenced around - m
 So the exit status cannot say whether a merge happened, and a rerun of `hand merge` would report success for a merge it did not perform.
 `runPRMerge` checks `PRIsMerged` before the merge for that reason, and `TestMergeRefusesAPRAnEarlierRunAlreadyMerged` is the check that fails without it.
 
-Both merge entries were observed on a throwaway PR and are the one part of this file `tests/contract` does not re-run: merging is not reversible, and no contract run may land a real PR.
+Both merge entries were observed on a throwaway PR and are the one part of this file `make contract-live` does not re-run: merging is not reversible, and no contract run may land a real PR.
 
 ### Slug case
 
@@ -324,7 +332,7 @@ Driven by `.github/scripts/edge-publish.sh` alone.
 `GHReleaseStore` models them as a mutable store so `tests/edgepublish` can assert the asset set a publish run leaves behind.
 
 Observed with `gh 2.97.0` against disposable private repositories that the probe created and deleted in the same run, so no release an operator owns was written to.
-`tests/contract` does not re-run them, for the reason the `pr merge` entries are not re-run: every call changes a release, and a contract run may change nothing an operator owns.
+`make contract-live` does not re-run them, for the reason the `pr merge` entries are not re-run: every call changes a release, and a contract run may change nothing an operator owns.
 Re-probe the same way after a `gh` upgrade, because the script's ordering depends on each result below.
 
 ### `gh release create <tag> --repo <slug> --target <sha> --title Edge --prerelease --draft --notes-file <file>`

--- a/internal/faketool/gh_test.go
+++ b/internal/faketool/gh_test.go
@@ -104,6 +104,25 @@ func TestGHPRListAnswersAnEmptyArrayForABranchWithNoPR(t *testing.T) {
 	}
 }
 
+func TestGHResponsesPreserveNetworkFailureShapes(t *testing.T) {
+	for _, response := range []GHResponse{
+		{Command: "pr list", Stdout: "[]\n"},
+		{Command: "pr list", Stderr: "HTTP 503: Service Unavailable\n", Exit: 1},
+		{Command: "pr list", Stderr: "dial tcp: lookup api.github.com: temporary failure in name resolution\n", Exit: 1},
+		{Command: "pr list", Stderr: "Post \"https://api.github.com/graphql\": i/o timeout\n", Exit: 1},
+	} {
+		t.Run(strings.TrimSpace(response.Stderr), func(t *testing.T) {
+			GH{Responses: []GHResponse{response}}.Install(t, Bin(t))
+
+			stdout, stderr, code := runGH(t, "pr", "list")
+			if stdout != response.Stdout || stderr != response.Stderr || code != response.Exit {
+				t.Fatalf("gh response = (%q, %q, %d), want (%q, %q, %d)",
+					stdout, stderr, code, response.Stdout, response.Stderr, response.Exit)
+			}
+		})
+	}
+}
+
 func TestGHPRListReportsEveryPROnTheBranch(t *testing.T) {
 	GH{PRs: []GHPR{
 		{Number: 7, URL: "https://github.com/owner/repo/pull/7", Branch: "task-1-branch", State: "CLOSED", Repo: "owner/repo"},

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -12,14 +12,6 @@ import (
 	"testing"
 )
 
-// Skips rather than fails, because CI installs none of these on purpose.
-func requireBin(t *testing.T, name string) {
-	t.Helper()
-	if _, err := exec.LookPath(name); err != nil {
-		t.Skipf("%s is not on PATH", name)
-	}
-}
-
 type result struct {
 	stdout string
 	stderr string

--- a/tests/contract/gh_fake_test.go
+++ b/tests/contract/gh_fake_test.go
@@ -1,0 +1,124 @@
+//go:build contract
+
+package contract
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+const (
+	contractGHRepo      = "atqamz/hand"
+	contractGHRepoCased = "AtqaMZ/Hand"
+	contractGHEdgeSHA   = "0123456789abcdef0123456789abcdef01234567"
+)
+
+func installContractGH(t *testing.T) {
+	t.Helper()
+	faketool.GH{
+		PRs: []faketool.GHPR{{
+			Number:   154,
+			URL:      "https://github.com/atqamz/hand/pull/154",
+			Branch:   "136-usage-limit-resume",
+			State:    "MERGED",
+			Repo:     contractGHRepo,
+			HeadRepo: contractGHRepo,
+			Checks:   []string{"pass", "skipping"},
+		}},
+		Repos: []faketool.GHRepo{{
+			Requested:     "atqamz/secondhand",
+			NameWithOwner: contractGHRepo,
+			URL:           "https://github.com/atqamz/hand",
+		}},
+		Responses: []faketool.GHResponse{{
+			Command: "pr view",
+			Stderr:  "Could not resolve to a PullRequest with the number of 999999.\n",
+			Exit:    1,
+		}},
+	}.Install(t, faketool.Bin(t))
+}
+
+func TestGHFixturesPreservePullRequestAndRepositoryContracts(t *testing.T) {
+	installContractGH(t)
+
+	empty := run(t, "", "gh", "pr", "list", "--repo", contractGHRepo, "--head", "no-such-branch-contract-test",
+		"--state", "all", "--limit", "200", "--json", "number,url,state,headRepository").requireCode(t, 0)
+	if strings.TrimSpace(empty.stdout) != "[]" {
+		t.Fatalf("stdout = %q, want an empty array rather than a failure", empty.stdout)
+	}
+
+	listed := run(t, "", "gh", "pr", "list", "--repo", contractGHRepoCased, "--head", "136-usage-limit-resume",
+		"--state", "all", "--limit", "200", "--json", "number,url,state,headRepository").requireCode(t, 0)
+	var prs []struct {
+		State          string `json:"state"`
+		HeadRepository struct {
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"headRepository"`
+	}
+	if err := json.Unmarshal([]byte(listed.stdout), &prs); err != nil {
+		t.Fatalf("parse stdout %q: %v", listed.stdout, err)
+	}
+	if len(prs) != 1 || prs[0].State != "MERGED" || prs[0].HeadRepository.NameWithOwner != contractGHRepo {
+		t.Fatalf("PRs = %+v, want one merged PR from %s", prs, contractGHRepo)
+	}
+
+	repo := run(t, "", "gh", "repo", "view", "atqamz/secondhand", "--json", "nameWithOwner,url").requireCode(t, 0)
+	if strings.TrimSpace(repo.stdout) != `{"nameWithOwner":"atqamz/hand","url":"https://github.com/atqamz/hand"}` {
+		t.Fatalf("repo = %q, want renamed canonical repository", repo.stdout)
+	}
+}
+
+func TestGHFixturesPreserveFailuresAndCheckBuckets(t *testing.T) {
+	installContractGH(t)
+
+	run(t, "", "gh", "pr", "view", "999999", "--repo", contractGHRepo, "--json", "state").
+		requireCode(t, 1).
+		requireStderrContains(t, "Could not resolve to a PullRequest")
+
+	checks := run(t, "", "gh", "pr", "checks", "154", "--repo", contractGHRepo, "--json", "bucket").requireCode(t, 0)
+	var got []struct {
+		Bucket string `json:"bucket"`
+	}
+	if err := json.Unmarshal([]byte(checks.stdout), &got); err != nil {
+		t.Fatalf("parse stdout %q: %v", checks.stdout, err)
+	}
+	if len(got) != 2 || got[0].Bucket != "pass" || got[1].Bucket != "skipping" {
+		t.Fatalf("buckets = %+v, want pass and skipping", got)
+	}
+}
+
+func TestGHFixturesPreserveEdgeRefOutcomes(t *testing.T) {
+	missing := faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "api repos/atqamz/hand/git/matching-refs/tags/edge", Stdout: "0\n"},
+		{Command: "api repos/atqamz/hand/commits/edge", Stderr: "HTTP 404: Not Found\n", Exit: 1},
+	}}
+	missing.Install(t, faketool.Bin(t))
+
+	refs := run(t, "", "gh", "api", "repos/atqamz/hand/git/matching-refs/tags/edge",
+		"--jq", `[.[] | select(.ref == "refs/tags/edge")] | length`).requireCode(t, 0)
+	if strings.TrimSpace(refs.stdout) != "0" {
+		t.Fatalf("refs = %q, want zero matching edge refs", refs.stdout)
+	}
+	run(t, "", "gh", "api", "repos/atqamz/hand/commits/edge", "--jq", ".sha").
+		requireCode(t, 1).
+		requireStderrContains(t, "HTTP 404")
+
+	published := faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "api repos/atqamz/hand/git/matching-refs/tags/edge", Stdout: "1\n"},
+		{Command: "api repos/atqamz/hand/commits/edge", Stdout: contractGHEdgeSHA + "\n"},
+	}}
+	published.Install(t, faketool.Bin(t))
+
+	refs = run(t, "", "gh", "api", "repos/atqamz/hand/git/matching-refs/tags/edge",
+		"--jq", `[.[] | select(.ref == "refs/tags/edge")] | length`).requireCode(t, 0)
+	if strings.TrimSpace(refs.stdout) != "1" {
+		t.Fatalf("refs = %q, want one matching edge ref", refs.stdout)
+	}
+	commit := run(t, "", "gh", "api", "repos/atqamz/hand/commits/edge", "--jq", ".sha").requireCode(t, 0)
+	if strings.TrimSpace(commit.stdout) != contractGHEdgeSHA {
+		t.Fatalf("edge commit = %q, want %q", commit.stdout, contractGHEdgeSHA)
+	}
+}

--- a/tests/contract/gh_test.go
+++ b/tests/contract/gh_test.go
@@ -1,9 +1,10 @@
-//go:build contract
+//go:build contract && contractlive
 
 package contract
 
 import (
 	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -17,6 +18,13 @@ const (
 	ghMergedPR  = "154"
 	ghMergedRef = "136-usage-limit-resume"
 )
+
+func requireBin(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s is not on PATH", name)
+	}
+}
 
 func requireGH(t *testing.T) {
 	t.Helper()

--- a/tests/contract/herdr_test.go
+++ b/tests/contract/herdr_test.go
@@ -1,4 +1,4 @@
-//go:build contract
+//go:build contract && contractlive
 
 package contract
 

--- a/tests/contract/treehouse_test.go
+++ b/tests/contract/treehouse_test.go
@@ -1,4 +1,4 @@
-//go:build contract
+//go:build contract && contractlive
 
 package contract
 


### PR DESCRIPTION
## Summary

- Make `make contract` hermetic by exercising shared `gh` fixtures only, with real `gh`, `herdr`, and `treehouse` probes retained in `make contract-live`.
- Exercise empty results, HTTP 503, DNS lookup, dial timeout, stderr, and exit-code `gh` failure shapes, and document the observed fidelity contract.
- Run the default contract lane in CI and require it before edge publication.

Closes atqamz/hand#243

## Offline proof

Ran `nix shell nixpkgs#bubblewrap -c bwrap --unshare-net --bind / / --dev-bind /dev /dev --proc /proc --chdir /home/atqa/.treehouse/secondhand-a7a4d5/2/secondhand nix develop -c make contract` successfully.
Repeated the same network-isolated default lane three times with no nondeterminism.

## Assertion inventory

- `gh pr list` empty output, slug casing, canonical repository response, missing PR diagnostics, check buckets, and both edge-ref outcomes now run against `tests/contract/gh_fake_test.go` fixtures.
- Real `gh`, `herdr`, and `treehouse` observations remain in `make contract-live`, invoked with `nix develop -c make contract-live`, because they validate installed external tools and, for GitHub, a live API.
- `internal/faketool/FIDELITY.md` now records transport and service failures, including HTTP 503, DNS lookup, dial timeout, nonzero stderr, and empty successful output.

## Test plan

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `nix develop -c make lint`
- `nix develop -c make build`
- `nix develop -c make contract`
- `nix develop -c make e2e`
- `nix flake check --print-build-logs`
- `git diff --check`
