### PR TITLE
fix(runtime): converge terminal attempt lifecycle and gate worktree return on commit safety

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -24,6 +24,11 @@ func newReconcileCmd() *cobra.Command {
 			"the landing cannot be observed at all the reported landing is `unknown`, no lifecycle value is\n" +
 			"invented, and the condition is recorded as needs-repair instead. Convergence releases no resource\n" +
 			"of its own, so a Herdr or worktree resource that needs repair never holds the lifecycle back.\n\n" +
+			"Automatic worktree return also requires proof that no commit exists only there: a commit reachable\n" +
+			"from a remote-tracking ref, or one GitHub records as the head of the task pull request, is held\n" +
+			"elsewhere too. Unpushed commits withhold the return, and so does a comparison that could not be\n" +
+			"made at all, recorded as its own condition rather than as work found at risk. The Attempt stays\n" +
+			"terminal either way, and reconciling the withheld state again changes nothing.\n\n" +
 			"--abandon-worktree attests that Hand relinquishes a recorded Treehouse lease whose pool cannot be\n" +
 			"observed at all, for instance after the pool key moved. It needs an explicit task ID, it refuses any\n" +
 			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -18,6 +18,12 @@ func newReconcileCmd() *cobra.Command {
 		Use:   "reconcile [id]",
 		Short: "Converge durable task state with observed external reality",
 		Long: "Converge durable task state with observed external reality.\n\n" +
+			"A running Attempt whose recorded Herdr pane is observed absent reaches a terminal lifecycle here,\n" +
+			"without `hand teardown`. Landing evidence picks which one: an observed merge, a recorded delivery\n" +
+			"or a scout report on disk completes it, and positively observed unlanded work interrupts it. Where\n" +
+			"the landing cannot be observed at all the reported landing is `unknown`, no lifecycle value is\n" +
+			"invented, and the condition is recorded as needs-repair instead. Convergence releases no resource\n" +
+			"of its own, so a Herdr or worktree resource that needs repair never holds the lifecycle back.\n\n" +
 			"--abandon-worktree attests that Hand relinquishes a recorded Treehouse lease whose pool cannot be\n" +
 			"observed at all, for instance after the pool key moved. It needs an explicit task ID, it refuses any\n" +
 			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
@@ -71,6 +77,9 @@ func renderReconcileReport(cmd *cobra.Command, report runtime.ReconcileReport, a
 		doc.Int("iterations", result.Iterations)
 		if result.AttemptID != 0 {
 			doc.Field("attempt", fmt.Sprintf("%d", result.AttemptID))
+		}
+		if result.Landing != "" {
+			doc.Field("landing", result.Landing)
 		}
 		if result.RepairCode != "" {
 			doc.Field("repair_code", result.RepairCode)

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -42,7 +42,10 @@ func TestReconcileCommandRendersNeedsRepairAndReturnsPrecondition(t *testing.T) 
 	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}}); err != nil {
+	if _, err := state.CreateAttempt(home, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	}); err != nil {
 		t.Fatal(err)
 	}
 	faketool.Herdr{Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}}}.Install(t, faketool.Bin(t))
@@ -55,8 +58,40 @@ func TestReconcileCommandRendersNeedsRepairAndReturnsPrecondition(t *testing.T) 
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
 		t.Fatalf("reconcile error = %v, want precondition exit 3", err)
 	}
-	if !bytes.Contains(out.Bytes(), []byte("repair_code: running-pane-missing")) || !bytes.Contains(out.Bytes(), []byte("result: needs-repair")) {
+	if !bytes.Contains(out.Bytes(), []byte("repair_code: launch-submitted-pane-missing")) || !bytes.Contains(out.Bytes(), []byte("result: needs-repair")) {
 		t.Fatalf("reconcile output = %q, want repair result", out.String())
+	}
+}
+
+func TestReconcileCommandRendersConvergedTerminalLifecycle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HAND_HOME", home)
+	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}}); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{Command: "workspace list", Stdout: `{"id":"cli:1","result":{"workspaces":[]}}`}}}.Install(t, faketool.Bin(t))
+	cmd := newReconcileCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("landing: unlanded")) || !bytes.Contains(out.Bytes(), []byte("converged to interrupted")) {
+		t.Fatalf("reconcile output = %q, want the converged landing and detail", out.String())
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt != nil || history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("history = %+v, want the Attempt converged without hand teardown", history)
 	}
 }
 

--- a/docs/adr/deterministic-reconciliation-observes-before-mutating.md
+++ b/docs/adr/deterministic-reconciliation-observes-before-mutating.md
@@ -29,7 +29,8 @@ Its persisted harness, model, effort, execution class, planned-against commit, r
 There is no automatic worker, harness, model, or profile fallback.
 
 Automatic resource cleanup requires exact ownership proof and a clean worktree.
-Dirty worktrees, incomplete or reused identities, missing running workers, and ambiguous launch evidence become `needs-repair`.
+Dirty worktrees, incomplete or reused identities, and ambiguous launch evidence become `needs-repair`.
+A running Attempt whose Herdr pane is observed absent instead converges to a terminal lifecycle from observed landing evidence, without an operator running `hand teardown`; it becomes `needs-repair` only where that landing itself cannot be observed.
 Released historical Herdr resources remain attributed anomalies when matching live identities are observed; reconciliation reports them without closing the resource.
 The reconciler does not run as a daemon and does not implement the send protocol.
 

--- a/docs/adr/deterministic-reconciliation-observes-before-mutating.md
+++ b/docs/adr/deterministic-reconciliation-observes-before-mutating.md
@@ -2,8 +2,8 @@
 
 - Date: 2026-08-15
 - Status: accepted
-- Issues: atqamz/hand#196
-- PRs: atqamz/hand#229
+- Issues: atqamz/hand#196, atqamz/hand#239
+- PRs: atqamz/hand#229, atqamz/hand#251
 
 ## Context
 
@@ -28,9 +28,12 @@ An existing Attempt is never rerouted during reconciliation.
 Its persisted harness, model, effort, execution class, planned-against commit, requested profile, and routing source remain the only execution identity.
 There is no automatic worker, harness, model, or profile fallback.
 
-Automatic resource cleanup requires exact ownership proof and a clean worktree.
-Dirty worktrees, incomplete or reused identities, and ambiguous launch evidence become `needs-repair`.
+Automatic resource cleanup requires exact ownership proof, a clean worktree, and positive proof that returning the worktree discards no commit held nowhere else.
+That last proof is a three-state observation rather than a boolean: the work is proven durable, found at risk, or unprovable, and only the first permits an automatic return.
+A clean `git status` is not that proof, because a clean worktree can still hold the only copy of a commit.
+Dirty worktrees, incomplete or reused identities, ambiguous launch evidence, commits reachable from no other copy, and a commit comparison that cannot be made become `needs-repair`.
 A running Attempt whose Herdr pane is observed absent instead converges to a terminal lifecycle from observed landing evidence, without an operator running `hand teardown`; it becomes `needs-repair` only where that landing itself cannot be observed.
+Resource cleanup and Attempt lifecycle stay orthogonal in both directions: an Attempt stays terminal while its worktree return is withheld, and the withheld return records a Task repair marker without reopening the Attempt.
 Released historical Herdr resources remain attributed anomalies when matching live identities are observed; reconciliation reports them without closing the resource.
 The reconciler does not run as a daemon and does not implement the send protocol.
 
@@ -50,4 +53,5 @@ Command rendering stays in Cobra, and status remains read-only.
 The command can safely progress through several durable checkpoints in one invocation while the iteration guard prevents a logic loop.
 Ambiguous ownership is resolved only by a fresh exact observation or an operator action explicitly supported by the owning resource decision, and dirty work remains manual.
 A worker that disappears while running is not silently replaced.
+A converged Attempt keeps its worktree until durability is proven, so unpushed or unprovable work stays on disk for the operator, and reconciling that state again leaves durable state unchanged.
 `unobservable-ownership-is-not-a-mismatch.md` adds the one supported gesture for a treehouse pool that can no longer be observed at all.

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -257,6 +257,12 @@ Exit 0 with the JSON object on stdout.
 A PR that does not exist is exit 1 with a GraphQL error on stderr.
 Real `gh` also writes warnings to stderr ahead of the JSON, which is why callers read stdout alone.
 
