### PR TITLE
feat: add checksum-verifying Hand installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,50 @@ Building from source additionally requires Go 1.26.5 or newer.
 
 ## Installation
 
+### Homebrew
+
+```sh
+brew install atqamz/tap/hand
+```
+
+### Nix
+
+Install into your profile:
+
+```sh
+nix profile install github:atqamz/hand
+```
+
+Or run it without installing:
+
+```sh
+nix shell github:atqamz/hand -c hand --version
+```
+
+The flake covers `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`. On Intel macOS, use a release binary or `go install`.
+
+### Go
+
+```sh
+go install github.com/atqamz/hand@latest
+```
+
+`go install` does not embed release-version metadata, so the binary reports `dev` and never checks for updates. Prefer a release binary, Homebrew, or Nix for a versioned build.
+
+### Install script
+
+Checksum-verifying installers for Linux, macOS, and Windows. Each installs `hand` only - never Herdr, Treehouse, `gh`, an agent harness, or no-mistakes.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/install.sh | sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/atqamz/hand/main/install.ps1 | iex
+```
+
+`HAND_INSTALL_DIR` overrides the install directory (`$HOME/.local/bin` on Linux/macOS, `%LOCALAPPDATA%\hand` on Windows); `HAND_INSTALL_VERSION` pins a release tag instead of the latest.
+
 ### Release binary
 
 Release tar archives are available for Linux and macOS on AMD64 and ARM64. A ZIP archive is available for Windows AMD64. Every release includes `checksums.txt`.
@@ -318,12 +362,6 @@ install -m755 hand ~/.local/bin/hand
 On Windows, download `hand-windows-amd64.zip`, extract `hand.exe`, and place it on `PATH`.
 
 See the [releases page](https://github.com/atqamz/hand/releases) for every asset.
-
-### Homebrew
-
-```sh
-brew install atqamz/tap/hand
-```
 
 ### Edge builds
 
@@ -354,30 +392,6 @@ hand update --check --channel edge
 After an edge binary is installed, plain `hand update` continues tracking edge.
 Switch back explicitly with `hand update --channel stable`.
 That switch is a downgrade from unreleased development state, so it may not be runtime-compatible with every future migration performed while using edge.
-
-### Nix
-
-Install into your profile:
-
-```sh
-nix profile install github:atqamz/hand
-```
-
-Or run it without installing:
-
-```sh
-nix shell github:atqamz/hand -c hand --version
-```
-
-The flake covers `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`. On Intel macOS, use a release binary or `go install`.
-
-### Go
-
-```sh
-go install github.com/atqamz/hand@latest
-```
-
-`go install` does not embed release-version metadata, so the binary reports `dev` and never checks for updates. Prefer a release binary or Nix installation for a versioned build.
 
 To build a checkout for contributing to Secondhand itself, see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Or run it without installing:
 nix shell github:atqamz/hand -c hand --version
 ```
 
