### PR TITLE
fix(watcher): wake on a fleet condition that was already actionable when the watch armed

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -142,7 +142,7 @@ func newWatchCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&poll, "poll", "", "poll interval (default: config/watch-interval, or 5s)")
-	cmd.Flags().BoolVar(&untilEvent, "until-event", false, "block until the first event, print it, and exit 0")
+	cmd.Flags().BoolVar(&untilEvent, "until-event", false, "wake on the fleet's already-actionable state, or the first event after it, print it, and exit 0")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "with --until-event, give up after this long and exit 4 (default: no timeout)")
 	cmd.Flags().StringSliceVar(&events, "event", nil, "with --until-event, wake only on these event kinds (default: any); repeatable or comma-separated")
 	cmd.Flags().BoolVar(&takeover, "takeover", false, "request the current watcher to stop, then wait to acquire ownership")

--- a/docs/adr/arming-a-watch-observes-before-it-waits.md
+++ b/docs/adr/arming-a-watch-observes-before-it-waits.md
@@ -1,0 +1,38 @@
+# Arming a watch observes before it waits
+
+- Date: 2026-08-19
+- Status: accepted
+- Issues: atqamz/hand#252
+- PRs: atqamz/hand#262
+
+## Context
+
+[Process exit delivers watcher events to the supervisor](the-until-event-exit-is-the-delivery.md) decided that until-event mode takes a silent baseline and that startup state is not an event.
+That made every wake edge-triggered.
+A condition already true when the watcher armed, and a condition that arrived while no watcher was alive, then had no transition left to fire on: a worker whose pane stopped before the arm, or a report written between two watchers, woke nobody.
+Supervising sessions found such state only when the operator asked for it.
+
+## Decision
+
+The supervisor-facing wake contract is the fleet's current actionable condition **or** the next transition, not the next transition only.
+
+Arming performs a real observation whose events are delivered.
+[`internal/watcher`](../../internal/watcher) seeds each task from durable state on the first arming tick and classifies it on the second, and `RunUntilEvent` returns whatever that pass found.
+`ClassifyCatchUp` asks the level question `ClassifyStatus` can only ask as an edge, and the attempt's durable `status_changed_for` is what says whether some watcher already announced the episode.
+`CatchUpFilter` bounds the delivery to kinds whose announcement durable state records, so a re-arm against an already-announced condition is silent.
+
+Announcement, not operator acknowledgement, is the idempotence unit here. atqamz/hand#244 owns the acknowledgement model.
+
+## Rejected alternatives
+
+- Keeping the silent baseline and letting supervisors poll `hand status` between arms restates the missed condition as the supervisor's problem and reintroduces the ad-hoc `sleep; poll` loop the issue rejects.
+- A daemon, an event bus, or a persistent subscription registry buys nothing the durable state already in `state/hand.db` and `state/<id>.status` cannot answer at arm time, and is atqamz/hand#244's design space rather than this defect's.
+- Delivering the whole arming pass unfiltered re-fires every dwell latch that is re-derived rather than persisted; `stale` alone is satisfied by any task whose herdr status has simply not changed lately, so every re-arm would return at once.
+- A new durable "announced" column per condition duplicates evidence the attempt row already carries.
+
+## Consequences
+
+An arm can return before it ever reaches its poll loop, and `--timeout` bounds only the waiting that follows.
+Events the arming pass delivers are the same events a transition would have delivered, so consumers need no new vocabulary.
+A watcher process that dies between announcing and persisting re-announces on the next arm, which is the duplicate this package already prefers over a suppressed announcement.
+`stale` remains recorded in `state/events.log` and on the streaming `hand watch` path, but never wakes an arm.

--- a/docs/adr/the-until-event-exit-is-the-delivery.md
+++ b/docs/adr/the-until-event-exit-is-the-delivery.md
@@ -1,7 +1,7 @@
 # Process exit delivers watcher events to the supervisor
 
 - Date: 2026-08-04
-- Status: accepted
+- Status: accepted, with its silent baseline superseded by [Arming a watch observes before it waits](arming-a-watch-observes-before-it-waits.md)
 - Issues: none
 - PRs: atqamz/hand#125
 

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -66,7 +66,7 @@ var supervisorInstructions = []string{
 	"Edit `data/backlog.md` to record the task with a unique ID.",
 	"Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.",
 	"`hand status <id>` shows a worker's reported state. Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.",
-	"Run `hand watch --until-event` as a background task to monitor the fleet. It exits on the first fleet event; exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. A supervisor should re-arm it after acting on an event or when intentionally resuming monitoring.",
+	"Run `hand watch --until-event` as a background task to monitor the fleet. Arming observes the fleet's already-actionable state first, so a condition that arrived while nothing was watching still wakes it; after that it exits on the first fleet event. Exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. A supervisor should re-arm it after acting on an event or when intentionally resuming monitoring.",
 	"Never merge without explicit authorization.",
 	"Run `hand teardown <id>` after work is landed. Work that is handed off but whose landing is someone else's call is recorded with `hand deliver <id> --reason <text>` first.",
 	"Never edit files under `projects/`. Workers do that in worktrees.",

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -56,6 +56,18 @@ func KnownKinds() []string {
 	}
 }
 
