### PR TITLE
refactor(supervision): unify status and watch on one attention definition

### DIFF
--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -31,6 +31,8 @@ const (
 )
 
 // Ranks fleet conditions so an existing unresolved obligation always outranks fresh queued work.
+// A ranking over cmd/statusview.go's unified attention definition, not a second one
+// (atqamz/hand#268): every predicate below is the same one needsAttention calls.
 func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSummary, views []taskView, holds []state.Hold) nextAction {
 	if cfg.harness == "" {
 		return nextAction{Kind: nextActionNeedsConfig, Command: "hand config set harness <name>", Reason: workerConfigHelp(cfg)[0]}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,6 +16,7 @@ import (
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/watcher"
 	"github.com/spf13/cobra"
 )
 
@@ -101,16 +102,18 @@ func reportSummary(id string, lines []state.ReportLine, readErr error, unacked, 
 	return truncateReportLine(line, reportSummaryBudget, id) + suffix
 }
 
-// Read-only status degrades to "unknown" when herdr or the pane cannot be queried.
-func paneAgentStatus(client *herdr.Client, paneID string) string {
+// Read-only status degrades to "unknown" when herdr or the pane cannot be queried. reachable is
+// false only for a claimed pane that failed to answer - hand watch's own ClassifyUnreachable outage -
+// never for a task with no pane to probe at all, which is not a finding about anything.
+func probePaneStatus(client *herdr.Client, paneID string) (agentState string, reachable bool) {
 	if paneID == "" {
-		return string(herdr.StatusUnknown)
+		return string(herdr.StatusUnknown), true
 	}
 	pane, err := client.PaneGet(paneID)
 	if err != nil || pane.AgentStatus == "" {
-		return string(herdr.StatusUnknown)
+		return string(herdr.StatusUnknown), false
 	}
-	return string(pane.AgentStatus)
+	return string(pane.AgentStatus), true
 }
 
 // Mirrors one classified line from state.ReportLine for JSON output: malformed lines carry their raw text
@@ -160,9 +163,13 @@ type statusJSON struct {
 	RepairObservedAt string `json:"repair_observed_at,omitempty"`
 	// Omitted when false so a consumer written before this field sees no change
 	// on the fleet it already understands.
-	Unacknowledged bool          `json:"unacknowledged,omitempty"`
-	Attempts       []attemptJSON `json:"attempts,omitempty"`
-	LatestSend     *sendJSON     `json:"latest_send,omitempty"`
+	Unacknowledged bool `json:"unacknowledged,omitempty"`
+	// The two conditions atqamz/hand#268 gave hand status a counterpart classifier for: a pane silent
+	// past its report state's bound, and one that claims a pane but never answered it.
+	Parked      bool          `json:"parked,omitempty"`
+	Unreachable bool          `json:"unreachable,omitempty"`
+	Attempts    []attemptJSON `json:"attempts,omitempty"`
+	LatestSend  *sendJSON     `json:"latest_send,omitempty"`
 }
 
 type sendJSON struct {
@@ -258,11 +265,11 @@ func holdDetail(h state.Hold) string {
 	return h.Reason
 }
 
-// The single predicate for whether the gate-run check has anything to say about a task: only a done ship
-// task with a recorded PR does. Everything the check needs - the project lookup above all, whose failure
-// the single-task view propagates - hangs off this, so a silent task never pays that cost nor fails over it.
+// The single predicate for whether the gate-run check has anything to say about a task: only a done
+// ship task with a recorded PR does. Delegates to watcher.GateApplies, the one copy of this rule hand
+// status and hand watch now share, so a silent task never pays for or fails over the check.
 func gateRunApplies(t state.Task, reportedDone bool) bool {
-	return t.Kind == state.KindShip && t.PR != "" && reportedDone
+	return watcher.GateApplies(t.Kind, t.PR, reportedDone)
 }
 
 // Bounds one no-mistakes process the gate-run check spawns, the same 5 seconds prdetect.go bounds
@@ -397,11 +404,15 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 		projectByName[p.Name] = p
 	}
 	runPRs := newGateRunReader(cmd.Context())
+	bounds, err := parkedBoundsFromConfig(home)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	views := make([]taskView, 0, len(histories))
 	for _, history := range histories {
 		t := history.Task
-		v, _ := buildTaskView(home, client, history, false, readOnly)
+		v, _ := buildTaskView(home, client, history, false, readOnly, bounds)
 		p, registered := projectByName[t.Project]
 		v.gateObserved = gateRunObservation(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)
@@ -457,8 +468,8 @@ func unacknowledged(home string, t state.Task, reported state.ReportLine, report
 
 // Derives everything both status views show from one already-read history, and returns the report lines
 // alongside so the detail view's history block and the summary line above it can never come from two
-// reads of the file.
-func buildTaskView(home string, client *herdr.Client, history state.TaskHistory, full, readOnly bool) (taskView, []state.ReportLine) {
+// reads of the file. bounds only applies to an open task's one running attempt.
+func buildTaskView(home string, client *herdr.Client, history state.TaskHistory, full, readOnly bool, bounds watcher.ParkedBounds) (taskView, []state.ReportLine) {
 	t := history.Task
 	attempts := history.Attempts
 	attempt := history.ActiveAttempt
@@ -469,7 +480,7 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 	if attempt != nil {
 		e = *attempt
 	}
-	agentState := paneAgentStatus(client, e.Herdr.PaneID)
+	agentState, reachable := probePaneStatus(client, e.Herdr.PaneID)
 	lines, readErr := state.ReadReportLines(home, t.ID)
 	reported, reportedOK := state.LastReportedState(lines)
 	unacked, readErr := unacknowledged(home, t, reported, reportedOK, readErr)
@@ -478,17 +489,25 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 	if len(lines) > 0 {
 		last = lines[len(lines)-1]
 	}
+	reportedState := ""
+	if reportedOK {
+		reportedState = reported.State
+	}
+	active := t.Lifecycle == state.TaskOpen && history.ActiveAttempt != nil && attempt.Lifecycle == state.AttemptRunning
 	v := taskView{
-		task:         t,
-		attempt:      attempt,
-		attempts:     attempts,
-		agentState:   agentState,
-		reportedLine: reportSummary(t.ID, lines, readErr, unacked, full),
-		lastReportAt: lastReportAt(home, t.ID),
-		reportFile:   state.ReportPath(home, t.ID),
-		unreadable:   readErr != nil,
-		unacked:      unacked,
-		reported:     reportedFrom(last, len(lines) > 0, readErr),
+		task:          t,
+		attempt:       attempt,
+		attempts:      attempts,
+		agentState:    agentState,
+		reportedState: reportedState,
+		reportedLine:  reportSummary(t.ID, lines, readErr, unacked, full),
+		lastReportAt:  lastReportAt(home, t.ID),
+		reportFile:    state.ReportPath(home, t.ID),
+		unreadable:    readErr != nil,
+		unacked:       unacked,
+		unreachable:   active && !reachable,
+		parked:        active && taskParked(home, t, e, reportedState, bounds),
+		reported:      reportedFrom(last, len(lines) > 0, readErr),
 	}
 	if attempt != nil {
 		latestSend := state.LatestSendMetadata
@@ -507,10 +526,36 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 			}
 		}
 	}
-	if reportedOK {
-		v.reportedState = reported.State
-	}
 	return v, lines
+}
+
+// Reports whether an open task's active pane has gone silent past its last reported state's bound,
+// the status-side counterpart ClassifyParked never had (atqamz/hand#32, atqamz/hand#268's
+// disagreement 2). Degrades to false on any read fault, like lastReportAt's own stat failure.
+func taskParked(home string, t state.Task, attempt state.Attempt, reportedState string, bounds watcher.ParkedBounds) bool {
+	silentSince, err := watcher.ReportEvidenceTime(home, t, attempt)
+	if err != nil {
+		return false
+	}
+	return watcher.Parked(reportedState, silentSince, time.Now(), bounds)
+}
+
+// Reads the same config/parked-*-bound keys hand watch does, once per render rather than once per
+// task, so a fleet of a hundred tasks reads config three times, not three hundred.
+func parkedBoundsFromConfig(home string) (watcher.ParkedBounds, error) {
+	paused, err := configSeconds(home, "parked-paused-bound", defaultParkedPausedBound)
+	if err != nil {
+		return watcher.ParkedBounds{}, err
+	}
+	done, err := configSeconds(home, "parked-done-bound", defaultParkedDoneBound)
+	if err != nil {
+		return watcher.ParkedBounds{}, err
+	}
+	other, err := configSeconds(home, "parked-other-bound", defaultParkedOtherBound)
+	if err != nil {
+		return watcher.ParkedBounds{}, err
+	}
+	return watcher.ParkedBounds{Paused: paused, Done: done, Other: other}, nil
 }
 
 // Bounds the attempt window both status renderers show, so the JSON and plain-text views can never
@@ -537,7 +582,7 @@ func (v taskView) json() statusJSON {
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt,
-		Reported: v.reported, GateObservation: string(v.gateObserved), RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Attempts: history,
+		Reported: v.reported, GateObservation: string(v.gateObserved), RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Parked: v.parked, Unreachable: v.unreachable, Attempts: history,
 		LatestSend: latestSendJSON(v.latestSend),
 	}
 }
@@ -571,10 +616,14 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	history.Task, prObserved = detectPRForStatus(cmd.Context(), home, history)
 	t := history.Task
 
+	bounds, err := parkedBoundsFromConfig(home)
+	if err != nil {
+		return err
+	}
 	// An unreadable report degrades exactly as it does in the fleet view: the
 	// fault is named on the report field and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
-	v, reportLines := buildTaskView(home, client, history, full, true)
+	v, reportLines := buildTaskView(home, client, history, full, true, bounds)
 	v.prObserved = prObserved
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -102,9 +101,9 @@ func reportSummary(id string, lines []state.ReportLine, readErr error, unacked, 
 	return truncateReportLine(line, reportSummaryBudget, id) + suffix
 }
 
-// Read-only status degrades to "unknown" when herdr or the pane cannot be queried. reachable is
-// false only for a claimed pane that failed to answer - hand watch's own ClassifyUnreachable outage -
-// never for a task with no pane to probe at all, which is not a finding about anything.
+// Read-only status degrades to "unknown" when herdr or the pane cannot be queried. reachable is false
+// only for a claimed pane that failed to answer, never a task with no pane to probe. Unlike hand
+// watch's dwelled ClassifyUnreachable, one failed probe is enough - a live read has no blink to filter.
 func probePaneStatus(client *herdr.Client, paneID string) (agentState string, reachable bool) {
 	if paneID == "" {
 		return string(herdr.StatusUnknown), true
@@ -308,13 +307,7 @@ func gateRunObservation(home string, t state.Task, reportedDone bool, p project.
 	if !gateRunApplies(t, reportedDone) {
 		return ""
 	}
-	// A project not registered or not run through no-mistakes stays silent alongside every task
-	// gateRunApplies rejects, since the check does not apply to it either.
-	if !registered || p.Mode != project.ModeNoMistakes {
-		return ""
-	}
-	prs, err := runPRs(filepath.Join(home, "projects", p.Name))
-	return project.ClassifyGateRun(prs, err, t.PR).State
+	return project.ObserveGateRun(home, p, registered, t.PR, runPRs)
 }
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool, cols []axi.Column[taskView]) error {
@@ -540,8 +533,8 @@ func taskParked(home string, t state.Task, attempt state.Attempt, reportedState 
 	return watcher.Parked(reportedState, silentSince, time.Now(), bounds)
 }
 
-// Reads the same config/parked-*-bound keys hand watch does, once per render rather than once per
-// task, so a fleet of a hundred tasks reads config three times, not three hundred.
+// Reads config/parked-*-bound, shared by newWatchCmd, once per render rather than once per task, so a
+// fleet of a hundred tasks reads config three times, not three hundred.
 func parkedBoundsFromConfig(home string) (watcher.ParkedBounds, error) {
 	paused, err := configSeconds(home, "parked-paused-bound", defaultParkedPausedBound)
 	if err != nil {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -14,10 +14,12 @@ import (
 
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
+	"github.com/atqamz/hand/internal/watcher"
 )
 
 // Fakes "pane get" as a query command per internal/herdr/client.go's call() doc: a non-null result
@@ -715,8 +717,10 @@ func TestStatusFleetFlagsIdleWithoutTerminalReportAsUnreported(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "idle")
 
+	// Recent, not the fixed 2026-07-24 fixture other tests use: a task this old with no report at all
+	// would now also cross the default parked-other-bound, which is not what this test is about.
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		CreatedAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -799,8 +803,10 @@ func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 	mkFleetDirs(t, home)
 	writeFakeHerdrPaneStatus(t, "working")
 
+	// Recent, not the fixed 2026-07-24 fixture other tests use: a task this old with no report at all
+	// would now also cross the default parked-other-bound, which is not what this test is about.
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		CreatedAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -814,6 +820,96 @@ func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 	row := fleetRow(t, out.String(), "task-1")
 	if !strings.HasPrefix(row, "task-1,working,none,") || !strings.HasSuffix(row, ",none") {
 		t.Fatalf("got %q, want a working task carrying no report and no flags", row)
+	}
+}
+
+// atqamz/hand#268's disagreement 4, attention half: the same outage hand watch's ClassifyUnreachable
+// already announces as failed used to render "state: unknown" here with no flag and no attention.
+// Representing that state itself is atqamz/hand#270's separate job.
+func TestStatusFleetFlagsUnreachablePaneAndCountsAttention(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	t.Setenv("PATH", t.TempDir())
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "attention: 1\n") {
+		t.Fatalf("got %q, want attention: 1 for a pane that claims a pane but never answers", out.String())
+	}
+	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "unreachable") {
+		t.Fatalf("flags = %v, want unreachable", got)
+	}
+}
+
+// atqamz/hand#268's disagreement 2: KindParked existed only in hand watch, and atqamz/hand#32's own
+// pane rendered plain "state: idle" with no counterpart at all. A busy pane isolates the new
+// condition from unreportedStop, which requires the pane to be not-busy.
+func TestStatusFleetFlagsParkedPaneAndCountsAttention(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "working")
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "parked-other-bound"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-5 * time.Second).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "attention: 1\n") {
+		t.Fatalf("got %q, want attention: 1 for a pane silent past the parked bound", out.String())
+	}
+	got := fleetFlags(t, out.String(), "task-1")
+	if !slices.Contains(got, "parked") {
+		t.Fatalf("flags = %v, want parked", got)
+	}
+	if slices.Contains(got, "unreported") {
+		t.Fatalf("flags = %v, want no unreported: the pane is busy, so only parked explains this", got)
+	}
+}
+
+// atqamz/hand#268's "done when": a condition is added once, and both hand status and hand watch see
+// it without a second registration. watcher.GateKind is that one edit's home, so the fleet view's
+// flag and hand watch's known-kind vocabulary can never name a gate-run problem differently.
+func TestGateFlagMatchesAWatchKnownKind(t *testing.T) {
+	for _, observed := range []ghutil.ObservationState{ghutil.ObservationAbsent, ghutil.ObservationUnknown} {
+		view := taskView{task: state.Task{ID: "task-1"}, gateObserved: observed}
+		kind, ok := watcher.GateKind(observed)
+		if !ok {
+			t.Fatalf("observed %q: GateKind reported no problem", observed)
+		}
+		if flags := taskFlags(view); !slices.Contains(flags, kind) {
+			t.Fatalf("observed %q: flags = %v, want %q", observed, flags, kind)
+		}
+		if !slices.Contains(watcher.KnownKinds(), kind) {
+			t.Fatalf("observed %q: %q is not one of hand watch's KnownKinds", observed, kind)
+		}
+		if !needsAttention(view) {
+			t.Fatalf("observed %q: want needsAttention true", observed)
+		}
 	}
 }
 
@@ -1670,7 +1766,7 @@ func TestBuildTaskViewUsesSendFromActiveAttempt(t *testing.T) {
 			{ID: 2, TaskID: "task-1", AttemptID: 2, State: state.SendSubmitted},
 		},
 	}
