### PR TITLE
fix(update): refuse to mutate a package-manager-owned build

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -67,6 +67,12 @@ func newUpdateCmd(info selfupdate.BuildInfo) *cobra.Command {
 				return doc.Render(cmd.OutOrStdout())
 			}
 
+			if !selfupdate.CanSelfUpdate(info.Distribution) {
+				doc := updateDoc(info, target, true, false, "not-applicable", "not-applicable", nil)
+				doc.Help(ownershipRefusalHelp(info.Distribution))
+				return doc.Render(cmd.OutOrStdout())
+			}
+
 			if err := selfupdate.Apply(selfupdate.Repo, target.Tag); err != nil {
 				return err
 			}
@@ -137,6 +143,7 @@ func updateDoc(info selfupdate.BuildInfo, target selfupdate.Target, available, u
 	doc.Field("current", info.Version)
 	doc.Field("current_channel", info.Channel)
 	doc.Field("current_commit", selfupdate.DisplayCommit(info.Commit))
+	doc.Field("distribution", info.Distribution)
 	doc.Field("latest", target.Version)
 	doc.Field("latest_channel", target.Channel)
 	doc.Field("latest_commit", selfupdate.DisplayCommit(target.Commit))
@@ -154,6 +161,18 @@ func updateHelp(target selfupdate.Target, explicit bool) string {
 		command += " --channel " + target.Channel
 	}
 	return "Run `" + command + "` to install " + target.Version + ", which also refreshes this home's AGENTS.md template"
+}
+
+// A package manager's install is its own to manage, and a go/source build was never a
+// hand release artifact, so self-replacing either would surprise whatever placed it.
+func ownershipRefusalHelp(distribution string) string {
+	command := selfupdate.UpgradeCommand(distribution)
+	switch distribution {
+	case selfupdate.DistributionGo, selfupdate.DistributionSource:
+		return "hand will not replace a " + distribution + " build; " + command
+	default:
+		return "hand will not replace a package-manager-owned build; " + command
+	}
 }
 
 // The binary is replaced whatever this says, so every outcome is a value of

