### PR TITLE
fix(runtime): clear resource repair codes for attempts with no teardown decision

### DIFF
--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1127,13 +1127,17 @@ func clearResolvedTerminalRepair(home string, history state.TaskHistory) (bool, 
 	if !terminalRepairEvidenceResolved(task.RepairCode, *attempt) {
 		return false, nil
 	}
-	if attempt.TeardownCompletionState != state.TeardownCompletionAppended {
-		return false, nil
-	}
-	if _, found, err := completion.FindAttempt(home, attempt.ID); err != nil {
-		return false, err
-	} else if !found {
-		return false, nil
+	// An attempt that reached its terminal lifecycle without ever recording a teardown decision never
+	// gets a completion record to wait for; the resolved resource evidence above is the whole answer.
+	if attempt.TeardownTerminalAttempt != "" {
+		if attempt.TeardownCompletionState != state.TeardownCompletionAppended {
+			return false, nil
+		}
+		if _, found, err := completion.FindAttempt(home, attempt.ID); err != nil {
+			return false, err
+		} else if !found {
+			return false, nil
+		}
 	}
 	if err := state.ClearTaskRepair(home, task.ID, task.RepairCode); err != nil {
 		return false, err

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -1528,6 +1528,66 @@ func TestReconcileAbandonWorktreeSettlesATerminalAttemptWithoutATeardownDecision
 	}
 }
 
+// atqamz/hand#263: a repair code recorded before an attestation must not survive the attestation it
+// names as the fix, even when the attempt it repairs reached its terminal lifecycle without ever
+// recording a teardown decision, so its completion state and record never get appended.
+func TestReconcileAbandonPaneClearsAPreviouslyRecordedRepairCode(t *testing.T) {
+	home := reconcileFixture(t)
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude",
+		Herdr:             state.Herdr{Session: "default", WorkspaceID: "ws-mismatch", TabID: "tab-mismatch", PaneID: "pane-mismatch"},
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt != nil || history.Attempts[0].TeardownTerminalAttempt != "" || history.Attempts[0].TeardownHerdrState != "" {
+		t.Fatalf("eligible attempt = %+v, want a terminal attempt with no teardown decision and no settled Herdr state", history.Attempts[0])
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	firstReport, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstReport.Results) != 1 || firstReport.Results[0].RepairCode != repairCodeTeardownResourceAmbiguous {
+		t.Fatalf("first report = %+v, want %q recorded before any attestation", firstReport, repairCodeTeardownResourceAmbiguous)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != repairCodeTeardownResourceAmbiguous {
+		t.Fatalf("durable repair code = %q, want %q persisted", history.Task.RepairCode, repairCodeTeardownResourceAmbiguous)
+	}
+	secondReport, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AbandonPane: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondReport.Results) != 1 || secondReport.Results[0].RepairCode != "" {
+		t.Fatalf("second report = %+v, want the recorded repair code cleared once the pane is abandoned", secondReport)
+	}
+	history, err = state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.RepairCode != "" {
+		t.Fatalf("durable repair code = %q, want cleared", history.Task.RepairCode)
+	}
+	if history.Attempts[0].TeardownHerdrState != state.TeardownResourceAbandoned {
+		t.Fatalf("Herdr teardown state = %q, want abandoned", history.Attempts[0].TeardownHerdrState)
+	}
+}
+
 // A latch is a refusal to guess, not a verdict: the observation that would have refused the release
 // is the one that resumes it once the pool answers again.
 func TestReconcileConvergesALatchedWorktreeOnceOwnershipIsProven(t *testing.T) {


### PR DESCRIPTION
## Intent

Closes atqamz/hand#263

Fix atqamz/hand#263: hand reconcile <id> --abandon-pane never converged. PR atqamz/hand#258 added --abandon-pane but reconcile still reported the same teardown-resource-ambiguous repair code forever, even after the attestation actually abandoned the Herdr pane resource. Root cause: clearResolvedTerminalRepair (internal/runtime/reconcile.go) unconditionally required the attempt's teardown completion record (TeardownCompletionState == Appended plus a matching completions.jsonl entry) before clearing a resource-only repair code such as teardown-resource-ambiguous or herdr-ownership-incomplete. An attempt that reached its terminal lifecycle through the ordinary completion path (task delivered/merged) rather than through hand teardown's decision-recording path never gets TeardownTerminalAttempt set, so that completion record can never appear - the repair code was stuck forever even once the resource itself had genuinely been abandoned. Fix: the completion-record gate in clearResolvedTerminalRepair now only applies when attempt.TeardownTerminalAttempt is non-empty (meaning a teardown decision was actually recorded for this attempt); when it is empty, the already-checked resource-level evidence (terminalRepairEvidenceResolved, i.e. herdrCleanupSettled/worktreeCleanupSettled) is sufficient to clear the repair. This does not weaken any existing guard: attempts that go through hand teardown or reconcile's own converge/unwind path still get TeardownTerminalAttempt set and still require the completion record before clearing, exactly as before - only attempts that never entered that pipeline at all (legacy or pre-dating the tracked field) are affected. Added a regression test, TestReconcileAbandonPaneClearsAPreviouslyRecordedRepairCode, reproducing the exact repro shape: an attempt already terminal with no teardown decision, a repair code persisted by an earlier non-attested reconcile call, then a later --abandon-pane call must both abandon the pane and clear the repair code in the same or next iteration. Verified the fix against the live stuck task named in the issue (nsr-gesture-display in fleet home /home/atqa/hand-fleet) by rebuilding the binary and running hand reconcile nsr-gesture-display --abandon-pane against it directly: it converged to result: healthy and hand status no longer reports needs-repair or lists it under attention. Checked atqamz/hand#259 (attempt liveness truth, touches the same reconcile subsystem) - it is still open with no PR yet, so there is nothing to rebase onto and no file-level overlap to flag.

## What Changed
- `clearResolvedTerminalRepair` in `internal/runtime/reconcile.go` now only requires the teardown completion record (`TeardownCompletionState == Appended` plus a matching `completions.jsonl` entry) when `attempt.TeardownTerminalAttempt` is non-empty; attempts that never recorded a teardown decision skip straight to the already-checked resource-level evidence (`herdrCleanupSettled`/`worktreeCleanupSettled`).
- Attempts that did go through `hand teardown` or reconcile's converge/unwind path are unaffected: `TeardownTerminalAttempt` is still set for them, so they still require the completion record before a resource-only repair code (e.g. `teardown-resource-ambiguous`, `herdr-ownership-incomplete`) is cleared.
- Added `TestReconcileAbandonPaneClearsAPreviouslyRecordedRepairCode` in `internal/runtime/reconcile_test.go`, reproducing an attempt already terminal with no teardown decision and a repair code from an earlier non-attested reconcile call, asserting `--abandon-pane` both abandons the pane and clears the repair code.

## Risk Assessment

✅ Low: The change narrows an over-broad completion-record gate in clearResolvedTerminalRepair to only apply when attempt.TeardownTerminalAttempt is non-empty; independent verification of the codebase confirms TeardownCompletionState can never become non-empty while TeardownTerminalAttempt is empty (it's only ever set alongside or after TeardownTerminalAttempt), so the removed check was permanently unsatisfiable dead weight for that case, not a real safety net - and this holds uniformly for worktree repair codes too, since their actual safety verification (lease observation, cleanliness, commit-safety) happens inline in reconcileHistoricalAttempt independent of this gate. The added regression test exercises real behavior via r.Reconcile (not source-text assertions) and matches the stated repro shape.

## Testing

<code>Ran the new regression test TestReconcileAbandonPaneClearsAPreviouslyRecordedRepairCode both before and after the fix by temporarily swapping in the pre-fix reconcile.go: it fails against the old code (reproducing the exact stuck-repair-code bug from the issue: an attempt terminal without a teardown decision keeps repairCodeTeardownResourceAmbiguous forever even after --abandon-pane) and passes against the fixed code, which is direct behavioral proof of the fix. The full targeted internal/runtime reconcile test suite (72 tests) also passes with the fix applied, including every existing test that exercises the completion-record gate for attempts that do go through hand teardown/reconcile&#39;s converge path, confirming that guard is unweakened. No UI surface is involved (this is a CLI/state-machine fix), so no screenshot/video artifact applies; the before/after test-run transcript is the relevant end-user-facing evidence (it exercises the same `hand reconcile &lt;id&gt; --abandon-pane` code path a user would trigger). Working tree left clean; no transient files remain.</code>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"16282397e9a6b9a2cd49c39a26fb5af8dff27246","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/runtime/... -run TestReconcileAbandonPaneClearsAPreviouslyRecordedRepairCode -v (at target commit 1628239): PASS`
- `Reverted only internal/runtime/reconcile.go to pre-fix content (base commit 42839a3) while keeping the new test, reran the same test: FAIL, reproducing the reported bug (repair code teardown-resource-ambiguous survives the --abandon-pane attestation)`
- `Restored fixed reconcile.go, reran full targeted suite: go test ./internal/runtime/... -run 'TestReconcile' -v: all pass, including the pre-existing completion-record guard tests (TestReconcileDoesNotClearUnknownRepairAfterTerminalTeardown, TestReconcilePendingTeardownCompletionResumesDurableDecision, TestReconcileCompletionStateWithoutRecordNeedsRepair) confirming no regression for attempts that did go through the teardown/converge path`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