-The flake covers `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`. On Intel macOS, use a release binary or `go install`.
+The flake covers `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`. On Intel macOS, use a release binary, the install script, or `go install`.
 
 ### Go
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,52 @@
+#Requires -Version 5.1
+# Installs hand only: no herdr, treehouse, gh, agent harness, or no-mistakes.
+# $env:HAND_INSTALL_DIR overrides the install directory; $env:HAND_INSTALL_VERSION pins a tag.
+$ErrorActionPreference = 'Stop'
+
+$repo = "atqamz/hand"
+$installDir = if ($env:HAND_INSTALL_DIR) { $env:HAND_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "hand" }
+$tag = $env:HAND_INSTALL_VERSION
+
+if (-not $tag) {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest"
+    $tag = $release.tag_name
+}
+
+$asset = "hand-windows-amd64.zip"
+$baseUrl = "https://github.com/$repo/releases/download/$tag"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $tmp | Out-Null
+try {
+    Write-Host "downloading $asset ($tag)..."
+    Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile (Join-Path $tmp $asset)
+    Invoke-WebRequest -Uri "$baseUrl/checksums.txt" -OutFile (Join-Path $tmp "checksums.txt")
+
+    $line = Get-Content (Join-Path $tmp "checksums.txt") | Where-Object { $_ -match [regex]::Escape($asset) + '\s*$' }
+    if (-not $line) {
+        throw "checksums.txt has no entry for $asset"
+    }
+    $want = (($line | Select-Object -First 1) -split '\s+')[0].ToLower()
+
+    $got = (Get-FileHash -Algorithm SHA256 (Join-Path $tmp $asset)).Hash.ToLower()
+    if ($got -ne $want) {
+        throw "checksum mismatch for ${asset}: want $want, got $got"
+    }
+
+    Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $tmp -Force
+    New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $tmp "hand.exe") -Destination (Join-Path $installDir "hand.exe") -Force
+
+    Write-Host "installed hand to $(Join-Path $installDir 'hand.exe')"
+    try {
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if (($userPath -split ';') -notcontains $installDir) {
+            Write-Host "note: $installDir is not on your PATH"
+        }
+    } catch {
+        # GetEnvironmentVariable's "User" scope is Windows-only; nothing to report elsewhere.
+    }
+}
+finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -eu
+
+# Installs hand only: no herdr, treehouse, gh, agent harness, or no-mistakes.
+# HAND_INSTALL_DIR overrides the install directory; HAND_INSTALL_VERSION pins a tag.
+
+repo="atqamz/hand"
+bin_dir="${HAND_INSTALL_DIR:-$HOME/.local/bin}"
+tag="${HAND_INSTALL_VERSION:-}"
+
+log() { printf '%s\n' "$*" >&2; }
+die() { log "install.sh: $*"; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required"; }
+need curl
+need tar
+
+case "$(uname -s)" in
+  Linux) goos=linux ;;
+  Darwin) goos=darwin ;;
+  *) die "unsupported OS $(uname -s)" ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) goarch=amd64 ;;
+  arm64|aarch64) goarch=arm64 ;;
+  *) die "unsupported architecture $(uname -m)" ;;
+esac
+
+if [ -z "$tag" ]; then
+  tag=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" |
+    sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)
+  [ -n "$tag" ] || die "could not resolve the latest release tag"
+fi
+
+asset="hand-${goos}-${goarch}.tar.gz"
+base_url="https://github.com/$repo/releases/download/$tag"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+log "downloading $asset ($tag)..."
+curl -fsSL -o "$tmp/$asset" "$base_url/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base_url/checksums.txt"
+
+want=$(sed -n "s/^\([0-9a-f]*\)[[:space:]]*\*\{0,1\}${asset}\$/\1/p" "$tmp/checksums.txt" | head -n1)
+[ -n "$want" ] || die "checksums.txt has no entry for $asset"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  got=$(sha256sum "$tmp/$asset" | cut -d' ' -f1)
+elif command -v shasum >/dev/null 2>&1; then
+  got=$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)
+else
+  die "sha256sum or shasum is required to verify the download"
+fi
+[ "$got" = "$want" ] || die "checksum mismatch for $asset: want $want, got $got"
+
+tar xzf "$tmp/$asset" -C "$tmp" hand
+mkdir -p "$bin_dir"
+install -m 755 "$tmp/hand" "$bin_dir/hand"
+
+log "installed hand to $bin_dir/hand"
+case ":$PATH:" in
+  *":$bin_dir:"*) ;;
+  *) log "note: $bin_dir is not on your PATH" ;;
+esac


### PR DESCRIPTION
## Intent

Implement atqamz/hand#177 in full. Final of a stacked PR sequence: 177-A (merged #271, embedded BuildInfo.Distribution) -> 177-B (merged #273, hand update refuses package-manager-owned/go/source distributions) -> 177-C (merged #277, Homebrew/npm/deb/rpm/WinGet/AUR packaging surfaces, atqamz/homebrew-tap live) -> 177-D (this PR, the final one, closes the issue).