--- a/cmd/update_ownership_test.go
+++ b/cmd/update_ownership_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/selfupdate"
+)
+
+func TestUpdateRefusesToMutatePackageManagerOwnedBuilds(t *testing.T) {
+	cases := []struct {
+		distribution string
+		command      string
+	}{
+		{selfupdate.DistributionBrew, "brew upgrade atqamz/tap/hand"},
+		{selfupdate.DistributionWinget, "winget upgrade Atqamz.Hand"},
+		{selfupdate.DistributionNpm, "npm update -g @atqamz/hand"},
+		{selfupdate.DistributionNix, "nix profile upgrade hand"},
+		{selfupdate.DistributionDeb, selfupdate.UpgradeCommand(selfupdate.DistributionDeb)},
+		{selfupdate.DistributionRpm, selfupdate.UpgradeCommand(selfupdate.DistributionRpm)},
+		{selfupdate.DistributionAur, selfupdate.UpgradeCommand(selfupdate.DistributionAur)},
+	}
+
+	for _, test := range cases {
+		t.Run(test.distribution, func(t *testing.T) {
+			t.Setenv("HAND_HOME", "")
+			execPath := setFakeExecutable(t)
+			writeFakeGHReleaseView(t, "v0.5.0")
+
+			cmd := newUpdateCmd(selfupdate.BuildInfo{Version: "v0.1.0", Channel: selfupdate.ChannelStable, Distribution: test.distribution})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs(nil)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+
+			got := out.String()
+			for _, want := range []string{
+				"distribution: " + test.distribution + "\n",
+				"update_available: true\n",
+				"updated: false\n",
+				"hand will not replace a package-manager-owned build; " + test.command + "\n",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("output = %q, want it to contain %q", got, want)
+				}
+			}
+
+			installed, err := os.ReadFile(execPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(installed) != "old binary contents" {
+				t.Fatalf("executable = %q, want it left untouched", installed)
+			}
+		})
+	}
+}
+
+func TestUpdateRefusesGoAndSourceBuildsWithTheirOwnUpgradeCommand(t *testing.T) {
+	cases := []struct {
+		distribution string
+		want         string
+	}{
+		{selfupdate.DistributionGo, "hand will not replace a go build; go install github.com/atqamz/hand@latest"},
+		{selfupdate.DistributionSource, "hand will not replace a source build; rebuild from source: git pull && make build"},
+	}
+
+	for _, test := range cases {
+		t.Run(test.distribution, func(t *testing.T) {
+			t.Setenv("HAND_HOME", "")
+			execPath := setFakeExecutable(t)
+			writeFakeGHReleaseView(t, "v0.5.0")
+
+			cmd := newUpdateCmd(selfupdate.BuildInfo{Version: "v0.1.0", Channel: selfupdate.ChannelStable, Distribution: test.distribution})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs(nil)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+
+			if !strings.Contains(out.String(), test.want+"\n") {
+				t.Fatalf("output = %q, want it to contain %q", out.String(), test.want)
+			}
+			installed, err := os.ReadFile(execPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(installed) != "old binary contents" {
+				t.Fatalf("executable = %q, want it left untouched", installed)
+			}
+		})
+	}
+}
+
+func TestUpdateStillSelfUpdatesExplicitlyHandOwnedDistributions(t *testing.T) {
+	for _, distribution := range []string{selfupdate.DistributionGitHub, selfupdate.DistributionInstallScript} {
+		t.Run(distribution, func(t *testing.T) {
+			execPath := setFakeExecutable(t)
+			home := t.TempDir()
+			t.Chdir(home)
+			mkFleetDirs(t, home)
+
+			fixture := buildUpdateFixture(t, []byte("new binary contents"))
+			writeFakeGHUpdate(t, "v0.5.0", "notes", fixture)
+
+			cmd := newUpdateCmd(selfupdate.BuildInfo{Version: "v0.1.0", Channel: selfupdate.ChannelStable, Distribution: distribution})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs(nil)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), "updated: true\n") {
+				t.Fatalf("output = %q, want a completed update", out.String())
+			}
+			installed, err := os.ReadFile(execPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(installed) != "new binary contents" {
+				t.Fatalf("executable = %q, want the new release installed", installed)
+			}
+		})
+	}
+}
+
+func TestUpdateCheckReportsAvailabilityWithoutRefusingAPackageManagerOwnedBuild(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	writeFakeGHReleaseView(t, "v0.5.0")
+
+	cmd := newUpdateCmd(selfupdate.BuildInfo{Version: "v0.1.0", Channel: selfupdate.ChannelStable, Distribution: selfupdate.DistributionBrew})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "update_available: true\n") || !strings.Contains(got, "distribution: brew\n") {
+		t.Fatalf("output = %q, want an available-update report naming the distribution", got)
+	}
+	if strings.Contains(got, "hand will not replace") {
+		t.Fatalf("output = %q, want --check to report availability without an ownership refusal", got)
+	}
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -127,6 +127,7 @@ func appliedUpdateDoc(agentsMD, sessionHook string, notes ...string) string {
 	doc := "current: v0.1.0\n" +
 		"current_channel: stable\n" +
 		"current_commit: unknown\n" +
+		"distribution: \"\"\n" +
 		"latest: v0.5.0\n" +
 		"latest_channel: stable\n" +
 		"latest_commit: unknown\n" +
@@ -526,6 +527,7 @@ func checkedUpdateDoc(current, latest string, available bool) string {
 	doc := "current: " + current + "\n" +
 		"current_channel: " + currentChannel + "\n" +
 		"current_commit: unknown\n" +
+		"distribution: \"\"\n" +
 		"latest: " + latest + "\n" +
 		"latest_channel: stable\n" +
 		"latest_commit: unknown\n" +


### PR DESCRIPTION
## Intent

Implement atqamz/hand#177 in full. Second of a stacked PR sequence: 177-A (merged, embedded BuildInfo.Distribution + runtime go/source detection) -> 177-B (this PR) -> 177-C (package surfaces) -> 177-D (installers/docs/acceptance).

This PR wires the distribution-ownership refusal semantics the issue's Phase 2 asks for: hand update must never overwrite a binary a package manager owns. Concretely: before calling selfupdate.Apply, hand update now checks selfupdate.CanSelfUpdate(info.Distribution). A package-manager-owned distribution (brew/winget/npm/nix/deb/rpm/aur) refuses and prints that manager's own upgrade command (e.g. 'brew upgrade atqamz/tap/hand', 'winget upgrade Atqamz.Hand', 'npm update -g @atqamz/hand', 'nix profile upgrade hand'); go and source builds also refuse (issue text: 'Go/source/dev builds remain non-destructive'), each with their own message, since neither is a hand release artifact that hand's own updater should be replacing in place. github/install-script distributions, and the legacy empty-string distribution (predates the Distribution field from the prior PR), keep self-updating exactly as before - this was a deliberate backward-compatibility default: no currently-deployed hand binary could already be package-manager-installed, since none of those package-manager surfaces exist yet (that's 177-C, not yet built).

--check is deliberately unaffected by this refusal: it returns from an earlier branch in the same function regardless of distribution, so 'hand update --check' always just reports availability. I added an explicit test proving --check does not print the ownership-refusal help text even for a package-managed distribution, so this decoupling doesn't regress later.

Also added: updateDoc now always renders a 'distribution' field (previously it had none), so I updated two existing test helpers (appliedUpdateDoc/checkedUpdateDoc in cmd/update_test.go) that assert full exact-match output to include the new 'distribution: ""' line for BuildInfo values that don't set Distribution (the stableBuild/devBuild test helpers). All existing update_channel_test.go tests use strings.Contains rather than exact match, so they were unaffected by the new field.

New tests added in cmd/update_ownership_test.go: table-driven refusal test per package-managed distribution (asserting the doc fields, the exact help text, and that the fake executable file's bytes are provably unchanged - no silent partial mutation), a similar test for go/source with their distinct messages, a test that github/install-script explicitly set still completes a real Apply() (binary replaced), and the --check decoupling test above.

Full race test suite, e2e suite, hermetic contract suite, and make lint all pass locally against the current main (which already includes the squashed 177-A merge, PR #271).

## What Changed

- `hand update` now checks `selfupdate.CanSelfUpdate(info.Distribution)` before calling `selfupdate.Apply`; package-manager distributions (brew/winget/npm/nix/deb/rpm/aur) and go/source builds refuse the in-place update and render each one's own upgrade/rebuild command via a new `ownershipRefusalHelp` helper, while `github`/install-script and the legacy empty-string distribution keep self-updating as before.
- `updateDoc` now always renders a `distribution` field; updated `appliedUpdateDoc`/`checkedUpdateDoc` exact-match test helpers in `cmd/update_test.go` to include the new `distribution: ""` line.
- Added `cmd/update_ownership_test.go` with table-driven tests covering refusal for each package-managed distribution (asserting doc fields, help text, and untouched executable bytes), go/source refusal with distinct messages, github/install-script still completing a real `Apply()`, and confirming `--check` is unaffected by the refusal path.

## Risk Assessment

✅ Low: Small, well-bounded change (19 lines of production code) that matches the stated intent exactly: refusal gating via CanSelfUpdate, per-distribution help text, --check decoupling preserved, and existing exact-match tests updated correctly for the new always-rendered distribution field; new tests exercise real command execution and byte-level file state rather than source inspection.

## Testing

Ran the targeted `cmd` update test suite via `go test -race ./cmd/... -run 'TestUpdate' -v` inside the project's Nix devshell: all tests pass, including the new TestUpdateRefusesToMutatePackageManagerOwnedBuilds (asserts exact refusal help text per distribution and byte-for-byte unchanged fake executable contents), TestUpdateRefusesGoAndSourceBuildsWithTheirOwnUpgradeCommand, TestUpdateStillSelfUpdatesExplicitlyHandOwnedDistributions (confirms github/install-script still complete a real Apply and replace the binary), and TestUpdateCheckReportsAvailabilityWithoutRefusingAPackageManagerOwnedBuild (confirms --check never prints ownership-refusal text). Also reran internal/selfupdate tests as a regression check since CanSelfUpdate/UpgradeCommand originate there. No source or test edits were needed; behavior matches the stated user intent exactly, and these CLI-transcript assertions (stdout content plus persisted executable bytes) are itself the end-user-observable evidence for a CLI tool, so no additional manual artifact capture was needed.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"329b2fcfbdac58514f1f977f064c45658aa20c3b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `cmd/update_ownership_test.go:21` - In TestUpdateRefusesToMutatePackageManagerOwnedBuilds, the deb/rpm/aur cases build their expected command via selfupdate.UpgradeCommand(test.distribution) instead of a literal string, unlike the brew/winget/npm/nix cases above them. This makes those three sub-tests tautological about the exact command text (they&#39;d pass even if UpgradeCommand&#39;s deb/rpm/aur strings silently changed), though the rest of the test (doc fields, unchanged binary bytes) still exercises real behavior.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./cmd/... -run 'TestUpdate' -v (full cmd update suite including new cmd/update_ownership_test.go table-driven tests)`
- `go test -race ./internal/selfupdate/... (regression check on CanSelfUpdate/UpgradeCommand from prior stacked PR)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