+// CatchUpFilter is the subset of kinds an arm-time observation may deliver: every kind whose
+// announcement durable state records, so a re-arm meeting a condition some watcher already
+// announced stays quiet instead of re-firing it once per arm.
+func CatchUpFilter() EventFilter {
+	f := NewEventFilter(KnownKinds())
+	// KindStale is the one exclusion. Its latch is re-derived per watcher process, and its dwell is
+	// satisfied by any task whose herdr status has simply not changed lately, so delivering it at arm
+	// would return from every re-arm at once, forever.
+	delete(f, KindStale)
+	return f
+}
+
 // NotifyFilter is the fixed subset of events worth sending through the
 // watcher's unattended notification channel.
 func NotifyFilter() EventFilter {
@@ -175,6 +187,10 @@ type TaskState struct {
 	// persisted. A restart mid-outage loses it and ClassifyUnreachable re-evaluates the dwell against
 	// durable evidence, so the safe failure mode is one duplicate announcement, never a suppressed one.
 	UnreachableFired bool
+	// Records that ClassifyCatchUp has had its one look at this task. Deliberately not persisted: the
+	// durable evidence it reads is what dedupes across processes, while this only keeps one watcher
+	// from re-asking a question whose answer cannot change until a status transition does.
+	CaughtUp bool
 }
 
 // NewTaskState seeds tracking for a task first observed at now, without emitting an
@@ -231,6 +247,35 @@ func ClassifyStatus(ts *TaskState, id string, status herdr.Status, probeErr erro
 		}
 	default:
 		ts.Blocked = false
+	}
+	return nil
+}
+
+// ClassifyCatchUp reports the condition a task is already in the first time this watcher classifies
+// it, which ClassifyStatus can only ever see as a transition. observedFor is the attempt's durable
+// status_changed_for: naming the observed status is what proves some watcher announced this episode.
+func ClassifyCatchUp(ts *TaskState, id string, status herdr.Status, observedFor, teardownHerdrState string) *Event {
+	// A pane released by hand teardown is nobody's condition to act on - atqamz/hand#235's rule, one
+	// classifier further on.
+	if teardownHerdrState != "" {
+		return nil
+	}
+	// A status this watcher has itself seen change belongs to ClassifyStatus's edge, and an episode
+	// durable state already names was announced when it was observed. Catching up on either says it twice.
+	if status != ts.Status || observedFor == string(status) {
+		return nil
+	}
+	switch {
+	case status.NotBusy():
+		// The same question ClassifyStatus asks of its own idle edge: has anything explained the stop.
+		if ts.LastReportState == "" || ts.LastReportState == state.ReportWorking {
+			return &Event{TaskID: id, Kind: KindIdleUnreported, Text: fmt.Sprintf("idle-unreported %s", id)}
+		}
+	case status == herdr.StatusBlocked:
+		if !ts.Blocked {
+			ts.Blocked = true
+			return &Event{TaskID: id, Kind: KindBlocked, Text: fmt.Sprintf("blocked %s: %s", id, blockedReason), Reason: blockedReason}
+		}
 	}
 	return nil
 }

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -152,6 +152,101 @@ func TestClassifyStatusRecoveryAfterFailureCanFireIdleUnreported(t *testing.T) {
 	}
 }
 
