### PR TITLE
fix(watcher): stop teardown from reporting a torn-down worker's success as a failure

### DIFF
--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -1318,6 +1318,52 @@ func TestTeardownForceSkipsLandedWorkChecks(t *testing.T) {
 	}
 }
 
+// Covers atqamz/hand#235 at the rendered-output boundary: a worker that reported itself failed must
+// have that failure survive to the exact text `hand teardown` prints, not just to durable state.
+func TestTeardownRendersGenuineWorkerFailureAsOutcomeFailed(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"},
+		state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"},
+			LastReportState: state.ReportFailed, LastReportNote: "tests would not pass"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "outcome: failed\n") || !strings.Contains(out.String(), "tests would not pass") {
+		t.Fatalf("output = %q, want the worker's own failure report rendered as the outcome", out.String())
+	}
+}
+
+// The --force half of the same issue: forcing past landed-work checks must never invent a failure for a
+// task nobody reported failed, in the same rendered text a `hand teardown` caller reads.
+func TestTeardownForceOnATaskWithNoFailureReportNeverRendersOutcomeFailed(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	if err := os.WriteFile(filepath.Join(worktree, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj"},
+		state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newTeardownCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "outcome: failed") {
+		t.Fatalf("output = %q, want --force on a task nobody reported failed to never render outcome: failed", out.String())
+	}
+}
+
 func TestTeardownWaitsForProjectLockBeforeClosingResources(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeScoutReport(t, home, "task-1")

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -546,7 +546,7 @@ func (r *Runtime) terminalizeWithoutRelease(home string, task state.Task, attemp
 	if err := state.SetAttemptTeardownCompletionState(home, task.ID, attempt.ID, attempt.Lifecycle, state.TeardownCompletionPending); err != nil {
 		return fmt.Errorf("record %s completion phase for attempt %d: %w", label, attempt.ID, err)
 	}
-	record := completionFor(task, decision.Disposition, true)
+	record := completionFor(task, decision.Disposition, true, attempt.LastReportState, attempt.LastReportNote)
 	record.AttemptID, record.AttemptLifecycle = attempt.ID, string(decision.TerminalAttempt)
 	record.TornDownAt = r.deps.now().Format(time.RFC3339)
 	if err := r.deps.appendCompletion(home, record); err != nil {
@@ -960,7 +960,7 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 		}
 		if !found {
 			launched := attempt.LaunchSubmittedAt != "" || attempt.LaunchConfirmedAt != "" || attempt.Lifecycle != state.AttemptInterrupted
-			record = completionFor(task, attempt.TeardownDisposition, launched)
+			record = completionFor(task, attempt.TeardownDisposition, launched, attempt.LastReportState, attempt.LastReportNote)
 			record.AttemptID, record.AttemptLifecycle = attempt.ID, string(attempt.TeardownTerminalAttempt)
 			record.TornDownAt = r.deps.now().Format(time.RFC3339)
 			if err := r.deps.appendCompletion(home, record); err != nil {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -106,7 +106,7 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 		return fail(err)
 	}
 
-	record := completionFor(task, disposition, launched)
+	record := completionFor(task, disposition, launched, active.LastReportState, active.LastReportNote)
 	record.AttemptID = active.ID
 	record.AttemptLifecycle = string(terminalAttempt)
 	record.TornDownAt = r.deps.now().Format(time.RFC3339)
@@ -283,12 +283,21 @@ func teardownDecision(forced, launched bool, lifecycle state.AttemptLifecycle, d
 	return state.AttemptCompleted, state.TeardownDispositionCompleted
 }
 
-func completionFor(t state.Task, disposition string, launched bool) completion.Record {
+func completionFor(t state.Task, disposition string, launched bool, lastReportState, lastReportNote string) completion.Record {
 	c := completion.Record{ID: t.ID, Project: t.Project, Kind: t.Kind}
 	// The delivered case sits ahead of the merge cases below only while no merge is on the row: a
 	// delivery that then genuinely landed has the stronger fact to record, so an observed or executed
 	// merge outranks the mark.
 	switch {
+	// Ahead of every case below, disposition included: disposition explains why hand decided to
+	// terminalize, not whether the worker's own attempt succeeded, and a forced or dirt-safe teardown
+	// must not turn a self-reported failure into a success absent from the record.
+	case lastReportState == state.ReportFailed:
+		c.Outcome = "failed"
+		c.Detail = lastReportNote
+		if c.Detail == "" {
+			c.Detail = "worker reported failed"
+		}
 	// Ahead of every case below, including the forced one: none of them can be true of an attempt
 	// whose agent never started, and recording a merge or a delivery for it would be a false fact.
 	case disposition == state.TeardownDispositionNeverLaunched || !launched:

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -240,6 +240,97 @@ func TestTeardownDoesNotUseAnOlderSameSecondCompletion(t *testing.T) {
 	}
 }
 
+// Covers atqamz/hand#235: the worker's own self-reported failure, not the teardown act, is what a
+// completion record must attribute a failed outcome to.
+func TestTeardownReportsGenuineWorkerFailureAsFailedOutcome(t *testing.T) {
+	home, _ := teardownFixture(t, false)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	history.ActiveAttempt.LastReportState = state.ReportFailed
+	history.ActiveAttempt.LastReportNote = "tests would not pass"
+	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := New().Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatalf("Teardown() = %v", err)
+	}
+	if result.Outcome != "failed" || result.Detail != "tests would not pass" {
+		t.Fatalf("result = %+v, want the worker's own failure report carried through, not a teardown detail", result)
+	}
+
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Outcome != "failed" {
+		t.Fatalf("completions = %+v, want the failure durable in the ledger, not only in rendered output", records)
+	}
+}
+
+// Covers atqamz/hand#235: --force skips the landed-work checks, but it must not turn a task nobody
+// reported failed into a recorded failure.
+func TestTeardownForceOnASuccessfulTaskIsNotRecordedAsFailed(t *testing.T) {
+	home, _ := teardownFixture(t, false)
+
+	result, err := New().Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: true})
+	if err != nil {
+		t.Fatalf("Teardown() = %v", err)
+	}
+	if result.Outcome != "torn-down" || result.Detail != "forced (landed-work checks skipped)" {
+		t.Fatalf("result = %+v, want the forced disposition outcome, not an invented failure", result)
+	}
+
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Outcome == "failed" {
+		t.Fatalf("completions = %+v, want --force on a successful task to leave the record's truth alone", records)
+	}
+}
+
+// Covers atqamz/hand#235: forcing both teardowns proves --force does not decide the outcome either
+// way - a genuine self-reported failure still reads as failed, a task nobody reported failed still
+// does not, and the two stay distinct in the same durable ledger shape.
+func TestTeardownDistinguishesGenuineFailureFromForcedSuccessInDurableState(t *testing.T) {
+	failedHome, _ := teardownFixture(t, false)
+	history, err := state.ReadHistory(failedHome, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	history.ActiveAttempt.LastReportState = state.ReportFailed
+	if err := state.UpdateAttempt(failedHome, *history.ActiveAttempt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New().Teardown(context.Background(), TeardownRequest{Home: failedHome, ID: "task-1", Force: true}); err != nil {
+		t.Fatalf("Teardown() = %v", err)
+	}
+
+	successHome, _ := teardownFixture(t, false)
+	if _, err := New().Teardown(context.Background(), TeardownRequest{Home: successHome, ID: "task-1", Force: true}); err != nil {
+		t.Fatalf("Teardown() = %v", err)
+	}
+
+	failedRecords, err := completion.List(failedHome)
+	if err != nil || len(failedRecords) != 1 {
+		t.Fatalf("failed completions = %+v, err=%v", failedRecords, err)
+	}
+	successRecords, err := completion.List(successHome)
+	if err != nil || len(successRecords) != 1 {
+		t.Fatalf("success completions = %+v, err=%v", successRecords, err)
+	}
+	if failedRecords[0].Outcome != "failed" {
+		t.Fatalf("failed record outcome = %q, want failed even under --force", failedRecords[0].Outcome)
+	}
+	if successRecords[0].Outcome == "failed" {
+		t.Fatalf("success record outcome = %q, want --force on success to stay distinct from a genuine failure", successRecords[0].Outcome)
+	}
+}
+
 func TestTeardownDecisionKeepsLaunchedProvisioningDetail(t *testing.T) {
 	terminal, disposition := teardownDecision(false, true, state.AttemptProvisioning, false)
 	if terminal != state.AttemptInterrupted {
@@ -248,7 +339,7 @@ func TestTeardownDecisionKeepsLaunchedProvisioningDetail(t *testing.T) {
 	if disposition != state.TeardownDispositionLaunchedProvisioning {
 		t.Fatalf("disposition = %q, want launched-provisioning", disposition)
 	}
-	record := completionFor(state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, PR: "https://example.com/pr/1"}, disposition, true)
+	record := completionFor(state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, PR: "https://example.com/pr/1"}, disposition, true, "", "")
 	if record.Detail == "attempt never launched" {
 		t.Fatalf("completion = %+v, launched provisioning must keep landed-work detail", record)
 	}

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -184,11 +184,15 @@ func NewTaskState(status herdr.Status, now time.Time) *TaskState {
 }
 
 // ClassifyStatus compares a fresh probe with tracked state. Actionable transitions return an event;
-// working and repeated not-busy or blocked states update ts and return nil.
-func ClassifyStatus(ts *TaskState, id string, status herdr.Status, probeErr error, now time.Time) *Event {
+// working and repeated not-busy or blocked states update ts and return nil. A non-empty
+// teardownHerdrState means hand teardown, not a crash, explains the pane going unreachable.
+func ClassifyStatus(ts *TaskState, id string, status herdr.Status, probeErr error, now time.Time, teardownHerdrState string) *Event {
 	if probeErr != nil {
 		wasProbed := ts.Probed
 		ts.Probed = false
+		if teardownHerdrState != "" {
+			return nil
+		}
 		if wasProbed {
 			ts.UnreachableFired = true
 			return &Event{TaskID: id, Kind: KindFailed, Text: fmt.Sprintf("failed %s", id)}
@@ -249,8 +253,11 @@ func ClassifyStale(ts *TaskState, id, deliveredAt string, now time.Time, thresho
 
 // ClassifyUnreachable covers the one outage ClassifyStatus's immediate branch cannot: a task whose
 // very first sighting - or first sighting after a restart - finds its pane unreachable, which leaves
-// ts.Probed false with no prior "was probed" edge to fire on.
-func ClassifyUnreachable(ts *TaskState, id string, now time.Time, threshold time.Duration) *Event {
+// ts.Probed false with no prior "was probed" edge to fire on. teardownHerdrState is as in ClassifyStatus.
+func ClassifyUnreachable(ts *TaskState, id string, now time.Time, threshold time.Duration, teardownHerdrState string) *Event {
+	if teardownHerdrState != "" {
+		return nil
+	}
 	// ClassifyStatus's success path clears ts.Probed back to true, so a pane that answers again before
 	// the dwell matures never reaches it.
 	if ts.Probed || ts.UnreachableFired {

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -21,10 +21,10 @@ func TestClassifyStatusWorkingToNotBusyFiresIdleUnreportedWhenNoTerminalReport(t
 		now := time.Now()
 		ts := NewTaskState(herdr.StatusWorking, now)
 
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second)); e == nil || e.Kind != KindIdleUnreported {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second), ""); e == nil || e.Kind != KindIdleUnreported {
 			t.Fatalf("status %q: got %+v, want idle-unreported event when nothing explained the stop", notBusy, e)
 		}
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(2*time.Second)); e != nil {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(2*time.Second), ""); e != nil {
 			t.Fatalf("status %q: repeated not-busy state fired again: %+v", notBusy, e)
 		}
 	}
@@ -35,16 +35,16 @@ func TestClassifyStatusIdleUnreportedRefiresOnlyAfterTheWorkerResumesAndStopsAga
 		now := time.Now()
 		ts := NewTaskState(herdr.StatusWorking, now)
 
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second)); e == nil || e.Kind != KindIdleUnreported {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second), ""); e == nil || e.Kind != KindIdleUnreported {
 			t.Fatalf("status %q: got %+v, want idle-unreported on the first stop", notBusy, e)
 		}
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(2*time.Second)); e != nil {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(2*time.Second), ""); e != nil {
 			t.Fatalf("status %q: fired again while the worker stayed in the condition: %+v", notBusy, e)
 		}
-		if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(3*time.Second)); e != nil {
+		if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(3*time.Second), ""); e != nil {
 			t.Fatalf("status %q: leaving the condition fired an event: %+v", notBusy, e)
 		}
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(4*time.Second)); e == nil || e.Kind != KindIdleUnreported {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(4*time.Second), ""); e == nil || e.Kind != KindIdleUnreported {
 			t.Fatalf("status %q: got %+v, want idle-unreported again once the worker left and re-entered the condition", notBusy, e)
 		}
 	}
@@ -56,7 +56,7 @@ func TestClassifyStatusWorkingToNotBusyFiresIdleUnreportedWhenLastReportWasStill
 		ts := NewTaskState(herdr.StatusWorking, now)
 		ts.LastReportState = state.ReportWorking
 
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second)); e == nil || e.Kind != KindIdleUnreported {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second), ""); e == nil || e.Kind != KindIdleUnreported {
 			t.Fatalf("status %q: got %+v, want idle-unreported even though a working report exists, since it doesn't explain a stop", notBusy, e)
 		}
 	}
