### PR TITLE
feat(cmd): add explicit acknowledgement for task status

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand deliver` | Mark work as handed off when landing is someone else's decision. |
 | `hand teardown` | Clean up a completed task safely while preserving Task and Attempt history. |
 
-Other commands cover session bootstrap, configuration, project sync and upstreams, holds, scout promotion, search, notifications, diagnostics, PR recording, and self-update.
+Other commands cover session bootstrap, configuration, project sync and upstreams, holds, acknowledgement, scout promotion, search, notifications, diagnostics, PR recording, and self-update.
 
 Run `hand --help` for the authoritative command reference.
 

--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
+| `hand ack <id> [--reason <text>]` | Record that a supervisor has acknowledged a task's report. |
 | `hand reconcile [id] [--abandon-worktree] [--abandon-pane] [--attempt-never-started]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; given a Task ID, explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, or attest that a running Attempt's worker took no turn so the ordinary release path can end it. |
 | `hand watch` | Wait for actionable fleet events. |
 | `hand send` | Steer a running worker. |
@@ -440,7 +441,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand deliver` | Mark work as handed off when landing is someone else's decision. |
 | `hand teardown` | Clean up a completed task safely while preserving Task and Attempt history. |
 
-Other commands cover session bootstrap, configuration, project sync and upstreams, holds, acknowledgement, scout promotion, search, notifications, diagnostics, PR recording, and self-update.
+Other commands cover session bootstrap, configuration, project sync and upstreams, holds, scout promotion, search, notifications, diagnostics, PR recording, and self-update.
 
 Run `hand --help` for the authoritative command reference.
 

--- a/cmd/ack.go
+++ b/cmd/ack.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newAckCmd() *cobra.Command {
+	var reason string
+
+	cmd := &cobra.Command{
+		Use:   "ack <id>",
+		Short: "Record that a supervisor has acknowledged this task's report",
+		Args:  usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+
+			home, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+
+			release, err := state.Lock(home, "task:"+id)
+			if err != nil {
+				return fmt.Errorf("lock task %q: %w", id, err)
+			}
+			defer release()
+
+			if _, err := state.Read(home, id); err != nil {
+				return asPrecondition(err)
+			}
+
+			// Whatever is in the channel right now, this act consumed - the same completeness rule a
+			// watcher's own announcement cursor follows, so a line still being appended is never claimed.
+			cursor, err := state.CurrentReportCursor(home, id)
+			if err != nil {
+				return fmt.Errorf("read report %q: %w", id, err)
+			}
+
+			ackedAt := time.Now().UTC().Format(time.RFC3339)
+			if err := state.SetTaskAcknowledgement(home, id, ackedAt, reason, cursor.Offset, cursor.Digest); err != nil {
+				return fmt.Errorf("write task state: %w", err)
+			}
+
+			var doc axi.Doc
+			doc.Field("id", id)
+			doc.Field("result", "acknowledged")
+			doc.Field("reason", orNone(reason))
+			doc.Field("acknowledged_at", ackedAt)
+			doc.Help("Run `hand status " + id + "` to confirm the unacknowledged flag is clear")
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVar(&reason, "reason", "", "why this report is considered handled")
+	return cmd
+}

--- a/cmd/ack_test.go
+++ b/cmd/ack_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/state"
+)
+
+func TestAckRecordsTheActDurably(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	report := "done: PR up\n"
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(report), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newAckCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1", "--reason", "reviewed the diff and merge is mine to do"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "result: acknowledged\n") {
+		t.Fatalf("out = %q, want an acknowledged confirmation", out.String())
+	}
+	for _, want := range []string{
+		"id: task-1\n",
+		"reason: reviewed the diff and merge is mine to do\n",
+		"acknowledged_at: ",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("out = %q, want field %q", out.String(), want)
+		}
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AcknowledgedReason != "reviewed the diff and merge is mine to do" {
+		t.Fatalf("AcknowledgedReason = %q", got.AcknowledgedReason)
+	}
+	if got.AcknowledgedAt == "" {
+		t.Fatal("AcknowledgedAt not stamped")
+	}
+	if got.AcknowledgedOffset != int64(len(report)) {
+		t.Fatalf("AcknowledgedOffset = %d, want %d", got.AcknowledgedOffset, len(report))
+	}
+}
+
+// hand ack takes no --reason at all: atqamz/hand#267 leaves it optional, unlike hand deliver's.
+func TestAckReasonIsOptional(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newAckCmd()
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AcknowledgedAt == "" {
+		t.Fatal("AcknowledgedAt not stamped without a --reason")
+	}
+}
+
+func TestAckRefusesWhenTaskMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+
+	cmd := newAckCmd()
+	cmd.SetArgs([]string{"missing-task"})
+	assertExitCode3(t, cmd.Execute())
+}
+
+// Re-running is a correction, not a conflict, the same convention hand deliver established: whatever
+// the channel carries right now replaces what an earlier ack claimed to cover.
+func TestAckIsIdempotentAndAdvancesTheCursor(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "myproj"}); err != nil {
+		t.Fatal(err)
+	}
+	first := "working: on it\n"
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(first), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newAckCmd()
+	cmd.SetOut(&strings.Builder{})
+	cmd.SetArgs([]string{"task-1", "--reason", "first pass"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	firstAck, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstAck.AcknowledgedOffset != int64(len(first)) {
+		t.Fatalf("AcknowledgedOffset = %d, want %d", firstAck.AcknowledgedOffset, len(first))
+	}
+
+	second := first + "done: PR up\n"
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte(second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	again := newAckCmd()
+	again.SetOut(&strings.Builder{})
+	again.SetArgs([]string{"task-1", "--reason", "second pass"})
+	if err := again.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	secondAck, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondAck.AcknowledgedReason != "second pass" {
+		t.Fatalf("AcknowledgedReason = %q, want the corrected reason", secondAck.AcknowledgedReason)
+	}
+	if secondAck.AcknowledgedOffset != int64(len(second)) {
+		t.Fatalf("AcknowledgedOffset = %d, want %d covering everything reported so far", secondAck.AcknowledgedOffset, len(second))
+	}
+}
+
+// The whole point of atqamz/hand#267: hand status renders no completion as acknowledged until this
+// command has actually run against it.
+func TestAckClearsTheUnacknowledgedFlagStatusRenders(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR up")
+
+	before := newStatusCmd()
+	var beforeOut strings.Builder
+	before.SetOut(&beforeOut)
+	before.SetArgs(nil)
+	if err := before.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(fleetFlags(t, beforeOut.String(), "task-1"), "unacknowledged") {
+		t.Fatalf("flags = %v, want unacknowledged before hand ack runs", fleetFlags(t, beforeOut.String(), "task-1"))
+	}
+
+	ack := newAckCmd()
+	ack.SetOut(&strings.Builder{})
+	ack.SetArgs([]string{"task-1"})
+	if err := ack.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	after := newStatusCmd()
+	var afterOut strings.Builder
+	after.SetOut(&afterOut)
+	after.SetArgs(nil)
+	if err := after.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(fleetFlags(t, afterOut.String(), "task-1"), "unacknowledged") {
+		t.Fatalf("flags = %v, want unacknowledged cleared once hand ack has run", fleetFlags(t, afterOut.String(), "task-1"))
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.AddCommand(newSendCmd())
 	root.AddCommand(newHoldCmd())
 	root.AddCommand(newDeliverCmd())
+	root.AddCommand(newAckCmd())
 	root.AddCommand(newTeardownCmd())
 	root.AddCommand(newWatchCmd())
 	root.AddCommand(newMergeCmd())

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -480,7 +480,7 @@ const reportUnreadable = "unreadable"
 // Shared by unannounced and unacknowledged: whether this task's terminal report sits past cur, whichever
 // durable cursor the caller names. Takes the state the caller already derived rather than reading the
 // file a second time, so a worker appending between the two reads can never surface a stale flag.
-func terminalReportPast(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error, cur state.ReportCursor) (bool, error) {
+func terminalReportPast(data []byte, reported state.ReportLine, reportedOK bool, readErr error, cur state.ReportCursor) (bool, error) {
 	// A read that fails folds into the caller's own report-read error: the file was readable a moment ago
 	// and is not now, which is what that error already says, and swallowing it would render an unread
 	// completion as covered.
@@ -491,20 +491,20 @@ func terminalReportPast(home string, t state.Task, reported state.ReportLine, re
 	if !reportedOK || !state.TerminalReport(reported.State) {
 		return false, nil
 	}
-	return state.TerminalReportPastCursor(home, t.ID, cur)
+	return state.TerminalReportInData(data, cur), nil
 }
 
 // Asks state whether some watcher has ever announced this task's terminal report - report_offset and
 // report_digest are the watcher's own cursor, distinct from whether a supervisor has acknowledged it
 // (atqamz/hand#267, docs/adr/attention-is-one-derivation-over-three-channels.md).
-func unannounced(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
-	return terminalReportPast(home, t, reported, reportedOK, readErr, state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest})
+func unannounced(data []byte, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
+	return terminalReportPast(data, reported, reportedOK, readErr, state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest})
 }
 
 // Asks state whether a supervisor has acknowledged this task's terminal report through `hand ack`,
 // the durable act atqamz/hand#267 records apart from watcher announcement.
-func unacknowledged(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
-	return terminalReportPast(home, t, reported, reportedOK, readErr, state.ReportCursor{Offset: t.AcknowledgedOffset, Digest: t.AcknowledgedDigest})
+func unacknowledged(data []byte, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
+	return terminalReportPast(data, reported, reportedOK, readErr, state.ReportCursor{Offset: t.AcknowledgedOffset, Digest: t.AcknowledgedDigest})
 }
 
 // Derives everything both status views show from one already-read history, and returns the report lines
@@ -522,10 +522,11 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 		e = *attempt
 	}
 	agentState, reachable := probePaneStatus(client, e.Herdr.PaneID)
-	lines, readErr := state.ReadReportLines(home, t.ID)
+	data, readErr := state.ReadReportData(home, t.ID)
+	lines := state.ReportLinesInData(data)
 	reported, reportedOK := state.LastReportedState(lines)
-	unacked, readErr := unacknowledged(home, t, reported, reportedOK, readErr)
-	unannounced, readErr := unannounced(home, t, reported, reportedOK, readErr)
+	unacked, readErr := unacknowledged(data, t, reported, reportedOK, readErr)
+	unannounced, readErr := unannounced(data, t, reported, reportedOK, readErr)
 
 	var last state.ReportLine
 	if len(lines) > 0 {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -171,6 +171,9 @@ type statusJSON struct {
 	// Omitted when false so a consumer written before this field sees no change
 	// on the fleet it already understands.
 	Unacknowledged bool `json:"unacknowledged,omitempty"`
+	// Distinct from Unacknowledged: whether some watcher has ever announced this report, rather than
+	// whether a supervisor has acknowledged it (atqamz/hand#267).
+	Unannounced bool `json:"unannounced,omitempty"`
 	// The two conditions atqamz/hand#268 gave hand status a counterpart classifier for: a pane silent
 	// past its report state's bound, and one that claims a pane but never answered it.
 	Parked      bool          `json:"parked,omitempty"`
@@ -474,13 +477,13 @@ func lastReportObservationJSON(o ghutil.ObservationState) string {
 // never reported.
 const reportUnreadable = "unreadable"
 
-// Asks state whether this task's terminal report reached a watcher. It takes the state the caller already
-// derived rather than reading the file a second time: a second snapshot with a worker appending between
-// the two would put "unacknowledged" next to a "working" this command reported in the same breath.
-func unacknowledged(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
+// Shared by unannounced and unacknowledged: whether this task's terminal report sits past cur, whichever
+// durable cursor the caller names. Takes the state the caller already derived rather than reading the
+// file a second time, so a worker appending between the two reads can never surface a stale flag.
+func terminalReportPast(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error, cur state.ReportCursor) (bool, error) {
 	// A read that fails folds into the caller's own report-read error: the file was readable a moment ago
 	// and is not now, which is what that error already says, and swallowing it would render an unread
-	// completion as an acknowledged one.
+	// completion as covered.
 	if readErr != nil {
 		return false, readErr
 	}
@@ -488,7 +491,20 @@ func unacknowledged(home string, t state.Task, reported state.ReportLine, report
 	if !reportedOK || !state.TerminalReport(reported.State) {
 		return false, nil
 	}
-	return state.UnacknowledgedTerminalReport(home, t.ID, state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest})
+	return state.TerminalReportPastCursor(home, t.ID, cur)
+}
+
+// Asks state whether some watcher has ever announced this task's terminal report - report_offset and
+// report_digest are the watcher's own cursor, distinct from whether a supervisor has acknowledged it
+// (atqamz/hand#267, docs/adr/attention-is-one-derivation-over-three-channels.md).
+func unannounced(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
+	return terminalReportPast(home, t, reported, reportedOK, readErr, state.ReportCursor{Offset: t.ReportOffset, Digest: t.ReportDigest})
+}
+
+// Asks state whether a supervisor has acknowledged this task's terminal report through `hand ack`,
+// the durable act atqamz/hand#267 records apart from watcher announcement.
+func unacknowledged(home string, t state.Task, reported state.ReportLine, reportedOK bool, readErr error) (bool, error) {
+	return terminalReportPast(home, t, reported, reportedOK, readErr, state.ReportCursor{Offset: t.AcknowledgedOffset, Digest: t.AcknowledgedDigest})
 }
 
 // Derives everything both status views show from one already-read history, and returns the report lines
@@ -509,6 +525,7 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 	lines, readErr := state.ReadReportLines(home, t.ID)
 	reported, reportedOK := state.LastReportedState(lines)
 	unacked, readErr := unacknowledged(home, t, reported, reportedOK, readErr)
+	unannounced, readErr := unannounced(home, t, reported, reportedOK, readErr)
 
 	var last state.ReportLine
 	if len(lines) > 0 {
@@ -532,6 +549,7 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 		reportFile:         state.ReportPath(home, t.ID),
 		unreadable:         readErr != nil,
 		unacked:            unacked,
+		unannounced:        unannounced,
 		unreachable:        active && !reachable,
 		parked:             active && taskParked(home, t, e, reportedState, bounds),
 		reported:           reportedFrom(last, len(lines) > 0, readErr),
@@ -609,7 +627,7 @@ func (v taskView) json() statusJSON {
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt, LastReportObservation: lastReportObservationJSON(v.lastReportObserved),
-		Reported: v.reported, GateObservation: string(v.gateObserved), RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Parked: v.parked, Unreachable: v.unreachable, Attempts: history,
+		Reported: v.reported, GateObservation: string(v.gateObserved), RepairCode: v.task.RepairCode, RepairReason: v.task.RepairReason, RepairAttemptID: v.task.RepairAttemptID, RepairObservedAt: v.task.RepairObservedAt, Unacknowledged: v.unacked, Unannounced: v.unannounced, Parked: v.parked, Unreachable: v.unreachable, Attempts: history,
 		LatestSend: latestSendJSON(v.latestSend),
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2529,8 +2529,12 @@ func TestStatusFleetFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if row := fleetRow(t, out.String(), "task-1"); !strings.HasPrefix(row, "task-1,idle,done,") || !strings.HasSuffix(row, ",unacknowledged") {
-		t.Fatalf("got %q, want the done report flagged unacknowledged", row)
+	row := fleetRow(t, out.String(), "task-1")
+	if !strings.HasPrefix(row, "task-1,idle,done,") {
+		t.Fatalf("got %q, want the reported state still shown", row)
+	}
+	if !slices.Contains(fleetFlags(t, out.String(), "task-1"), "unannounced") {
+		t.Fatalf("flags = %v, want the done report flagged unannounced", fleetFlags(t, out.String(), "task-1"))
 	}
 }
 
@@ -2562,8 +2566,8 @@ func TestStatusFleetDoesNotFlagATerminalReportAWatcherConsumed(t *testing.T) {
 	if !strings.HasPrefix(row, "task-1,idle,done,") {
 		t.Fatalf("got %q, want the reported state still shown", row)
 	}
-	if strings.Contains(row, "unacknowledged") {
-		t.Fatalf("got %q, want no flag on a report a watcher already announced", row)
+	if slices.Contains(fleetFlags(t, out.String(), "task-1"), "unannounced") {
+		t.Fatalf("flags = %v, want no flag on a report a watcher already announced", fleetFlags(t, out.String(), "task-1"))
 	}
 }
 
@@ -2586,12 +2590,12 @@ func TestStatusFleetJSONFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.String(), `"unacknowledged": true`) {
-		t.Fatalf("got %q, want unacknowledged true", out.String())
+	if !strings.Contains(out.String(), `"unannounced": true`) {
+		t.Fatalf("got %q, want unannounced true", out.String())
 	}
 }
 
-func TestStatusSingleTaskFlagsATerminalReportNoWatcherConsumed(t *testing.T) {
+func TestStatusSingleTaskFlagsATerminalReportNotAcknowledged(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -2687,8 +2691,9 @@ func TestStatusSingleTaskShowsTrailingFreeTextWhenAcknowledged(t *testing.T) {
 
 	report := "done: PR up\nstill tidying\n"
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		CreatedAt:    "2026-07-24T10:00:00Z",
-		ReportOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+		CreatedAt:          "2026-07-24T10:00:00Z",
+		AcknowledgedAt:     "2026-07-24T11:00:00Z",
+		AcknowledgedOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -2716,8 +2721,9 @@ func TestStatusSingleTaskJSONOmitsUnacknowledgedWhenAcknowledged(t *testing.T) {
 
 	report := "done: PR up\n"
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
-		CreatedAt:    "2026-07-24T10:00:00Z",
-		ReportOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
+		CreatedAt:          "2026-07-24T10:00:00Z",
+		AcknowledgedAt:     "2026-07-24T11:00:00Z",
+		AcknowledgedOffset: int64(len(report))}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -2797,7 +2803,62 @@ func TestStatusFleetFlagsATerminalReportWithNoTrailingNewline(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if row := fleetRow(t, out.String(), "task-1"); !strings.HasPrefix(row, "task-1,idle,done,") || !strings.HasSuffix(row, ",unacknowledged") {
-		t.Fatalf("got %q, want an unterminated done flagged like any other unread completion", row)
+	row := fleetRow(t, out.String(), "task-1")
+	if !strings.HasPrefix(row, "task-1,idle,done,") {
+		t.Fatalf("got %q, want the reported state still shown", row)
+	}
+	if !slices.Contains(fleetFlags(t, out.String(), "task-1"), "unannounced") {
+		t.Fatalf("flags = %v, want an unterminated done flagged like any other unannounced completion", fleetFlags(t, out.String(), "task-1"))
+	}
+}
+
+// Invariant 4 of docs/adr/attention-is-one-derivation-over-three-channels.md: observing is not
+// acknowledging, so running hand status against an unacknowledged report - fleet view, single-task
+// view, and --json alike - must leave the task exactly as unacknowledged as it found it.
+func TestStatusIsReadOnlyForAcknowledgement(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	writeDoneReport(t, home, "task-1", "PR up")
+
+	before, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{nil, {"task-1"}, {"--json"}, {"task-1", "--json"}} {
+		cmd := newStatusCmd()
+		cmd.SetOut(&strings.Builder{})
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("hand status %v: %v", args, err)
+		}
+	}
+
+	after, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("task changed after read-only hand status calls: before %+v, after %+v", before, after)
+	}
+	if after.AcknowledgedAt != "" || after.AcknowledgedOffset != 0 || after.AcknowledgedDigest != "" {
+		t.Fatalf("task %+v, want hand status to leave acknowledgement untouched", after)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(fleetFlags(t, out.String(), "task-1"), "unacknowledged") {
+		t.Fatalf("flags = %v, want the report still unacknowledged after only reading it", fleetFlags(t, out.String(), "task-1"))
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2768,7 +2768,7 @@ func TestUnacknowledgedAnswersForTheStateTheRowPrints(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := unacknowledged(home, task, c.reported, c.ok, nil)
+			got, err := unacknowledged([]byte("done: PR up\n"), task, c.reported, c.ok, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -30,7 +30,7 @@ type taskView struct {
 	unacked            bool
 	// Whether some watcher has ever announced this task's terminal report - a separate fact from unacked,
 	// which is whether a supervisor has acknowledged it through `hand ack` (atqamz/hand#267).
-	unannounced        bool
+	unannounced bool
 	// The two conditions hand watch's own Kind vocabulary already named and hand status never had a
 	// counterpart classifier for - atqamz/hand#268's disagreements 2 and 4 (attention half). Both are
 	// computed only for an open task's one running attempt; see buildTaskView.

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -28,6 +28,9 @@ type taskView struct {
 	reportFile         string
 	unreadable         bool
 	unacked            bool
+	// Whether some watcher has ever announced this task's terminal report - a separate fact from unacked,
+	// which is whether a supervisor has acknowledged it through `hand ack` (atqamz/hand#267).
+	unannounced        bool
 	// The two conditions hand watch's own Kind vocabulary already named and hand status never had a
 	// counterpart classifier for - atqamz/hand#268's disagreements 2 and 4 (attention half). Both are
 	// computed only for an open task's one running attempt; see buildTaskView.
@@ -91,6 +94,9 @@ func taskFlags(v taskView) []string {
 	}
 	if v.unacked {
 		flags = append(flags, "unacknowledged")
+	}
+	if v.unannounced {
+		flags = append(flags, "unannounced")
 	}
 	if unreportedStop(v) {
 		flags = append(flags, "unreported")

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -47,7 +47,7 @@ func initGitRepo(t *testing.T, dir string) {
 		t.Fatal(err)
 	}
 	run("add", "README.md")
-	run("commit", "-q", "-m", "initial commit")
+	run("-c", "commit.gpgsign=false", "commit", "-q", "-m", "initial commit")
 }
 
 // The PR recorded on a task whose test does not exercise detection.

--- a/docs/adr/arming-a-watch-observes-before-it-waits.md
+++ b/docs/adr/arming-a-watch-observes-before-it-waits.md
@@ -21,7 +21,7 @@ Arming performs a real observation whose events are delivered.
 `ClassifyCatchUp` asks the level question `ClassifyStatus` can only ask as an edge, and the attempt's durable `status_changed_for` is what says whether some watcher already announced the episode.
 `CatchUpFilter` bounds the delivery to kinds whose announcement durable state records, so a re-arm against an already-announced condition is silent.
 
-Announcement, not operator acknowledgement, is the idempotence unit here. atqamz/hand#244 owns the acknowledgement model.
+Announcement, not operator acknowledgement, is the idempotence unit here. The acknowledgement model is defined in [the attention record](attention-is-one-derivation-over-three-channels.md).
 
 ## Rejected alternatives
 

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -12,7 +12,7 @@ There is no stated contract for what a report is, what acknowledging one means, 
 
 Two decisions already settle pieces of it.
 [The report file owns worker outcome](the-report-channel-is-the-only-outcome-signal.md) made `state/<id>.status` the sole source of what a worker says happened, and kept herdr state independent of it.
-[Arming a watch observes before it waits](arming-a-watch-observes-before-it-waits.md) made wake level-triggered over durable fleet truth, and closed by naming atqamz/hand#244 as the owner of the acknowledgement model it deliberately did not define.
+[Arming a watch observes before it waits](arming-a-watch-observes-before-it-waits.md) made wake level-triggered over durable fleet truth, and deliberately left the acknowledgement model to this record.
 Neither says how many definitions of attention the tool is allowed to have, nor what distinguishes a condition some watcher announced from one a supervisor has taken responsibility for.
 
 The listed defects, each mapped to the invariant below that would have prevented it.

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -76,9 +76,9 @@ Announcement and acknowledgement are two different facts and the tool spells the
 Without the second, "needs attention" cannot be told from "needed attention, already handled", which is why the same condition resurfaces every poll.
 
 Binds `hand status`, `hand watch`, and `hand session`, and is recorded by [`internal/store`](../../internal/store).
-The two markers that exist today are both announcement markers, not acknowledgement markers: `internal/state.UnacknowledgedTerminalReport` reads the durable report cursor, and `attempt.status_changed_for` names the herdr episode a watcher already announced.
-The `unacknowledged` flag `cmd/statusview.go` prints therefore means unannounced, and that spelling is wrong under this record.
-The surface acknowledgement is performed through is the operator's to choose and is deliberately not decided here.
+The durable report cursor and `attempt.status_changed_for` remain announcement markers: the former records the report channel a watcher has delivered, and the latter names the herdr episode a watcher already announced.
+The durable acknowledgement cursor is separate, and `hand status` exposes both facts as `unacknowledged` and `unannounced`.
+The surface acknowledgement is `hand ack <id> [--reason <text>]`, which records the supervisor's act without redefining the announcement cursor.
 
 ### 4. Read-only observation does not silently mutate acknowledgement
 
@@ -87,7 +87,7 @@ Observing is not acknowledging.
 If reading should ever acknowledge, that is an explicit flag on an explicit contract, never the default.
 
 Binds `hand status` and every read-only path [`internal/state`](../../internal/state) and [`internal/project`](../../internal/project) expose for it, including `ReadHistoryReadOnly`, `ListReconciliationHistoriesReadOnly`, `ReadHoldReadOnly`, `project.ListReadOnly`, and `runtime.DetectPRReadOnly`.
-`hand status` satisfies this today only because there is no acknowledgement record to mutate, so this invariant is a constraint on how invariant 3 is built rather than a description of current behavior.
+`hand status` satisfies this by reading the acknowledgement cursor through migration-aware read-only paths; only explicit `hand ack` writes acknowledgement.
 
 ### 5. `status` and `watch` derive attention from compatible semantics
 
@@ -150,10 +150,10 @@ A fourth observation, including the report timestamp used by `hand status`, reus
 Five follow-on issues implement the rest, one per invariant: atqamz/hand#266 for invariant 1, atqamz/hand#267 for invariant 3 carrying invariant 4 as an acceptance criterion, atqamz/hand#268 for invariant 5, atqamz/hand#269 for invariant 6, and atqamz/hand#270 for invariant 7.
 Invariant 7 is implemented by atqamz/hand#270: status preserves an unknown report timestamp observation instead of rendering it as an absent report, and the already-unified unreachable-pane path renders unknown without guessing.
 Invariant 2 is met today, by atqamz/hand#140's parse fix and atqamz/hand#149's cursor digest, and gets no follow-on issue.
-Invariant 4 is met vacuously and becomes a test obligation on invariant 3's implementation rather than work of its own.
+Invariant 4 is met by invariant 3's implementation and its read-only regression test rather than by work of its own.
 Neither atqamz/hand#252 nor atqamz/hand#240 fully satisfies an invariant on its own: atqamz/hand#252 settles the announcement layer invariant 3 is defined against, and atqamz/hand#240 establishes the vocabulary invariant 7 generalizes.
 
-Announcement and acknowledgement stop being interchangeable words, and one existing output field is misnamed under that split until invariant 3 lands.
+Announcement and acknowledgement are now distinct words and output fields.
 `ghutil.ObservationState` becomes the vocabulary a new observation reuses rather than restates, so the count of found/absent/unknown types stops growing with the count of things hand observes.
 Any new attention condition is one edit that both `hand status` and `hand watch` inherit, and a consumer that wants less filters rather than redefines.
 A disagreement between channels becomes something a supervisor can read directly instead of discovering when a later command refuses a precondition.

--- a/docs/adr/the-report-channel-is-the-only-outcome-signal.md
+++ b/docs/adr/the-report-channel-is-the-only-outcome-signal.md
@@ -13,7 +13,7 @@ Herdr owns whether a pane is busy, but its idle and done labels do not explain w
 
 `state/<id>.status` is the sole source of what a worker says happened. It is a plain worker-written, hand-read file with a fixed small vocabulary. Herdr state is independent liveness evidence, and completion claims are checked against artifacts before the tool treats them as verified.
 
-When a stored projection and the file disagree about the worker's report, the file wins. There is no database-backed replacement or recovery dump. [`internal/state/report.go`](../../internal/state/report.go), status rendering, and watcher tests own parsing and acknowledgement behavior; [`internal/agentsmd`](../../internal/agentsmd) owns the worker guidance.
+When a stored projection and the file disagree about the worker's report, the file wins. There is no database-backed replacement or recovery dump. [`internal/state/report.go`](../../internal/state/report.go), status rendering, and watcher tests own parsing and announcement behavior; [`internal/agentsmd`](../../internal/agentsmd) owns the worker guidance.
 
 ## Rejected alternatives
 

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -66,6 +66,7 @@ var supervisorInstructions = []string{
 	"Edit `data/backlog.md` to record the task with a unique ID.",
 	"Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.",
 	"`hand status <id>` shows a worker's reported state. Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.",
+	"`unannounced` on a status row means no watcher has told anyone about a terminal report yet; `unacknowledged` means you have not. Run `hand ack <id> [--reason <text>]` once you have acted on it - reading `hand status` never clears it on its own.",
 	"Run `hand watch --until-event` as a background task to monitor the fleet. Arming observes the fleet's already-actionable state first, so a condition that arrived while nothing was watching still wakes it; after that it exits on the first fleet event. Exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. A supervisor should re-arm it after acting on an event or when intentionally resuming monitoring.",
 	"Never merge without explicit authorization.",
 	"Run `hand teardown <id>` after work is landed. Work that is handed off but whose landing is someone else's call is recorded with `hand deliver <id> --reason <text>` first.",

--- a/internal/state/report.go
+++ b/internal/state/report.go
@@ -166,6 +166,14 @@ func TailReport(path string, cur ReportCursor) ([]ReportLine, ReportCursor, erro
 // file, for stateless consumers like hand status that don't track an offset
 // across invocations.
 func ReadReportLines(homeDir, id string) ([]ReportLine, error) {
+	data, err := ReadReportData(homeDir, id)
+	if err != nil {
+		return nil, err
+	}
+	return ReportLinesInData(data), nil
+}
+
+func ReadReportData(homeDir, id string) ([]byte, error) {
 	data, err := os.ReadFile(ReportPath(homeDir, id))
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -173,7 +181,11 @@ func ReadReportLines(homeDir, id string) ([]ReportLine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read report %q: %w", id, err)
 	}
-	return classifyReportBytes(data), nil
+	return data, nil
+}
+
+func ReportLinesInData(data []byte) []ReportLine {
+	return classifyReportBytes(data)
 }
 
 // Classifies every line in data, a trailing line with no terminating newline included. That last
@@ -224,20 +236,23 @@ func TerminalReport(s string) bool {
 func TerminalReportPastCursor(homeDir, id string, cur ReportCursor) (bool, error) {
 	// A cursor the file's content no longer supports covers nothing, so a rewritten channel is read
 	// whole - the length-preserving rewrite included, whose `done:` cur never covered (atqamz/hand#149).
-	data, base, err := readReport(ReportPath(homeDir, id), cur)
+	data, err := ReadReportData(homeDir, id)
 	if err != nil {
 		return false, err
 	}
-	// Only the last classified line of the unconsumed tail counts: a terminal report the worker has
-	// since superseded needs no acknowledging, and done is routinely followed by more work. It
-	// classifies its own tail so a line with no terminating newline counts - TailReport would defer it.
+	return TerminalReportInData(data, cur), nil
+}
+
+func TerminalReportInData(data []byte, cur ReportCursor) bool {
+	base := cur
+	if !cur.covers(data) {
+		base = ReportCursor{}
+	}
 	last, ok := LastReportedState(classifyReportBytes(data[base.Offset:]))
 	if !ok {
-		return false, nil
+		return false
 	}
-	// A watcher denied the task lock announces a line and persists the cursor a tick later, so the
-	// transient error here is reporting a covered terminal state, never hiding an uncovered one.
-	return TerminalReport(last.State), nil
+	return TerminalReport(last.State)
 }
 
 // CurrentReportCursor covers every complete line currently in a task's report channel, the same

--- a/internal/state/report.go
+++ b/internal/state/report.go
@@ -218,13 +218,12 @@ func TerminalReport(s string) bool {
 	return s == ReportDone || s == ReportFailed
 }
 
-// UnacknowledgedTerminalReport reports a terminal state no hand watch has ever consumed. The task's
-// durable report cursor is the marker: the poll loop advances it only after a tick's events are
-// announced, and every announcement reaches state/events.log and the notify hook.
-func UnacknowledgedTerminalReport(homeDir, id string, cur ReportCursor) (bool, error) {
-	// So a terminal line still past that cursor has reached nobody (atqamz/hand#70). A cursor the
-	// file's content no longer supports covers nothing, so a rewritten channel is read whole - the
-	// length-preserving rewrite included, whose `done:` no watcher announced (atqamz/hand#149).
+// TerminalReportPastCursor reports whether a task's report channel carries a terminal state beyond
+// cur, generic over which durable cursor the caller names: report_offset/report_digest for watcher
+// announcement (atqamz/hand#70), or acknowledged_offset/acknowledged_digest for acknowledgement (atqamz/hand#267).
+func TerminalReportPastCursor(homeDir, id string, cur ReportCursor) (bool, error) {
+	// A cursor the file's content no longer supports covers nothing, so a rewritten channel is read
+	// whole - the length-preserving rewrite included, whose `done:` cur never covered (atqamz/hand#149).
 	data, base, err := readReport(ReportPath(homeDir, id), cur)
 	if err != nil {
 		return false, err
@@ -237,6 +236,14 @@ func UnacknowledgedTerminalReport(homeDir, id string, cur ReportCursor) (bool, e
 		return false, nil
 	}
 	// A watcher denied the task lock announces a line and persists the cursor a tick later, so the
-	// transient error here is reporting an acknowledged terminal state, never hiding an unacknowledged one.
+	// transient error here is reporting a covered terminal state, never hiding an uncovered one.
 	return TerminalReport(last.State), nil
+}
+
+// CurrentReportCursor covers every complete line currently in a task's report channel, the same
+// completeness rule TailReport applies to a watcher's own cursor: a trailing line with no terminating
+// newline is left uncovered, in case the worker's append is still in flight.
+func CurrentReportCursor(homeDir, id string) (ReportCursor, error) {
+	_, cursor, err := TailReport(ReportPath(homeDir, id), ReportCursor{})
+	return cursor, err
 }

--- a/internal/state/report_test.go
+++ b/internal/state/report_test.go
@@ -211,7 +211,7 @@ func TestTailReportAfterInPlaceRewrite(t *testing.T) {
 
 // The same rewrite must not cost a silent completion either: a done report read
 // from a stale offset is a fragment, and a fragment classifies as nothing.
-func TestUnacknowledgedTerminalReportAfterInPlaceRewrite(t *testing.T) {
+func TestTerminalReportPastCursorAfterInPlaceRewrite(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(Dir(home), 0o755); err != nil {
 		t.Fatal(err)
@@ -224,7 +224,7 @@ func TestUnacknowledgedTerminalReportAfterInPlaceRewrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := UnacknowledgedTerminalReport(home, "task-1", reportCursorFor([]byte(consumed)))
+	got, err := TerminalReportPastCursor(home, "task-1", reportCursorFor([]byte(consumed)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestTailReportAfterSameLengthInPlaceRewrite(t *testing.T) {
 // A same-length rewrite is the silent completion reached by its own path: with
 // nothing past the offset, hand status called the finished worker acknowledged
 // too.
-func TestUnacknowledgedTerminalReportAfterSameLengthRewrite(t *testing.T) {
+func TestTerminalReportPastCursorAfterSameLengthRewrite(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(Dir(home), 0o755); err != nil {
 		t.Fatal(err)
@@ -318,7 +318,7 @@ func TestUnacknowledgedTerminalReportAfterSameLengthRewrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := UnacknowledgedTerminalReport(home, "task-1", reportCursorFor([]byte(consumed)))
+	got, err := TerminalReportPastCursor(home, "task-1", reportCursorFor([]byte(consumed)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestLastReportedStateWithOnlyMalformedLines(t *testing.T) {
 	}
 }
 
-func TestUnacknowledgedTerminalReport(t *testing.T) {
+func TestTerminalReportPastCursor(t *testing.T) {
 	cases := []struct {
 		name     string
 		content  string
@@ -504,7 +504,7 @@ func TestUnacknowledgedTerminalReport(t *testing.T) {
 				}
 			}
 
-			got, err := UnacknowledgedTerminalReport(home, "task-1", reportCursorFor([]byte(c.consumed)))
+			got, err := TerminalReportPastCursor(home, "task-1", reportCursorFor([]byte(c.consumed)))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -512,5 +512,49 @@ func TestUnacknowledgedTerminalReport(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, c.want)
 			}
 		})
+	}
+}
+
+// hand ack takes this cursor as everything a supervisor is acknowledging right now, so it must cover
+// exactly what TailReport would announce - the trailing unterminated line included in neither.
+func TestCurrentReportCursorCoversOnlyCompleteLines(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "working: on it\ndone: PR up\nstill tidying"
+	if err := os.WriteFile(ReportPath(home, "task-1"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cursor, err := CurrentReportCursor(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "working: on it\ndone: PR up\n"
+	if cursor.Offset != int64(len(want)) {
+		t.Fatalf("Offset = %d, want %d (up to the last complete line)", cursor.Offset, len(want))
+	}
+	if cursor.Digest != reportDigest([]byte(want)) {
+		t.Fatal("Digest does not match the complete-lines prefix")
+	}
+
+	got, err := TerminalReportPastCursor(home, "task-1", cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Fatal("got true, want the acknowledged done report covered by its own cursor")
+	}
+}
+
+func TestCurrentReportCursorMissingFile(t *testing.T) {
+	home := t.TempDir()
+	cursor, err := CurrentReportCursor(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cursor != (ReportCursor{}) {
+		t.Fatalf("cursor = %+v, want the zero cursor for a report that does not exist", cursor)
 	}
 }

--- a/internal/state/report_test.go
+++ b/internal/state/report_test.go
@@ -515,6 +515,20 @@ func TestTerminalReportPastCursor(t *testing.T) {
 	}
 }
 
+func TestTerminalReportInData(t *testing.T) {
+	data := []byte("working: on it\ndone: PR up\n")
+	if !TerminalReportInData(data, ReportCursor{}) {
+		t.Fatal("got false, want terminal report")
+	}
+	cursor := reportCursorFor(data)
+	if TerminalReportInData(data, cursor) {
+		t.Fatal("got true, want covered terminal report")
+	}
+	if !TerminalReportInData(data, reportCursorFor([]byte("working: on it\n"))) {
+		t.Fatal("got false, want terminal report after cursor")
+	}
+}
+
 // hand ack takes this cursor as everything a supervisor is acknowledging right now, so it must cover
 // exactly what TailReport would announce - the trailing unterminated line included in neither.
 func TestCurrentReportCursorCoversOnlyCompleteLines(t *testing.T) {

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -367,6 +367,15 @@ func SetTaskReportState(homeDir, id string, offset int64, digest string, mergeAn
 	return db.SetTaskReportState(id, offset, digest, mergeAnnounced)
 }
 
+func SetTaskAcknowledgement(homeDir, id, at, reason string, offset int64, digest string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskAcknowledgement(id, at, reason, offset, digest)
+}
+
 func SetTaskRepair(homeDir, id, code, reason string, attemptID int64, observedAt string) error {
 	db, err := store.Open(homeDir)
 	if err != nil {

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -145,6 +145,10 @@ var migrations = []string{
 	// already carries the column, so a plain ALTER TABLE would fail wherever a test or a home
 	// builds its fixture from the current schema before stamping an older version onto it.
 	`SELECT 1;`,
+	// The real ALTER TABLEs run from ensureAcknowledgementColumns instead, guarded by column existence
+	// like ensureUsageLimitEpisodeColumns: a home already carrying the current schema.Task layout when
+	// its version is forced backward must replay this step without a duplicate-column error.
+	`SELECT 1;`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -162,10 +166,15 @@ const repairMetadataVersion = routingProvenanceVersion + 1
 const sendSchemaVersion = repairMetadataVersion + 1
 
 const sendHardeningMigrationVersion = sendSchemaVersion
-
 const holdInferredVersion = sendHardeningMigrationVersion + 1
 
 const attemptBranchVersion = holdInferredVersion + 1
+
+// The last version without the acknowledgement columns atqamz/hand#267 added - the read-only ladder's
+// guard against selecting them from a home migrateSchema has not yet reached.
+const preAcknowledgementVersion = attemptBranchVersion + 1
+
+const acknowledgedMetadataVersion = preAcknowledgementVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -206,6 +215,30 @@ func (db *DB) hasRepairMetadataColumns() (bool, error) {
 	var count int
 	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name IN ('repair_code', 'repair_reason', 'repair_attempt_id', 'repair_observed_at')`).Scan(&count); err != nil {
 		return false, fmt.Errorf("detect repair metadata columns: %w", err)
+	}
+	return count == 4, nil
+}
+
+func (db *DB) hasHoldInferredColumn() (bool, error) {
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('hold') WHERE name = 'inferred'`).Scan(&count); err != nil {
+		return false, fmt.Errorf("detect hold inferred column: %w", err)
+	}
+	return count == 1, nil
+}
+
+func (db *DB) hasAttemptBranchColumn() (bool, error) {
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name = 'branch'`).Scan(&count); err != nil {
+		return false, fmt.Errorf("detect attempt branch column: %w", err)
+	}
+	return count == 1, nil
+}
+
+func (db *DB) hasAcknowledgementColumns() (bool, error) {
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name IN ('acknowledged_at', 'acknowledged_reason', 'acknowledged_offset', 'acknowledged_digest')`).Scan(&count); err != nil {
+		return false, fmt.Errorf("detect acknowledgement columns: %w", err)
 	}
 	return count == 4, nil
 }
@@ -307,6 +340,27 @@ func (db *DB) migrateSchema() error {
 						}
 						if repairComplete && latest >= repairMetadataVersion {
 							stamp = repairMetadataVersion
+							holdInferredComplete, err := db.hasHoldInferredColumn()
+							if err != nil {
+								return err
+							}
+							if holdInferredComplete && latest >= holdInferredVersion {
+								stamp = holdInferredVersion
+								attemptBranchComplete, err := db.hasAttemptBranchColumn()
+								if err != nil {
+									return err
+								}
+								if attemptBranchComplete && latest >= attemptBranchVersion {
+									stamp = attemptBranchVersion
+									acknowledgementComplete, err := db.hasAcknowledgementColumns()
+									if err != nil {
+										return err
+									}
+									if acknowledgementComplete && latest >= acknowledgedMetadataVersion {
+										stamp = acknowledgedMetadataVersion
+									}
+								}
+							}
 						}
 					}
 				}
@@ -423,6 +477,11 @@ func (db *DB) applyMigration(version int) error {
 			return err
 		}
 	}
+	if version == preAcknowledgementVersion {
+		if err := ensureAcknowledgementColumns(tx); err != nil {
+			return err
+		}
+	}
 	if err := recordSchemaVersion(tx, version+1); err != nil {
 		return err
 	}
@@ -484,6 +543,40 @@ func ensureAttemptBranchColumn(tx *sql.Tx) error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE attempt ADD COLUMN branch TEXT NOT NULL DEFAULT ''`); err != nil {
 		return fmt.Errorf("add attempt branch column: %w", err)
+	}
+	return nil
+}
+
+func ensureAcknowledgementColumns(tx *sql.Tx) error {
+	rows, err := tx.Query(`SELECT name FROM pragma_table_info('task') WHERE name IN ('acknowledged_at', 'acknowledged_reason', 'acknowledged_offset', 'acknowledged_digest')`)
+	if err != nil {
+		return fmt.Errorf("inspect acknowledgement columns: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	found := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("inspect acknowledgement columns: %w", err)
+		}
+		found[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("inspect acknowledgement columns: %w", err)
+	}
+	columns := []struct{ name, ddl string }{
+		{"acknowledged_at", "TEXT NOT NULL DEFAULT ''"},
+		{"acknowledged_reason", "TEXT NOT NULL DEFAULT ''"},
+		{"acknowledged_offset", "INTEGER NOT NULL DEFAULT 0"},
+		{"acknowledged_digest", "TEXT NOT NULL DEFAULT ''"},
+	}
+	for _, column := range columns {
+		if found[column.name] {
+			continue
+		}
+		if _, err := tx.Exec(`ALTER TABLE task ADD COLUMN ` + column.name + ` ` + column.ddl); err != nil {
+			return fmt.Errorf("add %s: %w", column.name, err)
+		}
 	}
 	return nil
 }

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -134,7 +134,10 @@ func TestReadOnlyLadderAtHoldInferredVersionOmitsAttemptBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	preBranchSchema := strings.Replace(schema, "\tworktree               TEXT NOT NULL DEFAULT '',\n\tbranch                 TEXT NOT NULL DEFAULT '',\n", "\tworktree               TEXT NOT NULL DEFAULT '',\n", 1)
+	preBranchSchema := strings.NewReplacer(
+		"\tworktree               TEXT NOT NULL DEFAULT '',\n\tbranch                 TEXT NOT NULL DEFAULT '',\n", "\tworktree               TEXT NOT NULL DEFAULT '',\n",
+		"\trepair_observed_at TEXT NOT NULL DEFAULT '',\n\tacknowledged_at     TEXT NOT NULL DEFAULT '',\n\tacknowledged_reason TEXT NOT NULL DEFAULT '',\n\tacknowledged_offset INTEGER NOT NULL DEFAULT 0,\n\tacknowledged_digest TEXT NOT NULL DEFAULT ''\n", "\trepair_observed_at TEXT NOT NULL DEFAULT ''\n",
+	).Replace(schema)
 	db := &DB{sql: sqlDB, home: home}
 	if _, err := db.sql.Exec(preBranchSchema); err != nil {
 		t.Fatal(err)
@@ -174,9 +177,6 @@ func TestReadOnlyLadderAtAttemptBranchVersionOmitsAcknowledgement(t *testing.T) 
 	preAckSchema := strings.Replace(schema,
 		"\trepair_observed_at TEXT NOT NULL DEFAULT '',\n\tacknowledged_at     TEXT NOT NULL DEFAULT '',\n\tacknowledged_reason TEXT NOT NULL DEFAULT '',\n\tacknowledged_offset INTEGER NOT NULL DEFAULT 0,\n\tacknowledged_digest TEXT NOT NULL DEFAULT ''\n",
 		"\trepair_observed_at TEXT NOT NULL DEFAULT ''\n", 1)
-	if preAckSchema == schema {
-		t.Fatal("replace did not match schema text - update it to match the current column block")
-	}
 	db := &DB{sql: sqlDB, home: home}
 	if _, err := db.sql.Exec(preAckSchema); err != nil {
 		t.Fatal(err)

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -88,7 +88,10 @@ func TestMigrationAddsEmptyAttemptBranchToAnExistingDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 	db := &DB{sql: sqlDB, home: home}
-	preBranchSchema := strings.Replace(schema, "\tworktree               TEXT NOT NULL DEFAULT '',\n\tbranch                 TEXT NOT NULL DEFAULT '',\n", "\tworktree               TEXT NOT NULL DEFAULT '',\n", 1)
+	preBranchSchema := strings.NewReplacer(
+		"\tworktree               TEXT NOT NULL DEFAULT '',\n\tbranch                 TEXT NOT NULL DEFAULT '',\n", "\tworktree               TEXT NOT NULL DEFAULT '',\n",
+		"\trepair_observed_at TEXT NOT NULL DEFAULT '',\n\tacknowledged_at     TEXT NOT NULL DEFAULT '',\n\tacknowledged_reason TEXT NOT NULL DEFAULT '',\n\tacknowledged_offset INTEGER NOT NULL DEFAULT 0,\n\tacknowledged_digest TEXT NOT NULL DEFAULT ''\n", "\trepair_observed_at TEXT NOT NULL DEFAULT ''\n",
+	).Replace(schema)
 	if _, err := db.sql.Exec(preBranchSchema); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -98,7 +98,7 @@ func TestMigrationAddsEmptyAttemptBranchToAnExistingDatabase(t *testing.T) {
 	if _, err := db.sql.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle, harness, model, effort, worktree) VALUES ('legacy', 1, 'running', 'claude', 'opus', 'high', '/w/legacy')`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(len(migrations)-1)); err != nil {
+	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(attemptBranchVersion)); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -122,6 +122,88 @@ func TestMigrationAddsEmptyAttemptBranchToAnExistingDatabase(t *testing.T) {
 	}
 }
 
+// The two concurrent schema additions the acknowledgement columns landed alongside: holdInferredVersion
+// predates attempt.branch, and none of the migration-forward tests above exercise the read-only ladder
+// at either intermediate stop, which is exactly how store.go shipped with both gaps unnoticed.
+func TestReadOnlyLadderAtHoldInferredVersionOmitsAttemptBranch(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	preBranchSchema := strings.Replace(schema, "\tworktree               TEXT NOT NULL DEFAULT '',\n\tbranch                 TEXT NOT NULL DEFAULT '',\n", "\tworktree               TEXT NOT NULL DEFAULT '',\n", 1)
+	db := &DB{sql: sqlDB, home: home}
+	if _, err := db.sql.Exec(preBranchSchema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle, created_at) VALUES ('t1', 'demo', 'ship', 'open', '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle, harness, model, effort) VALUES ('t1', 1, 'running', 'claude', 'opus', 'high')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE task SET active_attempt_id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(holdInferredVersion)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, found, err := ReadTaskHistoryReadOnly(home, "t1")
+	if err != nil || !found || history.ActiveAttempt == nil {
+		t.Fatalf("ReadTaskHistoryReadOnly at holdInferredVersion = %+v, found=%v, err=%v", history, found, err)
+	}
+	histories, err := ListReconciliationHistoriesReadOnly(home)
+	if err != nil || len(histories) != 1 {
+		t.Fatalf("ListReconciliationHistoriesReadOnly at holdInferredVersion = %+v, err=%v, want the one open task", histories, err)
+	}
+}
+
+func TestReadOnlyLadderAtAttemptBranchVersionOmitsAcknowledgement(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	preAckSchema := strings.Replace(schema,
+		"\trepair_observed_at TEXT NOT NULL DEFAULT '',\n\tacknowledged_at     TEXT NOT NULL DEFAULT '',\n\tacknowledged_reason TEXT NOT NULL DEFAULT '',\n\tacknowledged_offset INTEGER NOT NULL DEFAULT 0,\n\tacknowledged_digest TEXT NOT NULL DEFAULT ''\n",
+		"\trepair_observed_at TEXT NOT NULL DEFAULT ''\n", 1)
+	if preAckSchema == schema {
+		t.Fatal("replace did not match schema text - update it to match the current column block")
+	}
+	db := &DB{sql: sqlDB, home: home}
+	if _, err := db.sql.Exec(preAckSchema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle, created_at) VALUES ('t1', 'demo', 'ship', 'open', '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle, harness, model, effort, branch) VALUES ('t1', 1, 'running', 'claude', 'opus', 'high', 'my-branch')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE task SET active_attempt_id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(attemptBranchVersion)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, found, err := ReadTaskHistoryReadOnly(home, "t1")
+	if err != nil || !found || history.ActiveAttempt == nil || history.ActiveAttempt.Branch != "my-branch" {
+		t.Fatalf("ReadTaskHistoryReadOnly at attemptBranchVersion = %+v, found=%v, err=%v, want branch carried through", history, found, err)
+	}
+	histories, err := ListReconciliationHistoriesReadOnly(home)
+	if err != nil || len(histories) != 1 {
+		t.Fatalf("ListReconciliationHistoriesReadOnly at attemptBranchVersion = %+v, err=%v, want the one open task", histories, err)
+	}
+}
+
 func TestMigrationV12AddsEmptyTaskRepairMetadata(t *testing.T) {
 	home := t.TempDir()
 	sqlDB, err := open(Path(home))

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -133,7 +133,10 @@ func TestMigrationV12AddsEmptyTaskRepairMetadata(t *testing.T) {
 		"\tcreated_at        TEXT NOT NULL DEFAULT '',\n", "\tcreated_at        TEXT NOT NULL DEFAULT ''\n",
 		"\trepair_code       TEXT NOT NULL DEFAULT '',\n", "",
 		"\trepair_reason     TEXT NOT NULL DEFAULT '',\n", "",
-		"\trepair_attempt_id INTEGER NOT NULL DEFAULT 0,\n\trepair_observed_at TEXT NOT NULL DEFAULT ''\n", "",
+		"\trepair_attempt_id INTEGER NOT NULL DEFAULT 0,\n\trepair_observed_at TEXT NOT NULL DEFAULT '',\n", "",
+		"\tacknowledged_at     TEXT NOT NULL DEFAULT '',\n", "",
+		"\tacknowledged_reason TEXT NOT NULL DEFAULT '',\n", "",
+		"\tacknowledged_offset INTEGER NOT NULL DEFAULT 0,\n\tacknowledged_digest TEXT NOT NULL DEFAULT ''\n", "",
 	).Replace(schema)
 	if _, err := db.sql.Exec(preV12Schema); err != nil {
 		t.Fatal(err)
@@ -189,7 +192,10 @@ func TestMigrationV11AddsEmptyAttemptRoutingProvenance(t *testing.T) {
 		"\trouting_source        TEXT NOT NULL DEFAULT '',\n", "",
 		"\trepair_code       TEXT NOT NULL DEFAULT '',\n", "",
 		"\trepair_reason     TEXT NOT NULL DEFAULT '',\n", "",
-		"\trepair_attempt_id INTEGER NOT NULL DEFAULT 0,\n\trepair_observed_at TEXT NOT NULL DEFAULT ''\n", "",
+		"\trepair_attempt_id INTEGER NOT NULL DEFAULT 0,\n\trepair_observed_at TEXT NOT NULL DEFAULT '',\n", "",
+		"\tacknowledged_at     TEXT NOT NULL DEFAULT '',\n", "",
+		"\tacknowledged_reason TEXT NOT NULL DEFAULT '',\n", "",
+		"\tacknowledged_offset INTEGER NOT NULL DEFAULT 0,\n\tacknowledged_digest TEXT NOT NULL DEFAULT ''\n", "",
 	).Replace(schema)
 	if _, err := db.sql.Exec(preV11Schema); err != nil {
 		t.Fatal(err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -556,6 +556,9 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
+	if current == acknowledgedMetadataVersion {
+		return db.ReadTaskHistory(id)
+	}
 	if current == preAcknowledgementVersion {
 		return db.readTaskHistoryBeforeAcknowledgement(id)
 	}
@@ -1097,6 +1100,9 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	defer func() { _ = db.Close() }()
 	if current == preAcknowledgementVersion {
 		return db.listReconciliationHistoriesBeforeAcknowledgement()
+	}
+	if current == acknowledgedMetadataVersion {
+		return db.ListReconciliationHistories()
 	}
 	if current == repairMetadataVersion || current == sendSchemaVersion {
 		return db.listReconciliationHistoriesBeforeSend()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -152,6 +152,12 @@ type Task struct {
 	RepairReason     string        `json:"repair_reason"`
 	RepairAttemptID  int64         `json:"repair_attempt_id"`
 	RepairObservedAt string        `json:"repair_observed_at"`
+	// A supervisor's own act, distinct from report_offset/report_digest which record what a watcher has
+	// announced: atqamz/hand#267 keeps the two markers apart because they answer different questions.
+	AcknowledgedAt     string `json:"acknowledged_at"`
+	AcknowledgedReason string `json:"acknowledged_reason"`
+	AcknowledgedOffset int64  `json:"acknowledged_offset"`
+	AcknowledgedDigest string `json:"acknowledged_digest"`
 }
 
 type Attempt struct {
@@ -285,7 +291,11 @@ CREATE TABLE IF NOT EXISTS task (
 	repair_code       TEXT NOT NULL DEFAULT '',
 	repair_reason     TEXT NOT NULL DEFAULT '',
 	repair_attempt_id INTEGER NOT NULL DEFAULT 0,
-	repair_observed_at TEXT NOT NULL DEFAULT ''
+	repair_observed_at TEXT NOT NULL DEFAULT '',
+	acknowledged_at     TEXT NOT NULL DEFAULT '',
+	acknowledged_reason TEXT NOT NULL DEFAULT '',
+	acknowledged_offset INTEGER NOT NULL DEFAULT 0,
+	acknowledged_digest TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS attempt (
 	id                     INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -546,6 +556,9 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
+	if current == preAcknowledgementVersion {
+		return db.readTaskHistoryBeforeAcknowledgement(id)
+	}
 	if current == sendSchemaVersion {
 		return db.readTaskHistoryBeforeSend(id)
 	}
@@ -601,11 +614,14 @@ var taskColumnNames = []string{
 	"id", "project", "kind", "brief", "lifecycle", "active_attempt_id", "pr",
 	"merge_executed", "merge_executed_at", "merge_announced", "delivered_at", "delivered_reason",
 	"report_offset", "report_digest", "created_at", "repair_code", "repair_reason", "repair_attempt_id", "repair_observed_at",
+	"acknowledged_at", "acknowledged_reason", "acknowledged_offset", "acknowledged_digest",
 }
 
 var taskColumns = strings.Join(taskColumnNames, ", ")
 
-var taskColumnsBeforeRepair = strings.Join(taskColumnNames[:len(taskColumnNames)-4], ", ")
+var taskColumnsBeforeRepair = strings.Join(taskColumnNames[:len(taskColumnNames)-8], ", ")
+
+var taskColumnsBeforeAcknowledgement = strings.Join(taskColumnNames[:len(taskColumnNames)-4], ", ")
 
 var attemptColumnNames = []string{
 	"id", "task_id", "ordinal", "lifecycle", "harness", "model", "effort",
@@ -634,7 +650,8 @@ func placeholders(count int) string {
 func taskValues(t Task) []any {
 	return []any{t.ID, t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
-		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt}
+		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt,
+		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest}
 }
 
 func nullableAttemptID(id int64) any {
@@ -645,6 +662,25 @@ func nullableAttemptID(id int64) any {
 }
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
+	var t Task
+	var activeID sql.NullInt64
+	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
+		&t.MergeExecuted, &t.MergeExecutedAt, &t.MergeAnnounced, &t.DeliveredAt, &t.DeliveredReason,
+		&t.ReportOffset, &t.ReportDigest, &t.CreatedAt, &t.RepairCode, &t.RepairReason, &t.RepairAttemptID, &t.RepairObservedAt,
+		&t.AcknowledgedAt, &t.AcknowledgedReason, &t.AcknowledgedOffset, &t.AcknowledgedDigest)
+	if activeID.Valid {
+		t.ActiveAttemptID = activeID.Int64
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	return t, err
+}
+
+// Reads a task row from a database migrated no further than sendSchemaVersion, one version behind
+// the acknowledgement columns atqamz/hand#267 added - the read-only ladder's guard against selecting
+// columns that migrateSchema has not yet added to this home.
+func scanTaskBeforeAcknowledgement(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
 	var activeID sql.NullInt64
 	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
@@ -747,10 +783,12 @@ func (db *DB) CreateTask(t Task) error {
 func (db *DB) UpdateTask(t Task) error {
 	_, err := db.sql.Exec(`UPDATE task SET project = ?, kind = ?, brief = ?,
 		pr = ?, merge_executed = ?, merge_executed_at = ?, merge_announced = ?, delivered_at = ?, delivered_reason = ?,
-		report_offset = ?, report_digest = ?, created_at = ?, repair_code = ?, repair_reason = ?, repair_attempt_id = ?, repair_observed_at = ? WHERE id = ?`,
+		report_offset = ?, report_digest = ?, created_at = ?, repair_code = ?, repair_reason = ?, repair_attempt_id = ?, repair_observed_at = ?,
+		acknowledged_at = ?, acknowledged_reason = ?, acknowledged_offset = ?, acknowledged_digest = ? WHERE id = ?`,
 		t.Project, t.Kind, t.Brief, t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
-		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt, t.ID)
+		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt,
+		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.ID)
 	if err != nil {
 		return fmt.Errorf("update task %q: %w", t.ID, err)
 	}
@@ -842,6 +880,35 @@ func (db *DB) readTaskHistoryBeforeRepair(id string) (TaskHistory, bool, error) 
 	}
 	if err := rows.Err(); err != nil {
 		return TaskHistory{}, false, fmt.Errorf("list attempts for task %q: %w", id, err)
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
+func (db *DB) readTaskHistoryBeforeAcknowledgement(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeAcknowledgement+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeAcknowledgement(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
+	}
+	attempts, err := db.ListAttempts(id)
+	if err != nil {
+		return TaskHistory{}, false, err
 	}
 	history := TaskHistory{Task: task, Attempts: attempts}
 	for i := range attempts {
@@ -1028,10 +1095,61 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
+	if current == preAcknowledgementVersion {
+		return db.listReconciliationHistoriesBeforeAcknowledgement()
+	}
 	if current == repairMetadataVersion || current == sendSchemaVersion {
 		return db.listReconciliationHistoriesBeforeSend()
 	}
 	return db.ListReconciliationHistories()
+}
+
+func (db *DB) listReconciliationHistoriesBeforeAcknowledgement() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
+	rows, err := db.sql.Query(`SELECT ` + taskColumnsBeforeAcknowledgement + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTaskBeforeAcknowledgement(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.ListAttempts(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("read task history %q: active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
 }
 
 func (db *DB) listReconciliationHistoriesBeforeSend() ([]TaskHistory, error) {
@@ -1972,6 +2090,15 @@ func (db *DB) SetTaskMerge(id, mergedAt string) error {
 func (db *DB) SetTaskReportState(id string, offset int64, digest string, mergeAnnounced bool) error {
 	result, err := db.sql.Exec(`UPDATE task SET report_offset = ?, report_digest = ?, merge_announced = merge_announced OR ? WHERE id = ?`, offset, digest, mergeAnnounced, id)
 	return updateTaskFact(result, err, "set report state", id)
+}
+
+// Distinct from SetTaskReportState: offset and digest here cover what a supervisor has acknowledged,
+// never what a watcher has announced. atqamz/hand#267 keeps the two cursors apart because
+// internal/watcher depends on report_offset/report_digest meaning announcement alone.
+func (db *DB) SetTaskAcknowledgement(id, at, reason string, offset int64, digest string) error {
+	result, err := db.sql.Exec(`UPDATE task SET acknowledged_at = ?, acknowledged_reason = ?, acknowledged_offset = ?, acknowledged_digest = ? WHERE id = ?`,
+		at, reason, offset, digest, id)
+	return updateTaskFact(result, err, "set acknowledgement", id)
 }
 
 func (db *DB) SetTaskRepair(id, code, reason string, attemptID int64, observedAt string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -559,7 +559,7 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == acknowledgedMetadataVersion {
 		return db.ReadTaskHistory(id)
 	}
-	if current == preAcknowledgementVersion {
+	if current == preAcknowledgementVersion || current == holdInferredVersion {
 		return db.readTaskHistoryBeforeAcknowledgement(id)
 	}
 	if current == sendSchemaVersion {
@@ -1098,7 +1098,7 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
-	if current == preAcknowledgementVersion {
+	if current == preAcknowledgementVersion || current == holdInferredVersion {
 		return db.listReconciliationHistoriesBeforeAcknowledgement()
 	}
 	if current == acknowledgedMetadataVersion {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -927,8 +927,8 @@ func (db *DB) readTaskHistoryBeforeSend(id string) (TaskHistory, bool, error) {
 	if db.empty {
 		return TaskHistory{}, false, nil
 	}
-	row := db.sql.QueryRow(`SELECT `+taskColumns+` FROM task WHERE id = ?`, id)
-	task, err := scanTask(row)
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeAcknowledgement+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeAcknowledgement(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return TaskHistory{}, false, nil
 	}
@@ -1156,7 +1156,7 @@ func (db *DB) listReconciliationHistoriesBeforeSend() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+	rows, err := db.sql.Query(`SELECT ` + taskColumnsBeforeAcknowledgement + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
 		SELECT 1 FROM attempt
 		WHERE attempt.task_id = task.id
 		AND attempt.lifecycle NOT IN ('provisioning', 'running')
@@ -1172,7 +1172,7 @@ func (db *DB) listReconciliationHistoriesBeforeSend() ([]TaskHistory, error) {
 	defer func() { _ = rows.Close() }()
 	var histories []TaskHistory
 	for rows.Next() {
-		task, err := scanTask(rows)
+		task, err := scanTaskBeforeAcknowledgement(rows)
 		if err != nil {
 			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -559,8 +559,11 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == acknowledgedMetadataVersion {
 		return db.ReadTaskHistory(id)
 	}
-	if current == preAcknowledgementVersion || current == holdInferredVersion {
+	if current == preAcknowledgementVersion || current == attemptBranchVersion {
 		return db.readTaskHistoryBeforeAcknowledgement(id)
+	}
+	if current == holdInferredVersion {
+		return db.readTaskHistoryBeforeAcknowledgementAndBranch(id)
 	}
 	if current == sendSchemaVersion {
 		return db.readTaskHistoryBeforeSend(id)
@@ -926,6 +929,38 @@ func (db *DB) readTaskHistoryBeforeAcknowledgement(id string) (TaskHistory, bool
 	return history, true, nil
 }
 
+// A database at holdInferredVersion has every column readTaskHistoryBeforeAcknowledgement's task side
+// needs, but not yet attempt.branch (added going into attemptBranchVersion), so its attempt side has to
+// stay on the pre-branch reader rather than db.ListAttempts, which now selects branch unconditionally.
+func (db *DB) readTaskHistoryBeforeAcknowledgementAndBranch(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeAcknowledgement+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeAcknowledgement(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
+	}
+	attempts, err := db.listAttemptsBeforeSend(id)
+	if err != nil {
+		return TaskHistory{}, false, err
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
 func (db *DB) readTaskHistoryBeforeSend(id string) (TaskHistory, bool, error) {
 	if db.empty {
 		return TaskHistory{}, false, nil
@@ -1098,8 +1133,11 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
-	if current == preAcknowledgementVersion || current == holdInferredVersion {
+	if current == preAcknowledgementVersion || current == attemptBranchVersion {
 		return db.listReconciliationHistoriesBeforeAcknowledgement()
+	}
+	if current == holdInferredVersion {
+		return db.listReconciliationHistoriesBeforeAcknowledgementAndBranch()
 	}
 	if current == acknowledgedMetadataVersion {
 		return db.ListReconciliationHistories()
@@ -1108,6 +1146,56 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 		return db.listReconciliationHistoriesBeforeSend()
 	}
 	return db.ListReconciliationHistories()
+}
+
+// The reconciliation-listing counterpart to readTaskHistoryBeforeAcknowledgementAndBranch: holdInferredVersion
+// predates attempt.branch, so its attempt side stays on the pre-branch reader.
+func (db *DB) listReconciliationHistoriesBeforeAcknowledgementAndBranch() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
+	rows, err := db.sql.Query(`SELECT ` + taskColumnsBeforeAcknowledgement + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTaskBeforeAcknowledgement(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.listAttemptsBeforeSend(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("read task history %q: active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
 }
 
 func (db *DB) listReconciliationHistoriesBeforeAcknowledgement() ([]TaskHistory, error) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -2640,25 +2640,63 @@ func TestRunUntilEventDoesNotWakeFailedWhileTeardownIsReleasingTheHerdrResource(
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
-	callLog := logPaneGets(t)
+
+	armDone := make(chan struct{})
+	watchTickDone := make(chan struct{})
+	oldAfterArmTick := afterArmTick
+	oldAfterWatchTick := afterWatchTick
+	t.Cleanup(func() {
+		afterArmTick = oldAfterArmTick
+		afterWatchTick = oldAfterWatchTick
+	})
+	armTicks := 0
+	afterArmTick = func() {
+		armTicks++
+		if armTicks == 2 {
+			close(armDone)
+		}
+	}
+	afterWatchTick = func() {
+		select {
+		case <-watchTickDone:
+		default:
+			close(watchTickDone)
+		}
+	}
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip},
 		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}, TeardownHerdrState: state.TeardownResourceReleasing})
 	cfg := Config{
-		Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: 300 * time.Millisecond,
+		Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour,
 		EventFilter: NewEventFilter([]string{KindFailed}),
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	var out bytes.Buffer
 	done := make(chan error, 1)
-	go func() { done <- RunUntilEvent(context.Background(), cfg, &out, io.Discard) }()
+	go func() { done <- RunUntilEvent(ctx, cfg, &out, io.Discard) }()
 
-	waitForPaneGets(t, callLog, 3)
+	select {
+	case <-armDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for RunUntilEvent to arm")
+	}
 	setStatus(t, statusFile, paneGoneStatus)
 
-	err := <-done
-	if !errors.Is(err, ErrNoEvent) {
-		t.Fatalf("RunUntilEvent = %v, want ErrNoEvent: teardown's own release must not read as a failed worker", err)
+	select {
+	case <-watchTickDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the post-transition watch tick")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("RunUntilEvent = %v, want it to keep waiting: teardown's own release must not read as a failed worker", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancel()
+	if err := <-done; !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("RunUntilEvent = %v, want ErrInterrupted after the test cancellation", err)
 	}
 	if out.Len() != 0 {
 		t.Fatalf("out = %q, want nothing woken: the pane going unreachable here is teardown's own release, not a failure", out.String())

--- a/tests/e2e/status_unacknowledged_test.go
+++ b/tests/e2e/status_unacknowledged_test.go
@@ -10,12 +10,8 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Drives atqamz/hand#70 end to end: a worker that finished while no watcher was attached has to be
-// visible to the next hand status, and has to stop being flagged unannounced once a watcher really
-// consumed it. Only real processes prove the second half, because what clears the flag is a persisted
-// report_offset. Announcement is a separate fact from acknowledgement (atqamz/hand#267,
-// docs/adr/attention-is-one-derivation-over-three-channels.md); TestHandAckClearsUnacknowledgedEndToEnd
-// drives that half.
+// Drives atqamz/hand#70 end to end: a report written without a watcher remains unannounced until a
+// real watcher consumes it. Announcement is separate from acknowledgement (atqamz/hand#267).
 func TestStatusFlagsATerminalReportNoWatcherEverRead(t *testing.T) {
 	home := seedOneTaskHome(t)
 

--- a/tests/e2e/status_unacknowledged_test.go
+++ b/tests/e2e/status_unacknowledged_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 // Drives atqamz/hand#70 end to end: a worker that finished while no watcher was attached has to be
-// visible to the next hand status, and has to stop being flagged once a watcher really consumed it. Only
-// real processes prove the second half, because what clears the flag is a persisted report_offset.
+// visible to the next hand status, and has to stop being flagged unannounced once a watcher really
+// consumed it. Only real processes prove the second half, because what clears the flag is a persisted
+// report_offset. Announcement is a separate fact from acknowledgement (atqamz/hand#267,
+// docs/adr/attention-is-one-derivation-over-three-channels.md); TestHandAckClearsUnacknowledgedEndToEnd
+// drives that half.
 func TestStatusFlagsATerminalReportNoWatcherEverRead(t *testing.T) {
 	home := seedOneTaskHome(t)
 
@@ -21,17 +24,13 @@ func TestStatusFlagsATerminalReportNoWatcherEverRead(t *testing.T) {
 	}
 
 	fleet := runHand(t, home, "status")
-	if !strings.Contains(fleet.stdout, ",done,") || !strings.Contains(fleet.stdout, "unacknowledged\n") {
-		t.Fatalf("hand status stdout %q, want the completion no watcher read flagged unacknowledged", fleet.stdout)
-	}
-	single := runHand(t, home, "status", "task-1")
-	if !strings.Contains(single.stdout, "done: PR up (unacknowledged)") {
-		t.Fatalf("hand status task-1 stdout %q, want the same flag in the detail view", single.stdout)
+	if !strings.Contains(fleet.stdout, ",done,") || !strings.Contains(fleet.stdout, "unannounced\n") {
+		t.Fatalf("hand status stdout %q, want the completion no watcher read flagged unannounced", fleet.stdout)
 	}
 
 	// Exit 0: arming observes the backlog and delivers it (atqamz/hand#252), because a report written
 	// while nothing was watching has no later transition to be announced by. Consuming it is what
-	// acknowledges it, whether or not it also woke someone.
+	// announces it, whether or not it also woke someone.
 	armed := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "300ms")
 	if armed.code != 0 {
 		t.Fatalf("hand watch --until-event: exit %d, want 0 (stderr %q)", armed.code, armed.stderr)
@@ -44,7 +43,42 @@ func TestStatusFlagsATerminalReportNoWatcherEverRead(t *testing.T) {
 	if !strings.Contains(after.stdout, ",done,") {
 		t.Fatalf("hand status stdout %q, want the reported state still shown", after.stdout)
 	}
-	if strings.Contains(after.stdout, "unacknowledged") {
+	if strings.Contains(after.stdout, "unannounced") {
 		t.Fatalf("hand status stdout %q, want the flag cleared once a watcher consumed the report", after.stdout)
+	}
+}
+
+// The acknowledgement half atqamz/hand#267 added: hand ack is what clears unacknowledged, not a
+// watcher, not hand status itself, and not the passage of time.
+func TestHandAckClearsUnacknowledgedEndToEnd(t *testing.T) {
+	home := seedOneTaskHome(t)
+
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: PR up\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := runHand(t, home, "status")
+	if !strings.Contains(before.stdout, ",done,") || !strings.Contains(before.stdout, "unacknowledged") {
+		t.Fatalf("hand status stdout %q, want the completion flagged unacknowledged before hand ack runs", before.stdout)
+	}
+	single := runHand(t, home, "status", "task-1")
+	if !strings.Contains(single.stdout, "done: PR up (unacknowledged)") {
+		t.Fatalf("hand status task-1 stdout %q, want the same flag in the detail view", single.stdout)
+	}
+
+	ack := runHand(t, home, "ack", "task-1", "--reason", "reviewed and merging myself")
+	if ack.code != 0 {
+		t.Fatalf("hand ack task-1: exit %d, want 0 (stderr %q)", ack.code, ack.stderr)
+	}
+	if !strings.Contains(ack.stdout, "result: acknowledged") {
+		t.Fatalf("hand ack task-1 stdout %q, want an acknowledged confirmation", ack.stdout)
+	}
+
+	after := runHand(t, home, "status")
+	if !strings.Contains(after.stdout, ",done,") {
+		t.Fatalf("hand status stdout %q, want the reported state still shown", after.stdout)
+	}
+	if strings.Contains(after.stdout, "unacknowledged") {
+		t.Fatalf("hand status stdout %q, want the flag cleared once hand ack has run", after.stdout)
 	}
 }


### PR DESCRIPTION
## Summary
- New top-level command `hand ack <id> [--reason <text>]` records that a supervisor has dealt with a task's terminal report, durably, in new `task.acknowledged_at`/`acknowledged_reason`/`acknowledged_offset`/`acknowledged_digest` columns - a separate record from the announcement cursor `internal/watcher` already owns.
- `hand status` and `hand status --json`'s `unacknowledged` flag now means what its name says (computed from the acknowledgement cursor), and a new `unannounced` flag carries the old, still-useful "no watcher has ever told anyone about this" fact under its own honest name.
- `hand status` stays read-only end to end: acknowledgement is mutated only by `hand ack`, never as a side effect of reading, with a regression test proving it; also fixes two latent read-only-ladder gaps in `internal/store/store.go` (holdInferredVersion and attemptBranchVersion) surfaced by rebasing across concurrently-merged atqamz/hand#282 and atqamz/hand#285, with new regression tests.

Implements invariant 3 of atqamz/hand#244 (carrying invariant 4 as an acceptance criterion), per `docs/adr/attention-is-one-derivation-over-three-channels.md`. The command surface and the new-column decision were both settled by the operator ahead of implementation, per atqamz/hand#267's own issue body.

Closes atqamz/hand#267

## Test plan
- [x] `go build ./...`
- [x] `make lint`
- [x] `go test -race ./...`
- [x] `make e2e`
- [x] `go test -tags=contract ./tests/contract/...`
- [x] New regression tests prove `hand status` leaves an unacknowledged report unacknowledged across fleet, single-task, and `--json` views, and that the read-only ladder handles every intermediate schema version without error.
- [x] All 7 required CI checks green (Contract, E2E, Lint, Nix build, Test ubuntu/macos/windows-latest).