+func TestClassifyCatchUpFiresIdleUnreportedForAStopThatPredatesTheWatcher(t *testing.T) {
+	for _, notBusy := range notBusyStatuses {
+		for _, lastReport := range []string{"", state.ReportWorking} {
+			ts := NewTaskState(notBusy, time.Now())
+			ts.LastReportState = lastReport
+
+			e := ClassifyCatchUp(ts, "task-1", notBusy, "working", "")
+			if e == nil || e.Kind != KindIdleUnreported || e.Text != "idle-unreported task-1" {
+				t.Fatalf("status %q, last report %q: got %+v, want idle-unreported", notBusy, lastReport, e)
+			}
+		}
+	}
+}
+
+func TestClassifyCatchUpStaysSilentOnAnEpisodeDurableStateAlreadyNames(t *testing.T) {
+	for _, notBusy := range notBusyStatuses {
+		ts := NewTaskState(notBusy, time.Now())
+
+		if e := ClassifyCatchUp(ts, "task-1", notBusy, string(notBusy), ""); e != nil {
+			t.Fatalf("status %q: got %+v, want silence: some watcher observed and announced this episode", notBusy, e)
+		}
+	}
+}
+
+// A stop the worker itself explained needs no wake here, exactly as ClassifyStatus's own idle edge
+// absorbs it: the report line was the news, and it has its own event.
+func TestClassifyCatchUpAbsorbsAStopAReportExplains(t *testing.T) {
+	for _, explained := range []string{state.ReportDone, state.ReportFailed, state.ReportBlocked, state.ReportNeedsDecision, state.ReportPaused} {
+		ts := NewTaskState(herdr.StatusDone, time.Now())
+		ts.LastReportState = explained
+
+		if e := ClassifyCatchUp(ts, "task-1", herdr.StatusDone, "working", ""); e != nil {
+			t.Fatalf("last report %q: got %+v, want the stop absorbed", explained, e)
+		}
+	}
+}
+
+func TestClassifyCatchUpFiresBlockedForAPaneAlreadyBlockedAtArm(t *testing.T) {
+	ts := NewTaskState(herdr.StatusBlocked, time.Now())
+
+	e := ClassifyCatchUp(ts, "task-1", herdr.StatusBlocked, "working", "")
+	if e == nil || e.Kind != KindBlocked || e.Text != "blocked task-1: agent needs help" {
+		t.Fatalf("got %+v, want blocked event", e)
+	}
+	if !ts.Blocked {
+		t.Fatal("ts.Blocked = false, want the episode claimed so the next tick does not announce it again")
+	}
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusBlocked, nil, time.Now(), ""); e != nil {
+		t.Fatalf("got %+v, want ClassifyStatus to find the caught-up blocked episode already claimed", e)
+	}
+}
+
+// atqamz/hand#252 must not reopen atqamz/hand#235: a pane hand teardown is releasing is nobody's
+// condition to act on, whichever classifier meets it first.
+func TestClassifyCatchUpSuppressesEveryConditionWhileTeardownHoldsTheHerdrResource(t *testing.T) {
+	for _, releasing := range []string{state.TeardownResourceReleasing, state.TeardownResourceReleased} {
+		for _, status := range []herdr.Status{herdr.StatusDone, herdr.StatusIdle, herdr.StatusBlocked} {
+			ts := NewTaskState(status, time.Now())
+
+			if e := ClassifyCatchUp(ts, "task-1", status, "working", releasing); e != nil {
+				t.Fatalf("status %q, teardown %q: got %+v, want no wake", status, releasing, e)
+			}
+		}
+	}
+}
+
+// The status this watcher has itself seen change is ClassifyStatus's edge, and announcing both would
+// wake the supervisor twice for one stop.
+func TestClassifyCatchUpLeavesAnObservedTransitionToClassifyStatus(t *testing.T) {
+	ts := NewTaskState(herdr.StatusWorking, time.Now())
+
+	if e := ClassifyCatchUp(ts, "task-1", herdr.StatusDone, "working", ""); e != nil {
+		t.Fatalf("got %+v, want silence while ts still holds the status it was seeded with", e)
+	}
+	if e := ClassifyStatus(ts, "task-1", herdr.StatusDone, nil, time.Now(), ""); e == nil || e.Kind != KindIdleUnreported {
+		t.Fatalf("got %+v, want the transition announced exactly once, by ClassifyStatus", e)
+	}
+}
+
+func TestCatchUpFilterCarriesEveryKindWhoseAnnouncementIsDurable(t *testing.T) {
+	f := CatchUpFilter()
+
+	if f.Matches(KindStale) {
+		t.Fatal("stale is deliverable at arm, so every re-arm against an unchanged status returns at once")
+	}
+	for _, kind := range KnownKinds() {
+		if kind == KindStale {
+			continue
+		}
+		if !f.Matches(kind) {
+			t.Fatalf("kind %q is not deliverable at arm, so a condition that arrived while no watcher was alive is lost", kind)
+		}
+	}
+}
+
 func TestClassifyStaleFiresOncePerWindow(t *testing.T) {
 	now := time.Now()
 	ts := NewTaskState(herdr.StatusWorking, now)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -26,6 +26,8 @@ const maxEventLogLines = 200
 
 var afterWatchTick = func() {}
 
+var afterArmTick = func() {}
+
 type Config struct {
 	Home           string
 	PollInterval   time.Duration
@@ -37,6 +39,10 @@ type Config struct {
 	// the Run path as much as the RunUntilEvent one. Keeping Run unfiltered is cmd/watch.go's doing,
 	// not this package's: it rejects --event without --until-event, so Run never gets a CLI filter.
 	EventFilter EventFilter
+	// Narrows the arming ticks further, on top of EventFilter, to what durable state dedupes across
+	// arms. Unexported because it describes this package's own two-tick arming rather than anything a
+	// caller asked for, and nil - matching every kind - on every other tick.
+	catchUp EventFilter
 }
 
 var ErrNoEvent = errors.New("no event")
@@ -102,9 +108,9 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	}
 }
 
-// RunUntilEvent blocks until a tick produces events, writes them to out and returns nil - the exit is
-// the delivery, since it is the one signal a supervisory agent's background-task runner already
-// honors.
+// RunUntilEvent observes what is already actionable, then blocks until a tick produces events, writes
+// them to out and returns nil - the exit is the delivery, since it is the one signal a supervisory
+// agent's background-task runner already honors.
 func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -125,11 +131,25 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 	}
 
 	states := make(map[string]*TaskState)
-	// The startup state is never delivered: two ticks take a silent baseline first, so an already-done
-	// worker is not mistaken for a fresh transition. Baseline events still reach events.log, just not
-	// stdout, which is what io.Discard as out means here.
-	tick(ctx, cfg, client, states, io.Discard, errOut)
-	tick(ctx, cfg, client, states, io.Discard, errOut)
+	// Arming observes before it waits: a condition already true here has no next transition left to
+	// wake on. The first tick seeds every task from durable state and the second classifies it, with
+	// cfg.catchUp holding the delivery to conditions durable state can prove were never announced.
+	arming := cfg
+	arming.catchUp = CatchUpFilter()
+	var caught bytes.Buffer
+	tick(ctx, arming, client, states, &caught, errOut)
+	afterArmTick()
+	tick(ctx, arming, client, states, &caught, errOut)
+	afterArmTick()
+	// Cancellation outranks a delivery here exactly as it does at the tick boundary below: a watcher
+	// that has been replaced or interrupted must not answer as though it were still the fleet's.
+	if ctxErr := contextLifecycleError(ctx); ctxErr != nil {
+		return runUntilEventContextError(ctx, cfg.Timeout)
+	}
+	if caught.Len() > 0 {
+		_, err := out.Write(caught.Bytes())
+		return err
+	}
 
 	ticker := time.NewTicker(cfg.PollInterval)
 	defer ticker.Stop()
@@ -301,6 +321,16 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		forgetPaneScopedCache(ts, t, attempt, now)
 
 		t = tailReport(ctx, cfg, ts, t, out, errOut)
+
+		// After the report tail, which may be what explains the stop, and before ClassifyStatus, whose
+		// edge would announce the same fact twice. One look per task: nothing this reads can change
+		// again without a status transition, which ClassifyStatus owns from here on.
+		if probeErr == nil && !ts.CaughtUp {
+			ts.CaughtUp = true
+			if e := ClassifyCatchUp(ts, t.ID, status, attempt.StatusChangedFor, attempt.TeardownHerdrState); e != nil {
+				handleEvent(cfg, e, out, errOut)
+			}
+		}
 
 		// Read before ClassifyStatus consumes the transition, which is the edge the
 		// usage-limit check reads a pane on.