+### `gh pr view <url-or-number> --json headRefOid`
+
+Exit 0 with the head branch's current commit SHA on stdout, the same GraphQL warnings-before-JSON shape as `--json state`.
+`PRHeadCommit` reads this rather than a local clone because GitHub's record of the head ref outlives that clone and survives the branch being deleted after a merge.
+A merged PR still answers with the SHA the head branch pointed at before deletion, so `PRHeadCommit` remains usable on a PR whose branch is long gone.
+
 ### `gh pr checks <url-or-number> --json bucket`
 
 Exit 0 with every check's bucket on stdout when they all pass.

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -14,13 +14,14 @@ import (
 
 // GHPR describes one pull request and the checks its fake reports.
 type GHPR struct {
-	Number   int
-	URL      string
-	Branch   string
-	State    string
-	Repo     string
-	HeadRepo string
-	Checks   []string
+	Number     int
+	URL        string
+	Branch     string
+	State      string
+	Repo       string
+	HeadRepo   string
+	HeadRefOid string
+	Checks     []string
 }
 
 type GHRepo struct {
@@ -201,12 +202,18 @@ func ghPRView(spec ghSpec, args []string) int {
 	if !ok {
 		return fail("no such pull request: %s", args[2])
 	}
-	state, err := os.ReadFile(ghStatePath(spec.StateDir, index))
-	if err != nil {
-		return fail("read gh pull request state: %v", err)
+	switch flagValue(args, "--json") {
+	case "headRefOid":
+		_, _ = fmt.Fprintf(os.Stdout, "{\"headRefOid\":%s}\n", jsonQuote(spec.PRs[index].HeadRefOid))
+		return 0
+	default:
+		state, err := os.ReadFile(ghStatePath(spec.StateDir, index))
+		if err != nil {
+			return fail("read gh pull request state: %v", err)
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "{\"state\":%s}\n", jsonQuote(strings.TrimSpace(string(state))))
+		return 0
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "{\"state\":%s}\n", jsonQuote(strings.TrimSpace(string(state))))
-	return 0
 }
 
 func ghPRList(spec ghSpec, args []string) int {

--- a/internal/ghutil/pr.go
+++ b/internal/ghutil/pr.go
@@ -34,6 +34,29 @@ func PRIsMerged(ctx context.Context, pr string) (bool, error) {
 	return body.State == "MERGED", nil
 }
 
+// PRHeadCommit reads the commit GitHub records as the PR head ref: the newest commit of that branch
+// GitHub was observed holding, which outlives any local clone and survives the head branch being
+// deleted after a merge.
+func PRHeadCommit(ctx context.Context, pr string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "headRefOid")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh pr view failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	var body struct {
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		return "", fmt.Errorf("parse gh pr view output: %w", err)
+	}
+	if body.HeadRefOid == "" {
+		return "", fmt.Errorf("gh pr view reported no head commit for %q", pr)
+	}
+	return body.HeadRefOid, nil
+}
+
 // PRSearchTarget names one repo FindPRByBranch searches for a head ref.
 type PRSearchTarget struct {
 	Repo string

--- a/internal/ghutil/pr_test.go
+++ b/internal/ghutil/pr_test.go
@@ -329,3 +329,22 @@ func TestRepoSlugFromRemote(t *testing.T) {
 		}
 	}
 }
+
+func TestPRHeadCommitReadsTheRecordedHeadRef(t *testing.T) {
+	faketool.GH{Responses: []faketool.GHResponse{{
+		Command: "pr view",
+		Stderr:  "Warning: gh version 2.40.0 is out of date",
+		Stdout:  "{\"headRefOid\":\"1111111111111111111111111111111111111111\"}\n",
+	}}}.Install(t, faketool.Bin(t))
+	got, err := PRHeadCommit(context.Background(), "42")
+	if err != nil || got != "1111111111111111111111111111111111111111" {
+		t.Fatalf("PRHeadCommit() = %q, %v, want the recorded head commit", got, err)
+	}
+}
+
+func TestPRHeadCommitRefusesAnEmptyHeadRef(t *testing.T) {
+	faketool.GH{Responses: []faketool.GHResponse{{Command: "pr view", Stdout: "{}\n"}}}.Install(t, faketool.Bin(t))
+	if _, err := PRHeadCommit(context.Background(), "42"); err == nil {
+		t.Fatal("want an error rather than an empty head commit standing in as evidence")
+	}
+}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -32,6 +32,7 @@ type worktreeDependencies struct {
 	get            func(string, string) (worktree.Lease, error)
 	observeLease   func(string, string) worktree.LeaseObservation
 	observeClean   func(string) (worktree.Cleanliness, error)
+	observeCommits func(string) worktree.CommitSafetyObservation
 	headCommit     func(string) (string, error)
 	returnWorktree func(string, bool) error
 	returnWithID   func(string, string, bool) error
@@ -47,6 +48,7 @@ type dependencies struct {
 	confirmLaunch     func(herdrClient, string, string) error
 	appendCompletion  func(string, completion.Record) error
 	prMerged          func(context.Context, string) (bool, error)
+	prHead            func(context.Context, string) (string, error)
 	branchMerged      func(string, string) (bool, error)
 	phase             func(lifecyclePhase) error
 }
@@ -59,12 +61,13 @@ func defaultDependencies() dependencies {
 	return dependencies{
 		now:               func() time.Time { return time.Now().UTC() },
 		herdr:             newHerdrClient,
-		worktree:          worktreeDependencies{get: worktree.Get, observeLease: worktree.ObserveLease, observeClean: worktree.ObserveCleanliness, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision},
+		worktree:          worktreeDependencies{get: worktree.Get, observeLease: worktree.ObserveLease, observeClean: worktree.ObserveCleanliness, observeCommits: worktree.ObserveCommitSafety, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision},
 		projectBaseCommit: projectBaseCommit,
 		buildHarness:      harness.Build,
 		confirmLaunch:     confirmLaunch,
 		appendCompletion:  completion.Append,
 		prMerged:          ghutil.PRIsMerged,
+		prHead:            ghutil.PRHeadCommit,
 		branchMerged:      branchIsMerged,
 		phase:             func(lifecyclePhase) error { return nil },
 	}

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -44,8 +44,6 @@ const (
 	treehouseLeaseUnknown    treehouseLeaseState = "unknown"
 )
 
-// Follows worktree.LeaseObservation: an observation that could not be made is unknown and never
-// collapses into a definite negative, because the terminal value this picks enters permanent history.
 type landingState string
 
 const (
@@ -350,8 +348,6 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		case reconciliationActionBlocked:
 			result.Outcome = reconcileOutcomeBlocked
 			return result, fmt.Errorf("reconciliation observation was incomplete")
-		// Ahead of every repair branch below, including the one that reports a marker another resource
-		// already recorded: a repair on one resource is exactly what must not hold this lifecycle back.
 		case reconciliationActionConvergeTerminal:
 			if err := r.convergeTerminalLifecycle(home, history.Task, attempt, decision); err != nil {
 				return result, err
@@ -468,9 +464,6 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 	return merged, !merged, "local-git", nil
 }
 
-// Never fails, for the reason ObserveLease does not: an observation that could not be made is not
-// evidence that nothing landed, and recording it as such would write a false outcome into the
-// permanent completion record of a task that may well have delivered.
 func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Task, mergeObserved bool) landingState {
 	if mergeObserved || task.DeliveredAt != "" {
 		return landingLanded
@@ -501,15 +494,11 @@ func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Ta
 	return landingUnlanded
 }
 
-// Terminal convergence turns on the pane observation alone, because that is the only evidence attempt
-// lifecycle depends on: a worktree or Herdr repair is about a different resource and must not hold it.
 func terminalConvergenceCandidate(attempt state.Attempt, observation reconciliationObservation) bool {
 	return attempt.Lifecycle == state.AttemptRunning && attempt.TeardownTerminalAttempt == "" &&
 		attempt.Herdr.PaneID != "" && observation.Herdr.State == herdrOwnershipAbsent
 }
 
-// Names the unknown landing in the repair marker rather than reporting the pane alone, so the durable
-// condition says which observation is missing and why convergence stopped.
 func runningPaneMissingReason(landing landingState) string {
 	if landing == landingUnknown {
 		return "persisted running Attempt has no matching Herdr pane and its landing evidence is unknown"
@@ -517,8 +506,6 @@ func runningPaneMissingReason(landing landingState) string {
 	return "persisted running Attempt has no matching Herdr pane"
 }
 
-// Landing evidence only chooses which terminal value the attempt reaches, so an unknown landing
-// converges nothing rather than guessing one.
 func decideTerminalConvergence(attempt state.Attempt, observation reconciliationObservation) (state.AttemptLifecycle, string, bool) {
 	if !terminalConvergenceCandidate(attempt, observation) {
 		return "", "", false
@@ -532,9 +519,6 @@ func decideTerminalConvergence(attempt state.Attempt, observation reconciliation
 	return "", "", false
 }
 
-// Records the terminal decision, the completion evidence and the lifecycle in the order teardown
-// uses, and releases no resource: releasing one can fail into needs-repair, and the lifecycle this
-// converges does not depend on any of them.
 func (r *Runtime) convergeTerminalLifecycle(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
 	if err := state.SetAttemptTeardownDecision(home, task.ID, attempt.ID, decision.TerminalAttempt, decision.Disposition); err != nil {
 		return fmt.Errorf("record converged teardown decision for attempt %d: %w", attempt.ID, err)

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -84,6 +84,8 @@ const (
 	repairCodeWorktreeOwnershipMismatch   = "worktree-ownership-mismatch"
 	repairCodeLegacyWorktreeUnprovable    = "legacy-worktree-ownership-unprovable"
 	repairCodeWorktreeUnobservable        = "worktree-ownership-unobservable"
+	repairCodeWorktreeLocalCommits        = "worktree-local-commits"
+	repairCodeWorktreeCommitSafetyUnknown = "worktree-commit-safety-unknown"
 	repairCodeTeardownResourceAmbiguous   = "teardown-resource-ambiguous"
 	repairCodeCompletionEvidenceMismatch  = "completion-evidence-mismatch"
 	repairCodeMergeFactMismatch           = "merge-fact-mismatch"
@@ -274,7 +276,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		}
 		if historical != nil {
 			result.AttemptID = historical.ID
-			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, *historical, abandonWorktree)
+			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, *historical, abandonWorktree)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
 				return result, err
@@ -310,7 +312,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		result.ExecutionClass, result.Profile = attempt.ExecutionClass, attempt.RequestedProfile
 		result.PlannedAgainst, result.RoutingSource = attempt.PlannedAgainst, attempt.RoutingSource
 		if attempt.TeardownTerminalAttempt != "" {
-			progress, decision, err := r.reconcileHistoricalAttempt(home, history.Task, attempt, abandonWorktree)
+			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, attempt, abandonWorktree)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
 				return result, err
@@ -775,7 +777,7 @@ func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) 
 	return nil, nil
 }
 
-func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attempt state.Attempt, abandonWorktree bool) (bool, reconciliationDecision, error) {
+func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, task state.Task, attempt state.Attempt, abandonWorktree bool) (bool, reconciliationDecision, error) {
 	if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
 		observation, err := observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
@@ -840,7 +842,7 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 			}
 			return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeOwnershipMismatch, "historical worktree path is held by a different Treehouse lease"), nil
 		case worktree.LeaseAbsent:
-			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable); err != nil {
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeWorktreeLocalCommits, repairCodeWorktreeCommitSafetyUnknown); err != nil {
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
@@ -861,7 +863,11 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 			if clean != worktree.Clean {
 				return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeDirty, "historical worktree is dirty; automatic reconciliation will not discard it"), nil
 			}
-			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeLegacyWorktreeUnprovable); err != nil {
+			safety := r.resolveWorktreeCommitSafety(ctx, task, attempt)
+			if safety.State != commitSafetyProvenDurable {
+				return false, repairDecision(reconciliationDecision{}, commitSafetyRepairCode(safety.State), safety.Reason), nil
+			}
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeLocalCommits, repairCodeWorktreeCommitSafetyUnknown); err != nil {
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
@@ -1005,6 +1011,7 @@ func terminalRepairCanBeResolved(code string) bool {
 		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
 		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeWorktreeDirty,
 		repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeUnobservable,
+		repairCodeWorktreeLocalCommits, repairCodeWorktreeCommitSafetyUnknown,
 		repairCodeTeardownResourceAmbiguous:
 		return true
 	default:
@@ -1018,7 +1025,8 @@ func terminalRepairEvidenceResolved(code string, attempt state.Attempt) bool {
 		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
 		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeTeardownResourceAmbiguous:
 		return !hasHerdrIdentity(attempt.Herdr) || attempt.TeardownHerdrState == state.TeardownResourceReleased
-	case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeUnobservable:
+	case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeUnobservable,
+		repairCodeWorktreeLocalCommits, repairCodeWorktreeCommitSafetyUnknown:
 		return attempt.Worktree == "" || worktreeCleanupSettled(attempt.TeardownWorktreeState)
 	default:
 		return false
@@ -1260,6 +1268,89 @@ func unobservableWorktreeReason(attempt state.Attempt, probe worktree.LeaseProbe
 	return fmt.Sprintf(
 		"recorded worktree ownership could not be observed: %s; observed by running %q with working directory %s, which is what selects the pool; recorded lease %s is neither proven nor disproven; destructive cleanup refused because ownership could not be proven, not because a lease mismatched",
 		probe.Reason, probe.Command, probe.WorkingDir, lease)
+}
+
+type commitSafety string
+
+const (
+	commitSafetyProvenDurable   commitSafety = "proven-durable"
+	commitSafetyLocalWorkAtRisk commitSafety = "local-work-at-risk"
+	commitSafetyUnprovable      commitSafety = "unprovable"
+)
+
+type commitSafetyDecision struct {
+	State  commitSafety
+	Reason string
+}
+
+func (r *Runtime) resolveWorktreeCommitSafety(ctx context.Context, task state.Task, attempt state.Attempt) commitSafetyDecision {
+	observeCommits := r.deps.worktree.observeCommits
+	if observeCommits == nil {
+		observeCommits = worktree.ObserveCommitSafety
+	}
+	observation := observeCommits(attempt.Worktree)
+	switch observation.State {
+	case worktree.CommitSafetyRemoteObserved:
+		return commitSafetyDecision{
+			State:  commitSafetyProvenDurable,
+			Reason: fmt.Sprintf("every commit reachable from %s in %s is also reachable from one of the %d remote-tracking refs this clone holds, so returning the worktree discards nothing", shortCommit(observation.Probe.Head), observation.Probe.WorkingDir, observation.Probe.RemoteRefs),
+		}
+	case worktree.CommitSafetyUnknown:
+		return commitSafetyDecision{State: commitSafetyUnprovable, Reason: unprovableCommitSafetyReason(attempt, observation.Probe)}
+	}
+	if task.PR == "" {
+		return commitSafetyDecision{
+			State:  commitSafetyLocalWorkAtRisk,
+			Reason: localOnlyCommitsReason(observation.Probe, "no pull request is recorded for this task, so no pushed head can hold them either"),
+		}
+	}
+	prHead := r.deps.prHead
+	if prHead == nil {
+		prHead = ghutil.PRHeadCommit
+	}
+	pushedHead, err := prHead(ctx, task.PR)
+	if err != nil {
+		return commitSafetyDecision{
+			State:  commitSafetyUnprovable,
+			Reason: fmt.Sprintf("%d commit(s) in %s are reachable from no remote-tracking ref and the head commit of pull request %s could not be read, so whether GitHub holds them is unobserved rather than answered: %v", observation.Probe.LocalOnly, observation.Probe.WorkingDir, task.PR, err),
+		}
+	}
+	if pushedHead == observation.Probe.Head {
+		return commitSafetyDecision{
+			State:  commitSafetyProvenDurable,
+			Reason: fmt.Sprintf("no remote-tracking ref in %s reaches %s, and GitHub records that exact commit as the head of pull request %s, which holds it independently of this worktree", observation.Probe.WorkingDir, shortCommit(observation.Probe.Head), task.PR),
+		}
+	}
+	return commitSafetyDecision{
+		State:  commitSafetyLocalWorkAtRisk,
+		Reason: localOnlyCommitsReason(observation.Probe, fmt.Sprintf("pull request %s records head commit %s instead, so GitHub was never observed holding %s", task.PR, shortCommit(pushedHead), shortCommit(observation.Probe.Head))),
+	}
+}
+
+func commitSafetyRepairCode(safety commitSafety) string {
+	if safety == commitSafetyLocalWorkAtRisk {
+		return repairCodeWorktreeLocalCommits
+	}
+	return repairCodeWorktreeCommitSafetyUnknown
+}
+
+func localOnlyCommitsReason(probe worktree.CommitSafetyProbe, unheldBecause string) string {
+	return fmt.Sprintf(
+		"%d commit(s) in %s are reachable from none of the %d remote-tracking refs this clone holds, and %s; observed by running %q with working directory %s; automatic reconciliation will not discard work no other copy is known to hold",
+		probe.LocalOnly, probe.WorkingDir, probe.RemoteRefs, unheldBecause, probe.Command, probe.WorkingDir)
+}
+
+func unprovableCommitSafetyReason(attempt state.Attempt, probe worktree.CommitSafetyProbe) string {
+	return fmt.Sprintf(
+		"whether worktree %s still holds the only copy of any commit could not be observed: %s; observed by running %q with working directory %s; the return is withheld because the question went unanswered, not because work was found at risk",
+		attempt.Worktree, probe.Reason, probe.Command, probe.WorkingDir)
+}
+
+func shortCommit(commit string) string {
+	if len(commit) <= 12 {
+		return commit
+	}
+	return commit[:12]
 }
 
 func repairDecision(decision reconciliationDecision, code, reason string) reconciliationDecision {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -26,6 +27,7 @@ const (
 	reconciliationActionConfirmLaunch        reconciliationAction = "confirm-launch"
 	reconciliationActionMarkRunning          reconciliationAction = "mark-running"
 	reconciliationActionCleanupTerminal      reconciliationAction = "cleanup-terminal-resources"
+	reconciliationActionConvergeTerminal     reconciliationAction = "converge-terminal-lifecycle"
 	reconciliationActionAbandonWorktree      reconciliationAction = "abandon-worktree"
 	reconciliationActionNeedsRepair          reconciliationAction = "needs-repair"
 	reconciliationActionBlocked              reconciliationAction = "blocked"
@@ -40,6 +42,16 @@ const (
 	treehouseLeaseMismatch   treehouseLeaseState = "mismatch"
 	treehouseLeaseUnprovable treehouseLeaseState = "unprovable"
 	treehouseLeaseUnknown    treehouseLeaseState = "unknown"
+)
+
+// Follows worktree.LeaseObservation: an observation that could not be made is unknown and never
+// collapses into a definite negative, because the terminal value this picks enters permanent history.
+type landingState string
+
+const (
+	landingLanded   landingState = "landed"
+	landingUnlanded landingState = "unlanded"
+	landingUnknown  landingState = "unknown"
 )
 
 type worktreeState string
@@ -97,21 +109,24 @@ type reconciliationObservation struct {
 	Treehouse        treehouseObservation
 	Worktree         worktreeObservation
 	Herdr            herdrObservation
+	Landing          landingState
 	ObservationError bool
 }
 
 type reconciliationDecision struct {
-	Action         reconciliationAction
-	RepairCode     string
-	RepairReason   string
-	Harness        string
-	Model          string
-	Effort         string
-	ExecutionClass string
-	PlannedAgainst string
-	Profile        string
-	RoutingSource  string
-	Detail         string
+	Action          reconciliationAction
+	TerminalAttempt state.AttemptLifecycle
+	Disposition     string
+	RepairCode      string
+	RepairReason    string
+	Harness         string
+	Model           string
+	Effort          string
+	ExecutionClass  string
+	PlannedAgainst  string
+	Profile         string
+	RoutingSource   string
+	Detail          string
 }
 
 type ReconcileRequest struct {
@@ -127,6 +142,7 @@ type ReconcileResult struct {
 	Action         string `json:"action"`
 	Iterations     int    `json:"iterations"`
 	AttemptID      int64  `json:"attempt,omitempty"`
+	Landing        string `json:"landing,omitempty"`
 	RepairCode     string `json:"repair_code,omitempty"`
 	RepairReason   string `json:"repair_reason,omitempty"`
 	Harness        string `json:"harness,omitempty"`
@@ -227,6 +243,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		}
 		mergeObserved, mergeMismatch, mergeSource, err := r.observeMerge(ctx, home, history)
 		if err != nil {
+			result.Landing = string(landingUnknown)
 			result.Outcome = reconcileOutcomeBlocked
 			return result, err
 		}
@@ -317,6 +334,10 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 			result.Outcome = reconcileOutcomeBlocked
 			return result, err
 		}
+		if terminalConvergenceCandidate(attempt, observation) {
+			observation.Landing = r.observeLanding(ctx, home, history.Task, mergeObserved)
+			result.Landing = string(observation.Landing)
+		}
 		decision := decideReconciliation(history.Task, attempt, observation)
 		result.Action = string(decision.Action)
 		switch decision.Action {
@@ -329,6 +350,14 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		case reconciliationActionBlocked:
 			result.Outcome = reconcileOutcomeBlocked
 			return result, fmt.Errorf("reconciliation observation was incomplete")
+		// Ahead of every repair branch below, including the one that reports a marker another resource
+		// already recorded: a repair on one resource is exactly what must not hold this lifecycle back.
+		case reconciliationActionConvergeTerminal:
+			if err := r.convergeTerminalLifecycle(home, history.Task, attempt, decision); err != nil {
+				return result, err
+			}
+			result.Outcome, result.Detail = reconcileOutcomeRecovered, decision.Detail
+			continue
 		}
 		if shouldClearRepair(history.Task, attempt, observation) {
 			if err := state.ClearTaskRepair(home, id, history.Task.RepairCode); err != nil {
@@ -437,6 +466,95 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 		return false, false, "local-git", fmt.Errorf("observe local merged branch for task %q: %w", task.ID, err)
 	}
 	return merged, !merged, "local-git", nil
+}
+
+// Never fails, for the reason ObserveLease does not: an observation that could not be made is not
+// evidence that nothing landed, and recording it as such would write a false outcome into the
+// permanent completion record of a task that may well have delivered.
+func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Task, mergeObserved bool) landingState {
+	if mergeObserved || task.DeliveredAt != "" {
+		return landingLanded
+	}
+	if task.Kind == state.KindScout {
+		if _, err := os.Stat(filepath.Join(home, "data", task.ID, "report.md")); err != nil {
+			if os.IsNotExist(err) {
+				return landingUnlanded
+			}
+			return landingUnknown
+		}
+		return landingLanded
+	}
+	if task.PR == "" {
+		return landingUnlanded
+	}
+	prMerged := r.deps.prMerged
+	if prMerged == nil {
+		prMerged = ghutil.PRIsMerged
+	}
+	merged, err := prMerged(ctx, task.PR)
+	if err != nil {
+		return landingUnknown
+	}
+	if merged {
+		return landingLanded
+	}
+	return landingUnlanded
+}
+
+// Terminal convergence turns on the pane observation alone, because that is the only evidence attempt
+// lifecycle depends on: a worktree or Herdr repair is about a different resource and must not hold it.
+func terminalConvergenceCandidate(attempt state.Attempt, observation reconciliationObservation) bool {
+	return attempt.Lifecycle == state.AttemptRunning && attempt.TeardownTerminalAttempt == "" &&
+		attempt.Herdr.PaneID != "" && observation.Herdr.State == herdrOwnershipAbsent
+}
+
+// Names the unknown landing in the repair marker rather than reporting the pane alone, so the durable
+// condition says which observation is missing and why convergence stopped.
+func runningPaneMissingReason(landing landingState) string {
+	if landing == landingUnknown {
+		return "persisted running Attempt has no matching Herdr pane and its landing evidence is unknown"
+	}
+	return "persisted running Attempt has no matching Herdr pane"
+}
+
+// Landing evidence only chooses which terminal value the attempt reaches, so an unknown landing
+// converges nothing rather than guessing one.
+func decideTerminalConvergence(attempt state.Attempt, observation reconciliationObservation) (state.AttemptLifecycle, string, bool) {
+	if !terminalConvergenceCandidate(attempt, observation) {
+		return "", "", false
+	}
+	switch observation.Landing {
+	case landingLanded:
+		return state.AttemptCompleted, state.TeardownDispositionCompleted, true
+	case landingUnlanded:
+		return state.AttemptInterrupted, state.TeardownDispositionWorkerExitedUnlanded, true
+	}
+	return "", "", false
+}
+
+// Records the terminal decision, the completion evidence and the lifecycle in the order teardown
+// uses, and releases no resource: releasing one can fail into needs-repair, and the lifecycle this
+// converges does not depend on any of them.
+func (r *Runtime) convergeTerminalLifecycle(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
+	if err := state.SetAttemptTeardownDecision(home, task.ID, attempt.ID, decision.TerminalAttempt, decision.Disposition); err != nil {
+		return fmt.Errorf("record converged teardown decision for attempt %d: %w", attempt.ID, err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionPending); err != nil {
+		return fmt.Errorf("record converged completion phase for attempt %d: %w", attempt.ID, err)
+	}
+	record := completionFor(task, decision.Disposition, true)
+	record.AttemptID, record.AttemptLifecycle = attempt.ID, string(decision.TerminalAttempt)
+	record.TornDownAt = r.deps.now().Format(time.RFC3339)
+	if err := r.deps.appendCompletion(home, record); err != nil {
+		return fmt.Errorf("append converged completion for attempt %d: %w", attempt.ID, err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionAppended); err != nil {
+		return fmt.Errorf("record converged completion evidence for attempt %d: %w", attempt.ID, err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, task.ID, attempt.ID, attempt.Lifecycle, decision.TerminalAttempt); err != nil {
+		return fmt.Errorf("converge attempt %d to %s: %w", attempt.ID, decision.TerminalAttempt, err)
+	}
+	return nil
 }
 
 func mergeWorktreeAttempt(history state.TaskHistory) (*state.Attempt, error) {
@@ -687,6 +805,11 @@ func (r *Runtime) reconcileHistoricalAttempt(home string, task state.Task, attem
 				return false, reconciliationDecision{}, err
 			} else if cleared {
 				return true, reconciliationDecision{}, nil
+			}
+			if attempt.TeardownHerdrState == "" {
+				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceReleasing); err != nil {
+					return false, reconciliationDecision{}, err
+				}
 			}
 			if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceReleased); err != nil {
 				return false, reconciliationDecision{}, err
@@ -1030,6 +1153,12 @@ func decideReconciliation(_ state.Task, attempt state.Attempt, observation recon
 		decision.Action = reconciliationActionBlocked
 		return decision
 	}
+	if terminal, disposition, converge := decideTerminalConvergence(attempt, observation); converge {
+		decision.Action = reconciliationActionConvergeTerminal
+		decision.TerminalAttempt, decision.Disposition = terminal, disposition
+		decision.Detail = fmt.Sprintf("attempt %d converged to %s on observed evidence", attempt.ID, terminal)
+		return decision
+	}
 	if attempt.Worktree != "" {
 		switch observation.Treehouse.State {
 		case treehouseLeaseMismatch:
@@ -1057,7 +1186,7 @@ func decideReconciliation(_ state.Task, attempt state.Attempt, observation recon
 			return decision
 		}
 		if observation.Herdr.State == herdrOwnershipAbsent {
-			return repairDecision(decision, repairCodeRunningPaneMissing, "persisted running Attempt has no matching Herdr pane")
+			return repairDecision(decision, repairCodeRunningPaneMissing, runningPaneMissingReason(observation.Landing))
 		}
 		if observation.Herdr.State == herdrOwnershipMismatch {
 			return repairDecision(decision, repairCodeRunningPaneIdentityMismatch, "persisted running Attempt points at a different Herdr resource")

--- a/internal/runtime/reconcile_commit_safety_test.go
+++ b/internal/runtime/reconcile_commit_safety_test.go
@@ -1,0 +1,346 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+const commitSafetyHead = "1111111111111111111111111111111111111111"
+
+func remoteObservedCommits(head string) worktree.CommitSafetyObservation {
+	return worktree.CommitSafetyObservation{
+		State: worktree.CommitSafetyRemoteObserved,
+		Probe: worktree.CommitSafetyProbe{Command: "git rev-list --count HEAD --not --remotes", WorkingDir: "/pool/1", Head: head, RemoteRefs: 2},
+	}
+}
+
+func localOnlyCommits(head string, count int) worktree.CommitSafetyObservation {
+	return worktree.CommitSafetyObservation{
+		State: worktree.CommitSafetyLocalOnly,
+		Probe: worktree.CommitSafetyProbe{Command: "git rev-list --count HEAD --not --remotes", WorkingDir: "/pool/1", Head: head, LocalOnly: count, RemoteRefs: 2},
+	}
+}
+
+func unobservableCommits(reason string) worktree.CommitSafetyObservation {
+	return worktree.CommitSafetyObservation{
+		State: worktree.CommitSafetyUnknown,
+		Probe: worktree.CommitSafetyProbe{Command: "git rev-list --count HEAD --not --remotes", WorkingDir: "/pool/1", Reason: reason},
+	}
+}
+
+func commitSafetyTask(t *testing.T, pr string, merged bool) (string, state.Attempt) {
+	t.Helper()
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if pr != "" {
+		if err := state.SetTaskPR(home, "task-1", pr); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if merged {
+		if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:02Z"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	return home, attempt
+}
+
+type commitSafetyProbeCount struct {
+	returns int
+	commits int
+}
+
+func commitSafetyRuntime(t *testing.T, observation worktree.CommitSafetyObservation) (*Runtime, *commitSafetyProbeCount) {
+	t.Helper()
+	counts := &commitSafetyProbeCount{}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.worktree.observeCommits = func(path string) worktree.CommitSafetyObservation {
+		counts.commits++
+		if path != "/pool/1" {
+			t.Fatalf("observeCommits(%q), want the recorded worktree", path)
+		}
+		return observation
+	}
+	r.deps.worktree.returnWithID = func(string, string, bool) error {
+		counts.returns++
+		return nil
+	}
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.prHead = func(context.Context, string) (string, error) {
+		t.Fatal("prHead called without a stub")
+		return "", nil
+	}
+	return r, counts
+}
+
+func reconcileNeedsRepair(t *testing.T, r *Runtime, home string) ReconcileResult {
+	t.Helper()
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Results) != 1 || report.Results[0].Outcome != reconcileOutcomeRepair {
+		t.Fatalf("report = %+v, want a single needs-repair result", report)
+	}
+	return report.Results[0]
+}
+
+func reconcileConverges(t *testing.T, r *Runtime, home string) {
+	t.Helper()
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Results) != 1 || report.Results[0].Outcome == reconcileOutcomeRepair {
+		t.Fatalf("report = %+v, want reconciliation to converge without repair", report)
+	}
+}
+
+func TestReconcileReturnsWorktreeWhenNoCommitIsLocalOnly(t *testing.T) {
+	home, _ := commitSafetyTask(t, "", false)
+	r, counts := commitSafetyRuntime(t, remoteObservedCommits(commitSafetyHead))
+	reconcileConverges(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.returns != 1 || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Task.RepairCode != "" {
+		t.Fatalf("returns=%d attempt=%+v task=%+v, want one proven return and no repair", counts.returns, history.Attempts[0], history.Task)
+	}
+}
+
+func TestReconcileRefusesDirtyWorktreeBeforeAskingAboutCommits(t *testing.T) {
+	home, _ := commitSafetyTask(t, "", false)
+	r, counts := commitSafetyRuntime(t, remoteObservedCommits(commitSafetyHead))
+	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+	reconcileNeedsRepair(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeDirty || counts.returns != 0 || counts.commits != 0 {
+		t.Fatalf("task=%+v returns=%d commits=%d, want the existing dirty refusal ahead of any commit observation", history.Task, counts.returns, counts.commits)
+	}
+	if history.Attempts[0].TeardownWorktreeState != "" {
+		t.Fatalf("worktree state = %q, want no cleanup recorded", history.Attempts[0].TeardownWorktreeState)
+	}
+}
+
+func TestReconcileWithholdsReturnForOneUnpushedCommit(t *testing.T) {
+	home, attempt := commitSafetyTask(t, "", false)
+	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 1))
+	reconcileNeedsRepair(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeLocalCommits || history.Task.RepairAttemptID != attempt.ID || counts.returns != 0 {
+		t.Fatalf("task=%+v returns=%d, want the local-only commit recorded against the attempt and no return", history.Task, counts.returns)
+	}
+	if history.Attempts[0].TeardownWorktreeState != "" {
+		t.Fatalf("worktree state = %q, want no cleanup recorded", history.Attempts[0].TeardownWorktreeState)
+	}
+	if !strings.Contains(history.Task.RepairReason, "1 commit(s)") || !strings.Contains(history.Task.RepairReason, "no pull request is recorded") {
+		t.Fatalf("repair reason = %q, want the count and the missing pull request named", history.Task.RepairReason)
+	}
+}
+
+func TestReconcileWithholdsReturnForSeveralUnpushedCommits(t *testing.T) {
+	home, _ := commitSafetyTask(t, "", false)
+	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 4))
+	reconcileNeedsRepair(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeLocalCommits || counts.returns != 0 {
+		t.Fatalf("task=%+v returns=%d, want the local-only commits recorded and no return", history.Task, counts.returns)
+	}
+	if !strings.Contains(history.Task.RepairReason, "4 commit(s)") {
+		t.Fatalf("repair reason = %q, want all four commits counted", history.Task.RepairReason)
+	}
+}
+
+func TestReconcileWithholdsReturnWhenCommitSafetyCannotBeObserved(t *testing.T) {
+	cases := []struct {
+		name        string
+		pr          string
+		observation worktree.CommitSafetyObservation
+		prHead      func(context.Context, string) (string, error)
+		wantReason  string
+	}{
+		{
+			name:        "no remote configured",
+			observation: unobservableCommits("the clone holds no remote-tracking ref, so no commit here can be compared against one"),
+			wantReason:  "holds no remote-tracking ref",
+		},
+		{
+			name:        "pruned remote-tracking ref",
+			observation: unobservableCommits("the branch records upstream origin/topic and no remote-tracking ref for it survives, so what the remote holds is no longer recorded here"),
+			wantReason:  "no remote-tracking ref for it survives",
+		},
+		{
+			name:        "github unreachable",
+			pr:          "https://github.com/atqamz/hand/pull/7",
+			observation: localOnlyCommits(commitSafetyHead, 1),
+			prHead: func(context.Context, string) (string, error) {
+				return "", errors.New("gh pr view failed: dial tcp: lookup api.github.com: no such host")
+			},
+			wantReason: "could not be read",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, _ := commitSafetyTask(t, tc.pr, false)
+			r, counts := commitSafetyRuntime(t, tc.observation)
+			if tc.prHead != nil {
+				r.deps.prHead = tc.prHead
+			}
+			reconcileNeedsRepair(t, r, home)
+			history, err := state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Task.RepairCode != repairCodeWorktreeCommitSafetyUnknown || counts.returns != 0 {
+				t.Fatalf("task=%+v returns=%d, want an unknown answer recorded and no return", history.Task, counts.returns)
+			}
+			if history.Attempts[0].TeardownWorktreeState != "" {
+				t.Fatalf("worktree state = %q, want no cleanup recorded", history.Attempts[0].TeardownWorktreeState)
+			}
+			if !strings.Contains(history.Task.RepairReason, tc.wantReason) {
+				t.Fatalf("repair reason = %q, want %q named so this cause is distinguishable", history.Task.RepairReason, tc.wantReason)
+			}
+			if strings.Contains(history.Task.RepairReason, "will not discard work") {
+				t.Fatalf("repair reason = %q, must not record an unanswered question as work found at risk", history.Task.RepairReason)
+			}
+		})
+	}
+}
+
+func TestReconcileReturnsWorktreeOfPushedAndMergedPullRequest(t *testing.T) {
+	home, _ := commitSafetyTask(t, "https://github.com/atqamz/hand/pull/7", true)
+	r, counts := commitSafetyRuntime(t, remoteObservedCommits(commitSafetyHead))
+	reconcileConverges(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.returns != 1 || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Task.RepairCode != "" {
+		t.Fatalf("returns=%d attempt=%+v task=%+v, want ordinary cleanup of merged pushed work", counts.returns, history.Attempts[0], history.Task)
+	}
+}
+
+func TestReconcileReturnsSquashMergedWorktreeOnPullRequestHeadEvidence(t *testing.T) {
+	home, _ := commitSafetyTask(t, "https://github.com/atqamz/hand/pull/7", true)
+	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 3))
+	r.deps.prHead = func(_ context.Context, pr string) (string, error) {
+		if pr != "https://github.com/atqamz/hand/pull/7" {
+			t.Fatalf("prHead(%q), want the recorded pull request", pr)
+		}
+		return commitSafetyHead, nil
+	}
+	reconcileConverges(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.returns != 1 || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Task.RepairCode != "" {
+		t.Fatalf("returns=%d attempt=%+v task=%+v, want the squashed branch returned on head evidence", counts.returns, history.Attempts[0], history.Task)
+	}
+}
+
+func TestReconcileWithholdsReturnForCommitPastThePushedPullRequestHead(t *testing.T) {
+	home, _ := commitSafetyTask(t, "https://github.com/atqamz/hand/pull/7", true)
+	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 1))
+	r.deps.prHead = func(context.Context, string) (string, error) {
+		return "2222222222222222222222222222222222222222", nil
+	}
+	reconcileNeedsRepair(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeLocalCommits || counts.returns != 0 {
+		t.Fatalf("task=%+v returns=%d, want work past the pushed head withheld", history.Task, counts.returns)
+	}
+	if !strings.Contains(history.Task.RepairReason, "222222222222") || !strings.Contains(history.Task.RepairReason, "111111111111") {
+		t.Fatalf("repair reason = %q, want both the pushed head and the local head named", history.Task.RepairReason)
+	}
+}
+
+func TestReconcileKeepsAttemptTerminalWhileWorktreeReturnIsWithheld(t *testing.T) {
+	home, attempt := commitSafetyTask(t, "", false)
+	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 2))
+	client := &healthyReconcileHerdr{}
+	r.deps.herdr = func() herdrClient { return client }
+	reconcileNeedsRepair(t, r, home)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt != nil || history.Attempts[0].Lifecycle != state.AttemptCompleted || history.Task.Lifecycle != state.TaskTerminal {
+		t.Fatalf("history=%+v, want the Attempt still terminal while cleanup is withheld", history)
+	}
+	if history.Attempts[0].TeardownHerdrState != state.TeardownResourceReleased || client.closed != 1 {
+		t.Fatalf("attempt=%+v closes=%d, want the Herdr resource released independently of the worktree", history.Attempts[0], client.closed)
+	}
+	if history.Task.RepairCode != repairCodeWorktreeLocalCommits || history.Task.RepairAttemptID != attempt.ID || counts.returns != 0 {
+		t.Fatalf("task=%+v returns=%d, want the withheld worktree recorded against the terminal attempt", history.Task, counts.returns)
+	}
+}
+
+func TestReconcileWithheldWorktreeReturnIsIdempotent(t *testing.T) {
+	home, _ := commitSafetyTask(t, "", false)
+	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 2))
+	reconcileNeedsRepair(t, r, home)
+	first := durableSnapshot(t, home)
+	r.deps.now = func() time.Time { return time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC) }
+	reconcileNeedsRepair(t, r, home)
+	second := durableSnapshot(t, home)
+	if !bytes.Equal(first, second) {
+		t.Fatalf("durable state changed across reconciles:\nfirst  = %s\nsecond = %s", first, second)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt != nil || history.Attempts[0].Lifecycle != state.AttemptCompleted {
+		t.Fatalf("history=%+v, want the Attempt still terminal after a second withheld pass", history)
+	}
+	if counts.returns != 0 || counts.commits != 2 {
+		t.Fatalf("returns=%d commits=%d, want one observation per pass and no return", counts.returns, counts.commits)
+	}
+}
+
+func durableSnapshot(t *testing.T, home string) []byte {
+	t.Helper()
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(history)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -418,7 +418,7 @@ func TestReconcileSubmittedLaunchConfirmsExistingPaneWithoutRelaunch(t *testing.
 	}
 }
 
-func TestReconcileRunningMissingPaneRecordsRepairWithoutReplacement(t *testing.T) {
+func TestReconcileRunningMissingPaneConvergesWithoutReplacement(t *testing.T) {
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
 		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
@@ -437,8 +437,14 @@ func TestReconcileRunningMissingPaneRecordsRepairWithoutReplacement(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if history.Task.RepairCode != repairCodeRunningPaneMissing || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
-		t.Fatalf("history=%+v, want running Attempt and repair marker", history)
+	if history.ActiveAttempt != nil || len(history.Attempts) != 1 {
+		t.Fatalf("history=%+v, want the same Attempt converged without a replacement", history)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("history=%+v, want a terminal task and interrupted Attempt", history)
+	}
+	if history.Task.RepairCode != "" {
+		t.Fatalf("task=%+v, want no repair marker for an Attempt that converged", history.Task)
 	}
 }
 
@@ -497,15 +503,9 @@ func TestReconcileClearsRepairAfterTeardownAndReopenResolvesOldAttempt(t *testin
 	if err := state.MarkAttemptRunning(home, "task-1", oldAttempt.ID); err != nil {
 		t.Fatal(err)
 	}
-	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
-	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+	if err := state.SetTaskRepair(home, "task-1", repairCodeRunningPaneIdentityMismatch, "pane belongs to another Attempt", oldAttempt.ID, "2026-08-15T00:00:02Z"); err != nil {
 		t.Fatal(err)
 	}
-	history, err := state.ReadHistory(home, "task-1")
-	if err != nil || history.Task.RepairCode != repairCodeRunningPaneMissing {
-		t.Fatalf("repair history = %+v, err=%v", history, err)
-	}
-
 	if err := state.SetAttemptTeardownDecision(home, "task-1", oldAttempt.ID, state.AttemptInterrupted, state.TeardownDispositionForced); err != nil {
 		t.Fatal(err)
 	}
@@ -551,7 +551,7 @@ func TestReconcileClearsRepairAfterTeardownAndReopenResolvesOldAttempt(t *testin
 	if _, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
-	history, err = state.ReadHistory(home, "task-1")
+	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -560,6 +560,336 @@ func TestReconcileClearsRepairAfterTeardownAndReopenResolvesOldAttempt(t *testin
 	}
 	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != newAttempt.ID {
 		t.Fatalf("active attempt = %+v, want reopened attempt %d", history.ActiveAttempt, newAttempt.ID)
+	}
+}
+
+func convergenceTask(t *testing.T, home string, task state.Task) state.Attempt {
+	t.Helper()
+	attempt, err := state.CreateTaskWithAttempt(home, task, state.Attempt{
+		TaskID: task.ID, Lifecycle: state.AttemptProvisioning, Harness: "claude",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, task.ID, attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	return attempt
+}
+
+func TestDecideTerminalConvergenceMatrix(t *testing.T) {
+	running := state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}}
+	tests := []struct {
+		name            string
+		attempt         state.Attempt
+		observation     reconciliationObservation
+		wantConverge    bool
+		wantLifecycle   state.AttemptLifecycle
+		wantDisposition string
+	}{
+		{
+			name:            "pane gone and work landed",
+			attempt:         running,
+			observation:     reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingLanded},
+			wantConverge:    true,
+			wantLifecycle:   state.AttemptCompleted,
+			wantDisposition: state.TeardownDispositionCompleted,
+		},
+		{
+			name:            "pane gone and nothing landed",
+			attempt:         running,
+			observation:     reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingUnlanded},
+			wantConverge:    true,
+			wantLifecycle:   state.AttemptInterrupted,
+			wantDisposition: state.TeardownDispositionWorkerExitedUnlanded,
+		},
+		{
+			name:        "pane gone and landing unknown",
+			attempt:     running,
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingUnknown},
+		},
+		{
+			name:        "pane gone and landing unobserved",
+			attempt:     running,
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}},
+		},
+		{
+			name:        "pane still present",
+			attempt:     running,
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}, Landing: landingLanded},
+		},
+		{
+			name:        "pane identity never persisted",
+			attempt:     state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude"},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingLanded},
+		},
+		{
+			name:        "teardown already decided the terminal value",
+			attempt:     state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: running.Herdr, TeardownTerminalAttempt: state.AttemptInterrupted},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingLanded},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle, disposition, converge := decideTerminalConvergence(tc.attempt, tc.observation)
+			if converge != tc.wantConverge || lifecycle != tc.wantLifecycle || disposition != tc.wantDisposition {
+				t.Fatalf("converge=%v lifecycle=%q disposition=%q, want %v/%q/%q", converge, lifecycle, disposition, tc.wantConverge, tc.wantLifecycle, tc.wantDisposition)
+			}
+		})
+	}
+}
+
+func TestReconcileConvergesExitedWorkerWhoseMergedPRLanded(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt := convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	writeReport(t, home, "task-1", "done: shipped\n")
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingLanded) {
+		t.Fatalf("landing = %q, want landed", report.Results[0].Landing)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil {
+		t.Fatalf("task = %+v, want a terminal task with no active Attempt", history.Task)
+	}
+	converged := history.Attempts[0]
+	if converged.Lifecycle != state.AttemptCompleted || converged.TeardownDisposition != state.TeardownDispositionCompleted {
+		t.Fatalf("attempt = %+v, want completed by convergence", converged)
+	}
+	if converged.TeardownCompletionState != state.TeardownCompletionAppended {
+		t.Fatalf("attempt = %+v, want appended completion evidence", converged)
+	}
+	record, found, err := completion.FindAttempt(home, attempt.ID)
+	if err != nil || !found || record.Outcome != "merged" {
+		t.Fatalf("record=%+v found=%v err=%v, want a merged completion record", record, found, err)
+	}
+	lines, err := state.ReadReportLines(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if last, ok := state.LastReportedState(lines); !ok || last.State != state.ReportDone {
+		t.Fatalf("last report = %+v ok=%v, want the done report still readable beside a terminal Attempt", last, ok)
+	}
+}
+
+func TestReconcileConvergesKilledWorkerToInterrupted(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt := convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	report, err := reconcileRuntime(&missingReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingUnlanded) {
+		t.Fatalf("landing = %q, want unlanded", report.Results[0].Landing)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("history = %+v, want an interrupted Attempt on a terminal task", history)
+	}
+	if history.Attempts[0].TeardownDisposition != state.TeardownDispositionWorkerExitedUnlanded {
+		t.Fatalf("disposition = %q, want %q", history.Attempts[0].TeardownDisposition, state.TeardownDispositionWorkerExitedUnlanded)
+	}
+	record, found, err := completion.FindAttempt(home, attempt.ID)
+	if err != nil || !found || record.Outcome != "unlanded" {
+		t.Fatalf("record=%+v found=%v err=%v, want an unlanded completion record", record, found, err)
+	}
+}
+
+func TestReconcileKeepsLiveWorkerThatReportedDone(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskMerge(home, "task-1", "2026-08-15T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	writeReport(t, home, "task-1", "done: shipped and merged\n")
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Action != string(reconciliationActionKeep) {
+		t.Fatalf("action = %q, want keep while the worker process is alive", report.Results[0].Action)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.Task.Lifecycle != state.TaskOpen {
+		t.Fatalf("history = %+v, want the running Attempt untouched by worker prose", history)
+	}
+	if _, found, err := completion.FindAttempt(home, history.ActiveAttempt.ID); err != nil || found {
+		t.Fatalf("found=%v err=%v, want no completion record from worker prose", found, err)
+	}
+}
+
+func TestReconcileIgnoresMalformedWorkerProse(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	writeReport(t, home, "task-1", "finished the thing\ndone shipped\n")
+	report, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Action != string(reconciliationActionKeep) {
+		t.Fatalf("action = %q, want keep through malformed prose", report.Results[0].Action)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.Task.Lifecycle != state.TaskOpen {
+		t.Fatalf("history = %+v, want no lifecycle transition from malformed prose", history)
+	}
+	lines, err := state.ReadReportLines(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 || !lines[0].Malformed || !lines[1].Malformed {
+		t.Fatalf("lines = %+v, want both prose lines recorded as malformed", lines)
+	}
+}
+
+func TestReconcileRecordsUnknownLandingWhenGitHubIsUnreachable(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return false, errors.New("GitHub unavailable") }
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingUnknown) || report.Results[0].Outcome != reconcileOutcomeRepair {
+		t.Fatalf("result = %+v, want an unknown landing recorded as needs-repair", report.Results[0])
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history = %+v, want no terminal value invented from an unknown landing", history)
+	}
+	if history.Task.RepairCode != repairCodeRunningPaneMissing || !strings.Contains(history.Task.RepairReason, "unknown") {
+		t.Fatalf("task = %+v, want the unknown landing recorded as the repair condition", history.Task)
+	}
+	if _, found, err := completion.FindAttempt(home, history.ActiveAttempt.ID); err != nil || found {
+		t.Fatalf("found=%v err=%v, want no completion record for an unknown landing", found, err)
+	}
+}
+
+func TestReconcileConvergesLifecycleWhileWorktreeStillNeedsRepair(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
+	}
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].RepairCode != repairCodeLegacyWorktreeUnprovable {
+		t.Fatalf("repair code = %q, want the unprovable worktree lease", report.Results[0].RepairCode)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil {
+		t.Fatalf("task = %+v, want the lifecycle converged independently of the worktree", history.Task)
+	}
+	if history.Attempts[0].Lifecycle != state.AttemptCompleted {
+		t.Fatalf("attempt = %+v, want completed despite the worktree repair", history.Attempts[0])
+	}
+	if history.Task.RepairCode != repairCodeLegacyWorktreeUnprovable {
+		t.Fatalf("task = %+v, want the worktree repair still recorded", history.Task)
+	}
+}
+
+func TestReconcileConvergesLifecycleDespiteRecordedRepairMarker(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskRepair(home, "task-1", repairCodeLegacyWorktreeUnprovable, "historical worktree has no exact lease identity", attempt.ID, "2026-08-15T00:00:02Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.Attempts[0].Lifecycle != state.AttemptCompleted {
+		t.Fatalf("history = %+v, want convergence through a repair marker recorded for another resource", history)
+	}
+	if history.Task.RepairCode != repairCodeLegacyWorktreeUnprovable {
+		t.Fatalf("task = %+v, want the unrelated repair marker left standing", history.Task)
+	}
+}
+
+func writeReport(t *testing.T, home, id, body string) {
+	t.Helper()
+	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(state.ReportPath(home, id), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -2013,6 +2013,12 @@ func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lea
 			observeClean: func(path string) (worktree.Cleanliness, error) {
 				return worktree.Clean, nil
 			},
+			observeCommits: func(path string) worktree.CommitSafetyObservation {
+				return worktree.CommitSafetyObservation{
+					State: worktree.CommitSafetyRemoteObserved,
+					Probe: worktree.CommitSafetyProbe{Command: "git rev-list --count HEAD --not --remotes", WorkingDir: path, Head: "1111111111111111111111111111111111111111", RemoteRefs: 1},
+				}
+			},
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },
 			returnWorktree: func(string, bool) error { return nil },
 			returnWithID:   func(string, string, bool) error { return nil },

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -297,6 +297,12 @@ func completionFor(t state.Task, disposition string, launched bool) completion.R
 	case disposition == state.TeardownDispositionForced:
 		c.Outcome = "torn-down"
 		c.Detail = "forced (landed-work checks skipped)"
+	// Ahead of every landing case below because it is the one disposition that already carries a
+	// landing observation of its own: convergence only picks it once the runtime has positively
+	// observed that nothing landed, so falling through to "merged" here would invent the fact.
+	case disposition == state.TeardownDispositionWorkerExitedUnlanded:
+		c.Outcome = "unlanded"
+		c.Detail = "worker process exited and no landed work was observed"
 	// A task whose landing was never ours to decide has to stay distinguishable from a merged one in
 	// the permanent record, or the fleet's history claims upstream merges that never happened
 	// (atqamz/hand#78).

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -82,4 +82,5 @@ const (
 	TeardownDispositionForced               = store.TeardownDispositionForced
 	TeardownDispositionNeverLaunched        = store.TeardownDispositionNeverLaunched
 	TeardownDispositionLaunchedProvisioning = store.TeardownDispositionLaunchedProvisioning
+	TeardownDispositionWorkerExitedUnlanded = store.TeardownDispositionWorkerExitedUnlanded
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -127,6 +127,7 @@ const (
 	TeardownDispositionForced               = "forced"
 	TeardownDispositionNeverLaunched        = "never-launched"
 	TeardownDispositionLaunchedProvisioning = "launched-provisioning"
+	TeardownDispositionWorkerExitedUnlanded = "worker-exited-unlanded"
 )
 
 type Task struct {

--- a/internal/worktree/commit_safety_test.go
+++ b/internal/worktree/commit_safety_test.go
@@ -1,0 +1,102 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	if out, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+
+func commitFile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", name)
+	runGit(t, dir, "commit", "-q", "-m", "add "+name)
+}
+
+func pushedRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	faketool.InitRepo(t, worktreePath)
+	remote := filepath.Join(root, "remote.git")
+	runGit(t, root, "init", "-q", "--bare", remote)
+	runGit(t, worktreePath, "remote", "add", "origin", remote)
+	runGit(t, worktreePath, "push", "-q", "-u", "origin", "main")
+	return worktreePath
+}
+
+func TestObserveCommitSafetyProvesDurabilityFromRemoteTrackingRefs(t *testing.T) {
+	worktreePath := pushedRepo(t)
+	observation := ObserveCommitSafety(worktreePath)
+	if observation.State != CommitSafetyRemoteObserved {
+		t.Fatalf("observation = %+v, want a pushed worktree proven durable", observation)
+	}
+	if observation.Probe.LocalOnly != 0 || observation.Probe.RemoteRefs == 0 || len(observation.Probe.Head) != 40 {
+		t.Fatalf("probe = %+v, want the compared head and remote-tracking refs recorded", observation.Probe)
+	}
+}
+
+func TestObserveCommitSafetyCountsCommitsHeldOnlyInTheWorktree(t *testing.T) {
+	worktreePath := pushedRepo(t)
+	commitFile(t, worktreePath, "one")
+	commitFile(t, worktreePath, "two")
+	observation := ObserveCommitSafety(worktreePath)
+	if observation.State != CommitSafetyLocalOnly || observation.Probe.LocalOnly != 2 {
+		t.Fatalf("observation = %+v, want both unpushed commits counted", observation)
+	}
+}
+
+func TestObserveCommitSafetyReportsUnknownForEveryUnobservableComparison(t *testing.T) {
+	t.Run("no remote configured", func(t *testing.T) {
+		worktreePath := filepath.Join(t.TempDir(), "worktree")
+		faketool.InitRepo(t, worktreePath)
+		observation := ObserveCommitSafety(worktreePath)
+		if observation.State != CommitSafetyUnknown || observation.Probe.RemoteRefs != 0 {
+			t.Fatalf("observation = %+v, want unknown with no remote-tracking ref to compare against", observation)
+		}
+		if !strings.Contains(observation.Probe.Reason, "no remote-tracking ref") {
+			t.Fatalf("reason = %q, want the absent remote-tracking refs named", observation.Probe.Reason)
+		}
+	})
+	t.Run("pruned remote-tracking ref", func(t *testing.T) {
+		worktreePath := pushedRepo(t)
+		runGit(t, worktreePath, "push", "-q", "origin", "main:refs/heads/survivor")
+		runGit(t, worktreePath, "fetch", "-q", "origin")
+		commitFile(t, worktreePath, "after-push")
+		runGit(t, worktreePath, "update-ref", "-d", "refs/remotes/origin/main")
+		observation := ObserveCommitSafety(worktreePath)
+		if observation.State != CommitSafetyUnknown || observation.Probe.RemoteRefs == 0 {
+			t.Fatalf("observation = %+v, want unknown while other remote-tracking refs still exist", observation)
+		}
+		if !strings.Contains(observation.Probe.Reason, "origin/main") {
+			t.Fatalf("reason = %q, want the pruned upstream named", observation.Probe.Reason)
+		}
+	})
+	t.Run("no repository at the recorded path", func(t *testing.T) {
+		observation := ObserveCommitSafety(filepath.Join(t.TempDir(), "gone"))
+		if observation.State != CommitSafetyUnknown || !strings.Contains(observation.Probe.Reason, "resolve worktree HEAD") {
+			t.Fatalf("observation = %+v, want unknown naming the failed head resolution", observation)
+		}
+	})
+	t.Run("no worktree recorded", func(t *testing.T) {
+		observation := ObserveCommitSafety("")
+		if observation.State != CommitSafetyUnknown || observation.Probe.Command != localOnlyCommitCommand {
+			t.Fatalf("observation = %+v, want unknown carrying the probe it would have run", observation)
+		}
+	})
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/atqamz/hand/internal/state"
@@ -151,6 +152,132 @@ func ObserveCleanliness(worktreePath string) (Cleanliness, error) {
 		return Dirty, nil
 	}
 	return Clean, nil
+}
+
+type CommitSafetyState string
+
+const (
+	CommitSafetyRemoteObserved CommitSafetyState = "remote-observed"
+	CommitSafetyLocalOnly      CommitSafetyState = "local-only"
+	CommitSafetyUnknown        CommitSafetyState = "unknown"
+)
+
+// CommitSafetyProbe records how HEAD was compared against remote-tracking refs. RemoteRefs is
+// load-bearing: with none configured there is nothing to compare against, so a zero LocalOnly
+// would record "the question was never asked" as if it meant "nothing is at risk".
+type CommitSafetyProbe struct {
+	Command    string
+	WorkingDir string
+	Reason     string
+	Head       string
+	LocalOnly  int
+	RemoteRefs int
+}
+
+type CommitSafetyObservation struct {
+	State CommitSafetyState
+	Probe CommitSafetyProbe
+}
+
+// A remote-tracking ref exists only as this clone's record of a ref observed on a remote, so every
+// commit this count reaches is one a remote was seen holding: zero is positive proof the work
+// outlives the worktree, established without a network call.
+const localOnlyCommitCommand = "git rev-list --count HEAD --not --remotes"
+
+// ObserveCommitSafety reports whether returning a worktree could discard commits held nowhere else
+// and never fails: every cause that stops the comparison being made is CommitSafetyUnknown carrying
+// its probe, because an observation that could not be made is not proof that the work is safe.
+func ObserveCommitSafety(worktreePath string) CommitSafetyObservation {
+	if worktreePath == "" {
+		return unknownCommitSafety(CommitSafetyProbe{}, "no worktree path is recorded")
+	}
+	probe := CommitSafetyProbe{Command: localOnlyCommitCommand, WorkingDir: worktreePath}
+	head, err := HeadCommit(worktreePath)
+	if err != nil {
+		return unknownCommitSafety(probe, err.Error())
+	}
+	probe.Head = head
+	remotes, err := gitLines(worktreePath, "for-each-ref", "--format=%(refname)", "refs/remotes")
+	if err != nil {
+		return unknownCommitSafety(probe, fmt.Sprintf("list remote-tracking refs: %v", err))
+	}
+	probe.RemoteRefs = len(remotes)
+	count, err := localOnlyCommitCount(worktreePath)
+	if err != nil {
+		return unknownCommitSafety(probe, err.Error())
+	}
+	probe.LocalOnly = count
+	if count == 0 && probe.RemoteRefs > 0 {
+		return CommitSafetyObservation{State: CommitSafetyRemoteObserved, Probe: probe}
+	}
+	if probe.RemoteRefs == 0 {
+		return unknownCommitSafety(probe, "the clone holds no remote-tracking ref, so no commit here can be compared against one")
+	}
+	if upstream, pruned := prunedUpstream(worktreePath); pruned {
+		return unknownCommitSafety(probe, fmt.Sprintf("the branch records upstream %s and no remote-tracking ref for it survives, so what the remote holds is no longer recorded here", upstream))
+	}
+	return CommitSafetyObservation{State: CommitSafetyLocalOnly, Probe: probe}
+}
+
+func unknownCommitSafety(probe CommitSafetyProbe, reason string) CommitSafetyObservation {
+	if probe.Command == "" {
+		probe.Command = localOnlyCommitCommand
+	}
+	probe.Reason = reason
+	return CommitSafetyObservation{State: CommitSafetyUnknown, Probe: probe}
+}
+
+func localOnlyCommitCount(worktreePath string) (int, error) {
+	out, err := gitOutput(worktreePath, "rev-list", "--count", "HEAD", "--not", "--remotes")
+	if err != nil {
+		return 0, fmt.Errorf("count commits held only in this worktree: %w", err)
+	}
+	count, convErr := strconv.Atoi(out)
+	if convErr != nil {
+		return 0, fmt.Errorf("count commits held only in this worktree: unreadable count %q", out)
+	}
+	return count, nil
+}
+
+func prunedUpstream(worktreePath string) (string, bool) {
+	branch, err := gitOutput(worktreePath, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil || branch == "" {
+		return "", false
+	}
+	remote, err := gitOutput(worktreePath, "config", "--get", "branch."+branch+".remote")
+	if err != nil || remote == "" {
+		return "", false
+	}
+	merge, err := gitOutput(worktreePath, "config", "--get", "branch."+branch+".merge")
+	if err != nil {
+		return "", false
+	}
+	upstream := remote + "/" + strings.TrimPrefix(merge, "refs/heads/")
+	if _, err := gitOutput(worktreePath, "rev-parse", "--verify", "--quiet", "refs/remotes/"+upstream+"^{commit}"); err != nil {
+		return upstream, true
+	}
+	return "", false
+}
+
+func gitOutput(worktreePath string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = worktreePath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitLines(worktreePath string, args ...string) ([]string, error) {
+	out, err := gitOutput(worktreePath, args...)
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
 }
 
 // Get acquires a worktree from the project clone's treehouse pool. clonePath must be the project

--- a/tests/contract/gh_fake_test.go
+++ b/tests/contract/gh_fake_test.go
@@ -11,22 +11,24 @@ import (
 )
 
 const (
-	contractGHRepo      = "atqamz/hand"
-	contractGHRepoCased = "AtqaMZ/Hand"
-	contractGHEdgeSHA   = "0123456789abcdef0123456789abcdef01234567"
+	contractGHRepo       = "atqamz/hand"
+	contractGHRepoCased  = "AtqaMZ/Hand"
+	contractGHEdgeSHA    = "0123456789abcdef0123456789abcdef01234567"
+	contractGHHeadRefOid = "898192c133d4786a9d5bee7b05fead923d5c902e"
 )
 
 func installContractGH(t *testing.T) {
 	t.Helper()
 	faketool.GH{
 		PRs: []faketool.GHPR{{
-			Number:   154,
-			URL:      "https://github.com/atqamz/hand/pull/154",
-			Branch:   "136-usage-limit-resume",
-			State:    "MERGED",
-			Repo:     contractGHRepo,
-			HeadRepo: contractGHRepo,
-			Checks:   []string{"pass", "skipping"},
+			Number:     154,
+			URL:        "https://github.com/atqamz/hand/pull/154",
+			Branch:     "136-usage-limit-resume",
+			State:      "MERGED",
+			Repo:       contractGHRepo,
+			HeadRepo:   contractGHRepo,
+			HeadRefOid: contractGHHeadRefOid,
+			Checks:     []string{"pass", "skipping"},
 		}},
 		Repos: []faketool.GHRepo{{
 			Requested:     "atqamz/secondhand",
@@ -68,6 +70,33 @@ func TestGHFixturesPreservePullRequestAndRepositoryContracts(t *testing.T) {
 	repo := run(t, "", "gh", "repo", "view", "atqamz/secondhand", "--json", "nameWithOwner,url").requireCode(t, 0)
 	if strings.TrimSpace(repo.stdout) != `{"nameWithOwner":"atqamz/hand","url":"https://github.com/atqamz/hand"}` {
 		t.Fatalf("repo = %q, want renamed canonical repository", repo.stdout)
+	}
+}
+
+// installContractGH's canned "pr view" failure response answers every pr view call regardless of
+// PR number, so headRefOid fixture coverage needs its own install without that override.
+func TestGHFixturesPreserveHeadRefOid(t *testing.T) {
+	faketool.GH{
+		PRs: []faketool.GHPR{{
+			Number:     154,
+			URL:        "https://github.com/atqamz/hand/pull/154",
+			Branch:     "136-usage-limit-resume",
+			State:      "MERGED",
+			Repo:       contractGHRepo,
+			HeadRepo:   contractGHRepo,
+			HeadRefOid: contractGHHeadRefOid,
+		}},
+	}.Install(t, faketool.Bin(t))
+
+	head := run(t, "", "gh", "pr", "view", "154", "--repo", contractGHRepo, "--json", "headRefOid").requireCode(t, 0)
+	var headBody struct {
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal([]byte(head.stdout), &headBody); err != nil {
+		t.Fatalf("parse stdout %q: %v", head.stdout, err)
+	}
+	if headBody.HeadRefOid != contractGHHeadRefOid {
+		t.Fatalf("headRefOid = %q, want %q", headBody.HeadRefOid, contractGHHeadRefOid)
 	}
 }
 

--- a/tests/contract/gh_test.go
+++ b/tests/contract/gh_test.go
@@ -99,6 +99,23 @@ func TestGHPRViewFailsForAPRThatDoesNotExist(t *testing.T) {
 		requireStderrContains(t, "Could not resolve to a PullRequest")
 }
 
+// PRHeadCommit reads headRefOid from a merged PR whose branch is long deleted, because GitHub's
+// record of the head ref outlives the clone; this pins that the field survives branch deletion.
+func TestGHPRViewReportsHeadRefOidAfterBranchDeletion(t *testing.T) {
+	requireGH(t)
+
+	res := run(t, "", "gh", "pr", "view", ghMergedPR, "--repo", ghRepo, "--json", "headRefOid").requireCode(t, 0)
+	var body struct {
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal([]byte(res.stdout), &body); err != nil {
+		t.Fatalf("parse stdout %q: %v", res.stdout, err)
+	}
+	if len(body.HeadRefOid) != 40 {
+		t.Fatalf("headRefOid = %q, want a full SHA", body.HeadRefOid)
+	}
+}
+
 // prChecksGreen reads the buckets and ignores the exit code once the JSON
 // parses, so what the fake owes is the bucket vocabulary, not the code.
 func TestGHPRChecksReportsBuckets(t *testing.T) {


### PR DESCRIPTION
## Summary

- A running Attempt whose recorded Herdr pane is observed absent now reaches a terminal lifecycle inside `hand reconcile`, with no `hand teardown` involved, and convergence releases no resource of its own so a `needs-repair` on Herdr or the worktree cannot hold it back.
- Landing evidence chooses the terminal value: an observed merge, a recorded delivery or a scout report on disk completes the Attempt, positively observed unlanded work interrupts it, and a landing that cannot be observed at all records `unknown` and converges nothing.
- Worker prose stays out of the decision entirely: `internal/runtime` reads no report file, so `done:` and malformed prose alike cause no transition.
- Automatic worktree return now requires positive proof that the commits in it are held somewhere else. A three-state observation decides: proven durable returns the worktree, local-only commits withhold it, and an observation that could not be made at all withholds it as its own distinct condition. A clean `git status` is no longer accepted as proof, and the Attempt stays terminal either way.

Closes atqamz/hand#239

## Audit against main at cb93eb3e19a60a9e5d43dc80c4954aee8274d1f4

The issue was not satisfied. Criterion by criterion:

**"the attempt reaches a terminal lifecycle deterministically, without requiring `hand teardown`" - not met.** `state.TerminalizeTaskAndAttempt` had exactly two non-test callers: `internal/runtime/teardown.go:155` and `internal/runtime/reconcile.go:802`. The reconcile caller was gated on `TeardownCompletionState == appended` (`internal/runtime/reconcile.go:785`) and on `TeardownTerminalAttempt != ""` (`internal/runtime/reconcile.go:798`), and both fields were only ever written by `Teardown` (`internal/runtime/teardown.go:86`, `:128`, `:134`). So reconcile could only finish a teardown that had already started; it could not begin one. A running Attempt with a missing pane instead returned `repairCodeRunningPaneMissing` at `internal/runtime/reconcile.go:1060`, which is exactly the reproduction in the issue.

**"driven by observable runtime and GitHub evidence, not by the report text alone" - held, but only vacuously.** `internal/runtime` never read `state/<id>.status`; the only non-test readers were `cmd/status.go:466` and `internal/watcher/watcher.go:555`. The channel separation was real, but there was no evidence-driven transition for it to protect. It is preserved here: `observeLanding` reads GitHub, the delivery timestamp and the scout report on disk, and reads no prose.

**"where evidence is unavailable, state records unknown" - partly met.** The precedent existed for worktree leases as `worktree.LeaseUnknown` (`internal/worktree/worktree.go:47`), carried on `LeaseObservation` (`:59`) which never fails (`:141`). There was no equivalent for the merge observation: `observeMerge` (`internal/runtime/reconcile.go:386`) turned an unreachable GitHub into a hard error and `reconcileTask` returned `blocked` (`internal/runtime/reconcile.go:228-231`), recording nothing.

**"a `needs-repair` on one resource does not prevent convergence of fields that do not depend on it" - not met.** `reconcileHistoricalAttempt` returned `needs-repair` for an unobservable lease at `internal/runtime/reconcile.go:723` and for an unprovable one at `:726`, both ahead of the completion and terminalize steps at `:785-806`. The issue's own observation is this shape: `legacy-worktree-ownership-unprovable` on the worktree blocking the Attempt lifecycle.

**"`hand status` cannot show `reported: done` plus a merged PR plus `attempt_lifecycle: running`" - not met.** `attempt_lifecycle` rendered `attempt.Lifecycle` raw (`cmd/statusview.go:130`), the `merged` flag came from durable task facts (`cmd/statusview.go:78`) and `reported` from the prose channel (`cmd/status.go:467`). Nothing reconciled the three.

**"tests cover ..." - not met.** No test existed for any of the five named cases.

## What triggers terminal convergence after this change

`terminalConvergenceCandidate` in `internal/runtime/reconcile.go`: the Attempt is `running`, it carries no recorded teardown decision, it has a recorded pane identity, and that pane is observed absent from Herdr. The pane observation alone gates it, because attempt lifecycle is the one fact that depends on the pane and on nothing else. Landing is then observed lazily, only for a candidate, and only chooses which terminal value is reached: `completed` with disposition `completed` for landed work, `interrupted` with disposition `worker-exited-unlanded` for work positively observed not to have landed.

`convergeTerminalLifecycle` writes the same durable sequence `Teardown` does - decision, completion phase pending, completion record, completion phase appended, terminalize - and deliberately releases no Herdr or Treehouse resource. Releasing one can fail into `needs-repair`, and the lifecycle does not depend on either. The release still happens, on the following reconcile iteration, through the existing historical-attempt path; if it fails there the marker is recorded against the resource and the lifecycle stays converged.

The convergence branch sits in `reconcileTask`'s action switch ahead of `shouldClearRepair` and `reportExistingRepair`. That ordering is load-bearing and has its own test: a task already carrying a repair marker for an unrelated resource previously short-circuited to reporting that marker and never converged, which is the failure the issue reports.

## How UNKNOWN is represented and where it travels

`landingState` follows `worktree.LeaseObservation` rather than inventing a second vocabulary, and `observeLanding` never fails for the same reason `ObserveLease` never fails: an observation that could not be made is not evidence that nothing landed, and the terminal value it picks enters a permanent completion record.

`landingUnknown` is in-memory only. It travels to `ReconcileResult.Landing`, is rendered as `landing: unknown` by `hand reconcile`, and is named in the durable repair reason through `runningPaneMissingReason`, so the recorded condition says which observation is missing. It latches nothing durable of its own: no lifecycle value is written, no completion record is appended, and the Attempt stays `running` under `needs-repair` until the observation can be made. This keeps the invariant #245 landed at `internal/runtime/teardown.go:218` - an observation that could not be made records nothing durable. `observeMerge` failing now also stamps `landing: unknown` on the blocked result instead of reporting nothing.

`CommitSafetyUnknown` is the second UNKNOWN in this PR and follows the same precedent on purpose: `ObserveCommitSafety` never returns an error, every cause that stops the comparison being made becomes `unknown` carrying the probe that failed, and the recorded reason names which observation was missing. It differs from `landingUnknown` in one way worth stating: it does latch a durable Task repair marker, because the right response to an unanswered durability question is to withhold an irreversible cleanup and leave the condition visible rather than retry it silently. What it never writes is a lifecycle value or a teardown resource state.

## Scope and the parallel lanes

The `internal/faketool/**` change is strictly additive: `GHPR` gains a `HeadRefOid` field and the fake's `gh pr view` dispatches on the requested `--json` field, leaving the existing `--json state` shape byte-identical; `FIDELITY.md` documents the new shape and `tests/contract` covers it hermetically and, under contract-live, against real `gh`. No contract make target and no CI workflow file is touched. Nothing under `internal/watcher/**` is touched, so the contested surface is untouched and there is no overlap with #236. Nothing in `hand doctor`, config, project or routing diagnostics is touched, so no overlap with #242. #235, #241 and #244 are not absorbed; on #244 the observation recorded here is that `cmd/status.go:467` is the only place worker prose reaches a factual surface, and this change does not move it.

One thing to state plainly rather than claim: `Runtime.Reconcile` has a single caller, `cmd/reconcile.go:56`. There is no automatic trigger in this repository, so the contradictory triple is still observable in the window between a worker exiting and the next reconcile pass. What this change removes is the durable steady state - the triple is no longer a condition that only `hand teardown` can clear, and reconcile is the owner the issue itself named. Wiring an automatic trigger would mean editing the watcher, which is out of scope here.

## Automatic worktree return now requires proof, not a clean status

Convergence makes an Attempt terminal, a terminal Attempt is historical, and the existing historical-attempt path reaches a historical worktree on the next reconcile iteration with no operator in the loop. Before amendment-1 that path returned any worktree `git status --porcelain` called clean. A clean worktree can still hold the only copy of a commit, so that was a data-loss shape. It is fixed here, in this PR, not documented as an accepted risk.

`worktree.ObserveCommitSafety` in `internal/worktree/worktree.go` is a git-only, network-free observation that never returns an error, following `ObserveLease` rather than inventing a second vocabulary. It reports one of three states, and only the first permits an automatic return:

| state | meaning | effect |
| --- | --- | --- |
| `remote-observed` | no commit reachable from HEAD is missing from every remote-tracking ref | return allowed |
| `local-only` | commits are reachable from no remote-tracking ref, and the count is recorded | return withheld as `worktree-local-commits` |
| `unknown` | the comparison could not be made at all | return withheld as `worktree-commit-safety-unknown` |

### Why a zero count is proof

`git rev-list --count HEAD --not --remotes` returning zero proves durability only because of one fact that is not visible from the command: a remote-tracking ref exists solely as this clone's record of a ref it observed on a remote. So every commit any remote-tracking ref reaches is a commit some remote was seen holding, and returning the worktree cannot be what destroys it. That is the load-bearing reasoning, and it is written both here and in the code, on `localOnlyCommitCommand` in `internal/worktree/worktree.go`, where doc comments are the local convention.

The corollary matters as much: a zero count means nothing when the clone holds no remote-tracking ref at all, because then the question was never asked. That is why `CommitSafetyProbe.RemoteRefs` is recorded and why a clone with zero remote-tracking refs lands in `unknown`, never in `remote-observed`.

The comparison counts every remote-tracking ref, not only `origin`. The invariant is "held somewhere other than this worktree", and a commit that reached a second remote survives a `treehouse return` exactly as well.

### The squash-merge trap, avoided

Reachability from `origin/main` is never consulted anywhere in this change. This fleet squash-merges every PR, so a rule of "HEAD must be reachable from `origin/main`" would classify every squash-merged branch as holding local-only work and would withhold cleanup fleet-wide, forever.

Instead, when commits are local-only, `internal/runtime` resolves the remaining question against GitHub. If the commit GitHub records as the head of the task's pull request is exactly the worktree HEAD, GitHub holds that commit independently of this worktree and the return is allowed. That read is `ghutil.PRHeadCommit`, one field from `gh pr view --json headRefOid`; it is deliberately not #241's generic GitHub tri-state. A commit created after that pushed head is not covered by it and withholds the return, naming both the pushed head and the local head in the reason.

One deviation from the proof model I stated before implementing, stated plainly rather than left to be noticed: I do not additionally require the pull request to be observed merged. Merge state adds nothing to durability once GitHub is recorded as holding that exact commit, and requiring it would record `local-work-at-risk` - a positive factual claim - for a pushed but open pull request, where the work is in fact safe. Both merged and open pull requests prove durability through the same head evidence, which is also why the squash-merge case needs no special case of its own.

### Unknown withholds, and unknown is not the same fact as at-risk

Three causes of an unavailable observation all withhold the return, and each is distinguishable in the durable repair reason. None of them is recorded as work found at risk:

- **no remote configured**: `unknown` at the worktree layer, the reason names that the clone holds no remote-tracking ref to compare against.
- **a pruned remote-tracking ref**: when local-only commits exist and the branch's recorded upstream no longer resolves, the negative answer is not trustworthy, so it is `unknown` and the reason names the upstream. The ordering is deliberate: a zero count is still positive proof, so pruning is consulted only when the count is nonzero.
- **GitHub unreachable, or the pull request head unreadable**: `unknown` at the runtime layer, the reason names the failed read.

`worktree-local-commits` says work exists that nothing else is known to hold. `worktree-commit-safety-unknown` says the question went unanswered. They are separate repair codes carrying separate reasons, and both refuse.

### Where the check sits, and why a second reconcile writes nothing

The gate runs after the existing dirty refusal and before the first `state.SetAttemptTeardownResourceState(..., releasing)` stamp. Stamping `releasing` and then refusing would rewrite durable state on every reconcile pass. Because `recordRepair` short-circuits on an unchanged code, reason and attempt ID, and every reason string is deterministic, a withheld return leaves durable state byte-identical across passes; `TeardownWorktreeState` is never written at all. The regression test proves this by advancing the runtime clock between the two passes and comparing serialised durable state byte for byte, so a rewrite would show up as a changed `repair_observed_at`.

`--force` does not become a new bypass. The automatic path already passes `force=false`, and the gate sits above the call, so no value of force reaches a return without proof. `--abandon-worktree` is unaffected, since it never returns, prunes or deletes a worktree.

The Attempt lifecycle is untouched by all of this. `convergeTerminalLifecycle` releases no resource, a repair marker never un-terminalizes an Attempt, and a withheld return records a Task marker against the worktree while the Attempt stays terminal with `active_attempt_id` NULL. Herdr still releases on the same pass, so a withheld worktree does not hold another resource back either.

One shape left in place and named rather than changed: `internal/runtime/promote.go:206` returns a scout's worktree with `force=true`. That is operator-initiated `hand promote`, not automatic reconciliation, so it sits outside amendment-1's named scope and is not touched here. It is the same harm shape and worth a decision of its own.

## Test plan

Behavioural tests on structured durable state, not on rendered strings, in `internal/runtime/reconcile_test.go`:

- `TestReconcileConvergesExitedWorkerWhoseMergedPRLanded` - worker exits cleanly, PR observed merged: task terminal, attempt `completed`, disposition `completed`, completion record outcome `merged`, and `state.LastReportedState` still reads `done` beside a terminal attempt.
- `TestReconcileConvergesKilledWorkerToInterrupted` - worker killed, nothing landed: attempt `interrupted`, disposition `worker-exited-unlanded`, completion record outcome `unlanded`.
- `TestReconcileKeepsLiveWorkerThatReportedDone` - healthy pane plus `done:` prose plus a merged PR: action `keep`, attempt still running, task still open, no completion record. Prose alone converges nothing.
- `TestReconcileIgnoresMalformedWorkerProse` - malformed prose: no transition, and both lines classify as `Malformed`.
- `TestReconcileRecordsUnknownLandingWhenGitHubIsUnreachable` - `landing: unknown`, outcome `needs-repair`, attempt still running, the repair reason names the unknown landing, no completion record.
- `TestReconcileConvergesLifecycleWhileWorktreeStillNeedsRepair` and `TestReconcileConvergesLifecycleDespiteRecordedRepairMarker` - the independence case, in both directions: a worktree repair discovered during the pass, and one already recorded before it. The lifecycle converges and the marker is left standing.
- `TestDecideTerminalConvergenceMatrix` - the candidate predicate over landed, unlanded, unknown, unobserved, pane present, no recorded pane identity, and an already recorded teardown decision.
- `TestReconcileRunningMissingPaneConvergesWithoutReplacement` - the pre-existing test for this shape, inverted: it asserted the repair marker, it now asserts convergence.
- `cmd/reconcile_test.go:TestReconcileCommandRendersConvergedTerminalLifecycle` - the command surface renders `landing` and the converged detail, and the durable Attempt is terminal with no active attempt.


The ten regression tests amendment-1 names, in `internal/runtime/reconcile_commit_safety_test.go`, all asserting durable state read back from the store rather than rendered output:

1. `TestReconcileReturnsWorktreeWhenNoCommitIsLocalOnly` - clean worktree, nothing local-only: one return, `TeardownWorktreeState` `released`, no repair marker.
2. `TestReconcileRefusesDirtyWorktreeBeforeAskingAboutCommits` - the existing dirty refusal still holds, `worktree-dirty` is recorded, and the commit observation is never even reached.
3. `TestReconcileWithholdsReturnForOneUnpushedCommit` - one unpushed commit: no return, `worktree-local-commits` recorded against the attempt, `TeardownWorktreeState` still empty.
4. `TestReconcileWithholdsReturnForSeveralUnpushedCommits` - four unpushed commits, all four counted in the reason.
5. `TestReconcileWithholdsReturnWhenCommitSafetyCannotBeObserved` - three subtests, one per cause: no remote configured, a pruned remote-tracking ref, and an unreachable GitHub. All three withhold, all three record `worktree-commit-safety-unknown`, each reason names its own cause, and none of them claims work was found at risk.
6. `TestReconcileReturnsWorktreeOfPushedAndMergedPullRequest` - pushed and merged: ordinary cleanup still works.
7. `TestReconcileReturnsSquashMergedWorktreeOnPullRequestHeadEvidence` - local-only commits whose head is the recorded pull request head: returned, no false data-loss positive.
8. `TestReconcileWithholdsReturnForCommitPastThePushedPullRequestHead` - a commit past the pushed head: withheld, both SHAs named.
9. `TestReconcileKeepsAttemptTerminalWhileWorktreeReturnIsWithheld` - the Attempt is still `completed`, the Task still terminal with no active attempt, and Herdr is released on the same pass, while the worktree return is withheld.
10. `TestReconcileWithheldWorktreeReturnIsIdempotent` - two reconciles with the clock advanced between them leave durable state byte-identical, the Attempt terminal on both passes, and no return on either.

The git semantics behind them are tested against real repositories in `internal/worktree/commit_safety_test.go`: a pushed worktree proves durable, unpushed commits are counted, and a clone with no remote, a deleted remote-tracking ref beside a surviving one, a path with no repository, and an empty worktree path all report `unknown`. `internal/ghutil/pr_test.go` covers `PRHeadCommit` reading the recorded head and refusing an empty one as evidence. The gate review then caught that the new `gh pr view --json headRefOid` shape was unmodeled by the shared fake, so `tests/contract/gh_fake_test.go:TestGHFixturesPreserveHeadRefOid` pins the fixture hermetically and `tests/contract/gh_test.go:TestGHPRViewReportsHeadRefOidAfterBranchDeletion` checks the real `gh` under contract-live, including that a merged PR still answers with the SHA its deleted branch pointed at.

Also run locally in `nix develop`: `go test ./...`, `go test -race ./...`, `go vet ./...`, `make lint`, `make build`, `make contract`, `make e2e`, `nix flake check`. Gate pipeline results are in the Gate section below.

## Gate

no-mistakes pipeline run `01M0ASKMX2Z2WFNA61PNH11ZV2` on head `01a64cf203c743fc01e917fe2c66c61b957f9da6`, driven to completion.

| step | result | duration |
| --- | --- | --- |
| intent | passed, 0 findings | 10ms |
| rebase | passed, 0 findings | 30s |
| review | 1 warning finding, fixed, re-checked clean | 815s |
| test | passed, 0 findings | 187s |
| document | passed, 0 findings | 112s |
| lint | passed, 0 findings | 21ms |
| push | passed, 0 findings | 27s |
| pr | passed, 0 findings | 48s |
| ci | skipped by the gate | 30s |

The `ci` step skipped itself with `skipping CI: gh CLI is not authenticated`, which is a fact about the daemon's environment rather than a CI result. GitHub Actions ran normally on this head and every required check is green, verified directly with `gh pr checks`.

The `review` step raised one warning, `gh-headrefoid-fidelity-gap`, and it was a real defect rather than noise: `PRHeadCommit` introduced a `gh pr view --json headRefOid` invocation the shared fake did not model, because `ghPRView` ignored the requested fields and always answered `{"state":...}`. That breaks the repository's rule that each external tool is faked once in `internal/faketool`, with `FIDELITY.md` recording observed behavior and `tests/contract` rechecking it. The pipeline fixed it in `01a64cf`, strictly additively: a `HeadRefOid` field on the `GHPR` fixture, dispatch on the requested `--json` field with the existing `--json state` answer unchanged, a `FIDELITY.md` entry, a hermetic contract case, and a contract-live check against real `gh` confirming that a merged PR still answers with the SHA its deleted branch pointed at. Nothing else was raised at any severity, and the review's later rounds found nothing to fix in the reconcile change itself.

The `document` and `lint` steps added no commit: the ADR update and the `hand reconcile` help text already in this PR satisfied them. Every commit on the branch is GPG signed with key `8AD7D4A302EE6771` and carries no `Co-Authored-By` trailer.

Focused suites the gate's test step ran, on top of the full local validation listed above:

- `go test ./internal/worktree/... -run TestObserveCommitSafety -v`
- `go test ./internal/runtime/... -run 'TestReconcile|TestConverge|TestCommitSafety|TestTerminal' -v`
- `go test ./internal/ghutil/... -run TestPRHead -v`
- `go test -tags=contract -run 'TestGHFixturesPreservePullRequestAndRepositoryContracts|TestGH' -v ./tests/contract/...`
- `go test ./cmd/... -run TestReconcile -v`

Evidence captured by the gate's own test step:

<details>
<summary>Evidence: hand reconcile CLI transcript: dead worker converges to interrupted on observed evidence</summary>

```text
=== RUN   TestManualEvidenceConvergeDeadWorker
=== hand reconcile task-1 (dead worker, herdr pane absent, no PR/merge/delivery recorded) ===
count: 1
id: task-1
result: healthy
action: cleanup-terminal-resources
iterations: 3
attempt: 1
landing: unlanded
detail: attempt 1 converged to interrupted on observed evidence

=== persisted history after reconcile: active_attempt=<nil> final_lifecycle=interrupted (no `hand teardown` invoked) ===
--- PASS: TestManualEvidenceConvergeDeadWorker (0.40s)
PASS
ok  	github.com/atqamz/hand/cmd	0.406s
```
</details>

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"01a64cf203c743fc01e917fe2c66c61b957f9da6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->