@@ -71,7 +71,7 @@ func TestClassifyStatusWorkingToNotBusyIsAbsorbedWhenTerminalReportExplainsIt(t 
 			ts := NewTaskState(herdr.StatusWorking, now)
 			ts.LastReportState = reportState
 
-			if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second)); e != nil {
+			if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(time.Second), ""); e != nil {
 				t.Fatalf("status %q report state %q: got %+v, want the transition absorbed silently", notBusy, reportState, e)
 			}
 		}
@@ -83,7 +83,7 @@ func TestClassifyStatusNotBusyToWorkingIsBenign(t *testing.T) {
 		now := time.Now()
 		ts := NewTaskState(notBusy, now)
 
-		if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(time.Second)); e != nil {
+		if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(time.Second), ""); e != nil {
 			t.Fatalf("status %q: got %+v, want no event for resuming work", notBusy, e)
 		}
 	}
@@ -93,20 +93,20 @@ func TestClassifyStatusBlockedFiresOnceUntilResolved(t *testing.T) {
 	now := time.Now()
 	ts := NewTaskState(herdr.StatusWorking, now)
 
-	e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(time.Second))
+	e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(time.Second), "")
 	if e == nil || e.Kind != KindBlocked || e.Text != "blocked task-1: agent needs help" {
 		t.Fatalf("got %+v, want blocked event", e)
 	}
 
