### PR TITLE
feat(runtime): give every reconcile repair diagnosis a reachable treatment

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
-| `hand reconcile [id] [--abandon-worktree]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; explicitly relinquish an unobservable historical worktree lease when given a Task ID. |
+| `hand reconcile [id] [--abandon-worktree] [--abandon-pane]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, when given a Task ID. |
 | `hand watch` | Wait for actionable fleet events. |
 | `hand send` | Steer a running worker. |
 | `hand merge` | Merge completed work after authorization. |

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
-| `hand reconcile [id] [--abandon-worktree] [--abandon-pane]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, when given a Task ID. |
+| `hand reconcile [id] [--abandon-worktree] [--abandon-pane] [--attempt-never-started]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; given a Task ID, explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, or attest that a running Attempt's worker took no turn so the ordinary release path can end it. |
 | `hand watch` | Wait for actionable fleet events. |
 | `hand send` | Steer a running worker. |
 | `hand merge` | Merge completed work after authorization. |

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -14,6 +14,7 @@ import (
 func newReconcileCmd() *cobra.Command {
 	var asJSON bool
 	var abandonWorktree bool
+	var abandonPane bool
 	cmd := &cobra.Command{
 		Use:   "reconcile [id]",
 		Short: "Converge durable task state with observed external reality",
@@ -29,9 +30,10 @@ func newReconcileCmd() *cobra.Command {
 			"elsewhere too. Unpushed commits withhold the return, and so does a comparison that could not be\n" +
 			"made at all, recorded as its own condition rather than as work found at risk. The Attempt stays\n" +
 			"terminal either way, and reconciling the withheld state again changes nothing.\n\n" +
-			"--abandon-worktree attests that Hand relinquishes a recorded Treehouse lease whose pool cannot be\n" +
-			"observed at all, for instance after the pool key moved. It needs an explicit task ID, it refuses any\n" +
-			"lease an observation can still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
+			"--abandon-worktree attests that Hand relinquishes a recorded Treehouse lease whose ownership cannot\n" +
+			"be established, either because the pool cannot be observed at all or because the pool holds no lease\n" +
+			"identity to compare against. It needs an explicit task ID, it refuses any lease an observation can\n" +
+			"still prove or disprove, and it never returns, prunes or deletes a worktree:\n" +
 			"the worktree is left exactly as it is for the operator to reclaim through treehouse itself. The flag\n" +
 			"only adds this worktree attestation and leaves every other reconciliation action unchanged, including\n" +
 			"ordinary Herdr cleanup, which still requires proven ownership. An attempt that is still active is\n" +
@@ -39,7 +41,14 @@ func newReconcileCmd() *cobra.Command {
 			"step leaves behind, while an attempt whose lifecycle is already terminal is eligible on its own once\n" +
 			"its worktree resource is unsettled. No worktree of a live worker can be abandoned on either route,\n" +
 			"because a provisioning or running attempt is skipped and the active attempt is reachable only through\n" +
-			"that recorded decision.",
+			"that recorded decision.\n\n" +
+			"--abandon-pane is the same attestation for a recorded Herdr pane identity: it relinquishes the claim\n" +
+			"and closes no pane, tab or workspace. It needs an explicit task ID, and it refuses any pane identity an\n" +
+			"observation confirms as Hand's or reports absent, because a confirmed pane is cleaned up and an absent\n" +
+			"one needs no attestation. What is left is a recorded identity too incomplete to observe and one whose\n" +
+			"workspace, tab or pane answers for something else, and those are the two states it covers. An active\n" +
+			"attempt is reached only through a recorded teardown decision, so no pane of a live worker can be\n" +
+			"abandoned.",
 		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()
@@ -53,8 +62,12 @@ func newReconcileCmd() *cobra.Command {
 			if abandonWorktree && id == "" {
 				return asPrecondition(runtime.Precondition(errors.New("--abandon-worktree needs an explicit task ID")))
 			}
+			if abandonPane && id == "" {
+				return asPrecondition(runtime.Precondition(errors.New("--abandon-pane needs an explicit task ID")))
+			}
 			report, reconcileErr := runtime.New().Reconcile(runtime.ReconcileRequest{
-				Context: cmd.Context(), Home: fleetHome, ID: id, AbandonWorktree: abandonWorktree,
+				Context: cmd.Context(), Home: fleetHome, ID: id,
+				AbandonWorktree: abandonWorktree, AbandonPane: abandonPane,
 			})
 			if err := renderReconcileReport(cmd, report, asJSON); err != nil {
 				return err
@@ -64,6 +77,7 @@ func newReconcileCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output JSON instead of TOON")
 	cmd.Flags().BoolVar(&abandonWorktree, "abandon-worktree", false, "attest that Hand relinquishes an unobservable Treehouse lease without touching the worktree")
+	cmd.Flags().BoolVar(&abandonPane, "abandon-pane", false, "attest that Hand relinquishes an unprovable Herdr pane identity without closing the pane")
 	return cmd
 }
 

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -15,6 +15,7 @@ func newReconcileCmd() *cobra.Command {
 	var asJSON bool
 	var abandonWorktree bool
 	var abandonPane bool
+	var attemptNeverStarted bool
 	cmd := &cobra.Command{
 		Use:   "reconcile [id]",
 		Short: "Converge durable task state with observed external reality",
@@ -48,7 +49,15 @@ func newReconcileCmd() *cobra.Command {
 			"one needs no attestation. What is left is a recorded identity too incomplete to observe and one whose\n" +
 			"workspace, tab or pane answers for something else, and those are the two states it covers. An active\n" +
 			"attempt is reached only through a recorded teardown decision, so no pane of a live worker can be\n" +
-			"abandoned.",
+			"abandoned.\n\n" +
+			"--attempt-never-started attests to the one fact durable state cannot hold: that the worker of a\n" +
+			"running Attempt took no turn at all, the shape a harness that stopped before its first turn leaves\n" +
+			"behind. It needs an explicit task ID, and it refuses whenever anything on record disproves it: a\n" +
+			"report line, a recorded pull request, merge or delivery, a reported state, a dirty worktree, or a\n" +
+			"commit no remote-tracking ref reaches. It releases nothing itself. It records the teardown decision\n" +
+			"`worker-never-started`, whose completion record claims no outcome about work, and the ordinary release\n" +
+			"path then closes the pane and returns the worktree under its own unchanged guards, so a resource whose\n" +
+			"ownership cannot be proven is still refused and still diagnosed.",
 		Args: usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()
@@ -65,9 +74,13 @@ func newReconcileCmd() *cobra.Command {
 			if abandonPane && id == "" {
 				return asPrecondition(runtime.Precondition(errors.New("--abandon-pane needs an explicit task ID")))
 			}
+			if attemptNeverStarted && id == "" {
+				return asPrecondition(runtime.Precondition(errors.New("--attempt-never-started needs an explicit task ID")))
+			}
 			report, reconcileErr := runtime.New().Reconcile(runtime.ReconcileRequest{
 				Context: cmd.Context(), Home: fleetHome, ID: id,
 				AbandonWorktree: abandonWorktree, AbandonPane: abandonPane,
+				AttemptNeverStarted: attemptNeverStarted,
 			})
 			if err := renderReconcileReport(cmd, report, asJSON); err != nil {
 				return err
@@ -78,6 +91,7 @@ func newReconcileCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output JSON instead of TOON")
 	cmd.Flags().BoolVar(&abandonWorktree, "abandon-worktree", false, "attest that Hand relinquishes an unobservable Treehouse lease without touching the worktree")
 	cmd.Flags().BoolVar(&abandonPane, "abandon-pane", false, "attest that Hand relinquishes an unprovable Herdr pane identity without closing the pane")
+	cmd.Flags().BoolVar(&attemptNeverStarted, "attempt-never-started", false, "attest that a running attempt's worker took no turn, recording an honest teardown decision")
 	return cmd
 }
 

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -89,7 +89,7 @@ func newReconcileCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output JSON instead of TOON")
-	cmd.Flags().BoolVar(&abandonWorktree, "abandon-worktree", false, "attest that Hand relinquishes an unobservable Treehouse lease without touching the worktree")
+	cmd.Flags().BoolVar(&abandonWorktree, "abandon-worktree", false, "attest that Hand relinquishes an unprovable Treehouse lease without touching the worktree")
 	cmd.Flags().BoolVar(&abandonPane, "abandon-pane", false, "attest that Hand relinquishes an unprovable Herdr pane identity without closing the pane")
 	cmd.Flags().BoolVar(&attemptNeverStarted, "attempt-never-started", false, "attest that a running attempt's worker took no turn, recording an honest teardown decision")
 	return cmd

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -126,7 +126,7 @@ func TestReconcileCommandPreservesRepairAndObservationErrors(t *testing.T) {
 
 // An attestation names one lease. Without a task ID it would relinquish whatever the fleet-wide
 // sweep happened to find unobservable, so the flag is refused before anything is read.
-func TestReconcileCommandRefusesFleetWideAbandonment(t *testing.T) {
+func TestReconcileCommandRefusesFleetWideAttestation(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HAND_HOME", home)
 	if err := os.MkdirAll(state.Dir(home), 0o755); err != nil {
@@ -135,7 +135,7 @@ func TestReconcileCommandRefusesFleetWideAbandonment(t *testing.T) {
 	if err := state.CreateTask(home, state.Task{ID: "task-1", Lifecycle: state.TaskTerminal}); err != nil {
 		t.Fatal(err)
 	}
-	for _, flag := range []string{"--abandon-worktree", "--abandon-pane"} {
+	for _, flag := range []string{"--abandon-worktree", "--abandon-pane", "--attempt-never-started"} {
 		t.Run(flag, func(t *testing.T) {
 			cmd := newReconcileCmd()
 			var out bytes.Buffer

--- a/cmd/reconcile_test.go
+++ b/cmd/reconcile_test.go
@@ -135,17 +135,36 @@ func TestReconcileCommandRefusesFleetWideAbandonment(t *testing.T) {
 	if err := state.CreateTask(home, state.Task{ID: "task-1", Lifecycle: state.TaskTerminal}); err != nil {
 		t.Fatal(err)
 	}
-	cmd := newReconcileCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--abandon-worktree"})
-	err := cmd.Execute()
-	var exitErr *ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
-		t.Fatalf("reconcile error = %v, want precondition exit 3", err)
+	for _, flag := range []string{"--abandon-worktree", "--abandon-pane"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := newReconcileCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs([]string{flag})
+			err := cmd.Execute()
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+				t.Fatalf("reconcile error = %v, want precondition exit 3", err)
+			}
+			if !strings.Contains(err.Error(), "explicit task ID") {
+				t.Fatalf("reconcile error = %v, want the missing task ID named", err)
+			}
+		})
 	}
-	if !strings.Contains(err.Error(), "explicit task ID") {
-		t.Fatalf("reconcile error = %v, want the missing task ID named", err)
+}
+
+func TestReconcileCommandRendersPaneAbandonmentDetail(t *testing.T) {
+	report := runtime.ReconcileReport{Results: []runtime.ReconcileResult{
+		{ID: "task-a", Outcome: "healthy", Action: "abandon-pane", Detail: "attempt 7 relinquished its Herdr identity (ws-1/tab-1) on operator attestation"},
+	}}
+	var out bytes.Buffer
+	cmd := newReconcileCmd()
+	cmd.SetOut(&out)
+	if err := renderReconcileReport(cmd, report, false); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("action: abandon-pane")) || !bytes.Contains(out.Bytes(), []byte("detail: attempt 7 relinquished its Herdr identity")) {
+		t.Fatalf("rendered report = %q, want the pane attestation recorded in the output", out.String())
 	}
 }
 

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -164,7 +164,12 @@ func TestWatchMapsContextCancelToInterruption(t *testing.T) {
 		done <- cmd.ExecuteContext(ctx)
 	}()
 
-	deadline := time.Now().Add(2 * time.Second)
+	// Both stages round-trip through a real spawned herdr process rather than a
+	// fake in-process double, so a loaded CI runner (Windows especially) needs
+	// more headroom than the other lifecycle tests in this file.
+	const budget = 10 * time.Second
+
+	deadline := time.Now().Add(budget)
 	for time.Now().Before(deadline) {
 		calls, err := os.ReadFile(os.Getenv("HERDR_CALL_LOG"))
 		if err == nil && bytes.Contains(calls, []byte("herdr workspace list\n")) {
@@ -188,7 +193,7 @@ func TestWatchMapsContextCancelToInterruption(t *testing.T) {
 		if !errors.Is(err, watcher.ErrInterrupted) {
 			t.Fatalf("err = %v, want it to wrap ErrInterrupted", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(budget):
 		t.Fatal("watch did not exit after context cancellation")
 	}
 }

--- a/docs/adr/every-diagnosis-names-a-reachable-treatment.md
+++ b/docs/adr/every-diagnosis-names-a-reachable-treatment.md
@@ -1,0 +1,73 @@
+# Every diagnosis names a reachable treatment
+
+- Date: 2026-08-19
+- Status: accepted
+- Issues: atqamz/hand#254
+- PRs: none
+
+## Context
+
+`hand reconcile` answers a Task it cannot converge with `needs-repair` and a `repair_code`.
+The codes accumulated one contradiction at a time, and nothing checked that a supported command could leave each one.
+Three of them could not be left at all.
+
+A historical Attempt whose Herdr identity is incomplete, or whose observed pane belongs to another identity, latched `teardown_herdr_state = ambiguous` during teardown and then answered `teardown-resource-ambiguous` on every later reconcile.
+`herdrCleanupSettled` accepted only `released`, teardown's release path returned early on `ambiguous`, and `SetAttemptTeardownResourceState` refused `abandoned` for any resource other than the worktree.
+So the pane resource had no terminal state reachable by any command, and the Task stayed diagnosed forever.
+One fleet Task sat in that state for five days after its work had already merged.
+
+A historical worktree with no comparable lease identity answered `legacy-worktree-ownership-unprovable`, which named no command either, because `--abandon-worktree` accepted `LeaseUnknown` alone.
+A provisioning Attempt that submitted a launch and persisted nothing answered `provisioning-pane-missing`, whose only exit was `hand teardown --force`, a flag that means "skip the landed-work checks" on an Attempt with no work and no resource to check.
+
+A diagnosis with no reachable treatment is worse than an unhandled error.
+It reports a real contradiction, refuses correctly, and offers the operator nothing, which is the pressure that produces a hand-edited database.
+atqamz/hand#239 fixed the converse for lifecycles: an Attempt may not become terminal in a way that makes its own cleanup unreachable.
+
+## Decision
+
+Every `repair_code` the runtime can emit has an entry in `repairTreatments` in `internal/runtime/repair.go` naming the supported commands that leave it, and the persisted `repair_reason` carries that treatment text with the Task ID substituted.
+What `hand status` and `hand reconcile` show is the text the Task row holds, so the refusal and its way out cannot drift apart.
+
+A treatment falls in exactly one of three classes.
+`supported-command`: an ordinary `hand` command leaves the state, attesting to nothing and changing nothing outside Hand first.
+`explicit-supported-attestation`: ownership is neither provable nor disprovable, so the only exit is an operator attestation scoped to that one resource, which relinquishes Hand's claim and destroys nothing.
+`retryable-after-external-fix`: the contradiction is about the world outside Hand, so reconciling again ends it once that world is fixed.
+
+The classes are named for what the operator must supply, not for how Hand implements the exit, because that is the distinction an operator reading a refusal has to make: run a command, assert a fact only they can establish, or change something outside Hand first.
+
+The pane attestation is `hand reconcile <id> --abandon-pane`.
+It takes the shape `--abandon-worktree` already established: an explicit Task ID is required, ownership states an observation can prove or disprove are refused on every route into it, no Herdr command runs, and only the durable resource state is recorded.
+`abandoned` becomes a terminal state for the Herdr resource as it already is for the worktree, and `herdrCleanupSettled` accepts it, so reconciliation converges the Task through its ordinary path afterwards.
+No pane, tab or workspace is closed, so a pane that answers in place of the recorded one stays exactly where it is.
+
+This extends one sentence of `unobservable-ownership-is-not-a-mismatch.md`, which recorded that `--abandon-worktree` refuses any observed state other than `LeaseUnknown`.
+It now also accepts `LeaseUnprovable`.
+That is the same category of unsettleable ownership rather than a weakening: a recorded worktree with no comparable lease identity offers nothing for a future observation to compare, so no later reconcile can prove or disprove the claim.
+`LeaseExact`, `LeaseAbsent` and `LeaseMismatch` stay refused, and the boundary that record exists to defend is unchanged, because the attestation still returns, prunes and deletes nothing.
+
+Where the facts prove no resource is at stake, reconciliation performs the repair itself rather than naming a command.
+`unwindableProvisioning` is that proof for a failed launch: the Attempt is still provisioning, no Herdr identity was ever persisted, no worktree lease is recorded, and no teardown has already decided the Attempt's terminal lifecycle.
+Reconciliation then converges the Attempt to `interrupted` under the disposition `provisioning-unwound`, releasing nothing, claiming no ownership and inventing no pane identity.
+The Attempt and its history stay durable and readable, and `hand reopen` spawns the task again through the ordinary path.
+A provisioning failure that did persist any of those facts is refused by name, so the unwind cannot reach an Attempt that owns something.
+
+A path Treehouse provably reports under a different lease is relinquished the same way, without an attestation, because a disproven claim was never this Attempt's to return.
+
+The enumeration is a test, not a convention.
+`internal/runtime/repair_test.go` parses the package's own source for `repairCode` constants, so a new code declared without a treatment, without one of the three classes, or without a case that drives a Task into it and back out through the commands its treatment names, fails the suite.
+
+## Rejected alternatives
+
+- A generic `--force` or `--repair-anything` flag on reconcile would make one gesture answer every diagnosis, which is exactly the unproven-ownership-authorizes-destruction shape atqamz/hand#245 removed.
+- Reusing `hand teardown --force` as the exit for a launch that persisted nothing would record "landed-work checks skipped" about an Attempt that produced no work, so the completion record would misdescribe what happened.
+- Letting reconcile release a pane whose ownership cannot be proven would close a pane Hand does not own; only Hand's claim is relinquished, never the resource.
+- Auto-unwinding any provisioning failure, rather than only one proven to hold no resource, would orphan a lease or a pane whenever the failure happened after acquisition.
+- Documenting the treatments in prose alone would leave the invariant unenforced, and the codes drifted for exactly that reason.
+- A single `unresolvable` class covering everything that is not a plain command would merge "assert a fact I alone can establish" with "fix something outside Hand and retry", which are different acts by the operator.
+
+## Consequences
+
+No state exists in which Hand answers `needs-repair` with a code no supported command can leave, and adding one fails the tests rather than a fleet.
+An operator who reads a refusal is told which command ends it, in the durable Task row rather than only in one run's rendered output.
+Refusals did not become weaker: unknown and unproven ownership still authorize no destructive cleanup, and the two attestations relinquish claims without touching a worktree or a pane.
+The Herdr resource gains a terminal state it lacked, so a Task whose pane ownership can never be settled converges instead of accumulating.

--- a/docs/adr/every-diagnosis-names-a-reachable-treatment.md
+++ b/docs/adr/every-diagnosis-names-a-reachable-treatment.md
@@ -65,6 +65,7 @@ It asserts one fact no observation settles, that this Attempt's worker took no t
 So a resource whose ownership cannot be proven is still refused and still diagnosed, and the attestation cannot become a way around a guard.
 It refuses whenever anything on record disproves it: a report line, a recorded pull request, merge or delivery, a reported state, a dirty worktree, or a commit no remote-tracking ref reaches.
 It does not refuse an unobservable worktree, because recording a decision destroys nothing and refusing there would replace one dead end with another while the release step still refuses with a diagnosed, treatable code.
+Reconcile-driven terminalization clears a usage-limit hold the same way `hand teardown` already does, because leaving it would end this dead end by making `hand reopen` unreachable behind a hold the attestation itself left no way to see coming.
 
 Whether the worker is actually dead is not a fact Hand can observe today, and atqamz/hand#255 owns that observation.
 The exit is registered before the diagnosis exists, so once reconcile can see a dead worker it can emit a code whose treatment is already enumerated and tested.

--- a/docs/adr/every-diagnosis-names-a-reachable-treatment.md
+++ b/docs/adr/every-diagnosis-names-a-reachable-treatment.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-08-19
 - Status: accepted
-- Issues: atqamz/hand#254
+- Issues: atqamz/hand#254, atqamz/hand#255
 - PRs: none
 
 ## Context
@@ -23,14 +23,21 @@ A diagnosis with no reachable treatment is worse than an unhandled error.
 It reports a real contradiction, refuses correctly, and offers the operator nothing, which is the pressure that produces a hand-edited database.
 atqamz/hand#239 fixed the converse for lifecycles: an Attempt may not become terminal in a way that makes its own cleanup unreachable.
 
+Worse still is a stuck state Hand cannot diagnose at all.
+A running Attempt whose harness stopped before its first turn is indistinguishable, in durable state and in every observation reconcile makes, from one whose worker is thinking: the pane exists, the worktree is clean, and nothing contradicts anything.
+So reconcile reports healthy, teardown refuses because no landed work can be found, and `--force` is the only exit, which records "landed-work checks skipped" about an Attempt that produced nothing.
+One fleet Task reached that state the day this was written.
+
 ## Decision
 
-Every `repair_code` the runtime can emit has an entry in `repairTreatments` in `internal/runtime/repair.go` naming the supported commands that leave it, and the persisted `repair_reason` carries that treatment text with the Task ID substituted.
-What `hand status` and `hand reconcile` show is the text the Task row holds, so the refusal and its way out cannot drift apart.
+Every state a Task can be stuck in has an entry in `stuckStateTreatments` in `internal/runtime/repair.go` naming the supported commands that leave it.
+The enumeration is of reachable stuck states, not of repair codes, because a dead end that emits no diagnosis is the worst member of that set rather than outside it.
+For a `repair_code` the persisted `repair_reason` carries the treatment text with the Task ID substituted, so what `hand status` and `hand reconcile` show is the way out, and the refusal cannot drift apart from it.
+A stuck state Hand cannot diagnose has no row to carry its treatment, so its entry is marked `Undiagnosed` and reaches the operator through `hand reconcile --help` instead.
 
 A treatment falls in exactly one of three classes.
 `supported-command`: an ordinary `hand` command leaves the state, attesting to nothing and changing nothing outside Hand first.
-`explicit-supported-attestation`: ownership is neither provable nor disprovable, so the only exit is an operator attestation scoped to that one resource, which relinquishes Hand's claim and destroys nothing.
+`explicit-supported-attestation`: the fact at issue is neither provable nor disprovable by observation, so the only exit is an operator attestation scoped to that one fact, which relinquishes a claim or records a decision and destroys nothing.
 `retryable-after-external-fix`: the contradiction is about the world outside Hand, so reconciling again ends it once that world is fixed.
 
 The classes are named for what the operator must supply, not for how Hand implements the exit, because that is the distinction an operator reading a refusal has to make: run a command, assert a fact only they can establish, or change something outside Hand first.
@@ -53,13 +60,24 @@ A provisioning failure that did persist any of those facts is refused by name, s
 
 A path Treehouse provably reports under a different lease is relinquished the same way, without an attestation, because a disproven claim was never this Attempt's to return.
 
+The attestation for an undiagnosable dead end is `hand reconcile <id> --attempt-never-started`.
+It asserts one fact no observation settles, that this Attempt's worker took no turn, and it releases nothing itself: it records the teardown decision `worker-never-started`, whose completion record says a worker never started rather than claiming any outcome about work, and the ordinary release path then closes the pane and returns the worktree under its own unchanged guards.
+So a resource whose ownership cannot be proven is still refused and still diagnosed, and the attestation cannot become a way around a guard.
+It refuses whenever anything on record disproves it: a report line, a recorded pull request, merge or delivery, a reported state, a dirty worktree, or a commit no remote-tracking ref reaches.
+It does not refuse an unobservable worktree, because recording a decision destroys nothing and refusing there would replace one dead end with another while the release step still refuses with a diagnosed, treatable code.
+
+Whether the worker is actually dead is not a fact Hand can observe today, and atqamz/hand#255 owns that observation.
+The exit is registered before the diagnosis exists, so once reconcile can see a dead worker it can emit a code whose treatment is already enumerated and tested.
+
 The enumeration is a test, not a convention.
-`internal/runtime/repair_test.go` parses the package's own source for `repairCode` constants, so a new code declared without a treatment, without one of the three classes, or without a case that drives a Task into it and back out through the commands its treatment names, fails the suite.
+`internal/runtime/repair_test.go` parses the package's own source for `repairCode` and `stuckState` constants, so a new one declared without a treatment, without one of the three classes, disagreeing about whether Hand can diagnose it, or without a case that drives a Task into it and back out through the commands its treatment names, fails the suite.
 
 ## Rejected alternatives
 
 - A generic `--force` or `--repair-anything` flag on reconcile would make one gesture answer every diagnosis, which is exactly the unproven-ownership-authorizes-destruction shape atqamz/hand#245 removed.
-- Reusing `hand teardown --force` as the exit for a launch that persisted nothing would record "landed-work checks skipped" about an Attempt that produced no work, so the completion record would misdescribe what happened.
+- Reusing `hand teardown --force` as the exit for a launch that persisted nothing, or for a worker that took no turn, would record "landed-work checks skipped" about an Attempt that produced no work, so the completion record would misdescribe what happened.
+- Letting `--attempt-never-started` release the pane and worktree itself, rather than recording a decision the ordinary path carries out, would put an operator assertion about a worker in front of the guards that protect resources, which is the shape atqamz/hand#245 removed.
+- Inferring a dead worker from pane text or idle time and auto-ending the Attempt would end a live worker on a heuristic; the observation belongs to atqamz/hand#255, and until it exists only the operator can assert it.
 - Letting reconcile release a pane whose ownership cannot be proven would close a pane Hand does not own; only Hand's claim is relinquished, never the resource.
 - Auto-unwinding any provisioning failure, rather than only one proven to hold no resource, would orphan a lease or a pane whenever the failure happened after acquisition.
 - Documenting the treatments in prose alone would leave the invariant unenforced, and the codes drifted for exactly that reason.
@@ -67,7 +85,7 @@ The enumeration is a test, not a convention.
 
 ## Consequences
 
-No state exists in which Hand answers `needs-repair` with a code no supported command can leave, and adding one fails the tests rather than a fleet.
+No state exists in which Hand answers `needs-repair` with a code no supported command can leave, and no enumerated stuck state lacks a way out, whether Hand can diagnose it or not; adding one fails the tests rather than a fleet.
 An operator who reads a refusal is told which command ends it, in the durable Task row rather than only in one run's rendered output.
 Refusals did not become weaker: unknown and unproven ownership still authorize no destructive cleanup, and the two attestations relinquish claims without touching a worktree or a pane.
 The Herdr resource gains a terminal state it lacked, so a Task whose pane ownership can never be settled converges instead of accumulating.

--- a/docs/adr/every-diagnosis-names-a-reachable-treatment.md
+++ b/docs/adr/every-diagnosis-names-a-reachable-treatment.md
@@ -45,6 +45,7 @@ The classes are named for what the operator must supply, not for how Hand implem
 The pane attestation is `hand reconcile <id> --abandon-pane`.
 It takes the shape `--abandon-worktree` already established: an explicit Task ID is required, ownership states an observation can prove or disprove are refused on every route into it, no Herdr command runs, and only the durable resource state is recorded.
 `abandoned` becomes a terminal state for the Herdr resource as it already is for the worktree, and `herdrCleanupSettled` accepts it, so reconciliation converges the Task through its ordinary path afterwards.
+A resource latched mid-release steps through `ambiguous` on its way there, because `ambiguous` is among `abandoned`'s predecessors and `releasing` is not, which keeps the transition table from growing an edge per latch.
 No pane, tab or workspace is closed, so a pane that answers in place of the recorded one stays exactly where it is.
 
 This extends one sentence of `unobservable-ownership-is-not-a-mismatch.md`, which recorded that `--abandon-worktree` refuses any observed state other than `LeaseUnknown`.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -34,7 +34,7 @@ Teardown that cannot observe the pool refuses and writes no resource state, so t
 `ambiguous` remains reachable from provable contradiction, and it stops being a dead end: both teardown and reconciliation may leave it, but only behind a fresh `LeaseExact` observation of the same lease identity.
 
 For the permanently unobservable pool there is one explicit operator gesture, `hand reconcile <task> --abandon-worktree`.
-It requires an explicit task ID and refuses any observed state other than `LeaseUnknown`, on every route into it.
+It requires an explicit task ID and refuses any observed state other than `LeaseUnknown`, on every route into it. (`every-diagnosis-names-a-reachable-treatment.md` later extends this to also accept `LeaseUnprovable`.)
 An attempt that is still active is reached only through a recorded teardown decision, the shape a teardown interrupted at the worktree step leaves behind.
 An attempt whose lifecycle is already terminal is eligible on its own once its worktree resource is unsettled, with no recorded teardown decision required, so a crash before teardown stays recoverable.
 No worktree of a live worker can be abandoned on either route, because a provisioning or running attempt is skipped and the active attempt is reachable only through that recorded decision.

--- a/docs/adr/unobservable-ownership-is-not-a-mismatch.md
+++ b/docs/adr/unobservable-ownership-is-not-a-mismatch.md
@@ -1,7 +1,7 @@
 # Unobservable ownership is not a mismatch
 
 - Date: 2026-08-17
-- Status: accepted
+- Status: accepted, superseded in part by [Every diagnosis names a reachable treatment](every-diagnosis-names-a-reachable-treatment.md)
 - Issues: atqamz/hand#245
 - PRs: atqamz/hand#248
 

--- a/internal/runtime/neverstarted_test.go
+++ b/internal/runtime/neverstarted_test.go
@@ -39,6 +39,9 @@ func TestAttemptNeverStartedAttestationEndsTheAttemptHonestly(t *testing.T) {
 	if readOnlyAttempt(t, home).Lifecycle != state.AttemptRunning {
 		t.Fatal("plain reconcile ended the attempt, want a worker Hand cannot observe left running")
 	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindLimit, Reason: "usage limit", SetAt: "2026-08-15T00:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
 
 	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AttemptNeverStarted: true})
 	if err != nil {
@@ -68,6 +71,11 @@ func TestAttemptNeverStartedAttestationEndsTheAttemptHonestly(t *testing.T) {
 	}
 	if record.Outcome != "torn-down" || !strings.Contains(record.Detail, "worker never started") {
 		t.Fatalf("completion record = %+v, want an outcome that claims nothing about work", record)
+	}
+	if _, hasHold, err := state.ReadHold(home, "task-1"); err != nil {
+		t.Fatal(err)
+	} else if hasHold {
+		t.Fatal("usage-limit hold survived the attestation, want reconcile terminalization to clear it so reopen stays reachable")
 	}
 
 	if _, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1", Harness: harness.Codex, HarnessFromFlag: true}); err != nil {

--- a/internal/runtime/neverstarted_test.go
+++ b/internal/runtime/neverstarted_test.go
@@ -1,0 +1,190 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+// The stuck state that emits no diagnosis at all: a running Attempt whose worker took no turn looks
+// exactly like one that is working, so only the operator can end it, and the exit has to run through
+// the ordinary release path rather than around it (atqamz/hand#254).
+func TestAttemptNeverStartedAttestationEndsTheAttemptHonestly(t *testing.T) {
+	useFastLaunchPolling(t)
+	home := executionPlanHome(t, "brief\n")
+	addHarnessToPath(t, harness.Codex)
+	paneText := fakeSwitchablePane(t, harness.Codex)
+	paneText("codex ready\n")
+	returns := 0
+	r := unwindRuntime(t, &returns)
+
+	if _, err := r.Spawn(context.Background(), SpawnRequest{
+		Home: home, ID: "task-1", Project: "demo", Kind: state.KindShip, Harness: harness.Codex, HarnessFromFlag: true,
+	}); err != nil {
+		t.Fatalf("Spawn() = %v, want a running attempt", err)
+	}
+	launched := readOnlyAttempt(t, home)
+	if launched.Lifecycle != state.AttemptRunning || launched.Worktree == "" || !hasHerdrIdentity(launched.Herdr) {
+		t.Fatalf("attempt after spawn = %+v, want a running attempt holding both resources", launched)
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("Reconcile() = %v, want the running attempt left alone", err)
+	}
+	if readOnlyAttempt(t, home).Lifecycle != state.AttemptRunning {
+		t.Fatal("plain reconcile ended the attempt, want a worker Hand cannot observe left running")
+	}
+
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AttemptNeverStarted: true})
+	if err != nil {
+		t.Fatalf("Reconcile(AttemptNeverStarted) = %v, want the attested attempt ended", err)
+	}
+	if len(report.Results) != 1 || !strings.Contains(report.Results[0].Detail, "operator attestation that its worker never started") {
+		t.Fatalf("reconcile report = %+v, want the attestation named in what it reports", report.Results)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ended := history.Attempts[0]
+	if history.Task.Lifecycle != state.TaskTerminal || ended.Lifecycle != state.AttemptInterrupted ||
+		ended.TeardownDisposition != state.TeardownDispositionWorkerNeverStarted {
+		t.Fatalf("task=%+v attempt=%+v, want a terminal task and an interrupted attempt disposed as worker-never-started", history.Task, ended)
+	}
+	if ended.TeardownHerdrState != state.TeardownResourceReleased || ended.TeardownWorktreeState != state.TeardownResourceReleased {
+		t.Fatalf("resource states = herdr %q worktree %q, want both released by the ordinary path", ended.TeardownHerdrState, ended.TeardownWorktreeState)
+	}
+	if returns != 1 {
+		t.Fatalf("worktree returns = %d, want the lease returned exactly once", returns)
+	}
+	record, found, err := completion.FindAttempt(home, ended.ID)
+	if err != nil || !found {
+		t.Fatalf("completion record found=%t err=%v, want the ended attempt accounted for", found, err)
+	}
+	if record.Outcome != "torn-down" || !strings.Contains(record.Detail, "worker never started") {
+		t.Fatalf("completion record = %+v, want an outcome that claims nothing about work", record)
+	}
+
+	if _, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1", Harness: harness.Codex, HarnessFromFlag: true}); err != nil {
+		t.Fatalf("Reopen() = %v, want the ended task to spawn again through the supported path", err)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 2 || history.Attempts[0].ID != ended.ID ||
+		history.Attempts[0].TeardownDisposition != state.TeardownDispositionWorkerNeverStarted {
+		t.Fatalf("history after reopen = %+v, want the ended attempt kept as it was beside the new one", history.Attempts)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("active attempt after reopen = %+v, want a running attempt", history.ActiveAttempt)
+	}
+}
+
+// The attestation is about one fact and refuses whenever durable state or an observation disproves it,
+// because an operator asserting that a worker took no turn cannot overrule what a turn left behind.
+func TestAttemptNeverStartedAttestationRefusesEvidenceOfWork(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		arrange func(t *testing.T, home string, r *Runtime, attempt state.Attempt)
+		wantErr string
+	}{
+		{
+			name: "reported-line",
+			arrange: func(t *testing.T, home string, _ *Runtime, _ state.Attempt) {
+				if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("working: first turn\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: "reported line",
+		},
+		{
+			name: "recorded-pull-request",
+			arrange: func(t *testing.T, home string, _ *Runtime, _ state.Attempt) {
+				if err := state.SetTaskPR(home, "task-1", "https://github.com/demo/demo/pull/1"); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: "pull request https://github.com/demo/demo/pull/1 is recorded",
+		},
+		{
+			name: "dirty-worktree",
+			arrange: func(_ *testing.T, _ string, r *Runtime, _ state.Attempt) {
+				r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+			},
+			wantErr: "holds uncommitted changes",
+		},
+		{
+			name: "local-only-commits",
+			arrange: func(_ *testing.T, _ string, r *Runtime, _ state.Attempt) {
+				repairCommitSafety(r, worktree.CommitSafetyLocalOnly, worktree.CommitSafetyProbe{LocalOnly: 2})
+			},
+			wantErr: "reachable from no remote-tracking ref",
+		},
+		{
+			name: "decision-already-recorded",
+			arrange: func(t *testing.T, home string, _ *Runtime, attempt state.Attempt) {
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+			},
+			wantErr: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home, attempt := repairFixture(t, state.Task{},
+				repairRunningAttempt("/pool/1", "lease-1", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}))
+			repairMarkRunning(t, home, attempt)
+			r := repairRuntime(&repairHerdr{})
+			test.arrange(t, home, r, attempt)
+
+			_, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AttemptNeverStarted: true})
+			after, readErr := state.ReadHistory(home, "task-1")
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Reconcile(AttemptNeverStarted) = %v, want the recorded decision honoured instead", err)
+				}
+				if after.Attempts[0].TeardownDisposition != state.TeardownDispositionCompleted {
+					t.Fatalf("disposition = %q, want the recorded decision left alone", after.Attempts[0].TeardownDisposition)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("Reconcile(AttemptNeverStarted) = %v, want a refusal naming %q", err, test.wantErr)
+			}
+			if !strings.Contains(err.Error(), "hand teardown task-1") {
+				t.Fatalf("refusal = %v, want it to name the supported command that ends the attempt instead", err)
+			}
+			if after.Attempts[0].TeardownDisposition != "" || after.Attempts[0].Lifecycle != state.AttemptRunning ||
+				after.Task.Lifecycle != state.TaskOpen {
+				t.Fatalf("state after the refusal = task %+v attempt %+v, want nothing recorded", after.Task, after.Attempts[0])
+			}
+		})
+	}
+}
+
+// A lifecycle other than running is refused whatever the operator asserts, because every other
+// lifecycle already has evidence of its own that reconcile acts on.
+func TestAttemptNeverStartedAttestationRefusesAnAttemptThatIsNotRunning(t *testing.T) {
+	home, attempt := repairFixture(t, state.Task{}, state.Attempt{
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z",
+	})
+	r := repairRuntime(&repairHerdr{})
+	_, err := r.attestAttemptNeverStarted(home, state.Task{ID: "task-1"}, attempt)
+	if err == nil || !strings.Contains(err.Error(), "records lifecycle \"provisioning\"") {
+		t.Fatalf("attestAttemptNeverStarted() = %v, want a refusal naming the lifecycle", err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].TeardownDisposition != "" {
+		t.Fatalf("disposition = %q, want a refused attestation to record nothing", history.Attempts[0].TeardownDisposition)
+	}
+}

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -952,6 +952,9 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 		}
 		if attempt.TeardownTerminalAttempt != "" {
 			if attempt.Lifecycle == attempt.TeardownTerminalAttempt {
+				if err := state.ClearHoldIfKind(home, task.ID, state.HoldKindLimit); err != nil {
+					return false, reconciliationDecision{}, fmt.Errorf("clear usage-limit hold for already-settled attempt %d: %w", attempt.ID, err)
+				}
 				return false, reconciliationDecision{}, nil
 			}
 			if err := terminalizeAndClearLimitHold(home, task.ID, attempt.ID, attempt.Lifecycle, attempt.TeardownTerminalAttempt); err != nil {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -563,8 +563,21 @@ func (r *Runtime) terminalizeWithoutRelease(home string, task state.Task, attemp
 	if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionAppended); err != nil {
 		return fmt.Errorf("record %s completion evidence for attempt %d: %w", label, attempt.ID, err)
 	}
-	if err := state.TerminalizeTaskAndAttempt(home, task.ID, attempt.ID, attempt.Lifecycle, decision.TerminalAttempt); err != nil {
+	if err := terminalizeAndClearLimitHold(home, task.ID, attempt.ID, attempt.Lifecycle, decision.TerminalAttempt); err != nil {
 		return fmt.Errorf("%s attempt %d to %s: %w", label, attempt.ID, decision.TerminalAttempt, err)
+	}
+	return nil
+}
+
+// A reconcile-driven terminalization is the only path to end an attempt outside `hand teardown`, so it
+// must close the same usage-limit hold that path clears (internal/runtime/teardown.go's finishTeardown)
+// - otherwise a task this call just ended keeps a live hold and `hand reopen` stays refused.
+func terminalizeAndClearLimitHold(home, taskID string, attemptID int64, attemptFrom, attemptTo state.AttemptLifecycle) error {
+	if err := state.TerminalizeTaskAndAttempt(home, taskID, attemptID, attemptFrom, attemptTo); err != nil {
+		return err
+	}
+	if err := state.ClearHoldIfKind(home, taskID, state.HoldKindLimit); err != nil {
+		return fmt.Errorf("clear usage-limit hold: %w", err)
 	}
 	return nil
 }
@@ -941,7 +954,7 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 			if attempt.Lifecycle == attempt.TeardownTerminalAttempt {
 				return false, reconciliationDecision{}, nil
 			}
-			if err := state.TerminalizeTaskAndAttempt(home, task.ID, attempt.ID, attempt.Lifecycle, attempt.TeardownTerminalAttempt); err != nil {
+			if err := terminalizeAndClearLimitHold(home, task.ID, attempt.ID, attempt.Lifecycle, attempt.TeardownTerminalAttempt); err != nil {
 				return false, reconciliationDecision{}, fmt.Errorf("finish recovered teardown: %w", err)
 			}
 			return true, reconciliationDecision{}, nil

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -28,7 +28,10 @@ const (
 	reconciliationActionMarkRunning          reconciliationAction = "mark-running"
 	reconciliationActionCleanupTerminal      reconciliationAction = "cleanup-terminal-resources"
 	reconciliationActionConvergeTerminal     reconciliationAction = "converge-terminal-lifecycle"
+	reconciliationActionUnwindProvisioning   reconciliationAction = "unwind-failed-provisioning"
 	reconciliationActionAbandonWorktree      reconciliationAction = "abandon-worktree"
+	reconciliationActionAbandonPane          reconciliationAction = "abandon-pane"
+	reconciliationActionRelinquishWorktree   reconciliationAction = "relinquish-worktree-claim"
 	reconciliationActionNeedsRepair          reconciliationAction = "needs-repair"
 	reconciliationActionBlocked              reconciliationAction = "blocked"
 )
@@ -69,26 +72,6 @@ const (
 	herdrOwnershipAbsent     herdrOwnershipState = "absent"
 	herdrOwnershipMismatch   herdrOwnershipState = "mismatch"
 	herdrOwnershipIncomplete herdrOwnershipState = "incomplete"
-)
-
-const (
-	repairCodeProvisioningLaunchAmbiguous = "provisioning-launch-ambiguous"
-	repairCodeProvisioningPaneMissing     = "provisioning-pane-missing"
-	repairCodeLaunchSubmittedPaneMissing  = "launch-submitted-pane-missing"
-	repairCodeLaunchAgentMismatch         = "launch-agent-mismatch"
-	repairCodeRunningPaneMissing          = "running-pane-missing"
-	repairCodeRunningPaneIdentityMismatch = "running-pane-identity-mismatch"
-	repairCodeHerdrOwnershipIncomplete    = "herdr-ownership-incomplete"
-	repairCodeHerdrOwnershipMismatch      = "herdr-ownership-mismatch"
-	repairCodeWorktreeDirty               = "worktree-dirty"
-	repairCodeWorktreeOwnershipMismatch   = "worktree-ownership-mismatch"
-	repairCodeLegacyWorktreeUnprovable    = "legacy-worktree-ownership-unprovable"
-	repairCodeWorktreeUnobservable        = "worktree-ownership-unobservable"
-	repairCodeWorktreeLocalCommits        = "worktree-local-commits"
-	repairCodeWorktreeCommitSafetyUnknown = "worktree-commit-safety-unknown"
-	repairCodeTeardownResourceAmbiguous   = "teardown-resource-ambiguous"
-	repairCodeCompletionEvidenceMismatch  = "completion-evidence-mismatch"
-	repairCodeMergeFactMismatch           = "merge-fact-mismatch"
 )
 
 type treehouseObservation struct {
@@ -134,7 +117,17 @@ type ReconcileRequest struct {
 	Home            string
 	ID              string
 	AbandonWorktree bool
+	AbandonPane     bool
 }
+
+// The operator attestations one reconcile run carries, each scoped to one kind of resource whose
+// ownership no observation can settle. Neither destroys anything; both only relinquish Hand's claim.
+type reconcileAttestations struct {
+	Worktree bool
+	Pane     bool
+}
+
+func (a reconcileAttestations) any() bool { return a.Worktree || a.Pane }
 
 type ReconcileResult struct {
 	ID             string `json:"id"`
@@ -187,15 +180,16 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	attest := reconcileAttestations{Worktree: req.AbandonWorktree, Pane: req.AbandonPane}
 	if req.ID != "" {
-		result, err := r.reconcileTask(ctx, req.Home, req.ID, req.AbandonWorktree)
+		result, err := r.reconcileTask(ctx, req.Home, req.ID, attest)
 		if err != nil {
 			result.Error = err.Error()
 		}
 		return ReconcileReport{Results: []ReconcileResult{result}}, err
 	}
-	if req.AbandonWorktree {
-		return ReconcileReport{}, Precondition(fmt.Errorf("abandoning a worktree lease needs an explicit task ID"))
+	if attest.any() {
+		return ReconcileReport{}, Precondition(fmt.Errorf("attesting that Hand relinquishes a recorded resource needs an explicit task ID"))
 	}
 	histories, err := state.ListReconciliationHistories(req.Home)
 	if err != nil {
@@ -204,7 +198,7 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	report := ReconcileReport{Results: make([]ReconcileResult, 0, len(histories))}
 	var errs []error
 	for _, history := range histories {
-		result, err := r.reconcileTask(ctx, req.Home, history.Task.ID, false)
+		result, err := r.reconcileTask(ctx, req.Home, history.Task.ID, reconcileAttestations{})
 		if err != nil {
 			result.Error = err.Error()
 		}
@@ -223,7 +217,7 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	return report, errors.Join(errs...)
 }
 
-func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWorktree bool) (ReconcileResult, error) {
+func (r *Runtime) reconcileTask(ctx context.Context, home, id string, attest reconcileAttestations) (ReconcileResult, error) {
 	release, err := state.Lock(home, "task:"+id)
 	if err != nil {
 		return ReconcileResult{ID: id, Outcome: reconcileOutcomeBlocked}, fmt.Errorf("lock task %q: %w", id, err)
@@ -257,10 +251,9 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 			if history.ActiveAttempt != nil {
 				attemptID = history.ActiveAttempt.ID
 			}
-			if err := r.recordRepair(home, history.Task, state.Attempt{ID: attemptID}, decision); err != nil {
+			if err := r.recordRepair(home, history.Task, state.Attempt{ID: attemptID}, decision, &result); err != nil {
 				return result, err
 			}
-			result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
 			return result, nil
 		}
 		if mergeObserved && history.Task.RepairCode == repairCodeMergeFactMismatch {
@@ -276,16 +269,15 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		}
 		if historical != nil {
 			result.AttemptID = historical.ID
-			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, *historical, abandonWorktree)
+			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, *historical, attest)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
 				return result, err
 			}
 			if decision.Action == reconciliationActionNeedsRepair {
-				if err := r.recordRepair(home, history.Task, *historical, decision); err != nil {
+				if err := r.recordRepair(home, history.Task, *historical, decision, &result); err != nil {
 					return result, err
 				}
-				result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
 				return result, nil
 			}
 			if progress {
@@ -312,16 +304,15 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		result.ExecutionClass, result.Profile = attempt.ExecutionClass, attempt.RequestedProfile
 		result.PlannedAgainst, result.RoutingSource = attempt.PlannedAgainst, attempt.RoutingSource
 		if attempt.TeardownTerminalAttempt != "" {
-			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, attempt, abandonWorktree)
+			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, attempt, attest)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
 				return result, err
 			}
 			if decision.Action == reconciliationActionNeedsRepair {
-				if err := r.recordRepair(home, history.Task, attempt, decision); err != nil {
+				if err := r.recordRepair(home, history.Task, attempt, decision, &result); err != nil {
 					return result, err
 				}
-				result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
 				return result, nil
 			}
 			if progress {
@@ -342,16 +333,21 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, abandonWor
 		result.Action = string(decision.Action)
 		switch decision.Action {
 		case reconciliationActionNeedsRepair:
-			if err := r.recordRepair(home, history.Task, attempt, decision); err != nil {
+			if err := r.recordRepair(home, history.Task, attempt, decision, &result); err != nil {
 				return result, err
 			}
-			result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, decision.RepairReason
 			return result, nil
 		case reconciliationActionBlocked:
 			result.Outcome = reconcileOutcomeBlocked
 			return result, fmt.Errorf("reconciliation observation was incomplete")
 		case reconciliationActionConvergeTerminal:
 			if err := r.convergeTerminalLifecycle(home, history.Task, attempt, decision); err != nil {
+				return result, err
+			}
+			result.Outcome, result.Detail = reconcileOutcomeRecovered, decision.Detail
+			continue
+		case reconciliationActionUnwindProvisioning:
+			if err := r.unwindFailedProvisioning(home, history.Task, attempt, decision); err != nil {
 				return result, err
 			}
 			result.Outcome, result.Detail = reconcileOutcomeRecovered, decision.Detail
@@ -522,23 +518,41 @@ func decideTerminalConvergence(attempt state.Attempt, observation reconciliation
 }
 
 func (r *Runtime) convergeTerminalLifecycle(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
+	return r.terminalizeWithoutRelease(home, task, attempt, decision, "converged")
+}
+
+// Unwinds a launch that persisted no owned resource at all, so there is nothing to release and no
+// ownership to claim: the attempt and its history stay durable and readable, and `hand reopen` is
+// what spawns the task again through the ordinary path.
+func (r *Runtime) unwindFailedProvisioning(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
+	if !unwindableProvisioning(attempt) {
+		return Precondition(fmt.Errorf("refusing to unwind attempt %d: it records lifecycle %q, worktree %q, lease %s, Herdr identity (%s) and teardown lifecycle %q, so this is not a launch that left nothing behind",
+			attempt.ID, attempt.Lifecycle, attempt.Worktree, leaseOrNone(attempt.LeaseID),
+			herdrIdentityText(attempt.Herdr), attempt.TeardownTerminalAttempt))
+	}
+	return r.terminalizeWithoutRelease(home, task, attempt, decision, "unwound")
+}
+
+// Records one terminal lifecycle and its completion evidence for an attempt whose resources are
+// already settled, releasing nothing of its own.
+func (r *Runtime) terminalizeWithoutRelease(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision, label string) error {
 	if err := state.SetAttemptTeardownDecision(home, task.ID, attempt.ID, decision.TerminalAttempt, decision.Disposition); err != nil {
-		return fmt.Errorf("record converged teardown decision for attempt %d: %w", attempt.ID, err)
+		return fmt.Errorf("record %s teardown decision for attempt %d: %w", label, attempt.ID, err)
 	}
 	if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionPending); err != nil {
-		return fmt.Errorf("record converged completion phase for attempt %d: %w", attempt.ID, err)
+		return fmt.Errorf("record %s completion phase for attempt %d: %w", label, attempt.ID, err)
 	}
 	record := completionFor(task, decision.Disposition, true)
 	record.AttemptID, record.AttemptLifecycle = attempt.ID, string(decision.TerminalAttempt)
 	record.TornDownAt = r.deps.now().Format(time.RFC3339)
 	if err := r.deps.appendCompletion(home, record); err != nil {
-		return fmt.Errorf("append converged completion for attempt %d: %w", attempt.ID, err)
+		return fmt.Errorf("append %s completion for attempt %d: %w", label, attempt.ID, err)
 	}
 	if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionAppended); err != nil {
-		return fmt.Errorf("record converged completion evidence for attempt %d: %w", attempt.ID, err)
+		return fmt.Errorf("record %s completion evidence for attempt %d: %w", label, attempt.ID, err)
 	}
 	if err := state.TerminalizeTaskAndAttempt(home, task.ID, attempt.ID, attempt.Lifecycle, decision.TerminalAttempt); err != nil {
-		return fmt.Errorf("converge attempt %d to %s: %w", attempt.ID, decision.TerminalAttempt, err)
+		return fmt.Errorf("%s attempt %d to %s: %w", label, attempt.ID, decision.TerminalAttempt, err)
 	}
 	return nil
 }
@@ -764,7 +778,7 @@ func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) 
 		if attempt.Lifecycle == state.AttemptProvisioning || attempt.Lifecycle == state.AttemptRunning {
 			continue
 		}
-		if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
+		if hasHerdrIdentity(attempt.Herdr) && !herdrCleanupSettled(attempt.TeardownHerdrState) {
 			return attempt, nil
 		}
 		if attempt.Worktree != "" && !worktreeCleanupSettled(attempt.TeardownWorktreeState) {
@@ -777,14 +791,17 @@ func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) 
 	return nil, nil
 }
 
-func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, task state.Task, attempt state.Attempt, abandonWorktree bool) (bool, reconciliationDecision, error) {
-	if hasHerdrIdentity(attempt.Herdr) && attempt.TeardownHerdrState != state.TeardownResourceReleased {
+func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, task state.Task, attempt state.Attempt, attest reconcileAttestations) (bool, reconciliationDecision, error) {
+	if hasHerdrIdentity(attempt.Herdr) && !herdrCleanupSettled(attempt.TeardownHerdrState) {
 		observation, err := observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
 			return false, reconciliationDecision{}, err
 		}
 		switch observation.State {
 		case herdrOwnershipIncomplete, herdrOwnershipMismatch:
+			if attest.Pane {
+				return r.abandonHistoricalPane(home, task, attempt, observation)
+			}
 			return false, repairDecision(reconciliationDecision{}, repairCodeTeardownResourceAmbiguous, "historical Herdr resource ownership cannot be proven safely"), nil
 		case herdrOwnershipAbsent:
 			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeTeardownResourceAmbiguous, repairCodeHerdrOwnershipMismatch); err != nil {
@@ -826,21 +843,21 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 	if attempt.Worktree != "" && !worktreeCleanupSettled(attempt.TeardownWorktreeState) {
 		lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
 		switch lease.State {
-		case worktree.LeaseUnknown:
-			if abandonWorktree {
+		case worktree.LeaseUnknown, worktree.LeaseUnprovable:
+			if attest.Worktree {
 				return r.abandonHistoricalWorktree(home, task, attempt, lease)
 			}
+			if lease.State == worktree.LeaseUnprovable {
+				return false, repairDecision(reconciliationDecision{}, repairCodeLegacyWorktreeUnprovable, "historical worktree has no exact lease identity"), nil
+			}
 			return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeUnobservable, unobservableWorktreeReason(attempt, lease.Probe)), nil
-		case worktree.LeaseUnprovable:
-			return false, repairDecision(reconciliationDecision{}, repairCodeLegacyWorktreeUnprovable, "historical worktree has no exact lease identity"), nil
 		case worktree.LeaseMismatch:
-			if attempt.TeardownWorktreeState == state.TeardownResourceReleasing {
-				if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
-					return false, reconciliationDecision{}, err
-				}
+			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeLegacyWorktreeUnprovable); err != nil {
+				return false, reconciliationDecision{}, err
+			} else if cleared {
 				return true, reconciliationDecision{}, nil
 			}
-			return false, repairDecision(reconciliationDecision{}, repairCodeWorktreeOwnershipMismatch, "historical worktree path is held by a different Treehouse lease"), nil
+			return r.relinquishHistoricalWorktree(home, task, attempt, lease)
 		case worktree.LeaseAbsent:
 			if cleared, err := clearHistoricalRepair(home, task, attempt, repairCodeWorktreeOwnershipMismatch, repairCodeWorktreeUnobservable, repairCodeWorktreeLocalCommits, repairCodeWorktreeCommitSafetyUnknown); err != nil {
 				return false, reconciliationDecision{}, err
@@ -948,14 +965,61 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 }
 
 func (r *Runtime) abandonHistoricalWorktree(home string, task state.Task, attempt state.Attempt, lease worktree.LeaseObservation) (bool, reconciliationDecision, error) {
-	if lease.State != worktree.LeaseUnknown {
-		return false, reconciliationDecision{}, Precondition(fmt.Errorf("refusing to abandon worktree %s of attempt %d: ownership observed as %s, which is provable evidence; abandonment is only for an unobservable pool", attempt.Worktree, attempt.ID, lease.State))
+	if lease.State != worktree.LeaseUnknown && lease.State != worktree.LeaseUnprovable {
+		return false, reconciliationDecision{}, Precondition(fmt.Errorf("refusing to abandon worktree %s of attempt %d: ownership observed as %s, which an observation can prove or disprove; abandonment is only for ownership neither observation can settle", attempt.Worktree, attempt.ID, lease.State))
 	}
-	if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAbandoned); err != nil {
+	if err := recordAbandonedResource(home, task.ID, attempt, "worktree", attempt.TeardownWorktreeState); err != nil {
 		return false, reconciliationDecision{}, fmt.Errorf("record abandoned worktree ownership: %w", err)
 	}
-	detail := fmt.Sprintf("attempt %d relinquished worktree %s with recorded lease %s on operator attestation; %s", attempt.ID, attempt.Worktree, leaseOrNone(attempt.LeaseID), unobservableWorktreeReason(attempt, lease.Probe))
+	detail := fmt.Sprintf("attempt %d relinquished worktree %s with recorded lease %s on operator attestation; %s", attempt.ID, attempt.Worktree, leaseOrNone(attempt.LeaseID), abandonedWorktreeReason(attempt, lease))
 	return true, reconciliationDecision{Action: reconciliationActionAbandonWorktree, Detail: detail}, nil
+}
+
+// The attestation for a pane whose ownership no observation can settle. It relinquishes the recorded
+// identity and closes nothing, so a pane that answers in its place stays exactly where it is.
+func (r *Runtime) abandonHistoricalPane(home string, task state.Task, attempt state.Attempt, observation herdrObservation) (bool, reconciliationDecision, error) {
+	if observation.State != herdrOwnershipIncomplete && observation.State != herdrOwnershipMismatch {
+		return false, reconciliationDecision{}, Precondition(fmt.Errorf("refusing to abandon the Herdr pane of attempt %d: ownership observed as %s, which an observation can prove or disprove and an ordinary reconcile settles; abandonment is only for ownership neither observation can settle", attempt.ID, observation.State))
+	}
+	if err := recordAbandonedResource(home, task.ID, attempt, "herdr", attempt.TeardownHerdrState); err != nil {
+		return false, reconciliationDecision{}, fmt.Errorf("record abandoned Herdr ownership: %w", err)
+	}
+	detail := fmt.Sprintf("attempt %d relinquished its Herdr identity (%s) on operator attestation; ownership observed as %s, and no pane, tab or workspace was closed",
+		attempt.ID, herdrIdentityText(attempt.Herdr), observation.State)
+	return true, reconciliationDecision{Action: reconciliationActionAbandonPane, Detail: detail}, nil
+}
+
+// A path another lease provably holds was never this attempt's to return, so the disproven claim is
+// relinquished instead of diagnosed forever, and the worktree itself is left untouched.
+func (r *Runtime) relinquishHistoricalWorktree(home string, task state.Task, attempt state.Attempt, lease worktree.LeaseObservation) (bool, reconciliationDecision, error) {
+	if err := recordAbandonedResource(home, task.ID, attempt, "worktree", attempt.TeardownWorktreeState); err != nil {
+		return false, reconciliationDecision{}, fmt.Errorf("record relinquished worktree claim: %w", err)
+	}
+	detail := fmt.Sprintf("attempt %d relinquished worktree %s with recorded lease %s, which Treehouse now reports under lease %s; nothing was returned, pruned or deleted",
+		attempt.ID, attempt.Worktree, leaseOrNone(attempt.LeaseID), leaseOrNone(lease.LeaseID))
+	return true, reconciliationDecision{Action: reconciliationActionRelinquishWorktree, Detail: detail}, nil
+}
+
+// 'abandoned' has 'ambiguous' among its predecessors and 'releasing' does not, so a resource latched
+// mid-release steps through it rather than the transition table growing an edge per latch.
+func recordAbandonedResource(home, taskID string, attempt state.Attempt, resource, current string) error {
+	if current == state.TeardownResourceReleasing {
+		if err := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, resource, state.TeardownResourceAmbiguous); err != nil {
+			return err
+		}
+	}
+	return state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, resource, state.TeardownResourceAbandoned)
+}
+
+func abandonedWorktreeReason(attempt state.Attempt, lease worktree.LeaseObservation) string {
+	if lease.State == worktree.LeaseUnprovable {
+		return fmt.Sprintf("recorded worktree %s has no exact lease identity, so ownership is neither proven nor disproven; nothing was returned, pruned or deleted", attempt.Worktree)
+	}
+	return unobservableWorktreeReason(attempt, lease.Probe)
+}
+
+func herdrIdentityText(ownership state.Herdr) string {
+	return fmt.Sprintf("workspace=%q, tab=%q, pane=%q", ownership.WorkspaceID, ownership.TabID, ownership.PaneID)
 }
 
 func clearHistoricalRepair(home string, task state.Task, attempt state.Attempt, codes ...string) (bool, error) {
@@ -1024,7 +1088,7 @@ func terminalRepairEvidenceResolved(code string, attempt state.Attempt) bool {
 	case repairCodeProvisioningLaunchAmbiguous, repairCodeProvisioningPaneMissing, repairCodeLaunchSubmittedPaneMissing,
 		repairCodeLaunchAgentMismatch, repairCodeRunningPaneMissing, repairCodeRunningPaneIdentityMismatch,
 		repairCodeHerdrOwnershipIncomplete, repairCodeHerdrOwnershipMismatch, repairCodeTeardownResourceAmbiguous:
-		return !hasHerdrIdentity(attempt.Herdr) || attempt.TeardownHerdrState == state.TeardownResourceReleased
+		return !hasHerdrIdentity(attempt.Herdr) || herdrCleanupSettled(attempt.TeardownHerdrState)
 	case repairCodeWorktreeDirty, repairCodeWorktreeOwnershipMismatch, repairCodeLegacyWorktreeUnprovable, repairCodeWorktreeUnobservable,
 		repairCodeWorktreeLocalCommits, repairCodeWorktreeCommitSafetyUnknown:
 		return attempt.Worktree == "" || worktreeCleanupSettled(attempt.TeardownWorktreeState)
@@ -1104,11 +1168,15 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 	}
 }
 
-func (r *Runtime) recordRepair(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
-	if task.RepairCode == decision.RepairCode && task.RepairReason == decision.RepairReason && task.RepairAttemptID == attempt.ID {
+// Persists the diagnosis with its supported treatment appended, and reports the same text it stored,
+// so what an operator reads is what the task row holds.
+func (r *Runtime) recordRepair(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision, result *ReconcileResult) error {
+	reason := repairReasonWithTreatment(task.ID, decision.RepairCode, decision.RepairReason)
+	result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, reason
+	if task.RepairCode == decision.RepairCode && task.RepairReason == reason && task.RepairAttemptID == attempt.ID {
 		return nil
 	}
-	return state.SetTaskRepair(home, task.ID, decision.RepairCode, decision.RepairReason, attempt.ID, r.deps.now().Format(time.RFC3339))
+	return state.SetTaskRepair(home, task.ID, decision.RepairCode, reason, attempt.ID, r.deps.now().Format(time.RFC3339))
 }
 
 func shouldClearRepair(task state.Task, attempt state.Attempt, observation reconciliationObservation) bool {
@@ -1224,6 +1292,12 @@ func decideProvisioning(attempt state.Attempt, observation reconciliationObserva
 		return decision
 	}
 	if attempt.LaunchSubmittedAt != "" || attempt.LaunchConfirmedAt != "" {
+		if unwindableProvisioning(attempt) {
+			decision.Action = reconciliationActionUnwindProvisioning
+			decision.TerminalAttempt, decision.Disposition = state.AttemptInterrupted, state.TeardownDispositionProvisioningUnwound
+			decision.Detail = fmt.Sprintf("attempt %d unwound: launch evidence exists but no worktree lease and no Herdr identity were ever persisted, so nothing was released and no ownership was claimed", attempt.ID)
+			return decision
+		}
 		return repairDecision(decision, repairCodeProvisioningPaneMissing, "launch evidence exists but no Herdr pane identity was persisted")
 	}
 
@@ -1251,6 +1325,14 @@ func decideProvisioning(attempt state.Attempt, observation reconciliationObserva
 
 	decision.Action = reconciliationActionContinueProvisioning
 	return decision
+}
+
+// The facts that make unwinding a failed launch provably safe: the attempt is still provisioning, no
+// Herdr identity was ever persisted, no worktree lease is recorded, and no teardown has already
+// decided this attempt's terminal lifecycle, so no resource is at stake and no work can be lost.
+func unwindableProvisioning(attempt state.Attempt) bool {
+	return attempt.Lifecycle == state.AttemptProvisioning && !hasHerdrIdentity(attempt.Herdr) &&
+		attempt.Worktree == "" && attempt.LeaseID == "" && attempt.TeardownTerminalAttempt == ""
 }
 
 func leaseOrNone(leaseID string) string {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -122,9 +122,6 @@ type ReconcileRequest struct {
 	AttemptNeverStarted bool
 }
 
-// The operator attestations one reconcile run carries, each scoped to one fact Hand cannot settle by
-// observation. None destroys anything: the resource ones relinquish a claim, and the attempt one
-// records the teardown decision that the ordinary release path then carries out under its own guards.
 type reconcileAttestations struct {
 	Worktree     bool
 	Pane         bool
@@ -533,9 +530,6 @@ func (r *Runtime) convergeTerminalLifecycle(home string, task state.Task, attemp
 	return r.terminalizeWithoutRelease(home, task, attempt, decision, "converged")
 }
 
-// Unwinds a launch that persisted no owned resource at all, so there is nothing to release and no
-// ownership to claim: the attempt and its history stay durable and readable, and `hand reopen` is
-// what spawns the task again through the ordinary path.
 func (r *Runtime) unwindFailedProvisioning(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
 	if !unwindableProvisioning(attempt) {
 		return Precondition(fmt.Errorf("refusing to unwind attempt %d: it records lifecycle %q, worktree %q, lease %s, Herdr identity (%s) and teardown lifecycle %q, so this is not a launch that left nothing behind",
@@ -545,8 +539,6 @@ func (r *Runtime) unwindFailedProvisioning(home string, task state.Task, attempt
 	return r.terminalizeWithoutRelease(home, task, attempt, decision, "unwound")
 }
 
-// Records one terminal lifecycle and its completion evidence for an attempt whose resources are
-// already settled, releasing nothing of its own.
 func (r *Runtime) terminalizeWithoutRelease(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision, label string) error {
 	if err := state.SetAttemptTeardownDecision(home, task.ID, attempt.ID, decision.TerminalAttempt, decision.Disposition); err != nil {
 		return fmt.Errorf("record %s teardown decision for attempt %d: %w", label, attempt.ID, err)
@@ -569,9 +561,6 @@ func (r *Runtime) terminalizeWithoutRelease(home string, task state.Task, attemp
 	return nil
 }
 
-// A reconcile-driven terminalization is the only path to end an attempt outside `hand teardown`, so it
-// must close the same usage-limit hold that path clears (internal/runtime/teardown.go's finishTeardown)
-// - otherwise a task this call just ended keeps a live hold and `hand reopen` stays refused.
 func terminalizeAndClearLimitHold(home, taskID string, attemptID int64, attemptFrom, attemptTo state.AttemptLifecycle) error {
 	if err := state.TerminalizeTaskAndAttempt(home, taskID, attemptID, attemptFrom, attemptTo); err != nil {
 		return err
@@ -1003,8 +992,6 @@ func (r *Runtime) abandonHistoricalWorktree(home string, task state.Task, attemp
 	return true, reconciliationDecision{Action: reconciliationActionAbandonWorktree, Detail: detail}, nil
 }
 
-// The attestation for a pane whose ownership no observation can settle. It relinquishes the recorded
-// identity and closes nothing, so a pane that answers in its place stays exactly where it is.
 func (r *Runtime) abandonHistoricalPane(home string, task state.Task, attempt state.Attempt, observation herdrObservation) (bool, reconciliationDecision, error) {
 	if observation.State != herdrOwnershipIncomplete && observation.State != herdrOwnershipMismatch {
 		return false, reconciliationDecision{}, Precondition(fmt.Errorf("refusing to abandon the Herdr pane of attempt %d: ownership observed as %s, which an observation can prove or disprove and an ordinary reconcile settles; abandonment is only for ownership neither observation can settle", attempt.ID, observation.State))
@@ -1017,9 +1004,6 @@ func (r *Runtime) abandonHistoricalPane(home string, task state.Task, attempt st
 	return true, reconciliationDecision{Action: reconciliationActionAbandonPane, Detail: detail}, nil
 }
 
-// The attestation for a worker that never started, which durable state cannot tell apart from one
-// still working (atqamz/hand#255 owns that observation). It records the teardown decision the ordinary
-// release path then carries out under its own guards, and releases nothing itself.
 func (r *Runtime) attestAttemptNeverStarted(home string, task state.Task, attempt state.Attempt) (reconciliationDecision, error) {
 	if attempt.Lifecycle != state.AttemptRunning {
 		return reconciliationDecision{}, Precondition(fmt.Errorf("refusing to attest that attempt %d never started: it records lifecycle %q rather than %q, and reconcile treats every other lifecycle on its own evidence",
@@ -1058,8 +1042,6 @@ func (r *Runtime) attestAttemptNeverStarted(home string, task state.Task, attemp
 	return reconciliationDecision{Action: reconciliationActionAttestNeverStarted, Detail: detail}, nil
 }
 
-// What durable state holds that a worker did start. Each of these is a fact only a worker that took a
-// turn can produce, so any one of them disproves the attestation.
 func startedWorkEvidence(home string, task state.Task, attempt state.Attempt) (string, bool, error) {
 	lines, err := state.ReadReportLines(home, task.ID)
 	if err != nil {
@@ -1083,8 +1065,6 @@ func startedWorkEvidence(home string, task state.Task, attempt state.Attempt) (s
 	return "", false, nil
 }
 
-// A path another lease provably holds was never this attempt's to return, so the disproven claim is
-// relinquished instead of diagnosed forever, and the worktree itself is left untouched.
 func (r *Runtime) relinquishHistoricalWorktree(home string, task state.Task, attempt state.Attempt, lease worktree.LeaseObservation) (bool, reconciliationDecision, error) {
 	if err := recordAbandonedResource(home, task.ID, attempt, "worktree", attempt.TeardownWorktreeState); err != nil {
 		return false, reconciliationDecision{}, fmt.Errorf("record relinquished worktree claim: %w", err)
@@ -1094,8 +1074,6 @@ func (r *Runtime) relinquishHistoricalWorktree(home string, task state.Task, att
 	return true, reconciliationDecision{Action: reconciliationActionRelinquishWorktree, Detail: detail}, nil
 }
 
-// 'abandoned' has 'ambiguous' among its predecessors and 'releasing' does not, so a resource latched
-// mid-release steps through it rather than the transition table growing an edge per latch.
 func recordAbandonedResource(home, taskID string, attempt state.Attempt, resource, current string) error {
 	if current == state.TeardownResourceReleasing {
 		if err := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, resource, state.TeardownResourceAmbiguous); err != nil {
@@ -1262,8 +1240,6 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 	}
 }
 
-// Persists the diagnosis with its supported treatment appended, and reports the same text it stored,
-// so what an operator reads is what the task row holds.
 func (r *Runtime) recordRepair(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision, result *ReconcileResult) error {
 	reason := repairReasonWithTreatment(task.ID, decision.RepairCode, decision.RepairReason)
 	result.Outcome, result.RepairCode, result.RepairReason = reconcileOutcomeRepair, decision.RepairCode, reason
@@ -1421,9 +1397,6 @@ func decideProvisioning(attempt state.Attempt, observation reconciliationObserva
 	return decision
 }
 
-// The facts that make unwinding a failed launch provably safe: the attempt is still provisioning, no
-// Herdr identity was ever persisted, no worktree lease is recorded, and no teardown has already
-// decided this attempt's terminal lifecycle, so no resource is at stake and no work can be lost.
 func unwindableProvisioning(attempt state.Attempt) bool {
 	return attempt.Lifecycle == state.AttemptProvisioning && !hasHerdrIdentity(attempt.Herdr) &&
 		attempt.Worktree == "" && attempt.LeaseID == "" && attempt.TeardownTerminalAttempt == ""

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -31,6 +31,7 @@ const (
 	reconciliationActionUnwindProvisioning   reconciliationAction = "unwind-failed-provisioning"
 	reconciliationActionAbandonWorktree      reconciliationAction = "abandon-worktree"
 	reconciliationActionAbandonPane          reconciliationAction = "abandon-pane"
+	reconciliationActionAttestNeverStarted   reconciliationAction = "attest-attempt-never-started"
 	reconciliationActionRelinquishWorktree   reconciliationAction = "relinquish-worktree-claim"
 	reconciliationActionNeedsRepair          reconciliationAction = "needs-repair"
 	reconciliationActionBlocked              reconciliationAction = "blocked"
@@ -113,21 +114,24 @@ type reconciliationDecision struct {
 }
 
 type ReconcileRequest struct {
-	Context         context.Context
-	Home            string
-	ID              string
-	AbandonWorktree bool
-	AbandonPane     bool
+	Context             context.Context
+	Home                string
+	ID                  string
+	AbandonWorktree     bool
+	AbandonPane         bool
+	AttemptNeverStarted bool
 }
 
-// The operator attestations one reconcile run carries, each scoped to one kind of resource whose
-// ownership no observation can settle. Neither destroys anything; both only relinquish Hand's claim.
+// The operator attestations one reconcile run carries, each scoped to one fact Hand cannot settle by
+// observation. None destroys anything: the resource ones relinquish a claim, and the attempt one
+// records the teardown decision that the ordinary release path then carries out under its own guards.
 type reconcileAttestations struct {
-	Worktree bool
-	Pane     bool
+	Worktree     bool
+	Pane         bool
+	NeverStarted bool
 }
 
-func (a reconcileAttestations) any() bool { return a.Worktree || a.Pane }
+func (a reconcileAttestations) any() bool { return a.Worktree || a.Pane || a.NeverStarted }
 
 type ReconcileResult struct {
 	ID             string `json:"id"`
@@ -180,7 +184,7 @@ func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	attest := reconcileAttestations{Worktree: req.AbandonWorktree, Pane: req.AbandonPane}
+	attest := reconcileAttestations{Worktree: req.AbandonWorktree, Pane: req.AbandonPane, NeverStarted: req.AttemptNeverStarted}
 	if req.ID != "" {
 		result, err := r.reconcileTask(ctx, req.Home, req.ID, attest)
 		if err != nil {
@@ -303,6 +307,14 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, attest rec
 		result.Harness, result.Model, result.Effort = attempt.Harness, attempt.Model, attempt.Effort
 		result.ExecutionClass, result.Profile = attempt.ExecutionClass, attempt.RequestedProfile
 		result.PlannedAgainst, result.RoutingSource = attempt.PlannedAgainst, attempt.RoutingSource
+		if attest.NeverStarted && attempt.TeardownTerminalAttempt == "" {
+			decision, err := r.attestAttemptNeverStarted(home, history.Task, attempt)
+			if err != nil {
+				return result, err
+			}
+			result.Action, result.Outcome, result.Detail = string(decision.Action), reconcileOutcomeRecovered, decision.Detail
+			continue
+		}
 		if attempt.TeardownTerminalAttempt != "" {
 			progress, decision, err := r.reconcileHistoricalAttempt(ctx, home, history.Task, attempt, attest)
 			if err != nil {
@@ -987,6 +999,72 @@ func (r *Runtime) abandonHistoricalPane(home string, task state.Task, attempt st
 	detail := fmt.Sprintf("attempt %d relinquished its Herdr identity (%s) on operator attestation; ownership observed as %s, and no pane, tab or workspace was closed",
 		attempt.ID, herdrIdentityText(attempt.Herdr), observation.State)
 	return true, reconciliationDecision{Action: reconciliationActionAbandonPane, Detail: detail}, nil
+}
+
+// The attestation for a worker that never started, which durable state cannot tell apart from one
+// still working (atqamz/hand#255 owns that observation). It records the teardown decision the ordinary
+// release path then carries out under its own guards, and releases nothing itself.
+func (r *Runtime) attestAttemptNeverStarted(home string, task state.Task, attempt state.Attempt) (reconciliationDecision, error) {
+	if attempt.Lifecycle != state.AttemptRunning {
+		return reconciliationDecision{}, Precondition(fmt.Errorf("refusing to attest that attempt %d never started: it records lifecycle %q rather than %q, and reconcile treats every other lifecycle on its own evidence",
+			attempt.ID, attempt.Lifecycle, state.AttemptRunning))
+	}
+	if evidence, found, err := startedWorkEvidence(home, task, attempt); err != nil {
+		return reconciliationDecision{}, err
+	} else if found {
+		return reconciliationDecision{}, Precondition(fmt.Errorf("refusing to attest that attempt %d never started: %s, which disproves it; end this attempt with `hand teardown %s` instead", attempt.ID, evidence, task.ID))
+	}
+	if attempt.Worktree != "" {
+		observeClean := r.deps.worktree.observeClean
+		if observeClean == nil {
+			observeClean = worktree.ObserveCleanliness
+		}
+		clean, err := observeClean(attempt.Worktree)
+		if err != nil {
+			return reconciliationDecision{}, fmt.Errorf("observe worktree cleanliness for attempt %d: %w", attempt.ID, err)
+		}
+		if clean == worktree.Dirty {
+			return reconciliationDecision{}, Precondition(fmt.Errorf("refusing to attest that attempt %d never started: worktree %s holds uncommitted changes, which disproves it; end this attempt with `hand teardown %s` instead", attempt.ID, attempt.Worktree, task.ID))
+		}
+		observeCommits := r.deps.worktree.observeCommits
+		if observeCommits == nil {
+			observeCommits = worktree.ObserveCommitSafety
+		}
+		if commits := observeCommits(attempt.Worktree); commits.State == worktree.CommitSafetyLocalOnly {
+			return reconciliationDecision{}, Precondition(fmt.Errorf("refusing to attest that attempt %d never started: %d commit(s) in %s are reachable from no remote-tracking ref, which disproves it; end this attempt with `hand teardown %s` instead",
+				attempt.ID, commits.Probe.LocalOnly, commits.Probe.WorkingDir, task.ID))
+		}
+	}
+	if err := state.SetAttemptTeardownDecision(home, task.ID, attempt.ID, state.AttemptInterrupted, state.TeardownDispositionWorkerNeverStarted); err != nil {
+		return reconciliationDecision{}, fmt.Errorf("record unstarted teardown decision for attempt %d: %w", attempt.ID, err)
+	}
+	detail := fmt.Sprintf("attempt %d recorded interrupted on operator attestation that its worker never started; no outcome about work was claimed, and its pane and worktree are released by the ordinary path under their own guards", attempt.ID)
+	return reconciliationDecision{Action: reconciliationActionAttestNeverStarted, Detail: detail}, nil
+}
+
+// What durable state holds that a worker did start. Each of these is a fact only a worker that took a
+// turn can produce, so any one of them disproves the attestation.
+func startedWorkEvidence(home string, task state.Task, attempt state.Attempt) (string, bool, error) {
+	lines, err := state.ReadReportLines(home, task.ID)
+	if err != nil {
+		return "", false, fmt.Errorf("read reported state for task %q: %w", task.ID, err)
+	}
+	if len(lines) > 0 {
+		return fmt.Sprintf("%s holds %d reported line(s)", state.ReportPath(home, task.ID), len(lines)), true, nil
+	}
+	switch {
+	case task.PR != "":
+		return "pull request " + task.PR + " is recorded for this task", true, nil
+	case task.MergeExecuted || task.MergeAnnounced:
+		return "a merge is recorded for this task", true, nil
+	case task.DeliveredAt != "":
+		return "this task is recorded as delivered at " + task.DeliveredAt, true, nil
+	case attempt.LastReportState != "":
+		return fmt.Sprintf("attempt %d last reported state %q", attempt.ID, attempt.LastReportState), true, nil
+	case attempt.DoneVerified:
+		return fmt.Sprintf("attempt %d is recorded as verified done", attempt.ID), true, nil
+	}
+	return "", false, nil
 }
 
 // A path another lease provably holds was never this attempt's to return, so the disproven claim is

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -562,6 +562,46 @@ func TestReconcileClearsRepairAfterTeardownAndReopenResolvesOldAttempt(t *testin
 	}
 }
 
+// A retry after a terminalization whose lifecycle write committed but whose hold clear did not still has
+// to converge: the historical attempt already sits at its recorded terminal lifecycle, so reconcile must
+// clear a surviving usage-limit hold on that no-progress path too, not only on the transition that sets it.
+func TestReconcileClearsUsageLimitHoldOnAlreadySettledHistoricalAttempt(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptInterrupted, state.TeardownDispositionWorkerNeverStarted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptProvisioning, state.TeardownCompletionPending); err != nil {
+		t.Fatal(err)
+	}
+	if err := completion.Append(home, completion.Record{ID: "task-1", Project: "demo", Outcome: "torn-down", Detail: "worker never started", AttemptID: attempt.ID, AttemptLifecycle: string(state.AttemptInterrupted)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptProvisioning, state.TeardownCompletionAppended); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindLimit, Reason: "usage limit", SetAt: "2026-08-15T00:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := reconcileRuntime(&healthyReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, hasHold, err := state.ReadHold(home, "task-1"); err != nil {
+		t.Fatal(err)
+	} else if hasHold {
+		t.Fatal("usage-limit hold survived reconcile on an already-settled historical attempt, want reopen to stay reachable")
+	}
+}
+
 func convergenceTask(t *testing.T, home string, task state.Task) state.Attempt {
 	t.Helper()
 	attempt, err := state.CreateTaskWithAttempt(home, task, state.Attempt{

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -1204,8 +1204,11 @@ func TestReconcileReusedTerminalLeaseDoesNotReturnNewOwner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if history.Task.RepairCode != "worktree-ownership-mismatch" || returns != 0 {
-		t.Fatalf("history=%+v returns=%d, want mismatch repair without touching new lease", history, returns)
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceAbandoned || returns != 0 {
+		t.Fatalf("history=%+v returns=%d, want the disproven claim relinquished without touching the new lease", history, returns)
+	}
+	if history.Task.RepairCode != "" {
+		t.Fatalf("repair code = %q, want a disproven claim to end rather than persist a diagnosis", history.Task.RepairCode)
 	}
 }
 
@@ -1336,8 +1339,8 @@ func TestReconcileAbandonWorktreeConvergesAnUnobservableLease(t *testing.T) {
 	}
 }
 
-// Abandonment is only for what cannot be observed. A lease held by another owner and a lease proven
-// to be ours both keep their ordinary handling even when the operator passes the attestation.
+// Abandonment is only for what cannot be observed. A lease another owner provably holds and a lease
+// proven to be ours both keep their ordinary handling even when the operator passes the attestation.
 func TestReconcileAbandonWorktreeRefusesProvableOwnership(t *testing.T) {
 	for _, test := range []struct {
 		name        string
@@ -1349,8 +1352,7 @@ func TestReconcileAbandonWorktreeRefusesProvableOwnership(t *testing.T) {
 		{
 			name:        "another owner",
 			observation: worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-2"},
-			wantState:   state.TeardownResourceAmbiguous,
-			wantRepair:  repairCodeWorktreeOwnershipMismatch,
+			wantState:   state.TeardownResourceAbandoned,
 		},
 		{
 			name:        "proven ours",
@@ -1384,11 +1386,13 @@ func TestReconcileAbandonWorktreeRefusesProvableOwnership(t *testing.T) {
 	}
 }
 
-func TestAbandonHistoricalWorktreeRefusesAnyObservedOwnership(t *testing.T) {
+// Unknown and unprovable are the two states no observation settles; every other observation proves or
+// disproves the lease, so the attestation has nothing to add and refuses.
+func TestAbandonHistoricalWorktreeRefusesOwnershipAnObservationSettles(t *testing.T) {
 	home, attempt := unobservableTeardownFixture(t, "")
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
 	task := state.Task{ID: "task-1"}
-	for _, observed := range []worktree.LeaseObservationState{worktree.LeaseExact, worktree.LeaseMismatch, worktree.LeaseAbsent, worktree.LeaseUnprovable} {
+	for _, observed := range []worktree.LeaseObservationState{worktree.LeaseExact, worktree.LeaseMismatch, worktree.LeaseAbsent} {
 		_, _, err := r.abandonHistoricalWorktree(home, task, attempt, worktree.LeaseObservation{State: observed})
 		if err == nil {
 			t.Fatalf("abandonHistoricalWorktree() accepted a %s observation", observed)

--- a/internal/runtime/repair.go
+++ b/internal/runtime/repair.go
@@ -22,24 +22,32 @@ const (
 	repairCodeMergeFactMismatch           = "merge-fact-mismatch"
 )
 
-// How a diagnosis ends, from the operator's side of it.
+// A state a task can be stuck in while Hand answers no diagnosis at all, which is the worst member of
+// the set the enumeration below covers: nothing tells the operator it exists, so nothing tells them
+// how to leave it. Named here so its treatment is enumerated and tested like any code's.
+const stuckStateRunningAttemptNeverStarted = "running-attempt-never-started"
+
+// How a stuck state ends, from the operator's side of it.
 type repairClass string
 
 const (
 	// A supported hand command leaves the state, without attesting to anything and without changing
 	// the world outside Hand first.
 	repairClassSupportedCommand repairClass = "supported-command"
-	// Ownership can be neither proven nor disproven, so the only way out is an operator attestation
-	// scoped to that one resource, which relinquishes Hand's claim and destroys nothing.
+	// A fact no observation can settle, so the only way out is an operator attestation scoped to that
+	// one fact, which relinquishes a claim or records a decision and destroys nothing.
 	repairClassAttestation repairClass = "explicit-supported-attestation"
 	// The diagnosis is about the world outside Hand, so reconciling again is what ends it once that
 	// world is fixed.
 	repairClassExternalFix repairClass = "retryable-after-external-fix"
 )
 
-type repairTreatment struct {
+type stuckStateTreatment struct {
 	Class     repairClass
 	Treatment string
+	// Set for a stuck state Hand cannot diagnose, whose treatment is therefore reachable only through
+	// command help and this enumeration rather than through a persisted repair reason.
+	Undiagnosed bool
 }
 
 const (
@@ -47,43 +55,65 @@ const (
 	treatmentTeardownSettleReopen = "end this attempt with `hand teardown <id>`, which records the teardown decision even when the recorded lease cannot be released, after which `hand reconcile <id>` settles the recorded claim and clears this diagnosis, and `hand reopen <id>` starts a new attempt"
 	treatmentAbandonWorktree      = "end this attempt with `hand teardown <id>` if it is still active, then `hand reconcile <id> --abandon-worktree` attests that Hand relinquishes the recorded lease, and returns, prunes or deletes nothing"
 	treatmentAbandonPane          = "end this attempt with `hand teardown <id>` if it is still active, then `hand reconcile <id> --abandon-pane` attests that Hand relinquishes the recorded pane identity, and closes no pane, tab or workspace"
+	treatmentAttemptNeverStarted  = "`hand reconcile <id> --attempt-never-started` attests that this attempt's worker took no turn, which records an honest teardown decision and releases nothing itself, after which the ordinary release path converges the attempt under its own guards and `hand reopen <id>` starts a new one"
 )
 
-// The one enumeration of every repair code Hand can answer with, and of the supported treatment that
-// ends each one. A code missing from here is a diagnosis an operator cannot act on, so the package
-// tests assert this map covers every declared code (atqamz/hand#254).
-var repairTreatments = map[string]repairTreatment{
-	repairCodeProvisioningLaunchAmbiguous: {repairClassSupportedCommand, treatmentTeardownReopen},
-	repairCodeProvisioningPaneMissing: {repairClassSupportedCommand,
-		"reconcile unwinds a launch that persisted no owned resource on its own; while a worktree lease is still recorded, " + treatmentTeardownReopen},
-	repairCodeLaunchSubmittedPaneMissing: {repairClassSupportedCommand, treatmentTeardownReopen},
-	repairCodeLaunchAgentMismatch: {repairClassExternalFix,
-		"answer the harness first-run dialog in that pane yourself once so the recorded harness becomes observable and `hand reconcile <id>` clears this diagnosis, or " + treatmentTeardownReopen},
-	repairCodeRunningPaneMissing: {repairClassSupportedCommand,
-		"restore the landing evidence so reconcile can converge this attempt to the lifecycle that evidence proves, or " + treatmentTeardownReopen},
-	repairCodeRunningPaneIdentityMismatch: {repairClassSupportedCommand, treatmentTeardownReopen},
-	repairCodeHerdrOwnershipIncomplete:    {repairClassAttestation, treatmentAbandonPane},
-	repairCodeHerdrOwnershipMismatch:      {repairClassSupportedCommand, treatmentTeardownReopen},
-	repairCodeWorktreeDirty: {repairClassExternalFix,
-		"commit, push or discard what that worktree holds, then `hand reconcile <id>` clears this diagnosis"},
-	repairCodeWorktreeOwnershipMismatch: {repairClassSupportedCommand,
-		"reconcile relinquishes a historical claim on a path another lease now holds; for the current attempt, " + treatmentTeardownSettleReopen},
-	repairCodeLegacyWorktreeUnprovable: {repairClassAttestation, treatmentAbandonWorktree},
-	repairCodeWorktreeUnobservable:     {repairClassAttestation, treatmentAbandonWorktree},
-	repairCodeWorktreeLocalCommits: {repairClassExternalFix,
-		"push those commits, or record the pull request whose head commit holds them, then `hand reconcile <id>` clears this diagnosis"},
-	repairCodeWorktreeCommitSafetyUnknown: {repairClassExternalFix,
-		"restore the named observation in that clone so the comparison can be made, then `hand reconcile <id>` clears this diagnosis"},
-	repairCodeTeardownResourceAmbiguous:  {repairClassAttestation, treatmentAbandonPane},
-	repairCodeCompletionEvidenceMismatch: {repairClassExternalFix, "restore that attempt's record in the fleet home's state/completions.jsonl, then `hand reconcile <id>` clears this diagnosis"},
-	repairCodeMergeFactMismatch: {repairClassExternalFix,
-		"merge the recorded pull request or branch, or restore the access that makes the merge observable, then `hand reconcile <id>` clears this diagnosis"},
+// The one enumeration of every state a task can be stuck in, and of the supported treatment that ends
+// each one. An entry missing from here is a state an operator cannot act on, so the package tests
+// assert this map covers every declared repair code and stuck state (atqamz/hand#254).
+var stuckStateTreatments = map[string]stuckStateTreatment{
+	repairCodeProvisioningLaunchAmbiguous: {Class: repairClassSupportedCommand, Treatment: treatmentTeardownReopen},
+	repairCodeProvisioningPaneMissing: {
+		Class:     repairClassSupportedCommand,
+		Treatment: "reconcile unwinds a launch that persisted no owned resource on its own; while a worktree lease is still recorded, " + treatmentTeardownReopen,
+	},
+	repairCodeLaunchSubmittedPaneMissing: {Class: repairClassSupportedCommand, Treatment: treatmentTeardownReopen},
+	repairCodeLaunchAgentMismatch: {
+		Class:     repairClassExternalFix,
+		Treatment: "answer the harness first-run dialog in that pane yourself once so the recorded harness becomes observable and `hand reconcile <id>` clears this diagnosis, or " + treatmentTeardownReopen,
+	},
+	repairCodeRunningPaneMissing: {
+		Class:     repairClassSupportedCommand,
+		Treatment: "restore the landing evidence so reconcile can converge this attempt to the lifecycle that evidence proves, or " + treatmentTeardownReopen,
+	},
+	repairCodeRunningPaneIdentityMismatch: {Class: repairClassSupportedCommand, Treatment: treatmentTeardownReopen},
+	repairCodeHerdrOwnershipIncomplete:    {Class: repairClassAttestation, Treatment: treatmentAbandonPane},
+	repairCodeHerdrOwnershipMismatch:      {Class: repairClassSupportedCommand, Treatment: treatmentTeardownReopen},
+	repairCodeWorktreeDirty: {
+		Class:     repairClassExternalFix,
+		Treatment: "commit, push or discard what that worktree holds, then `hand reconcile <id>` clears this diagnosis",
+	},
+	repairCodeWorktreeOwnershipMismatch: {
+		Class:     repairClassSupportedCommand,
+		Treatment: "reconcile relinquishes a historical claim on a path another lease now holds; for the current attempt, " + treatmentTeardownSettleReopen,
+	},
+	repairCodeLegacyWorktreeUnprovable: {Class: repairClassAttestation, Treatment: treatmentAbandonWorktree},
+	repairCodeWorktreeUnobservable:     {Class: repairClassAttestation, Treatment: treatmentAbandonWorktree},
+	repairCodeWorktreeLocalCommits: {
+		Class:     repairClassExternalFix,
+		Treatment: "push those commits, or record the pull request whose head commit holds them, then `hand reconcile <id>` clears this diagnosis",
+	},
+	repairCodeWorktreeCommitSafetyUnknown: {
+		Class:     repairClassExternalFix,
+		Treatment: "restore the named observation in that clone so the comparison can be made, then `hand reconcile <id>` clears this diagnosis",
+	},
+	repairCodeTeardownResourceAmbiguous:  {Class: repairClassAttestation, Treatment: treatmentAbandonPane},
+	repairCodeCompletionEvidenceMismatch: {Class: repairClassExternalFix, Treatment: "restore that attempt's record in the fleet home's state/completions.jsonl, then `hand reconcile <id>` clears this diagnosis"},
+	repairCodeMergeFactMismatch: {
+		Class:     repairClassExternalFix,
+		Treatment: "merge the recorded pull request or branch, or restore the access that makes the merge observable, then `hand reconcile <id>` clears this diagnosis",
+	},
+	stuckStateRunningAttemptNeverStarted: {
+		Class:       repairClassAttestation,
+		Treatment:   treatmentAttemptNeverStarted,
+		Undiagnosed: true,
+	},
 }
 
 // A persisted reason names its own way out, because the reason is what `hand status` and `hand
 // reconcile` show an operator who has nothing else to go on.
 func repairReasonWithTreatment(taskID, code, reason string) string {
-	treatment, found := repairTreatments[code]
+	treatment, found := stuckStateTreatments[code]
 	if !found {
 		return reason + "; no supported treatment is recorded for this diagnosis, which is a defect in Hand rather than a state you can repair"
 	}

--- a/internal/runtime/repair.go
+++ b/internal/runtime/repair.go
@@ -1,0 +1,91 @@
+package runtime
+
+import "strings"
+
+const (
+	repairCodeProvisioningLaunchAmbiguous = "provisioning-launch-ambiguous"
+	repairCodeProvisioningPaneMissing     = "provisioning-pane-missing"
+	repairCodeLaunchSubmittedPaneMissing  = "launch-submitted-pane-missing"
+	repairCodeLaunchAgentMismatch         = "launch-agent-mismatch"
+	repairCodeRunningPaneMissing          = "running-pane-missing"
+	repairCodeRunningPaneIdentityMismatch = "running-pane-identity-mismatch"
+	repairCodeHerdrOwnershipIncomplete    = "herdr-ownership-incomplete"
+	repairCodeHerdrOwnershipMismatch      = "herdr-ownership-mismatch"
+	repairCodeWorktreeDirty               = "worktree-dirty"
+	repairCodeWorktreeOwnershipMismatch   = "worktree-ownership-mismatch"
+	repairCodeLegacyWorktreeUnprovable    = "legacy-worktree-ownership-unprovable"
+	repairCodeWorktreeUnobservable        = "worktree-ownership-unobservable"
+	repairCodeWorktreeLocalCommits        = "worktree-local-commits"
+	repairCodeWorktreeCommitSafetyUnknown = "worktree-commit-safety-unknown"
+	repairCodeTeardownResourceAmbiguous   = "teardown-resource-ambiguous"
+	repairCodeCompletionEvidenceMismatch  = "completion-evidence-mismatch"
+	repairCodeMergeFactMismatch           = "merge-fact-mismatch"
+)
+
+// How a diagnosis ends, from the operator's side of it.
+type repairClass string
+
+const (
+	// A supported hand command leaves the state, without attesting to anything and without changing
+	// the world outside Hand first.
+	repairClassSupportedCommand repairClass = "supported-command"
+	// Ownership can be neither proven nor disproven, so the only way out is an operator attestation
+	// scoped to that one resource, which relinquishes Hand's claim and destroys nothing.
+	repairClassAttestation repairClass = "explicit-supported-attestation"
+	// The diagnosis is about the world outside Hand, so reconciling again is what ends it once that
+	// world is fixed.
+	repairClassExternalFix repairClass = "retryable-after-external-fix"
+)
+
+type repairTreatment struct {
+	Class     repairClass
+	Treatment string
+}
+
+const (
+	treatmentTeardownReopen       = "end this attempt with `hand teardown <id>` (add --force when no worktree is left to inspect), then `hand reconcile <id>` clears this diagnosis and `hand reopen <id>` starts a new attempt"
+	treatmentTeardownSettleReopen = "end this attempt with `hand teardown <id>`, which records the teardown decision even when the recorded lease cannot be released, after which `hand reconcile <id>` settles the recorded claim and clears this diagnosis, and `hand reopen <id>` starts a new attempt"
+	treatmentAbandonWorktree      = "end this attempt with `hand teardown <id>` if it is still active, then `hand reconcile <id> --abandon-worktree` attests that Hand relinquishes the recorded lease, and returns, prunes or deletes nothing"
+	treatmentAbandonPane          = "end this attempt with `hand teardown <id>` if it is still active, then `hand reconcile <id> --abandon-pane` attests that Hand relinquishes the recorded pane identity, and closes no pane, tab or workspace"
+)
+
+// The one enumeration of every repair code Hand can answer with, and of the supported treatment that
+// ends each one. A code missing from here is a diagnosis an operator cannot act on, so the package
+// tests assert this map covers every declared code (atqamz/hand#254).
+var repairTreatments = map[string]repairTreatment{
+	repairCodeProvisioningLaunchAmbiguous: {repairClassSupportedCommand, treatmentTeardownReopen},
+	repairCodeProvisioningPaneMissing: {repairClassSupportedCommand,
+		"reconcile unwinds a launch that persisted no owned resource on its own; while a worktree lease is still recorded, " + treatmentTeardownReopen},
+	repairCodeLaunchSubmittedPaneMissing: {repairClassSupportedCommand, treatmentTeardownReopen},
+	repairCodeLaunchAgentMismatch: {repairClassExternalFix,
+		"answer the harness first-run dialog in that pane yourself once so the recorded harness becomes observable and `hand reconcile <id>` clears this diagnosis, or " + treatmentTeardownReopen},
+	repairCodeRunningPaneMissing: {repairClassSupportedCommand,
+		"restore the landing evidence so reconcile can converge this attempt to the lifecycle that evidence proves, or " + treatmentTeardownReopen},
+	repairCodeRunningPaneIdentityMismatch: {repairClassSupportedCommand, treatmentTeardownReopen},
+	repairCodeHerdrOwnershipIncomplete:    {repairClassAttestation, treatmentAbandonPane},
+	repairCodeHerdrOwnershipMismatch:      {repairClassSupportedCommand, treatmentTeardownReopen},
+	repairCodeWorktreeDirty: {repairClassExternalFix,
+		"commit, push or discard what that worktree holds, then `hand reconcile <id>` clears this diagnosis"},
+	repairCodeWorktreeOwnershipMismatch: {repairClassSupportedCommand,
+		"reconcile relinquishes a historical claim on a path another lease now holds; for the current attempt, " + treatmentTeardownSettleReopen},
+	repairCodeLegacyWorktreeUnprovable: {repairClassAttestation, treatmentAbandonWorktree},
+	repairCodeWorktreeUnobservable:     {repairClassAttestation, treatmentAbandonWorktree},
+	repairCodeWorktreeLocalCommits: {repairClassExternalFix,
+		"push those commits, or record the pull request whose head commit holds them, then `hand reconcile <id>` clears this diagnosis"},
+	repairCodeWorktreeCommitSafetyUnknown: {repairClassExternalFix,
+		"restore the named observation in that clone so the comparison can be made, then `hand reconcile <id>` clears this diagnosis"},
+	repairCodeTeardownResourceAmbiguous:  {repairClassAttestation, treatmentAbandonPane},
+	repairCodeCompletionEvidenceMismatch: {repairClassExternalFix, "restore that attempt's record in the fleet home's state/completions.jsonl, then `hand reconcile <id>` clears this diagnosis"},
+	repairCodeMergeFactMismatch: {repairClassExternalFix,
+		"merge the recorded pull request or branch, or restore the access that makes the merge observable, then `hand reconcile <id>` clears this diagnosis"},
+}
+
+// A persisted reason names its own way out, because the reason is what `hand status` and `hand
+// reconcile` show an operator who has nothing else to go on.
+func repairReasonWithTreatment(taskID, code, reason string) string {
+	treatment, found := repairTreatments[code]
+	if !found {
+		return reason + "; no supported treatment is recorded for this diagnosis, which is a defect in Hand rather than a state you can repair"
+	}
+	return reason + "; " + strings.ReplaceAll(treatment.Treatment, "<id>", taskID)
+}

--- a/internal/runtime/repair_test.go
+++ b/internal/runtime/repair_test.go
@@ -1,0 +1,574 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+// One Herdr fake whose observed agent and workspace presence are settable, so a case can drive exact,
+// absent, mismatched and agent-mismatched ownership from the same client.
+type repairHerdr struct {
+	healthyReconcileHerdr
+	agent  string
+	absent bool
+}
+
+func (f *repairHerdr) FindWorkspaceByLabel(label string) (herdr.Workspace, bool, error) {
+	if f.absent {
+		return herdr.Workspace{}, false, nil
+	}
+	return f.healthyReconcileHerdr.FindWorkspaceByLabel(label)
+}
+
+func (f *repairHerdr) PaneGet(string) (herdr.Pane, error) {
+	agent := f.agent
+	if agent == "" {
+		agent = "claude"
+	}
+	return herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1", Agent: agent}, nil
+}
+
+func repairFixture(t *testing.T, task state.Task, attempt state.Attempt) (string, state.Attempt) {
+	t.Helper()
+	home := reconcileFixture(t)
+	task.ID, task.Project, task.Brief = "task-1", "demo", "data/task-1/brief.md"
+	if task.Kind == "" {
+		task.Kind = state.KindShip
+	}
+	if task.Lifecycle == "" {
+		task.Lifecycle = state.TaskOpen
+	}
+	attempt.TaskID = "task-1"
+	if attempt.Lifecycle == "" {
+		attempt.Lifecycle = state.AttemptProvisioning
+	}
+	if attempt.Harness == "" {
+		attempt.Harness = "claude"
+	}
+	created, err := state.CreateTaskWithAttempt(home, task, attempt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return home, created
+}
+
+// The launch evidence a running Attempt has to carry before state accepts the lifecycle.
+func repairRunningAttempt(worktreePath, leaseID string, ownership state.Herdr) state.Attempt {
+	return state.Attempt{
+		Lifecycle: state.AttemptProvisioning, Worktree: worktreePath, LeaseID: leaseID, Herdr: ownership,
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	}
+}
+
+func repairMarkRunning(t *testing.T, home string, attempt state.Attempt) {
+	t.Helper()
+	if err := state.MarkAttemptRunning(home, attempt.TaskID, attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func repairTeardownDecision(t *testing.T, home string, attempt state.Attempt, terminal state.AttemptLifecycle, disposition string) {
+	t.Helper()
+	if err := state.SetAttemptTeardownDecision(home, attempt.TaskID, attempt.ID, terminal, disposition); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func repairReconcile(t *testing.T, home string, r *Runtime, req ReconcileRequest) {
+	t.Helper()
+	req.Home, req.ID = home, "task-1"
+	if _, err := r.Reconcile(req); err != nil {
+		t.Fatalf("Reconcile(%+v) = %v", req, err)
+	}
+}
+
+// Teardown is the treatment for most diagnoses, and a teardown blocked at the worktree step is still
+// the supported way to record the decision reconcile needs, so a case says which it expects.
+func repairTeardown(t *testing.T, home string, r *Runtime, force bool, wantErr string) {
+	t.Helper()
+	_, err := r.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: force})
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("Teardown() = %v, want the attempt ended", err)
+		}
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("Teardown() = %v, want a refusal containing %q", err, wantErr)
+	}
+}
+
+func repairRuntime(client herdrClient) *Runtime {
+	r := reconcileRuntime(client, nil)
+	r.deps.prMerged = func(context.Context, string) (bool, error) {
+		return false, errors.New("no GitHub access in this test")
+	}
+	r.deps.prHead = func(context.Context, string) (string, error) {
+		return "", errors.New("no GitHub access in this test")
+	}
+	return r
+}
+
+func repairLeaseObservation(r *Runtime, lease worktree.LeaseObservation) {
+	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return lease }
+}
+
+func repairCommitSafety(r *Runtime, state worktree.CommitSafetyState, probe worktree.CommitSafetyProbe) {
+	r.deps.worktree.observeCommits = func(path string) worktree.CommitSafetyObservation {
+		probe.Command, probe.WorkingDir = "git rev-list --count HEAD --not --remotes", path
+		return worktree.CommitSafetyObservation{State: state, Probe: probe}
+	}
+}
+
+// One repair code, driven into durable state and then treated with the supported commands its
+// treatment names. The treatment is what the diagnosis promises an operator, so the way out has to be
+// exercised, not just described.
+type repairPathCase struct {
+	code  string
+	drive func(t *testing.T) (string, *Runtime)
+	treat func(t *testing.T, home string, r *Runtime)
+}
+
+func repairPathCases() []repairPathCase {
+	return []repairPathCase{
+		{
+			code: repairCodeProvisioningLaunchAmbiguous,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, _ := repairFixture(t, state.Task{}, state.Attempt{Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}})
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, false, "")
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeProvisioningPaneMissing,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, _ := repairFixture(t, state.Task{}, state.Attempt{
+					Worktree: "/pool/1", LeaseID: "lease-1", LaunchSubmittedAt: "2026-08-15T00:00:00Z",
+				})
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, true, "")
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeLaunchSubmittedPaneMissing,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, _ := repairFixture(t, state.Task{}, state.Attempt{
+					Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z",
+				})
+				return home, repairRuntime(&repairHerdr{absent: true})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, true, "")
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeLaunchAgentMismatch,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, _ := repairFixture(t, state.Task{}, state.Attempt{
+					Harness: "codex", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+					LaunchSubmittedAt: "2026-08-15T00:00:00Z",
+				})
+				return home, repairRuntime(&repairHerdr{agent: "claude"})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				r.deps.herdr = func() herdrClient { return &repairHerdr{agent: "codex"} }
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeRunningPaneMissing,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{PR: "https://github.com/demo/demo/pull/1"},
+					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}))
+				repairMarkRunning(t, home, attempt)
+				return home, repairRuntime(&repairHerdr{absent: true})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeRunningPaneIdentityMismatch,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{},
+					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-9"}))
+				repairMarkRunning(t, home, attempt)
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, true, "")
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeHerdrOwnershipIncomplete,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1"}))
+				repairMarkRunning(t, home, attempt)
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, true, "")
+				repairReconcile(t, home, r, ReconcileRequest{AbandonPane: true})
+			},
+		},
+		{
+			code: repairCodeHerdrOwnershipMismatch,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, _ := repairFixture(t, state.Task{}, state.Attempt{
+					Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-9"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z",
+				})
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, true, "")
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeWorktreeDirty,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
+				repairMarkRunning(t, home, attempt)
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+				r := repairRuntime(&repairHerdr{})
+				r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Clean, nil }
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeWorktreeOwnershipMismatch,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
+				repairMarkRunning(t, home, attempt)
+				r := repairRuntime(&repairHerdr{})
+				repairLeaseObservation(r, worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-9"})
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairTeardown(t, home, r, true, "prove worktree ownership")
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeLegacyWorktreeUnprovable,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
+				repairMarkRunning(t, home, attempt)
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+				r := repairRuntime(&repairHerdr{})
+				repairLeaseObservation(r, worktree.LeaseObservation{State: worktree.LeaseUnprovable})
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairReconcile(t, home, r, ReconcileRequest{AbandonWorktree: true})
+			},
+		},
+		{
+			code: repairCodeWorktreeUnobservable,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
+				repairMarkRunning(t, home, attempt)
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+				r := repairRuntime(&repairHerdr{})
+				repairLeaseObservation(r, worktree.LeaseObservation{State: worktree.LeaseUnknown, Probe: worktree.LeaseProbe{
+					Command: "treehouse status --json", WorkingDir: "/pool/1", Reason: "treehouse reported no pool entries",
+				}})
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairReconcile(t, home, r, ReconcileRequest{AbandonWorktree: true})
+			},
+		},
+		{
+			code: repairCodeWorktreeLocalCommits,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
+				repairMarkRunning(t, home, attempt)
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+				r := repairRuntime(&repairHerdr{})
+				repairCommitSafety(r, worktree.CommitSafetyLocalOnly, worktree.CommitSafetyProbe{LocalOnly: 2, RemoteRefs: 1})
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairCommitSafety(r, worktree.CommitSafetyRemoteObserved, worktree.CommitSafetyProbe{RemoteRefs: 1})
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeWorktreeCommitSafetyUnknown,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
+				repairMarkRunning(t, home, attempt)
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+				r := repairRuntime(&repairHerdr{})
+				repairCommitSafety(r, worktree.CommitSafetyUnknown, worktree.CommitSafetyProbe{Reason: "resolve worktree HEAD failed"})
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairCommitSafety(r, worktree.CommitSafetyRemoteObserved, worktree.CommitSafetyProbe{RemoteRefs: 1})
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeTeardownResourceAmbiguous,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{},
+					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-9"}))
+				repairMarkRunning(t, home, attempt)
+				repairTeardownDecision(t, home, attempt, state.AttemptCompleted, state.TeardownDispositionCompleted)
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairReconcile(t, home, r, ReconcileRequest{AbandonPane: true})
+			},
+		},
+		{
+			code: repairCodeCompletionEvidenceMismatch,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{}, state.Attempt{LaunchSubmittedAt: "2026-08-15T00:00:00Z"})
+				repairTeardownDecision(t, home, attempt, state.AttemptInterrupted, state.TeardownDispositionForced)
+				for _, next := range []string{state.TeardownCompletionPending, state.TeardownCompletionAppended} {
+					if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptProvisioning, next); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+					t.Fatal(err)
+				}
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				history, err := state.ReadHistoryReadOnly(home, "task-1")
+				if err != nil {
+					t.Fatal(err)
+				}
+				record := completion.Record{
+					ID: "task-1", Project: "demo", Kind: state.KindShip, Outcome: "interrupted",
+					TornDownAt: "2026-08-15T00:00:02Z", AttemptID: history.Attempts[0].ID, AttemptLifecycle: string(state.AttemptInterrupted),
+				}
+				if err := completion.Append(home, record); err != nil {
+					t.Fatal(err)
+				}
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+		{
+			code: repairCodeMergeFactMismatch,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{PR: "https://github.com/demo/demo/pull/1"},
+					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}))
+				repairMarkRunning(t, home, attempt)
+				if err := state.SetTaskMergeAnnounced(home, "task-1"); err != nil {
+					t.Fatal(err)
+				}
+				r := repairRuntime(&repairHerdr{})
+				r.deps.prMerged = func(context.Context, string) (bool, error) { return false, nil }
+				return home, r
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+				repairReconcile(t, home, r, ReconcileRequest{})
+			},
+		},
+	}
+}
+
+// Every diagnosis Hand can answer with is driven into durable state and then out of it again through
+// the commands its treatment names, so no repair code can be reachable without a way out
+// (atqamz/hand#254).
+func TestEveryRepairCodeIsDrivenInAndTreatedOut(t *testing.T) {
+	for _, test := range repairPathCases() {
+		t.Run(test.code, func(t *testing.T) {
+			home, r := test.drive(t)
+			repairReconcile(t, home, r, ReconcileRequest{})
+			history, err := state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Task.RepairCode != test.code {
+				t.Fatalf("repair code = %q (%q), want %q", history.Task.RepairCode, history.Task.RepairReason, test.code)
+			}
+			treatment := repairTreatments[test.code].Treatment
+			if want := strings.ReplaceAll(treatment, "<id>", "task-1"); !strings.Contains(history.Task.RepairReason, want) {
+				t.Fatalf("repair reason = %q, want it to name its treatment %q", history.Task.RepairReason, want)
+			}
+			test.treat(t, home, r)
+			history, err = state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Task.RepairCode != "" {
+				t.Fatalf("repair code after treatment = %q (%q), want the diagnosis cleared", history.Task.RepairCode, history.Task.RepairReason)
+			}
+		})
+	}
+}
+
+// The enumeration itself: a repair code declared in the package but absent from the treatment registry
+// or from the matrix above is a diagnosis with no reachable way out, and fails here rather than in a
+// fleet.
+func TestRepairCodeEnumerationIsComplete(t *testing.T) {
+	declared := declaredRepairCodes(t)
+	if len(declared) == 0 {
+		t.Fatal("no repair codes found in the package source")
+	}
+	covered := map[string]bool{}
+	for _, test := range repairPathCases() {
+		if covered[test.code] {
+			t.Fatalf("repair code %q has more than one matrix case", test.code)
+		}
+		covered[test.code] = true
+	}
+	for name, code := range declared {
+		treatment, found := repairTreatments[code]
+		if !found {
+			t.Fatalf("%s (%q) has no entry in repairTreatments, so an operator who reaches it has nothing to run", name, code)
+		}
+		switch treatment.Class {
+		case repairClassSupportedCommand, repairClassAttestation, repairClassExternalFix:
+		default:
+			t.Fatalf("%s (%q) has class %q, which is none of the three supported treatment classes", name, code, treatment.Class)
+		}
+		if !strings.Contains(treatment.Treatment, "hand ") {
+			t.Fatalf("%s (%q) has treatment %q, which names no hand command", name, code, treatment.Treatment)
+		}
+		if !covered[code] {
+			t.Fatalf("%s (%q) has no case in repairPathCases, so its treatment is described but never exercised", name, code)
+		}
+		delete(covered, code)
+	}
+	for code := range covered {
+		t.Fatalf("repairPathCases covers %q, which no repair code constant declares", code)
+	}
+	for code := range repairTreatments {
+		if !containsDeclaredCode(declared, code) {
+			t.Fatalf("repairTreatments covers %q, which no repair code constant declares", code)
+		}
+	}
+}
+
+func declaredRepairCodes(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	codes := map[string]string{}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, decl := range file.Decls {
+			group, ok := decl.(*ast.GenDecl)
+			if !ok || group.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range group.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, ident := range value.Names {
+					if !strings.HasPrefix(ident.Name, "repairCode") || i >= len(value.Values) {
+						continue
+					}
+					literal, ok := value.Values[i].(*ast.BasicLit)
+					if !ok || literal.Kind != token.STRING {
+						t.Fatalf("%s in %s is not a string literal, so the enumeration cannot be read", ident.Name, name)
+					}
+					codes[ident.Name] = strings.Trim(literal.Value, `"`)
+				}
+			}
+		}
+	}
+	return codes
+}
+
+func containsDeclaredCode(declared map[string]string, code string) bool {
+	for _, candidate := range declared {
+		if candidate == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRepairReasonNamesItsTreatment(t *testing.T) {
+	reason := repairReasonWithTreatment("task-7", repairCodeWorktreeUnobservable, "recorded Treehouse lease was not observed")
+	for _, want := range []string{"recorded Treehouse lease was not observed", "hand reconcile task-7 --abandon-worktree", "returns, prunes or deletes nothing"} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("reason = %q, want it to contain %q", reason, want)
+		}
+	}
+	if strings.Contains(reason, "<id>") {
+		t.Fatalf("reason = %q, want the task ID substituted", reason)
+	}
+	undiagnosed := repairReasonWithTreatment("task-7", "invented-code", "something Hand cannot treat")
+	if !strings.Contains(undiagnosed, "defect in Hand rather than a state you can repair") {
+		t.Fatalf("reason for an unregistered code = %q, want it to name the defect", undiagnosed)
+	}
+}
+
+// Durable state is written through the store, never around it: a test that hand-edited the fleet
+// database or a Treehouse pool file would prove nothing about the commands operators actually run.
+func TestPackageTestsWriteNoDurableStateDirectly(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Split so this guard does not match itself.
+		for _, forbidden := range []string{"hand" + ".db", "treehouse-state" + ".json"} {
+			if strings.Contains(string(body), forbidden) {
+				t.Fatalf("%s mentions %q; runtime tests must drive durable state through internal/state and internal/worktree", filepath.Join(mustWorkingDir(t), entry.Name()), forbidden)
+			}
+		}
+	}
+}
+
+func mustWorkingDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/internal/runtime/repair_test.go
+++ b/internal/runtime/repair_test.go
@@ -132,19 +132,19 @@ func repairCommitSafety(r *Runtime, state worktree.CommitSafetyState, probe work
 	}
 }
 
-// One repair code, driven into durable state and then treated with the supported commands its
-// treatment names. The treatment is what the diagnosis promises an operator, so the way out has to be
-// exercised, not just described.
-type repairPathCase struct {
-	code  string
+// One stuck state, driven into durable state and then treated with the supported commands its
+// treatment names. The treatment is what the enumeration promises an operator, so the way out has to
+// be exercised, not just described.
+type stuckStatePathCase struct {
+	stuck string
 	drive func(t *testing.T) (string, *Runtime)
 	treat func(t *testing.T, home string, r *Runtime)
 }
 
-func repairPathCases() []repairPathCase {
-	return []repairPathCase{
+func stuckStatePathCases() []stuckStatePathCase {
+	return []stuckStatePathCase{
 		{
-			code: repairCodeProvisioningLaunchAmbiguous,
+			stuck: repairCodeProvisioningLaunchAmbiguous,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, _ := repairFixture(t, state.Task{}, state.Attempt{Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}})
 				return home, repairRuntime(&repairHerdr{})
@@ -155,7 +155,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeProvisioningPaneMissing,
+			stuck: repairCodeProvisioningPaneMissing,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, _ := repairFixture(t, state.Task{}, state.Attempt{
 					Worktree: "/pool/1", LeaseID: "lease-1", LaunchSubmittedAt: "2026-08-15T00:00:00Z",
@@ -168,7 +168,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeLaunchSubmittedPaneMissing,
+			stuck: repairCodeLaunchSubmittedPaneMissing,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, _ := repairFixture(t, state.Task{}, state.Attempt{
 					Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z",
@@ -181,7 +181,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeLaunchAgentMismatch,
+			stuck: repairCodeLaunchAgentMismatch,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, _ := repairFixture(t, state.Task{}, state.Attempt{
 					Harness: "codex", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
@@ -195,7 +195,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeRunningPaneMissing,
+			stuck: repairCodeRunningPaneMissing,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{PR: "https://github.com/demo/demo/pull/1"},
 					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}))
@@ -208,7 +208,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeRunningPaneIdentityMismatch,
+			stuck: repairCodeRunningPaneIdentityMismatch,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{},
 					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-9"}))
@@ -221,7 +221,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeHerdrOwnershipIncomplete,
+			stuck: repairCodeHerdrOwnershipIncomplete,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1"}))
 				repairMarkRunning(t, home, attempt)
@@ -233,7 +233,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeHerdrOwnershipMismatch,
+			stuck: repairCodeHerdrOwnershipMismatch,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, _ := repairFixture(t, state.Task{}, state.Attempt{
 					Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-9"}, LaunchSubmittedAt: "2026-08-15T00:00:00Z",
@@ -246,7 +246,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeWorktreeDirty,
+			stuck: repairCodeWorktreeDirty,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
 				repairMarkRunning(t, home, attempt)
@@ -261,7 +261,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeWorktreeOwnershipMismatch,
+			stuck: repairCodeWorktreeOwnershipMismatch,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
 				repairMarkRunning(t, home, attempt)
@@ -275,7 +275,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeLegacyWorktreeUnprovable,
+			stuck: repairCodeLegacyWorktreeUnprovable,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
 				repairMarkRunning(t, home, attempt)
@@ -289,7 +289,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeWorktreeUnobservable,
+			stuck: repairCodeWorktreeUnobservable,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
 				repairMarkRunning(t, home, attempt)
@@ -305,7 +305,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeWorktreeLocalCommits,
+			stuck: repairCodeWorktreeLocalCommits,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
 				repairMarkRunning(t, home, attempt)
@@ -320,7 +320,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeWorktreeCommitSafetyUnknown,
+			stuck: repairCodeWorktreeCommitSafetyUnknown,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, repairRunningAttempt("/pool/1", "lease-1", state.Herdr{}))
 				repairMarkRunning(t, home, attempt)
@@ -335,7 +335,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeTeardownResourceAmbiguous,
+			stuck: repairCodeTeardownResourceAmbiguous,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{},
 					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-9"}))
@@ -348,7 +348,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeCompletionEvidenceMismatch,
+			stuck: repairCodeCompletionEvidenceMismatch,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{}, state.Attempt{LaunchSubmittedAt: "2026-08-15T00:00:00Z"})
 				repairTeardownDecision(t, home, attempt, state.AttemptInterrupted, state.TeardownDispositionForced)
@@ -378,7 +378,7 @@ func repairPathCases() []repairPathCase {
 			},
 		},
 		{
-			code: repairCodeMergeFactMismatch,
+			stuck: repairCodeMergeFactMismatch,
 			drive: func(t *testing.T) (string, *Runtime) {
 				home, attempt := repairFixture(t, state.Task{PR: "https://github.com/demo/demo/pull/1"},
 					repairRunningAttempt("", "", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}))
@@ -395,84 +395,138 @@ func repairPathCases() []repairPathCase {
 				repairReconcile(t, home, r, ReconcileRequest{})
 			},
 		},
+		{
+			stuck: stuckStateRunningAttemptNeverStarted,
+			drive: func(t *testing.T) (string, *Runtime) {
+				home, attempt := repairFixture(t, state.Task{},
+					repairRunningAttempt("/pool/1", "lease-1", state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}))
+				repairMarkRunning(t, home, attempt)
+				return home, repairRuntime(&repairHerdr{})
+			},
+			treat: func(t *testing.T, home string, r *Runtime) {
+				repairReconcile(t, home, r, ReconcileRequest{AttemptNeverStarted: true})
+			},
+		},
 	}
 }
 
-// Every diagnosis Hand can answer with is driven into durable state and then out of it again through
-// the commands its treatment names, so no repair code can be reachable without a way out
-// (atqamz/hand#254).
-func TestEveryRepairCodeIsDrivenInAndTreatedOut(t *testing.T) {
-	for _, test := range repairPathCases() {
-		t.Run(test.code, func(t *testing.T) {
+// Every state a task can be stuck in is driven into durable state and then out of it again through the
+// commands its treatment names, so no stuck state is reachable without a way out (atqamz/hand#254).
+func TestEveryStuckStateIsDrivenInAndTreatedOut(t *testing.T) {
+	for _, test := range stuckStatePathCases() {
+		t.Run(test.stuck, func(t *testing.T) {
+			registered := stuckStateTreatments[test.stuck]
 			home, r := test.drive(t)
 			repairReconcile(t, home, r, ReconcileRequest{})
-			history, err := state.ReadHistory(home, "task-1")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if history.Task.RepairCode != test.code {
-				t.Fatalf("repair code = %q (%q), want %q", history.Task.RepairCode, history.Task.RepairReason, test.code)
-			}
-			treatment := repairTreatments[test.code].Treatment
-			if want := strings.ReplaceAll(treatment, "<id>", "task-1"); !strings.Contains(history.Task.RepairReason, want) {
-				t.Fatalf("repair reason = %q, want it to name its treatment %q", history.Task.RepairReason, want)
+			history := repairHistory(t, home)
+			if registered.Undiagnosed {
+				assertUndiagnosedStuckState(t, history)
+			} else {
+				if history.Task.RepairCode != test.stuck {
+					t.Fatalf("repair code = %q (%q), want %q", history.Task.RepairCode, history.Task.RepairReason, test.stuck)
+				}
+				if want := strings.ReplaceAll(registered.Treatment, "<id>", "task-1"); !strings.Contains(history.Task.RepairReason, want) {
+					t.Fatalf("repair reason = %q, want it to name its treatment %q", history.Task.RepairReason, want)
+				}
 			}
 			test.treat(t, home, r)
-			history, err = state.ReadHistory(home, "task-1")
-			if err != nil {
-				t.Fatal(err)
-			}
+			history = repairHistory(t, home)
 			if history.Task.RepairCode != "" {
-				t.Fatalf("repair code after treatment = %q (%q), want the diagnosis cleared", history.Task.RepairCode, history.Task.RepairReason)
+				t.Fatalf("repair code after treatment = %q (%q), want no diagnosis left", history.Task.RepairCode, history.Task.RepairReason)
+			}
+			if registered.Undiagnosed && history.Task.Lifecycle != state.TaskTerminal {
+				t.Fatalf("task lifecycle after treatment = %q, want %q", history.Task.Lifecycle, state.TaskTerminal)
 			}
 		})
 	}
 }
 
-// The enumeration itself: a repair code declared in the package but absent from the treatment registry
-// or from the matrix above is a diagnosis with no reachable way out, and fails here rather than in a
-// fleet.
-func TestRepairCodeEnumerationIsComplete(t *testing.T) {
-	declared := declaredRepairCodes(t)
-	if len(declared) == 0 {
-		t.Fatal("no repair codes found in the package source")
+func repairHistory(t *testing.T, home string) state.TaskHistory {
+	t.Helper()
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return history
+}
+
+// The dead end that answers nothing: an open task whose attempt still records running, which reconcile
+// leaves exactly as it is because no observation available to it can tell that worker from a live one.
+func assertUndiagnosedStuckState(t *testing.T, history state.TaskHistory) {
+	t.Helper()
+	if history.Task.RepairCode != "" {
+		t.Fatalf("repair code = %q, want this stuck state to emit no diagnosis at all", history.Task.RepairCode)
+	}
+	if history.Task.Lifecycle != state.TaskOpen {
+		t.Fatalf("task lifecycle = %q, want %q", history.Task.Lifecycle, state.TaskOpen)
+	}
+	if len(history.Attempts) != 1 || history.Attempts[0].Lifecycle != state.AttemptRunning {
+		t.Fatalf("attempts = %+v, want one attempt recorded %q", history.Attempts, state.AttemptRunning)
+	}
+}
+
+// The enumeration itself: a repair code or stuck state declared in the package but absent from the
+// treatment registry or from the matrix above is a dead end with no reachable way out, and fails here
+// rather than in a fleet.
+func TestStuckStateEnumerationIsComplete(t *testing.T) {
+	codes, states := declaredConstants(t, "repairCode"), declaredConstants(t, "stuckState")
+	if len(codes) == 0 || len(states) == 0 {
+		t.Fatalf("found %d repair codes and %d stuck states in the package source, want both", len(codes), len(states))
 	}
 	covered := map[string]bool{}
-	for _, test := range repairPathCases() {
-		if covered[test.code] {
-			t.Fatalf("repair code %q has more than one matrix case", test.code)
+	for _, test := range stuckStatePathCases() {
+		if covered[test.stuck] {
+			t.Fatalf("stuck state %q has more than one matrix case", test.stuck)
 		}
-		covered[test.code] = true
+		covered[test.stuck] = true
 	}
-	for name, code := range declared {
-		treatment, found := repairTreatments[code]
-		if !found {
-			t.Fatalf("%s (%q) has no entry in repairTreatments, so an operator who reaches it has nothing to run", name, code)
-		}
-		switch treatment.Class {
-		case repairClassSupportedCommand, repairClassAttestation, repairClassExternalFix:
-		default:
-			t.Fatalf("%s (%q) has class %q, which is none of the three supported treatment classes", name, code, treatment.Class)
-		}
-		if !strings.Contains(treatment.Treatment, "hand ") {
-			t.Fatalf("%s (%q) has treatment %q, which names no hand command", name, code, treatment.Treatment)
-		}
-		if !covered[code] {
-			t.Fatalf("%s (%q) has no case in repairPathCases, so its treatment is described but never exercised", name, code)
-		}
-		delete(covered, code)
+	declared := map[string]string{}
+	for name, value := range codes {
+		assertTreatable(t, name, value, covered, false)
+		declared[value] = name
 	}
-	for code := range covered {
-		t.Fatalf("repairPathCases covers %q, which no repair code constant declares", code)
+	for name, value := range states {
+		assertTreatable(t, name, value, covered, true)
+		declared[value] = name
 	}
-	for code := range repairTreatments {
-		if !containsDeclaredCode(declared, code) {
-			t.Fatalf("repairTreatments covers %q, which no repair code constant declares", code)
+	for value := range covered {
+		if declared[value] == "" {
+			t.Fatalf("stuckStatePathCases covers %q, which no repair code or stuck state constant declares", value)
+		}
+	}
+	for value := range stuckStateTreatments {
+		if declared[value] == "" {
+			t.Fatalf("stuckStateTreatments covers %q, which no repair code or stuck state constant declares", value)
 		}
 	}
 }
 
-func declaredRepairCodes(t *testing.T) map[string]string {
+// One enumerated state has to name a class, name a hand command, be exercised by a matrix case, and
+// agree about whether Hand can diagnose it, because an undiagnosable state reaches its operator only
+// through command help while a diagnosed one carries its treatment in the task row.
+func assertTreatable(t *testing.T, name, value string, covered map[string]bool, undiagnosed bool) {
+	t.Helper()
+	treatment, found := stuckStateTreatments[value]
+	if !found {
+		t.Fatalf("%s (%q) has no entry in stuckStateTreatments, so an operator who reaches it has nothing to run", name, value)
+	}
+	switch treatment.Class {
+	case repairClassSupportedCommand, repairClassAttestation, repairClassExternalFix:
+	default:
+		t.Fatalf("%s (%q) has class %q, which is none of the three supported treatment classes", name, value, treatment.Class)
+	}
+	if !strings.Contains(treatment.Treatment, "hand ") {
+		t.Fatalf("%s (%q) has treatment %q, which names no hand command", name, value, treatment.Treatment)
+	}
+	if treatment.Undiagnosed != undiagnosed {
+		t.Fatalf("%s (%q) records Undiagnosed=%t, want %t for a %s constant", name, value, treatment.Undiagnosed, undiagnosed, name)
+	}
+	if !covered[value] {
+		t.Fatalf("%s (%q) has no case in stuckStatePathCases, so its treatment is described but never exercised", name, value)
+	}
+}
+
+func declaredConstants(t *testing.T, prefix string) map[string]string {
 	t.Helper()
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -500,7 +554,7 @@ func declaredRepairCodes(t *testing.T) map[string]string {
 					continue
 				}
 				for i, ident := range value.Names {
-					if !strings.HasPrefix(ident.Name, "repairCode") || i >= len(value.Values) {
+					if !strings.HasPrefix(ident.Name, prefix) || i >= len(value.Values) {
 						continue
 					}
 					literal, ok := value.Values[i].(*ast.BasicLit)
@@ -513,15 +567,6 @@ func declaredRepairCodes(t *testing.T) map[string]string {
 		}
 	}
 	return codes
-}
-
-func containsDeclaredCode(declared map[string]string, code string) bool {
-	for _, candidate := range declared {
-		if candidate == code {
-			return true
-		}
-	}
-	return false
 }
 
 func TestRepairReasonNamesItsTreatment(t *testing.T) {

--- a/internal/runtime/repair_test.go
+++ b/internal/runtime/repair_test.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -112,12 +111,8 @@ func repairTeardown(t *testing.T, home string, r *Runtime, force bool, wantErr s
 
 func repairRuntime(client herdrClient) *Runtime {
 	r := reconcileRuntime(client, nil)
-	r.deps.prMerged = func(context.Context, string) (bool, error) {
-		return false, errors.New("no GitHub access in this test")
-	}
-	r.deps.prHead = func(context.Context, string) (string, error) {
-		return "", errors.New("no GitHub access in this test")
-	}
+	r.deps.prMerged = unobservedPR("no GitHub access in this test")
+	r.deps.prHead = unobservedPR("no GitHub access in this test")
 	return r
 }
 
@@ -203,7 +198,7 @@ func stuckStatePathCases() []stuckStatePathCase {
 				return home, repairRuntime(&repairHerdr{absent: true})
 			},
 			treat: func(t *testing.T, home string, r *Runtime) {
-				r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+				r.deps.prMerged = observedMergedPR(true)
 				repairReconcile(t, home, r, ReconcileRequest{})
 			},
 		},
@@ -387,11 +382,11 @@ func stuckStatePathCases() []stuckStatePathCase {
 					t.Fatal(err)
 				}
 				r := repairRuntime(&repairHerdr{})
-				r.deps.prMerged = func(context.Context, string) (bool, error) { return false, nil }
+				r.deps.prMerged = observedMergedPR(false)
 				return home, r
 			},
 			treat: func(t *testing.T, home string, r *Runtime) {
-				r.deps.prMerged = func(context.Context, string) (bool, error) { return true, nil }
+				r.deps.prMerged = observedMergedPR(true)
 				repairReconcile(t, home, r, ReconcileRequest{})
 			},
 		},

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -112,6 +112,12 @@ func worktreeCleanupSettled(teardownWorktreeState string) bool {
 	return teardownWorktreeState == state.TeardownResourceReleased || teardownWorktreeState == state.TeardownResourceAbandoned
 }
 
+// Settled covers abandonment as well as release: an attested relinquishment closes the question of
+// what Hand still claims, even though the resource itself was never touched.
+func herdrCleanupSettled(teardownHerdrState string) bool {
+	return teardownHerdrState == state.TeardownResourceReleased || teardownHerdrState == state.TeardownResourceAbandoned
+}
+
 func incompleteHerdrOwnership(ownership state.Herdr) error {
 	if ownership.WorkspaceID == "" && ownership.TabID == "" && ownership.PaneID == "" {
 		return nil

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -172,7 +172,7 @@ func (r *Runtime) releaseHerdr(home, taskID string, attempt state.Attempt, warni
 	if attempt.Herdr.WorkspaceID == "" && attempt.Herdr.TabID == "" && attempt.Herdr.PaneID == "" {
 		return nil
 	}
-	if attempt.TeardownHerdrState == state.TeardownResourceReleased {
+	if herdrCleanupSettled(attempt.TeardownHerdrState) {
 		return nil
 	}
 	if attempt.TeardownHerdrState == state.TeardownResourceReleasing || attempt.TeardownHerdrState == state.TeardownResourceAmbiguous {
@@ -294,6 +294,11 @@ func completionFor(t state.Task, disposition string, launched bool) completion.R
 	case disposition == state.TeardownDispositionNeverLaunched || !launched:
 		c.Outcome = "torn-down"
 		c.Detail = "attempt never launched"
+	// A launch that persisted no owned resource submitted a launch but produced no worker, so every
+	// landing case below would invent a fact about work this attempt never did.
+	case disposition == state.TeardownDispositionProvisioningUnwound:
+		c.Outcome = "torn-down"
+		c.Detail = "provisioning unwound: the launch persisted no owned resource"
 	case disposition == state.TeardownDispositionForced:
 		c.Outcome = "torn-down"
 		c.Detail = "forced (landed-work checks skipped)"

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -294,6 +294,11 @@ func completionFor(t state.Task, disposition string, launched bool) completion.R
 	case disposition == state.TeardownDispositionNeverLaunched || !launched:
 		c.Outcome = "torn-down"
 		c.Detail = "attempt never launched"
+	// A worker that never started produced nothing to land, so this belongs with the cases above
+	// rather than with any outcome that describes work.
+	case disposition == state.TeardownDispositionWorkerNeverStarted:
+		c.Outcome = "torn-down"
+		c.Detail = "worker never started: the harness took no turn before it stopped"
 	// A launch that persisted no owned resource submitted a launch but produced no worker, so every
 	// landing case below would invent a fact about work this attempt never did.
 	case disposition == state.TeardownDispositionProvisioningUnwound:

--- a/internal/runtime/unwind_test.go
+++ b/internal/runtime/unwind_test.go
@@ -1,0 +1,254 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
+)
+
+// A pane whose text and agent come from a file and an environment variable the test controls, so one
+// installed herdr fake serves both a launch that refuses on a first-run dialog and the later launch
+// that confirms.
+func fakeSwitchablePane(t *testing.T, agent string) func(string) {
+	t.Helper()
+	dir := t.TempDir()
+	textFile := filepath.Join(dir, "pane.txt")
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Creates: []faketool.HerdrWorkspace{
+			{ID: "ws-1", Label: "hand:demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: "1", Pane: "pane-1"}}},
+			{ID: "ws-2", Label: "hand:demo", Tabs: []faketool.HerdrTab{{ID: "tab-2", Label: "1", Pane: "pane-2"}}},
+		},
+		PaneAgentEnv: true, PaneReadFileEnv: true, PaneStatus: "idle",
+		KeyLog: filepath.Join(dir, "keys.log"),
+	}.Install(t, bin)
+	t.Setenv("PANE_AGENT", agent)
+	t.Setenv("PANE_TEXT_FILE", textFile)
+	return func(text string) {
+		if err := os.WriteFile(textFile, []byte(text), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// The reconcile runtime with the two dependencies this path has to exercise for real: the Herdr client
+// that talks to the installed fake, and the launch confirmation that reads the pane.
+func unwindRuntime(t *testing.T, returns *int) *Runtime {
+	t.Helper()
+	pool := t.TempDir()
+	r := reconcileRuntime(nil, func(string, string) (worktree.Lease, error) {
+		return worktree.Lease{Path: filepath.Join(pool, "slot-1"), ID: "lease-1"}, nil
+	})
+	r.deps.herdr = newHerdrClient
+	r.deps.confirmLaunch = confirmLaunch
+	r.deps.worktree.returnWorktree = func(string, bool) error { *returns++; return nil }
+	r.deps.worktree.returnWithID = func(string, string, bool) error { *returns++; return nil }
+	return r
+}
+
+// The whole path atqamz/hand#254 exists for, driven only through supported commands: a spawn refused
+// at a first-run dialog hand will not answer, the reconcile that unwinds what it left, and the reopen
+// that spawns the task again.
+func TestSpawnRefusedAtTheTrustPromptUnwindsAndSpawnsAgain(t *testing.T) {
+	useFastLaunchPolling(t)
+	home := executionPlanHome(t, "brief\n")
+	addHarnessToPath(t, harness.Codex)
+	paneText := fakeSwitchablePane(t, harness.Codex)
+	paneText(launchCodexTrustFrame)
+	returns := 0
+	r := unwindRuntime(t, &returns)
+
+	_, err := r.Spawn(context.Background(), SpawnRequest{
+		Home: home, ID: "task-1", Project: "demo", Kind: state.KindShip, Harness: harness.Codex, HarnessFromFlag: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "waiting on the directory trust prompt") {
+		t.Fatalf("Spawn() = %v, want the launch refused at the codex directory trust prompt", err)
+	}
+	failed := readOnlyAttempt(t, home)
+	if failed.Lifecycle != state.AttemptProvisioning || failed.LaunchSubmittedAt == "" || failed.LaunchConfirmedAt != "" ||
+		failed.Worktree != "" || failed.LeaseID != "" || hasHerdrIdentity(failed.Herdr) {
+		t.Fatalf("attempt after the refused launch = %+v, want launch evidence with every acquired resource released", failed)
+	}
+	if returns != 1 {
+		t.Fatalf("worktree returns after the refused launch = %d, want the acquired lease returned once", returns)
+	}
+
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("Reconcile() = %v, want the failed provisioning unwound", err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unwound := history.Attempts[0]
+	if history.Task.Lifecycle != state.TaskTerminal || unwound.Lifecycle != state.AttemptInterrupted ||
+		unwound.TeardownDisposition != state.TeardownDispositionProvisioningUnwound {
+		t.Fatalf("task=%+v attempt=%+v, want a terminal task and an interrupted attempt disposed as provisioning-unwound", history.Task, unwound)
+	}
+	if unwound.Worktree != "" || unwound.LeaseID != "" || hasHerdrIdentity(unwound.Herdr) ||
+		unwound.TeardownWorktreeState != "" || unwound.TeardownHerdrState != "" {
+		t.Fatalf("unwound attempt = %+v, want no ownership claim and no resource state invented by the unwind", unwound)
+	}
+	if returns != 1 {
+		t.Fatalf("worktree returns after the unwind = %d, want the unwind to release nothing of its own", returns)
+	}
+	if unwound.LaunchSubmittedAt != failed.LaunchSubmittedAt || unwound.CreatedAt != failed.CreatedAt || unwound.Ordinal != 1 {
+		t.Fatalf("unwound attempt = %+v, want the refused launch still readable as attempt 1", unwound)
+	}
+	record, found, err := completion.FindAttempt(home, unwound.ID)
+	if err != nil || !found || record.AttemptLifecycle != string(state.AttemptInterrupted) {
+		t.Fatalf("completion record = %+v found=%t err=%v, want the unwound attempt accounted for", record, found, err)
+	}
+
+	paneText("codex ready\n")
+	reopenReq := ReopenRequest{Home: home, ID: "task-1", Harness: harness.Codex, HarnessFromFlag: true}
+	if _, err := r.Reopen(context.Background(), reopenReq); err != nil {
+		t.Fatalf("Reopen() = %v, want the unwound task to spawn again through the supported path", err)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 2 || history.Attempts[0].ID != unwound.ID || history.Attempts[0].Lifecycle != state.AttemptInterrupted {
+		t.Fatalf("history after reopen = %+v, want the unwound attempt kept beside the new one", history.Attempts)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning ||
+		history.ActiveAttempt.Herdr.PaneID == "" || history.ActiveAttempt.Worktree == "" {
+		t.Fatalf("active attempt after reopen = %+v, want a running attempt with its own pane and worktree", history.ActiveAttempt)
+	}
+}
+
+func readOnlyAttempt(t *testing.T, home string) state.Attempt {
+	t.Helper()
+	history, err := state.ReadHistoryReadOnly(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil {
+		t.Fatal("task-1 has no active attempt")
+	}
+	return *history.ActiveAttempt
+}
+
+// The converse of the unwind: every fact that makes unwinding provably safe is a fact reconcile has
+// to check, so a failed launch that did persist a resource is diagnosed instead of unwound.
+func TestReconcileRefusesToUnwindProvisioningThatOwnsAResource(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		attempt  state.Attempt
+		wantCode string
+	}{
+		{
+			name:     "a persisted pane identity",
+			attempt:  state.Attempt{Herdr: state.Herdr{Session: "default", WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}},
+			wantCode: repairCodeLaunchSubmittedPaneMissing,
+		},
+		{
+			name:     "a partial pane identity",
+			attempt:  state.Attempt{Herdr: state.Herdr{WorkspaceID: "ws-1"}},
+			wantCode: repairCodeHerdrOwnershipIncomplete,
+		},
+		{
+			name:     "a recorded worktree lease",
+			attempt:  state.Attempt{Worktree: "/pool/1", LeaseID: "lease-1"},
+			wantCode: repairCodeProvisioningPaneMissing,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := reconcileFixture(t)
+			attempt := test.attempt
+			attempt.TaskID, attempt.Lifecycle, attempt.Harness = "task-1", state.AttemptProvisioning, "claude"
+			attempt.LaunchSubmittedAt = "2026-08-15T00:00:00Z"
+			if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, attempt); err != nil {
+				t.Fatal(err)
+			}
+			r := reconcileRuntime(&missingReconcileHerdr{}, nil)
+			if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+				t.Fatal(err)
+			}
+			history, err := state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Task.RepairCode != test.wantCode || history.Task.Lifecycle != state.TaskOpen ||
+				history.Attempts[0].Lifecycle != state.AttemptProvisioning {
+				t.Fatalf("task=%+v attempt=%+v, want %s recorded without unwinding the attempt", history.Task, history.Attempts[0], test.wantCode)
+			}
+			if err := r.unwindFailedProvisioning(home, history.Task, history.Attempts[0], reconciliationDecision{
+				TerminalAttempt: state.AttemptInterrupted, Disposition: state.TeardownDispositionProvisioningUnwound,
+			}); err == nil || !strings.Contains(err.Error(), "not a launch that left nothing behind") {
+				t.Fatalf("unwindFailedProvisioning() = %v, want a refusal naming what the attempt still records", err)
+			}
+		})
+	}
+}
+
+// The pane attestation is for ownership no observation settles. Where an observation does settle it,
+// reconcile either cleans the pane up or has nothing to relinquish, so the attestation refuses.
+func TestAbandonHistoricalPaneRefusesOwnershipAnObservationSettles(t *testing.T) {
+	for _, observed := range []herdrOwnershipState{herdrOwnershipExact, herdrOwnershipAbsent, herdrOwnershipUnobserved} {
+		t.Run(string(observed), func(t *testing.T) {
+			home := reconcileFixture(t)
+			attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+				TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+				t.Fatal(err)
+			}
+			attempt.Lifecycle = state.AttemptInterrupted
+			r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+			_, _, err = r.abandonHistoricalPane(home, state.Task{ID: "task-1"}, attempt, herdrObservation{State: observed})
+			if err == nil || !strings.Contains(err.Error(), "abandonment is only for ownership neither observation can settle") {
+				t.Fatalf("abandonHistoricalPane(%s) = %v, want a refusal", observed, err)
+			}
+			history, err := state.ReadHistory(home, "task-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if history.Attempts[0].TeardownHerdrState != "" {
+				t.Fatalf("herdr resource state = %q, want a refused attestation to record nothing", history.Attempts[0].TeardownHerdrState)
+			}
+		})
+	}
+}
+
+// No automatic path releases a resource whose ownership cannot be proven: without the attestation the
+// unprovable pane stays claimed, diagnosed, and closed by nobody.
+func TestReconcileLeavesAnUnprovablePaneClaimedWithoutAnAttestation(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptProvisioning, state.AttemptInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	client := &healthyReconcileHerdr{}
+	r := reconcileRuntime(client, nil)
+	for range 2 {
+		if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeTeardownResourceAmbiguous || history.Attempts[0].TeardownHerdrState == state.TeardownResourceAbandoned ||
+		history.Attempts[0].TeardownHerdrState == state.TeardownResourceReleased || client.closed != 0 {
+		t.Fatalf("task=%+v attempt=%+v closed=%d, want the unprovable pane still claimed and untouched", history.Task, history.Attempts[0], client.closed)
+	}
+}

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -132,7 +132,7 @@ func TestListHerdrOwnershipsIncludesLifecycleAndTeardownMetadata(t *testing.T) {
 }
 
 // A latch has to be leavable in both directions: forward to a release once ownership is proven, and
-// sideways to abandonment when an operator attests. Only the worktree can be abandoned.
+// sideways to abandonment when an operator attests, for either resource (atqamz/hand#254).
 func TestSetAttemptTeardownResourceStateLeavesAmbiguousBothWays(t *testing.T) {
 	for _, test := range []struct {
 		name     string
@@ -144,7 +144,9 @@ func TestSetAttemptTeardownResourceStateLeavesAmbiguousBothWays(t *testing.T) {
 		{name: "worktree is abandonable", resource: "worktree", next: TeardownResourceAbandoned},
 		{name: "worktree cannot skip to released", resource: "worktree", next: TeardownResourceReleased, wantErr: store.ErrLifecycleConflict},
 		{name: "herdr resumes releasing", resource: "herdr", next: TeardownResourceReleasing},
-		{name: "herdr is not abandonable", resource: "herdr", next: TeardownResourceAbandoned, wantErr: store.ErrInvalidTransition},
+		{name: "herdr is abandonable", resource: "herdr", next: TeardownResourceAbandoned},
+		{name: "herdr cannot skip to released", resource: "herdr", next: TeardownResourceReleased, wantErr: store.ErrLifecycleConflict},
+		{name: "neither resource takes an unknown state", resource: "herdr", next: "relinquished", wantErr: store.ErrInvalidTransition},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			home := t.TempDir()

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -84,4 +84,5 @@ const (
 	TeardownDispositionLaunchedProvisioning = store.TeardownDispositionLaunchedProvisioning
 	TeardownDispositionWorkerExitedUnlanded = store.TeardownDispositionWorkerExitedUnlanded
 	TeardownDispositionProvisioningUnwound  = store.TeardownDispositionProvisioningUnwound
+	TeardownDispositionWorkerNeverStarted   = store.TeardownDispositionWorkerNeverStarted
 )

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -83,4 +83,5 @@ const (
 	TeardownDispositionNeverLaunched        = store.TeardownDispositionNeverLaunched
 	TeardownDispositionLaunchedProvisioning = store.TeardownDispositionLaunchedProvisioning
 	TeardownDispositionWorkerExitedUnlanded = store.TeardownDispositionWorkerExitedUnlanded
+	TeardownDispositionProvisioningUnwound  = store.TeardownDispositionProvisioningUnwound
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -128,6 +128,7 @@ const (
 	TeardownDispositionNeverLaunched        = "never-launched"
 	TeardownDispositionLaunchedProvisioning = "launched-provisioning"
 	TeardownDispositionWorkerExitedUnlanded = "worker-exited-unlanded"
+	TeardownDispositionProvisioningUnwound  = "provisioning-unwound"
 )
 
 type Task struct {
@@ -2119,9 +2120,6 @@ func (db *DB) SetAttemptTeardownResourceState(taskID string, attemptID int64, ex
 	}
 	if next != TeardownResourceReleasing && next != TeardownResourceReleased && next != TeardownResourceAmbiguous && next != TeardownResourceRetryable && next != TeardownResourceAbandoned {
 		return fmt.Errorf("%w: unknown teardown resource state %q", ErrInvalidTransition, next)
-	}
-	if next == TeardownResourceAbandoned && resource != "worktree" {
-		return fmt.Errorf("%w: teardown resource %q cannot be abandoned", ErrInvalidTransition, resource)
 	}
 	currentAllowed := "''"
 	switch next {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -129,6 +129,7 @@ const (
 	TeardownDispositionLaunchedProvisioning = "launched-provisioning"
 	TeardownDispositionWorkerExitedUnlanded = "worker-exited-unlanded"
 	TeardownDispositionProvisioningUnwound  = "provisioning-unwound"
+	TeardownDispositionWorkerNeverStarted   = "worker-never-started"
 )
 
 type Task struct {


### PR DESCRIPTION
## Summary

- Every `repair_code` the runtime can emit now has an entry in `stuckStateTreatments` (`internal/runtime/repair.go`) naming the supported commands that leave it, and the persisted `repair_reason` carries that treatment with the task ID substituted, so a refusal and its way out cannot drift apart. Three codes previously had no reachable exit at all.
- Reconcile unwinds a provisioning attempt when the facts prove no resource is at stake (still provisioning, no Herdr identity ever persisted, no worktree lease recorded, no teardown decision taken): it converges the attempt to `interrupted` under the new disposition `provisioning-unwound`, releases nothing, claims no ownership, keeps the attempt and its history readable, and `hand reopen` spawns the task again through the ordinary path.
- `hand reconcile <id> --abandon-pane` relinquishes a recorded pane identity whose ownership no observation can settle, taking the shape `--abandon-worktree` established: explicit task ID, refuses any ownership an observation proves or disproves, runs no Herdr command, closes no pane, tab or workspace.
- `hand reconcile <id> --attempt-never-started` is the exit for the dead end that emits no diagnosis at all: a running attempt whose harness stopped before its first turn. It records the honest teardown decision `worker-never-started` and releases nothing itself, so every resource guard still applies.

Closes atqamz/hand#254

## The audit

Eighteen entries, one per reachable stuck state, each classified by what the operator must supply rather than by how Hand implements the exit, because that is the distinction someone reading a refusal has to make: run a command, assert a fact only they can establish, or change something outside Hand first.

The enumeration is of stuck states, not of repair codes. A dead end that answers nothing is the worst member of that set rather than outside it, so `stuckStateTreatments` covers a state Hand cannot diagnose too, marked `Undiagnosed` because it has no task row to carry its treatment and reaches the operator through `hand reconcile --help` instead.

`supported-command` (an ordinary `hand` command leaves the state, attesting to nothing):

| code | treatment |
| --- | --- |
| `provisioning-launch-ambiguous` | `hand teardown`, then `hand reconcile`, then `hand reopen` |
| `provisioning-pane-missing` | reconcile unwinds it when nothing was persisted; teardown and reopen when a lease is recorded |
| `launch-submitted-pane-missing` | `hand teardown --force`, then reconcile, then reopen |
| `running-pane-missing` | restore the landing evidence so reconcile converges the attempt, or teardown and reopen |
| `running-pane-identity-mismatch` | `hand teardown --force`, then reconcile, then reopen |
| `herdr-ownership-mismatch` | `hand teardown`, which closes the recorded tab for any complete identity, then reconcile, then reopen |
| `worktree-ownership-mismatch` | reconcile relinquishes a historical claim on a path another lease provably holds; teardown records the decision for the active attempt |

`explicit-supported-attestation` (the fact at issue is neither provable nor disprovable, so only an operator can end it, scoped to that one fact):

| state | treatment |
| --- | --- |
| `herdr-ownership-incomplete` | `hand reconcile <id> --abandon-pane` |
| `teardown-resource-ambiguous` | `hand reconcile <id> --abandon-pane` |
| `legacy-worktree-ownership-unprovable` | `hand reconcile <id> --abandon-worktree` |
| `worktree-ownership-unobservable` | `hand reconcile <id> --abandon-worktree` |
| `running-attempt-never-started` (no diagnosis) | `hand reconcile <id> --attempt-never-started`, then reopen |

`retryable-after-external-fix` (the contradiction is about the world outside Hand):

| code | treatment |
| --- | --- |
| `launch-agent-mismatch` | answer the harness first-run dialog in that pane once so the recorded harness becomes observable, then reconcile |
| `worktree-dirty` | commit, push or discard what the worktree holds, then reconcile |
| `worktree-local-commits` | push the commits, or record the PR whose head holds them, then reconcile |
| `worktree-commit-safety-unknown` | restore the named observation in that clone, then reconcile |
| `completion-evidence-mismatch` | restore the attempt's record in `state/completions.jsonl`, then reconcile |
| `merge-fact-mismatch` | merge the recorded PR or branch, or restore the access that makes the merge observable, then reconcile |

I kept the three classes the issue suggested. The one reclassification worth naming is `herdr-ownership-mismatch`, which reads like an attestation case and is not: `releaseHerdr` closes the recorded tab whenever the identity is complete, without requiring proven ownership, so a plain teardown settles an active mismatch. Only the two codes where teardown latches `ambiguous` and stops need the pane attestation.

The enumeration is a test, not a convention. `TestStuckStateEnumerationIsComplete` parses this package's own source for `repairCode` and `stuckState` constants, so a new one declared without a treatment, without one of the three classes, disagreeing about whether Hand can diagnose it, or without a matrix case that drives a task into it and back out, fails the suite. Verified by temporarily declaring an untreated code: the suite failed with `repairCodeProbeUntreated ("probe-untreated") has no entry in stuckStateTreatments`.

## What was unreachable before

- A historical attempt whose Herdr identity is incomplete latched `teardown_herdr_state = ambiguous` during teardown and then answered `teardown-resource-ambiguous` forever: `herdrCleanupSettled` accepted only `released`, teardown's release path returned early on `ambiguous`, and `SetAttemptTeardownResourceState` refused `abandoned` for any resource other than the worktree. The pane resource had no terminal state any command could reach.
- `legacy-worktree-ownership-unprovable` named no gesture, because `--abandon-worktree` accepted `LeaseUnknown` alone.
- `provisioning-pane-missing` on a launch that persisted nothing exited only through `hand teardown --force`, which records "landed-work checks skipped" about an attempt that produced no work.
- A running attempt whose worker took no turn had no exit and no diagnosis. Nothing contradicts anything in that state, so reconcile reports healthy, teardown refuses because it can find no landed work, and `--force` was the only way out, recording the same dishonest disposition. The new attestation records `worker-never-started` instead, whose completion record reads "worker never started: the harness took no turn before it stopped".

## The dead end that answers nothing

Durable state cannot tell a worker that stopped before its first turn from one that is thinking: the pane exists, the worktree is clean, the launch was confirmed. Observing that the worker is dead is atqamz/hand#255's job, not this PR's, so the exit here is an operator attestation rather than a diagnosis.

The attestation is deliberately not a release. It records the teardown decision and stops; the existing historical-release path then closes the pane and returns the worktree under its own unchanged guards, so an unprovable pane, a dirty worktree or a local-only commit is still refused and still diagnosed with a treatment of its own. It refuses whenever anything on record disproves the assertion: a report line, a recorded pull request, merge or delivery, a reported state, a dirty worktree, or a commit no remote-tracking ref reaches. It does not refuse an unobservable worktree, because recording a decision destroys nothing and refusing there would replace one dead end with another.

Registering the treatment before the diagnosis exists is the point: once atqamz/hand#255 lands the observation, reconcile can emit a code whose way out is already enumerated and tested.

## Safety

Refusals did not get weaker. Unknown and unproven ownership still authorize no destructive cleanup (atqamz/hand#245), and no attempt becomes terminal in a way that makes its own cleanup unreachable (atqamz/hand#239, whose converse this is).

- Both resource attestations relinquish only Hand's claim. Neither runs a Treehouse or Herdr command, and each refuses every ownership state an observation can prove or disprove, on every route into it.
- The attempt attestation is not a resource gesture at all: it records a teardown decision and releases nothing, so it cannot become a way around a resource guard. Every release it leads to happens through the unchanged path, with the unchanged refusals.
- `--abandon-worktree` now also accepts `LeaseUnprovable` alongside `LeaseUnknown`. That is the same unsettleable category rather than a weakening: a recorded worktree with no comparable lease identity offers nothing for a later observation to compare, so no future reconcile can prove or disprove the claim. `LeaseExact`, `LeaseAbsent` and `LeaseMismatch` stay refused. `docs/adr/every-diagnosis-names-a-reachable-treatment.md` names `docs/adr/unobservable-ownership-is-not-a-mismatch.md` and records the extension, per that directory's convention for later changes.
- A reconcile-driven terminalization now clears a usage-limit hold, as `hand teardown` already did. A hold that outlived the attempt it paused made `hand reopen` refuse on a task reconcile had just ended, which is the same "terminal with its own next step unreachable" shape atqamz/hand#239 removed. The already-settled path clears it too, so a retry after a failed clear converges instead of freezing once the lifecycle looks settled.
- The unwind refuses by name when any of its four facts is absent, so it cannot reach an attempt that owns something, and it invents no pane identity, lease or resource state.
- A path Treehouse provably reports under a different lease is relinquished rather than diagnosed forever, without an attestation, because a disproven claim was never that attempt's to return.

## The live fixtures

`hand-pr-metadata-ownership` is the shape the attestation above exists for: task open, attempt 1 running, its codex harness stopped by a usage limit before its first turn, no diagnosis emitted, and no command that gives it an honest exit. `hand reconcile <id> --attempt-never-started` is that exit. Deciding that the worker is in fact dead needs the observation atqamz/hand#255 owns; asserting it is the operator's call today.

`nsr-gesture-display`: the mechanism it needs lands here. It sits at `teardown-resource-ambiguous`, which is now treated by `hand reconcile <id> --abandon-pane`: its work merged in yes2games/nsr#3036, its worktree is already recycled, it holds no unpushed commits, and pane ownership is the only thing left unprovable, which is exactly the attestation's domain.

Running either command against a live fleet task is not part of this PR. This branch was developed entirely against the test suite and the repository's fakes, and both fleet tasks stay untouched.

## Test plan

- `internal/runtime/unwind_test.go` drives a real spawn to failure at a harness first-run trust prompt through the installed fakes, with no manual state edit anywhere, then asserts durable state across the whole path: the attempt is provisioning with launch evidence and no owned resource, reconcile converges it to `interrupted` under `provisioning-unwound` without inventing a pane identity, lease or resource state, the lease return count does not change, the unwound attempt stays readable through the read-only history and its completion record, and `hand reopen` then produces a second running attempt with its own pane and worktree while attempt 1 stays as it was.
- The converse: a provisioning failure that persisted a complete pane identity, a partial identity, or a worktree lease is diagnosed rather than unwound, and `unwindFailedProvisioning` refuses each by name.
- `internal/runtime/repair_test.go` drives all seventeen codes into durable state, asserts the persisted reason names its treatment, and treats each one back out through the commands that treatment names. The undiagnosed stuck state is in the same matrix, asserting first that reconcile emits no diagnosis and leaves the task open with a running attempt, and then that the attestation makes it terminal. Plus the enumeration test above, and a guard that no test file in `internal/runtime` names the fleet database or a Treehouse pool file.
- `internal/runtime/neverstarted_test.go` spawns a task to a running attempt through the installed fakes, shows plain reconcile leaving it running, then attests: the attempt ends interrupted under `worker-never-started`, both resources reach `released` through the ordinary path, the lease is returned exactly once, the completion record claims no outcome about work, and `hand reopen` produces attempt 2 with attempt 1 unchanged. Six refusals cover a report line, a recorded pull request, a dirty worktree, local-only commits, a lifecycle other than running, and an already-recorded teardown decision, each asserting that nothing is written on refusal.
- The pane attestation refuses `herdrOwnershipExact`, `Absent` and `Unobserved` and records no resource state, and without the attestation an unprovable pane claim stays claimed, stays diagnosed, and is closed by nobody.
- `cmd/reconcile_test.go` covers both attestation flags refusing a fleet-wide sweep, and the pane attestation appearing in the reconcile output.
- The hold: the never-started path asserts a live usage-limit hold is gone once reconcile ends the attempt and that `hand reopen` then succeeds, and `internal/runtime/reconcile_test.go` covers the retry shape where the attempt already sits at its recorded terminal lifecycle and the hold is still there.
- Full sweep from the worktree: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...`, `make lint`, `make contract`, `make e2e`, `nix flake check`, `git diff --check`.
- One change here belongs to nothing above: `cmd/watch_test.go`'s `TestWatchMapsContextCancelToInterruption` failed on `Test (windows-latest)` at `cb0fc25` on a 2s deadline for two round trips through a real spawned Herdr process. The deadline is now 10s. It is a pre-existing flake this branch neither caused nor touches otherwise, kept because CI has to be green at the head under review.