@@ -834,7 +864,7 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 // run unconditionally, so narrowing --event never narrows what reaches
 // config/notify.
 func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
-	if cfg.EventFilter.Matches(e.Kind) {
+	if cfg.EventFilter.Matches(e.Kind) && cfg.catchUp.Matches(e.Kind) {
 		_, _ = fmt.Fprintln(out, e.Text)
 	}
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1067,6 +1067,48 @@ func TestTickResumesReportTailAfterRestart(t *testing.T) {
 	}
 }
 
+// Covers atqamz/hand#252's third and eighth acceptance tests together: the stop lands while no
+// watcher is alive, so recovery has to come from durable state, and the watcher after that one has
+// to find the same condition already answered.
+func TestTickCatchesUpOnAStopThatLandedBetweenTwoWatchers(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}, LastReportState: state.ReportWorking})
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
+	client := herdr.NewClient()
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	watched := make(map[string]*TaskState)
+	tick(ctx, cfg, client, watched, &buf, io.Discard)
+	tick(ctx, cfg, client, watched, &buf, io.Discard)
+	if buf.Len() != 0 {
+		t.Fatalf("output = %q, want nothing while the worker is still working", buf.String())
+	}
+
+	// No watcher is alive across this transition, so no edge exists for anyone to have observed.
+	setStatus(t, statusFile, "done")
+
+	buf.Reset()
+	rearmed := make(map[string]*TaskState)
+	tick(ctx, cfg, client, rearmed, &buf, io.Discard)
+	tick(ctx, cfg, client, rearmed, &buf, io.Discard)
+	if !strings.Contains(buf.String(), "idle-unreported task-1") {
+		t.Fatalf("output = %q, want idle-unreported task-1 recovered from durable state", buf.String())
+	}
+
+	buf.Reset()
+	again := make(map[string]*TaskState)
+	tick(ctx, cfg, client, again, &buf, io.Discard)
+	tick(ctx, cfg, client, again, &buf, io.Discard)
+	if buf.Len() != 0 {
+		t.Fatalf("output = %q, want silence: the condition was announced once and nothing changed since", buf.String())
+	}
+}
+
 // A `done:` rewrite landing on the byte count of the `working:` line before it was skipped outright
 // (atqamz/hand#149): the offset still sat just past the final newline with nothing after it, so
 // nothing was announced, LastReportState stayed `working`, and ClassifyDeferredDone - gated on it - never ran.
@@ -1662,6 +1704,7 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 		PersistedLimitStuckEpisode: 7,
 		LimitProbed:                true,
 		UnreachableFired:           true,
+		CaughtUp:                   true,
 	}
 	promoted := state.Task{CreatedAt: "2020-01-01T00:00:00Z"}
 	promotedAttempt := state.Attempt{
@@ -1682,6 +1725,10 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 		"PersistedPRMerged":       true,
 		"ParkedFiredFor":          true,
 		"PersistedParkedFiredFor": true,
+		// CaughtUp records this watcher's own one look at the task, anchored to no pane. The ship's
+		// first probe is deliberately a baseline - Status is reset to StatusUnknown right here - so a
+		// re-run of the catch-up against it could only ever return nil anyway.
+		"CaughtUp": true,
 	}
 
 	ts := before
@@ -2189,37 +2236,29 @@ func TestRunExitsWhenPaneProbeIsCanceled(t *testing.T) {
 	}
 }
 
