### PR TITLE
fix(cmd): preserve unknown report observations

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -143,16 +143,20 @@ type statusJSON struct {
 	PR               string      `json:"pr"`
 	// Omitted where no live lookup applied, so a consumer sees "unknown" only where an
 	// empty pr field is a failed observation rather than a PR that is not there.
-	PRObservation   string        `json:"pr_observation,omitempty"`
-	MergeExecuted   bool          `json:"merged"`
-	MergeAnnounced  bool          `json:"pr_merged_observed"`
-	DeliveredAt     string        `json:"delivered_at,omitempty"`
-	DeliveredReason string        `json:"delivered_reason,omitempty"`
-	CreatedAt       string        `json:"created_at"`
-	LastReportAt    string        `json:"last_report_at,omitempty"`
-	Reported        *reportedJSON `json:"reported,omitempty"`
-	ReportHistory   []string      `json:"report_history,omitempty"`
-	Held            *holdJSON     `json:"held,omitempty"`
+	PRObservation   string `json:"pr_observation,omitempty"`
+	MergeExecuted   bool   `json:"merged"`
+	MergeAnnounced  bool   `json:"pr_merged_observed"`
+	DeliveredAt     string `json:"delivered_at,omitempty"`
+	DeliveredReason string `json:"delivered_reason,omitempty"`
+	CreatedAt       string `json:"created_at"`
+	LastReportAt    string `json:"last_report_at,omitempty"`
+	// Omitted where a report file exists (found) or genuinely never has (absent), the same way
+	// PRObservation is: a consumer sees "unknown" only where an empty last_report_at is a failed
+	// stat rather than a task that has never reported.
+	LastReportObservation string        `json:"last_report_observation,omitempty"`
+	Reported              *reportedJSON `json:"reported,omitempty"`
+	ReportHistory         []string      `json:"report_history,omitempty"`
+	Held                  *holdJSON     `json:"held,omitempty"`
 	// Omitted where the gate-run check does not apply to this task, the same way PRObservation
 	// is: found, absent and unknown are otherwise distinct answers, never collapsed together.
 	GateObservation  string `json:"gate_observation,omitempty"`
@@ -427,15 +431,27 @@ func fleetHelp(views []taskView, attention int) []string {
 	return append(help, "Run `hand status --fields <a,b>` to pick columns, `hand status --help` for every field name")
 }
 
-// A stat fault reads the same as no report at all: the column is a staleness
-// hint, and failing hand status over it would trade a whole fleet view for one
-// unreadable timestamp.
-func lastReportAt(home, id string) string {
+// A stat fault degrades to unknown rather than absent: state.ReportModTime already tells the two
+// apart, and failing hand status over one unreadable timestamp would trade away a whole fleet view
+// for it - so the fault travels as an observation instead (atqamz/hand#270).
+func lastReportAt(home, id string) (string, ghutil.ObservationState) {
 	mtime, ok, err := state.ReportModTime(home, id)
-	if err != nil || !ok {
+	if err != nil {
+		return "", ghutil.ObservationUnknown
+	}
+	if !ok {
+		return "", ghutil.ObservationAbsent
+	}
+	return mtime.UTC().Format(time.RFC3339), ghutil.ObservationFound
+}
+
+// Named only for unknown: found already has the timestamp and absent has neither, so naming those
+// too would repeat what LastReportAt's own emptiness already says.
+func lastReportObservationJSON(o ghutil.ObservationState) string {
+	if o != ghutil.ObservationUnknown {
 		return ""
 	}
-	return mtime.UTC().Format(time.RFC3339)
+	return string(o)
 }
 
 // Distinct from "unreported": an I/O fault is not evidence that the worker
@@ -487,20 +503,22 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 		reportedState = reported.State
 	}
 	active := t.Lifecycle == state.TaskOpen && history.ActiveAttempt != nil && attempt.Lifecycle == state.AttemptRunning
+	reportAt, reportAtObserved := lastReportAt(home, t.ID)
 	v := taskView{
-		task:          t,
-		attempt:       attempt,
-		attempts:      attempts,
-		agentState:    agentState,
-		reportedState: reportedState,
-		reportedLine:  reportSummary(t.ID, lines, readErr, unacked, full),
-		lastReportAt:  lastReportAt(home, t.ID),
-		reportFile:    state.ReportPath(home, t.ID),
-		unreadable:    readErr != nil,
-		unacked:       unacked,
-		unreachable:   active && !reachable,
-		parked:        active && taskParked(home, t, e, reportedState, bounds),
-		reported:      reportedFrom(last, len(lines) > 0, readErr),
+		task:               t,
+		attempt:            attempt,
+		attempts:           attempts,
+		agentState:         agentState,
+		reportedState:      reportedState,
+		reportedLine:       reportSummary(t.ID, lines, readErr, unacked, full),
+		lastReportAt:       reportAt,
+		lastReportObserved: reportAtObserved,
+		reportFile:         state.ReportPath(home, t.ID),
+		unreadable:         readErr != nil,
+		unacked:            unacked,
+		unreachable:        active && !reachable,
+		parked:             active && taskParked(home, t, e, reportedState, bounds),
+		reported:           reportedFrom(last, len(lines) > 0, readErr),
 	}
 	if attempt != nil {
 		latestSend := state.LatestSendMetadata
@@ -574,7 +592,7 @@ func (v taskView) json() statusJSON {
 		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR, PRObservation: string(v.prObserved),
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
-		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt,
+		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt, LastReportObservation: lastReportObservationJSON(v.lastReportObserved),
 		Reported: v.reported, GateObservation: string(v.gateObserved), RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Parked: v.parked, Unreachable: v.unreachable, Attempts: history,
 		LatestSend: latestSendJSON(v.latestSend),
 	}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -825,7 +825,7 @@ func TestStatusFleetDoesNotFlagWorkingTasks(t *testing.T) {
 
 // atqamz/hand#268's disagreement 4, attention half: the same outage hand watch's ClassifyUnreachable
 // already announces as failed used to render "state: unknown" here with no flag and no attention.
-// Representing that state itself is atqamz/hand#270's separate job.
+// atqamz/hand#270 is the state itself, already probePaneStatus's honest degrade rather than a guess.
 func TestStatusFleetFlagsUnreachablePaneAndCountsAttention(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
@@ -1042,6 +1042,81 @@ func TestStatusReportsNoDwellTimeWithoutAReportFile(t *testing.T) {
 	}
 	if got := detailField(t, out.String(), "last_report"); got != "none" {
 		t.Fatalf("last_report = %q, want no dwell time invented for a task that never reported", got)
+	}
+}
+
+// atqamz/hand#270: lastReportAt used to fold a missing report file and a failed stat into the same
+// empty string. Exercised directly rather than through the whole command: a stat fault on state's
+// own directory would take the sqlite store down with it before this ever gets a chance to run.
+func TestLastReportAtDistinguishesAbsentFromAFailedStat(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+
+	if at, observed := lastReportAt(home, "task-1"); at != "" || observed != ghutil.ObservationAbsent {
+		t.Fatalf("got (%q, %s), want absent for no report file at all", at, observed)
+	}
+
+	reportPath := state.ReportPath(home, "task-1")
+	if err := os.WriteFile(reportPath, []byte("working: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if at, observed := lastReportAt(home, "task-1"); at == "" || observed != ghutil.ObservationFound {
+		t.Fatalf("got (%q, %s), want found for a readable report", at, observed)
+	}
+
+	// A self-referential symlink is a real ELOOP from os.Stat, isolated to this one path, unlike
+	// stripping permissions from state's own directory which would take sqlite down with it.
+	if err := os.Remove(reportPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(reportPath, reportPath); err != nil {
+		t.Fatal(err)
+	}
+	if at, observed := lastReportAt(home, "task-1"); at != "" || observed != ghutil.ObservationUnknown {
+		t.Fatalf("got (%q, %s), want unknown for a failed stat, never folded into absent", at, observed)
+	}
+}
+
+// The command-level counterpart: a stat fault on the report file must render distinguishably from a
+// task that never reported, in both the plain-text and JSON views.
+func TestStatusSingleTaskDistinguishesUnreadableReportTimestampFromAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	reportPath := state.ReportPath(home, "task-1")
+	if err := os.Symlink(reportPath, reportPath); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want the stat fault degraded rather than failing the command", err)
+	}
+	if got := detailField(t, out.String(), "last_report"); got != "unknown" {
+		t.Fatalf("last_report = %q, want unknown rather than none for a failed stat", got)
+	}
+
+	jsonCmd := newStatusCmd()
+	var jsonOut bytes.Buffer
+	jsonCmd.SetOut(&jsonOut)
+	jsonCmd.SetArgs([]string{"task-1", "--json"})
+	if err := jsonCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(jsonOut.String(), `"last_report_observation": "unknown"`) {
+		t.Fatalf("got %q, want last_report_observation naming unknown", jsonOut.String())
+	}
+	if strings.Contains(jsonOut.String(), `"last_report_at"`) {
+		t.Fatalf("got %q, want last_report_at omitted rather than a fabricated timestamp", jsonOut.String())
 	}
 }
 

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -22,9 +22,12 @@ type taskView struct {
 	reportedLine  string
 	reported      *reportedJSON
 	lastReportAt  string
-	reportFile    string
-	unreadable    bool
-	unacked       bool
+	// found for a real mtime, absent for no report file, unknown for a stat error - atqamz/hand#270,
+	// so an I/O fault on the report channel never renders identically to a worker that never reported.
+	lastReportObserved ghutil.ObservationState
+	reportFile         string
+	unreadable         bool
+	unacked            bool
 	// The two conditions hand watch's own Kind vocabulary already named and hand status never had a
 	// counterpart classifier for - atqamz/hand#268's disagreements 2 and 4 (attention half). Both are
 	// computed only for an open task's one running attempt; see buildTaskView.
@@ -177,7 +180,12 @@ var taskFields = []axi.Column[taskView]{
 	{Name: "report", Value: func(v taskView) string { return orNone(v.reportedLine) }},
 	{Name: "age", Value: func(v taskView) string { return formatAge(v.task.CreatedAt) }},
 	{Name: "created", Value: func(v taskView) string { return orNone(v.task.CreatedAt) }},
-	{Name: "last_report", Value: func(v taskView) string { return formatReportAge(v.lastReportAt) }},
+	{Name: "last_report", Value: func(v taskView) string {
+		if v.lastReportObserved == ghutil.ObservationUnknown {
+			return "unknown"
+		}
+		return formatReportAge(v.lastReportAt)
+	}},
 	{Name: "pr", Value: func(v taskView) string {
 		if v.task.PR == "" && v.prObserved == ghutil.ObservationUnknown {
 			return "unknown"

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -119,7 +119,7 @@ Unknown is not a guess in either direction, and it never collapses into a defini
 Binds every command that observes: `hand status`, `hand watch`, `hand merge`, `hand teardown`, `hand reconcile`, and `hand session`.
 [`ghutil.ObservationState`](../../internal/ghutil/observation.go) is the canonical vocabulary, with `found` and `absent` as the two positive findings and everything that stopped a query from completing as `unknown`, carrying a `Probe` so the unknown travels with the command that asked.
 [`project.GateRunObservation`](../../internal/project/gaterun.go) is a second instance of that same vocabulary rather than a separate idea, and [`worktree.LeaseObservation`](../../internal/worktree/worktree.go) is a third with two extra positive findings for the same reason.
-A fourth observation reuses `ghutil.ObservationState` and adds a type over it; it does not restate the vocabulary a fourth time.
+A fourth observation, including the report timestamp used by `hand status`, reuses `ghutil.ObservationState` and adds a type over it; it does not restate the vocabulary a fourth time.
 
 ## Rejected alternatives
 
@@ -147,7 +147,8 @@ A fourth observation reuses `ghutil.ObservationState` and adds a type over it; i
 
 ## Consequences
 
-Five follow-on issues implement the rest, one per invariant: atqamz/hand#266 for invariant 1, atqamz/hand#267 for invariant 3 carrying invariant 4 as an acceptance criterion, atqamz/hand#268 for invariant 5, atqamz/hand#269 for invariant 6, and atqamz/hand#270 for invariant 7.
+Four follow-on issues implement the rest, one per invariant: atqamz/hand#266 for invariant 1, atqamz/hand#267 for invariant 3 carrying invariant 4 as an acceptance criterion, atqamz/hand#268 for invariant 5, and atqamz/hand#269 for invariant 6.
+Invariant 7 is implemented by atqamz/hand#270: status preserves an unknown report timestamp observation instead of rendering it as an absent report, and the already-unified unreachable-pane path renders unknown without guessing.
 Invariant 2 is met today, by atqamz/hand#140's parse fix and atqamz/hand#149's cursor digest, and gets no follow-on issue.
 Invariant 4 is met vacuously and becomes a test obligation on invariant 3's implementation rather than work of its own.
 Neither atqamz/hand#252 nor atqamz/hand#240 fully satisfies an invariant on its own: atqamz/hand#252 settles the announcement layer invariant 3 is defined against, and atqamz/hand#240 establishes the vocabulary invariant 7 generalizes.

--- a/internal/ghutil/observation.go
+++ b/internal/ghutil/observation.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 )
 
-// ObservationState is the one vocabulary every GitHub observation in hand answers in. Absent is a
-// positive finding from a query that completed; anything that stopped a query from completing is
-// unknown, and nothing may be concluded from it.
+// ObservationState is the vocabulary every observation in hand answers in, GitHub or not - reused by
+// project.GateRunObservation and mirrored by worktree.LeaseObservationState. Absent is a positive
+// finding from a completed query; anything else is unknown, and nothing may be concluded from it.
 type ObservationState string
 
 const (


### PR DESCRIPTION
## Intent

Closes atqamz/hand#270

Implement atqamz/hand#270, invariant 7 of atqamz/hand#244's ADR (docs/adr/attention-is-one-derivation-over-three-channels.md): where the runtime cannot observe, the recorded and rendered value must be unknown, never a guess in either direction, never collapsed into a definite negative.

Two collapse sites were named in the issue. Site 2 (real bug, fixed here): cmd/status.go's lastReportAt returned an empty string for both a missing report file and a failed stat, even though state.ReportModTime already distinguishes them via its (mtime, ok, err) return - so an I/O fault on the report channel rendered identically to a worker that never reported. Fixed by having lastReportAt return the ghutil.ObservationState (found/absent/unknown) alongside the timestamp, threaded through taskView, the JSON statusJSON struct (new last_report_observation field, omitted except for unknown so the common case stays quiet), and the last_report TOON column (prints "unknown" instead of "none" only for a stat fault).

Site 1 (verified already resolved, no new code needed): the issue's own text about an unreachable pane having no taskFlags entry or needsAttention branch was written before atqamz/hand#268 (invariant 5, unified attention definition) merged. I confirmed by reading cmd/statusview.go and the existing test TestStatusFleetFlagsUnreachablePaneAndCountsAttention (whose own comment says 'representing that state itself is atqamz/hand#270's separate job') that #268 already added the unreachable flag, the needsAttention branch, and that probePaneStatus's degrade already renders literally as state: unknown (never a guessed idle) - so invariant 7 is already satisfied there. I updated that test's stale comment to say so rather than leaving a dangling forward-reference to this now-closed issue, and left the behavior untouched.

I also dispatched an independent audit (a fresh Explore-agent read, not just grep) across hand watch (internal/watcher), hand merge, hand teardown, hand reconcile (internal/runtime), and hand session for any place that treats an unknown observation (ghutil.ObservationState, project.GateRunObservation, worktree.LeaseObservationState) as a definite negative rather than refusing or surfacing it - found zero violations; every one of those paths already refuses or routes to a distinct attention/repair condition on unknown, most from earlier issues (#241, #245, #253, #259). So this PR does not touch those commands.

Per the issue's vocabulary section, I strengthened ghutil.ObservationState's doc comment (kept to the repo's enforced 3-line comment-block limit) to say plainly that project.GateRunObservation reuses it directly and worktree.LeaseObservationState mirrors its absent/unknown boundary with extra positive findings, so a fourth observation follows that lead rather than restating the vocabulary - satisfying the issue's 'a test or lint pins this, or the package docs say it plainly enough' acceptance criterion via docs rather than adding new type machinery for a boundary audit that found the three existing declarations already agree.

Tests added: TestLastReportAtDistinguishesAbsentFromAFailedStat (unit-level, using a self-referential symlink to force a genuine ELOOP stat error isolated to the one report file, since stripping permissions from state's own directory would also break the sqlite store) and TestStatusSingleTaskDistinguishesUnreadableReportTimestampFromAbsent (end-to-end through the real hand status command, TOON and JSON). Verified make lint, go build ./..., and go test -race ./... all pass. Checked for file overlap with the other invariant-issue siblings (#266, #267, #269): none touch cmd/status.go/statusview.go as open PRs at the time I finalized.

## What Changed

- Preserve unknown report timestamp observations through `hand status`, rendering `unknown` instead of collapsing stat failures into `none`.
- Add JSON observation output and unit/end-to-end coverage distinguishing absent reports from failed stats.
- Update status observation documentation and clarify invariant 7's completed unreachable-pane behavior.

## Risk Assessment

✅ Low: The change cleanly preserves absent versus unknown report observations and exposes the distinction through both status renderers without introducing a material source risk.

## Testing

Verified absent versus failed report-stat handling through unit tests and real plain/JSON status command paths, including race testing. No screenshot applies to this CLI-only change.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"27d75c52ed25888f40e8d88510c3d5da479176bc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --command go test ./cmd -run 'Test(LastReportAtDistinguishesAbsentFromAFailedStat|StatusSingleTaskDistinguishesUnreadableReportTimestampFromAbsent|StatusFleetFlagsUnreachablePaneAndCountsAttention)$' -count=1`
- `nix develop --command go test -race ./cmd -run 'Test(LastReportAtDistinguishesAbsentFromAFailedStat|StatusSingleTaskDistinguishesUnreadableReportTimestampFromAbsent|StatusFleetFlagsUnreachablePaneAndCountsAttention)$' -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