-	if e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(2*time.Second)); e != nil {
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(2*time.Second), ""); e != nil {
 		t.Fatalf("repeated blocked state fired again: %+v", e)
 	}
 
-	if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(3*time.Second)); e != nil {
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(3*time.Second), ""); e != nil {
 		t.Fatalf("leaving blocked fired an event: %+v", e)
 	}
 
-	if e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(4*time.Second)); e == nil || e.Kind != KindBlocked {
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(4*time.Second), ""); e == nil || e.Kind != KindBlocked {
 		t.Fatalf("got %+v, want blocked event to refire after resolving and re-blocking", e)
 	}
 }
@@ -116,11 +116,24 @@ func TestClassifyStatusProbeFailureFiresFailedOnce(t *testing.T) {
 	ts := NewTaskState(herdr.StatusWorking, now)
 	probeErr := errors.New("pane not found")
 
-	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(time.Second)); e == nil || e.Kind != KindFailed {
+	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(time.Second), ""); e == nil || e.Kind != KindFailed {
 		t.Fatalf("got %+v, want failed event", e)
 	}
-	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(2*time.Second)); e != nil {
+	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(2*time.Second), ""); e != nil {
 		t.Fatalf("repeated probe failure fired again: %+v", e)
+	}
+}
+
+func TestClassifyStatusSuppressesFailedWhenTeardownClaimedTheHerdrResource(t *testing.T) {
+	now := time.Now()
+	ts := NewTaskState(herdr.StatusWorking, now)
+	probeErr := errors.New("pane not found")
+
+	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(time.Second), state.TeardownResourceReleasing); e != nil {
+		t.Fatalf("got %+v, want no event: teardown's own release explains the pane going unreachable", e)
+	}
+	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(2*time.Second), state.TeardownResourceReleased); e != nil {
+		t.Fatalf("got %+v, want no event on a later tick either, once teardown has finished releasing", e)
 	}
 }
 
