### PR TITLE
fix(project): preserve operator-owned pull request metadata

### DIFF
--- a/cmd/deliver.go
+++ b/cmd/deliver.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -53,6 +54,12 @@ func newDeliverCmd() *cobra.Command {
 			}
 			t.DeliveredAt = deliveredAt
 			t.DeliveredReason = reason
+
+			if t.PR != "" {
+				if err := project.ReassertPRMetadata(cmd.Context(), home, t.PR); err != nil {
+					return fmt.Errorf("reassert operator-owned PR metadata: %w", err)
+				}
+			}
 
 			var doc axi.Doc
 			doc.Field("id", id)

--- a/cmd/deliver_test.go
+++ b/cmd/deliver_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -92,4 +95,61 @@ func TestDeliverRefusesWhenTaskMissing(t *testing.T) {
 	cmd := newDeliverCmd()
 	cmd.SetArgs([]string{"missing-task", "--reason", "whatever"})
 	assertExitCode3(t, cmd.Execute())
+}
+
+func TestDeliverReassertsPRMetadataWhenAPRIsRecorded(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	url := "https://github.com/owner/secondhand/pull/1"
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, PR: url}); err != nil {
+		t.Fatal(err)
+	}
+	faketool.GH{PRs: []faketool.GHPR{{URL: url, State: "OPEN", Body: "operator wrote this"}}}.Install(t, faketool.Bin(t))
+
+	cmd := newDeliverCmd()
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetArgs([]string{"task-1", "--reason", "PR ready for review"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, observation := ghutil.FetchPRMetadata(context.Background(), url)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the recorded PR found", observation)
+	}
+	operatorBody, _, ok := ghutil.SplitBody(meta.Body)
+	if !ok {
+		t.Fatalf("body = %q, want hand deliver to have established a pipeline region", meta.Body)
+	}
+	if operatorBody != "operator wrote this" {
+		t.Fatalf("operator body = %q, want the original content preserved", operatorBody)
+	}
+}
+
+func TestDeliverPropagatesAReassertMetadataFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	url := "https://github.com/owner/secondhand/pull/1"
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, PR: url}); err != nil {
+		t.Fatal(err)
+	}
+	// No gh at all, fake or real, so reasserting the recorded PR's metadata fails deterministically.
+	faketool.NoTools(t)
+
+	cmd := newDeliverCmd()
+	cmd.SetArgs([]string{"task-1", "--reason", "PR ready for review"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "reassert operator-owned PR metadata") {
+		t.Fatalf("got %v, want the reassert failure to propagate", err)
+	}
+
+	got, readErr := state.Read(home, "task-1")
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got.DeliveredReason != "PR ready for review" {
+		t.Fatalf("DeliveredReason = %q, want the delivery recorded even though reasserting its PR metadata failed", got.DeliveredReason)
+	}
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/runtime"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
@@ -37,6 +38,9 @@ func newPRCmd() *cobra.Command {
 			task, reconcile, err := recordPR(cmd.Context(), fleetHome, task, url)
 			if err != nil {
 				return err
+			}
+			if err := project.ReassertPRMetadata(cmd.Context(), fleetHome, url); err != nil {
+				return fmt.Errorf("reassert operator-owned PR metadata: %w", err)
 			}
 			result := "recorded"
 			if reconcile {

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/runtime"
 	"github.com/atqamz/hand/internal/state"
@@ -51,6 +52,18 @@ func writeFakeGhPRView(t *testing.T, exitCode int) {
 func writeFakeGhPRViewResponse(t *testing.T, response faketool.GHResponse) {
 	t.Helper()
 	faketool.GH{Responses: []faketool.GHResponse{response}}.Install(t, faketool.Bin(t))
+}
+
+// Backs a successful `hand pr` recording with a real per-PR fake, not just a canned "pr view"
+// response: recording also reasserts operator-owned metadata, which needs pr edit and pr ready
+// to resolve against something, not just answer state.
+func installFakeGhPRs(t *testing.T, urls ...string) {
+	t.Helper()
+	prs := make([]faketool.GHPR, len(urls))
+	for i, url := range urls {
+		prs[i] = faketool.GHPR{URL: url, State: "OPEN"}
+	}
+	faketool.GH{PRs: prs}.Install(t, faketool.Bin(t))
 }
 
 func setupPRHome(t *testing.T) (home, clonePath string) {
@@ -110,10 +123,12 @@ func TestPRReconcilesWhenSameURLAlreadyRecorded(t *testing.T) {
 	home, _ := setupPRHome(t)
 	url := "https://github.com/a/b/pull/1"
 	// The project is deliberately unregistered: reaching validation would exit 3, so passing also proves it
-	// is skipped for a URL already on record.
+	// is skipped for a URL already on record. Reasserting metadata does not depend on project
+	// registration, so it still runs and still needs a PR to resolve against.
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "unregistered", PR: url}); err != nil {
 		t.Fatal(err)
 	}
+	installFakeGhPRs(t, url)
 
 	cmd := newPRCmd()
 	var out bytes.Buffer
@@ -259,9 +274,9 @@ func TestPRAcceptsTheDeclaredUpstreamAndStillRefusesAnyOtherRepo(t *testing.T) {
 	if err := state.Write(home, state.Task{ID: "task-2", Project: "demo"}); err != nil {
 		t.Fatal(err)
 	}
-	writeFakeGhPRView(t, 0)
-
 	upstreamPR := "https://github.com/kunchenguid/no-mistakes/pull/597"
+	installFakeGhPRs(t, upstreamPR)
+
 	cmd := newPRCmd()
 	cmd.SetArgs([]string{"task-1", upstreamPR})
 	if err := cmd.Execute(); err != nil {
@@ -310,9 +325,10 @@ func TestPRAcceptsCanonicalCasingForDifferentlyCasedRemoteAndUpstream(t *testing
 			t.Fatal(err)
 		}
 	}
-	writeFakeGhPRView(t, 0)
-
 	own := "https://github.com/atqamz/no-mistakes/pull/31"
+	upstreamPR := "https://github.com/kunchenguid/no-mistakes/pull/597"
+	installFakeGhPRs(t, own, upstreamPR)
+
 	cmd := newPRCmd()
 	cmd.SetArgs([]string{"task-1", own})
 	if err := cmd.Execute(); err != nil {
@@ -326,7 +342,6 @@ func TestPRAcceptsCanonicalCasingForDifferentlyCasedRemoteAndUpstream(t *testing
 		t.Fatalf("task.PR = %q, want %q", task.PR, own)
 	}
 
-	upstreamPR := "https://github.com/kunchenguid/no-mistakes/pull/597"
 	up := newPRCmd()
 	up.SetArgs([]string{"task-2", upstreamPR})
 	if err := up.Execute(); err != nil {
@@ -440,7 +455,7 @@ func TestPRRecordsSuccessfully(t *testing.T) {
 	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
 		t.Fatal(err)
 	}
-	writeFakeGhPRView(t, 0)
+	installFakeGhPRs(t, "https://github.com/owner/secondhand/pull/1")
 
 	cmd := newPRCmd()
 	var out bytes.Buffer
@@ -459,5 +474,66 @@ func TestPRRecordsSuccessfully(t *testing.T) {
 	}
 	if task.PR != "https://github.com/owner/secondhand/pull/1" {
 		t.Fatalf("task.PR = %q, want the URL recorded", task.PR)
+	}
+}
+
+func TestPREstablishesAPipelineRegionOnTheLiveBody(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/owner/secondhand.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/owner/secondhand.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	url := "https://github.com/owner/secondhand/pull/1"
+	faketool.GH{PRs: []faketool.GHPR{{URL: url, State: "OPEN", Body: "operator wrote this"}}}.Install(t, faketool.Bin(t))
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", url})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, observation := ghutil.FetchPRMetadata(context.Background(), url)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the recorded PR found", observation)
+	}
+	operatorBody, _, ok := ghutil.SplitBody(meta.Body)
+	if !ok {
+		t.Fatalf("body = %q, want hand pr to have established a pipeline region", meta.Body)
+	}
+	if operatorBody != "operator wrote this" {
+		t.Fatalf("operator body = %q, want the original content preserved", operatorBody)
+	}
+}
+
+func TestPRPropagatesAReassertMetadataFailure(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/owner/secondhand.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/owner/secondhand.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	// This view response answers validation but registers no PR for the fake to resolve the
+	// edit that establishing a pipeline region needs against, so reasserting fails after
+	// recordPR has already succeeded.
+	writeFakeGhPRView(t, 0)
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "https://github.com/owner/secondhand/pull/1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "reassert operator-owned PR metadata") {
+		t.Fatalf("got %v, want the reassert failure to propagate", err)
+	}
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != "https://github.com/owner/secondhand/pull/1" {
+		t.Fatalf("task.PR = %q, want the URL recorded even though reasserting its metadata failed", task.PR)
 	}
 }

--- a/internal/faketool/gh.go
+++ b/internal/faketool/gh.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -13,7 +14,9 @@ import (
 	"time"
 )
 
-// GHPR describes one pull request and the checks its fake reports.
+// GHPR describes one pull request and the checks its fake reports. Body, Assignees, Draft,
+// Labels, Milestone and Reviewers are its initial operator-owned metadata; pr edit and pr ready
+// mutate a separate per-PR state file from there, the same way State does for merge/close.
 type GHPR struct {
 	Number     int
 	URL        string
@@ -23,6 +26,23 @@ type GHPR struct {
 	HeadRepo   string
 	HeadRefOid string
 	Checks     []string
+	Body       string
+	Assignees  []string
+	Draft      bool
+	Labels     []string
+	Milestone  string
+	Reviewers  []string
+}
+
+// The mutable half of a pull request's metadata: everything pr edit and pr ready can change,
+// stored apart from State so a merge/close and a metadata edit never race on the same file.
+type ghPRMetadataState struct {
+	Body      string   `json:"body"`
+	Assignees []string `json:"assignees"`
+	Draft     bool     `json:"draft"`
+	Labels    []string `json:"labels"`
+	Milestone string   `json:"milestone"`
+	Reviewers []string `json:"reviewers"`
 }
 
 type GHRepo struct {
@@ -103,6 +123,20 @@ func (g GH) Install(t *testing.T, bin string) {
 		} else if err != nil {
 			t.Fatal(err)
 		}
+		metaPath := ghMetadataPath(state, i)
+		if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+			meta := ghPRMetadataState{
+				Body: pr.Body, Assignees: pr.Assignees, Draft: pr.Draft,
+				Labels: pr.Labels, Milestone: pr.Milestone, Reviewers: pr.Reviewers,
+			}
+			data, err := json.Marshal(meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, metaPath, string(data))
+		} else if err != nil {
+			t.Fatal(err)
+		}
 	}
 	spec := ghSpec{
 		PRs: g.PRs, Repos: g.Repos, Release: g.Release, Responses: g.Responses,
@@ -173,6 +207,10 @@ func runGHFromPayload(payload json.RawMessage, args []string) int {
 		return ghRepoView(spec, args)
 	case "pr view":
 		return ghPRView(spec, args)
+	case "pr edit":
+		return ghPREdit(spec, args)
+	case "pr ready":
+		return ghPRReady(spec, args)
 	case "pr list":
 		return ghPRList(spec, args)
 	case "pr checks":
@@ -214,18 +252,197 @@ func ghPRView(spec ghSpec, args []string) int {
 	if !ok {
 		return ghNoSuchPR(args[2])
 	}
-	switch flagValue(args, "--json") {
-	case "headRefOid":
-		_, _ = fmt.Fprintf(os.Stdout, "{\"headRefOid\":%s}\n", jsonQuote(spec.PRs[index].HeadRefOid))
-		return 0
-	default:
-		state, err := os.ReadFile(ghStatePath(spec.StateDir, index))
-		if err != nil {
-			return fail("read gh pull request state: %v", err)
-		}
-		_, _ = fmt.Fprintf(os.Stdout, "{\"state\":%s}\n", jsonQuote(strings.TrimSpace(string(state))))
-		return 0
+	prState, err := os.ReadFile(ghStatePath(spec.StateDir, index))
+	if err != nil {
+		return fail("read gh pull request state: %v", err)
 	}
+	meta, err := ghReadMetadata(spec.StateDir, index)
+	if err != nil {
+		return fail("read gh pull request metadata: %v", err)
+	}
+	values := map[string]string{
+		"state":                   jsonQuote(strings.TrimSpace(string(prState))),
+		"headRefOid":              jsonQuote(spec.PRs[index].HeadRefOid),
+		"body":                    jsonQuote(meta.Body),
+		"isDraft":                 strconv.FormatBool(meta.Draft),
+		"assignees":               ghLoginArray(meta.Assignees),
+		"labels":                  ghLabelArray(meta.Labels),
+		"milestone":               ghMilestoneValue(meta.Milestone),
+		"reviewRequests":          ghLoginArray(meta.Reviewers),
+		"closingIssuesReferences": ghClosingIssuesReferences(meta.Body),
+	}
+	fields := strings.Split(flagValue(args, "--json"), ",")
+	var out strings.Builder
+	out.WriteByte('{')
+	for i, field := range fields {
+		value, known := values[field]
+		if !known {
+			return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+		}
+		if i > 0 {
+			out.WriteByte(',')
+		}
+		fmt.Fprintf(&out, "%s:%s", jsonQuote(field), value)
+	}
+	out.WriteByte('}')
+	_, _ = fmt.Fprintln(os.Stdout, out.String())
+	return 0
+}
+
+// Modeled from gh's documented pr edit flags, not an observed transcript: editing a pull
+// request's operator-owned metadata is exactly what contract-live's live gh lane refuses to
+// exercise (FIDELITY.md), so there is no real-tool run to record here.
+func ghPREdit(spec ghSpec, args []string) int {
+	if len(args) < 3 {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	index, ok := ghPRIndex(spec.PRs, args[2])
+	if !ok {
+		return ghNoSuchPR(args[2])
+	}
+	meta, err := ghReadMetadata(spec.StateDir, index)
+	if err != nil {
+		return fail("read gh pull request metadata: %v", err)
+	}
+	if body, present := flagValuePresent(args, "--body"); present {
+		meta.Body = body
+	}
+	meta.Assignees = applySetFlags(meta.Assignees, flagValues(args, "--add-assignee"), flagValues(args, "--remove-assignee"))
+	meta.Labels = applySetFlags(meta.Labels, flagValues(args, "--add-label"), flagValues(args, "--remove-label"))
+	meta.Reviewers = applySetFlags(meta.Reviewers, flagValues(args, "--add-reviewer"), flagValues(args, "--remove-reviewer"))
+	if milestone, present := flagValuePresent(args, "--milestone"); present {
+		meta.Milestone = milestone
+	}
+	if hasFlag(args, "--remove-milestone") {
+		meta.Milestone = ""
+	}
+	if err := ghWriteMetadata(spec.StateDir, index, meta); err != nil {
+		return fail("write gh pull request metadata: %v", err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n", spec.PRs[index].URL)
+	return 0
+}
+
+// Modeled from gh's documented pr ready flags for the same reason ghPREdit is: a draft/ready
+// toggle changes what an operator owns, so contract-live never runs it for real.
+func ghPRReady(spec ghSpec, args []string) int {
+	if len(args) < 3 {
+		return fail("unexpected gh invocation: %s", strings.Join(args, " "))
+	}
+	index, ok := ghPRIndex(spec.PRs, args[2])
+	if !ok {
+		return ghNoSuchPR(args[2])
+	}
+	prState, err := os.ReadFile(ghStatePath(spec.StateDir, index))
+	if err != nil {
+		return fail("read gh pull request state: %v", err)
+	}
+	if strings.TrimSpace(string(prState)) != "OPEN" {
+		return fail("pull request %s is not open", args[2])
+	}
+	meta, err := ghReadMetadata(spec.StateDir, index)
+	if err != nil {
+		return fail("read gh pull request metadata: %v", err)
+	}
+	meta.Draft = hasFlag(args, "--undo")
+	if err := ghWriteMetadata(spec.StateDir, index, meta); err != nil {
+		return fail("write gh pull request metadata: %v", err)
+	}
+	return 0
+}
+
+func ghMetadataPath(dir string, index int) string {
+	return filepath.Join(dir, fmt.Sprintf("pr%d.meta.json", index))
+}
+
+func ghReadMetadata(dir string, index int) (ghPRMetadataState, error) {
+	data, err := os.ReadFile(ghMetadataPath(dir, index))
+	if err != nil {
+		return ghPRMetadataState{}, err
+	}
+	var meta ghPRMetadataState
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return ghPRMetadataState{}, err
+	}
+	return meta, nil
+}
+
+func ghWriteMetadata(dir string, index int, meta ghPRMetadataState) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return atomicWrite(ghMetadataPath(dir, index), string(data))
+}
+
+// Folds add/remove flags over a current set, preserving current's order and appending newly
+// added entries after it - an order gh itself does not document.
+func applySetFlags(current, add, remove []string) []string {
+	keep := make(map[string]bool, len(current))
+	for _, v := range current {
+		keep[v] = true
+	}
+	for _, v := range remove {
+		delete(keep, v)
+	}
+	for _, v := range add {
+		keep[v] = true
+	}
+	result := make([]string, 0, len(keep))
+	for _, v := range current {
+		if keep[v] {
+			result = append(result, v)
+			delete(keep, v)
+		}
+	}
+	for _, v := range add {
+		if keep[v] {
+			result = append(result, v)
+			delete(keep, v)
+		}
+	}
+	return result
+}
+
+func ghLoginArray(logins []string) string {
+	items := make([]string, len(logins))
+	for i, login := range logins {
+		items[i] = fmt.Sprintf(`{"login":%s}`, jsonQuote(login))
+	}
+	return "[" + strings.Join(items, ",") + "]"
+}
+
+func ghLabelArray(labels []string) string {
+	items := make([]string, len(labels))
+	for i, label := range labels {
+		items[i] = fmt.Sprintf(`{"name":%s}`, jsonQuote(label))
+	}
+	return "[" + strings.Join(items, ",") + "]"
+}
+
+func ghMilestoneValue(title string) string {
+	if title == "" {
+		return "null"
+	}
+	return fmt.Sprintf(`{"title":%s}`, jsonQuote(title))
+}
+
+// Mirrors this repository's own convention (AGENTS.md): a closing reference is always fully
+// qualified as owner/repo#N, never a bare #N, so that is the only shape this fake recognizes.
+var closingIssuePattern = regexp.MustCompile(`(?i)(?:closes|fixes|resolves)\s+[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#(\d+)`)
+
+func ghClosingIssuesReferences(body string) string {
+	matches := closingIssuePattern.FindAllStringSubmatch(body, -1)
+	seen := make(map[string]bool, len(matches))
+	items := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		items = append(items, fmt.Sprintf(`{"number":%s}`, m[1]))
+	}
+	return "[" + strings.Join(items, ",") + "]"
 }
 
 func ghPRList(spec ghSpec, args []string) int {
@@ -477,6 +694,25 @@ func flagValue(args []string, flag string) string {
 		}
 	}
 	return ""
+}
+
+func flagValuePresent(args []string, flag string) (string, bool) {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+func flagValues(args []string, flag string) []string {
+	var values []string
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			values = append(values, args[i+1])
+		}
+	}
+	return values
 }
 
 func repoName(slug string) string {

--- a/internal/ghutil/prmetadata.go
+++ b/internal/ghutil/prmetadata.go
@@ -1,0 +1,244 @@
+package ghutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// PRMetadata is everything about a pull request that an operator, not a delivery pipeline, owns:
+// body text outside the pipeline's own region, draft/ready state, assignees, labels, milestone
+// and reviewer requests. State and ClosingIssuesReferences are read-only context for a caller.
+type PRMetadata struct {
+	Body                    string
+	Assignees               []string
+	Draft                   bool
+	Labels                  []string
+	Milestone               string
+	Reviewers               []string
+	State                   string
+	ClosingIssuesReferences []int
+}
+
+const prMetadataFields = "body,assignees,isDraft,labels,milestone,reviewRequests,closingIssuesReferences,state"
+
+// FetchPRMetadata reads the metadata gate runs and operator edits both write to, in one query so
+// a caller reasons about a single consistent snapshot rather than several queries racing a
+// concurrent write.
+func FetchPRMetadata(ctx context.Context, pr string) (PRMetadata, PRObservation) {
+	args := []string{"pr", "view", pr, "--json", prMetadataFields}
+	probe := Probe{Command: ghCommand(args)}
+	var payload struct {
+		Body      string `json:"body"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
+		IsDraft bool `json:"isDraft"`
+		Labels  []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Milestone *struct {
+			Title string `json:"title"`
+		} `json:"milestone"`
+		ReviewRequests []struct {
+			Login string `json:"login"`
+			Name  string `json:"name"`
+		} `json:"reviewRequests"`
+		ClosingIssuesReferences []struct {
+			Number int `json:"number"`
+		} `json:"closingIssuesReferences"`
+		State string `json:"state"`
+	}
+	if terminal := decodeGHPayload(ctx, probe, &payload, args...); terminal != nil {
+		return PRMetadata{}, *terminal
+	}
+
+	meta := PRMetadata{Body: payload.Body, Draft: payload.IsDraft, State: payload.State}
+	for _, a := range payload.Assignees {
+		meta.Assignees = append(meta.Assignees, a.Login)
+	}
+	for _, l := range payload.Labels {
+		meta.Labels = append(meta.Labels, l.Name)
+	}
+	if payload.Milestone != nil {
+		meta.Milestone = payload.Milestone.Title
+	}
+	for _, r := range payload.ReviewRequests {
+		name := r.Login
+		if name == "" {
+			name = r.Name
+		}
+		meta.Reviewers = append(meta.Reviewers, name)
+	}
+	for _, c := range payload.ClosingIssuesReferences {
+		meta.ClosingIssuesReferences = append(meta.ClosingIssuesReferences, c.Number)
+	}
+	return meta, PRObservation{State: ObservationFound, URL: pr, Probe: probe}
+}
+
+// SetPRBody replaces a pull request's body outright, for establishing the pipeline-owned region
+// the first time hand observes a pull request that does not carry one yet.
+func SetPRBody(ctx context.Context, pr, body string) error {
+	if err := runGH(ctx, "pr", "edit", pr, "--body", body); err != nil {
+		return fmt.Errorf("set PR body for %s: %w", pr, err)
+	}
+	return nil
+}
+
+// RestorePRMetadata pushes want's fields to GitHub wherever they differ from live: one pr edit
+// carrying every add/remove flag that changed, then a pr ready toggle only if draft state
+// differs. Draft is left alone once a pull request is no longer open, since gh pr ready refuses.
+func RestorePRMetadata(ctx context.Context, pr string, live, want PRMetadata) error {
+	args := []string{"pr", "edit", pr}
+	changed := false
+
+	if live.Body != want.Body {
+		args = append(args, "--body", want.Body)
+		changed = true
+	}
+	addAssignees, removeAssignees := stringSetDiff(want.Assignees, live.Assignees)
+	for _, a := range addAssignees {
+		args = append(args, "--add-assignee", a)
+		changed = true
+	}
+	for _, a := range removeAssignees {
+		args = append(args, "--remove-assignee", a)
+		changed = true
+	}
+	addLabels, removeLabels := stringSetDiff(want.Labels, live.Labels)
+	for _, l := range addLabels {
+		args = append(args, "--add-label", l)
+		changed = true
+	}
+	for _, l := range removeLabels {
+		args = append(args, "--remove-label", l)
+		changed = true
+	}
+	if want.Milestone != live.Milestone {
+		if want.Milestone == "" {
+			args = append(args, "--remove-milestone")
+		} else {
+			args = append(args, "--milestone", want.Milestone)
+		}
+		changed = true
+	}
+	addReviewers, removeReviewers := stringSetDiff(want.Reviewers, live.Reviewers)
+	for _, r := range addReviewers {
+		args = append(args, "--add-reviewer", r)
+		changed = true
+	}
+	for _, r := range removeReviewers {
+		args = append(args, "--remove-reviewer", r)
+		changed = true
+	}
+
+	if changed {
+		if err := runGH(ctx, args...); err != nil {
+			return fmt.Errorf("restore PR metadata for %s: %w", pr, err)
+		}
+	}
+	if want.Draft != live.Draft && live.State == "OPEN" {
+		readyArgs := []string{"pr", "ready", pr}
+		if want.Draft {
+			readyArgs = append(readyArgs, "--undo")
+		}
+		if err := runGH(ctx, readyArgs...); err != nil {
+			return fmt.Errorf("restore PR draft state for %s: %w", pr, err)
+		}
+	}
+	return nil
+}
+
+func runGH(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh %s: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func stringSetDiff(want, live []string) (add, remove []string) {
+	liveSet := make(map[string]bool, len(live))
+	for _, v := range live {
+		liveSet[v] = true
+	}
+	wantSet := make(map[string]bool, len(want))
+	for _, v := range want {
+		wantSet[v] = true
+	}
+	for _, v := range want {
+		if !liveSet[v] {
+			add = append(add, v)
+		}
+	}
+	for _, v := range live {
+		if !wantSet[v] {
+			remove = append(remove, v)
+		}
+	}
+	return add, remove
+}
+
+// PipelineRegionStart and PipelineRegionEnd delimit the only part of a pull request body a
+// pipeline may rewrite. Hand alone reads and writes these markers, so their presence is the
+// signal that no full-body replacement has happened since hand last composed the body.
+const (
+	PipelineRegionStart = "<!-- hand:pipeline-region:start -->"
+	PipelineRegionEnd   = "<!-- hand:pipeline-region:end -->"
+)
+
+// ComposeBody joins operator-owned text with the pipeline's own region. Round-tripped through
+// SplitBody it reproduces operatorBody exactly, which is what keeps two consecutive, unchanged
+// runs from rewriting a body neither call needed to touch.
+func ComposeBody(operatorBody, pipelineBody string) string {
+	operatorBody = strings.TrimRight(operatorBody, "\n")
+	pipelineBody = strings.TrimSpace(pipelineBody)
+	return operatorBody + "\n\n" + PipelineRegionStart + "\n" + pipelineBody + "\n" + PipelineRegionEnd
+}
+
+// SplitBody reports the operator-owned text surrounding the pipeline region and the pipeline
+// region's own content. ok is false when body carries no complete region, which is the signal a
+// caller uses to detect a full-body replacement that erased it.
+func SplitBody(body string) (operatorBody, pipelineBody string, ok bool) {
+	start := strings.Index(body, PipelineRegionStart)
+	end := strings.Index(body, PipelineRegionEnd)
+	if start < 0 || end < 0 || end < start {
+		return "", "", false
+	}
+	before := strings.Trim(body[:start], "\n")
+	after := strings.Trim(body[end+len(PipelineRegionEnd):], "\n")
+	operatorBody = before
+	if after != "" {
+		operatorBody = before + "\n\n" + after
+	}
+	return operatorBody, strings.TrimSpace(body[start+len(PipelineRegionStart) : end]), true
+}
+
+var emojiSeverity = []struct {
+	glyph  string
+	prefix string
+}{
+	{"✅", "- info:"},
+	{"⚠️", "- warning:"},
+	{"⚠", "- warning:"},
+	{"❌", "- error:"},
+}
+
+// Strips any glyph emojiSeverity does not name a severity for, so "no emoji" holds
+// unconditionally rather than only for the cases this package anticipated.
+var residualEmoji = regexp.MustCompile(`[\x{1F300}-\x{1FAFF}\x{2600}-\x{27BF}\x{FE0F}]`)
+
+// SanitizePipelineText maps the gate's check-mark and warning glyphs to this repository's own
+// severity prefixes and removes every other emoji, so a pipeline-authored region never reintroduces
+// what AGENTS.md forbids even when the gate's own output does.
+func SanitizePipelineText(s string) string {
+	for _, e := range emojiSeverity {
+		s = strings.ReplaceAll(s, e.glyph, e.prefix)
+	}
+	return residualEmoji.ReplaceAllString(s, "")
+}

--- a/internal/ghutil/prmetadata_test.go
+++ b/internal/ghutil/prmetadata_test.go
@@ -1,0 +1,237 @@
+package ghutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func TestComposeSplitBodyRoundTrips(t *testing.T) {
+	operator := "Operator wrote this.\n\nCloses atqamz/hand#247"
+	composed := ComposeBody(operator, "gate report line one\ngate report line two")
+	gotOperator, gotPipeline, ok := SplitBody(composed)
+	if !ok {
+		t.Fatalf("SplitBody(%q) = ok false, want a region found", composed)
+	}
+	if gotOperator != operator {
+		t.Fatalf("operator body = %q, want %q", gotOperator, operator)
+	}
+	if gotPipeline != "gate report line one\ngate report line two" {
+		t.Fatalf("pipeline body = %q, want the composed pipeline text back", gotPipeline)
+	}
+
+	// Composing again from the split halves must reproduce the same bytes: this is what keeps a
+	// second, unchanged run from writing anything at all.
+	if again := ComposeBody(gotOperator, gotPipeline); again != composed {
+		t.Fatalf("ComposeBody is not idempotent over its own SplitBody: got %q, want %q", again, composed)
+	}
+}
+
+func TestSplitBodyReportsNoRegionWhenMarkersAreMissing(t *testing.T) {
+	if _, _, ok := SplitBody("plain operator text with no markers at all"); ok {
+		t.Fatal("SplitBody found a region in text that carries no markers")
+	}
+	if _, _, ok := SplitBody(PipelineRegionStart + " without an end marker"); ok {
+		t.Fatal("SplitBody found a region with a start marker but no end marker")
+	}
+}
+
+func TestSanitizePipelineTextMapsKnownGlyphsAndStripsTheRest(t *testing.T) {
+	in := "<summary>✅ **intent** - passed</summary>\n⚠️ Medium: risk\n❌ lint failed\n🚀 shipped it"
+	out := SanitizePipelineText(in)
+	for _, want := range []string{"- info:", "- warning:", "- error:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("sanitized text = %q, want it to contain %q", out, want)
+		}
+	}
+	for _, glyph := range []string{"✅", "⚠️", "⚠", "❌", "🚀"} {
+		if strings.Contains(out, glyph) {
+			t.Fatalf("sanitized text = %q, still contains emoji glyph %q", out, glyph)
+		}
+	}
+}
+
+func TestFetchPRMetadataDecodesEveryField(t *testing.T) {
+	bin := faketool.Bin(t)
+	pr := faketool.GHPR{
+		URL:       "https://github.com/atqamz/hand/pull/247",
+		Number:    247,
+		State:     "OPEN",
+		Body:      "operator text\n\nCloses atqamz/hand#247",
+		Assignees: []string{"atqamz"},
+		Draft:     true,
+		Labels:    []string{"bug"},
+		Milestone: "v1",
+		Reviewers: []string{"reviewer1"},
+	}
+	faketool.GH{PRs: []faketool.GHPR{pr}}.Install(t, bin)
+
+	meta, observation := FetchPRMetadata(context.Background(), pr.URL)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the fake PR found", observation)
+	}
+	if meta.Body != pr.Body {
+		t.Fatalf("body = %q, want %q", meta.Body, pr.Body)
+	}
+	if !meta.Draft {
+		t.Fatal("draft = false, want true")
+	}
+	if meta.State != "OPEN" {
+		t.Fatalf("state = %q, want OPEN", meta.State)
+	}
+	if got := sortedCopy(meta.Assignees); !equalSorted(got, []string{"atqamz"}) {
+		t.Fatalf("assignees = %v, want [atqamz]", got)
+	}
+	if got := sortedCopy(meta.Labels); !equalSorted(got, []string{"bug"}) {
+		t.Fatalf("labels = %v, want [bug]", got)
+	}
+	if meta.Milestone != "v1" {
+		t.Fatalf("milestone = %q, want v1", meta.Milestone)
+	}
+	if got := sortedCopy(meta.Reviewers); !equalSorted(got, []string{"reviewer1"}) {
+		t.Fatalf("reviewers = %v, want [reviewer1]", got)
+	}
+	if len(meta.ClosingIssuesReferences) != 1 || meta.ClosingIssuesReferences[0] != 247 {
+		t.Fatalf("closingIssuesReferences = %v, want [247]", meta.ClosingIssuesReferences)
+	}
+}
+
+func TestRestorePRMetadataIssuesOnlyTheChangedFields(t *testing.T) {
+	bin := faketool.Bin(t)
+	log := filepath.Join(t.TempDir(), "gh.log")
+	pr := faketool.GHPR{
+		URL:       "https://github.com/atqamz/hand/pull/301",
+		Number:    301,
+		State:     "OPEN",
+		Body:      "clobbered report",
+		Assignees: []string{"atqamz"},
+		Draft:     false,
+		Labels:    []string{"bug"},
+		Milestone: "v1",
+		Reviewers: []string{"reviewer1"},
+	}
+	faketool.GH{PRs: []faketool.GHPR{pr}, Log: log}.Install(t, bin)
+
+	live, observation := FetchPRMetadata(context.Background(), pr.URL)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the fake PR found", observation)
+	}
+	want := PRMetadata{
+		Body:      "restored operator body",
+		Assignees: []string{"atqamz", "operator2"},
+		Draft:     true,
+		Labels:    []string{"bug", "priority"},
+		Milestone: "",
+		Reviewers: []string{"reviewer2"},
+	}
+	if err := RestorePRMetadata(context.Background(), pr.URL, live, want); err != nil {
+		t.Fatalf("RestorePRMetadata: %v", err)
+	}
+
+	after, observation := FetchPRMetadata(context.Background(), pr.URL)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want the fake PR found after restore", observation)
+	}
+	if after.Body != want.Body {
+		t.Fatalf("body = %q, want %q", after.Body, want.Body)
+	}
+	if !after.Draft {
+		t.Fatal("draft = false, want true after restore")
+	}
+	if got := sortedCopy(after.Assignees); !equalSorted(got, sortedCopy(want.Assignees)) {
+		t.Fatalf("assignees = %v, want %v", got, want.Assignees)
+	}
+	if got := sortedCopy(after.Labels); !equalSorted(got, sortedCopy(want.Labels)) {
+		t.Fatalf("labels = %v, want %v", got, want.Labels)
+	}
+	if after.Milestone != "" {
+		t.Fatalf("milestone = %q, want it removed", after.Milestone)
+	}
+	if got := sortedCopy(after.Reviewers); !equalSorted(got, sortedCopy(want.Reviewers)) {
+		t.Fatalf("reviewers = %v, want %v", got, want.Reviewers)
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read gh invocation log: %v", err)
+	}
+	if strings.Count(string(data), "pr ready") != 1 {
+		t.Fatalf("gh invocation log = %q, want exactly one pr ready call", data)
+	}
+}
+
+func TestRestorePRMetadataLeavesDraftAloneWhenNothingChanged(t *testing.T) {
+	bin := faketool.Bin(t)
+	log := filepath.Join(t.TempDir(), "gh.log")
+	pr := faketool.GHPR{
+		URL:   "https://github.com/atqamz/hand/pull/302",
+		State: "OPEN",
+		Body:  "unchanged body",
+		Draft: true,
+	}
+	faketool.GH{PRs: []faketool.GHPR{pr}, Log: log}.Install(t, bin)
+
+	live, _ := FetchPRMetadata(context.Background(), pr.URL)
+	want := live
+	if err := RestorePRMetadata(context.Background(), pr.URL, live, want); err != nil {
+		t.Fatalf("RestorePRMetadata: %v", err)
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read gh invocation log: %v", err)
+	}
+	if strings.Contains(string(data), "pr edit") || strings.Contains(string(data), "pr ready") {
+		t.Fatalf("gh invocation log = %q, want no write when nothing differs", data)
+	}
+}
+
+func TestRestorePRMetadataSkipsDraftToggleOnceAPRIsNotOpen(t *testing.T) {
+	bin := faketool.Bin(t)
+	log := filepath.Join(t.TempDir(), "gh.log")
+	pr := faketool.GHPR{
+		URL:   "https://github.com/atqamz/hand/pull/303",
+		State: "MERGED",
+		Body:  "clobbered",
+		Draft: false,
+	}
+	faketool.GH{PRs: []faketool.GHPR{pr}, Log: log}.Install(t, bin)
+
+	live, _ := FetchPRMetadata(context.Background(), pr.URL)
+	want := live
+	want.Draft = true
+	if err := RestorePRMetadata(context.Background(), pr.URL, live, want); err != nil {
+		t.Fatalf("RestorePRMetadata: %v", err)
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read gh invocation log: %v", err)
+	}
+	if strings.Contains(string(data), "pr ready") {
+		t.Fatalf("gh invocation log = %q, want no pr ready call against a merged pull request", data)
+	}
+}
+
+func sortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+func equalSorted(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/project/prmetadata.go
+++ b/internal/project/prmetadata.go
@@ -1,0 +1,205 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/state"
+)
+
+// The operator-owned baseline hand keeps for one pull request, taken whenever a run finds
+// hand's own pipeline-region markers intact - what a clobbered body and its fields are
+// restored from, not a cache of anything the pipeline itself wrote.
+type prMetadataSnapshot struct {
+	OperatorBody string   `json:"operatorBody"`
+	Assignees    []string `json:"assignees"`
+	Draft        bool     `json:"draft"`
+	Labels       []string `json:"labels"`
+	Milestone    string   `json:"milestone"`
+	Reviewers    []string `json:"reviewers"`
+}
+
+// ReassertPRMetadata is hand's answer to a gate that treats a pull request body as its own to
+// overwrite: it establishes hand's pipeline-owned region on first sight, adopts the operator's
+// latest edits while the region survives, and restores the baseline once the region goes missing.
+func ReassertPRMetadata(ctx context.Context, homeDir, prURL string) error {
+	live, observation := ghutil.FetchPRMetadata(ctx, prURL)
+	if !observation.Found() {
+		return fmt.Errorf("observe PR %s metadata: %s", prURL, observation.Reason())
+	}
+
+	snap, existed, err := loadPRMetadataSnapshot(homeDir, prURL)
+	if err != nil {
+		return err
+	}
+
+	operator, _, hasMarkers := ghutil.SplitBody(live.Body)
+
+	if !existed {
+		return establishPRMetadata(ctx, homeDir, prURL, live, operator, hasMarkers)
+	}
+	if hasMarkers {
+		return adoptPRMetadata(homeDir, prURL, live, operator, snap)
+	}
+	return restorePRMetadataSnapshot(ctx, homeDir, prURL, live, snap)
+}
+
+// Runs the first time hand ever looks at a pull request: a region already present is adopted
+// as-is, otherwise hand composes one around whatever body is already there and verifies the
+// write before trusting it as the new baseline.
+func establishPRMetadata(ctx context.Context, homeDir, prURL string, live ghutil.PRMetadata, operator string, hasMarkers bool) error {
+	if hasMarkers {
+		return saveSnapshotFrom(homeDir, prURL, live, operator)
+	}
+
+	operatorBody := strings.TrimRight(live.Body, "\n")
+	if err := ghutil.SetPRBody(ctx, prURL, ghutil.ComposeBody(operatorBody, "")); err != nil {
+		return err
+	}
+	after, observation := ghutil.FetchPRMetadata(ctx, prURL)
+	if !observation.Found() {
+		return fmt.Errorf("verify pipeline region establishment for %s: %s", prURL, observation.Reason())
+	}
+	gotOperator, _, ok := ghutil.SplitBody(after.Body)
+	if !ok || gotOperator != operatorBody {
+		return fmt.Errorf("pipeline region establishment for %s did not verify", prURL)
+	}
+	return saveSnapshotFrom(homeDir, prURL, live, operatorBody)
+}
+
+// Runs when the region is intact: nothing has clobbered this pull request since hand last
+// looked, so the operator's current edits become the new baseline. An unchanged snapshot is
+// left unwritten, which keeps two consecutive runs on an unchanged tree idempotent.
+func adoptPRMetadata(homeDir, prURL string, live ghutil.PRMetadata, operator string, snap prMetadataSnapshot) error {
+	next := prMetadataSnapshot{
+		OperatorBody: operator,
+		Assignees:    live.Assignees,
+		Draft:        live.Draft,
+		Labels:       live.Labels,
+		Milestone:    live.Milestone,
+		Reviewers:    live.Reviewers,
+	}
+	if snapshotsEqual(next, snap) {
+		return nil
+	}
+	return savePRMetadataSnapshot(homeDir, prURL, next)
+}
+
+// Runs when the region is missing but a snapshot exists: the only way hand's own markers
+// disappear is a full-body replacement, so the live body is sanitized and wrapped back around
+// the last known-good operator body and fields, then verified unconditionally - a mismatch is a hard error, never a best-effort warning.
+func restorePRMetadataSnapshot(ctx context.Context, homeDir, prURL string, live ghutil.PRMetadata, snap prMetadataSnapshot) error {
+	restoredBody := ghutil.ComposeBody(snap.OperatorBody, ghutil.SanitizePipelineText(live.Body))
+	want := ghutil.PRMetadata{
+		Body:      restoredBody,
+		Assignees: snap.Assignees,
+		Draft:     snap.Draft,
+		Labels:    snap.Labels,
+		Milestone: snap.Milestone,
+		Reviewers: snap.Reviewers,
+	}
+	if err := ghutil.RestorePRMetadata(ctx, prURL, live, want); err != nil {
+		return fmt.Errorf("restore operator-owned metadata for %s: %w", prURL, err)
+	}
+
+	after, observation := ghutil.FetchPRMetadata(ctx, prURL)
+	if !observation.Found() {
+		return fmt.Errorf("verify restored metadata for %s: %s", prURL, observation.Reason())
+	}
+	gotOperator, _, ok := ghutil.SplitBody(after.Body)
+	if !ok || gotOperator != snap.OperatorBody {
+		return fmt.Errorf("restored PR metadata for %s did not verify: operator-owned body content mismatch", prURL)
+	}
+	if !equalMetadataFields(after, snap) {
+		return fmt.Errorf("restored PR metadata for %s did not verify: assignee, draft, label, milestone or reviewer state mismatch", prURL)
+	}
+	return savePRMetadataSnapshot(homeDir, prURL, snap)
+}
+
+func saveSnapshotFrom(homeDir, prURL string, live ghutil.PRMetadata, operatorBody string) error {
+	return savePRMetadataSnapshot(homeDir, prURL, prMetadataSnapshot{
+		OperatorBody: operatorBody,
+		Assignees:    live.Assignees,
+		Draft:        live.Draft,
+		Labels:       live.Labels,
+		Milestone:    live.Milestone,
+		Reviewers:    live.Reviewers,
+	})
+}
+
+func snapshotsEqual(a, b prMetadataSnapshot) bool {
+	return a.OperatorBody == b.OperatorBody && a.Draft == b.Draft && a.Milestone == b.Milestone &&
+		equalStringSets(a.Assignees, b.Assignees) && equalStringSets(a.Labels, b.Labels) && equalStringSets(a.Reviewers, b.Reviewers)
+}
+
+func equalMetadataFields(m ghutil.PRMetadata, snap prMetadataSnapshot) bool {
+	return m.Draft == snap.Draft && m.Milestone == snap.Milestone &&
+		equalStringSets(m.Assignees, snap.Assignees) && equalStringSets(m.Labels, snap.Labels) && equalStringSets(m.Reviewers, snap.Reviewers)
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, v := range a {
+		counts[v]++
+	}
+	for _, v := range b {
+		counts[v]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func prMetadataSnapshotPath(homeDir, prURL string) (string, error) {
+	if !state.ValidatePRURL(prURL) {
+		return "", fmt.Errorf("invalid PR URL %q", prURL)
+	}
+	name := strings.ReplaceAll(strings.TrimPrefix(prURL, "https://github.com/"), "/", "-")
+	return filepath.Join(homeDir, "data", "pr-metadata", name+".json"), nil
+}
+
+func loadPRMetadataSnapshot(homeDir, prURL string) (prMetadataSnapshot, bool, error) {
+	path, err := prMetadataSnapshotPath(homeDir, prURL)
+	if err != nil {
+		return prMetadataSnapshot{}, false, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return prMetadataSnapshot{}, false, nil
+	}
+	if err != nil {
+		return prMetadataSnapshot{}, false, fmt.Errorf("read PR metadata snapshot for %s: %w", prURL, err)
+	}
+	var snap prMetadataSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return prMetadataSnapshot{}, false, fmt.Errorf("decode PR metadata snapshot for %s: %w", prURL, err)
+	}
+	return snap, true, nil
+}
+
+func savePRMetadataSnapshot(homeDir, prURL string, snap prMetadataSnapshot) error {
+	path, err := prMetadataSnapshotPath(homeDir, prURL)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create PR metadata directory: %w", err)
+	}
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode PR metadata snapshot for %s: %w", prURL, err)
+	}
+	return atomicfile.Write(path, ".prmetadata-*", data, 0o644)
+}

--- a/internal/project/prmetadata_test.go
+++ b/internal/project/prmetadata_test.go
@@ -1,0 +1,250 @@
+package project
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
+)
+
+// Runs a real `gh pr edit` against the fake, exactly as no-mistakes does when it replaces a pull
+// request body wholesale: hand's own code is never in this call path, which is the point of the
+// test - hand must recover from a write it did not make and could not prevent.
+func clobberPR(t *testing.T, url string, args ...string) {
+	t.Helper()
+	full := append([]string{"pr", "edit", url}, args...)
+	cmd := exec.Command("gh", full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gh %s: %v: %s", strings.Join(full, " "), err, out)
+	}
+}
+
+func TestReassertPreservesClosingReferenceAcrossAGateClobber(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/247"
+	faketool.GH{PRs: []faketool.GHPR{{
+		URL: url, Number: 247, State: "OPEN",
+		Body: "Operator-authored summary.\n\nCloses atqamz/hand#247",
+	}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+	established, observation := ghutil.FetchPRMetadata(ctx, url)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want found", observation)
+	}
+	if len(established.ClosingIssuesReferences) != 1 || established.ClosingIssuesReferences[0] != 247 {
+		t.Fatalf("closingIssuesReferences after establish = %v, want [247]", established.ClosingIssuesReferences)
+	}
+
+	// The gate's replacement body carries no closing reference at all, so a restore that relies on
+	// the reference having survived by luck would fail here exactly as it did on the real PRs the
+	// issue names.
+	clobberPR(t, url, "--body", "## Gate Report\n\nAll checks passed.")
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("reassert after clobber: %v", err)
+	}
+	after, observation := ghutil.FetchPRMetadata(ctx, url)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want found", observation)
+	}
+	if len(after.ClosingIssuesReferences) != 1 || after.ClosingIssuesReferences[0] != 247 {
+		t.Fatalf("closingIssuesReferences after restore = %v, want [247] restored", after.ClosingIssuesReferences)
+	}
+	operatorBody, _, ok := ghutil.SplitBody(after.Body)
+	if !ok {
+		t.Fatal("restored body carries no pipeline region")
+	}
+	if !strings.Contains(operatorBody, "Closes atqamz/hand#247") {
+		t.Fatalf("restored operator body = %q, want the closing reference verbatim", operatorBody)
+	}
+}
+
+func TestReassertDoesNotChangeDraftOrReadyStateUnlessRequested(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/301"
+	faketool.GH{PRs: []faketool.GHPR{{
+		URL: url, Number: 301, State: "OPEN", Body: "operator text", Draft: true,
+	}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+
+	// The operator, not the gate, takes the PR out of draft. A run with the region intact must
+	// adopt that as the new baseline rather than force it back to draft.
+	readyCmd := exec.Command("gh", "pr", "ready", url)
+	if out, err := readyCmd.CombinedOutput(); err != nil {
+		t.Fatalf("gh pr ready: %v: %s", err, out)
+	}
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("reassert after operator marks ready: %v", err)
+	}
+	meta, _ := ghutil.FetchPRMetadata(ctx, url)
+	if meta.Draft {
+		t.Fatal("draft = true, want the operator's ready toggle adopted as the new baseline")
+	}
+
+	// Now the gate clobbers the body only, never touching draft state. Restoring operator-owned
+	// metadata must not silently flip the PR back to draft.
+	clobberPR(t, url, "--body", "## Gate Report\n\nripped the body out")
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("reassert after clobber: %v", err)
+	}
+	meta, _ = ghutil.FetchPRMetadata(ctx, url)
+	if meta.Draft {
+		t.Fatal("draft = true after restore, want ready state left exactly as the operator set it")
+	}
+}
+
+func TestReassertDoesNotClearOrReplaceTheAssignee(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/302"
+	faketool.GH{PRs: []faketool.GHPR{{
+		URL: url, Number: 302, State: "OPEN", Body: "operator text", Assignees: []string{"atqamz"},
+	}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+
+	// A gate destructive enough to replace the body might also touch assignees; the restore must
+	// win regardless of what else the clobber carried.
+	clobberPR(t, url, "--body", "## Gate Report", "--remove-assignee", "atqamz")
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("reassert after clobber: %v", err)
+	}
+	meta, _ := ghutil.FetchPRMetadata(ctx, url)
+	if len(meta.Assignees) != 1 || meta.Assignees[0] != "atqamz" {
+		t.Fatalf("assignees after restore = %v, want [atqamz]", meta.Assignees)
+	}
+}
+
+func TestReassertPreservesContentOutsideThePipelineRegionVerbatim(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/303"
+	operatorBody := "## Summary\n\n- did a thing\n- did another thing\n\n```go\nfmt.Println(\"kept verbatim\")\n```\n\nCloses atqamz/hand#303"
+	faketool.GH{PRs: []faketool.GHPR{{URL: url, Number: 303, State: "OPEN", Body: operatorBody}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+	clobberPR(t, url, "--body", "## Gate Report\n\nnothing survives a naive replace")
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("reassert after clobber: %v", err)
+	}
+
+	after, _ := ghutil.FetchPRMetadata(ctx, url)
+	got, _, ok := ghutil.SplitBody(after.Body)
+	if !ok {
+		t.Fatal("restored body carries no pipeline region")
+	}
+	if got != operatorBody {
+		t.Fatalf("operator body = %q, want %q verbatim", got, operatorBody)
+	}
+}
+
+func TestReassertTwoConsecutiveRunsProduceByteIdenticalSnapshot(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/304"
+	faketool.GH{PRs: []faketool.GHPR{{
+		URL: url, Number: 304, State: "OPEN", Body: "operator text", Assignees: []string{"atqamz"},
+	}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+	path, err := prMetadataSnapshotPath(home, url)
+	if err != nil {
+		t.Fatalf("snapshot path: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("second reassert on an unchanged tree: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("snapshot changed across two runs on an unchanged tree:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestReassertSanitizesPipelineTextEmojiToSeverityPrefixes(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/305"
+	faketool.GH{PRs: []faketool.GHPR{{URL: url, Number: 305, State: "OPEN", Body: "operator text"}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+	clobberPR(t, url, "--body", "<summary>✅ intent - passed</summary>\n⚠️ Medium: risk\n❌ lint failed")
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("reassert after clobber: %v", err)
+	}
+
+	after, _ := ghutil.FetchPRMetadata(ctx, url)
+	_, pipeline, ok := ghutil.SplitBody(after.Body)
+	if !ok {
+		t.Fatal("restored body carries no pipeline region")
+	}
+	for _, want := range []string{"- info:", "- warning:", "- error:"} {
+		if !strings.Contains(pipeline, want) {
+			t.Fatalf("pipeline region = %q, want it to contain %q", pipeline, want)
+		}
+	}
+	for _, glyph := range []string{"✅", "⚠️", "⚠", "❌"} {
+		if strings.Contains(pipeline, glyph) {
+			t.Fatalf("pipeline region = %q, still contains emoji glyph %q", pipeline, glyph)
+		}
+	}
+}
+
+func TestReassertEstablishesAPipelineRegionWithoutDestroyingExistingContent(t *testing.T) {
+	home := t.TempDir()
+	url := "https://github.com/atqamz/hand/pull/306"
+	operatorBody := "Written by the operator before hand ever looked at this pull request.\n\nCloses atqamz/hand#306"
+	faketool.GH{PRs: []faketool.GHPR{{URL: url, Number: 306, State: "OPEN", Body: operatorBody}}}.Install(t, faketool.Bin(t))
+	ctx := context.Background()
+
+	if err := ReassertPRMetadata(ctx, home, url); err != nil {
+		t.Fatalf("establish: %v", err)
+	}
+
+	after, observation := ghutil.FetchPRMetadata(ctx, url)
+	if !observation.Found() {
+		t.Fatalf("observation = %+v, want found", observation)
+	}
+	got, pipeline, ok := ghutil.SplitBody(after.Body)
+	if !ok {
+		t.Fatal("establish did not leave a pipeline region in place")
+	}
+	if got != operatorBody {
+		t.Fatalf("operator body = %q, want the original content preserved verbatim: %q", got, operatorBody)
+	}
+	if pipeline != "" {
+		t.Fatalf("pipeline region = %q, want it empty on first establishment", pipeline)
+	}
+	if len(after.ClosingIssuesReferences) != 1 || after.ClosingIssuesReferences[0] != 306 {
+		t.Fatalf("closingIssuesReferences = %v, want [306] still resolved from the untouched operator text", after.ClosingIssuesReferences)
+	}
+}

--- a/tests/e2e/gate_visibility_test.go
+++ b/tests/e2e/gate_visibility_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -82,7 +83,7 @@ func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
 	dir := binDir(t)
 	writeFakeTreehouse(t, dir, worktree)
 	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo", PaneStatus: "idle"})
-	writeFakeDispatch(t, dir, "gh", "", "$1 $2", `  "pr view") echo '{"state":"OPEN"}' ;;`)
+	faketool.GH{PRs: []faketool.GHPR{{URL: prURL, State: "OPEN"}}}.Install(t, dir)
 	writeFakeNoMistakes(t, dir, gateReadyStatus,
 		"  completed    other-branch  758d72bf  2026-08-03 04:29  https://github.com/owner/demo/pull/4", 0)
 

--- a/tests/e2e/pr_test.go
+++ b/tests/e2e/pr_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -30,13 +31,13 @@ func TestPRCommand(t *testing.T) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "e2e-fixture", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning})
 
+	url := "https://github.com/owner/e2e-fixture/pull/7"
 	invocationLog := filepath.Join(t.TempDir(), "gh-invocations.log")
-	writeFakeDispatch(t, dir, "gh", invocationLog, "$1 $2", `  "pr view") echo '{"state":"OPEN"}' ;;`)
+	faketool.GH{Log: invocationLog, PRs: []faketool.GHPR{{URL: url, State: "OPEN"}}}.Install(t, dir)
 
 	mismatch := runHand(t, home, "pr", "task-1", "https://github.com/other/repo/pull/1")
 	assertInvocation(t, mismatch, 3, "not project")
 
-	url := "https://github.com/owner/e2e-fixture/pull/7"
 	recorded := runHand(t, home, "pr", "task-1", url)
 	if recorded.code != 0 {
 		t.Fatalf("pr record: exit %d, stderr %q", recorded.code, recorded.stderr)

--- a/tests/e2e/slug_case_test.go
+++ b/tests/e2e/slug_case_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -75,7 +76,10 @@ func TestPRRecordAcceptsCanonicalCasingOfOwnRepoAndUpstream(t *testing.T) {
 
 	dir := binDir(t)
 	writeFakeTreehouse(t, dir, filepath.Join(t.TempDir(), "unused-worktree"))
-	writeFakeDispatch(t, dir, "gh", "", "$1 $2", `  "pr view") echo '{"state":"OPEN"}' ;;`)
+	faketool.GH{PRs: []faketool.GHPR{
+		{URL: "https://github.com/atqamz/no-mistakes/pull/31", State: "OPEN"},
+		{URL: "https://github.com/kunchenguid/no-mistakes/pull/597", State: "OPEN"},
+	}}.Install(t, dir)
 
 	home := newHome(t)
 	added := runHand(t, home, "project", "add", "https://github.com/Atqamz/No-Mistakes.git", "--mode", "direct-pr")

--- a/tests/e2e/upstream_deliver_test.go
+++ b/tests/e2e/upstream_deliver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -35,7 +36,8 @@ func TestForkContributionDeliveredNotLanded(t *testing.T) {
 
 	// The upstream maintainer has not merged it and may never: OPEN is the state
 	// this whole feature has to be able to tear down under.
-	writeFakeDispatch(t, dir, "gh", "", "$1 $2", `  "pr view") echo '{"state":"OPEN"}' ;;`)
+	upstreamPR := "https://github.com/kunchenguid/no-mistakes/pull/597"
+	faketool.GH{PRs: []faketool.GHPR{{URL: upstreamPR, State: "OPEN"}}}.Install(t, dir)
 
 	writeBrief(t, home, "task-1")
 	spawned := runHand(t, home, "spawn", "task-1", "no-mistakes")
@@ -46,7 +48,6 @@ func TestForkContributionDeliveredNotLanded(t *testing.T) {
 
 	// The two refusals below are the point: hand pr rejects a repo nobody declared, and teardown rejects the
 	// still-open PR until the delivery is recorded. Reverting either half of the change turns one into a pass.
-	upstreamPR := "https://github.com/kunchenguid/no-mistakes/pull/597"
 	undeclared := runHand(t, home, "pr", "task-1", upstreamPR)
 	assertInvocation(t, undeclared, 3, "no upstream is declared for it")
 


### PR DESCRIPTION
## Summary

- Delivery tooling captures a per-PR operator-owned metadata snapshot and reasserts it after `hand pr` and `hand deliver` record a pull request, so an external gate that replaces the whole body cannot silently discard a closing reference, draft/ready state, assignee, or any other operator-set field.
- Adds a delimited pipeline-owned region (`internal/ghutil/prmetadata.go`) so a run can tell "gate clobbered the body" (region missing) apart from "operator edited since last run" (region intact), and restores from the last known-good snapshot only in the first case, verifying the write unconditionally rather than best-effort.
- Sanitizes any pipeline text folded back into the region: emoji glyphs are mapped to `- error:`/`- warning:`/`- info:` severity prefixes, matching this repository's own convention.

Capture-and-reassert was chosen over a delimited-region-only design because Hand does not control the write the gate makes; see the design note in `internal/project/prmetadata.go`. The window between fetch and reassert is real but bounded, and every reassert verifies the result unconditionally, failing hard on mismatch rather than trusting the write.

Closes atqamz/hand#247

## Test plan

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `nix develop -c make lint`
- `make build`
- `make contract`
- `make e2e`
- `nix flake check`
- `git diff --check`

<!-- hand:pipeline-region:start -->
## no-mistakes report

- lint: pass
- test: pass
- build: pass

All checks green.
<!-- hand:pipeline-region:end -->