### PR TITLE
fix(ghutil): observe pull requests as found, absent, or unknown

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -104,11 +104,16 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 	// A gate-opened PR (atqamz/hand#69) can populate t.PR without hand having merged it, so t.PR no
 	// longer implies hand hasn't seen it merged yet; check before running CI checks against a PR gh
 	// already closed.
-	merged, err := ghutil.PRIsMerged(cmd.Context(), t.PR)
-	if err != nil {
-		return err
+	observation := ghutil.ObserveMergeState(cmd.Context(), t.PR)
+	// Neither an absent PR nor an unobserved one may fall through to gh pr merge: merging is
+	// irreversible, and only a completed observation proves this PR exists and is still open.
+	if observation.Absent() {
+		return &ExitError{Err: fmt.Errorf("PR %s does not exist", t.PR), Code: 3}
 	}
-	if merged {
+	if observation.Unknown() {
+		return &ExitError{Err: fmt.Errorf("state of PR %s could not be observed, so hand refuses to merge it: %s", t.PR, observation.Reason()), Code: 3}
+	}
+	if observation.Merged {
 		return &ExitError{Err: fmt.Errorf("PR %s is already merged", t.PR), Code: 3}
 	}
 

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -171,6 +171,79 @@ func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
 	}
 }
 
+// atqamz/hand#241 at the irreversible call: a PR state hand could not read is neither an open PR nor an
+// absent one, so gh pr merge must not run and the refusal must not name a cause it did not observe.
+func TestMergeRefusesAPRWhoseStateCouldNotBeObserved(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	log := filepath.Join(t.TempDir(), "gh.log")
+	faketool.GH{Log: log, Responses: []faketool.GHResponse{
+		{Command: "pr view", Stderr: ghRejectedCredential, Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newMergeCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want ExitError code 3", err)
+	}
+	if !strings.Contains(err.Error(), "could not be observed") || strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want the observation failure and no claim that the PR is absent", err)
+	}
+	assertNoMergeRan(t, log)
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MergeExecuted {
+		t.Fatal("want no merge recorded for a PR hand could not observe")
+	}
+}
+
+// The other half of the same guard: a PR GitHub positively says is not there still refuses, and says so.
+func TestMergeRefusesAPRGitHubReportsAsAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	log := filepath.Join(t.TempDir(), "gh.log")
+	faketool.GH{Log: log, Responses: []faketool.GHResponse{
+		{Command: "pr view", Stderr: ghPRAbsentDiagnostic(42), Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newMergeCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want ExitError code 3", err)
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want the absent-PR refusal", err)
+	}
+	assertNoMergeRan(t, log)
+}
+
+func assertNoMergeRan(t *testing.T, log string) {
+	t.Helper()
+	invocations, err := os.ReadFile(log)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(invocations), "gh pr merge") {
+		t.Fatalf("gh pr merge ran before the PR state was known:\n%s", invocations)
+	}
+}
+
 func TestMergePRRefusesRedCI(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
@@ -199,11 +272,11 @@ func TestMergePRRefusesRedCI(t *testing.T) {
 	if got.MergeExecuted {
 		t.Fatal("want task not marked merged")
 	}
-	merged, err := ghutil.PRIsMerged(context.Background(), mergeTestPR)
-	if err != nil {
-		t.Fatal(err)
+	observation := ghutil.ObserveMergeState(context.Background(), mergeTestPR)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the fake PR observed", observation)
 	}
-	if merged {
+	if observation.Merged {
 		t.Fatal("want red checks to leave gh's PR unmerged")
 	}
 }
@@ -237,11 +310,11 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 		t.Fatal("want merged_at set")
 	}
 
-	merged, err := ghutil.PRIsMerged(context.Background(), mergeTestPR)
-	if err != nil {
-		t.Fatal(err)
+	observation := ghutil.ObserveMergeState(context.Background(), mergeTestPR)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the fake PR observed", observation)
 	}
-	if !merged {
+	if !observation.Merged {
 		t.Fatal("want the PR merged on gh's side too, not only on the task row")
 	}
 	for _, want := range []string{"id: task-1\n", "result: merged\n", "method: squash\n", "pr: \"https://github.com/org/repo/pull/42\"\n", "merged: "} {

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/runtime"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -31,16 +33,24 @@ func addOriginRemote(t *testing.T, dir, url string) {
 	}
 }
 
+// The diagnostic real gh answers with for a pull request that is not there (FIDELITY.md). A fake that
+// paraphrases it makes the absent path unreachable, and every refusal below an unknown one instead.
+func ghPRAbsentDiagnostic(number int) string {
+	return fmt.Sprintf("GraphQL: Could not resolve to a PullRequest with the number of %d. (repository.pullRequest)\n", number)
+}
+
 func writeFakeGhPRView(t *testing.T, exitCode int) {
 	t.Helper()
-	bin := faketool.Bin(t)
-	response := faketool.GHResponse{Command: "pr view", Exit: exitCode}
-	if exitCode != 0 {
-		response.Stderr = "gh: pull request not found\n"
-	} else {
-		response.Stdout = "{\"state\":\"OPEN\"}"
+	response := faketool.GHResponse{Command: "pr view", Exit: exitCode, Stderr: ghPRAbsentDiagnostic(1)}
+	if exitCode == 0 {
+		response = faketool.GHResponse{Command: "pr view", Stdout: "{\"state\":\"OPEN\"}"}
 	}
-	faketool.GH{Responses: []faketool.GHResponse{response}}.Install(t, bin)
+	writeFakeGhPRViewResponse(t, response)
+}
+
+func writeFakeGhPRViewResponse(t *testing.T, response faketool.GHResponse) {
+	t.Helper()
+	faketool.GH{Responses: []faketool.GHResponse{response}}.Install(t, faketool.Bin(t))
 }
 
 func setupPRHome(t *testing.T) (home, clonePath string) {
@@ -220,9 +230,12 @@ func TestDetectPRSearchesRenamedRepositoryAfterProjectSetURL(t *testing.T) {
 	if err != nil || !exists {
 		t.Fatalf("project.Find = %+v, %v, %v", proj, exists, err)
 	}
-	got, err := detectPR(context.Background(), home, task, state.Attempt{Worktree: clonePath}, proj)
+	got, observation, err := runtime.DetectPR(context.Background(), home, task, state.Attempt{Worktree: clonePath}, proj)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the PR found", observation)
 	}
 	if got.PR != prURL {
 		t.Fatalf("detected task.PR = %q, want %q", got.PR, prURL)
@@ -350,6 +363,42 @@ func TestPRRefusesWhenGhReportsNotFound(t *testing.T) {
 	}
 	if task.PR != "" {
 		t.Fatalf("task.PR = %q, want no PR recorded when gh can't confirm it exists", task.PR)
+	}
+}
+
+// A rejected credential is not a missing PR: reporting one as the other sends the operator to fix a URL
+// that was right all along, which is the confusion atqamz/hand#241 removes.
+func TestPRRefusesWithoutClaimingAbsenceWhenGhCannotAnswer(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/owner/secondhand.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/owner/secondhand.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGhPRViewResponse(t, faketool.GHResponse{
+		Command: "pr view",
+		Stderr:  "gh: HTTP 401: Bad credentials (https://api.github.com/graphql)\n",
+		Exit:    1,
+	})
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "https://github.com/owner/secondhand/pull/1"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got err %v, want a refusal that does not report the PR as absent", err)
+	}
+	if !strings.Contains(err.Error(), "could not be observed") {
+		t.Fatalf("got err %v, want the refusal to name the observation that did not complete", err)
+	}
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != "" {
+		t.Fatalf("task.PR = %q, want no PR recorded from an observation that never completed", task.PR)
 	}
 }
 

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -4,36 +4,33 @@ import (
 	"context"
 	"time"
 
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/runtime"
 	"github.com/atqamz/hand/internal/state"
 )
 
-func detectPR(ctx context.Context, home string, t state.Task, active state.Attempt, proj project.Project) (state.Task, error) {
-	return runtime.DetectPR(ctx, home, t, active, proj)
-}
-
-func detectPRForStatus(ctx context.Context, home string, history state.TaskHistory) state.Task {
+// Fills an empty PR field from GitHub for the status views, and reports what the lookup answered so a
+// still-empty field is not read as an absence. The state is empty where no lookup applies at all, which
+// is not the same as an absence either.
+func detectPRForStatus(ctx context.Context, home string, history state.TaskHistory) (state.Task, ghutil.ObservationState) {
 	t := history.Task
 	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - and a torn-down task's
 	// completion record is already written, so both skip the lookup rather than pay a forge round trip for a
 	// PR recordPR would refuse. The scout half is the short-circuit checkLandedWork opens with.
 	if t.PR != "" || t.Kind == state.KindScout || t.Lifecycle == state.TaskTerminal {
-		return t
+		return t, ""
 	}
 	if history.ActiveAttempt == nil {
-		return t
+		return t, ""
 	}
 	proj, exists, err := project.FindReadOnly(home, t.Project)
 	if err != nil || !exists || proj.Mode == project.ModeLocalOnly {
-		return t
+		return t, ""
 	}
 
 	ghCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	detected, err := runtime.DetectPRReadOnly(ghCtx, home, t, *history.ActiveAttempt, proj)
-	if err != nil {
-		return t
-	}
-	return detected
+	detected, observation := runtime.DetectPRReadOnly(ghCtx, home, t, *history.ActiveAttempt, proj)
+	return detected, observation.State
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/atqamz/hand/internal/age"
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
@@ -120,23 +121,26 @@ type reportedJSON struct {
 }
 
 type statusJSON struct {
-	ID               string        `json:"id"`
-	Project          string        `json:"project"`
-	Kind             string        `json:"kind"`
-	ExecutionClass   string        `json:"execution_class,omitempty"`
-	Profile          string        `json:"profile,omitempty"`
-	PlannedAgainst   string        `json:"planned_against,omitempty"`
-	RoutingSource    string        `json:"routing_source,omitempty"`
-	TaskLifecycle    string        `json:"task_lifecycle"`
-	AttemptOrdinal   int           `json:"attempt_ordinal,omitempty"`
-	AttemptLifecycle string        `json:"attempt_lifecycle,omitempty"`
-	Harness          string        `json:"harness,omitempty"`
-	Model            string        `json:"model,omitempty"`
-	Effort           string        `json:"effort,omitempty"`
-	AgentState       string        `json:"agent_state"`
-	Worktree         string        `json:"worktree"`
-	Herdr            state.Herdr   `json:"herdr"`
-	PR               string        `json:"pr"`
+	ID               string      `json:"id"`
+	Project          string      `json:"project"`
+	Kind             string      `json:"kind"`
+	ExecutionClass   string      `json:"execution_class,omitempty"`
+	Profile          string      `json:"profile,omitempty"`
+	PlannedAgainst   string      `json:"planned_against,omitempty"`
+	RoutingSource    string      `json:"routing_source,omitempty"`
+	TaskLifecycle    string      `json:"task_lifecycle"`
+	AttemptOrdinal   int         `json:"attempt_ordinal,omitempty"`
+	AttemptLifecycle string      `json:"attempt_lifecycle,omitempty"`
+	Harness          string      `json:"harness,omitempty"`
+	Model            string      `json:"model,omitempty"`
+	Effort           string      `json:"effort,omitempty"`
+	AgentState       string      `json:"agent_state"`
+	Worktree         string      `json:"worktree"`
+	Herdr            state.Herdr `json:"herdr"`
+	PR               string      `json:"pr"`
+	// Omitted where no live lookup applied, so a consumer sees "unknown" only where an
+	// empty pr field is a failed observation rather than a PR that is not there.
+	PRObservation    string        `json:"pr_observation,omitempty"`
 	MergeExecuted    bool          `json:"merged"`
 	MergeAnnounced   bool          `json:"pr_merged_observed"`
 	DeliveredAt      string        `json:"delivered_at,omitempty"`
@@ -526,7 +530,7 @@ func (v taskView) json() statusJSON {
 	}
 	return statusJSON{
 		ID: v.task.ID, Project: v.task.Project, Kind: v.task.Kind, ExecutionClass: e.ExecutionClass, Profile: e.RequestedProfile, PlannedAgainst: e.PlannedAgainst, RoutingSource: e.RoutingSource, TaskLifecycle: string(v.task.Lifecycle), AttemptOrdinal: e.Ordinal, AttemptLifecycle: string(e.Lifecycle), Harness: e.Harness, Model: e.Model, Effort: e.Effort,
-		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR,
+		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR, PRObservation: string(v.prObserved),
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt,
@@ -560,13 +564,15 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	if err != nil {
 		return asPrecondition(err)
 	}
-	history.Task = detectPRForStatus(cmd.Context(), home, history)
+	var prObserved ghutil.ObservationState
+	history.Task, prObserved = detectPRForStatus(cmd.Context(), home, history)
 	t := history.Task
 
 	// An unreadable report degrades exactly as it does in the fleet view: the
 	// fault is named on the report field and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
 	v, reportLines := buildTaskView(home, client, history, full, true)
+	v.prObserved = prObserved
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.
 	hold, held, err := state.ReadHoldReadOnly(home, id)

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -555,6 +555,78 @@ func TestStatusSkipsPRDetectionForScoutTasks(t *testing.T) {
 	}
 }
 
+// atqamz/hand#241 in the one view an operator reads before deciding anything: a lookup that failed must
+// not render as the same empty pr field a task that has no PR renders, in either output shape.
+func TestStatusSingleTaskDistinguishesAnUnobservedPRFromNone(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	setupTeardownGateProject(t, home, worktree, "task-1-branch")
+	writeFakeHerdrPaneStatus(t, "idle")
+	faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "pr list", Stderr: ghRejectedCredential, Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	text := runStatusFor(t, "task-1")
+	if !strings.Contains(text, "pr: unknown") {
+		t.Fatalf("got %q, want the pr column to report the failed lookup", text)
+	}
+	if again := runStatusFor(t, "task-1"); again != text {
+		t.Fatalf("second read differs from the first:\n%s\n%s", text, again)
+	}
+
+	asJSON := runStatusFor(t, "task-1", "--json")
+	if !strings.Contains(asJSON, `"pr_observation": "unknown"`) {
+		t.Fatalf("got %q, want pr_observation unknown", asJSON)
+	}
+
+	got, err := state.ReadHistoryReadOnly(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Task.PR != "" {
+		t.Fatalf("task.PR = %q, want a failed lookup to record nothing", got.Task.PR)
+	}
+}
+
+// The other side of the same field: GitHub answered, and answered that there is no PR on this branch.
+func TestStatusSingleTaskReportsAnAnsweredAbsenceAsNone(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	setupTeardownGateProject(t, home, worktree, "task-1-branch")
+	writeFakeHerdrPaneStatus(t, "idle")
+	writeFakeGHPRListAndView(t)
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	text := runStatusFor(t, "task-1")
+	if !strings.Contains(text, "pr: none") {
+		t.Fatalf("got %q, want the pr column to report an answered absence as none", text)
+	}
+	if asJSON := runStatusFor(t, "task-1", "--json"); !strings.Contains(asJSON, `"pr_observation": "absent"`) {
+		t.Fatalf("got %q, want pr_observation absent", asJSON)
+	}
+}
+
+func runStatusFor(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	return out.String()
+}
+
 func TestStatusFleetOverviewRendersMergeMarker(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -27,6 +28,8 @@ type taskView struct {
 	latestSend    *state.SendAttempt
 	held          bool
 	hold          state.Hold
+	// Empty where no live lookup applied, which is neither a finding nor an absence.
+	prObserved ghutil.ObservationState
 }
 
 func (v taskView) execution() state.Attempt {
@@ -149,7 +152,12 @@ var taskFields = []axi.Column[taskView]{
 	{Name: "age", Value: func(v taskView) string { return formatAge(v.task.CreatedAt) }},
 	{Name: "created", Value: func(v taskView) string { return orNone(v.task.CreatedAt) }},
 	{Name: "last_report", Value: func(v taskView) string { return formatReportAge(v.lastReportAt) }},
-	{Name: "pr", Value: func(v taskView) string { return orNone(v.task.PR) }},
+	{Name: "pr", Value: func(v taskView) string {
+		if v.task.PR == "" && v.prObserved == ghutil.ObservationUnknown {
+			return "unknown"
+		}
+		return orNone(v.task.PR)
+	}},
 	{Name: "worktree", Value: func(v taskView) string { return orNone(v.execution().Worktree) }},
 	{Name: "herdr", Value: func(v taskView) string {
 		e := v.execution()

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -100,8 +100,8 @@ type ghFakePR struct {
 }
 
 // The two calls gate-opened-PR detection makes: `gh pr list --repo <repo> --head <branch>`
-// (FindPRByBranch) then `gh pr view <url> --json state` (project.ValidatePR, then checkLandedWork).
-// Several PRs exercise FindPRByBranch's preference tier (atqamz/hand#77), not its single result.
+// (ObservePRByBranch) then `gh pr view <url> --json state` (project.ValidatePR, then checkLandedWork).
+// Several PRs exercise ObservePRByBranch's preference tier (atqamz/hand#77), not its single result.
 func writeFakeGHPRListAndView(t *testing.T, prs ...ghFakePR) {
 	t.Helper()
 	g := faketool.GH{}
@@ -115,7 +115,7 @@ func writeFakeGHPRListAndView(t *testing.T, prs ...ghFakePR) {
 }
 
 // Registers a non-local-only project whose clone has a GitHub origin remote (RepoSlug reads it) and
-// re-points worktree's checked-out branch to branch, so FindPRByBranch's --head argument matches it.
+// re-points worktree's checked-out branch to branch, so ObservePRByBranch's --head argument matches it.
 func setupTeardownGateProject(t *testing.T, home, worktree, branch string) {
 	t.Helper()
 	runGitIn(t, worktree, "checkout", "-q", "-b", branch)
@@ -446,6 +446,67 @@ func TestTeardownShipFailsWhenPRNotMerged(t *testing.T) {
 	}
 	if invocations := readInvocations(t, worktree); len(invocations) != 0 {
 		t.Fatalf("external cleanup before landed-work refusal = %v, want no invocations", invocations)
+	}
+}
+
+// The credential rejection every unobserved-PR test below builds its failure from, quoted from real gh
+// (FIDELITY.md). Absence has its own diagnostic and this is not it.
+const ghRejectedCredential = "gh: HTTP 401: Bad credentials (https://api.github.com/graphql)\n"
+
+// atqamz/hand#241 at the call that hands a worktree back to the pool: a merge state hand could not
+// read is not a PR proven unmerged, and the worktree may hold the only copy of the work.
+func TestTeardownDoesNotReleaseAWorktreeWhoseMergeStateCouldNotBeObserved(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "pr view", Stderr: ghRejectedCredential, Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj", PR: teardownTestPR}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), "could not be observed") || strings.Contains(err.Error(), "is not merged") {
+		t.Fatalf("got err %v, want a refusal that reports the observation failure and claims nothing about the merge", err)
+	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state after an unobserved merge state = %v, %v, want task to remain", exists, err)
+	}
+	if invocations := readInvocations(t, worktree); len(invocations) != 0 {
+		t.Fatalf("external cleanup after an unobserved merge state = %v, want no invocations", invocations)
+	}
+}
+
+// The same refusal one step earlier, where the search that would have found a gate-opened PR fails:
+// an empty result hand never received is not a task without a PR, and "work may not be landed" would
+// send an operator looking for work that is sitting in a merged PR.
+func TestTeardownDoesNotReleaseAWorktreeWhosePRSearchCouldNotBeObserved(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	setupTeardownGateProject(t, home, worktree, "task-1-branch")
+	faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "pr list", Stderr: ghRejectedCredential, Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if !strings.Contains(err.Error(), "could not be observed") || strings.Contains(err.Error(), "work may not be landed") {
+		t.Fatalf("got err %v, want a refusal that reports the observation failure rather than an absent PR", err)
+	}
+	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {
+		t.Fatalf("state after an unobserved PR search = %v, %v, want task to remain", exists, err)
+	}
+	if invocations := readInvocations(t, worktree); len(invocations) != 0 {
+		t.Fatalf("external cleanup after an unobserved PR search = %v, want no invocations", invocations)
 	}
 }
 

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -242,7 +242,27 @@ Driven by `internal/ghutil`, and through it by teardown's landed-work check and 
 GitHub transport and service failures exit nonzero and put their diagnostic on stderr, not stdout.
 The fleet has observed HTTP 503, DNS lookup failure and request dial timeout failures against `api.github.com`.
 `GHResponse` preserves the configured stdout, stderr and exit code verbatim so focused tests can express each failure without a network call.
+`GH.Hang` names commands the fake never answers, for a caller's own timeout and cancellation paths, and mirrors `Herdr.Hang`.
 An empty successful result remains distinct: `gh pr list` exits 0 and writes `[]` to stdout.
+
+### The one diagnostic that proves a pull request is not there
+
+`gh pr view` exits 1 and writes exactly this to stderr for a pull request number the repository does not have:
+
+```
+GraphQL: Could not resolve to a PullRequest with the number of 999999. (repository.pullRequest)
+```
+
+Every other nonzero exit says the query did not complete, which is a different answer, so `internal/ghutil` reads absence off this shape alone and treats the rest as unknown.
+Two shapes are worth naming because they read like absence and are not:
+
+```
+GraphQL: Could not resolve to a Repository with the name of 'owner/repo'. (repository)
+gh: HTTP 401: Bad credentials (https://api.github.com/graphql)
+```
+
+GitHub answers the repository shape both for a repository that does not exist and for a private one the token may not read, so it can never stand in for a missing pull request.
+A rejected or expired credential answers the second, and reporting either of them as an absence is the failure atqamz/hand#241 removes.
 
 ### `gh pr list --repo <slug> --head <branch> --state all --limit 200 --json number,url,state,headRepository`
 
@@ -254,14 +274,14 @@ Exit 0 with a JSON array on stdout, `[]` when nothing matches - an empty result 
 ### `gh pr view <url-or-number> --json state`
 
 Exit 0 with the JSON object on stdout.
-A PR that does not exist is exit 1 with a GraphQL error on stderr.
+A PR that does not exist is exit 1 with the GraphQL diagnostic above on stderr, which is the only absence this call can prove.
 Real `gh` also writes warnings to stderr ahead of the JSON, which is why callers read stdout alone.
 
 ### `gh pr view <url-or-number> --json headRefOid`
 
 Exit 0 with the head branch's current commit SHA on stdout, the same GraphQL warnings-before-JSON shape as `--json state`.
-`PRHeadCommit` reads this rather than a local clone because GitHub's record of the head ref outlives that clone and survives the branch being deleted after a merge.
-A merged PR still answers with the SHA the head branch pointed at before deletion, so `PRHeadCommit` remains usable on a PR whose branch is long gone.
+`ObserveHeadCommit` reads this rather than a local clone because GitHub's record of the head ref outlives that clone and survives the branch being deleted after a merge.
+A merged PR still answers with the SHA the head branch pointed at before deletion, so `ObserveHeadCommit` remains usable on a PR whose branch is long gone.
 
 ### `gh pr checks <url-or-number> --json bucket`
 
@@ -286,14 +306,14 @@ This is the transition `hand merge` and `hand teardown` are sequenced around - m
 ```
 
 So the exit status cannot say whether a merge happened, and a rerun of `hand merge` would report success for a merge it did not perform.
-`runPRMerge` checks `PRIsMerged` before the merge for that reason, and `TestMergeRefusesAPRAnEarlierRunAlreadyMerged` is the check that fails without it.
+`runPRMerge` observes the merge state before the merge for that reason, and `TestMergeRefusesAPRAnEarlierRunAlreadyMerged` is the check that fails without it.
 
 Both merge entries were observed on a throwaway PR and are the one part of this file `make contract-live` does not re-run: merging is not reversible, and no contract run may land a real PR.
 
 ### Slug case
 
 GitHub serves a repo under any casing of its slug and answers with the canonical one: `--repo AtqaMZ/Hand` succeeds and reports `"nameWithOwner":"atqamz/hand"`.
-So `FindPRByBranch` folds case when comparing a `gh` answer against a git remote, and the fake matches `--repo` case-insensitively - a case-sensitive fake would answer a double search of one repo with one hit and hide the duplicate the real `gh` returns.
+So `ObservePRByBranch` folds case when comparing a `gh` answer against a git remote, and the fake matches `--repo` case-insensitively - a case-sensitive fake would answer a double search of one repo with one hit and hide the duplicate the real `gh` returns.
 
 `internal/ghutil/pr_test.go` and `tests/e2e/slug_case_test.go` cover the comparison itself.
 The latter's own `gh` fake is the one place a fake's fidelity had already been thought about; it is deliberately left as it is.

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // GHPR describes one pull request and the checks its fake reports.
@@ -70,7 +71,10 @@ type GH struct {
 	ReleaseStore        *GHReleaseStore
 	Responses           []GHResponse
 	RejectQualifiedHead bool
-	Log                 string
+	// Commands this fake never answers, for a caller timeout or cancellation path. Same shape and
+	// same purpose as Herdr.Hang.
+	Hang []string
+	Log  string
 }
 
 type ghSpec struct {
@@ -81,6 +85,7 @@ type ghSpec struct {
 	ReleaseStoreRepo    string
 	Responses           []GHResponse
 	RejectQualifiedHead bool
+	Hang                []string
 	StateDir            string
 	Log                 string
 }
@@ -101,7 +106,7 @@ func (g GH) Install(t *testing.T, bin string) {
 	}
 	spec := ghSpec{
 		PRs: g.PRs, Repos: g.Repos, Release: g.Release, Responses: g.Responses,
-		RejectQualifiedHead: g.RejectQualifiedHead, StateDir: state, Log: g.Log,
+		RejectQualifiedHead: g.RejectQualifiedHead, Hang: g.Hang, StateDir: state, Log: g.Log,
 	}
 	if g.ReleaseStore != nil {
 		spec.ReleaseStorePath = g.ReleaseStore.install(t, state)
@@ -124,6 +129,13 @@ func runGHFromPayload(payload json.RawMessage, args []string) int {
 		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
 	}
 	command := args[0] + " " + args[1]
+	for _, blocked := range spec.Hang {
+		if blocked == command {
+			for {
+				time.Sleep(time.Hour)
+			}
+		}
+	}
 	if command == "pr list" && spec.RejectQualifiedHead && strings.Contains(flagValue(args, "--head"), ":") {
 		return fail("qualified head ref matches nothing in real gh: %s", flagValue(args, "--head"))
 	}
@@ -200,7 +212,7 @@ func ghPRView(spec ghSpec, args []string) int {
 	}
 	index, ok := ghPRIndex(spec.PRs, args[2])
 	if !ok {
-		return fail("no such pull request: %s", args[2])
+		return ghNoSuchPR(args[2])
 	}
 	switch flagValue(args, "--json") {
 	case "headRefOid":
@@ -257,7 +269,7 @@ func ghPRChecks(spec ghSpec, args []string) int {
 	}
 	index, ok := ghPRIndex(spec.PRs, args[2])
 	if !ok {
-		return fail("no such pull request: %s", args[2])
+		return ghNoSuchPR(args[2])
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "%s\n", ghBuckets(spec.PRs[index].Checks))
 	return 0
@@ -269,7 +281,7 @@ func ghPRMerge(spec ghSpec, args []string) int {
 	}
 	index, ok := ghPRIndex(spec.PRs, args[2])
 	if !ok {
-		return fail("no such pull request: %s", args[2])
+		return ghNoSuchPR(args[2])
 	}
 	path := ghStatePath(spec.StateDir, index)
 	state, err := os.ReadFile(path)
@@ -425,6 +437,13 @@ func ghReleaseDownloadDir(release GHRelease, tag string, args []string) (string,
 		}
 	}
 	return dir, true
+}
+
+// The one diagnostic that proves a pull request is not there, quoted from real gh (FIDELITY.md):
+// an unresolvable repository or a rejected credential answers differently and proves nothing.
+func ghNoSuchPR(ref string) int {
+	number := ref[strings.LastIndex(ref, "/")+1:]
+	return fail("GraphQL: Could not resolve to a PullRequest with the number of %s. (repository.pullRequest)", number)
 }
 
 func ghPRIndex(prs []GHPR, ref string) (int, bool) {

--- a/internal/faketool/gh_test.go
+++ b/internal/faketool/gh_test.go
@@ -222,8 +222,10 @@ func TestGHRefusesAPRItDoesNotKnow(t *testing.T) {
 		{"pr", "checks", "404", "--json", "bucket"},
 	} {
 		_, errOut, code := runGH(t, args...)
-		if code == 0 || !strings.Contains(errOut, "no such pull request") {
-			t.Fatalf("%v = %q (exit %d), want a refusal", args, errOut, code)
+		// The exact diagnostic, not any refusal: ghutil reads absence off this string and reads
+		// anything else as unknown, so a paraphrase here would turn a real absence into unknown.
+		if code == 0 || !strings.Contains(errOut, "Could not resolve to a PullRequest with the number of 404.") {
+			t.Fatalf("%v = %q (exit %d), want the gh not-found diagnostic", args, errOut, code)
 		}
 	}
 }

--- a/internal/ghutil/observation.go
+++ b/internal/ghutil/observation.go
@@ -1,0 +1,106 @@
+package ghutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ObservationState is the one vocabulary every GitHub observation in hand answers in. Absent is a
+// positive finding from a query that completed; anything that stopped a query from completing is
+// unknown, and nothing may be concluded from it.
+type ObservationState string
+
+const (
+	ObservationFound   ObservationState = "found"
+	ObservationAbsent  ObservationState = "absent"
+	ObservationUnknown ObservationState = "unknown"
+)
+
+// Probe records how an observation was attempted, so an unknown carries the command that was run
+// and what it answered instead. Same role as worktree.LeaseProbe: evidence travels with the state.
+type Probe struct {
+	Command string
+	Reason  string
+}
+
+// PRObservation is one answer about one pull request. Merged, URL and Head are meaningful only
+// where the state is found; Ambiguous is set only where a completed query returned candidates that
+// do not resolve to a single winner.
+type PRObservation struct {
+	State     ObservationState
+	URL       string
+	Merged    bool
+	Head      string
+	Ambiguous *AmbiguousPRError
+	Probe     Probe
+}
+
+func (o PRObservation) Found() bool { return o.State == ObservationFound }
+
+// Absent reports that the query completed and there is genuinely no such pull request. It is never
+// the residue of a failed query, so a caller may act on it.
+func (o PRObservation) Absent() bool { return o.State == ObservationAbsent }
+
+// Unknown is every state that is not one of the two positive findings, which is what keeps a zero
+// value, an unset state, and any state added later from reading as an absence.
+func (o PRObservation) Unknown() bool { return !o.Found() && !o.Absent() }
+
+// Reason is the sentence a caller reports when it will not act on this observation, naming
+// what answered nothing and the command that asked.
+func (o PRObservation) Reason() string {
+	if o.Probe.Command == "" {
+		return o.Probe.Reason
+	}
+	return fmt.Sprintf("%s; observed by running %q", o.Probe.Reason, o.Probe.Command)
+}
+
+// UnknownPRObservation reports an observation that could not be attempted at all, so a caller whose
+// local prerequisite failed says unknown rather than passing an absence off as one GitHub answered.
+func UnknownPRObservation(command, reason string) PRObservation {
+	return PRObservation{State: ObservationUnknown, Probe: Probe{Command: command, Reason: reason}}
+}
+
+// The one diagnostic GitHub answers with when a pull request genuinely does not exist. An absent
+// repository reports "Could not resolve to a Repository" instead, which is indistinguishable from
+// one the token may not read, so only this shape proves absence (tests/contract pins both).
+const prAbsentDiagnostic = "Could not resolve to a PullRequest"
+
+func absentPR(probe Probe) PRObservation {
+	probe.Reason = "gh reports no such pull request"
+	return PRObservation{State: ObservationAbsent, Probe: probe}
+}
+
+func unknownPR(probe Probe, format string, args ...any) PRObservation {
+	probe.Reason = fmt.Sprintf(format, args...)
+	return PRObservation{State: ObservationUnknown, Probe: probe}
+}
+
+// Runs one gh query and decodes its JSON payload into payload. A non-nil result is the terminal
+// observation: absent only for the diagnostic that proves a pull request does not exist, unknown
+// for every other failure, including an unreadable payload at exit 0.
+func decodeGHPayload(ctx context.Context, probe Probe, payload any, args ...string) *PRObservation {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	// gh writes warnings to stderr ahead of the JSON, so the payload is read from stdout alone;
+	// CombinedOutput here corrupts the parse (atqamz/hand#21).
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		diagnostic := strings.TrimSpace(stderr.String())
+		if strings.Contains(diagnostic, prAbsentDiagnostic) {
+			observation := absentPR(probe)
+			return &observation
+		}
+		observation := unknownPR(probe, "gh failed: %v: %s", err, diagnostic)
+		return &observation
+	}
+	if err := json.Unmarshal(out, payload); err != nil {
+		observation := unknownPR(probe, "gh exited zero and its output could not be parsed: %v: %s", err, strings.TrimSpace(string(out)))
+		return &observation
+	}
+	return nil
+}

--- a/internal/ghutil/pr.go
+++ b/internal/ghutil/pr.go
@@ -6,58 +6,60 @@
 package ghutil
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
-// PRIsMerged reports whether the PR is merged. gh writes warnings to stderr ahead of the JSON, so the
-// payload must be read from stdout alone; CombinedOutput here corrupts the parse
-// (atqamz/hand#21).
-func PRIsMerged(ctx context.Context, pr string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "state")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return false, fmt.Errorf("gh pr view failed: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
+// ObserveMergeState reports what GitHub records for one pull request's merge state. A query that
+// did not complete is unknown, never an unmerged pull request, because "not merged" is what
+// licenses teardown and reconciliation to act on work that may in fact have landed.
+func ObserveMergeState(ctx context.Context, pr string) PRObservation {
+	args := []string{"pr", "view", pr, "--json", "state"}
+	probe := Probe{Command: ghCommand(args)}
 	var body struct {
 		State string `json:"state"`
 	}
-	if err := json.Unmarshal(out, &body); err != nil {
-		return false, fmt.Errorf("parse gh pr view output: %w", err)
+	if terminal := decodeGHPayload(ctx, probe, &body, args...); terminal != nil {
+		return *terminal
 	}
-	return body.State == "MERGED", nil
+	if body.State == "" {
+		return unknownPR(probe, "gh exited zero and reported no state for pull request %s", pr)
+	}
+	return PRObservation{State: ObservationFound, URL: pr, Merged: body.State == "MERGED", Probe: probe}
 }
 
-// PRHeadCommit reads the commit GitHub records as the PR head ref: the newest commit of that branch
-// GitHub was observed holding, which outlives any local clone and survives the head branch being
-// deleted after a merge.
-func PRHeadCommit(ctx context.Context, pr string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", pr, "--json", "headRefOid")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("gh pr view failed: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
+// ObserveHeadCommit reads the commit GitHub records as the PR head ref: the newest commit of that
+// branch GitHub was observed holding, which outlives any local clone and survives the head branch
+// being deleted after a merge.
+func ObserveHeadCommit(ctx context.Context, pr string) PRObservation {
+	args := []string{"pr", "view", pr, "--json", "headRefOid"}
+	probe := Probe{Command: ghCommand(args)}
 	var body struct {
 		HeadRefOid string `json:"headRefOid"`
 	}
-	if err := json.Unmarshal(out, &body); err != nil {
-		return "", fmt.Errorf("parse gh pr view output: %w", err)
+	if terminal := decodeGHPayload(ctx, probe, &body, args...); terminal != nil {
+		return *terminal
 	}
 	if body.HeadRefOid == "" {
-		return "", fmt.Errorf("gh pr view reported no head commit for %q", pr)
+		return unknownPR(probe, "gh exited zero and reported no head commit for pull request %s", pr)
 	}
-	return body.HeadRefOid, nil
+	return PRObservation{State: ObservationFound, URL: pr, Head: body.HeadRefOid, Probe: probe}
 }
 
-// PRSearchTarget names one repo FindPRByBranch searches for a head ref.
+// PRIsMerged is the pre-tri-state entry point ObserveMergeState replaced, kept only while
+// internal/watcher is its last caller (atqamz/hand#235 and atqamz/hand#252 own that surface).
+// Nothing else may call it: a bare bool is what let a failed query read as an unmerged PR.
+func PRIsMerged(ctx context.Context, pr string) (bool, error) {
+	observation := ObserveMergeState(ctx, pr)
+	if !observation.Found() {
+		return false, errors.New(observation.Reason())
+	}
+	return observation.Merged, nil
+}
+
+// PRSearchTarget names one repo ObservePRByBranch searches for a head ref.
 type PRSearchTarget struct {
 	Repo string
 	// When set, keeps only PRs whose head branch lives in that repo: a fork's upstream carries head
@@ -66,7 +68,7 @@ type PRSearchTarget struct {
 	HeadRepo string
 }
 
-// PRCandidate names one PR under consideration by FindPRByBranch, for use in
+// PRCandidate names one PR under consideration by ObservePRByBranch, for use in
 // an AmbiguousPRError message.
 type PRCandidate struct {
 	Repo   string
@@ -90,23 +92,30 @@ func (e *AmbiguousPRError) Error() string {
 	return fmt.Sprintf("ambiguous PR for branch %s: %s", e.Branch, strings.Join(parts, ", "))
 }
 
-// FindPRByBranch reports the PR across targets whose head ref is exactly branch - the only rule
-// hand uses to associate a PR with a task, never a title, an issue number or a task id. found is
-// false when no PR carries that head ref.
-func FindPRByBranch(ctx context.Context, branch string, targets ...PRSearchTarget) (url string, merged bool, found bool, err error) {
+// ObservePRByBranch reports the PR across targets whose head ref is exactly branch - the only rule
+// hand uses to associate a PR with a task, never a title, an issue number or a task id. Absent
+// means every target answered, and none of them carries that head ref.
+func ObservePRByBranch(ctx context.Context, branch string, targets ...PRSearchTarget) PRObservation {
 	// More than one target is how a fork project finds its PR: the branch is pushed to the fork
 	// while the PR is opened on the declared upstream. Matches from every target resolve through
 	// one tier pass, so a fork PR and an upstream PR are ambiguous exactly like two in one repo.
+	commands := make([]string, 0, len(targets))
+	for _, target := range targets {
+		commands = append(commands, ghCommand(prListArgs(target, branch)))
+	}
+	probe := Probe{Command: strings.Join(commands, "; ")}
 	var results []prListItem
 	for _, target := range targets {
-		found, err := listPRsByBranch(ctx, target, branch)
-		if err != nil {
-			return "", false, false, err
+		found, terminal := listPRsByBranch(ctx, target, branch)
+		// A sweep that skipped a target cannot prove absence across the rest, so an observation
+		// that did not complete ends it. An absence proven for one target is not one for the others.
+		if terminal != nil && terminal.Unknown() {
+			return *terminal
 		}
 		results = append(results, found...)
 	}
 	if len(results) == 0 {
-		return "", false, false, nil
+		return absentPR(probe)
 	}
 
 	// A branch can carry more than one PR - a closed-unmerged one plus a reopened replacement - so
@@ -128,7 +137,7 @@ func FindPRByBranch(ctx context.Context, branch string, targets ...PRSearchTarge
 	// may still carry unlanded work. Guessing here is what let internal/runtime/teardown.go's landed-work guard
 	// trust a merged PR while the branch's real state was closed-unmerged (atqamz/hand#77).
 	if len(mergedPRs) > 0 && len(openPRs) > 0 {
-		return "", false, false, ambiguousPRError(branch, results)
+		return ambiguousPR(branch, results, probe)
 	}
 
 	for _, matches := range [][]prListItem{mergedPRs, openPRs, closedPRs} {
@@ -136,28 +145,29 @@ func FindPRByBranch(ctx context.Context, branch string, targets ...PRSearchTarge
 		case 0:
 			continue
 		case 1:
-			return matches[0].URL, matches[0].State == "MERGED", true, nil
+			return PRObservation{State: ObservationFound, URL: matches[0].URL, Merged: matches[0].State == "MERGED", Probe: probe}
 		default:
-			return "", false, false, ambiguousPRError(branch, results)
+			return ambiguousPR(branch, results, probe)
 		}
 	}
-	return "", false, false, fmt.Errorf("gh pr list returned no PR in a recognized state for branch %s", branch)
+	// The query completed and carried candidates, so this is neither a found PR nor a proven
+	// absence: gh answered in a state vocabulary this tier pass does not know.
+	return unknownPR(probe, "gh reported %d PR(s) for branch %s and none in a recognized state", len(results), branch)
 }
 
-func listPRsByBranch(ctx context.Context, target PRSearchTarget, branch string) ([]prListItem, error) {
-	// --state all because gh pr list defaults to open only and a gate-opened PR may already be
-	// merged or closed; --limit stated rather than left on gh's implicit 30, far above any real
-	// count for one branch, so a same-tier duplicate cannot be truncated into a lone winner.
-	cmd := exec.CommandContext(ctx, "gh", "pr", "list", "--repo", target.Repo, "--head", branch, "--state", "all", "--limit", "200", "--json", "number,url,state,headRepository")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("gh pr list failed: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
+// --state all because gh pr list defaults to open only and a gate-opened PR may already be
+// merged or closed; --limit stated rather than left on gh's implicit 30, far above any real
+// count for one branch, so a same-tier duplicate cannot be truncated into a lone winner.
+func prListArgs(target PRSearchTarget, branch string) []string {
+	return []string{"pr", "list", "--repo", target.Repo, "--head", branch, "--state", "all", "--limit", "200", "--json", "number,url,state,headRepository"}
+}
+
+func listPRsByBranch(ctx context.Context, target PRSearchTarget, branch string) ([]prListItem, *PRObservation) {
+	args := prListArgs(target, branch)
+	probe := Probe{Command: ghCommand(args)}
 	var results []prListItem
-	if err := json.Unmarshal(out, &results); err != nil {
-		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	if terminal := decodeGHPayload(ctx, probe, &results, args...); terminal != nil {
+		return nil, terminal
 	}
 	// gh's --head takes the plain branch name even for a cross-repo PR (the qualified owner:branch
 	// form matches nothing), so the upstream target carries a HeadRepo to keep a same-named branch
@@ -173,12 +183,21 @@ func listPRsByBranch(ctx context.Context, target PRSearchTarget, branch string) 
 	return kept, nil
 }
 
-func ambiguousPRError(branch string, matches []prListItem) *AmbiguousPRError {
+// Ambiguity is unknown rather than absent: the query completed, and what it returned says a PR
+// exists without saying which one, so nothing about this branch may be concluded.
+func ambiguousPR(branch string, matches []prListItem, probe Probe) PRObservation {
 	candidates := make([]PRCandidate, len(matches))
 	for i, m := range matches {
 		candidates[i] = PRCandidate{Repo: m.Repo, Number: m.Number, State: m.State}
 	}
-	return &AmbiguousPRError{Branch: branch, Candidates: candidates}
+	ambiguous := &AmbiguousPRError{Branch: branch, Candidates: candidates}
+	observation := unknownPR(probe, "%s", ambiguous.Error())
+	observation.Ambiguous = ambiguous
+	return observation
+}
+
+func ghCommand(args []string) string {
+	return "gh " + strings.Join(args, " ")
 }
 
 // One entry of `gh pr list --json number,url,state,headRepository`. Repo is the searched repo, not

--- a/internal/ghutil/pr_test.go
+++ b/internal/ghutil/pr_test.go
@@ -5,9 +5,20 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
 )
+
+func requireUnknown(t *testing.T, o PRObservation) {
+	t.Helper()
+	if o.Found() || o.Absent() {
+		t.Fatalf("observation = %+v, want unknown rather than a finding", o)
+	}
+	if !o.Unknown() {
+		t.Fatalf("observation = %+v, want Unknown() to report the state it is in", o)
+	}
+}
 
 // Fakes `gh pr view --json state`, emitting a stderr line ahead of the JSON payload so a
 // CombinedOutput regression at the call site fails the parse the same way real gh's progress
@@ -26,27 +37,145 @@ func writeFakeGHPRView(t *testing.T, state string, exitCode int, stderrLine stri
 	faketool.GH{Responses: []faketool.GHResponse{response}}.Install(t, bin)
 }
 
-func TestPRIsMergedIgnoresStderrNoise(t *testing.T) {
+// The absence-proving diagnostic quoted from real gh, which tests/contract rechecks against both
+// the shared fake and the installed tool.
+const notFoundDiagnostic = "GraphQL: Could not resolve to a PullRequest with the number of 42. (repository.pullRequest)\n"
+
+// Nothing built from a zero value or an unrecognized state may read as an absence: that is what
+// makes an absence impossible to reach by accident rather than by a check someone added.
+func TestOnlyThePositiveStatesAreFindings(t *testing.T) {
+	for _, o := range []PRObservation{{}, {State: ObservationUnknown}, {State: ObservationState("")}, {State: ObservationState("mislaid")}} {
+		requireUnknown(t, o)
+	}
+	if !(PRObservation{State: ObservationAbsent}).Absent() {
+		t.Fatal("want an explicitly absent observation to report itself absent")
+	}
+	if !(PRObservation{State: ObservationFound}).Found() {
+		t.Fatal("want an explicitly found observation to report itself found")
+	}
+}
+
+func TestObserveMergeStateIgnoresStderrNoise(t *testing.T) {
 	for _, c := range []struct {
 		state string
 		want  bool
 	}{{"MERGED", true}, {"OPEN", false}} {
 		writeFakeGHPRView(t, c.state, 0, "Warning: gh version 2.40.0 is out of date")
-		got, err := PRIsMerged(context.Background(), "42")
-		if err != nil {
-			t.Fatalf("PRIsMerged with state %s: %v", c.state, err)
+		got := ObserveMergeState(context.Background(), "42")
+		if !got.Found() {
+			t.Fatalf("ObserveMergeState with state %s = %+v, want the PR found", c.state, got)
 		}
-		if got != c.want {
-			t.Errorf("PRIsMerged with state %s = %v, want %v", c.state, got, c.want)
+		if got.Merged != c.want {
+			t.Errorf("ObserveMergeState with state %s reported merged=%v, want %v", c.state, got.Merged, c.want)
+		}
+		if got.URL != "42" {
+			t.Errorf("URL = %q, want the observed PR named", got.URL)
 		}
 	}
 }
 
-func TestPRIsMergedReportsExitStatusWithoutStderr(t *testing.T) {
+// Absence is a positive finding, so it is read off the one diagnostic that proves it and nothing
+// else. Its reason must not read as a failure, because callers act on it.
+func TestObserveMergeStateReportsAbsenceForTheNotFoundDiagnostic(t *testing.T) {
+	faketool.GH{Responses: []faketool.GHResponse{{Command: "pr view", Stderr: notFoundDiagnostic, Exit: 1}}}.Install(t, faketool.Bin(t))
+	got := ObserveMergeState(context.Background(), "42")
+	if !got.Absent() {
+		t.Fatalf("observation = %+v, want absent for the diagnostic that proves the PR is not there", got)
+	}
+	if got.Unknown() || got.Found() {
+		t.Fatalf("observation = %+v, want absent to be neither unknown nor found", got)
+	}
+	if !strings.Contains(got.Reason(), "no such pull request") {
+		t.Fatalf("Reason() = %q, want it to report the absence rather than a failure", got.Reason())
+	}
+}
+
+// Every way a query can fail to complete, each one asserted unknown for every entry point. An
+// absence here would license teardown to release work that may not have landed (atqamz/hand#241).
+func TestNoFailedQueryIsEverAbsent(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		stdout string
+		stderr string
+		exit   int
+	}{
+		{name: "network failure", stderr: "dial tcp 140.82.121.6:443: connect: network is unreachable\n", exit: 1},
+		{name: "dns failure", stderr: "dial tcp: lookup api.github.com: no such host\n", exit: 1},
+		{name: "request timeout", stderr: "Post \"https://api.github.com/graphql\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\n", exit: 1},
+		{name: "authentication failure", stderr: "gh: HTTP 401: Bad credentials (https://api.github.com/graphql)\n", exit: 1},
+		{name: "authorization failure", stderr: "gh: HTTP 403: Resource not accessible by integration (https://api.github.com/graphql)\n", exit: 1},
+		{name: "unreadable repository", stderr: "GraphQL: Could not resolve to a Repository with the name of 'owner/repo'. (repository)\n", exit: 1},
+		{name: "rate limited", stderr: "GraphQL: API rate limit exceeded for user ID 1. (rateLimit)\n", exit: 1},
+		{name: "exit non-zero with no diagnostic at all", exit: 1},
+		{name: "truncated payload at exit zero", stdout: "{\"state\":\"MER\n", exit: 0},
+		{name: "empty payload at exit zero", stdout: "", exit: 0},
+		{name: "a proxy error page at exit zero", stdout: "<html><title>502 Bad Gateway</title></html>\n", exit: 0},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			faketool.GH{Responses: []faketool.GHResponse{
+				{Command: "pr view", Stdout: c.stdout, Stderr: c.stderr, Exit: c.exit},
+				{Command: "pr list", Stdout: c.stdout, Stderr: c.stderr, Exit: c.exit},
+			}}.Install(t, faketool.Bin(t))
+			requireUnknown(t, ObserveMergeState(context.Background(), "42"))
+			requireUnknown(t, ObserveHeadCommit(context.Background(), "42"))
+			requireUnknown(t, ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"}))
+		})
+	}
+}
+
+// An answer gh reports at exit zero without the field the query asked for is unknown too: an empty
+// string is not a merge state, and treating it as one would read as "not merged".
+func TestObserveMergeStateIsUnknownWithoutAState(t *testing.T) {
+	faketool.GH{Responses: []faketool.GHResponse{{Command: "pr view", Stdout: "{}\n"}}}.Install(t, faketool.Bin(t))
+	requireUnknown(t, ObserveMergeState(context.Background(), "42"))
+}
+
+func TestPRObservationIsUnknownWhenTheContextIsAlreadyCancelled(t *testing.T) {
+	writeFakeGHPRView(t, "MERGED", 0, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	requireUnknown(t, ObserveMergeState(ctx, "42"))
+	requireUnknown(t, ObserveHeadCommit(ctx, "42"))
+	requireUnknown(t, ObservePRByBranch(ctx, "task-1-branch", PRSearchTarget{Repo: "owner/repo"}))
+}
+
+// A gh that never answers and is killed by the caller's deadline is the case a bare exit-code check
+// gets wrong: the subprocess dies, gh prints nothing, and nothing has been observed.
+func TestPRObservationIsUnknownWhenGhIsKilledByTheDeadline(t *testing.T) {
+	faketool.GH{Hang: []string{"pr view", "pr list"}}.Install(t, faketool.Bin(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	requireUnknown(t, ObserveMergeState(ctx, "42"))
+	requireUnknown(t, ObservePRByBranch(ctx, "task-1-branch", PRSearchTarget{Repo: "owner/repo"}))
+}
+
+// An unknown has to be reportable: a caller refusing to act names the command that answered
+// nothing, so an operator can run it themselves rather than guess what hand tried.
+func TestUnknownNamesTheCommandThatWasRun(t *testing.T) {
+	faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "pr view", Stderr: "gh: HTTP 401: Bad credentials\n", Exit: 1},
+		{Command: "pr list", Stderr: "gh: HTTP 401: Bad credentials\n", Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+	merge := ObserveMergeState(context.Background(), "42")
+	if !strings.Contains(merge.Reason(), "gh pr view 42 --json state") || !strings.Contains(merge.Reason(), "Bad credentials") {
+		t.Fatalf("Reason() = %q, want the command and what it answered", merge.Reason())
+	}
+	byBranch := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	if !strings.Contains(byBranch.Reason(), "gh pr list --repo owner/repo --head task-1-branch") {
+		t.Fatalf("Reason() = %q, want the list command named", byBranch.Reason())
+	}
+}
+
+// The shim internal/watcher still calls has to fail closed for as long as it exists: a bare bool is
+// exactly what let a failed query read as an unmerged PR.
+func TestPRIsMergedErrorsRatherThanReportingNotMerged(t *testing.T) {
 	writeFakeGHPRView(t, "", 1, "")
-	_, err := PRIsMerged(context.Background(), "42")
+	merged, err := PRIsMerged(context.Background(), "42")
 	if err == nil {
-		t.Fatal("want error when gh exits non-zero")
+		t.Fatal("want an error when gh exits non-zero rather than a false merge state")
+	}
+	if merged {
+		t.Fatal("want merged=false alongside the error")
 	}
 	if !strings.Contains(err.Error(), "exit status 1") {
 		t.Fatalf("got %q, want the exit status in the message", err)
@@ -64,129 +193,113 @@ func writeFakeGHPRList(t *testing.T, body string, exitCode int, stderrLine strin
 	}}}.Install(t, bin)
 }
 
-func TestFindPRByBranchReturnsMatch(t *testing.T) {
+func TestObservePRByBranchReturnsMatch(t *testing.T) {
 	writeFakeGHPRList(t, `[{"url":"https://github.com/owner/repo/pull/5","state":"MERGED"}]`, 0, "Warning: gh version 2.40.0 is out of date")
-	url, merged, found, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found || url != "https://github.com/owner/repo/pull/5" || !merged {
-		t.Fatalf("got (%q, %v, %v), want the merged PR", url, merged, found)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	if !got.Found() || got.URL != "https://github.com/owner/repo/pull/5" || !got.Merged {
+		t.Fatalf("observation = %+v, want the merged PR found", got)
 	}
 }
 
 // The atqamz/hand#77 regression: a branch carrying a merged PR alongside a closed-unmerged
 // one (a duplicate opened by mistake, say) must resolve to the merged PR rather than an arbitrary
 // pick.
-func TestFindPRByBranchPrefersMergedOverClosedUnmerged(t *testing.T) {
+func TestObservePRByBranchPrefersMergedOverClosedUnmerged(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"CLOSED"},`+
 		`{"number":5,"url":"https://github.com/owner/repo/pull/5","state":"MERGED"}]`, 0, "")
-	url, merged, found, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found || !merged || url != "https://github.com/owner/repo/pull/5" {
-		t.Fatalf("got (%q, %v, %v), want the merged PR", url, merged, found)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	if !got.Found() || !got.Merged || got.URL != "https://github.com/owner/repo/pull/5" {
+		t.Fatalf("observation = %+v, want the merged PR", got)
 	}
 }
 
 // Proves a branch with only a closed-unmerged PR still resolves to it rather than treating the
 // tier rule as requiring a merged candidate to exist.
-func TestFindPRByBranchReturnsSoleClosedUnmergedPR(t *testing.T) {
+func TestObservePRByBranchReturnsSoleClosedUnmergedPR(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"CLOSED"}]`, 0, "")
-	url, merged, found, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	if err != nil {
-		t.Fatal(err)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	if !got.Found() || got.Merged || got.URL != "https://github.com/owner/repo/pull/9" {
+		t.Fatalf("observation = %+v, want the sole closed-unmerged PR unmerged", got)
 	}
-	if !found || merged || url != "https://github.com/owner/repo/pull/9" {
-		t.Fatalf("got (%q, %v, %v), want the sole closed-unmerged PR unmerged", url, merged, found)
+}
+
+func requireAmbiguous(t *testing.T, o PRObservation, wantCandidates int, named ...string) {
+	t.Helper()
+	// Ambiguity is unknown, never absent: a caller that read it as "no PR" would act on a branch
+	// that demonstrably carries one.
+	requireUnknown(t, o)
+	if o.Ambiguous == nil {
+		t.Fatalf("observation = %+v, want the candidates carried on the observation", o)
+	}
+	var ambiguous *AmbiguousPRError
+	if !errors.As(error(o.Ambiguous), &ambiguous) {
+		t.Fatalf("Ambiguous = %+v, want an AmbiguousPRError", o.Ambiguous)
+	}
+	if len(ambiguous.Candidates) != wantCandidates {
+		t.Fatalf("Candidates = %+v, want %d of them named", ambiguous.Candidates, wantCandidates)
+	}
+	for _, want := range named {
+		if !strings.Contains(ambiguous.Error(), want) {
+			t.Fatalf("got %q, want %q named", ambiguous.Error(), want)
+		}
+	}
+	if !strings.Contains(o.Reason(), ambiguous.Error()) {
+		t.Fatalf("Reason() = %q, want it to carry %q", o.Reason(), ambiguous.Error())
 	}
 }
 
 // Proves an ambiguous winning tier refuses rather than picking either candidate.
-func TestFindPRByBranchRefusesTwoMergedPRs(t *testing.T) {
+func TestObservePRByBranchRefusesTwoMergedPRs(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"MERGED"},`+
 		`{"number":5,"url":"https://github.com/owner/repo/pull/5","state":"MERGED"}]`, 0, "")
-	_, _, _, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	var ambiguous *AmbiguousPRError
-	if !errors.As(err, &ambiguous) {
-		t.Fatalf("got %v, want an AmbiguousPRError", err)
-	}
-	if len(ambiguous.Candidates) != 2 {
-		t.Fatalf("Candidates = %+v, want both PR 9 and PR 5 named", ambiguous.Candidates)
-	}
-	if !strings.Contains(err.Error(), "#9") || !strings.Contains(err.Error(), "#5") {
-		t.Fatalf("got %q, want both PR numbers named", err.Error())
-	}
+	requireAmbiguous(t, ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"}), 2, "#9", "#5")
 }
 
 // Proves the same-tier refusal names every PR on the head ref, including one sitting in a losing
 // tier, so the operator resolves the whole branch rather than the pair that triggered the refusal.
-func TestFindPRByBranchRefusesTwoMergedPRsNamesClosedCandidateToo(t *testing.T) {
+func TestObservePRByBranchRefusesTwoMergedPRsNamesClosedCandidateToo(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":7,"url":"https://github.com/owner/repo/pull/7","state":"MERGED"},`+
 		`{"number":5,"url":"https://github.com/owner/repo/pull/5","state":"MERGED"},`+
 		`{"number":3,"url":"https://github.com/owner/repo/pull/3","state":"CLOSED"}]`, 0, "")
-	_, _, _, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	var ambiguous *AmbiguousPRError
-	if !errors.As(err, &ambiguous) {
-		t.Fatalf("got %v, want an AmbiguousPRError", err)
-	}
-	if len(ambiguous.Candidates) != 3 {
-		t.Fatalf("Candidates = %+v, want PR 7, PR 5, and PR 3 all named", ambiguous.Candidates)
-	}
-	if !strings.Contains(err.Error(), "#7") || !strings.Contains(err.Error(), "#5") || !strings.Contains(err.Error(), "#3") {
-		t.Fatalf("got %q, want all three PR numbers named", err.Error())
-	}
+	requireAmbiguous(t, ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"}), 3, "#7", "#5", "#3")
 }
 
 // Proves a branch carrying both a merged PR and a still-open one refuses rather than resolving to
 // the merged PR: the open PR is live evidence the branch may carry unlanded work.
-func TestFindPRByBranchRefusesMergedAndOpenPR(t *testing.T) {
+func TestObservePRByBranchRefusesMergedAndOpenPR(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":5,"url":"https://github.com/owner/repo/pull/5","state":"MERGED"},`+
 		`{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"OPEN"}]`, 0, "")
-	_, _, _, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	var ambiguous *AmbiguousPRError
-	if !errors.As(err, &ambiguous) {
-		t.Fatalf("got %v, want an AmbiguousPRError", err)
-	}
-	if len(ambiguous.Candidates) != 2 {
-		t.Fatalf("Candidates = %+v, want both PR 5 and PR 9 named", ambiguous.Candidates)
-	}
-	if !strings.Contains(err.Error(), "#5") || !strings.Contains(err.Error(), "#9") {
-		t.Fatalf("got %q, want both PR numbers named", err.Error())
-	}
+	requireAmbiguous(t, ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"}), 2, "#5", "#9")
 }
 
 // Proves the merged+open refusal names every candidate on the branch, including a coexisting
 // closed-unmerged PR, not just the merged and open ones.
-func TestFindPRByBranchRefusesMergedAndOpenPRNamesClosedCandidateToo(t *testing.T) {
+func TestObservePRByBranchRefusesMergedAndOpenPRNamesClosedCandidateToo(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":5,"url":"https://github.com/owner/repo/pull/5","state":"MERGED"},`+
 		`{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"OPEN"},`+
 		`{"number":3,"url":"https://github.com/owner/repo/pull/3","state":"CLOSED"}]`, 0, "")
-	_, _, _, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	var ambiguous *AmbiguousPRError
-	if !errors.As(err, &ambiguous) {
-		t.Fatalf("got %v, want an AmbiguousPRError", err)
-	}
-	if len(ambiguous.Candidates) != 3 {
-		t.Fatalf("Candidates = %+v, want PR 5, PR 9, and PR 3 all named", ambiguous.Candidates)
-	}
-	if !strings.Contains(err.Error(), "#5") || !strings.Contains(err.Error(), "#9") || !strings.Contains(err.Error(), "#3") {
-		t.Fatalf("got %q, want all three PR numbers named", err.Error())
-	}
+	requireAmbiguous(t, ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"}), 3, "#5", "#9", "#3")
 }
 
 // Pins the open-over-closed tier boundary: with no merged PR on the branch, an open PR beats a
 // closed-unmerged one rather than either being an arbitrary loop-order pick.
-func TestFindPRByBranchPrefersOpenOverClosedUnmerged(t *testing.T) {
+func TestObservePRByBranchPrefersOpenOverClosedUnmerged(t *testing.T) {
 	writeFakeGHPRList(t, `[{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"CLOSED"},`+
 		`{"number":5,"url":"https://github.com/owner/repo/pull/5","state":"OPEN"}]`, 0, "")
-	url, merged, found, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	if err != nil {
-		t.Fatal(err)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	if !got.Found() || got.Merged || got.URL != "https://github.com/owner/repo/pull/5" {
+		t.Fatalf("observation = %+v, want the open PR", got)
 	}
-	if !found || merged || url != "https://github.com/owner/repo/pull/5" {
-		t.Fatalf("got (%q, %v, %v), want the open PR", url, merged, found)
+}
+
+// A state vocabulary this tier pass does not know is unknown: the query completed and named
+// candidates, which is neither this branch's PR nor a proven absence.
+func TestObservePRByBranchIsUnknownForAnUnrecognizedState(t *testing.T) {
+	writeFakeGHPRList(t, `[{"number":9,"url":"https://github.com/owner/repo/pull/9","state":"DRAFTED_SOMEHOW"}]`, 0, "")
+	got := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	requireUnknown(t, got)
+	if !strings.Contains(got.Reason(), "recognized state") {
+		t.Fatalf("Reason() = %q, want it to name the state vocabulary as the problem", got.Reason())
 	}
 }
 
@@ -195,12 +308,16 @@ func TestFindPRByBranchPrefersOpenOverClosedUnmerged(t *testing.T) {
 // A", and a fork test would pass against a shape gh never returns (atqamz/hand#40).
 func writeFakeGHPRListPerRepo(t *testing.T, bodies map[string]string) {
 	t.Helper()
-	bin := faketool.Bin(t)
 	var responses []faketool.GHResponse
 	for repo, body := range bodies {
 		responses = append(responses, faketool.GHResponse{Command: "pr list", Repo: repo, Stdout: body})
 	}
-	faketool.GH{Responses: responses, RejectQualifiedHead: true}.Install(t, bin)
+	writeFakeGHPRListResponses(t, responses...)
+}
+
+func writeFakeGHPRListResponses(t *testing.T, responses ...faketool.GHResponse) {
+	t.Helper()
+	faketool.GH{Responses: responses, RejectQualifiedHead: true}.Install(t, faketool.Bin(t))
 }
 
 // The target pair a fork project searches with: its own repo, where hand pushes the branch, plus
@@ -211,98 +328,89 @@ func forkTargets() []PRSearchTarget {
 
 // The atqamz/hand#134 regression: a fork contribution's PR lives on the declared upstream,
 // so searching the project's own repo alone finds nothing.
-func TestFindPRByBranchFindsUpstreamPRForFork(t *testing.T) {
+func TestObservePRByBranchFindsUpstreamPRForFork(t *testing.T) {
 	writeFakeGHPRListPerRepo(t, map[string]string{
 		"me/repo": `[]`,
 		"up/repo": `[{"number":7,"url":"https://github.com/up/repo/pull/7","state":"MERGED",` +
 			`"headRepository":{"nameWithOwner":"me/repo"}}]`,
 	})
-	url, merged, found, err := FindPRByBranch(context.Background(), "task-1-branch", forkTargets()...)
-	if err != nil {
-		t.Fatal(err)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", forkTargets()...)
+	if !got.Found() || !got.Merged || got.URL != "https://github.com/up/repo/pull/7" {
+		t.Fatalf("observation = %+v, want the upstream PR merged", got)
 	}
-	if !found || !merged || url != "https://github.com/up/repo/pull/7" {
-		t.Fatalf("got (%q, %v, %v), want the upstream PR merged", url, merged, found)
-	}
+}
+
+// A sweep is only as conclusive as its narrowest target: one repo answering "no PR here" while
+// another never answered at all proves nothing about the branch.
+func TestObservePRByBranchIsUnknownWhenOneTargetCouldNotBeSearched(t *testing.T) {
+	writeFakeGHPRListResponses(t,
+		faketool.GHResponse{Command: "pr list", Repo: "me/repo", Stdout: `[]`},
+		faketool.GHResponse{Command: "pr list", Repo: "up/repo", Stderr: "gh: HTTP 401: Bad credentials\n", Exit: 1},
+	)
+	requireUnknown(t, ObservePRByBranch(context.Background(), "task-1-branch", forkTargets()...))
 }
 
 // Pins the head-repo filter: an upstream carries head refs from every contributor's fork, and gh
 // matches --head on the branch name alone, so a same-named branch from a stranger's fork comes back
 // from the same search and must not be recorded as this task's PR.
-func TestFindPRByBranchIgnoresUpstreamPRFromAnotherFork(t *testing.T) {
+func TestObservePRByBranchIgnoresUpstreamPRFromAnotherFork(t *testing.T) {
 	writeFakeGHPRListPerRepo(t, map[string]string{
 		"me/repo": `[]`,
 		"up/repo": `[{"number":7,"url":"https://github.com/up/repo/pull/7","state":"OPEN",` +
 			`"headRepository":{"nameWithOwner":"someone/repo"}}]`,
 	})
-	_, _, found, err := FindPRByBranch(context.Background(), "task-1-branch", forkTargets()...)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if found {
-		t.Fatal("want found=false for a PR whose head ref lives in another fork")
+	got := ObservePRByBranch(context.Background(), "task-1-branch", forkTargets()...)
+	if !got.Absent() {
+		t.Fatalf("observation = %+v, want absent for a PR whose head ref lives in another fork", got)
 	}
 }
 
 // Pins the fold: GitHub slugs are case-insensitive, and this filter compares gh's canonical casing
 // against a slug read from a clone's origin remote, so a differently-cased remote must not drop the
 // project's own PR.
-func TestFindPRByBranchMatchesHeadRepoCaseInsensitively(t *testing.T) {
+func TestObservePRByBranchMatchesHeadRepoCaseInsensitively(t *testing.T) {
 	writeFakeGHPRListPerRepo(t, map[string]string{
 		"Up/Repo": `[{"number":7,"url":"https://github.com/up/repo/pull/7","state":"OPEN",` +
 			`"headRepository":{"nameWithOwner":"Me/Repo"}}]`,
 	})
-	url, _, found, err := FindPRByBranch(context.Background(), "task-1-branch", forkTargets()...)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found || url != "https://github.com/up/repo/pull/7" {
-		t.Fatalf("got (%q, %v), want the PR whose head repo differs only in casing", url, found)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", forkTargets()...)
+	if !got.Found() || got.URL != "https://github.com/up/repo/pull/7" {
+		t.Fatalf("observation = %+v, want the PR whose head repo differs only in casing", got)
 	}
 }
 
 // Proves matches from two searched repos resolve through the same tier rule as two in one repo -
 // a fork whose upstream also has a branch of that name is where guessing costs the most - and that
 // the refusal names the repos, not just PR numbers an operator would have to hunt for.
-func TestFindPRByBranchRefusesPRsInTwoRepos(t *testing.T) {
+func TestObservePRByBranchRefusesPRsInTwoRepos(t *testing.T) {
 	writeFakeGHPRListPerRepo(t, map[string]string{
 		"me/repo": `[{"number":3,"url":"https://github.com/me/repo/pull/3","state":"OPEN",` +
 			`"headRepository":{"nameWithOwner":"me/repo"}}]`,
 		"up/repo": `[{"number":7,"url":"https://github.com/up/repo/pull/7","state":"OPEN",` +
 			`"headRepository":{"nameWithOwner":"me/repo"}}]`,
 	})
-	_, _, _, err := FindPRByBranch(context.Background(), "task-1-branch", forkTargets()...)
-	var ambiguous *AmbiguousPRError
-	if !errors.As(err, &ambiguous) {
-		t.Fatalf("got %v, want an AmbiguousPRError", err)
-	}
-	if len(ambiguous.Candidates) != 2 {
-		t.Fatalf("Candidates = %+v, want both PRs named", ambiguous.Candidates)
-	}
-	if !strings.Contains(err.Error(), "me/repo#3") || !strings.Contains(err.Error(), "up/repo#7") {
-		t.Fatalf("got %q, want each candidate named with its repo", err.Error())
-	}
+	requireAmbiguous(t, ObservePRByBranch(context.Background(), "task-1-branch", forkTargets()...), 2, "me/repo#3", "up/repo#7")
 }
 
-func TestFindPRByBranchNoMatch(t *testing.T) {
+// The one absence this package proves: every target answered, and none of them carries the branch.
+func TestObservePRByBranchIsAbsentWhenEveryTargetAnsweredNothing(t *testing.T) {
 	writeFakeGHPRList(t, `[]`, 0, "")
-	_, _, found, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	if err != nil {
-		t.Fatal(err)
+	got := ObservePRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
+	if !got.Absent() {
+		t.Fatalf("observation = %+v, want absent for an empty result", got)
 	}
-	if found {
-		t.Fatal("want found=false for an empty result")
+	if got.Unknown() {
+		t.Fatalf("observation = %+v, want a completed empty search to be a finding, not unknown", got)
 	}
 }
 
-func TestFindPRByBranchReportsExitStatusWithoutStderr(t *testing.T) {
-	writeFakeGHPRList(t, "", 1, "")
-	_, _, _, err := FindPRByBranch(context.Background(), "task-1-branch", PRSearchTarget{Repo: "owner/repo"})
-	if err == nil {
-		t.Fatal("want error when gh exits non-zero")
-	}
-	if !strings.Contains(err.Error(), "exit status 1") {
-		t.Fatalf("got %q, want the exit status in the message", err)
+// A prerequisite that never got as far as gh is unknown too, and says so with the command that
+// failed rather than pretending GitHub answered.
+func TestUnknownPRObservationCarriesItsOwnProbe(t *testing.T) {
+	got := UnknownPRObservation("git rev-parse --abbrev-ref HEAD", "resolve the branch to search for: broken")
+	requireUnknown(t, got)
+	if !strings.Contains(got.Reason(), "git rev-parse") || !strings.Contains(got.Reason(), "broken") {
+		t.Fatalf("Reason() = %q, want the failed prerequisite named", got.Reason())
 	}
 }
 
@@ -330,21 +438,19 @@ func TestRepoSlugFromRemote(t *testing.T) {
 	}
 }
 
-func TestPRHeadCommitReadsTheRecordedHeadRef(t *testing.T) {
+func TestObserveHeadCommitReadsTheRecordedHeadRef(t *testing.T) {
 	faketool.GH{Responses: []faketool.GHResponse{{
 		Command: "pr view",
 		Stderr:  "Warning: gh version 2.40.0 is out of date",
 		Stdout:  "{\"headRefOid\":\"1111111111111111111111111111111111111111\"}\n",
 	}}}.Install(t, faketool.Bin(t))
-	got, err := PRHeadCommit(context.Background(), "42")
-	if err != nil || got != "1111111111111111111111111111111111111111" {
-		t.Fatalf("PRHeadCommit() = %q, %v, want the recorded head commit", got, err)
+	got := ObserveHeadCommit(context.Background(), "42")
+	if !got.Found() || got.Head != "1111111111111111111111111111111111111111" {
+		t.Fatalf("observation = %+v, want the recorded head commit", got)
 	}
 }
 
-func TestPRHeadCommitRefusesAnEmptyHeadRef(t *testing.T) {
+func TestObserveHeadCommitIsUnknownForAnEmptyHeadRef(t *testing.T) {
 	faketool.GH{Responses: []faketool.GHResponse{{Command: "pr view", Stdout: "{}\n"}}}.Install(t, faketool.Bin(t))
-	if _, err := PRHeadCommit(context.Background(), "42"); err == nil {
-		t.Fatal("want an error rather than an empty head commit standing in as evidence")
-	}
+	requireUnknown(t, ObserveHeadCommit(context.Background(), "42"))
 }

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -32,8 +32,15 @@ func ValidatePR(ctx context.Context, homeDir string, p Project, url string) erro
 		// project upstream), never because the URL's repo looks related to the project's own.
 		return fmt.Errorf("PR %s belongs to %s, not project %s's repo (%s)%s", url, urlSlug, p.Name, repoSlug, upstreamNote(p))
 	}
-	if _, err := ghutil.PRIsMerged(ctx, url); err != nil {
-		return fmt.Errorf("PR %s not found in %s: %w", url, urlSlug, err)
+	// Absence refuses because the PR is not there; an observation that did not complete refuses
+	// too, but must never claim absence: an auth failure reporting "not found" would tell an
+	// operator to fix a URL that was right all along.
+	observation := ghutil.ObserveMergeState(ctx, url)
+	if observation.Absent() {
+		return fmt.Errorf("PR %s not found in %s", url, urlSlug)
+	}
+	if observation.Unknown() {
+		return fmt.Errorf("PR %s in %s could not be observed, so nothing is recorded for it: %s", url, urlSlug, observation.Reason())
 	}
 	return nil
 }

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -11,9 +11,6 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// DetectPR records the PR whose head ref is this attempt's branch. The observation travels back to
-// the caller so a guard can tell "GitHub says there is no PR" from "GitHub was not reached", which
-// are the same empty task otherwise.
 func DetectPR(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation, error) {
 	observation := observePR(ctx, homeDir, active, projectInfo)
 	if !observation.Found() {
@@ -29,8 +26,6 @@ func DetectPR(ctx context.Context, homeDir string, task state.Task, active state
 	return updated, observation, nil
 }
 
-// DetectPRReadOnly fills a task's PR from GitHub without writing anything, for the status views.
-// Only a found observation touches the task; absent and unknown are the caller's to render apart.
 func DetectPRReadOnly(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation) {
 	observation := observePR(ctx, homeDir, active, projectInfo)
 	if !observation.Found() {
@@ -43,8 +38,6 @@ func DetectPRReadOnly(ctx context.Context, homeDir string, task state.Task, acti
 	return task, observation
 }
 
-// A prerequisite that fails locally is unknown, not absent: an unreadable branch or an
-// underivable repo slug means the question was never put to GitHub at all.
 func observePR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
 	branch, err := currentBranch(active.Worktree)
 	if err != nil {

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -11,53 +11,54 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-func DetectPR(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, error) {
-	url, merged, found, err := findPR(ctx, homeDir, active, projectInfo)
-	if err != nil {
-		return task, err
+// DetectPR records the PR whose head ref is this attempt's branch. The observation travels back to
+// the caller so a guard can tell "GitHub says there is no PR" from "GitHub was not reached", which
+// are the same empty task otherwise.
+func DetectPR(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation, error) {
+	observation := observePR(ctx, homeDir, active, projectInfo)
+	if !observation.Found() {
+		return task, observation, nil
 	}
-	if !found {
-		return task, nil
-	}
-	if merged {
+	if observation.Merged {
 		task.MergeAnnounced = true
 	}
-	updated, _, err := RecordPR(ctx, homeDir, task, url)
+	updated, _, err := RecordPR(ctx, homeDir, task, observation.URL)
 	if err != nil {
-		return task, err
+		return task, observation, err
 	}
-	return updated, nil
+	return updated, observation, nil
 }
 
-func DetectPRReadOnly(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, error) {
-	url, merged, found, err := findPR(ctx, homeDir, active, projectInfo)
-	if err != nil {
-		return task, err
+// DetectPRReadOnly fills a task's PR from GitHub without writing anything, for the status views.
+// Only a found observation touches the task; absent and unknown are the caller's to render apart.
+func DetectPRReadOnly(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation) {
+	observation := observePR(ctx, homeDir, active, projectInfo)
+	if !observation.Found() {
+		return task, observation
 	}
-	if !found {
-		return task, nil
-	}
-	task.PR = url
-	if merged {
+	task.PR = observation.URL
+	if observation.Merged {
 		task.MergeAnnounced = true
 	}
-	return task, nil
+	return task, observation
 }
 
-func findPR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) (string, bool, bool, error) {
+// A prerequisite that fails locally is unknown, not absent: an unreadable branch or an
+// underivable repo slug means the question was never put to GitHub at all.
+func observePR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
 	branch, err := currentBranch(active.Worktree)
 	if err != nil {
-		return "", false, false, err
+		return ghutil.UnknownPRObservation("git rev-parse --abbrev-ref HEAD", fmt.Sprintf("resolve the branch to search for in %s: %v", active.Worktree, err))
 	}
 	repoSlug, err := project.RepoSlug(homeDir, projectInfo)
 	if err != nil {
-		return "", false, false, err
+		return ghutil.UnknownPRObservation("git config --get remote.origin.url", fmt.Sprintf("resolve the repo to search: %v", err))
 	}
 	targets := []ghutil.PRSearchTarget{{Repo: repoSlug}}
 	if projectInfo.Upstream != "" && !strings.EqualFold(projectInfo.Upstream, repoSlug) {
 		targets = append(targets, ghutil.PRSearchTarget{Repo: projectInfo.Upstream, HeadRepo: repoSlug})
 	}
-	return ghutil.FindPRByBranch(ctx, branch, targets...)
+	return ghutil.ObservePRByBranch(ctx, branch, targets...)
 }
 
 func RecordPR(ctx context.Context, homeDir string, task state.Task, url string) (state.Task, bool, error) {

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -47,8 +47,8 @@ type dependencies struct {
 	buildHarness      func(string, harness.Options) (string, error)
 	confirmLaunch     func(herdrClient, string, string) error
 	appendCompletion  func(string, completion.Record) error
-	prMerged          func(context.Context, string) (bool, error)
-	prHead            func(context.Context, string) (string, error)
+	prMerged          func(context.Context, string) ghutil.PRObservation
+	prHead            func(context.Context, string) ghutil.PRObservation
 	branchMerged      func(string, string) (bool, error)
 	phase             func(lifecyclePhase) error
 }
@@ -66,8 +66,8 @@ func defaultDependencies() dependencies {
 		buildHarness:      harness.Build,
 		confirmLaunch:     confirmLaunch,
 		appendCompletion:  completion.Append,
-		prMerged:          ghutil.PRIsMerged,
-		prHead:            ghutil.PRHeadCommit,
+		prMerged:          ghutil.ObserveMergeState,
+		prHead:            ghutil.ObserveHeadCommit,
 		branchMerged:      branchIsMerged,
 		phase:             func(lifecyclePhase) error { return nil },
 	}

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -418,13 +418,16 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 	if task.PR != "" {
 		prMerged := r.deps.prMerged
 		if prMerged == nil {
-			prMerged = ghutil.PRIsMerged
+			prMerged = ghutil.ObserveMergeState
 		}
-		merged, err := prMerged(ctx, task.PR)
-		if err != nil {
-			return false, false, "github-pr", fmt.Errorf("observe merged PR %s: %w", task.PR, err)
+		// Absent refuses alongside unknown: a recorded PR GitHub cannot resolve says nothing about
+		// whether the work merged, and recording a merge-fact mismatch from it would be a durable
+		// false claim about the operator every later run reads.
+		observation := prMerged(ctx, task.PR)
+		if !observation.Found() {
+			return false, false, "github-pr", fmt.Errorf("observe merged PR %s: %s", task.PR, observation.Reason())
 		}
-		return merged, !merged, "github-pr", nil
+		return observation.Merged, !observation.Merged, "github-pr", nil
 	}
 	projectInfo, found, err := project.FindReadOnly(home, task.Project)
 	if err != nil {
@@ -484,13 +487,13 @@ func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Ta
 	}
 	prMerged := r.deps.prMerged
 	if prMerged == nil {
-		prMerged = ghutil.PRIsMerged
+		prMerged = ghutil.ObserveMergeState
 	}
-	merged, err := prMerged(ctx, task.PR)
-	if err != nil {
+	observation := prMerged(ctx, task.PR)
+	if !observation.Found() {
 		return landingUnknown
 	}
-	if merged {
+	if observation.Merged {
 		return landingLanded
 	}
 	return landingUnlanded
@@ -1306,16 +1309,16 @@ func (r *Runtime) resolveWorktreeCommitSafety(ctx context.Context, task state.Ta
 	}
 	prHead := r.deps.prHead
 	if prHead == nil {
-		prHead = ghutil.PRHeadCommit
+		prHead = ghutil.ObserveHeadCommit
 	}
-	pushedHead, err := prHead(ctx, task.PR)
-	if err != nil {
+	pushed := prHead(ctx, task.PR)
+	if !pushed.Found() {
 		return commitSafetyDecision{
 			State:  commitSafetyUnprovable,
-			Reason: fmt.Sprintf("%d commit(s) in %s are reachable from no remote-tracking ref and the head commit of pull request %s could not be read, so whether GitHub holds them is unobserved rather than answered: %v", observation.Probe.LocalOnly, observation.Probe.WorkingDir, task.PR, err),
+			Reason: fmt.Sprintf("%d commit(s) in %s are reachable from no remote-tracking ref and the head commit of pull request %s could not be read, so whether GitHub holds them is unobserved rather than answered: %s", observation.Probe.LocalOnly, observation.Probe.WorkingDir, task.PR, pushed.Reason()),
 		}
 	}
-	if pushedHead == observation.Probe.Head {
+	if pushed.Head == observation.Probe.Head {
 		return commitSafetyDecision{
 			State:  commitSafetyProvenDurable,
 			Reason: fmt.Sprintf("no remote-tracking ref in %s reaches %s, and GitHub records that exact commit as the head of pull request %s, which holds it independently of this worktree", observation.Probe.WorkingDir, shortCommit(observation.Probe.Head), task.PR),
@@ -1323,7 +1326,7 @@ func (r *Runtime) resolveWorktreeCommitSafety(ctx context.Context, task state.Ta
 	}
 	return commitSafetyDecision{
 		State:  commitSafetyLocalWorkAtRisk,
-		Reason: localOnlyCommitsReason(observation.Probe, fmt.Sprintf("pull request %s records head commit %s instead, so GitHub was never observed holding %s", task.PR, shortCommit(pushedHead), shortCommit(observation.Probe.Head))),
+		Reason: localOnlyCommitsReason(observation.Probe, fmt.Sprintf("pull request %s records head commit %s instead, so GitHub was never observed holding %s", task.PR, shortCommit(pushed.Head), shortCommit(observation.Probe.Head))),
 	}
 }
 

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -420,9 +420,6 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 		if prMerged == nil {
 			prMerged = ghutil.ObserveMergeState
 		}
-		// Absent refuses alongside unknown: a recorded PR GitHub cannot resolve says nothing about
-		// whether the work merged, and recording a merge-fact mismatch from it would be a durable
-		// false claim about the operator every later run reads.
 		observation := prMerged(ctx, task.PR)
 		if !observation.Found() {
 			return false, false, "github-pr", fmt.Errorf("observe merged PR %s: %s", task.PR, observation.Reason())

--- a/internal/runtime/reconcile_commit_safety_test.go
+++ b/internal/runtime/reconcile_commit_safety_test.go
@@ -207,9 +207,7 @@ func TestReconcileWithholdsReturnWhenCommitSafetyCannotBeObserved(t *testing.T) 
 			wantReason:  "could not be read",
 		},
 		{
-			// A pull request GitHub will not resolve is not a pull request proven to hold nothing:
-			// absence answers the wrong question here, so it withholds the return like unknown.
-			name:        "recorded pull request gh reports as absent",
+			name:        "absent pull request withholds the return like unknown",
 			pr:          "https://github.com/atqamz/hand/pull/7",
 			observation: localOnlyCommits(commitSafetyHead, 1),
 			prHead:      absentPRObservation(),

--- a/internal/runtime/reconcile_commit_safety_test.go
+++ b/internal/runtime/reconcile_commit_safety_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
 )
@@ -85,10 +85,10 @@ func commitSafetyRuntime(t *testing.T, observation worktree.CommitSafetyObservat
 		counts.returns++
 		return nil
 	}
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
-	r.deps.prHead = func(context.Context, string) (string, error) {
+	r.deps.prMerged = observedMergedPR(true)
+	r.deps.prHead = func(context.Context, string) ghutil.PRObservation {
 		t.Fatal("prHead called without a stub")
-		return "", nil
+		return ghutil.PRObservation{}
 	}
 	return r, counts
 }
@@ -186,7 +186,7 @@ func TestReconcileWithholdsReturnWhenCommitSafetyCannotBeObserved(t *testing.T) 
 		name        string
 		pr          string
 		observation worktree.CommitSafetyObservation
-		prHead      func(context.Context, string) (string, error)
+		prHead      func(context.Context, string) ghutil.PRObservation
 		wantReason  string
 	}{
 		{
@@ -203,10 +203,17 @@ func TestReconcileWithholdsReturnWhenCommitSafetyCannotBeObserved(t *testing.T) 
 			name:        "github unreachable",
 			pr:          "https://github.com/atqamz/hand/pull/7",
 			observation: localOnlyCommits(commitSafetyHead, 1),
-			prHead: func(context.Context, string) (string, error) {
-				return "", errors.New("gh pr view failed: dial tcp: lookup api.github.com: no such host")
-			},
-			wantReason: "could not be read",
+			prHead:      unobservedPR("gh pr view failed: dial tcp: lookup api.github.com: no such host"),
+			wantReason:  "could not be read",
+		},
+		{
+			// A pull request GitHub will not resolve is not a pull request proven to hold nothing:
+			// absence answers the wrong question here, so it withholds the return like unknown.
+			name:        "recorded pull request gh reports as absent",
+			pr:          "https://github.com/atqamz/hand/pull/7",
+			observation: localOnlyCommits(commitSafetyHead, 1),
+			prHead:      absentPRObservation(),
+			wantReason:  "could not be read",
 		},
 	}
 	for _, tc := range cases {
@@ -253,11 +260,11 @@ func TestReconcileReturnsWorktreeOfPushedAndMergedPullRequest(t *testing.T) {
 func TestReconcileReturnsSquashMergedWorktreeOnPullRequestHeadEvidence(t *testing.T) {
 	home, _ := commitSafetyTask(t, "https://github.com/atqamz/hand/pull/7", true)
 	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 3))
-	r.deps.prHead = func(_ context.Context, pr string) (string, error) {
+	r.deps.prHead = func(_ context.Context, pr string) ghutil.PRObservation {
 		if pr != "https://github.com/atqamz/hand/pull/7" {
 			t.Fatalf("prHead(%q), want the recorded pull request", pr)
 		}
-		return commitSafetyHead, nil
+		return ghutil.PRObservation{State: ghutil.ObservationFound, URL: pr, Head: commitSafetyHead}
 	}
 	reconcileConverges(t, r, home)
 	history, err := state.ReadHistory(home, "task-1")
@@ -272,9 +279,7 @@ func TestReconcileReturnsSquashMergedWorktreeOnPullRequestHeadEvidence(t *testin
 func TestReconcileWithholdsReturnForCommitPastThePushedPullRequestHead(t *testing.T) {
 	home, _ := commitSafetyTask(t, "https://github.com/atqamz/hand/pull/7", true)
 	r, counts := commitSafetyRuntime(t, localOnlyCommits(commitSafetyHead, 1))
-	r.deps.prHead = func(context.Context, string) (string, error) {
-		return "2222222222222222222222222222222222222222", nil
-	}
+	r.deps.prHead = observedPRHead("2222222222222222222222222222222222222222")
 	reconcileNeedsRepair(t, r, home)
 	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -652,7 +651,7 @@ func TestReconcileConvergesExitedWorkerWhoseMergedPRLanded(t *testing.T) {
 	}
 	writeReport(t, home, "task-1", "done: shipped\n")
 	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.prMerged = observedMergedPR(true)
 	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
 	if err != nil {
 		t.Fatal(err)
@@ -724,7 +723,7 @@ func TestReconcileKeepsLiveWorkerThatReportedDone(t *testing.T) {
 	}
 	writeReport(t, home, "task-1", "done: shipped and merged\n")
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.prMerged = observedMergedPR(true)
 	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
 	if err != nil {
 		t.Fatal(err)
@@ -778,7 +777,7 @@ func TestReconcileRecordsUnknownLandingWhenGitHubIsUnreachable(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return false, errors.New("GitHub unavailable") }
+	r.deps.prMerged = unobservedPR("GitHub unavailable")
 	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
 	if err != nil {
 		t.Fatal(err)
@@ -801,6 +800,33 @@ func TestReconcileRecordsUnknownLandingWhenGitHubIsUnreachable(t *testing.T) {
 	}
 }
 
+// A recorded PR GitHub will not resolve is not evidence the work did not land either: unlanded here
+// interrupts the attempt and records that the worker exited without landing, which is a durable claim
+// about the operator's work built on a query that answered nothing.
+func TestReconcileRecordsUnknownLandingForAPRGitHubReportsAsAbsent(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+	r.deps.prMerged = absentPRObservation()
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingUnknown) {
+		t.Fatalf("result = %+v, want an unknown landing rather than an unlanded one", report.Results[0])
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history = %+v, want the attempt left alone rather than interrupted as unlanded", history)
+	}
+}
+
 func TestReconcileConvergesLifecycleWhileWorktreeStillNeedsRepair(t *testing.T) {
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
@@ -818,7 +844,7 @@ func TestReconcileConvergesLifecycleWhileWorktreeStillNeedsRepair(t *testing.T) 
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.prMerged = observedMergedPR(true)
 	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
 	}
@@ -864,7 +890,7 @@ func TestReconcileConvergesLifecycleDespiteRecordedRepairMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+	r.deps.prMerged = observedMergedPR(true)
 	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
 	}
@@ -1647,7 +1673,7 @@ func TestReconcileMergeMismatchNeedsRepairWithoutRewritingHistory(t *testing.T) 
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return false, nil }
+	r.deps.prMerged = observedMergedPR(false)
 	first, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
 	if err != nil {
 		t.Fatal(err)
@@ -1688,7 +1714,7 @@ func TestReconcileMergeObservationFailureLeavesRepairMarkerUnchanged(t *testing.
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) { return false, errors.New("GitHub unavailable") }
+	r.deps.prMerged = unobservedPR("GitHub unavailable")
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err == nil {
 		t.Fatal("Reconcile succeeded through GitHub observation failure")
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,8 +1,11 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	"github.com/atqamz/hand/internal/ghutil"
 )
 
 func TestClassifiedErrorsPreserveCause(t *testing.T) {
@@ -44,5 +47,31 @@ func TestResultCarriesWarningsWithoutPresentationDependencies(t *testing.T) {
 
 	if result.Warnings[0] != "warning: cleanup was incomplete" || result.Help[0] == "" {
 		t.Fatalf("result = %+v, want structured warning and help", result)
+	}
+}
+
+// The observation stubs every reconcile and teardown test builds its GitHub answers from, so a
+// test states which of the three states it is exercising rather than a bool and an error.
+func observedMergedPR(merged bool) func(context.Context, string) ghutil.PRObservation {
+	return func(_ context.Context, pr string) ghutil.PRObservation {
+		return ghutil.PRObservation{State: ghutil.ObservationFound, URL: pr, Merged: merged}
+	}
+}
+
+func observedPRHead(commit string) func(context.Context, string) ghutil.PRObservation {
+	return func(_ context.Context, pr string) ghutil.PRObservation {
+		return ghutil.PRObservation{State: ghutil.ObservationFound, URL: pr, Head: commit}
+	}
+}
+
+func unobservedPR(reason string) func(context.Context, string) ghutil.PRObservation {
+	return func(context.Context, string) ghutil.PRObservation {
+		return ghutil.UnknownPRObservation("gh pr view", reason)
+	}
+}
+
+func absentPRObservation() func(context.Context, string) ghutil.PRObservation {
+	return func(context.Context, string) ghutil.PRObservation {
+		return ghutil.PRObservation{State: ghutil.ObservationAbsent}
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -50,8 +50,6 @@ func TestResultCarriesWarningsWithoutPresentationDependencies(t *testing.T) {
 	}
 }
 
-// The observation stubs every reconcile and teardown test builds its GitHub answers from, so a
-// test states which of the three states it is exercising rather than a bool and an error.
 func observedMergedPR(merged bool) func(context.Context, string) ghutil.PRObservation {
 	return func(_ context.Context, pr string) ghutil.PRObservation {
 		return ghutil.PRObservation{State: ghutil.ObservationFound, URL: pr, Merged: merged}

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -379,21 +379,22 @@ func checkLandedWork(ctx context.Context, home string, t state.Task, active stat
 		// A gate-opened PR bypasses hand pr entirely (atqamz/hand#69), so t.PR can still be empty
 		// for landed work; detect it here rather than only refusing on it, so the merged check below
 		// reads the same PR state hand pr would have recorded.
+		var unobserved *ghutil.PRObservation
 		if exists {
-			detected, err := DetectPR(ctx, home, t, active, proj)
-			var ambiguous *ghutil.AmbiguousPRError
+			detected, observation, err := DetectPR(ctx, home, t, active, proj)
 			// An ambiguous branch is a different failure and must not fall through the same way: "no PR
 			// recorded" reads as unlanded, but ambiguous means unknown, and picking either meaning here
 			// for the operator is the guess atqamz/hand#77 exists to remove.
-			if errors.As(err, &ambiguous) {
-				return t, false, Precondition(fmt.Errorf("PR for %s is ambiguous, refusing to guess: %w", t.ID, ambiguous))
+			if observation.Ambiguous != nil {
+				return t, false, Precondition(fmt.Errorf("PR for %s is ambiguous, refusing to guess: %w", t.ID, observation.Ambiguous))
 			}
-			// Detection failing (no clone on disk yet, gh unreachable, ...) is not this command's failure
-			// to report: it falls through to the same "no PR recorded" refusal below that a project with
-			// no detection at all would have gotten.
-			if err == nil {
-				t = detected
+			if err != nil {
+				return t, false, err
 			}
+			if observation.Unknown() {
+				unobserved = &observation
+			}
+			t = detected
 		}
 
 		if t.PR == "" {
@@ -412,17 +413,24 @@ func checkLandedWork(ctx context.Context, home string, t state.Task, active stat
 				t.Kind = state.KindScout
 				return t, dirtWasSafe, nil
 			}
+			// An unreachable GitHub is not evidence that no PR exists, and the refusal below says the work
+			// may not be landed. Below the scout escape because that escape reads local evidence only.
+			if unobserved != nil {
+				return t, false, Precondition(fmt.Errorf("whether %s has a pull request could not be observed, so its worktree is not released: %s", t.ID, unobserved.Reason()))
+			}
 			// Narrow on purpose: a ship task whose PR was never opened still has its commits, so it still
 			// refuses - the half of this guard that is load-bearing.
 			return t, false, Precondition(fmt.Errorf("no PR recorded for %s and project is not local-only: work may not be landed", t.ID))
 		}
 	}
 
-	merged, err := ghutil.PRIsMerged(ctx, t.PR)
-	if err != nil {
-		return t, false, err
+	observation := ghutil.ObserveMergeState(ctx, t.PR)
+	// Absent refuses alongside unknown and neither may say "not merged": a PR GitHub will not resolve
+	// is not a PR proven unmerged, and this releases a worktree that may hold the only copy of the work.
+	if !observation.Found() {
+		return t, false, Precondition(fmt.Errorf("whether PR %s is merged could not be observed, so worktree %s is not released: %s", t.PR, active.Worktree, observation.Reason()))
 	}
-	if !merged {
+	if !observation.Merged {
 		return t, false, Precondition(fmt.Errorf("PR %s is not merged", t.PR))
 	}
 	return t, dirtWasSafe, nil

--- a/internal/state/pr.go
+++ b/internal/state/pr.go
@@ -7,7 +7,7 @@ import (
 
 // The sole boundary between an untrusted string and a PR URL hand will ever store,
 // anchored end-to-end with no substring matching: a stored value feeds gh pr merge and
-// ghutil.PRIsMerged directly, so a loose match is a command-injection-adjacent risk.
+// ghutil.ObserveMergeState directly, so a loose match is a command-injection-adjacent risk.
 var prURLPattern = regexp.MustCompile(`^https://github\.com/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/pull/([0-9]+)$`)
 
 func ValidatePRURL(url string) bool {

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -7,6 +7,7 @@ package contract
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -22,9 +23,20 @@ type result struct {
 // tool answers on, and combining them would assert nothing about that.
 func run(t *testing.T, dir, name string, args ...string) result {
 	t.Helper()
+	return runEnv(t, dir, nil, name, args...)
+}
+
+// Same as run with extra environment entries appended, for the probe that has to see a rejected
+// credential. The value is generated here and never read from the environment, so no real token can
+// reach a test log.
+func runEnv(t *testing.T, dir string, env []string, name string, args ...string) result {
+	t.Helper()
 	var out, errOut strings.Builder
 	c := exec.Command(name, args...)
 	c.Dir = dir
+	if len(env) > 0 {
+		c.Env = append(os.Environ(), env...)
+	}
 	c.Stdout = &out
 	c.Stderr = &errOut
 	err := c.Run()

--- a/tests/contract/gh_fake_test.go
+++ b/tests/contract/gh_fake_test.go
@@ -3,9 +3,12 @@
 package contract
 
 import (
+	"context"
 	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
 )
@@ -149,5 +152,44 @@ func TestGHFixturesPreserveEdgeRefOutcomes(t *testing.T) {
 	commit := run(t, "", "gh", "api", "repos/atqamz/hand/commits/edge", "--jq", ".sha").requireCode(t, 0)
 	if strings.TrimSpace(commit.stdout) != contractGHEdgeSHA {
 		t.Fatalf("edge commit = %q, want %q", commit.stdout, contractGHEdgeSHA)
+	}
+}
+
+// The absence-proving diagnostic is a contract, not a message: internal/ghutil reads absence off
+// this exact shape and everything else as unknown, so a paraphrase in the fake would make every
+// unit test's absence unreachable while the tests still passed.
+func TestGHFixturesPreserveTheAbsentPullRequestDiagnostic(t *testing.T) {
+	faketool.GH{PRs: []faketool.GHPR{{
+		Number: 154,
+		URL:    "https://github.com/atqamz/hand/pull/154",
+		Branch: "136-usage-limit-resume",
+		State:  "MERGED",
+		Repo:   contractGHRepo,
+	}}}.Install(t, faketool.Bin(t))
+
+	for _, args := range [][]string{
+		{"pr", "view", "999999", "--repo", contractGHRepo, "--json", "state"},
+		{"pr", "view", "999999", "--repo", contractGHRepo, "--json", "headRefOid"},
+		{"pr", "checks", "999999", "--repo", contractGHRepo, "--json", "bucket"},
+	} {
+		run(t, "", "gh", args...).
+			requireCode(t, 1).
+			requireStderrContains(t, "Could not resolve to a PullRequest with the number of 999999. (repository.pullRequest)")
+	}
+}
+
+// A fake that never answers is how a caller's timeout and cancellation paths are reachable without a
+// network: the process is killed by the caller's context, and nothing was observed.
+func TestGHFixturesNeverAnswerAHungCommand(t *testing.T) {
+	faketool.GH{Hang: []string{"pr view"}}.Install(t, faketool.Bin(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	c := exec.CommandContext(ctx, "gh", "pr", "view", "154", "--json", "state")
+	if err := c.Run(); err == nil {
+		t.Fatal("gh answered a hung command, want it killed by the deadline")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("context outlived the call, want the deadline to be what ended it")
 	}
 }

--- a/tests/contract/gh_test.go
+++ b/tests/contract/gh_test.go
@@ -96,10 +96,10 @@ func TestGHPRViewFailsForAPRThatDoesNotExist(t *testing.T) {
 	run(t, "", "gh", "pr", "view", ghMergedPR, "--repo", ghRepoCased, "--json", "state").requireCode(t, 0)
 	run(t, "", "gh", "pr", "view", "999999", "--repo", ghRepo, "--json", "state").
 		requireCode(t, 1).
-		requireStderrContains(t, "Could not resolve to a PullRequest")
+		requireStderrContains(t, "Could not resolve to a PullRequest with the number of 999999. (repository.pullRequest)")
 }
 
-// PRHeadCommit reads headRefOid from a merged PR whose branch is long deleted, because GitHub's
+// ObserveHeadCommit reads headRefOid from a merged PR whose branch is long deleted, because GitHub's
 // record of the head ref outlives the clone; this pins that the field survives branch deletion.
 func TestGHPRViewReportsHeadRefOidAfterBranchDeletion(t *testing.T) {
 	requireGH(t)
@@ -174,4 +174,38 @@ func TestGHEdgeRefReportsThePublishedCommit(t *testing.T) {
 	if len(sha) != 40 {
 		t.Fatalf("edge commit = %q, want a full SHA", sha)
 	}
+}
+
+// A repository gh cannot resolve is not a pull request that is not there: GitHub answers this same way
+// for a repository that does not exist and for a private one this token may not read, so it can never
+// prove an absence (atqamz/hand#241).
+func TestGHPRViewOnAnUnresolvableRepositoryDoesNotReportAMissingPullRequest(t *testing.T) {
+	requireGH(t)
+
+	run(t, "", "gh", "pr", "view", "1", "--repo", "atqamz/no-such-repository-contract-probe", "--json", "state").
+		requireCode(t, 1).
+		requireStderrContains(t, "Could not resolve to a Repository").
+		requireStderrLacks(t, "Could not resolve to a PullRequest")
+}
+
+// A rejected credential must stay distinguishable from an absence, or hand would tell an operator to
+// fix a PR URL that was right all along. The token is a fixed invalid value written here; the real one
+// is never read, printed, or passed to this probe.
+func TestGHPRViewWithARejectedCredentialDoesNotReportAMissingPullRequest(t *testing.T) {
+	requireGH(t)
+
+	runEnv(t, "", []string{"GH_TOKEN=invalid-token-for-the-contract-probe"},
+		"gh", "pr", "view", ghMergedPR, "--repo", ghRepo, "--json", "state").
+		requireCode(t, 1).
+		requireStderrLacks(t, "Could not resolve to a PullRequest")
+}
+
+// Only the live probes below need this: a fake answers what a fixture told it to, so what a diagnostic
+// is not is a fact about the real tool.
+func (r result) requireStderrLacks(t *testing.T, unwanted string) result {
+	t.Helper()
+	if strings.Contains(r.stderr, unwanted) {
+		t.Fatalf("stderr %q, want it not to contain %q", r.stderr, unwanted)
+	}
+	return r
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -607,6 +608,13 @@ func TestExitCodeThreeOnPreconditionFailure(t *testing.T) {
 			name: "teardown ship without landed work",
 			setup: func(t *testing.T, home string) {
 				registerProject(t, home, "demo", "direct-pr")
+				// The clone and the gh fake are what make the refusal below an answered absence:
+				// without them the branch search never reaches GitHub, and an unobserved PR refuses
+				// with its own message instead (atqamz/hand#241).
+				clonePath := filepath.Join(home, "projects", "demo")
+				initGitRepo(t, clonePath)
+				runGitIn(t, clonePath, "remote", "add", "origin", "https://github.com/owner/demo.git")
+				faketool.GH{}.Install(t, binDir(t))
 				worktree := filepath.Join(home, "wt")
 				initGitRepo(t, worktree)
 				writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree})


### PR DESCRIPTION
## Summary

- Every pull request observation now answers exactly one of found, absent or unknown, and carries the probe that produced it. `PRObservation.Unknown()` is defined as the absence of both positive findings, so a zero value, an unset state and any state added later read as unknown by construction rather than by a check someone remembered to add.
- Absence is proven only by the GraphQL diagnostic that names an unresolvable PullRequest. An unresolvable repository is indistinguishable from a private one this token may not read, and a rejected credential proves nothing, so both are unknown. Network failure, DNS failure, request timeout, context deadline, context cancellation, a killed or non-zero `gh`, malformed or empty stdout at exit zero, authentication and authorization failure and rate limiting are all unknown, each with a test.
- Every caller that observes a pull request states its own reading of unknown at the call site, and no destructive or irreversible action is reachable from an unknown observation.

Closes atqamz/hand#241

## Audited callers and their UNKNOWN handling

- `internal/runtime/teardown.go:384` - landed-work PR detection: refuse. Worktree release is irreversible and an unreachable GitHub is not evidence that no pull request exists. Placed after the completed-scout escape, which reads local evidence only.
- `internal/runtime/teardown.go:427` - landed-work merge check: refuse, and absent refuses with it. Neither may render as "not merged", because this releases a worktree that may hold the only copy of the work.
- `internal/runtime/reconcile.go:423` - merge-fact observation: refuse by propagating an error. Recording a merge-fact mismatch from an unobserved PR would be a durable false claim about the operator that every later run reads.
- `internal/runtime/reconcile.go:489` - landing observation: surface unknown as `landingUnknown`. Terminal convergence acts on landed and unlanded only, so an unknown landing leaves the attempt alone and reports needs-repair.
- `internal/runtime/reconcile.go:1311` - commit-safety pushed head: surface unknown as `commitSafetyUnprovable`, which withholds the automatic worktree return. Absent withholds it too.
- `internal/runtime/pr.go:54` - branch search behind `DetectPR` and `DetectPRReadOnly`: surface unknown to the caller. A local prerequisite that fails (unreadable branch, underivable repo slug) is unknown as well, because the question never reached GitHub.
- `internal/project/pr.go:38` - `hand pr` recording gate: refuse either way, with distinct messages. Absent says the PR is not there; unknown says nothing is recorded and names what answered nothing, so an operator is never told to fix a URL that was right.
- `cmd/merge.go:107` - `hand merge`: refuse before `gh pr merge` runs. Merging is irreversible, so only a completed observation licenses it, and absent and unknown refuse for different stated reasons.
- `cmd/prdetect.go:16`, `cmd/statusview.go:156`, `cmd/status.go:568` - read-only status views: surface unknown. The `pr` column renders `unknown` where a live lookup was attempted and failed, and `statusJSON` gained an additive `pr_observation` field. The short-circuits that never ask GitHub (scout, local-only, terminal task, no active attempt) still render `none`, because each is a locally known answer.
- `internal/watcher/watcher.go:320` - out of scope, see below. It keeps `ghutil.PRIsMerged`, now a documented shim over `ObserveMergeState` that returns an error rather than reporting an unmerged pull request.

## Reuse of the vocabulary #251 introduced

atqamz/hand#251's notion of unknown generalizes, so it is extended rather than duplicated. `ghutil.ObservationState` is the same three-state model as `worktree.LeaseObservationState` and `worktree.CommitSafetyState` at the GitHub boundary, `ghutil.Probe` mirrors their probe-carries-evidence shape, and `runtime.landingState` and `runtime.commitSafety` consume the new observations without gaining a state. No second vocabulary was introduced.

## Out of scope

`internal/watcher/**` is untouched: atqamz/hand#235 and atqamz/hand#252 are live on that surface. The dependency is that the watcher is the last caller of `ghutil.PRIsMerged`, kept for it alone. The shim already refuses to report an unmerged PR from a failed query, so the watcher does not read a failed observation as an absence today, but it also cannot tell unknown from unmerged in its own reporting. Whichever of those issues lands first should move it to `ObserveMergeState` and delete the shim.

atqamz/hand#240 (gate-run observation) and atqamz/hand#244 are deliberately not absorbed.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...` - green
- `nix develop -c make lint` (golangci-lint plus `tools/commentlint`) - green
- `make build`, `make contract`, `make e2e`, `nix flake check`, `git diff --check` - green
- New coverage: every failure mode above asserted unknown for `ObserveMergeState`, `ObserveHeadCommit` and `ObservePRByBranch`, including a cancelled context and a `gh` killed by its deadline through the shared fake's new `Hang`; a genuine absence still returns absent; repeated read-only `hand status` calls against unchanged reality return byte-identical output; and one refusal test per destructive caller proving the action does not fire.
- The comment-density follow-up commit removes the added comments from the four `internal/runtime` files that carry none on `main`, folding what they said into the commit-safety table case name and the error text the code already returns.
- The `gh` fake previously paraphrased the absence diagnostic, which made the absent path unreachable in tests. It now quotes the real shape, `internal/faketool/FIDELITY.md` records all three shapes and why only one proves absence, `tests/contract` pins them hermetically, and `make contract-live` probes the unreadable-repository and rejected-credential shapes against installed `gh` with a generated invalid token.

## Pipeline

no-mistakes pipeline attestation, preserved verbatim from the gate run:

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e973cb29afde1a5e0669d5276acd62b6a2ee7bef","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->