-// The regression test for the delivery failure of 2026-07-28: the grep-on-first-line wrapper this
-// mode replaces matched a done worker's startup line, took it for a transition, and left the two real
-// events that followed unread for three hours.
-func TestRunUntilEventTakesTheStartupStateAsBaseline(t *testing.T) {
+// Covers atqamz/hand#252: the report was written while no watcher was alive, so there is no future
+// transition left to wake on. Arming has to observe it, not take it as a baseline it may discard.
+func TestRunUntilEventDeliversAReportWrittenBeforeTheArm(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "done")
 	writeFakeHerdr(t, statusFile)
-	callLog := logPaneGets(t)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR checks green\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	var out bytes.Buffer
-	done := make(chan error, 1)
-	go func() {
-		done <- RunUntilEvent(ctx, Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour}, &out, io.Discard)
-	}()
-
-	waitForPaneGets(t, callLog, 4)
-	cancel()
-	err := <-done
-
-	if !errors.Is(err, ErrInterrupted) {
-		t.Fatalf("RunUntilEvent = %v, want ErrInterrupted after the baseline was observed", err)
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
+	if err := RunUntilEvent(context.Background(), cfg, &out, io.Discard); err != nil {
+		t.Fatalf("RunUntilEvent = %v, want nil so the exit code reads as a delivered event", err)
 	}
-	if out.Len() != 0 {
-		t.Fatalf("out = %q, want the startup state delivered as nothing", out.String())
+	if !strings.Contains(out.String(), "reported-done task-1") {
+		t.Fatalf("out = %q, want reported-done task-1 delivered by the arm itself", out.String())
+	}
+	// The report line explains the stop, so the pane being not-busy is not a second condition.
+	if strings.Contains(out.String(), "idle-unreported") {
+		t.Fatalf("out = %q, want no idle-unreported alongside the report that explains the stop", out.String())
 	}
 
 	logData, err := os.ReadFile(filepath.Join(home, "state", "events.log"))
@@ -2227,7 +2266,169 @@ func TestRunUntilEventTakesTheStartupStateAsBaseline(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(logData), "reported-done task-1") {
-		t.Fatalf("events.log = %q, want the baseline's own events still recorded: the report line is consumed either way", string(logData))
+		t.Fatalf("events.log = %q, want the arm's own events recorded there too", string(logData))
+	}
+}
+
+// Covers atqamz/hand#252's central case: the worker's pane stopped before the watcher armed, and its
+// last word was a `working:` line an earlier watcher already announced. No edge is left to fire.
+func TestRunUntilEventWakesOnAWorkerAlreadyStoppedBeforeTheArm(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "done")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+			StatusChangedFor: "working", LastReportState: state.ReportWorking, LastReportNote: "still on the migration"})
+
+	var out bytes.Buffer
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
+	if err := RunUntilEvent(context.Background(), cfg, &out, io.Discard); err != nil {
+		t.Fatalf("RunUntilEvent = %v, want nil so the exit code reads as a delivered event", err)
+	}
+	if !strings.Contains(out.String(), "idle-unreported task-1") {
+		t.Fatalf("out = %q, want idle-unreported task-1 from the arm-time observation", out.String())
+	}
+
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	if attempt.StatusChangedFor != "done" {
+		t.Fatalf("status_changed_for = %q, want the caught-up episode recorded so a re-arm has evidence it was announced", attempt.StatusChangedFor)
+	}
+}
+
+// The other half of the same contract: an arm that finds nothing actionable has to wait for a real
+// transition, and a re-arm meeting the same already-announced condition must not fire again.
+func TestRunUntilEventStaysArmedWhenTheCaughtUpConditionWasAlreadyAnnounced(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "done")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+			StatusChangedFor: "working", LastReportState: state.ReportWorking})
+
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
+	var first bytes.Buffer
+	if err := RunUntilEvent(context.Background(), cfg, &first, io.Discard); err != nil {
+		t.Fatalf("first RunUntilEvent = %v, want the caught-up wake", err)
+	}
+	if !strings.Contains(first.String(), "idle-unreported task-1") {
+		t.Fatalf("first out = %q, want idle-unreported task-1", first.String())
+	}
+
+	cfg.Timeout = 300 * time.Millisecond
+	var second bytes.Buffer
+	err := RunUntilEvent(context.Background(), cfg, &second, io.Discard)
+	if !errors.Is(err, ErrNoEvent) {
+		t.Fatalf("re-armed RunUntilEvent = %v, want ErrNoEvent: the condition was announced once and nothing has changed since", err)
+	}
+	if second.Len() != 0 {
+		t.Fatalf("re-armed out = %q, want silence rather than one wake per arm", second.String())
+	}
+}
+
+// atqamz/hand#252 and atqamz/hand#235 together: the arm observes what it missed, and a pane hand
+// teardown is releasing is still not one of the things it missed.
+func TestRunUntilEventCatchesUpOnAStoppedWorkerWithoutWakingOnATeardownRelease(t *testing.T) {
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{
+			{ID: "wA:t1", Label: "torn-down", Pane: "p1"},
+			{ID: "wA:t2", Label: "stopped", Pane: "p2"},
+		}}},
+		PaneStatus: "done",
+	}.Install(t, faketool.Bin(t))
+
+	quiet := state.Attempt{Lifecycle: state.AttemptRunning, StatusChangedFor: "working", LastReportState: state.ReportWorking}
+	tornDown := quiet
+	tornDown.Herdr = state.Herdr{PaneID: "p1"}
+	tornDown.TeardownHerdrState = state.TeardownResourceReleasing
+	stopped := quiet
+	stopped.Herdr = state.Herdr{PaneID: "p2"}
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, tornDown)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-2", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339)}, stopped); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
+	if err := RunUntilEvent(context.Background(), cfg, &out, io.Discard); err != nil {
+		t.Fatalf("RunUntilEvent = %v, want nil", err)
+	}
+	if !strings.Contains(out.String(), "idle-unreported task-2") {
+		t.Fatalf("out = %q, want the genuinely stopped worker caught up", out.String())
+	}
+	if strings.Contains(out.String(), "task-1") {
+		t.Fatalf("out = %q, want nothing for the task teardown is releasing", out.String())
+	}
+}
+
+// Covers atqamz/hand#252's sixth acceptance test. stale is satisfied by any task whose herdr status
+// has simply not changed lately, so delivering it at arm would make every re-arm return at once -
+// a busy poll wearing an event's clothes.
+func TestRunUntilEventKeepsWaitingWhenOnlyStaleWouldFireAtArm(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := t.TempDir()
+	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, CreatedAt: dwelling},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+			StatusChangedAt: dwelling, StatusChangedFor: "working"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: 20 * time.Minute, Timeout: 500 * time.Millisecond}
+	err := RunUntilEvent(context.Background(), cfg, &out, io.Discard)
+
+	if !errors.Is(err, ErrNoEvent) {
+		t.Fatalf("RunUntilEvent = %v, want ErrNoEvent: a working worker whose status has not changed is not actionable", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("out = %q, want the watcher still waiting", out.String())
+	}
+	logData, err := os.ReadFile(filepath.Join(home, "state", "events.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "stale task-1") {
+		t.Fatalf("events.log = %q, want stale still recorded: the arm withholds the wake, not the record", string(logData))
+	}
+}
+
+// Covers atqamz/hand#252's ninth acceptance test: --until-event returns once, so everything the arm
+// found actionable has to leave with it rather than be dropped behind the first task's event.
+func TestRunUntilEventDeliversEveryTaskActionableAtArm(t *testing.T) {
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{
+			{ID: "wA:t1", Label: "task-1", Pane: "p1"},
+			{ID: "wA:t2", Label: "task-2", Pane: "p2"},
+		}}},
+		PaneStatus: "done",
+	}.Install(t, faketool.Bin(t))
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+			StatusChangedFor: "working", LastReportState: state.ReportWorking})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-2", Project: "nsr", Kind: state.KindShip,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p2"},
+			StatusChangedFor: "working", LastReportState: state.ReportWorking}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
+	if err := RunUntilEvent(context.Background(), cfg, &out, io.Discard); err != nil {
+		t.Fatalf("RunUntilEvent = %v, want nil", err)
+	}
+	for _, want := range []string{"idle-unreported task-1", "idle-unreported task-2"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("out = %q, want %q: the second actionable task must not be lost behind the first", out.String(), want)
+		}
 	}
 }
 