This PR is the last piece of Phase 4: checksum-verifying install.sh (POSIX sh) and install.ps1 (PowerShell), plus reordering README installation docs package-manager-first, plus the acceptance checklist itself in the PR body.

install.sh and install.ps1: download the matching release asset (hand-linux-amd64.tar.gz / hand-darwin-*.tar.gz / hand-windows-amd64.zip) plus checksums.txt from a GitHub release, verify the sha256 before extracting anything, then install only the hand binary - never Herdr, Treehouse, gh, an agent harness, or no-mistakes, per the issue text (installers install Hand only). HAND_INSTALL_DIR overrides the install directory (default $HOME/.local/bin on Linux/macOS, %LOCALAPPDATA%\hand on Windows via install.ps1); HAND_INSTALL_VERSION pins a specific release tag instead of resolving latest.

I actually ran both scripts end to end against the real v0.5.0 GitHub release (not a hypothetical): confirmed the happy path installs a working hand binary for both the default-latest and pinned-version cases, and separately forced a checksum mismatch (by patching a throwaway copy of each script to compare against a deliberately wrong value) and confirmed both abort with a clear error and, critically, create no output directory/file at all - no partial or unverified install ever lands on disk. install.sh also passes shellcheck -s sh cleanly. install.ps1 (tested via PowerShell Core, which runs fine on Linux since the logic is all cross-platform Invoke-WebRequest/Get-FileHash/Expand-Archive) has exactly one PSScriptAnalyzer finding, PSAvoidUsingWriteHost, which I judged correct to keep rather than fix: Write-Host is the conventional choice for an interactive installers user-facing console progress output (not a function meant to return objects down a pipeline), and is what real-world installers like this one typically use.

README changes: moved Homebrew above Nix/Go (package-manager-first per the issue), added a new Install script section documenting install.sh/install.ps1 with the env var overrides, kept the manual Release binary steps as a transparent fallback below the script, and removed the old duplicate Nix/Go sections that used to sit right before the Edge builds section (they got moved up, not left in two places). WinGet, npm, and AUR are still not mentioned anywhere in the README, since none of those three are actually published - matching the issues own rule that install docs only appear once a surface genuinely exists, never in advance of it.

This PR title uses Closes atqamz/hand#177 since it is the final PR in the stack. Please verify the full acceptance checklist in the issue body is genuinely satisfied by the cumulative work across all four merged/mergeable PRs (271, 273, 277, and this one), not just by this PRs own diff in isolation, since no single PR in the stack does everything - please read atqamz/hand#177s actual current issue body (not any older cached description) to check acceptance criteria if you have access to gh.

Explicitly NOT done in this issue, by a deliberate scoping decision I made myself mid-session (not something the operator asked for) rather than an oversight: actually running npm publish, actually pushing to aur.archlinux.org, and actually opening a submission PR against microsoft/winget-pkgs. All three surfaces are fully built and locally verified in PR 277, but: no NPM_TOKEN secret exists in this repo (confirmed via gh secret list, which returned empty), no AUR account or SSH key exists that I have access to, and opening a PR against a third-party repository under the real operators GitHub identity is something I judged needs explicit sign-off rather than being mine to do unilaterally, especially since I already flagged this exact gap to the user earlier in the session via my own harnesss interactive question dialog (not a hand send message, so per this repos own fleet-worker convention that is my own decision to record, not an operator-authorized one). Homebrew is the one surface that had neither blocker (existing gh auth was sufficient to create a new public GitHub repo, atqamz/homebrew-tap, under the already-authenticated atqamz account), so it is the only one that actually went live this session.