-	view, _ := buildTaskView(t.TempDir(), nil, history, false, false)
+	view, _ := buildTaskView(t.TempDir(), nil, history, false, false, watcher.ParkedBounds{})
 	if view.latestSend == nil || view.latestSend.ID != 2 || view.latestSend.AttemptID != active.ID {
 		t.Fatalf("latest send = %+v, want active Attempt send", view.latestSend)
 	}
@@ -1696,7 +1792,7 @@ func TestStatusFlagsPartialSendAfterFreshRead(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			history := base
 			history.Sends = []state.SendAttempt{{ID: 1, TaskID: "task-1", AttemptID: active.ID, State: test.send.State, ReasonCode: test.send.ReasonCode}}
-			view, _ := buildTaskView(t.TempDir(), nil, history, false, false)
+			view, _ := buildTaskView(t.TempDir(), nil, history, false, false, watcher.ParkedBounds{})
 			flags := strings.Join(taskFlags(view), " ")
 			if test.wantFlag != "" && !strings.Contains(flags, test.wantFlag) {
 				t.Fatalf("flags = %q, want %q", flags, test.wantFlag)
@@ -1736,7 +1832,7 @@ func TestStatusReadsPartialSendAttentionFromDurableMetadata(t *testing.T) {
 	if history.Sends != nil {
 		t.Fatalf("history.Sends = %+v, want metadata fetched by status only", history.Sends)
 	}
-	view, _ := buildTaskView(home, nil, history, false, false)
+	view, _ := buildTaskView(home, nil, history, false, false, watcher.ParkedBounds{})
 	if !needsAttention(view) || !strings.Contains(strings.Join(taskFlags(view), " "), "send-partial") {
 		t.Fatalf("view flags=%v attention=%t, want durable partial send attention", taskFlags(view), needsAttention(view))
 	}

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -8,6 +8,7 @@ import (
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/watcher"
 )
 
 // One task as both status renderers see it: the durable row plus everything derived for display, so the
@@ -24,9 +25,14 @@ type taskView struct {
 	reportFile    string
 	unreadable    bool
 	unacked       bool
-	latestSend    *state.SendAttempt
-	held          bool
-	hold          state.Hold
+	// The two conditions hand watch's own Kind vocabulary already named and hand status never had a
+	// counterpart classifier for - atqamz/hand#268's disagreements 2 and 4 (attention half). Both are
+	// computed only for an open task's one running attempt; see buildTaskView.
+	unreachable bool
+	parked      bool
+	latestSend  *state.SendAttempt
+	held        bool
+	hold        state.Hold
 	// Empty where no live lookup applied, which is neither a finding nor an absence.
 	prObserved ghutil.ObservationState
 	// Empty where the gate-run check does not apply to this task, which is neither a finding nor
@@ -35,9 +41,11 @@ type taskView struct {
 }
 
 // Reports whether the gate-run check found something an operator should look at: a found run and a
-// check that does not apply are both fine, so only absent and unknown count.
+// check that does not apply are both fine, so only absent and unknown count. watcher.GateKind is the
+// one place that decision is made, shared with hand watch's own gate classifier (atqamz/hand#268).
 func gateProblem(v taskView) bool {
-	return v.gateObserved != "" && v.gateObserved != ghutil.ObservationFound
+	_, ok := watcher.GateKind(v.gateObserved)
+	return ok
 }
 
 func (v taskView) execution() state.Attempt {
@@ -80,6 +88,12 @@ func taskFlags(v taskView) []string {
 	if unreportedStop(v) {
 		flags = append(flags, "unreported")
 	}
+	if v.unreachable {
+		flags = append(flags, "unreachable")
+	}
+	if v.parked {
+		flags = append(flags, "parked")
+	}
 	if v.task.DeliveredAt != "" {
 		flags = append(flags, "delivered")
 	}
@@ -90,8 +104,8 @@ func taskFlags(v taskView) []string {
 	case v.task.MergeAnnounced:
 		flags = append(flags, "merged-external")
 	}
-	if gateProblem(v) {
-		flags = append(flags, "gate-"+string(v.gateObserved))
+	if kind, ok := watcher.GateKind(v.gateObserved); ok {
+		flags = append(flags, kind)
 	}
 	if v.task.RepairCode != "" {
 		flags = append(flags, "needs-repair")
@@ -107,10 +121,14 @@ func taskFlags(v taskView) []string {
 	return flags
 }
 
-// The predicate behind the fleet view's attention aggregate: a supervisor reading only the count knows
-// whether any row is asking for something without reading the rows.
+// The predicate behind the fleet view's attention aggregate - the fleet's one definition of attention
+// every consumer reads (atqamz/hand#268, docs/adr/attention-is-one-derivation-over-three-channels.md).
+// No elapsed-time staleness condition here, matching CatchUpFilter's own deliberate KindStale exclusion.
 func needsAttention(v taskView) bool {
 	if v.unreadable || v.unacked || gateProblem(v) || v.task.RepairCode != "" {
+		return true
+	}
+	if v.unreachable || v.parked {
 		return true
 	}
 	if v.latestSend != nil && state.SendNeedsAttention(*v.latestSend) {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -80,15 +80,7 @@ func newWatchCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			parkedPausedBound, err := configSeconds(home, "parked-paused-bound", defaultParkedPausedBound)
-			if err != nil {
-				return err
-			}
-			parkedDoneBound, err := configSeconds(home, "parked-done-bound", defaultParkedDoneBound)
-			if err != nil {
-				return err
-			}
-			parkedOtherBound, err := configSeconds(home, "parked-other-bound", defaultParkedOtherBound)
+			parkedBounds, err := parkedBoundsFromConfig(home)
 			if err != nil {
 				return err
 			}
@@ -123,12 +115,8 @@ func newWatchCmd() *cobra.Command {
 				PollInterval:   pollInterval,
 				StaleThreshold: staleThreshold,
 				Timeout:        timeout,
-				ParkedBounds: watcher.ParkedBounds{
-					Paused: parkedPausedBound,
-					Done:   parkedDoneBound,
-					Other:  parkedOtherBound,
-				},
-				EventFilter: watcher.NewEventFilter(events),
+				ParkedBounds:   parkedBounds,
+				EventFilter:    watcher.NewEventFilter(events),
 			}
 			if !untilEvent {
 				return mapWatchResult(watcher.Run(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr()))

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-20
 - Status: accepted
 - Issues: atqamz/hand#244, atqamz/hand#232, atqamz/hand#53, atqamz/hand#149, atqamz/hand#140, atqamz/hand#32, atqamz/hand#65
-- PRs: atqamz/hand#265
+- PRs: atqamz/hand#265, atqamz/hand#274
 
 ## Context
 

--- a/internal/project/gaterun.go
+++ b/internal/project/gaterun.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/atqamz/hand/internal/ghutil"
@@ -44,6 +45,17 @@ func ClassifyGateRun(prs map[string]bool, err error, pr string) GateRunObservati
 	}
 	probe.Reason = "no completed no-mistakes run recorded this pull request"
 	return GateRunObservation{State: ghutil.ObservationAbsent, Probe: probe}
+}
+
+// ObserveGateRun is the applicability check hand status and hand watch share: empty when p is not
+// registered or not run through no-mistakes, so a caller cannot answer the question differently for
+// the same project. runPRs is the caller's own no-mistakes invocation, cached or not.
+func ObserveGateRun(home string, p Project, registered bool, pr string, runPRs func(clonePath string) (map[string]bool, error)) ghutil.ObservationState {
+	if !registered || p.Mode != ModeNoMistakes {
+		return ""
+	}
+	prs, err := runPRs(filepath.Join(home, "projects", p.Name))
+	return ClassifyGateRun(prs, err, pr).State
 }
 
 // GateRunPRs returns the PR URLs recorded by completed no-mistakes runs in clonePath, scraped

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/age"
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -20,6 +21,11 @@ const (
 	KindFailed         = "failed"
 	KindStale          = "stale"
 	KindPRMerged       = "pr-merged"
+	// The two answers cmd/statusview.go's gateProblem already renders as "gate-absent"/"gate-unknown" -
+	// GateKind is the one place both hand status and hand watch turn a gate-run observation into these
+	// tokens, so the strings can never drift apart the way atqamz/hand#268 found them.
+	KindGateAbsent  = "gate-absent"
+	KindGateUnknown = "gate-unknown"
 	// An auto-record attempted and not completed, for any reason from refused validation through
 	// unreadable state. The remedy is `hand pr`, which reconciles all of them rather than no-opping.
 	KindPRNotRecorded = "pr-not-recorded"
@@ -49,6 +55,7 @@ const (
 func KnownKinds() []string {
 	return []string{
 		KindIdleUnreported, KindBlocked, KindFailed, KindStale, KindPRMerged,
+		KindGateAbsent, KindGateUnknown,
 		KindPRNotRecorded, KindPRRecordUnknown, KindReportWorking, KindReportPaused,
 		KindReportBlocked, KindReportNeedsDecision, KindReportDone, KindReportFailed,
 		KindReportMalformed, KindParked,
@@ -57,19 +64,20 @@ func KnownKinds() []string {
 }
 
 // CatchUpFilter is the subset of kinds an arm-time observation may deliver: every kind whose
-// announcement durable state records, so a re-arm meeting a condition some watcher already
-// announced stays quiet instead of re-firing it once per arm.
+// announcement durable state records, so a re-arm meeting an already-announced condition stays quiet.
+// KindStale is the one exclusion, and needsAttention never modeled it either - the same call (atqamz/hand#268).
 func CatchUpFilter() EventFilter {
 	f := NewEventFilter(KnownKinds())
-	// KindStale is the one exclusion. Its latch is re-derived per watcher process, and its dwell is
-	// satisfied by any task whose herdr status has simply not changed lately, so delivering it at arm
-	// would return from every re-arm at once, forever.
+	// Its latch is re-derived per watcher process, and its dwell is satisfied by any task whose herdr
+	// status has simply not changed lately, so delivering it at arm would return from every re-arm at
+	// once, forever.
 	delete(f, KindStale)
 	return f
 }
 
-// NotifyFilter is the fixed subset of events worth sending through the
-// watcher's unattended notification channel.
+// NotifyFilter is the fixed subset of events worth sending through the watcher's unattended
+// notification channel: a curated filter over KnownKinds, not a second attention definition
+// (atqamz/hand#268). Neither gate kind is in it - a merge precondition, not an unattended interrupt.
 func NotifyFilter() EventFilter {
 	// report-blocked is listed even though blocked already is: it is the worker's own report-channel
 	// declaration that it is stuck, not the herdr transition, and ClassifyStatus suppresses
@@ -138,6 +146,9 @@ type TaskState struct {
 	Blocked          bool
 	Stale            bool
 	PRMerged         bool
+	// Re-derived, never persisted, for the reason UnreachableFired is: a restart re-asking no-mistakes
+	// once more is cheap, while a suppressed regression is not.
+	GateProblemFired bool
 	ReportCursor     state.ReportCursor
 	// The Persisted* fields mirror what the task's durable state already carries,
 	// so a write skipped for lock contention is retried on the next tick instead
@@ -345,19 +356,29 @@ func parkedBound(lastState string, bounds ParkedBounds) (bound time.Duration, ex
 	return bound, false
 }
 
+// Parked is the level check behind ClassifyParked's latch, exported so cmd/statusview.go can ask the
+// same question for atqamz/hand#32's own case (atqamz/hand#268's disagreement 2). silentSince is the
+// evidence instant ReportEvidenceTime floors, the same one ClassifyParked calls mtime.
+func Parked(lastReportState string, silentSince, now time.Time, bounds ParkedBounds) bool {
+	bound, exempt := parkedBound(lastReportState, bounds)
+	if exempt {
+		return false
+	}
+	return now.Sub(silentSince) >= bound
+}
+
 // mtime is deliberately never reset to "now" on resume: --until-event restarts on
 // every delivered event, and a busy fleet would otherwise erase the clock before
 // it ever completes once.
 func ClassifyParked(ts *TaskState, id, lastState, lastLine string, mtime, now time.Time, bounds ParkedBounds) *Event {
-	bound, exempt := parkedBound(lastState, bounds)
-	if exempt {
+	if _, exempt := parkedBound(lastState, bounds); exempt {
 		ts.ParkedFiredFor = time.Time{}
 		return nil
 	}
 	if mtime.Equal(ts.ParkedFiredFor) {
 		return nil
 	}
-	if now.Sub(mtime) < bound {
+	if !Parked(lastState, mtime, now, bounds) {
 		return nil
 	}
 	ts.ParkedFiredFor = mtime
@@ -376,6 +397,46 @@ func ClassifyPRMerged(ts *TaskState, id string, merged bool) *Event {
 	}
 	ts.PRMerged = true
 	return &Event{TaskID: id, Kind: KindPRMerged, Text: fmt.Sprintf("pr-merged %s", id)}
+}
+
+// GateApplies is cmd/statusview.go's gateRunApplies, exported: the gate-run check has anything to say
+// about a task only when it is a done ship task carrying a recorded PR, and hand status and hand
+// watch must agree on that before either of them shells out to ask no-mistakes anything.
+func GateApplies(taskKind, pr string, reportedDone bool) bool {
+	return taskKind == state.KindShip && pr != "" && reportedDone
+}
+
+// GateKind maps a gate-run observation to the attention condition it represents, the token
+// cmd/statusview.go's taskFlags already renders as "gate-absent"/"gate-unknown". ok is false for a
+// found run or an observation the check never reached, neither of which is a problem to report.
+func GateKind(observed ghutil.ObservationState) (kind string, ok bool) {
+	switch observed {
+	case ghutil.ObservationAbsent:
+		return KindGateAbsent, true
+	case ghutil.ObservationUnknown:
+		return KindGateUnknown, true
+	}
+	return "", false
+}
+
+// ClassifyGateProblem closes atqamz/hand#268's disagreement 1: a PR behind no completed gate run used
+// to be attention in hand status and silence here. Fires once per process like ClassifyPRMerged, and
+// resets as soon as the check stops applying so a later attempt gets its own announcement.
+func ClassifyGateProblem(ts *TaskState, id string, applies bool, observed ghutil.ObservationState) *Event {
+	if !applies {
+		ts.GateProblemFired = false
+		return nil
+	}
+	kind, ok := GateKind(observed)
+	if !ok {
+		ts.GateProblemFired = false
+		return nil
+	}
+	if ts.GateProblemFired {
+		return nil
+	}
+	ts.GateProblemFired = true
+	return &Event{TaskID: id, Kind: kind, Text: fmt.Sprintf("%s %s", kind, id)}
 }
 
 // ClassifyReportLine turns one classified report line into an event and records it as

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -417,6 +418,47 @@ func TestClassifyPRMergedFiresOnce(t *testing.T) {
 	}
 	if e := ClassifyPRMerged(ts, "task-1", true); e != nil {
 		t.Fatalf("pr-merged fired again: %+v", e)
+	}
+}
+
+// atqamz/hand#268's disagreement 1: a PR behind no completed gate run was attention in hand status
+// and silence in hand watch, because nothing here ever asked the question. GateKind is the same
+// mapping cmd/statusview.go's taskFlags renders, so the two can never drift on what the tokens mean.
+func TestGateKindMatchesTheTokensStatusRenders(t *testing.T) {
+	if kind, ok := GateKind(ghutil.ObservationAbsent); !ok || kind != KindGateAbsent {
+		t.Fatalf("GateKind(absent) = %q, %t, want %q, true", kind, ok, KindGateAbsent)
+	}
+	if kind, ok := GateKind(ghutil.ObservationUnknown); !ok || kind != KindGateUnknown {
+		t.Fatalf("GateKind(unknown) = %q, %t, want %q, true", kind, ok, KindGateUnknown)
+	}
+	if _, ok := GateKind(ghutil.ObservationFound); ok {
+		t.Fatal("GateKind(found) reported a problem, want none: a found run is not attention")
+	}
+	if _, ok := GateKind(""); ok {
+		t.Fatal("GateKind(\"\") reported a problem, want none: an empty observation means the check never applied")
+	}
+}
+
+func TestClassifyGateProblemFiresOnceThenResetsWhenApplicabilityLapses(t *testing.T) {
+	ts := NewTaskState(herdr.StatusWorking, time.Now())
+
+	if e := ClassifyGateProblem(ts, "task-1", false, ghutil.ObservationAbsent); e != nil {
+		t.Fatalf("got %+v, want no event while the check does not apply", e)
+	}
+	if e := ClassifyGateProblem(ts, "task-1", true, ghutil.ObservationFound); e != nil {
+		t.Fatalf("got %+v, want no event for a found run", e)
+	}
+	if e := ClassifyGateProblem(ts, "task-1", true, ghutil.ObservationAbsent); e == nil || e.Kind != KindGateAbsent {
+		t.Fatalf("got %+v, want a gate-absent event", e)
+	}
+	if e := ClassifyGateProblem(ts, "task-1", true, ghutil.ObservationAbsent); e != nil {
+		t.Fatalf("gate-absent fired again in the same episode: %+v", e)
+	}
+	if e := ClassifyGateProblem(ts, "task-1", false, ""); e != nil {
+		t.Fatalf("got %+v, want no event once the check stops applying", e)
+	}
+	if e := ClassifyGateProblem(ts, "task-1", true, ghutil.ObservationUnknown); e == nil || e.Kind != KindGateUnknown {
+		t.Fatalf("got %+v, want gate-unknown to fire once more: the earlier episode ended when applicability lapsed", e)
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -358,15 +358,16 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		if e := ClassifyDeferredDone(cfg.Home, ts, t); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
-		// Only shells out to no-mistakes when the check applies: a task the gate-run check has no
-		// opinion about never pays for one.
+		// Only shells out to no-mistakes when the check applies and has not already fired: mirrors
+		// !ts.PRMerged above, so an absent gate run does not re-exec no-mistakes on every tick forever.
 		gateApplies := GateApplies(t.Kind, t.PR, ts.LastReportState == state.ReportDone)
-		var gateObserved ghutil.ObservationState
-		if gateApplies {
-			gateObserved = gateRunObservation(ctx, cfg.Home, t)
-		}
-		if e := ClassifyGateProblem(ts, t.ID, gateApplies, gateObserved); e != nil {
-			handleEvent(cfg, e, out, errOut)
+		switch {
+		case !gateApplies:
+			ClassifyGateProblem(ts, t.ID, false, "")
+		case !ts.GateProblemFired:
+			if e := ClassifyGateProblem(ts, t.ID, true, gateRunObservation(ctx, cfg.Home, t)); e != nil {
+				handleEvent(cfg, e, out, errOut)
+			}
 		}
 		if mtime, err := ReportEvidenceTime(cfg.Home, t, attempt); err != nil {
 			_, _ = fmt.Fprintf(errOut, "watch: stat report %s failed: %v\n", t.ID, err)
@@ -733,13 +734,14 @@ const gateRunTimeout = 5 * time.Second
 // gate-run check applies here" means.
 func gateRunObservation(ctx context.Context, home string, t state.Task) ghutil.ObservationState {
 	p, registered, err := project.Find(home, t.Project)
-	if err != nil || !registered || p.Mode != project.ModeNoMistakes {
+	if err != nil {
 		return ""
 	}
-	runCtx, cancel := context.WithTimeout(ctx, gateRunTimeout)
-	defer cancel()
-	prs, err := project.GateRunPRs(runCtx, filepath.Join(home, "projects", p.Name))
-	return project.ClassifyGateRun(prs, err, t.PR).State
+	return project.ObserveGateRun(home, p, registered, t.PR, func(clonePath string) (map[string]bool, error) {
+		runCtx, cancel := context.WithTimeout(ctx, gateRunTimeout)
+		defer cancel()
+		return project.GateRunPRs(runCtx, clonePath)
+	})
 }
 
 // Routes a worker-supplied URL through hand pr's own validation before it can reach task state: a

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -358,7 +358,17 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		if e := ClassifyDeferredDone(cfg.Home, ts, t); e != nil {
 			handleEvent(cfg, e, out, errOut)
 		}
-		if mtime, err := reportEvidenceTime(cfg.Home, t, attempt); err != nil {
+		// Only shells out to no-mistakes when the check applies: a task the gate-run check has no
+		// opinion about never pays for one.
+		gateApplies := GateApplies(t.Kind, t.PR, ts.LastReportState == state.ReportDone)
+		var gateObserved ghutil.ObservationState
+		if gateApplies {
+			gateObserved = gateRunObservation(ctx, cfg.Home, t)
+		}
+		if e := ClassifyGateProblem(ts, t.ID, gateApplies, gateObserved); e != nil {
+			handleEvent(cfg, e, out, errOut)
+		}
+		if mtime, err := ReportEvidenceTime(cfg.Home, t, attempt); err != nil {
 			_, _ = fmt.Fprintf(errOut, "watch: stat report %s failed: %v\n", t.ID, err)
 		} else if e := ClassifyParked(ts, t.ID, ts.LastReportState, lastReportLine(ts), mtime, now, cfg.ParkedBounds); e != nil {
 			handleEvent(cfg, e, out, errOut)
@@ -630,10 +640,10 @@ func statusChangeSeed(t state.Task, a state.Attempt, status herdr.Status, now ti
 	return now
 }
 
-// Floors the report file's mtime at the instant the task's current pane started, because hand
-// promote leaves the scout's report file - and so its mtime - untouched while clearing the
-// last-report state that had the scout's silence under the long done/failed bound.
-func reportEvidenceTime(home string, t state.Task, a state.Attempt) (time.Time, error) {
+// ReportEvidenceTime floors the report file's mtime at the instant the task's current pane started,
+// because hand promote leaves the scout's report file - and so its mtime - untouched while clearing
+// the last-report state that had the scout's silence under the long done/failed bound.
+func ReportEvidenceTime(home string, t state.Task, a state.Attempt) (time.Time, error) {
 	started, err := paneStartTime(t, a)
 	if err != nil {
 		return time.Time{}, err
@@ -712,6 +722,24 @@ func flattenError(err error) string {
 		}
 	}
 	return strings.Join(parts, "; ")
+}
+
+// Bounds one no-mistakes process the gate-run check spawns, mirroring cmd/status.go's own
+// gateRunTimeout: a hung subprocess must cost one tick, not the whole poll loop.
+const gateRunTimeout = 5 * time.Second
+
+// Mirrors cmd/status.go's gateRunObservation for the poll loop - same project lookup, same
+// no-mistakes invocation - so the fleet view and hand watch can never disagree about what "the
+// gate-run check applies here" means.
+func gateRunObservation(ctx context.Context, home string, t state.Task) ghutil.ObservationState {
+	p, registered, err := project.Find(home, t.Project)
+	if err != nil || !registered || p.Mode != project.ModeNoMistakes {
+		return ""
+	}
+	runCtx, cancel := context.WithTimeout(ctx, gateRunTimeout)
+	defer cancel()
+	prs, err := project.GateRunPRs(runCtx, filepath.Join(home, "projects", p.Name))
+	return project.ClassifyGateRun(prs, err, t.PR).State
 }
 
 // Routes a worker-supplied URL through hand pr's own validation before it can reach task state: a

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -502,6 +502,75 @@ func TestTickClassifiesPRMerged(t *testing.T) {
 	}
 }
 
+// atqamz/hand#268's disagreement 1, closed: a PR behind no completed gate run used to be attention
+// in hand status and silence in hand watch, since nothing here ever asked no-mistakes the question.
+func TestTickClassifiesGateProblem(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "idle")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: "https://github.com/atqamz/hand/pull/120"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	faketool.NoMistakes{Stdout: "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n"}.Install(t, faketool.Bin(t))
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: shipped\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	// The first tick only seeds tracking for a task not seen before, the same as every other
+	// classifier in this suite - see TestTickFiresParkedOnFirstResumedTickWhenTheSilenceAlreadyExceedsTheBound.
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if !strings.Contains(buf.String(), "gate-absent task-1") {
+		t.Fatalf("output = %q, want gate-absent task-1: the recorded PR is not among the completed runs", buf.String())
+	}
+
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if buf.Len() != 0 {
+		t.Fatalf("gate-absent fired again: %q", buf.String())
+	}
+}
+
+// Neither a task the gate-run check does not apply to nor one whose project is unregistered ever
+// shells out to no-mistakes at all - the same silent skip cmd/status.go's own gateRunApplies gives.
+func TestTickSkipsGateCheckWhenItDoesNotApply(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "idle")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "ungated", Kind: state.KindShip,
+		PR: "https://github.com/atqamz/hand/pull/120"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: shipped\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No no-mistakes fake installed at all: a call through here would fail the test's PATH lookup.
+
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if strings.Contains(buf.String(), "gate-") {
+		t.Fatalf("output = %q, want no gate event for an unregistered project", buf.String())
+	}
+}
+
 func TestTickFiresIdleUnreportedWhenPaneGoesNotBusyWithNoReport(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
@@ -1172,7 +1241,7 @@ func TestTickFiresParkedOnFirstResumedTickWhenTheSilenceAlreadyExceedsTheBound(t
 	setStatus(t, statusFile, "idle")
 	writeFakeHerdr(t, statusFile)
 
-	// Created before the silence it is about to be blamed for: reportEvidenceTime
+	// Created before the silence it is about to be blamed for: ReportEvidenceTime
 	// floors the mtime at the pane's start, so a task younger than its own report
 	// file could not accumulate this silence in the first place.
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip,
@@ -1285,7 +1354,7 @@ func TestReportEvidenceTimeFloorsOnThePaneStartNotTheOutageStamp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := reportEvidenceTime(home, task, attempt)
+	got, err := ReportEvidenceTime(home, task, attempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1296,7 +1365,7 @@ func TestReportEvidenceTimeFloorsOnThePaneStartNotTheOutageStamp(t *testing.T) {
 	promoted := task
 	promotedAttempt := attempt
 	promotedAttempt.PaneStartedAt = now.Add(-time.Minute).UTC().Format(time.RFC3339)
-	got, err = reportEvidenceTime(home, promoted, promotedAttempt)
+	got, err = ReportEvidenceTime(home, promoted, promotedAttempt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1681,6 +1750,7 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 		Blocked:                    true,
 		Stale:                      true,
 		PRMerged:                   true,
+		GateProblemFired:           true,
 		ReportCursor:               state.ReportCursor{Offset: 42, Digest: "consumed-digest"},
 		PersistedCursor:            state.ReportCursor{Offset: 43, Digest: "persisted-digest"},
 		PersistedPRMerged:          true,
@@ -1716,10 +1786,13 @@ func TestForgetPaneScopedCacheHandlesEveryField(t *testing.T) {
 	// forgetPaneScopedCache is right to leave it alone: identity, PR facts, report-file position, and
 	// the parked latch, keyed to the report mtime not the pane. Persisted* entries mirror those facts.
 	carried := map[string]bool{
-		"CreatedAt":               true,
-		"AttemptID":               true,
-		"AttemptLifecycle":        true,
-		"PRMerged":                true,
+		"CreatedAt":        true,
+		"AttemptID":        true,
+		"AttemptLifecycle": true,
+		"PRMerged":         true,
+		// The gate-run problem latch is about the recorded PR, not the pane it was announced from -
+		// exactly PRMerged's own reasoning, one field down.
+		"GateProblemFired":        true,
 		"ReportCursor":            true,
 		"PersistedCursor":         true,
 		"PersistedPRMerged":       true,

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -545,6 +545,52 @@ func TestTickClassifiesGateProblem(t *testing.T) {
 	}
 }
 
+// Mirrors !ts.PRMerged three lines above the gate check in tick(): once ClassifyGateProblem has
+// fired for this attempt, later ticks must not keep re-execing no-mistakes to ask a question already
+// answered, the way an unbounded poll loop otherwise would forever.
+func TestTickStopsAskingNoMistakesOnceGateProblemHasFired(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "idle")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "gated", Kind: state.KindShip,
+		PR: "https://github.com/atqamz/hand/pull/120"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	countFile := filepath.Join(t.TempDir(), "calls")
+	faketool.NoMistakes{
+		Stdout:   "  completed    other-branch   758d72bf  2026-08-03 04:29  https://github.com/atqamz/hand/pull/999\n",
+		CountLog: countFile,
+	}.Install(t, faketool.Bin(t))
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: shipped\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	for range 5 {
+		tick(ctx, cfg, client, states, &buf, io.Discard)
+	}
+	if !strings.Contains(buf.String(), "gate-absent task-1") {
+		t.Fatalf("output = %q, want gate-absent task-1 to have fired once across five ticks", buf.String())
+	}
+	calls, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(strings.Fields(string(calls))); got != 1 {
+		t.Fatalf("no-mistakes ran %d times across five ticks, want 1: the gate-run problem already fired", got)
+	}
+}
+
 // Neither a task the gate-run check does not apply to nor one whose project is unregistered ever
 // shells out to no-mistakes at all - the same silent skip cmd/status.go's own gateRunApplies gives.
 func TestTickSkipsGateCheckWhenItDoesNotApply(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implements invariant 5 of atqamz/hand#244's ADR (docs/adr/attention-is-one-derivation-over-three-channels.md): one shared definition of "needs attention" instead of three disagreeing ones.
- `watcher.GateApplies`/`watcher.GateKind` are now the single place a gate-run observation becomes an attention condition, shared by `cmd/statusview.go`'s `gateProblem`/`taskFlags` and a new `watcher.ClassifyGateProblem` classifier that gives `hand watch` the `gate-absent`/`gate-unknown` events it never had (disagreement 1).
- `hand status` gains the two conditions that existed only in `hand watch`: `parked`, backed by newly exported `watcher.Parked`/`watcher.ReportEvidenceTime` (atqamz/hand#32's own case, disagreement 2), and `unreachable`, for a claimed pane that never answers (disagreement 4's attention half - representability of that state is atqamz/hand#270's separate job).
- `KindStale`'s exclusion from `CatchUpFilter` and its absence from `needsAttention` are now documented as the same deliberate call at both sites, confirmed rather than an accidental gap (disagreement 3).
- `classifyNextAction` is unchanged in the set of categories it ranks; every predicate it calls now routes through the shared definition, so it stays a ranking rather than a second definition.

Closes atqamz/hand#268

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`, `gofmt -l .`, `golangci-lint run`, `go run ./tools/commentlint .`
- [x] `go test -race ./...`
- [x] `go test -tags=e2e -timeout=10m ./tests/e2e/...`
- [x] `make contract`
- [x] `nix build .#default`
- [x] New tests: `TestTickClassifiesGateProblem`, `TestTickSkipsGateCheckWhenItDoesNotApply`, `TestGateKindMatchesTheTokensStatusRenders`, `TestClassifyGateProblemFiresOnceThenResetsWhenApplicabilityLapses` (watcher); `TestStatusFleetFlagsUnreachablePaneAndCountsAttention`, `TestStatusFleetFlagsParkedPaneAndCountsAttention`, `TestGateFlagMatchesAWatchKnownKind` (status)