@@ -2351,10 +2552,11 @@ func TestRunUntilEventDeliversIdleUnreportedForAWorkerThatWentQuiet(t *testing.T
 	writeFakeHerdr(t, statusFile)
 	callLog := logPaneGets(t)
 
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("working: still on the migration\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	// Durable, not a fresh report file: an unconsumed line is itself news the arm would deliver, and
+	// this is about the transition after the arm.
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+			StatusChangedFor: "working", LastReportState: state.ReportWorking, LastReportNote: "still on the migration"})
 	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}
 
 	var out bytes.Buffer
@@ -2573,6 +2775,39 @@ func TestRunUntilEventReportsReplacementOnTakeoverCause(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("RunUntilEvent did not return after a replacement cause")
+	}
+}
+
+// The same precedence at the other boundary: an arm that found something actionable still belongs to
+// a watcher that has since been replaced, so the replacement is what the caller hears about.
+func TestRunUntilEventDoesNotDeliverAnArmObservationAfterCancellation(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "done")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
+		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+			StatusChangedFor: "working", LastReportState: state.ReportWorking})
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	oldAfterArmTick := afterArmTick
+	t.Cleanup(func() { afterArmTick = oldAfterArmTick })
+	arms := 0
+	afterArmTick = func() {
+		arms++
+		if arms == 2 {
+			cancel(ErrReplaced)
+		}
+	}
+
+	var out bytes.Buffer
+	err := RunUntilEvent(ctx, Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 10 * time.Second}, &out, io.Discard)
+	if !errors.Is(err, ErrReplaced) {
+		t.Fatalf("RunUntilEvent = %v, want ErrReplaced when cancellation follows the arm-time observation", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("out = %q, want no delivery from a watcher that has been replaced", out.String())
 	}
 }
 

--- a/tests/e2e/status_unacknowledged_test.go
+++ b/tests/e2e/status_unacknowledged_test.go
@@ -29,12 +29,15 @@ func TestStatusFlagsATerminalReportNoWatcherEverRead(t *testing.T) {
 		t.Fatalf("hand status task-1 stdout %q, want the same flag in the detail view", single.stdout)
 	}
 
-	// Exit 4, not 0: arming consumes the backlog into state/events.log and the
-	// notify hook without printing it, and only a later event is fleet news. That
-	// consumption is exactly what acknowledges the report.
+	// Exit 0: arming observes the backlog and delivers it (atqamz/hand#252), because a report written
+	// while nothing was watching has no later transition to be announced by. Consuming it is what
+	// acknowledges it, whether or not it also woke someone.
 	armed := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "300ms")
-	if armed.code != 4 {
-		t.Fatalf("hand watch --until-event: exit %d, want 4 (stderr %q)", armed.code, armed.stderr)
+	if armed.code != 0 {
+		t.Fatalf("hand watch --until-event: exit %d, want 0 (stderr %q)", armed.code, armed.stderr)
+	}
+	if !strings.Contains(armed.stdout, "reported-done task-1: PR up") {
+		t.Fatalf("hand watch --until-event stdout %q, want the unread completion delivered", armed.stdout)
 	}
 
 	after := runHand(t, home, "status")

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -13,18 +13,20 @@ import (
 )
 
 // Drives `hand watch` as a background process against two seeded tasks and asserts on its actual contract:
-// a task's status at watch startup never retroactively fires an event, only a later transition does.
+// a status some watcher already observed and announced never fires again, only a later transition does.
 func TestWatchEventStream(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
+	// task-2's blocked episode carries durable evidence that it was already announced, so this run has
+	// nothing to catch up on and every event below is a transition it saw for itself.
 	for _, tc := range []struct {
 		task    state.Task
 		attempt state.Attempt
 	}{
-		{state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}}},
-		{state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}}},
+		{state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, StatusChangedFor: "working"}},
+		{state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}, StatusChangedFor: "blocked"}},
 	} {
 		writeTaskAttempt(t, home, tc.task, tc.attempt)
 	}
@@ -50,8 +52,8 @@ func TestWatchEventStream(t *testing.T) {
 	setPaneStatus(t, statusDir, "pane-1", "done")
 	watch.waitForStdout(t, "idle-unreported task-1", 5*time.Second)
 	// task-1's event is the liveness signal: it proves the watcher has run a post-seed tick over both tasks,
-	// so the absence of any task-2 output is a real suppression of task-2's pre-existing "blocked" status
-	// rather than a watcher that has not polled yet.
+	// so the absence of any task-2 output is a real suppression of task-2's already-announced "blocked"
+	// status rather than a watcher that has not polled yet.
 	if strings.Contains(watch.stdout.String(), "task-2") {
 		t.Fatalf("watch fired an event for task-2's pre-existing status before any transition: stdout=%q", watch.stdout.String())
 	}
@@ -86,26 +88,24 @@ func TestWatchEventStream(t *testing.T) {
 	}
 }
 