@@ -130,10 +143,10 @@ func TestClassifyStatusRecoveryAfterFailureCanFireIdleUnreported(t *testing.T) {
 		ts := NewTaskState(herdr.StatusWorking, now)
 		probeErr := errors.New("pane not found")
 
-		if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(time.Second)); e == nil || e.Kind != KindFailed {
+		if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(time.Second), ""); e == nil || e.Kind != KindFailed {
 			t.Fatalf("status %q: got %+v, want failed event", notBusy, e)
 		}
-		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(2*time.Second)); e == nil || e.Kind != KindIdleUnreported {
+		if e := ClassifyStatus(ts, "task-1", notBusy, nil, now.Add(2*time.Second), ""); e == nil || e.Kind != KindIdleUnreported {
 			t.Fatalf("status %q: got %+v, want idle-unreported event on recovery", notBusy, e)
 		}
 	}
@@ -154,7 +167,7 @@ func TestClassifyStaleFiresOncePerWindow(t *testing.T) {
 		t.Fatalf("stale event fired again in the same window: %+v", e)
 	}
 
-	ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, now.Add(11*time.Minute))
+	ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, now.Add(11*time.Minute), "")
 	if e := ClassifyStale(ts, "task-1", "", now.Add(12*time.Minute), threshold); e != nil {
 		t.Fatalf("stale fired right after a status change reset the window: %+v", e)
 	}
