### PR TITLE
fix(cmd): preserve PR observation provenance

### DIFF
--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -10,27 +10,26 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Fills an empty PR field from GitHub for the status views, and reports what the lookup answered so a
-// still-empty field is not read as an absence. The state is empty where no lookup applies at all, which
-// is not the same as an absence either.
-func detectPRForStatus(ctx context.Context, home string, history state.TaskHistory) (state.Task, ghutil.ObservationState) {
+// Answers what GitHub reports for a task's PR, never the task itself: the caller renders a found
+// answer as evidence rather than folding it into the durable pr field (ADR
+// attention-is-one-derivation-over-three-channels.md, invariant 1). Empty where no lookup applies.
+func detectPRForStatus(ctx context.Context, home string, history state.TaskHistory) ghutil.PRObservation {
 	t := history.Task
 	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - and a torn-down task's
 	// completion record is already written, so both skip the lookup rather than pay a forge round trip for a
 	// PR recordPR would refuse. The scout half is the short-circuit checkLandedWork opens with.
 	if t.PR != "" || t.Kind == state.KindScout || t.Lifecycle == state.TaskTerminal {
-		return t, ""
+		return ghutil.PRObservation{}
 	}
 	if history.ActiveAttempt == nil {
-		return t, ""
+		return ghutil.PRObservation{}
 	}
 	proj, exists, err := project.FindReadOnly(home, t.Project)
 	if err != nil || !exists || proj.Mode == project.ModeLocalOnly {
-		return t, ""
+		return ghutil.PRObservation{}
 	}
 
 	ghCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	detected, observation := runtime.DetectPRReadOnly(ghCtx, home, t, *history.ActiveAttempt, proj)
-	return detected, observation.State
+	return runtime.DetectPRReadOnly(ghCtx, home, *history.ActiveAttempt, proj)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -143,20 +143,24 @@ type statusJSON struct {
 	PR               string      `json:"pr"`
 	// Omitted where no live lookup applied, so a consumer sees "unknown" only where an
 	// empty pr field is a failed observation rather than a PR that is not there.
-	PRObservation   string `json:"pr_observation,omitempty"`
-	MergeExecuted   bool   `json:"merged"`
-	MergeAnnounced  bool   `json:"pr_merged_observed"`
-	DeliveredAt     string `json:"delivered_at,omitempty"`
-	DeliveredReason string `json:"delivered_reason,omitempty"`
-	CreatedAt       string `json:"created_at"`
-	LastReportAt    string `json:"last_report_at,omitempty"`
+	PRObservation string `json:"pr_observation,omitempty"`
+	// Set only alongside PRObservation "found", carrying the URL GitHub answered with. Never mirrored
+	// into PR: that field is the durable record alone, so a found-but-unrecorded PR can never render
+	// as though hand merge's durable check would also see it (atqamz/hand#266).
+	PRObservedURL   string        `json:"pr_observed_url,omitempty"`
+	MergeExecuted   bool          `json:"merged"`
+	MergeAnnounced  bool          `json:"pr_merged_observed"`
+	DeliveredAt     string        `json:"delivered_at,omitempty"`
+	DeliveredReason string        `json:"delivered_reason,omitempty"`
+	CreatedAt       string        `json:"created_at"`
+	LastReportAt    string        `json:"last_report_at,omitempty"`
+	Reported        *reportedJSON `json:"reported,omitempty"`
+	ReportHistory   []string      `json:"report_history,omitempty"`
+	Held            *holdJSON     `json:"held,omitempty"`
 	// Omitted where a report file exists (found) or genuinely never has (absent), the same way
 	// PRObservation is: a consumer sees "unknown" only where an empty last_report_at is a failed
 	// stat rather than a task that has never reported.
-	LastReportObservation string        `json:"last_report_observation,omitempty"`
-	Reported              *reportedJSON `json:"reported,omitempty"`
-	ReportHistory         []string      `json:"report_history,omitempty"`
-	Held                  *holdJSON     `json:"held,omitempty"`
+	LastReportObservation string `json:"last_report_observation,omitempty"`
 	// Omitted where the gate-run check does not apply to this task, the same way PRObservation
 	// is: found, absent and unknown are otherwise distinct answers, never collapsed together.
 	GateObservation  string `json:"gate_observation,omitempty"`
@@ -589,7 +593,7 @@ func (v taskView) json() statusJSON {
 	}
 	return statusJSON{
 		ID: v.task.ID, Project: v.task.Project, Kind: v.task.Kind, ExecutionClass: e.ExecutionClass, Profile: e.RequestedProfile, PlannedAgainst: e.PlannedAgainst, RoutingSource: e.RoutingSource, TaskLifecycle: string(v.task.Lifecycle), AttemptOrdinal: e.Ordinal, AttemptLifecycle: string(e.Lifecycle), Harness: e.Harness, Model: e.Model, Effort: e.Effort,
-		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR, PRObservation: string(v.prObserved),
+		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR, PRObservation: string(v.prObserved), PRObservedURL: v.prObservedURL,
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt, LastReportObservation: lastReportObservationJSON(v.lastReportObserved),
@@ -623,8 +627,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	if err != nil {
 		return asPrecondition(err)
 	}
-	var prObserved ghutil.ObservationState
-	history.Task, prObserved = detectPRForStatus(cmd.Context(), home, history)
+	observed := detectPRForStatus(cmd.Context(), home, history)
 	t := history.Task
 
 	bounds, err := parkedBoundsFromConfig(home)
@@ -635,7 +638,8 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 	// fault is named on the report field and the rest of the detail view still
 	// prints, rather than the whole command failing over one bad read.
 	v, reportLines := buildTaskView(home, client, history, full, true, bounds)
-	v.prObserved = prObserved
+	v.prObserved = observed.State
+	v.prObservedURL = observed.URL
 
 	// Propagated, not degraded: see the same comment in runStatusFleet.
 	hold, held, err := state.ReadHoldReadOnly(home, id)
@@ -747,6 +751,11 @@ func detailHelp(v taskView, full bool) []string {
 	switch {
 	case v.task.DeliveredAt != "" || v.task.MergeExecuted || v.task.MergeAnnounced:
 		help = append(help, "Run `hand teardown "+v.task.ID+"` to clean up this task")
+	// hand merge reads the durable pr column, not this observation, and refuses with "no PR recorded"
+	// against exactly this task until it is recorded - naming the recording step first is what keeps
+	// hand status from promising a command hand merge is guaranteed to refuse (atqamz/hand#266).
+	case v.reportedState == state.ReportDone && v.task.PR == "" && v.prObserved == ghutil.ObservationFound:
+		help = append(help, "Run `hand pr "+v.task.ID+" "+v.prObservedURL+"` to record the PR github reports, then `hand merge "+v.task.ID+"` once merging is authorized")
 	case v.reportedState == state.ReportDone && v.task.PR != "":
 		help = append(help, "Run `hand merge "+v.task.ID+"` once merging is authorized, or `hand deliver "+v.task.ID+" --reason <text>` if landing it is someone else's call")
 	case v.reportedState == state.ReportNeedsDecision || v.reportedState == state.ReportBlocked:

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -523,6 +524,46 @@ func TestStatusSingleTaskDetectsGateOpenedPR(t *testing.T) {
 	}
 	if got.Task.PR != "" {
 		t.Fatalf("task.PR = %q, want status to leave persisted state unchanged", got.Task.PR)
+	}
+}
+
+// atqamz/hand#266: an empty durable pr column with a done report and a gate-opened PR observed live
+// used to render the same pr field a recorded PR renders in and tell the operator to run hand merge,
+// which reads the durable column alone, finds it empty, and exits 3.
+func TestStatusThenMergeAgreeOnAnObservedButUnrecordedPR(t *testing.T) {
+	home, worktree := setupTeardownHome(t)
+	setupTeardownGateProject(t, home, worktree, "task-1-branch")
+	writeFakeHerdrPaneStatus(t, "idle")
+	writeFakeGHPRListAndView(t, ghFakePR{Number: 9, URL: "https://github.com/owner/repo/pull/9", State: "OPEN"})
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
+		Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR https://github.com/owner/repo/pull/9 checks green")
+
+	got := runStatusFor(t, "task-1")
+	if pr := detailField(t, got, "pr"); pr == "https://github.com/owner/repo/pull/9" {
+		t.Fatalf("pr = %q, want the observed URL distinguishable from a recorded one", pr)
+	}
+	if !strings.Contains(got, "hand pr task-1 https://github.com/owner/repo/pull/9") {
+		t.Fatalf("got %q, want the help line to name the recording step before hand merge", got)
+	}
+	if strings.Contains(got, "Run `hand merge task-1` once merging is authorized") {
+		t.Fatalf("got %q, want hand status not to offer hand merge while the PR is unrecorded", got)
+	}
+
+	mergeCmd := newMergeCmd()
+	mergeCmd.SetOut(&bytes.Buffer{})
+	mergeCmd.SetArgs([]string{"task-1"})
+	err := mergeCmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want ExitError code 3", err)
+	}
+	if !strings.Contains(err.Error(), "no PR recorded") {
+		t.Fatalf("err = %v, want hand merge to refuse with no PR recorded", err)
 	}
 }
 

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -38,6 +38,10 @@ type taskView struct {
 	hold        state.Hold
 	// Empty where no live lookup applied, which is neither a finding nor an absence.
 	prObserved ghutil.ObservationState
+	// The URL prObserved == ghutil.ObservationFound answers with. Rendered alongside task.PR rather
+	// than folded into it, so a found-but-unrecorded PR never takes the shape a recorded one renders
+	// in (atqamz/hand#266, docs/adr/attention-is-one-derivation-over-three-channels.md invariant 1).
+	prObservedURL string
 	// Empty where the gate-run check does not apply to this task, which is neither a finding nor
 	// an absence either: found, absent and unknown are the only three answers it ever gives.
 	gateObserved ghutil.ObservationState
@@ -187,10 +191,16 @@ var taskFields = []axi.Column[taskView]{
 		return formatReportAge(v.lastReportAt)
 	}},
 	{Name: "pr", Value: func(v taskView) string {
-		if v.task.PR == "" && v.prObserved == ghutil.ObservationUnknown {
-			return "unknown"
+		if v.task.PR != "" {
+			return v.task.PR
 		}
-		return orNone(v.task.PR)
+		switch v.prObserved {
+		case ghutil.ObservationUnknown:
+			return "unknown"
+		case ghutil.ObservationFound:
+			return fmt.Sprintf("none (observed only: %s)", v.prObservedURL)
+		}
+		return "none"
 	}},
 	{Name: "worktree", Value: func(v taskView) string { return orNone(v.execution().Worktree) }},
 	{Name: "herdr", Value: func(v taskView) string {

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -3,7 +3,7 @@
 - Date: 2026-08-20
 - Status: accepted
 - Issues: atqamz/hand#244, atqamz/hand#232, atqamz/hand#53, atqamz/hand#149, atqamz/hand#140, atqamz/hand#32, atqamz/hand#65
-- PRs: atqamz/hand#265, atqamz/hand#274
+- PRs: atqamz/hand#265, atqamz/hand#274, atqamz/hand#278
 
 ## Context
 
@@ -147,7 +147,7 @@ A fourth observation, including the report timestamp used by `hand status`, reus
 
 ## Consequences
 
-Four follow-on issues implement the rest, one per invariant: atqamz/hand#266 for invariant 1, atqamz/hand#267 for invariant 3 carrying invariant 4 as an acceptance criterion, atqamz/hand#268 for invariant 5, and atqamz/hand#269 for invariant 6.
+Five follow-on issues implement the rest, one per invariant: atqamz/hand#266 for invariant 1, atqamz/hand#267 for invariant 3 carrying invariant 4 as an acceptance criterion, atqamz/hand#268 for invariant 5, atqamz/hand#269 for invariant 6, and atqamz/hand#270 for invariant 7.
 Invariant 7 is implemented by atqamz/hand#270: status preserves an unknown report timestamp observation instead of rendering it as an absent report, and the already-unified unreachable-pane path renders unknown without guessing.
 Invariant 2 is met today, by atqamz/hand#140's parse fix and atqamz/hand#149's cursor digest, and gets no follow-on issue.
 Invariant 4 is met vacuously and becomes a test obligation on invariant 3's implementation rather than work of its own.

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -26,16 +26,11 @@ func DetectPR(ctx context.Context, homeDir string, task state.Task, active state
 	return updated, observation, nil
 }
 
-func DetectPRReadOnly(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation) {
-	observation := observePR(ctx, homeDir, active, projectInfo)
-	if !observation.Found() {
-		return task, observation
-	}
-	task.PR = observation.URL
-	if observation.Merged {
-		task.MergeAnnounced = true
-	}
-	return task, observation
+// DetectPRReadOnly answers what GitHub reports without writing task.PR or task.MergeAnnounced, unlike
+// DetectPR: a rendering caller must never receive a task shaped as though the durable record already
+// carried a value only this observation found (ADR attention-is-one-derivation..., invariant 1).
+func DetectPRReadOnly(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
+	return observePR(ctx, homeDir, active, projectInfo)
 }
 
 func observePR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -26,7 +26,7 @@ func DetectPR(ctx context.Context, homeDir string, task state.Task, active state
 	return updated, observation, nil
 }
 
-// DetectPRReadOnly answers what GitHub reports without writing task.PR or task.MergeAnnounced, unlike
+// The read-only detector answers what GitHub reports without writing task.PR or task.MergeAnnounced, unlike
 // DetectPR: a rendering caller must never receive a task shaped as though the durable record already
 // carried a value only this observation found (ADR attention-is-one-derivation..., invariant 1).
 func DetectPRReadOnly(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {


### PR DESCRIPTION
Closes atqamz/hand#266

## Intent

Implement atqamz/hand#266, invariant 1 of atqamz/hand#244's ADR (docs/adr/attention-is-one-derivation-over-three-channels.md): a rendered field must state which channel (durable record vs live observation) it came from. Concrete bug: internal/runtime.DetectPRReadOnly mutated its returned state.Task's PR (and MergeAnnounced) fields to the live-observed GitHub value even though nothing durable changed, so hand status's pr field and JSON rendered an observed-but-unrecorded PR identically to a durably recorded one, with pr_observation as the only (easy-to-miss) tell. hand status then recommended running hand merge, but hand merge (cmd/merge.go:100) reads the durable pr column alone and refuses with 'no PR recorded' - the exact hand status/hand merge disagreement recorded on atqamz/hand#244. Fix: DetectPRReadOnly now returns only the ghutil.PRObservation, never a mutated task - the durable task is never touched by a read-only observation. Added taskView.prObservedURL and a new pr_observed_url JSON field so an observed URL is rendered as 'none (observed only: <url>)' rather than the bare URL. detailHelp now recommends 'hand pr <id> <url>' (the recording step) before hand merge whenever the durable PR is empty but GitHub found one, so hand status never promises a command hand merge is guaranteed to refuse. Deliberately out of scope (per the brief): reconciling a task with a terminal report + merged PR + still-running attempt is atqamz/hand#258's job, not this one - this issue only needs hand status to name the disagreement, not resolve it. Coordination: atqamz/hand#269 and #270 are dispatched concurrently over the same files (different concerns - pane-scrape labelling and unknown-representability) but neither has an open PR yet, so nothing to rebase against. Added regression test TestStatusThenMergeAgreeOnAnObservedButUnrecordedPR covering the exact hand status then hand merge sequence from the brief's Done-when criteria. Already pushed branch 266-status-pr-provenance and opened https://github.com/atqamz/hand/pull/278 manually before invoking no-mistakes; local go build, go vet, gofmt, golangci-lint, commentlint, go test -race ./... (all packages), make contract, make e2e, and nix build .#default are all green.

## What Changed

- Keep read-only GitHub PR observations separate from durable task state.
- Render observed-only PR URLs distinctly and expose them through `pr_observed_url`; guide users to record the PR before merging.
- Add regression coverage for the status-then-merge disagreement and update the ADR.

## Risk Assessment

✅ Low: The change cleanly separates live PR observations from durable task state and aligns status rendering with merge guidance without introducing a reachable source defect.

## Testing

The focused tests passed. End-to-end CLI evidence shows status rendering the observed-only URL, JSON preserving `pr` as empty with `pr_observed_url`, recommending `hand pr` before `hand merge`, and merge refusing with `no PR recorded`; the temporary evidence test was removed from the worktree.

<details>
<summary>Evidence: PR provenance CLI transcript</summary>

```text
=== RUN   TestStatusPRProvenanceEvidence
Error: no PR recorded for task-1
$ hand status task-1
id: task-1
project: myproj
kind: ship
execution_class: none
profile: none
planned_against: none
routing_source: none
task_lifecycle: open
attempt_ordinal: 1
attempt_lifecycle: running
harness: none
model: none
effort: none
state: idle
worktree: /tmp/nix-shell.jxnzB4/TestStatusPRProvenanceEvidence1226936307/002/wt
herdr: none
age: unknown
last_report: just now
pr: "none (observed only: https://github.com/owner/repo/pull/9)"
reported: done
report: "done: PR https://github.com/owner/repo/pull/9 checks green (unacknowledged)"
delivered: none
send_id: none
send_attempt: none
send_state: none
send_origin: none
send_reason: none
held: none
gate: none
flags: unacknowledged
report_file: /tmp/nix-shell.jxnzB4/TestStatusPRProvenanceEvidence1226936307/001/state/task-1.status
report_history[0]:
attempts[1]:
  - Attempt 1: running (none, none, /tmp/nix-shell.jxnzB4/TestStatusPRProvenanceEvidence1226936307/002/wt)
help[1]:
  - Run `hand pr task-1 https://github.com/owner/repo/pull/9` to record the PR github reports, then `hand merge task-1` once merging is authorized
$ hand status task-1 --json
{
  "id": "task-1",
  "project": "myproj",
  "kind": "ship",
  "task_lifecycle": "open",
  "attempt_ordinal": 1,
  "attempt_lifecycle": "running",
  "agent_state": "idle",
  "worktree": "/tmp/nix-shell.jxnzB4/TestStatusPRProvenanceEvidence1226936307/002/wt",
  "herdr": {
    "session": "",
    "workspace_id": "",
    "tab_id": "",
    "pane_id": "wA:pB"
  },
  "pr": "",
  "pr_observation": "found",
  "pr_observed_url": "https://github.com/owner/repo/pull/9",
  "merged": false,
  "pr_merged_observed": false,
  "created_at": "",
  "last_report_at": "2026-08-20T03:55:30Z",
  "reported": {
    "state": "done",
    "note": "PR https://github.com/owner/repo/pull/9 checks green"
  },
  "report_history": [
    "done: PR https://github.com/owner/repo/pull/9 checks green"
  ],
  "unacknowledged": true,
  "attempts": [
    {
      "ordinal": 1,
      "lifecycle": "running",
      "worktree": "/tmp/nix-shell.jxnzB4/TestStatusPRProvenanceEvidence1226936307/002/wt"
    }
  ]
}
$ hand merge task-1
no PR recorded for task-1
--- PASS: TestStatusPRProvenanceEvidence (1.83s)
PASS
ok  	github.com/atqamz/hand/cmd	1.836s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5094f731c7c9da825af96e5f205c5e0313eb19c2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --command go test ./cmd -run 'TestStatusThenMergeAgreeOnAnObservedButUnrecordedPR|TestStatus.*PR|TestStatusDetectsPR' -count=1 -v`
- `End-to-end status and merge transcript captured in the evidence artifact.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

