### PR TITLE
feat(selfupdate): embed distribution identity in build metadata

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -108,7 +108,7 @@ jobs:
         run: |
           set -eu
           version="edge.${CANDIDATE:0:12}"
-          go build -ldflags "-s -w -X main.version=${version} -X main.channel=edge -X main.commit=${CANDIDATE}" -o hand .
+          go build -ldflags "-s -w -X main.version=${version} -X main.channel=edge -X main.commit=${CANDIDATE} -X main.distribution=github" -o hand .
           if [ "$GOOS" = linux ] && [ "$GOARCH" = amd64 ]; then
             test "$(./hand --version)" = "$version"
           fi
@@ -123,7 +123,7 @@ jobs:
         run: |
           set -eu
           version="edge.${CANDIDATE:0:12}"
-          go build -ldflags "-s -w -X main.version=${version} -X main.channel=edge -X main.commit=${CANDIDATE}" -o hand.exe .
+          go build -ldflags "-s -w -X main.version=${version} -X main.channel=edge -X main.commit=${CANDIDATE} -X main.distribution=github" -o hand.exe .
           zip "hand-${GOOS}-${GOARCH}.zip" hand.exe
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           commit=$(git rev-parse HEAD)
-          go build -ldflags "-s -w -X main.version=${{ needs.release-please.outputs.version }} -X main.channel=stable -X main.commit=${commit}" -o hand .
+          go build -ldflags "-s -w -X main.version=${{ needs.release-please.outputs.version }} -X main.channel=stable -X main.commit=${commit} -X main.distribution=github" -o hand .
           tar czf hand-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz hand
       - name: Build (windows)
         if: matrix.goos == 'windows'
@@ -77,7 +77,7 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           commit=$(git rev-parse HEAD)
-          go build -ldflags "-s -w -X main.version=${{ needs.release-please.outputs.version }} -X main.channel=stable -X main.commit=${commit}" -o hand.exe .
+          go build -ldflags "-s -w -X main.version=${{ needs.release-please.outputs.version }} -X main.channel=stable -X main.commit=${commit} -X main.distribution=github" -o hand.exe .
           zip hand-${{ matrix.goos }}-${{ matrix.goarch }}.zip hand.exe
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 VERSION ?= dev
 CHANNEL ?= dev
 COMMIT ?=
-LDFLAGS := -s -w -X main.version=$(VERSION) -X main.channel=$(CHANNEL) -X main.commit=$(COMMIT)
+DISTRIBUTION ?= source
+LDFLAGS := -s -w -X main.version=$(VERSION) -X main.channel=$(CHANNEL) -X main.commit=$(COMMIT) -X main.distribution=$(DISTRIBUTION)
 
 build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" .

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,8 +152,8 @@ func usageValue(fromFlag bool, err error) error {
 	return err
 }
 