@@ -221,7 +234,7 @@ func TestClassifyStaleTreatsHerdrDoneAsNotBusyOnly(t *testing.T) {
 func TestClassifyStaleSkipsUnprobedTasks(t *testing.T) {
 	now := time.Now()
 	ts := NewTaskState(herdr.StatusWorking, now)
-	ClassifyStatus(ts, "task-1", "", errors.New("down"), now.Add(time.Second))
+	ClassifyStatus(ts, "task-1", "", errors.New("down"), now.Add(time.Second), "")
 
 	if e := ClassifyStale(ts, "task-1", "", now.Add(time.Hour), time.Minute); e != nil {
 		t.Fatalf("got %+v, want no stale event while probe is failing", e)
@@ -237,14 +250,25 @@ func TestClassifyUnreachableFiresOnceAfterTheDwellForATaskFirstSeenDown(t *testi
 	ts := NewTaskState(herdr.StatusUnknown, now)
 	ts.Probed = false
 
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(time.Minute), threshold); e != nil {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(time.Minute), threshold, ""); e != nil {
 		t.Fatalf("got %+v, want no event before the dwell matures: this is what makes a blink silent", e)
 	}
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), threshold); e == nil || e.Kind != KindFailed {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), threshold, ""); e == nil || e.Kind != KindFailed {
 		t.Fatalf("got %+v, want a failed event once the outage outlasts the dwell", e)
 	}
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(10*time.Minute), threshold); e != nil {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(10*time.Minute), threshold, ""); e != nil {
 		t.Fatalf("failed event fired again for the same outage: %+v", e)
+	}
+}
+
+func TestClassifyUnreachableSuppressesFailedWhenTeardownClaimedTheHerdrResource(t *testing.T) {
+	now := time.Now()
+	threshold := 5 * time.Minute
+	ts := NewTaskState(herdr.StatusUnknown, now)
+	ts.Probed = false
+
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), threshold, state.TeardownResourceReleasing); e != nil {
+		t.Fatalf("got %+v, want no event past the dwell either: teardown's own release explains the outage", e)
 	}
 }
 
@@ -254,13 +278,13 @@ func TestClassifyUnreachableStaysSilentOnABlink(t *testing.T) {
 	ts := NewTaskState(herdr.StatusUnknown, now)
 	ts.Probed = false
 
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(time.Minute), threshold); e != nil {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(time.Minute), threshold, ""); e != nil {
 		t.Fatalf("got %+v, want no event before the dwell matures", e)
 	}
-	if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(2*time.Minute)); e != nil {
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(2*time.Minute), ""); e != nil {
 		t.Fatalf("recovery from a first-sighting outage fired an event: %+v", e)
 	}
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(10*time.Minute), threshold); e != nil {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(10*time.Minute), threshold, ""); e != nil {
 		t.Fatalf("got %+v, want no failed event: the pane recovered before the dwell matured", e)
 	}
 }