-// task-2 sits in a state the grep-on-first-line wrapper this mode replaces would
-// have matched immediately (see TestRunUntilEventTakesTheStartupStateAsBaseline),
-// so nothing about it may appear on stdout.
+// task-2 is settled: its terminal report is consumed and its stopped pane is an episode durable state
+// already names, so nothing about it may appear on stdout however long the watcher waits.
 func TestWatchUntilEventExitsOnTheFirstTransition(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
 
 	now := time.Now().UTC().Format(time.RFC3339)
+	settled := "done: PR merged already\n"
 	for _, tc := range []struct {
 		task    state.Task
 		attempt state.Attempt
 	}{
-		{state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}}},
-		{state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}}},
+		{state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}, StatusChangedFor: "working"}},
+		{state.Task{ID: "task-2", Project: "demo", Kind: state.KindShip, CreatedAt: now, ReportOffset: int64(len(settled))}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}, StatusChangedFor: "done", LastReportState: state.ReportDone, LastReportNote: "PR merged already"}},
 	} {
 		writeTaskAttempt(t, home, tc.task, tc.attempt)
 	}
-	// A terminal report line nobody consumed: report_offset is still 0, so the
-	// poll loop classifies it as new. The baseline has to absorb it silently.
-	if err := os.WriteFile(state.ReportPath(home, "task-2"), []byte("done: PR merged already\n"), 0o644); err != nil {
+	if err := os.WriteFile(state.ReportPath(home, "task-2"), []byte(settled), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -135,15 +135,63 @@ func TestWatchUntilEventExitsOnTheFirstTransition(t *testing.T) {
 		t.Fatalf("stdout = %q, want idle-unreported task-1", result.stdout)
 	}
 	if strings.Contains(result.stdout, "task-2") {
-		t.Fatalf("stdout = %q, want nothing about task-2: its state and its unconsumed report line are both baseline, not transitions", result.stdout)
+		t.Fatalf("stdout = %q, want nothing about task-2: its report is consumed and its stopped pane already announced", result.stdout)
 	}
 
 	logData, err := os.ReadFile(filepath.Join(state.Dir(home), "events.log"))
 	if err != nil {
 		t.Fatalf("read events.log: %v", err)
 	}
-	if !strings.Contains(string(logData), "reported-done task-2") {
-		t.Fatalf("events.log = %q, want task-2's baseline report line recorded", string(logData))
+	if !strings.Contains(string(logData), "idle-unreported task-1") {
+		t.Fatalf("events.log = %q, want the delivered event recorded durably too", string(logData))
+	}
+}
+
+// Covers atqamz/hand#252 end to end: the worker stopped and the report landed while nothing was
+// watching, so the arm has to be the wake. No status changes at all after the watcher starts.
+func TestWatchUntilEventWakesOnAFleetAlreadyActionableAtArm(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "direct-pr")
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, tc := range []struct {
+		task    state.Task
+		attempt state.Attempt
+	}{
+		{state.Task{ID: "quiet-worker", Project: "demo", Kind: state.KindShip, CreatedAt: now},
+			state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
+				StatusChangedFor: "working", LastReportState: state.ReportWorking, LastReportNote: "acknowledged, fixing it now"}},
+		{state.Task{ID: "finished-worker", Project: "demo", Kind: state.KindShip, CreatedAt: now},
+			state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-2"), Herdr: state.Herdr{PaneID: "pane-2"}, StatusChangedFor: "working"}},
+	} {
+		writeTaskAttempt(t, home, tc.task, tc.attempt)
+	}
+	if err := os.WriteFile(state.ReportPath(home, "finished-worker"), []byte("done: branch pushed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	statusDir := t.TempDir()
+	setPaneStatus(t, statusDir, "pane-1", "done")
+	setPaneStatus(t, statusDir, "pane-2", "done")
+	writeFakeHerdrWatch(t, binDir(t), statusDir, filepath.Join(t.TempDir(), "herdr-invocations.log"))
+
+	got := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "30s")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 for a delivered event (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	for _, want := range []string{"idle-unreported quiet-worker", "reported-done finished-worker: branch pushed"} {
+		if !strings.Contains(got.stdout, want) {
+			t.Fatalf("stdout = %q, want %q: the operator should not have to ask for state Hand already had", got.stdout, want)
+		}
+	}
+
+	// Nothing has changed since, so the re-arm has to wait rather than announce the same conditions again.
+	rearmed := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "1s")
+	if rearmed.code != 4 {
+		t.Fatalf("re-armed exit = %d, want 4 (stdout %q, stderr %q)", rearmed.code, rearmed.stdout, rearmed.stderr)
+	}
+	if strings.TrimSpace(rearmed.stdout) != "" {
+		t.Fatalf("re-armed stdout = %q, want silence: one wake per condition, not one per arm", rearmed.stdout)
 	}
 }
 
@@ -208,12 +256,16 @@ func TestWatchUntilEventDeliversParkedWhenTheReportChannelGoesSilent(t *testing.
 	registerProject(t, home, "demo", "direct-pr")
 	writeConfig(t, home, "parked-other-bound", "2")
 
+	// Recorded as already consumed and announced, so the arm-time observation has nothing to catch up
+	// on and the parked bound is what this run is left to cross.
+	line := "working: still on the migration\n"
 	writeTaskAttempt(t, home, state.Task{
 		ID: "slow-migration", Project: "demo", Kind: state.KindShip,
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"}})
+		CreatedAt: time.Now().UTC().Format(time.RFC3339), ReportOffset: int64(len(line)),
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: filepath.Join(home, "wt-1"), Herdr: state.Herdr{PaneID: "pane-1"},
+		StatusChangedFor: "working", LastReportState: state.ReportWorking, LastReportNote: "still on the migration"})
 	// Written now so the bound is crossed while the poll loop runs, not before it.
-	if err := os.WriteFile(state.ReportPath(home, "slow-migration"), []byte("working: still on the migration\n"), 0o644); err != nil {
+	if err := os.WriteFile(state.ReportPath(home, "slow-migration"), []byte(line), 0o644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

- `hand watch --until-event` now observes before it waits. The two arming ticks are delivered instead of discarded, so a condition that was already true at the arm, or that landed while no watcher was alive, wakes the supervisor instead of being consumed into `state/events.log` and answered with exit 4.
- `ClassifyCatchUp` (`internal/watcher/events.go`) asks the level question `ClassifyStatus` can only ask as an edge: a pane that is not busy with nothing explaining the stop, or a pane already blocked. Idempotence comes from evidence the attempt row already carries - `status_changed_for` naming the observed status proves some watcher announced that episode - so there is no new column, no daemon, and no subscription registry.
- `CatchUpFilter` bounds what the arming pass may deliver to kinds whose announcement durable state records. `KindStale` is the single exclusion: its latch is re-derived per watcher process and its dwell is satisfied by any task whose herdr status has simply not changed lately, so delivering it would make every re-arm return at once. It still reaches `events.log`, the notify hook, and the streaming `hand watch`.
- atqamz/hand#235 stays fixed: a pane `hand teardown` is releasing wakes nobody in the new classifier either, and `TestRunUntilEventCatchesUpOnAStoppedWorkerWithoutWakingOnATeardownRelease` proves both defects together in one fleet.

Closes atqamz/hand#252

## Contract

    current actionable condition OR next transition

Announcement, not operator acknowledgement, is the idempotence unit. atqamz/hand#244 owns the acknowledgement model and none of it is implemented here.

`docs/adr/arming-a-watch-observes-before-it-waits.md` records the boundary and names the record whose silent baseline it reverses; `docs/adr/the-until-event-exit-is-the-delivery.md` points forward to it. The exit-is-the-delivery contract itself is unchanged.

## Acceptance tests

| Issue acceptance test | Test |
| --- | --- |
| 1. actionable before the arm -> immediate wake | `TestRunUntilEventWakesOnAWorkerAlreadyStoppedBeforeTheArm`, `TestWatchUntilEventWakesOnAFleetAlreadyActionableAtArm` (e2e) |
| 2. actionable after the arm -> normal wake | `TestRunUntilEventDeliversIdleUnreportedForAWorkerThatWentQuiet`, `TestWatchUntilEventExitsOnTheFirstTransition` (e2e) |
| 3. re-arm after a missed edge recovers from durable truth | `TestTickCatchesUpOnAStopThatLandedBetweenTwoWatchers` |
| 4. terminal before the monitor is armed -> surfaced | `TestRunUntilEventWakesOnAWorkerAlreadyStoppedBeforeTheArm`; an unreachable pane keeps its distinct exit 5 (`TestRunUntilEventFailsToArmWhenATaskCannotBeProbed`) |
| 5. report already written before the arm -> surfaced | `TestRunUntilEventDeliversAReportWrittenBeforeTheArm`, `TestStatusFlagsATerminalReportNoWatcherEverRead` (e2e) |
| 6. nothing actionable -> the watcher actually waits | `TestRunUntilEventKeepsWaitingWhenOnlyStaleWouldFireAtArm` |
| 7. teardown's false event stays owned by atqamz/hand#235 | `TestRunUntilEventCatchesUpOnAStoppedWorkerWithoutWakingOnATeardownRelease`, `TestClassifyCatchUpSuppressesEveryConditionWhileTeardownHoldsTheHerdrResource` |
| 8. no notification storm on re-arm | `TestRunUntilEventStaysArmedWhenTheCaughtUpConditionWasAlreadyAnnounced`, `TestTickCatchesUpOnAStopThatLandedBetweenTwoWatchers`, the e2e re-arm |
| 9. multiple actionable tasks are not lost after the first | `TestRunUntilEventDeliversEveryTaskActionableAtArm` |

## Dogfood

Run against a scratch fleet home with real `herdr`, real `treehouse`, a real spawned `claude` worker, and the built binary. Task `missed-wake-fixture`, spawned with `hand spawn missed-wake-fixture demo --skip-gate-check`. Its brief told it to append one `working:` line and stop, which it did; its pane went quiet with no watcher ever armed in that home (no `state/events.log` existed at all).

`state/hand.db` was snapshotted at that point and both binaries were armed against byte-identical state:

- pre-fix binary built from `2486b20`: `exit 4`, empty stdout, after burning the full 20s window. The two facts were written to `events.log` and never delivered.
- this branch: `exit 0` in under a second, stdout `working missed-wake-fixture: fixture worker started, waiting for the supervisor` and `idle-unreported missed-wake-fixture`.
- two further re-arms on the same unchanged state: `exit 4`, empty stdout, no new `events.log` lines.
- with a watcher armed, `hand send` to the worker produced a real post-arm wake 35s later: `reported-done missed-wake-fixture: fixture complete`.

The fixture was then delivered and torn down; its herdr workspace is closed and its worktree returned.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...`, `nix develop -c make lint`, `make build`, `make contract`, `make e2e`, `nix flake check`, `git diff --check` all pass locally.
- A canceled or replaced watcher still outranks an arm-time delivery, the same precedence the tick boundary already had: `TestRunUntilEventDoesNotDeliverAnArmObservationAfterCancellation`.
- Behaviour changes recorded in the tests that owned the old contract rather than left implicit: `TestRunUntilEventTakesTheStartupStateAsBaseline` is replaced by `TestRunUntilEventDeliversAReportWrittenBeforeTheArm`, and `TestStatusFlagsATerminalReportNoWatcherEverRead` now expects exit 0 with the report delivered while still asserting the atqamz/hand#70 flag clears.

## STACKS

    STACKS
    - stack used? no
    - parent -> child: none
    - reason stack was necessary: none; this branch is based on main at 2486b20 and shares no code with atqamz/hand#240's lane
    - post-squash restack verification: not applicable, no parent branch exists
