### PR TITLE
fix(status): distinguish an unobserved gate run from an absent one

### DIFF
--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -88,7 +88,7 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 		return nextAction{Kind: nextActionHold, Task: h.ID, Command: "none",
 			Reason: "Operator or supervisor judgment is needed to resolve its active hold"}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.gateIssue != "" }); ok {
+	if v, ok := firstView(sorted, gateProblem); ok {
 		return nextAction{Kind: nextActionGate, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "confirm its delivery gate status")}
 	}

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
@@ -123,7 +124,7 @@ func TestClassifyNextActionExactPrecedence(t *testing.T) {
 		{
 			"gate outranks queued work",
 			configuredWorker, 1, queuedBacklog,
-			[]taskView{{task: state.Task{ID: "gate-task"}, gateIssue: "no run found"}}, nil,
+			[]taskView{{task: state.Task{ID: "gate-task"}, gateObserved: ghutil.ObservationAbsent}}, nil,
 			nextAction{Kind: nextActionGate, Task: "gate-task", Command: "hand status gate-task", Reason: statusReason("gate-task", "confirm its delivery gate status")},
 		},
 		{

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -140,21 +141,23 @@ type statusJSON struct {
 	PR               string      `json:"pr"`
 	// Omitted where no live lookup applied, so a consumer sees "unknown" only where an
 	// empty pr field is a failed observation rather than a PR that is not there.
-	PRObservation    string        `json:"pr_observation,omitempty"`
-	MergeExecuted    bool          `json:"merged"`
-	MergeAnnounced   bool          `json:"pr_merged_observed"`
-	DeliveredAt      string        `json:"delivered_at,omitempty"`
-	DeliveredReason  string        `json:"delivered_reason,omitempty"`
-	CreatedAt        string        `json:"created_at"`
-	LastReportAt     string        `json:"last_report_at,omitempty"`
-	Reported         *reportedJSON `json:"reported,omitempty"`
-	ReportHistory    []string      `json:"report_history,omitempty"`
-	Held             *holdJSON     `json:"held,omitempty"`
-	GateRunIssue     string        `json:"gate_run_issue,omitempty"`
-	RepairCode       string        `json:"repair_code,omitempty"`
-	RepairReason     string        `json:"repair_reason,omitempty"`
-	RepairAttemptID  int64         `json:"repair_attempt,omitempty"`
-	RepairObservedAt string        `json:"repair_observed_at,omitempty"`
+	PRObservation   string        `json:"pr_observation,omitempty"`
+	MergeExecuted   bool          `json:"merged"`
+	MergeAnnounced  bool          `json:"pr_merged_observed"`
+	DeliveredAt     string        `json:"delivered_at,omitempty"`
+	DeliveredReason string        `json:"delivered_reason,omitempty"`
+	CreatedAt       string        `json:"created_at"`
+	LastReportAt    string        `json:"last_report_at,omitempty"`
+	Reported        *reportedJSON `json:"reported,omitempty"`
+	ReportHistory   []string      `json:"report_history,omitempty"`
+	Held            *holdJSON     `json:"held,omitempty"`
+	// Omitted where the gate-run check does not apply to this task, the same way PRObservation
+	// is: found, absent and unknown are otherwise distinct answers, never collapsed together.
+	GateObservation  string `json:"gate_observation,omitempty"`
+	RepairCode       string `json:"repair_code,omitempty"`
+	RepairReason     string `json:"repair_reason,omitempty"`
+	RepairAttemptID  int64  `json:"repair_attempt,omitempty"`
+	RepairObservedAt string `json:"repair_observed_at,omitempty"`
 	// Omitted when false so a consumer written before this field sees no change
 	// on the fleet it already understands.
 	Unacknowledged bool          `json:"unacknowledged,omitempty"`
@@ -262,13 +265,18 @@ func gateRunApplies(t state.Task, reportedDone bool) bool {
 	return t.Kind == state.KindShip && t.PR != "" && reportedDone
 }
 
+// Bounds one no-mistakes process the gate-run check spawns, the same 5 seconds prdetect.go bounds
+// its own live GitHub fallback by: a hung subprocess must cost one render its answer, not the whole
+// `hand status` invocation.
+const gateRunTimeout = 5 * time.Second
+
 // Answers "which PRs did completed no-mistakes runs record" for one clone path.
 type gateRunReader func(clonePath string) (map[string]bool, error)
 
 // Caches each clone path's answer for the life of one render, so a fleet with several done ship tasks on
 // the same project spawns one no-mistakes process for it, not one per task. Failures are cached too: a
 // clone that could not be asked once is not worth re-asking within the same render.
-func newGateRunReader() gateRunReader {
+func newGateRunReader(ctx context.Context) gateRunReader {
 	type answer struct {
 		prs map[string]bool
 		err error
@@ -277,17 +285,19 @@ func newGateRunReader() gateRunReader {
 	return func(clonePath string) (map[string]bool, error) {
 		a, ok := cache[clonePath]
 		if !ok {
-			a.prs, a.err = project.GateRunPRs(clonePath)
+			runCtx, cancel := context.WithTimeout(ctx, gateRunTimeout)
+			a.prs, a.err = project.GateRunPRs(runCtx, clonePath)
+			cancel()
 			cache[clonePath] = a
 		}
 		return a.prs, a.err
 	}
 }
 
-// Reports why a done ship task's recorded PR cannot be confirmed to have gone through a no-mistakes gate
-// run, using the same "unreachable" bucket gateIssue (cmd/project.go) uses for any failure to ask
-// no-mistakes at all, so a question this check cannot answer never renders as "no run found".
-func gateRunIssue(home string, t state.Task, reportedDone bool, p project.Project, registered bool, runPRs gateRunReader) string {
+// Reports whether a done ship task's recorded PR was found in, is absent from, or could not be
+// checked against a no-mistakes gate run, in the found/absent/unknown vocabulary atqamz/hand#241
+// established. Empty where the check does not apply, which is neither a finding nor an absence.
+func gateRunObservation(home string, t state.Task, reportedDone bool, p project.Project, registered bool, runPRs gateRunReader) ghutil.ObservationState {
 	if !gateRunApplies(t, reportedDone) {
 		return ""
 	}
@@ -297,14 +307,7 @@ func gateRunIssue(home string, t state.Task, reportedDone bool, p project.Projec
 		return ""
 	}
 	prs, err := runPRs(filepath.Join(home, "projects", p.Name))
-	if err != nil {
-		// A missing clone, an unrunnable binary, or a gate never initialized all land in this bucket.
-		return "unreachable"
-	}
-	if !prs[t.PR] {
-		return "no run found"
-	}
-	return ""
+	return project.ClassifyGateRun(prs, err, t.PR).State
 }
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool, cols []axi.Column[taskView]) error {
@@ -393,14 +396,14 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 	for _, p := range projects {
 		projectByName[p.Name] = p
 	}
-	runPRs := newGateRunReader()
+	runPRs := newGateRunReader(cmd.Context())
 
 	views := make([]taskView, 0, len(histories))
 	for _, history := range histories {
 		t := history.Task
 		v, _ := buildTaskView(home, client, history, false, readOnly)
 		p, registered := projectByName[t.Project]
-		v.gateIssue = gateRunIssue(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
+		v.gateObserved = gateRunObservation(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)
 	}
 	return views, holds, nil
@@ -534,7 +537,7 @@ func (v taskView) json() statusJSON {
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt,
-		Reported: v.reported, GateRunIssue: v.gateIssue, RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Attempts: history,
+		Reported: v.reported, GateObservation: string(v.gateObserved), RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Attempts: history,
 		LatestSend: latestSendJSON(v.latestSend),
 	}
 }
@@ -591,7 +594,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		if err != nil {
 			return err
 		}
-		v.gateIssue = gateRunIssue(home, t, reportedDone, p, registered, newGateRunReader())
+		v.gateObserved = gateRunObservation(home, t, reportedDone, p, registered, newGateRunReader(cmd.Context()))
 	}
 
 	// The whole file, sliced afterwards: deriving the flag from the 5-line

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1867,7 +1867,7 @@ func TestStatusFleetEmptyStillShowsHeldBlock(t *testing.T) {
 	}
 }
 
-// Registers a no-mistakes-mode project and creates its clone directory, so gateRunIssue's
+// Registers a no-mistakes-mode project and creates its clone directory, so gateRunObservation's
 // os.Stat(clonePath) check and its no-mistakes invocation both have something to find.
 func registerNoMistakesProject(t *testing.T, home, name string) {
 	t.Helper()
@@ -1909,7 +1909,7 @@ func TestStatusFleetFlagsShippedPRWithNoGateRun(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "gate-no-run-found") {
+	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "gate-absent") {
 		t.Fatalf("flags = %v, want a gate marker naming the shipped PR never ran through the gate", got)
 	}
 }
@@ -1934,8 +1934,8 @@ func TestStatusFleetJSONFlagsShippedPRWithNoGateRun(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.String(), `"gate_run_issue": "no run found"`) {
-		t.Fatalf("got %q, want gate_run_issue naming no run found", out.String())
+	if !strings.Contains(out.String(), `"gate_observation": "absent"`) {
+		t.Fatalf("got %q, want gate_observation naming absent", out.String())
 	}
 }
 
@@ -1964,7 +1964,7 @@ func TestStatusFleetNoGateMarkerWhenRunFound(t *testing.T) {
 	}
 }
 
-func TestStatusFleetGateRunUnreachableWhenNoMistakesBinaryMissing(t *testing.T) {
+func TestStatusFleetGateRunUnknownWhenNoMistakesBinaryMissing(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -1984,8 +1984,8 @@ func TestStatusFleetGateRunUnreachableWhenNoMistakesBinaryMissing(t *testing.T) 
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "gate-unreachable") {
-		t.Fatalf("flags = %v, want the gate check named unreachable rather than the stronger no-run-found claim", got)
+	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "gate-unknown") {
+		t.Fatalf("flags = %v, want the gate check named unknown rather than the stronger absent claim", got)
 	}
 }
 
@@ -2035,7 +2035,7 @@ func TestStatusSingleTaskFlagsShippedPRWithNoGateRun(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if got := detailField(t, out.String(), "gate"); got != "no run found" {
+	if got := detailField(t, out.String(), "gate"); got != "absent" {
 		t.Fatalf("gate = %q, want it naming that the shipped PR never ran through the gate", got)
 	}
 }
@@ -2060,12 +2060,12 @@ func TestStatusSingleTaskJSONFlagsShippedPRWithNoGateRun(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.String(), `"gate_run_issue": "no run found"`) {
-		t.Fatalf("got %q, want gate_run_issue naming no run found", out.String())
+	if !strings.Contains(out.String(), `"gate_observation": "absent"`) {
+		t.Fatalf("got %q, want gate_observation naming absent", out.String())
 	}
 }
 
-func TestStatusSingleTaskNoGateLineWhenRunFound(t *testing.T) {
+func TestStatusSingleTaskGateFoundWhenRunFound(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -2085,8 +2085,8 @@ func TestStatusSingleTaskNoGateLineWhenRunFound(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if got := detailField(t, out.String(), "gate"); got != "none" {
-		t.Fatalf("gate = %q, want none once a completed run recorded this PR", got)
+	if got := detailField(t, out.String(), "gate"); got != "found" {
+		t.Fatalf("gate = %q, want found once a completed run recorded this PR - a completed run must never render the same as no check having run at all", got)
 	}
 }
 
@@ -2125,7 +2125,7 @@ func TestStatusFleetAsksNoMistakesOncePerProject(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Count(out.String(), " gate-no-run-found\n") != 3 {
+	if strings.Count(out.String(), " gate-absent\n") != 3 {
 		t.Fatalf("got %q, want all three ungated tasks marked", out.String())
 	}
 	calls, err := os.ReadFile(countFile)
@@ -2221,9 +2221,9 @@ func TestStatusSingleTaskPropagatesAnUnreadableRegistryWhenTheGateCheckApplies(t
 	}
 }
 
-// The uninitialized-gate half of the unreachable bucket: no-mistakes still holds that repo's completed
+// The uninitialized-gate half of the unknown bucket: no-mistakes still holds that repo's completed
 // runs, so reading its refusal as an empty run list would report a genuinely gated PR as never gated.
-func TestStatusGateRunUnreachableWhenGateNotInitialized(t *testing.T) {
+func TestStatusGateRunUnknownWhenGateNotInitialized(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -2243,8 +2243,8 @@ func TestStatusGateRunUnreachableWhenGateNotInitialized(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "gate-unreachable") {
-		t.Fatalf("flags = %v, want an uninitialized gate read as unreachable, never as no run found", got)
+	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "gate-unknown") {
+		t.Fatalf("flags = %v, want an uninitialized gate read as unknown, never as absent", got)
 	}
 }
 

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -24,12 +24,20 @@ type taskView struct {
 	reportFile    string
 	unreadable    bool
 	unacked       bool
-	gateIssue     string
 	latestSend    *state.SendAttempt
 	held          bool
 	hold          state.Hold
 	// Empty where no live lookup applied, which is neither a finding nor an absence.
 	prObserved ghutil.ObservationState
+	// Empty where the gate-run check does not apply to this task, which is neither a finding nor
+	// an absence either: found, absent and unknown are the only three answers it ever gives.
+	gateObserved ghutil.ObservationState
+}
+
+// Reports whether the gate-run check found something an operator should look at: a found run and a
+// check that does not apply are both fine, so only absent and unknown count.
+func gateProblem(v taskView) bool {
+	return v.gateObserved != "" && v.gateObserved != ghutil.ObservationFound
 }
 
 func (v taskView) execution() state.Attempt {
@@ -82,8 +90,8 @@ func taskFlags(v taskView) []string {
 	case v.task.MergeAnnounced:
 		flags = append(flags, "merged-external")
 	}
-	if v.gateIssue != "" {
-		flags = append(flags, "gate-"+strings.ReplaceAll(v.gateIssue, " ", "-"))
+	if gateProblem(v) {
+		flags = append(flags, "gate-"+string(v.gateObserved))
 	}
 	if v.task.RepairCode != "" {
 		flags = append(flags, "needs-repair")
@@ -102,7 +110,7 @@ func taskFlags(v taskView) []string {
 // The predicate behind the fleet view's attention aggregate: a supervisor reading only the count knows
 // whether any row is asking for something without reading the rows.
 func needsAttention(v taskView) bool {
-	if v.unreadable || v.unacked || v.gateIssue != "" || v.task.RepairCode != "" {
+	if v.unreadable || v.unacked || gateProblem(v) || v.task.RepairCode != "" {
 		return true
 	}
 	if v.latestSend != nil && state.SendNeedsAttention(*v.latestSend) {
@@ -206,7 +214,7 @@ var taskFields = []axi.Column[taskView]{
 		}
 		return holdDetail(v.hold)
 	}},
-	{Name: "gate", Value: func(v taskView) string { return orNone(v.gateIssue) }},
+	{Name: "gate", Value: func(v taskView) string { return orNone(string(v.gateObserved)) }},
 	{Name: "report_file", Value: func(v taskView) string { return orNone(v.reportFile) }},
 	{Name: "flags", Value: func(v taskView) string { return orNone(strings.Join(taskFlags(v), " ")) }},
 	{Name: "repair", Value: func(v taskView) string {

--- a/internal/faketool/nomistakes.go
+++ b/internal/faketool/nomistakes.go
@@ -5,9 +5,12 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 )
 
-// NoMistakes models the text and command-specific exit status hand consumes.
+// NoMistakes models the text and command-specific exit status hand consumes. Hang names
+// subcommands (e.g. "runs") the fake never answers, for a caller's own timeout and cancellation
+// paths - same shape and purpose as GH.Hang and Herdr.Hang.
 type NoMistakes struct {
 	Stdout     string
 	Exit       int
@@ -17,6 +20,7 @@ type NoMistakes struct {
 	RunsExit   int
 	Init       string
 	InitExit   int
+	Hang       []string
 	Log        string
 	CountLog   string
 }
@@ -30,6 +34,7 @@ type noMistakesSpec struct {
 	RunsExit   int
 	Init       string
 	InitExit   int
+	Hang       []string
 	Log        string
 	CountLog   string
 }
@@ -56,6 +61,13 @@ func runNoMistakesFromPayload(payload json.RawMessage, args []string) int {
 	}
 	stdout, exit := spec.Stdout, spec.Exit
 	if len(args) > 0 {
+		for _, blocked := range spec.Hang {
+			if blocked == args[0] {
+				for {
+					time.Sleep(time.Hour)
+				}
+			}
+		}
 		switch args[0] {
 		case "status":
 			if spec.Status != "" {

--- a/internal/ghutil/observation.go
+++ b/internal/ghutil/observation.go
@@ -27,6 +27,15 @@ type Probe struct {
 	Reason  string
 }
 
+// Explain names the command a probe ran alongside its reason, when there is one. Shared by every
+// observation type that carries a Probe, so the wording never drifts between them.
+func (p Probe) Explain() string {
+	if p.Command == "" {
+		return p.Reason
+	}
+	return fmt.Sprintf("%s; observed by running %q", p.Reason, p.Command)
+}
+
 // PRObservation is one answer about one pull request. Merged, URL and Head are meaningful only
 // where the state is found; Ambiguous is set only where a completed query returned candidates that
 // do not resolve to a single winner.
@@ -52,10 +61,7 @@ func (o PRObservation) Unknown() bool { return !o.Found() && !o.Absent() }
 // Reason is the sentence a caller reports when it will not act on this observation, naming
 // what answered nothing and the command that asked.
 func (o PRObservation) Reason() string {
-	if o.Probe.Command == "" {
-		return o.Probe.Reason
-	}
-	return fmt.Sprintf("%s; observed by running %q", o.Probe.Reason, o.Probe.Command)
+	return o.Probe.Explain()
 }
 
 // UnknownPRObservation reports an observation that could not be attempted at all, so a caller whose

--- a/internal/project/gaterun.go
+++ b/internal/project/gaterun.go
@@ -1,10 +1,13 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/atqamz/hand/internal/ghutil"
 )
 
 // Bounds how far back `no-mistakes runs` is asked to look. Large enough to cover any project's
@@ -12,19 +15,56 @@ import (
 // literally unbounded output on every check.
 const gateRunLimit = "10000"
 
+// GateRunObservation answers whether a completed no-mistakes gate run recorded a pull request, in
+// the same found/absent/unknown vocabulary ghutil.PRObservation uses (atqamz/hand#241). Absent is a
+// positive finding; any reason the run list could not be read is unknown, never absent.
+type GateRunObservation struct {
+	State ghutil.ObservationState
+	Probe ghutil.Probe
+}
+
+func (o GateRunObservation) Found() bool   { return o.State == ghutil.ObservationFound }
+func (o GateRunObservation) Absent() bool  { return o.State == ghutil.ObservationAbsent }
+func (o GateRunObservation) Unknown() bool { return !o.Found() && !o.Absent() }
+
+// Reason is the sentence a caller reports when it will not act on this observation.
+func (o GateRunObservation) Reason() string { return o.Probe.Explain() }
+
+// ClassifyGateRun turns one clone's completed-run PR set - or the failure that kept GateRunPRs from
+// reading it - into one observation about pr. Keyed on the PR URL a completed run's own `pr` step
+// recorded, never a commit or branch, so a squash merge's unreachable pre-squash head never touches it.
+func ClassifyGateRun(prs map[string]bool, err error, pr string) GateRunObservation {
+	probe := ghutil.Probe{Command: fmt.Sprintf("no-mistakes runs --limit %s", gateRunLimit)}
+	if err != nil {
+		probe.Reason = err.Error()
+		return GateRunObservation{State: ghutil.ObservationUnknown, Probe: probe}
+	}
+	if prs[pr] {
+		return GateRunObservation{State: ghutil.ObservationFound, Probe: probe}
+	}
+	probe.Reason = "no completed no-mistakes run recorded this pull request"
+	return GateRunObservation{State: ghutil.ObservationAbsent, Probe: probe}
+}
+
 // GateRunPRs returns the PR URLs recorded by completed no-mistakes runs in clonePath, scraped
 // from `no-mistakes runs` text the way GateStatus does, never out of `~/.no-mistakes` directly.
 // Per clone rather than per PR, so many tasks on one project pay one no-mistakes process.
-func GateRunPRs(clonePath string) (map[string]bool, error) {
+func GateRunPRs(ctx context.Context, clonePath string) (map[string]bool, error) {
 	// Every way of failing to ask no-mistakes at all is an error, never an empty set, so a
 	// caller can keep "the gate recorded no such run" separate from "the question could not be
 	// asked".
 	if _, err := os.Stat(clonePath); err != nil {
 		return nil, fmt.Errorf("no-mistakes clone path: %w", err)
 	}
-	cmd := exec.Command("no-mistakes", "runs", "--limit", gateRunLimit)
+	cmd := exec.CommandContext(ctx, "no-mistakes", "runs", "--limit", gateRunLimit)
 	cmd.Dir = clonePath
 	out, err := cmd.CombinedOutput()
+	// Checked ahead of the output text: a subprocess ctx killed mid-write can still leave text
+	// that happens to contain a marker, and blaming the binary for a deadline hand itself set
+	// would name a remedy that would not help either.
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("no-mistakes runs did not complete: %w", ctx.Err())
+	}
 	text := string(out)
 	// Both read out of the output text rather than the exit code, the way GateStatus reads
 	// them: `no-mistakes runs` exits 1 for an uninitialized gate and for a non-git clone path

--- a/internal/project/gaterun_test.go
+++ b/internal/project/gaterun_test.go
@@ -1,16 +1,23 @@
 package project
 
 import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/faketool"
 )
 
 func TestGateRunPRsCollectsCompletedRunPRs(t *testing.T) {
 	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/120\n"+
 		"  running      74-workspace-leak    b2f584f9  2026-08-03 04:20\n")
 
-	prs, err := GateRunPRs(t.TempDir())
+	prs, err := GateRunPRs(context.Background(), t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +34,7 @@ func TestGateRunPRsCollectsCompletedRunPRs(t *testing.T) {
 func TestGateRunPRsIgnoresNonCompletedRuns(t *testing.T) {
 	fakeNoMistakes(t, "  failed       97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/120\n")
 
-	prs, err := GateRunPRs(t.TempDir())
+	prs, err := GateRunPRs(context.Background(), t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +46,7 @@ func TestGateRunPRsIgnoresNonCompletedRuns(t *testing.T) {
 func TestGateRunPRsMissingClonePath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
 
-	prs, err := GateRunPRs(missing)
+	prs, err := GateRunPRs(context.Background(), missing)
 	if err == nil {
 		t.Fatal("expected error for a clone path that does not exist")
 	}
@@ -51,7 +58,7 @@ func TestGateRunPRsMissingClonePath(t *testing.T) {
 func TestGateRunPRsMissingBinary(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 
-	prs, err := GateRunPRs(t.TempDir())
+	prs, err := GateRunPRs(context.Background(), t.TempDir())
 	if err == nil {
 		t.Fatal("expected error when the no-mistakes binary is not on PATH")
 	}
@@ -66,7 +73,7 @@ func TestGateRunPRsMissingBinary(t *testing.T) {
 func TestGateRunPRsNotInitializedIsAnError(t *testing.T) {
 	fakeNoMistakesExit(t, "repo not initialized (run 'no-mistakes init' first)", 1)
 
-	prs, err := GateRunPRs(t.TempDir())
+	prs, err := GateRunPRs(context.Background(), t.TempDir())
 	if err == nil {
 		t.Fatal("expected an uninitialized gate to be an error, not an empty run set")
 	}
@@ -88,7 +95,7 @@ func TestGateRunPRsNotAGitRepoIsAnError(t *testing.T) {
 	dir := t.TempDir()
 	fakeNoMistakesExit(t, "not in a git repository", 1)
 
-	prs, err := GateRunPRs(dir)
+	prs, err := GateRunPRs(context.Background(), dir)
 	if err == nil {
 		t.Fatal("expected a non-git clone path to be an error, not an empty run set")
 	}
@@ -101,4 +108,140 @@ func TestGateRunPRsNotAGitRepoIsAnError(t *testing.T) {
 	if strings.Contains(err.Error(), "binary not found or not runnable") {
 		t.Fatalf("err = %v, must not blame the binary for a clone path that is not a git repository", err)
 	}
+}
+
+// A no-mistakes that never answers and is killed by the caller's deadline is the case a bare
+// exit-code check gets wrong: the subprocess dies, no-mistakes prints nothing, and nothing has
+// been observed - it must read as an error, never as an empty (absent) run set.
+func TestGateRunPRsKilledByDeadline(t *testing.T) {
+	faketool.NoMistakes{Hang: []string{"runs"}}.Install(t, faketool.Bin(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	prs, err := GateRunPRs(ctx, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error when no-mistakes is killed by the caller's deadline")
+	}
+	if prs != nil {
+		t.Fatal("a killed subprocess must never report a run set")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want it to wrap context.DeadlineExceeded", err)
+	}
+	if strings.Contains(err.Error(), "binary not found or not runnable") {
+		t.Fatalf("err = %v, must not blame the binary for a deadline hand itself set", err)
+	}
+}
+
+func TestGateRunPRsContextAlreadyCancelled(t *testing.T) {
+	fakeNoMistakes(t, "  completed    97-gate-visibility   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/120\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	prs, err := GateRunPRs(ctx, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for an already-cancelled context")
+	}
+	if prs != nil {
+		t.Fatal("an already-cancelled context must never report a run set")
+	}
+}
+
+func TestClassifyGateRunFound(t *testing.T) {
+	prURL := "https://github.com/atqamz/hand/pull/120"
+	obs := ClassifyGateRun(map[string]bool{prURL: true}, nil, prURL)
+	if !obs.Found() || obs.Absent() || obs.Unknown() {
+		t.Fatalf("obs = %+v, want Found", obs)
+	}
+}
+
+func TestClassifyGateRunAbsent(t *testing.T) {
+	prURL := "https://github.com/atqamz/hand/pull/120"
+	obs := ClassifyGateRun(map[string]bool{"https://github.com/atqamz/hand/pull/999": true}, nil, prURL)
+	if !obs.Absent() || obs.Found() || obs.Unknown() {
+		t.Fatalf("obs = %+v, want Absent", obs)
+	}
+}
+
+// The state a failed lookup must never produce: a nil run set can only ever be unknown, whatever
+// the failure behind it, because no list was ever read to check the PR against.
+func TestClassifyGateRunUnknownOnLookupFailure(t *testing.T) {
+	prURL := "https://github.com/atqamz/hand/pull/120"
+	obs := ClassifyGateRun(nil, errors.New("no-mistakes gate not initialized"), prURL)
+	if !obs.Unknown() || obs.Found() || obs.Absent() {
+		t.Fatalf("obs = %+v, want Unknown", obs)
+	}
+	if !strings.Contains(obs.Reason(), "no-mistakes gate not initialized") {
+		t.Fatalf("Reason() = %q, want it to name the lookup failure", obs.Reason())
+	}
+	if !strings.Contains(obs.Reason(), "no-mistakes runs --limit") {
+		t.Fatalf("Reason() = %q, want it to name the command that was run", obs.Reason())
+	}
+}
+
+// Covers atqamz/hand#240's squash-merge scenario for real: a gate run happens against a pre-squash
+// branch head that is never an ancestor of main once its PR merges, and that unreachability must
+// never turn a real historical FOUND into an ABSENT or an UNKNOWN.
+func TestGateRunObservationSurvivesSquashMergeUnreachability(t *testing.T) {
+	clonePath := t.TempDir()
+	isolateGateTestGitConfig(t)
+
+	runGateTestGit(t, clonePath, "init", "-q", "-b", "main")
+	runGateTestGit(t, clonePath, "commit", "-q", "--allow-empty", "-m", "initial commit")
+
+	runGateTestGit(t, clonePath, "checkout", "-q", "-b", "task-branch")
+	if err := os.WriteFile(filepath.Join(clonePath, "feature.txt"), []byte("feature work"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGateTestGit(t, clonePath, "add", "feature.txt")
+	runGateTestGit(t, clonePath, "commit", "-q", "-m", "feature work")
+	preSquashHead := strings.TrimSpace(runGateTestGit(t, clonePath, "rev-parse", "HEAD"))
+
+	runGateTestGit(t, clonePath, "checkout", "-q", "main")
+	runGateTestGit(t, clonePath, "merge", "--squash", "-q", "task-branch")
+	runGateTestGit(t, clonePath, "commit", "-q", "-m", "squash-merge task-branch")
+	runGateTestGit(t, clonePath, "branch", "-D", "task-branch")
+
+	// Proves the unreachability this test exists to survive, rather than assuming it: the
+	// pre-squash branch head is genuinely gone from main's ancestry after the squash merge.
+	isAncestor := exec.Command("git", "merge-base", "--is-ancestor", preSquashHead, "main")
+	isAncestor.Dir = clonePath
+	if err := isAncestor.Run(); err == nil {
+		t.Fatal("expected the pre-squash branch head to be unreachable from main after a squash merge")
+	}
+
+	prURL := "https://github.com/atqamz/hand/pull/237"
+	fakeNoMistakes(t, "  completed    task-branch   "+preSquashHead[:8]+"  2026-08-03 04:29  "+prURL+"\n")
+
+	prs, err := GateRunPRs(context.Background(), clonePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obs := ClassifyGateRun(prs, err, prURL)
+	if !obs.Found() {
+		t.Fatalf("obs = %+v, want Found once a completed run recorded this PR, even with its commit unreachable from main", obs)
+	}
+}
+
+func isolateGateTestGitConfig(t *testing.T) {
+	t.Helper()
+	cfg := filepath.Join(t.TempDir(), "gitconfig")
+	content := "[user]\n\tname = hand-test\n\temail = hand-test@example.invalid\n" +
+		"[commit]\n\tgpgsign = false\n[init]\n\tdefaultBranch = main\n"
+	if err := os.WriteFile(cfg, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func runGateTestGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	out, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v: %s", args, err, out)
+	}
+	return string(out)
 }

--- a/tests/e2e/gate_visibility_test.go
+++ b/tests/e2e/gate_visibility_test.go
@@ -113,21 +113,22 @@ func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
 	if fleet.code != 0 {
 		t.Fatalf("status: exit %d, stderr %q", fleet.code, fleet.stderr)
 	}
-	if !strings.Contains(fleet.stdout, " gate-no-run-found\n") {
+	if !strings.Contains(fleet.stdout, " gate-absent\n") {
 		t.Fatalf("status stdout = %q, want the shipped PR flagged as never having run through the gate", fleet.stdout)
 	}
 
 	single := runHand(t, home, "status", "ship-login-fix")
-	if single.code != 0 || !strings.Contains(single.stdout, "\ngate: no run found\n") {
+	if single.code != 0 || !strings.Contains(single.stdout, "\ngate: absent\n") {
 		t.Fatalf("status ship-login-fix stdout = %q (exit %d), want the gate field naming it", single.stdout, single.code)
 	}
 
 	singleJSON := runHand(t, home, "status", "ship-login-fix", "--json")
-	if singleJSON.code != 0 || !strings.Contains(singleJSON.stdout, `"gate_run_issue": "no run found"`) {
-		t.Fatalf("status --json stdout = %q (exit %d), want gate_run_issue", singleJSON.stdout, singleJSON.code)
+	if singleJSON.code != 0 || !strings.Contains(singleJSON.stdout, `"gate_observation": "absent"`) {
+		t.Fatalf("status --json stdout = %q (exit %d), want gate_observation", singleJSON.stdout, singleJSON.code)
 	}
 
-	// And both have to stop saying it the moment a completed run records that exact URL.
+	// And both have to stop saying absent, and start saying found, the moment a completed run
+	// records that exact URL - a completed run must never render the same as one that never ran.
 	writeFakeNoMistakes(t, dir, gateReadyStatus,
 		"  completed    ship-login-fix  758d72bf  2026-08-03 04:29  "+prURL, 0)
 
@@ -137,6 +138,11 @@ func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
 	}
 	if strings.Contains(gated.stdout, "gate-") {
 		t.Fatalf("status stdout = %q, want no gate marker once a completed run recorded this PR", gated.stdout)
+	}
+
+	gatedSingle := runHand(t, home, "status", "ship-login-fix")
+	if gatedSingle.code != 0 || !strings.Contains(gatedSingle.stdout, "\ngate: found\n") {
+		t.Fatalf("status ship-login-fix stdout = %q (exit %d), want the gate field naming the completed run found", gatedSingle.stdout, gatedSingle.code)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `hand status` collapsed a completed no-mistakes gate run, a genuine absence, and a failed lookup into the same rendered value, so a successful gate and one that never ran were indistinguishable (the `gate` field read `none` for both). Extends the found/absent/unknown vocabulary atqamz/hand#241 landed for pull request observations to gate-run observations rather than inventing a second one: `project.GateRunObservation` / `project.ClassifyGateRun` reuse `ghutil.ObservationState` and `ghutil.Probe` directly.
- The lookup key is the PR URL a completed `no-mistakes runs` record carries, never a commit or branch, so a squash merge that leaves the pre-squash branch head unreachable from `main` never turns a real historical FOUND into an ABSENT or an UNKNOWN. Proven with a test that performs a real `git merge --squash`, deletes the source branch, and asserts via `git merge-base --is-ancestor` that the pre-squash head is genuinely unreachable before checking the observation still reads FOUND.
- Every `no-mistakes runs` lookup failure - missing clone path, uninitialized gate, unrunnable binary, not-a-git-repository, a killed or timed-out subprocess, an already-cancelled context - now surfaces as unknown, never silently as absent. `GateRunPRs` takes a `context.Context` and is bounded by a 5s timeout at its `cmd/status.go` call sites, matching `prdetect.go`'s existing PR-observation timeout. `internal/faketool.NoMistakes` gained a `Hang` field mirroring `GH.Hang`/`Herdr.Hang` to test the killed-subprocess path.
- `hand status`'s `gate` field and flags, and `--json`'s `gate_observation` field (renamed from `gate_run_issue`), now render `found`/`absent`/`unknown` distinctly; `none` is reserved for tasks the check does not apply to at all.

Closes atqamz/hand#240

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...` - green
- `nix develop -c make lint` - green (`golangci-lint`, `commentlint`)
- `make build`, `make contract`, `make e2e`, `nix flake check`, `git diff --check` - green
- New coverage: `internal/project/gaterun_test.go` adds `ClassifyGateRun` found/absent/unknown unit tests, a killed-by-deadline test via the new `faketool.NoMistakes.Hang`, an already-cancelled-context test, and a real squash-merge test that proves unreachability before asserting FOUND. `cmd/status_test.go` and `tests/e2e/gate_visibility_test.go` updated to the new vocabulary, and the e2e test now also asserts the single-task view explicitly renders `gate: found` once a run is recorded (previously asserted `none`, which was the bug).