@@ -271,18 +295,18 @@ func TestClassifyUnreachableRefiresOnANewOutageAfterRecovery(t *testing.T) {
 	ts := NewTaskState(herdr.StatusUnknown, now)
 	ts.Probed = false
 
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), threshold); e == nil || e.Kind != KindFailed {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), threshold, ""); e == nil || e.Kind != KindFailed {
 		t.Fatalf("got %+v, want a failed event for the first outage", e)
 	}
-	if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(7*time.Minute)); e != nil {
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusWorking, nil, now.Add(7*time.Minute), ""); e != nil {
 		t.Fatalf("recovery fired an event: %+v", e)
 	}
 
 	probeErr := errors.New("pane not found")
-	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(8*time.Minute)); e == nil || e.Kind != KindFailed {
+	if e := ClassifyStatus(ts, "task-1", "", probeErr, now.Add(8*time.Minute), ""); e == nil || e.Kind != KindFailed {
 		t.Fatalf("got %+v, want ClassifyStatus's immediate branch to fire for a known-good task going dark", e)
 	}
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(20*time.Minute), threshold); e != nil {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(20*time.Minute), threshold, ""); e != nil {
 		t.Fatalf("got %+v, want no duplicate: ClassifyStatus's immediate branch already claimed this outage", e)
 	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -306,10 +306,10 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		// usage-limit check reads a pane on.
 		justStopped := status.NotBusy() && status != ts.Status
 
-		if e := ClassifyStatus(ts, t.ID, status, probeErr, now); e != nil {
+		if e := ClassifyStatus(ts, t.ID, status, probeErr, now, attempt.TeardownHerdrState); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
-		if e := ClassifyUnreachable(ts, t.ID, now, cfg.StaleThreshold); e != nil {
+		if e := ClassifyUnreachable(ts, t.ID, now, cfg.StaleThreshold, attempt.TeardownHerdrState); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
 		if e := ClassifyStale(ts, t.ID, t.DeliveredAt, now, cfg.StaleThreshold); e != nil {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1613,13 +1613,13 @@ func TestForgetPaneScopedCacheGivesTheShipsFirstProbeFailureADwell(t *testing.T)
 
 	forgetPaneScopedCache(ts, promotedTask(now), promotedAttempt(now), now)
 
-	if e := ClassifyStatus(ts, "task-1", "", errors.New("pane not found"), now); e != nil {
+	if e := ClassifyStatus(ts, "task-1", "", errors.New("pane not found"), now, ""); e != nil {
 		t.Fatalf("event = %+v, want none: a blink on the ship's first probe is not a failure", e)
 	}
-	if e := ClassifyUnreachable(ts, "task-1", now.Add(time.Second), 5*time.Minute); e != nil {
+	if e := ClassifyUnreachable(ts, "task-1", now.Add(time.Second), 5*time.Minute, ""); e != nil {
 		t.Fatalf("event = %+v, want none: the ship's outage has not outlived the threshold", e)
 	}
-	e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), 5*time.Minute)
+	e := ClassifyUnreachable(ts, "task-1", now.Add(6*time.Minute), 5*time.Minute, "")
 	if e == nil || e.Kind != KindFailed {
 		t.Fatalf("event = %+v, want failed: the ship's pane stayed unreachable past the threshold", e)
 	}
@@ -1737,7 +1737,7 @@ func TestForgetPaneScopedCacheStopsIdleUnreportedForAStatusTheShipNeverHeld(t *t
 
 	forgetPaneScopedCache(ts, promotedTask(now), promotedAttempt(now), now)
 
-	if e := ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, now.Add(time.Second)); e != nil {
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, now.Add(time.Second), ""); e != nil {
 		t.Fatalf("event = %+v, want none: the ship was never observed working, so its first probe cannot be an unexplained stop", e)
 	}
 }
@@ -1756,7 +1756,7 @@ func TestForgetPaneScopedCacheLetsTheShipsOwnBlockedFireAfterABlockedScout(t *te
 
 	forgetPaneScopedCache(ts, promotedTask(now), promotedAttempt(now), now)
 
-	e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(time.Second))
+	e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, now.Add(time.Second), "")
 	if e == nil || e.Kind != KindBlocked {
 		t.Fatalf("event = %+v, want blocked: the ship's pane raised its own question", e)
 	}
@@ -2310,6 +2310,38 @@ func TestRunUntilEventFiltersWakesToTheRequestedKinds(t *testing.T) {
 	}
 	if !strings.Contains(string(logData), "idle-unreported task-1") {
 		t.Fatalf("events.log = %q, want the filtered-out event still recorded", string(logData))
+	}
+}
+
+// Covers atqamz/hand#235: releaseHerdr commits TeardownResourceReleasing before it closes the pane, so
+// a caller armed on failed while a deliberate hand teardown is in flight must not read that release as
+// a worker failure and wake early.
+func TestRunUntilEventDoesNotWakeFailedWhileTeardownIsReleasingTheHerdrResource(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+	callLog := logPaneGets(t)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}, TeardownHerdrState: state.TeardownResourceReleasing})
+	cfg := Config{
+		Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 300 * time.Millisecond,
+		EventFilter: NewEventFilter([]string{KindFailed}),
+	}
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- RunUntilEvent(context.Background(), cfg, &out, io.Discard) }()
+
+	waitForPaneGets(t, callLog, 3)
+	setStatus(t, statusFile, paneGoneStatus)
+
+	err := <-done
+	if !errors.Is(err, ErrNoEvent) {
+		t.Fatalf("RunUntilEvent = %v, want ErrNoEvent: teardown's own release must not read as a failed worker", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("out = %q, want nothing woken: the pane going unreachable here is teardown's own release, not a failure", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `hand teardown` no longer emits a false `failed` event to a `hand watch --until-event` caller when tearing down a task that actually succeeded: `releaseHerdr` commits `TeardownHerdrState` before it physically closes the pane, and `ClassifyStatus`/`ClassifyUnreachable` now suppress `KindFailed` whenever that durable state is non-empty, since the pane going unreachable there is teardown's own release, not a worker failure.
- The durable completion ledger (`completions.jsonl`) now attributes a `failed` outcome to the worker's own last reported state, ahead of every teardown disposition - so `--force` or a safe-dirt teardown of a genuinely failed worker still records `failed`, while a forced teardown of a task nobody reported failed stays distinct (`torn-down`, `merged`, `delivered`, or `done`, per the existing disposition rules). `--force` changes what checks run, not what the record says happened.

Closes atqamz/hand#235

## Event vocabulary decision

No new watcher event kind was added for teardown-as-an-observable-event. The actor who runs `hand teardown` already gets synchronous confirmation from the command's own output; an async watch-channel notification for the same act would be redundant, and per the issue's own framing, an event kind nobody subscribes to is worse than none. The fix instead corrects the existing `failed` classification to stop misfiring during a deliberate teardown.

## Test plan

- `TestClassifyStatusSuppressesFailedWhenTeardownClaimedTheHerdrResource` / `TestClassifyUnreachableSuppressesFailedWhenTeardownClaimedTheHerdrResource` (`internal/watcher/events_test.go`): a pane-probe failure with a non-empty `TeardownHerdrState` emits no event, at any of the release states.
- `TestRunUntilEventDoesNotWakeFailedWhileTeardownIsReleasingTheHerdrResource` (`internal/watcher/watcher_test.go`): an armed `--until-event` watcher subscribed to `failed` is not woken when a task's pane goes unreachable while its attempt carries a non-empty `TeardownHerdrState`; it correctly times out with `ErrNoEvent` instead.
- `TestTeardownReportsGenuineWorkerFailureAsFailedOutcome` (`internal/runtime/teardown_test.go`): a task whose worker last reported `failed` still records `Outcome: "failed"` with the worker's own detail through an ordinary teardown.
- `TestTeardownForceOnASuccessfulTaskIsNotRecordedAsFailed`: `--force` on a task nobody reported failed records the forced disposition outcome (`torn-down`), never `failed`.
- `TestTeardownDistinguishesGenuineFailureFromForcedSuccessInDurableState`: forcing both a genuinely failed teardown and a successful one shows `--force` does not decide the outcome either way, and the two stay distinct in the same completion ledger.
- `TestTeardownRendersGenuineWorkerFailureAsOutcomeFailed` / `TestTeardownForceOnATaskWithNoFailureReportNeverRendersOutcomeFailed` (`cmd/teardown_test.go`): the same distinction survives to the real `hand teardown` cobra command's rendered TOON output, not just to durable state.
- `go test ./...`, `go test -race ./...`, `go vet ./...`, `nix develop -c make lint`, `make build`, `make contract`, `make e2e`, `nix flake check`, `git diff --check` all pass.