Also worth knowing for review: partway through 177-C I discovered that simply repackaging hands existing prebuilt release binaries for Homebrew/npm/deb/rpm would have been actively wrong, not just incomplete - those prebuilt assets already embed -X main.distribution=github (baked in by release.yaml), so a brew/npm/deb/rpm-installed binary built that way would falsely self-report as a direct GitHub download, and hand update would then try to self-replace a package-manager-owned binary in place, which is exactly the bug 177-Bs ownership-refusal logic exists to prevent. That correctness requirement (verified empirically, not just reasoned about) is why 177-C ended up building Homebrew/npm/deb/rpm from source with their own distribution value rather than just repackaging release archives, and why cutting the real v0.5.0 release became a hard prerequisite partway through that work (verifying against the older v0.4.0 tag produced a binary with no distribution field at all, since that tag predates 177-A). All of that is already merged in 271/273/277; flagging it here only so the reviewer has full context for why the stack looks the way it does when reading this final PR in isolation.

All Go tests/lint pass locally; this PR touches zero Go source, only install.sh, install.ps1, and README.md.

## What Changed

- Added checksum-verifying POSIX shell and PowerShell installers that download release archives, validate `sha256` checksums before extraction, and install only the `hand` binary.
- Added `HAND_INSTALL_DIR` and `HAND_INSTALL_VERSION` overrides with platform-specific default install directories.
- Reordered README installation guidance to prioritize package managers, document the installers, and retain release binaries as a fallback.

## Risk Assessment

✅ Low: The installer and documentation changes satisfy the stated acceptance criteria without a source-verifiable defect identified in the review.

## Testing

Ran targeted real-release end-to-end checks for both installers, latest and pinned versions, successful binary/file installation, checksum rejection before extraction or output-directory creation, POSIX syntax, and current issue acceptance context. PowerShell was executed through PowerShell Core 7.6.4. No source changes were made and no linters were run per phase instructions.

<details>
<summary>Evidence: install.sh happy paths</summary>

`Live v0.5.0 install succeeded for latest and pinned POSIX flows; both installed hand 0.5.0.`

```text
downloading hand-linux-amd64.tar.gz (v0.5.0)...
installed hand to /home/atqa/.no-mistakes/evidence/01M0EMV0M3GGM6G71K9DCV99N4/sh-latest/hand
note: /home/atqa/.no-mistakes/evidence/01M0EMV0M3GGM6G71K9DCV99N4/sh-latest is not on your PATH
```
</details>
<details>
<summary>Evidence: install.ps1 happy paths</summary>

`Live v0.5.0 PowerShell installs succeeded for latest and pinned flows, producing hand.exe.`

```text
downloading hand-windows-amd64.zip (v0.5.0)...
installed hand to /home/atqa/.no-mistakes/evidence/01M0EMV0M3GGM6G71K9DCV99N4/ps-latest/hand.exe
note: /home/atqa/.no-mistakes/evidence/01M0EMV0M3GGM6G71K9DCV99N4/ps-latest is not on your PATH
```
</details>
<details>
<summary>Evidence: checksum rejection evidence</summary>

`Both checksum-mismatch cases exited 1 with clear errors and created no install output directory.`

```text
downloading hand-linux-amd64.tar.gz (v0.5.0)...
install.sh: checksum mismatch for hand-linux-amd64.tar.gz: want 0000000000000000000000000000000000000000000000000000000000000000, got facb93a841b091f84e021357df14c0d65e1a4adf50f704b917437506d61ad803
exit=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c181b2dbe7df065478f6ad798efaed4695f06b80","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`HAND_INSTALL_DIR=... sh ./install.sh` using latest release resolution</code>
- `HAND_INSTALL_DIR=... HAND_INSTALL_VERSION=v0.5.0 sh ./install.sh`
- <code>`pwsh -File ./install.ps1` using latest release resolution</code>
- <code>`pwsh -File ./install.ps1` with `HAND_INSTALL_VERSION=v0.5.0`</code>
- `Deliberately patched checksum-mismatch copies of both installers; verified exit 1, clear errors, and no output directories`
- `sh -n install.sh`
- <code>`gh issue view 177 --repo atqamz/hand --json title,state,body` against the current issue body</code>
- <code>Verified installed-file contents and `hand --version` output</code>
- `Verified clean worktree and no transient test artifacts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