-func Execute(version, channel, commit string) {
-	root := newRootCmd(selfupdate.NormalizeBuildInfo(version, channel, commit))
+func Execute(version, channel, commit, distribution string) {
+	root := newRootCmd(selfupdate.NormalizeBuildInfo(version, channel, commit, distribution))
 	found, err := root.ExecuteC()
 	if err == nil {
 		return

--- a/docs/adr/edge-is-one-mutable-tag-published-only-by-ci.md
+++ b/docs/adr/edge-is-one-mutable-tag-published-only-by-ci.md
@@ -18,7 +18,7 @@ A development channel is only worth installing if every build it offers passed t
 Exactly one non-SemVer `edge` tag and one mutable GitHub prerelease name the newest `main` commit that passed the complete CI gate.
 Their asset set matches the stable one, so a channel changes which tag is downloaded and nothing else.
 
-Every build embeds version, channel, and commit through `main.version`, `main.channel`, and `main.commit`.
+Every build embeds version, channel, commit, and distribution through `main.version`, `main.channel`, `main.commit`, and `main.distribution`.
 The [`Makefile`](../../Makefile) default is `dev`, while [`.github/workflows/release.yaml`](../../.github/workflows/release.yaml), [`flake.nix`](../../flake.nix), and [`.github/workflows/edge.yaml`](../../.github/workflows/edge.yaml) set `stable` or `edge`.
 
 Freshness is compared per channel: stable by release SemVer, edge by the embedded commit against the commit the `edge` ref resolves to.

--- a/docs/adr/package-manifests-are-hand-rolled-not-goreleaser-generated.md
+++ b/docs/adr/package-manifests-are-hand-rolled-not-goreleaser-generated.md
@@ -1,0 +1,62 @@
+# Package manifests are hand-rolled, not GoReleaser-generated
+
+- Date: 2026-08-20
+- Status: accepted
+- Issues: atqamz/hand#177
+- PRs: none
+
+## Context
+
+atqamz/hand#177 asks whether GoReleaser should replace or absorb parts of the release pipeline while
+Hand adds Homebrew, WinGet, npm, AUR, `.deb`, and `.rpm` distribution surfaces.
+
+The existing pipeline is not a generic "build and tag" job. [`release-please-config.json`](../../release-please-config.json)
+and [`.github/workflows/release.yaml`](../../.github/workflows/release.yaml) own version, release PR, and tag
+lifecycle. [`.github/workflows/edge.yaml`](../../.github/workflows/edge.yaml) and
+[`.github/scripts/edge-publish.sh`](../../.github/scripts/edge-publish.sh) publish a rolling `edge` prerelease
+under invariants [`edge-is-one-mutable-tag-published-only-by-ci.md`](edge-is-one-mutable-tag-published-only-by-ci.md)
+records: candidate ancestry checks before and after the build, refusal on diverged history, staged uploads under
+unique names before the exact download names are replaced, and recovery from exactly one interrupted candidate's
+backup group. [`tests/edgepublish`](../../tests/edgepublish) pins that sequence against the shared `gh` fake.
+
+GoReleaser's release model is one version, one tag, one release per invocation. It has no first-class concept of
+a mutable rolling prerelease with ancestry-checked promotion, staged-then-renamed asset replacement, or
+interrupted-run recovery from a specific backup group. Reproducing those invariants through GoReleaser hooks
+would mean writing the same safety-critical logic a second time, behind an abstraction this repository does not
+otherwise need, only to reach parity with what already works and is tested.
+
+Homebrew formulae, WinGet manifests, npm packages, an AUR `PKGBUILD`, and `.deb`/`.rpm` packages are each a small,
+well-documented text or archive format. Every one of them can be produced directly from the artifacts
+`release.yaml` and `edge.yaml` already build and checksum, without a templating engine standing between the
+source archive and the package manifest.
+
+## Decision
+
+The release pipeline keeps its current shape: release-please owns version/PR/tag lifecycle, and
+`.github/workflows/release.yaml` plus `edge.yaml`/`edge-publish.sh` keep owning stable and edge publication
+exactly as documented in `edge-is-one-mutable-tag-published-only-by-ci.md`. GoReleaser is not adopted.
+
+Each new package surface is a small, independent generator that reads the already-built and checksummed release
+archives and produces that surface's manifest or archive: a Homebrew formula, a WinGet manifest, npm package
+files, an AUR `PKGBUILD`, and `.deb`/`.rpm` archives. None of them touches version, tag, or edge-publication logic.
+
+## Rejected alternatives
+
+- Migrating wholesale to GoReleaser for uniformity would force reimplementing edge's ancestry, no-backwards-
+  movement, and partial-publication recovery behind a tool that has no first-class model for a rolling mutable
+  prerelease, trading a tested implementation for an untested one for the sake of using one tool everywhere.
+- Adopting GoReleaser only for the stable channel and hand-rolling edge would leave two different build
+  definitions for the one asset set both channels must keep identical, exactly the drift
+  `edge-is-one-mutable-tag-published-only-by-ci.md` warns a shared matrix prevents.
+- Adopting `nfpm` (the library GoReleaser itself uses for `.deb`/`.rpm`) as a standalone dependency was considered
+  and rejected for the same reason hand-rolling `.deb`/`.rpm` was chosen instead: a single static binary's
+  package is simple enough that the tool adds a dependency without adding capability.
+
+## Consequences
+
+A future package surface is added as its own small generator consuming the existing release artifacts, not as a
+GoReleaser configuration block.
+
+A new release invariant (a new platform archive, a new checksum entry) is still added to `release.yaml` and
+`edge.yaml` together, as `edge-is-one-mutable-tag-published-only-by-ci.md` already requires; no separate
+GoReleaser config exists to fall out of sync with them.

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
             inherit version;
             src = ./.;
             vendorHash = "sha256-v84XwEQIPE8kqHDOhWcOS9pwk+ebjRJ/3XFuuwa0+aU=";
-            ldflags = [ "-s" "-w" "-X main.version=v${version}" "-X main.channel=stable" "-X main.commit=" ];
+            ldflags = [ "-s" "-w" "-X main.version=v${version}" "-X main.channel=stable" "-X main.commit=" "-X main.distribution=nix" ];
             nativeCheckInputs = [ pkgs.git ]; # test suite execs git directly
             meta.mainProgram = "hand";
           };

--- a/internal/selfupdate/distribution.go
+++ b/internal/selfupdate/distribution.go
@@ -1,0 +1,65 @@
+package selfupdate
+
+import "runtime/debug"
+
+const (
+	DistributionGitHub        = "github"
+	DistributionInstallScript = "install-script"
+	DistributionBrew          = "brew"
+	DistributionWinget        = "winget"
+	DistributionNpm           = "npm"
+	DistributionNix           = "nix"
+	DistributionDeb           = "deb"
+	DistributionRpm           = "rpm"
+	DistributionAur           = "aur"
+	DistributionGo            = "go"
+	DistributionSource        = "source"
+)
+
+// A var so a test can simulate the one signal that tells a `go install`-fetched
+// binary from a bare `go build`/`go run` in a source checkout.
+var readBuildInfo = debug.ReadBuildInfo
+
+func detectDistribution() string {
+	info, ok := readBuildInfo()
+	if ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return DistributionGo
+	}
+	return DistributionSource
+}
+
+// A build from before this field existed carries no distribution and self-updated
+// freely, so the empty string keeps that behavior rather than newly refusing it.
+var handOwned = map[string]bool{
+	"":                        true,
+	DistributionGitHub:        true,
+	DistributionInstallScript: true,
+}
+
+// CanSelfUpdate reports whether hand's own updater may replace the running binary in
+// place. A package-manager-owned, go-installed, or source build must instead be
+// upgraded through the channel that placed it.
+func CanSelfUpdate(distribution string) bool {
+	return handOwned[distribution]
+}
+
+var upgradeCommands = map[string]string{
+	DistributionBrew:   "brew upgrade atqamz/tap/hand",
+	DistributionWinget: "winget upgrade Atqamz.Hand",
+	DistributionNpm:    "npm update -g @atqamz/hand",
+	DistributionNix:    "nix profile upgrade hand",
+	DistributionDeb:    "download and install the latest hand-*.deb from the GitHub release",
+	DistributionRpm:    "download and install the latest hand-*.rpm from the GitHub release",
+	DistributionAur:    "update hand-bin with your AUR helper, e.g. yay -Syu hand-bin",
+	DistributionGo:     "go install github.com/atqamz/hand@latest",
+	DistributionSource: "rebuild from source: git pull && make build",
+}
+
+// UpgradeCommand names the command that installs a newer build through the
+// distribution that owns it, for a distribution CanSelfUpdate refuses.
+func UpgradeCommand(distribution string) string {
+	if command, ok := upgradeCommands[distribution]; ok {
+		return command
+	}
+	return "reinstall hand through the channel it came from"
+}

--- a/internal/selfupdate/distribution_test.go
+++ b/internal/selfupdate/distribution_test.go
@@ -1,0 +1,41 @@
+package selfupdate
+
+import "testing"
+
+func TestCanSelfUpdateAllowsOnlyHandOwnedDistributions(t *testing.T) {
+	for _, distribution := range []string{"", DistributionGitHub, DistributionInstallScript} {
+		if !CanSelfUpdate(distribution) {
+			t.Errorf("CanSelfUpdate(%q) = false, want true", distribution)
+		}
+	}
+
+	for _, distribution := range []string{
+		DistributionBrew, DistributionWinget, DistributionNpm, DistributionNix,
+		DistributionDeb, DistributionRpm, DistributionAur, DistributionGo, DistributionSource,
+	} {
+		if CanSelfUpdate(distribution) {
+			t.Errorf("CanSelfUpdate(%q) = true, want false", distribution)
+		}
+	}
+}
+
+func TestUpgradeCommandNamesEachPackageManagersOwnCommand(t *testing.T) {
+	cases := map[string]string{
+		DistributionBrew:   "brew upgrade atqamz/tap/hand",
+		DistributionWinget: "winget upgrade Atqamz.Hand",
+		DistributionNpm:    "npm update -g @atqamz/hand",
+		DistributionNix:    "nix profile upgrade hand",
+		DistributionGo:     "go install github.com/atqamz/hand@latest",
+	}
+	for distribution, want := range cases {
+		if got := UpgradeCommand(distribution); got != want {
+			t.Errorf("UpgradeCommand(%q) = %q, want %q", distribution, got, want)
+		}
+	}
+}
+
+func TestUpgradeCommandFallsBackForAnUnrecognizedDistribution(t *testing.T) {
+	if got := UpgradeCommand("some-future-manager"); got == "" {
+		t.Fatal("want a non-empty fallback for an unrecognized distribution")
+	}
+}

--- a/internal/selfupdate/notice.go
+++ b/internal/selfupdate/notice.go
@@ -28,7 +28,7 @@ type versionCache struct {
 // build's channel, or "" when up to date or when the check can't be completed. Bounded by checkTimeout
 // and never fails the caller: startup version checks are non-blocking and non-fatal.
 func CheckNoticeForBuild(home, repo string, info BuildInfo) string {
-	info = NormalizeBuildInfo(info.Version, info.Channel, info.Commit)
+	info = NormalizeBuildInfo(info.Version, info.Channel, info.Commit, info.Distribution)
 	if info.Channel == ChannelDev {
 		return ""
 	}

--- a/internal/selfupdate/target.go
+++ b/internal/selfupdate/target.go
@@ -13,9 +13,10 @@ const (
 )
 
 type BuildInfo struct {
-	Version string
-	Channel string
-	Commit  string
+	Version      string
+	Channel      string
+	Commit       string
+	Distribution string
 }
 
 type Target struct {
@@ -25,11 +26,14 @@ type Target struct {
 	Commit  string
 }
 
-func NormalizeBuildInfo(version, channel, commit string) BuildInfo {
+func NormalizeBuildInfo(version, channel, commit, distribution string) BuildInfo {
 	if channel != ChannelStable && channel != ChannelEdge {
 		channel = ChannelDev
 	}
-	return BuildInfo{Version: version, Channel: channel, Commit: commit}
+	if distribution == "" {
+		distribution = detectDistribution()
+	}
+	return BuildInfo{Version: version, Channel: channel, Commit: commit, Distribution: distribution}
 }
 
 func ResolveTarget(repo, channel string) (Target, error) {
@@ -89,7 +93,7 @@ func NeedsUpdate(current BuildInfo, target Target) (bool, error) {
 	if err := validateChannel(target.Channel); err != nil {
 		return false, err
 	}
-	current = NormalizeBuildInfo(current.Version, current.Channel, current.Commit)
+	current = NormalizeBuildInfo(current.Version, current.Channel, current.Commit, current.Distribution)
 	if current.Channel != target.Channel {
 		return true, nil
 	}

--- a/internal/selfupdate/target_test.go
+++ b/internal/selfupdate/target_test.go
@@ -1,6 +1,7 @@
 package selfupdate
 
 import (
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -16,15 +17,33 @@ func writeFakeGHTarget(t *testing.T, stable, edge string) {
 
 func TestNormalizeBuildInfoDefaultsUnknownChannelsToDev(t *testing.T) {
 	for _, channel := range []string{"", "nightly", "EDGE"} {
-		info := NormalizeBuildInfo("edge.deadbeef", channel, edgeTestCommit)
+		info := NormalizeBuildInfo("edge.deadbeef", channel, edgeTestCommit, DistributionGitHub)
 		if info.Channel != ChannelDev {
 			t.Errorf("NormalizeBuildInfo(%q) channel = %q, want %q", channel, info.Channel, ChannelDev)
 		}
 	}
 
-	info := NormalizeBuildInfo("edge.deadbeef", ChannelEdge, edgeTestCommit)
-	if info != (BuildInfo{Version: "edge.deadbeef", Channel: ChannelEdge, Commit: edgeTestCommit}) {
+	info := NormalizeBuildInfo("edge.deadbeef", ChannelEdge, edgeTestCommit, DistributionGitHub)
+	if info != (BuildInfo{Version: "edge.deadbeef", Channel: ChannelEdge, Commit: edgeTestCommit, Distribution: DistributionGitHub}) {
 		t.Fatalf("NormalizeBuildInfo(edge) = %#v", info)
+	}
+}
+
+func TestNormalizeBuildInfoDetectsDistributionWhenUnset(t *testing.T) {
+	t.Cleanup(func() { readBuildInfo = debug.ReadBuildInfo })
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "v0.5.0"}}, true
+	}
+	if info := NormalizeBuildInfo("v0.5.0", ChannelStable, "", ""); info.Distribution != DistributionGo {
+		t.Fatalf("distribution = %q, want %q for a go-install build", info.Distribution, DistributionGo)
+	}
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}, true
+	}
+	if info := NormalizeBuildInfo("dev", ChannelDev, "", ""); info.Distribution != DistributionSource {
+		t.Fatalf("distribution = %q, want %q for a source build", info.Distribution, DistributionSource)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,8 @@ import "github.com/atqamz/hand/cmd"
 var version = "dev"
 var channel = "dev"
 var commit = ""
+var distribution = ""
 
 func main() {
-	cmd.Execute(version, channel, commit)
+	cmd.Execute(version, channel, commit, distribution)
 }


### PR DESCRIPTION
## Intent

Implement atqamz/hand#177 (package-manager-first cross-platform distribution) in full, per the current 0.5-realigned issue body. This is the first of a stacked PR sequence (177-A metadata -> 177-B update ownership semantics -> 177-C package surfaces -> 177-D installers/docs). This PR (177-A) only embeds distribution identity metadata; it does not yet change hand update's runtime behavior (that's 177-B).

Specifically: add selfupdate.BuildInfo.Distribution (github/install-script/brew/winget/npm/nix/deb/rpm/aur/go/source). When no explicit -X main.distribution ldflag is set (bare go build/go run, or go install), detect go-install vs source-checkout at runtime via runtime/debug.ReadBuildInfo: Main.Version != "(devel)" and non-empty means go install, otherwise source. This was a deliberate choice to avoid plumbing extra state through go install, which cannot pass ldflags. An empty/unset distribution (a legacy build from before this field existed) is deliberately treated as hand-owned/mutable for backward compatibility with real binaries already deployed - none of them could have been package-manager-installed since no package-manager surface exists yet.

Set the ldflag explicitly in Makefile (DISTRIBUTION ?= source), flake.nix (nix), and release.yaml/edge.yaml (github) so every CI-built artifact is explicit rather than relying on runtime detection.

Also added an ADR (docs/adr/package-manifests-are-hand-rolled-not-goreleaser-generated.md) recording the issue's phase-1 decision: keep release-please + the existing edge-publish.sh script rather than adopt GoReleaser, since GoReleaser has no first-class model for a mutable rolling edge prerelease with ancestry checks, staged-then-renamed asset replacement, and interrupted-run recovery - reimplementing those invariants behind GoReleaser would just duplicate already-tested logic behind a new dependency. Future package surfaces (Homebrew/WinGet/npm/AUR/deb/rpm, in later stacked PRs) will each be a small generator reading the already-built and checksummed release archives directly, not a GoReleaser config.

Rebased onto origin/main mid-session since local main was 11 commits stale (missed #256/#249/#258/#261/#264/#265 among others) - verified clean rebase, full race test suite, e2e, and hermetic contract suite all pass against the current trunk.

## What Changed
- Add `selfupdate.BuildInfo.Distribution` and a `detectDistribution()` fallback (`internal/selfupdate/distribution.go`) that uses `runtime/debug.ReadBuildInfo` to distinguish `go install` from a source checkout when no `-X main.distribution` ldflag is set; also defines the full distribution constant set (github/install-script/brew/winget/npm/nix/deb/rpm/aur/go/source) plus `CanSelfUpdate`/`UpgradeCommand` helpers (not yet called from any runtime path).
- Thread `distribution` through `main.go`, `cmd/root.go`'s `Execute`, and `selfupdate.NormalizeBuildInfo`/`NeedsUpdate`, treating an empty/unset value as hand-owned for backward compatibility with binaries built before this field existed.
- Set `-X main.distribution=...` explicitly in the Makefile (new `DISTRIBUTION ?= source` variable), `flake.nix` (`nix`), and both `release.yaml`/`edge.yaml` workflows (`github`) so CI-built artifacts carry an explicit value instead of relying on runtime detection.
- Add `docs/adr/package-manifests-are-hand-rolled-not-goreleaser-generated.md` recording the decision to keep release-please plus the existing edge-publish script instead of adopting GoReleaser, and update the edge-tag ADR accordingly.

## Risk Assessment

✅ Low: Purely additive metadata plumbing (new Distribution field, runtime go-install-vs-source detection, ldflag wiring in Makefile/flake.nix/CI, and an ADR); no existing runtime behavior (e.g. hand update's NeedsUpdate logic) is altered, matching the stated 177-A scope, and all new code paths are covered by tests.

## Testing

Ran the full internal/selfupdate test suite (new distribution-metadata tests plus target/notice tests) and cmd package update/version tests - all pass; confirmed a full `go build ./...` succeeds with the new 4-arg signatures. Manually verified the Makefile's explicit -X main.distribution=source ldflag is embedded in a built binary, and exercised the runtime detectDistribution() path end-to-end (go run/go build/go install of an uninstalled local module all correctly resolve to "source", consistent with the go-install path being covered by the existing mocked-ReadBuildInfo unit test). No CLI command yet surfaces Distribution/CanSelfUpdate/UpgradeCommand to an end user, which matches the stated intent that 177-A is metadata-only and runtime-behavior wiring is deferred to 177-B - so no additional user-facing evidence beyond the above was expected or possible for this phase. All scratch test artifacts (temp module copy, built binaries) were removed; the worktree is clean.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"925ab1b2a65471a3a2c8d2de04616163772ade8c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/selfupdate/... -v (all pass, incl. new TestCanSelfUpdateAllowsOnlyHandOwnedDistributions, TestUpgradeCommandNamesEachPackageManagersOwnCommand, TestUpgradeCommandFallsBackForAnUnrecognizedDistribution, TestNormalizeBuildInfoDetectsDistributionWhenUnset)`
- `go build ./... (full module compiles with new 4-arg Execute/NormalizeBuildInfo signatures)`
- `go test ./cmd/... -run 'Version|Execute|Update' -v (update command and root wiring unaffected)`
- <code>make build in a scratch copy of the worktree, confirmed embedded ldflag: -X main.distribution=source, and `strings hand | grep main.distribution` showed the value baked in</code>
- <code>manual runtime check: built a throwaway program calling selfupdate.NormalizeBuildInfo with distribution=&#34;&#34; via `go run`, `go build`+run, and `go install`+run from a local (non-versioned) module path - all three report distribution=&#34;source&#34;, matching intent&#39;s documented behavior since Main.Version stays &#34;(devel)&#34; outside a real tagged `go install pkg@version`; the go-install branch itself is exercised by the existing readBuildInfo-mocking unit test, which is the accepted technique per the code&#39;s own comment</code>
- `grep confirmed no remaining callers of the old 3-arg Execute/NormalizeBuildInfo signatures`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
