### PR TITLE
fix(runtime): consult pull request head evidence before returning commit safety unknown

### DIFF
--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1289,20 +1289,14 @@ func (r *Runtime) resolveWorktreeCommitSafety(ctx context.Context, task state.Ta
 		observeCommits = worktree.ObserveCommitSafety
 	}
 	observation := observeCommits(attempt.Worktree)
-	switch observation.State {
-	case worktree.CommitSafetyRemoteObserved:
+	if observation.State == worktree.CommitSafetyRemoteObserved {
 		return commitSafetyDecision{
 			State:  commitSafetyProvenDurable,
 			Reason: fmt.Sprintf("every commit reachable from %s in %s is also reachable from one of the %d remote-tracking refs this clone holds, so returning the worktree discards nothing", shortCommit(observation.Probe.Head), observation.Probe.WorkingDir, observation.Probe.RemoteRefs),
 		}
-	case worktree.CommitSafetyUnknown:
-		return commitSafetyDecision{State: commitSafetyUnprovable, Reason: unprovableCommitSafetyReason(attempt, observation.Probe)}
 	}
 	if task.PR == "" {
-		return commitSafetyDecision{
-			State:  commitSafetyLocalWorkAtRisk,
-			Reason: localOnlyCommitsReason(observation.Probe, "no pull request is recorded for this task, so no pushed head can hold them either"),
-		}
+		return withheldCommitSafety(attempt, observation, "no pull request is recorded for this task, so no pushed head can hold them either")
 	}
 	prHead := r.deps.prHead
 	if prHead == nil {
@@ -1312,19 +1306,23 @@ func (r *Runtime) resolveWorktreeCommitSafety(ctx context.Context, task state.Ta
 	if !pushed.Found() {
 		return commitSafetyDecision{
 			State:  commitSafetyUnprovable,
-			Reason: fmt.Sprintf("%d commit(s) in %s are reachable from no remote-tracking ref and the head commit of pull request %s could not be read, so whether GitHub holds them is unobserved rather than answered: %s", observation.Probe.LocalOnly, observation.Probe.WorkingDir, task.PR, pushed.Reason()),
+			Reason: unprovableCommitSafetyReason(attempt, observation, fmt.Sprintf("the head commit of pull request %s could not be read, so whether GitHub holds them is unobserved rather than answered: %s", task.PR, pushed.Reason())),
 		}
 	}
-	if pushed.Head == observation.Probe.Head {
+	if observation.Probe.Head != "" && pushed.Head == observation.Probe.Head {
 		return commitSafetyDecision{
 			State:  commitSafetyProvenDurable,
-			Reason: fmt.Sprintf("no remote-tracking ref in %s reaches %s, and GitHub records that exact commit as the head of pull request %s, which holds it independently of this worktree", observation.Probe.WorkingDir, shortCommit(observation.Probe.Head), task.PR),
+			Reason: fmt.Sprintf("the remote-tracking refs in %s do not prove %s durable, and GitHub records that exact commit as the head of pull request %s, which holds it independently of this worktree", observation.Probe.WorkingDir, shortCommit(observation.Probe.Head), task.PR),
 		}
 	}
-	return commitSafetyDecision{
-		State:  commitSafetyLocalWorkAtRisk,
-		Reason: localOnlyCommitsReason(observation.Probe, fmt.Sprintf("pull request %s records head commit %s instead, so GitHub was never observed holding %s", task.PR, shortCommit(pushed.Head), shortCommit(observation.Probe.Head))),
+	return withheldCommitSafety(attempt, observation, fmt.Sprintf("pull request %s records head commit %s instead, so GitHub was never observed holding %s", task.PR, shortCommit(pushed.Head), shortCommit(observation.Probe.Head)))
+}
+
+func withheldCommitSafety(attempt state.Attempt, observation worktree.CommitSafetyObservation, unheldBecause string) commitSafetyDecision {
+	if observation.State == worktree.CommitSafetyLocalOnly {
+		return commitSafetyDecision{State: commitSafetyLocalWorkAtRisk, Reason: localOnlyCommitsReason(observation, unheldBecause)}
 	}
+	return commitSafetyDecision{State: commitSafetyUnprovable, Reason: unprovableCommitSafetyReason(attempt, observation, unheldBecause)}
 }
 
 func commitSafetyRepairCode(safety commitSafety) string {
@@ -1334,16 +1332,24 @@ func commitSafetyRepairCode(safety commitSafety) string {
 	return repairCodeWorktreeCommitSafetyUnknown
 }
 
-func localOnlyCommitsReason(probe worktree.CommitSafetyProbe, unheldBecause string) string {
-	return fmt.Sprintf(
-		"%d commit(s) in %s are reachable from none of the %d remote-tracking refs this clone holds, and %s; observed by running %q with working directory %s; automatic reconciliation will not discard work no other copy is known to hold",
-		probe.LocalOnly, probe.WorkingDir, probe.RemoteRefs, unheldBecause, probe.Command, probe.WorkingDir)
+func commitSafetyFinding(observation worktree.CommitSafetyObservation) string {
+	if observation.State == worktree.CommitSafetyLocalOnly {
+		return fmt.Sprintf("%d commit(s) in %s are reachable from none of the %d remote-tracking refs this clone holds",
+			observation.Probe.LocalOnly, observation.Probe.WorkingDir, observation.Probe.RemoteRefs)
+	}
+	return observation.Probe.Reason
 }
 
-func unprovableCommitSafetyReason(attempt state.Attempt, probe worktree.CommitSafetyProbe) string {
+func localOnlyCommitsReason(observation worktree.CommitSafetyObservation, unheldBecause string) string {
 	return fmt.Sprintf(
-		"whether worktree %s still holds the only copy of any commit could not be observed: %s; observed by running %q with working directory %s; the return is withheld because the question went unanswered, not because work was found at risk",
-		attempt.Worktree, probe.Reason, probe.Command, probe.WorkingDir)
+		"%s, and %s; observed by running %q with working directory %s; automatic reconciliation will not discard work no other copy is known to hold",
+		commitSafetyFinding(observation), unheldBecause, observation.Probe.Command, observation.Probe.WorkingDir)
+}
+
+func unprovableCommitSafetyReason(attempt state.Attempt, observation worktree.CommitSafetyObservation, unheldBecause string) string {
+	return fmt.Sprintf(
+		"whether worktree %s still holds the only copy of any commit could not be observed: %s, and %s; observed by running %q with working directory %s; the return is withheld because the question went unanswered, not because work was found at risk",
+		attempt.Worktree, commitSafetyFinding(observation), unheldBecause, observation.Probe.Command, observation.Probe.WorkingDir)
 }
 
 func shortCommit(commit string) string {

--- a/internal/runtime/reconcile_commit_safety_ordering_test.go
+++ b/internal/runtime/reconcile_commit_safety_ordering_test.go
@@ -1,0 +1,182 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+const commitSafetyPR = "https://github.com/atqamz/hand/pull/7"
+
+type squashMergedWorktree struct {
+	path       string
+	pushedHead string
+}
+
+func squashMergedFixture(t *testing.T, localOnly int) squashMergedWorktree {
+	t.Helper()
+	root := t.TempDir()
+	path := filepath.Join(root, "worktree")
+	faketool.InitRepo(t, path)
+	remote := filepath.Join(root, "remote.git")
+	runRuntimeGit(t, root, "init", "-q", "--bare", remote)
+	runRuntimeGit(t, path, "remote", "add", "origin", remote)
+	runRuntimeGit(t, path, "push", "-q", "-u", "origin", "main")
+	runRuntimeGit(t, path, "checkout", "-q", "-b", "topic")
+	commitFixtureFile(t, path, "feature")
+	runRuntimeGit(t, path, "push", "-q", "-u", "origin", "topic")
+	pushedHead := gitOutput(t, path, "rev-parse", "HEAD")
+	runRuntimeGit(t, path, "checkout", "-q", "main")
+	runRuntimeGit(t, path, "merge", "-q", "--squash", "topic")
+	runRuntimeGit(t, path, "commit", "-q", "-m", "squash topic")
+	runRuntimeGit(t, path, "push", "-q", "origin", "main")
+	runRuntimeGit(t, path, "checkout", "-q", "topic")
+	for i := 0; i < localOnly; i++ {
+		commitFixtureFile(t, path, fmt.Sprintf("local-only-%d", i))
+	}
+	return squashMergedWorktree{path: path, pushedHead: pushedHead}
+}
+
+func commitFixtureFile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeGit(t, dir, "add", name)
+	runRuntimeGit(t, dir, "commit", "-q", "-m", "add "+name)
+}
+
+func deleteHeadBranchAndPrune(t *testing.T, fixture squashMergedWorktree) {
+	t.Helper()
+	runRuntimeGit(t, fixture.path, "push", "-q", "origin", "--delete", "topic")
+	runRuntimeGit(t, fixture.path, "fetch", "-q", "--prune", "origin")
+	survivor := exec.Command("git", "rev-parse", "--verify", "--quiet", "refs/remotes/origin/topic")
+	survivor.Dir = fixture.path
+	if err := survivor.Run(); err == nil {
+		t.Fatal("refs/remotes/origin/topic survived the prune, so the fixture never reaches the state under test")
+	}
+	if observed := worktree.ObserveCommitSafety(fixture.path); observed.State != worktree.CommitSafetyUnknown || observed.Probe.RemoteRefs == 0 {
+		t.Fatalf("observation = %+v, want the remote-tracking comparison unable to answer while other remote-tracking refs survive", observed)
+	}
+}
+
+func pruningRuntime(t *testing.T, fixture squashMergedWorktree) (*Runtime, *commitSafetyProbeCount) {
+	t.Helper()
+	r, counts := observingCommitSafetyRuntime(t, fixture.path, worktree.ObserveCommitSafety)
+	r.deps.worktree.observeClean = worktree.ObserveCleanliness
+	return r, counts
+}
+
+func assertWorktreeReturned(t *testing.T, home string, counts *commitSafetyProbeCount) {
+	t.Helper()
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.returns != 1 || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Task.RepairCode != "" {
+		t.Fatalf("returns=%d attempt=%+v task=%+v, want the worktree proven durable and returned", counts.returns, history.Attempts[0], history.Task)
+	}
+}
+
+func assertWorktreeWithheld(t *testing.T, home string, counts *commitSafetyProbeCount, wantRepairCode string) {
+	t.Helper()
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != wantRepairCode || counts.returns != 0 {
+		t.Fatalf("task=%+v returns=%d, want %q recorded and no return", history.Task, counts.returns, wantRepairCode)
+	}
+	if history.Attempts[0].TeardownWorktreeState != "" {
+		t.Fatalf("worktree state = %q, want no cleanup recorded", history.Attempts[0].TeardownWorktreeState)
+	}
+}
+
+func TestReconcileReturnsSquashMergedWorktreeAfterTheStaleRemoteTrackingRefIsPruned(t *testing.T) {
+	fixture := squashMergedFixture(t, 0)
+	deleteHeadBranchAndPrune(t, fixture)
+	home, _ := commitSafetyTaskAt(t, fixture.path, commitSafetyPR, true)
+	r, counts := pruningRuntime(t, fixture)
+	r.deps.prHead = observedPRHead(fixture.pushedHead)
+	reconcileConverges(t, r, home)
+	assertWorktreeReturned(t, home, counts)
+}
+
+func TestReconcileWithholdsPrunedWorktreeWithNoPullRequestEvidence(t *testing.T) {
+	fixture := squashMergedFixture(t, 0)
+	deleteHeadBranchAndPrune(t, fixture)
+	home, _ := commitSafetyTaskAt(t, fixture.path, "", false)
+	r, counts := pruningRuntime(t, fixture)
+	reconcileNeedsRepair(t, r, home)
+	assertWorktreeWithheld(t, home, counts, repairCodeWorktreeCommitSafetyUnknown)
+}
+
+func TestReconcileWithholdsPrunedWorktreeCarryingALocalOnlyCommit(t *testing.T) {
+	fixture := squashMergedFixture(t, 1)
+	deleteHeadBranchAndPrune(t, fixture)
+	head := gitOutput(t, fixture.path, "rev-parse", "HEAD")
+	if head == fixture.pushedHead {
+		t.Fatal("the fixture head equals the pushed head, so it carries no local-only commit to lose")
+	}
+	home, _ := commitSafetyTaskAt(t, fixture.path, commitSafetyPR, true)
+	r, counts := pruningRuntime(t, fixture)
+	r.deps.prHead = observedPRHead(fixture.pushedHead)
+	reconcileNeedsRepair(t, r, home)
+	assertWorktreeWithheld(t, home, counts, repairCodeWorktreeCommitSafetyUnknown)
+	if kept := gitOutput(t, fixture.path, "rev-parse", "HEAD"); kept != head {
+		t.Fatalf("head = %s, want the local-only commit still held at %s", kept, head)
+	}
+}
+
+func TestReconcileWithholdsCommitMadeAfterTheRecordedPullRequestHead(t *testing.T) {
+	fixture := squashMergedFixture(t, 1)
+	home, _ := commitSafetyTaskAt(t, fixture.path, commitSafetyPR, true)
+	r, counts := pruningRuntime(t, fixture)
+	r.deps.prHead = observedPRHead(fixture.pushedHead)
+	reconcileNeedsRepair(t, r, home)
+	assertWorktreeWithheld(t, home, counts, repairCodeWorktreeLocalCommits)
+}
+
+func TestReconcileWithholdsPrunedWorktreeWhenGitHubCannotBeReached(t *testing.T) {
+	fixture := squashMergedFixture(t, 0)
+	deleteHeadBranchAndPrune(t, fixture)
+	home, _ := commitSafetyTaskAt(t, fixture.path, commitSafetyPR, true)
+	r, counts := pruningRuntime(t, fixture)
+	r.deps.prHead = unobservedPR("gh pr view failed: dial tcp: lookup api.github.com: no such host")
+	reconcileNeedsRepair(t, r, home)
+	assertWorktreeWithheld(t, home, counts, repairCodeWorktreeCommitSafetyUnknown)
+}
+
+func TestCommitSafetyAnswerSurvivesThePruneThatChangesWhichSourceProvesIt(t *testing.T) {
+	fixture := squashMergedFixture(t, 0)
+	if observed := worktree.ObserveCommitSafety(fixture.path); observed.State != worktree.CommitSafetyRemoteObserved {
+		t.Fatalf("observation = %+v, want the stale remote-tracking ref proving durability before the prune", observed)
+	}
+	before, _ := commitSafetyTaskAt(t, fixture.path, commitSafetyPR, true)
+	cached, cachedCounts := pruningRuntime(t, fixture)
+	reconcileConverges(t, cached, before)
+	assertWorktreeReturned(t, before, cachedCounts)
+
+	deleteHeadBranchAndPrune(t, fixture)
+
+	after, _ := commitSafetyTaskAt(t, fixture.path, commitSafetyPR, true)
+	observed, observedCounts := pruningRuntime(t, fixture)
+	asked := 0
+	observed.deps.prHead = func(ctx context.Context, pr string) ghutil.PRObservation {
+		asked++
+		return observedPRHead(fixture.pushedHead)(ctx, pr)
+	}
+	reconcileConverges(t, observed, after)
+	assertWorktreeReturned(t, after, observedCounts)
+	if asked != 1 {
+		t.Fatalf("pull request head observations = %d, want the pruned clone to prove durability from GitHub exactly once", asked)
+	}
+}

--- a/internal/runtime/reconcile_commit_safety_test.go
+++ b/internal/runtime/reconcile_commit_safety_test.go
@@ -38,9 +38,14 @@ func unobservableCommits(reason string) worktree.CommitSafetyObservation {
 
 func commitSafetyTask(t *testing.T, pr string, merged bool) (string, state.Attempt) {
 	t.Helper()
+	return commitSafetyTaskAt(t, "/pool/1", pr, merged)
+}
+
+func commitSafetyTaskAt(t *testing.T, worktreePath, pr string, merged bool) (string, state.Attempt) {
+	t.Helper()
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
-		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/pool/1", LeaseID: "lease-1",
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: worktreePath, LeaseID: "lease-1",
 		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
 	})
 	if err != nil {
@@ -72,14 +77,19 @@ type commitSafetyProbeCount struct {
 
 func commitSafetyRuntime(t *testing.T, observation worktree.CommitSafetyObservation) (*Runtime, *commitSafetyProbeCount) {
 	t.Helper()
+	return observingCommitSafetyRuntime(t, "/pool/1", func(string) worktree.CommitSafetyObservation { return observation })
+}
+
+func observingCommitSafetyRuntime(t *testing.T, worktreePath string, observe func(string) worktree.CommitSafetyObservation) (*Runtime, *commitSafetyProbeCount) {
+	t.Helper()
 	counts := &commitSafetyProbeCount{}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
 	r.deps.worktree.observeCommits = func(path string) worktree.CommitSafetyObservation {
 		counts.commits++
-		if path != "/pool/1" {
+		if path != worktreePath {
 			t.Fatalf("observeCommits(%q), want the recorded worktree", path)
 		}
-		return observation
+		return observe(path)
 	}
 	r.deps.worktree.returnWithID = func(string, string, bool) error {
 		counts.returns++


### PR DESCRIPTION
## Intent

Fix atqamz/hand#253: the commit-safety gate must not end its observation just because one evidence source is absent. atqamz/hand#239 (merged as PR 251) made automatic worktree return require positive proof that no local-only work would be lost; that safety property is correct and must stay. The defect is ordering, not the individual sources: internal/runtime/reconcile.go resolveWorktreeCommitSafety decided from remote-tracking refs first and returned commitSafetyUnprovable the moment worktree.ObserveCommitSafety answered CommitSafetyUnknown, so the recorded pull request head was never consulted. In the ordinary squash-merge workflow the head branch is deleted at merge, the stale refs/remotes/origin/<branch> is the only thing making 'git rev-list --count HEAD --not --remotes' return zero, and a routine 'git fetch --prune' removes it; the count then goes non-zero because a squash merge produces a different sha, so a provably durable worktree could never be returned automatically again.

Required behaviour the user asked for, in their terms: a pruned, deleted or never-fetched remote-tracking ref is the absence of one evidence source, not a finding about durability, and must not terminate the observation; every evidence source the model already recognises is consulted before unknown is returned; recorded pull request head evidence in particular survives the head branch being deleted, which is exactly the state a merged pull request leaves behind; unknown still withholds and nothing an unproven state permits may be widened; and no evidence source may be treated as durable purely because a local ref remembers it, so once GitHub has been asked its answer governs and the local cache never rescues it.

Deliberate decisions I made while doing the work, which a reviewer reading only the diff would not know:
- internal/worktree is intentionally left unchanged. It stays the local remote-tracking source only, with no GitHub knowledge; the aggregation of sources belongs in the consuming gate in internal/runtime where the pull request observer already lives. CommitSafetyUnknown from that package is still the right answer for that one source; it simply no longer terminates the aggregate.
- The user explicitly required consuming atqamz/hand#241's tri-state layer (internal/ghutil/observation.go, merged as PR 256) rather than adding a second way to ask GitHub about a pull request, and rather than introducing a second vocabulary for found/absent/unknown. No new GitHub query and no new evidence source were added; in particular 'git ls-remote' was deliberately NOT added even though it would directly observe whether a commit is on a remote now, because the user asked only that existing sources be consulted before unknown is returned.
- The residual answer when nothing proves durability is decided by the local source alone, so no repair code changes meaning: a positive CommitSafetyLocalOnly finding stays commitSafetyLocalWorkAtRisk / worktree-local-commits, and an unanswerable comparison stays commitSafetyUnprovable / worktree-commit-safety-unknown. The only behaviour that changes is that CommitSafetyUnknown plus a matching pull request head now proves durability. An absent pull request keeps withholding exactly as it did before, because absence answers a different question than 'does this worktree hold the only copy'.
- Proof from the pull request head now additionally requires a non-empty observed worktree head. CommitSafetyUnknown can carry an empty Probe.Head (for example when 'git rev-parse HEAD' failed), and empty-equals-empty must never read as proof of durability. This guard is new and deliberate.
- withheldCommitSafety and commitSafetyFinding were extracted so the two withholding reason sentences share one description of what the local source actually found, instead of the previous bespoke sentence that hardcoded a local-only commit count into a path that can now be reached with no count at all.
- Two reason strings changed wording. They are diagnostic prose, not a contract: no test, command output shape or documentation asserts them, and the repository's own convention is to assert durable state rather than rendered strings.

Tests, all six required by the user, in internal/runtime/reconcile_commit_safety_ordering_test.go. They drive real git fixtures (a bare remote, a topic branch pushed and then squash-merged onto main, the head branch deleted on the remote and the stale remote-tracking ref pruned inside the fixture) through the real reconciliation gate and assert durable state - whether the worktree was returned, TeardownWorktreeState, RepairCode - never rendered strings: (1) a clean worktree whose head branch was deleted after a squash merge, with the stale remote-tracking ref pruned, is still proven durable from pull request head evidence and is returned; (2) the same worktree with no pull request evidence at all returns unknown and withholds; (3) the mandatory data-loss test - a worktree carrying a genuine local-only commit still withholds after the prune and is not rescued by pull request head evidence for an earlier commit; (4) a local commit made after the recorded pull request head still blocks the return; (5) GitHub unreachable yields unknown and withholds and does not fall back to the surviving remote-tracking refs; (6) the answer is idempotent across the prune - before it the remote-tracking comparison proves durability and GitHub is never asked, after it the pull request head proves it, and the answer is the same. I verified the new tests catch the defect by reinstating the old early return, watching tests 1 and 6 fail, then restoring the fix.

Existing test helpers commitSafetyTask and commitSafetyRuntime were generalised into commitSafetyTaskAt and observingCommitSafetyRuntime so the new real-git tests reuse one implementation instead of duplicating the harness.

Style constraints the user set: zero comments by default, matching the local comment density of every file touched - internal/runtime/reconcile.go and internal/runtime/reconcile_commit_safety_test.go each carry zero comment lines on main and this diff adds zero to both; the new test file also carries none. No em dash anywhere, plain hyphen only. No emoji.

Delivery: this must open as a DRAFT pull request assigned to atqamz, targeting main, with 'Closes atqamz/hand#253' on its own line in the body. It must be left as a draft - do not mark it ready for review, do not merge it, do not enable auto-merge. The supervisor merges.

## What Changed

- `resolveWorktreeCommitSafety` no longer returns `commitSafetyUnprovable` as soon as `worktree.ObserveCommitSafety` reports `CommitSafetyUnknown`; it now falls through to check the recorded pull request head before withholding, and only treats a pull-request-head match as proof when the observed worktree head is non-empty.
- Extracted `withheldCommitSafety` and `commitSafetyFinding` so the local-only and unprovable reason strings share one description of what the local evidence source found, instead of a bespoke sentence that assumed a local-only commit count.
- Added `internal/runtime/reconcile_commit_safety_ordering_test.go` with real-git-fixture tests covering: durability proven from pull request head after a squash merge deletes the head branch and prunes the stale remote-tracking ref; withholding when no pull request evidence exists; the local-only-commit data-loss guard surviving the prune; a local commit made after the recorded pull request head still blocking return; GitHub-unreachable withholding without falling back to remote-tracking refs; and idempotent results across the prune. Generalized the `commitSafetyTask`/`commitSafetyRuntime` test helpers into `commitSafetyTaskAt`/`observingCommitSafetyRuntime` for reuse.

Closes atqamz/hand#253

## Risk Assessment

Low: The fix is narrowly scoped to resolveWorktreeCommitSafety's control flow, reuses the existing tri-state ghutil PR observer with no new evidence source, adds a correct empty-head guard, and is backed by six real-git-fixture tests (bare remote, push, squash-merge, branch delete, fetch --prune) that reproduce the exact reported failure and verify durable state (RepairCode/TeardownWorktreeState) rather than string content; internal/worktree is untouched as the author stated, and the caller at reconcile.go:866-868 is unaffected.

## Testing

All six required real-git regression tests in reconcile_commit_safety_ordering_test.go pass, along with the pre-existing commit-safety table tests in the same package; reverting the ordering fix reproduces the exact reported defect (a provably-durable squash-merged worktree gets withheld as worktree-commit-safety-unknown once its stale remote-tracking ref is pruned), and restoring the fix resolves it, confirming the fix addresses the real regression end-to-end via the actual reconciliation gate rather than mocked internals.

<details>
<summary>Evidence: Regression reproduction: reverting the ordering fix reproduces issue #253</summary>

```text
With reconcile.go's early-return-on-CommitSafetyUnknown restored, TestReconcileReturnsSquashMergedWorktreeAfterTheStaleRemoteTrackingRefIsPruned and TestCommitSafetyAnswerSurvivesThePruneThatChangesWhichSourceProvesIt both fail with RepairCode:worktree-commit-safety-unknown - the exact regression described in the issue (pruned remote-tracking ref blocks an otherwise-provably-durable worktree from being returned). Restoring the fix makes both pass again.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"76c2f6f52d8eefa2638ec75120da3547872c6ed4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>**intent** - passed</summary>

No issues found.

</details>

<details>
<summary>**Rebase** - passed</summary>

No issues found.

</details>

<details>
<summary>**Review** - passed</summary>

No issues found.

</details>

<details>
<summary>**Test** - passed</summary>

No issues found.
- `go test ./internal/runtime/... -run 'TestReconcileReturnsSquashMergedWorktreeAfterTheStaleRemoteTrackingRefIsPruned|TestReconcileWithholdsPrunedWorktreeWithNoPullRequestEvidence|TestReconcileWithholdsPrunedWorktreeCarryingALocalOnlyCommit|TestReconcileWithholdsCommitMadeAfterTheRecordedPullRequestHead|TestReconcileWithholdsPrunedWorktreeWhenGitHubCannotBeReached|TestCommitSafetyAnswerSurvivesThePruneThatChangesWhichSourceProvesIt' -v`
- `go test ./internal/runtime/... -run 'CommitSafety' -v (full adjacent suite, includes pre-existing table-driven withholding tests)`
- `manual regression check: temporarily restored the pre-fix internal/runtime/reconcile.go (early return on worktree.CommitSafetyUnknown) via a scratch copy in /tmp, re-ran the ordering tests, confirmed tests 1 and 6 fail with RepairCode=worktree-commit-safety-unknown, then restored the fixed reconcile.go and re-verified all tests pass, and that git status is clean`

</details>

<details>
<summary>**Document** - passed</summary>

No issues found.

</details>

<details>
<summary>**Lint** - passed</summary>

No issues found.

</details>

<details>
<summary>**Push** - passed</summary>

No issues found.

</details>

