### PR TITLE
fix(runtime): preserve PR detection after detached HEAD

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -16,12 +16,15 @@ func hasUncommittedChanges(worktreePath string) (bool, error) {
 	return strings.TrimRight(string(out), "\n") != "", nil
 }
 
+// git symbolic-ref, not rev-parse --abbrev-ref: the latter exits 0 and prints the literal string
+// "HEAD" on a detached HEAD instead of failing, which every caller would otherwise have to
+// special-case itself to avoid treating that sentinel as a real branch name.
 func currentBranch(worktreePath string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := exec.Command("git", "symbolic-ref", "--short", "-q", "HEAD")
 	cmd.Dir = worktreePath
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git rev-parse failed: %w", err)
+		return "", fmt.Errorf("git symbolic-ref failed: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -33,10 +33,16 @@ func DetectPRReadOnly(ctx context.Context, homeDir string, active state.Attempt,
 	return observePR(ctx, homeDir, active, projectInfo)
 }
 
+// Live worktree state wins when it is determinable, since it is more current than what attempt
+// creation recorded; the durably stored branch is the fallback, since a detached or torn-down
+// worktree cannot answer at all - not evidence that no branch, and so no PR, ever existed.
 func observePR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
-	branch, err := currentBranch(active.Worktree)
-	if err != nil {
-		return ghutil.UnknownPRObservation("git rev-parse --abbrev-ref HEAD", fmt.Sprintf("resolve the branch to search for in %s: %v", active.Worktree, err))
+	branch, liveErr := currentBranch(active.Worktree)
+	if liveErr != nil {
+		branch = active.Branch
+	}
+	if branch == "" {
+		return ghutil.UnknownPRObservation("git symbolic-ref --short -q HEAD", fmt.Sprintf("resolve the branch to search for in %s: %v", active.Worktree, liveErr))
 	}
 	repoSlug, err := project.RepoSlug(homeDir, projectInfo)
 	if err != nil {

--- a/internal/runtime/pr_test.go
+++ b/internal/runtime/pr_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/state"
+)
+
+const prDetectionRepo = "atqamz/detach-fixture"
+
+// A worktree whose HEAD has been detached from branch after committing to it, the exact state a
+// worker leaves behind deleting its feature branch post-merge (atqamz/hand#284).
+func detachedHeadWorktreeFixture(t *testing.T, branch string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "worktree")
+	faketool.InitRepo(t, path)
+	runRuntimeGit(t, path, "checkout", "-q", "-b", branch)
+	commitFixtureFile(t, path, "feature")
+	head := gitOutput(t, path, "rev-parse", "HEAD")
+	runRuntimeGit(t, path, "checkout", "-q", head)
+	return path
+}
+
+func prDetectionProjectFixture(t *testing.T, home string) project.Project {
+	t.Helper()
+	name := "demo"
+	clonePath := filepath.Join(home, "projects", name)
+	if err := os.MkdirAll(clonePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeGit(t, clonePath, "init", "-q")
+	runRuntimeGit(t, clonePath, "remote", "add", "origin", "https://github.com/"+prDetectionRepo+".git")
+	return project.Project{Name: name}
+}
+
+func TestObservePRFindsAMergedPRByTheDurablyStoredBranchAfterDetachedHead(t *testing.T) {
+	home := t.TempDir()
+	worktreePath := detachedHeadWorktreeFixture(t, "topic")
+	proj := prDetectionProjectFixture(t, home)
+	faketool.GH{PRs: []faketool.GHPR{{
+		Number: 9, URL: "https://github.com/" + prDetectionRepo + "/pull/9",
+		Branch: "topic", State: "MERGED", Repo: prDetectionRepo,
+	}}}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: worktreePath, Branch: "topic"}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if !observation.Found() || observation.URL != "https://github.com/"+prDetectionRepo+"/pull/9" || !observation.Merged {
+		t.Fatalf("observation = %+v, want the durably stored branch to find the merged PR", observation)
+	}
+}
+
+func TestObservePRReportsUnknownNotAbsentOnDetachedHeadWithNoBranchHistory(t *testing.T) {
+	home := t.TempDir()
+	worktreePath := detachedHeadWorktreeFixture(t, "topic")
+	proj := prDetectionProjectFixture(t, home)
+	faketool.GH{}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: worktreePath}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if observation.Absent() {
+		t.Fatalf("observation = %+v, want unknown: GitHub was never actually asked, so absent is a false claim", observation)
+	}
+	if !observation.Unknown() {
+		t.Fatalf("observation = %+v, want unknown", observation)
+	}
+}
+
+// The regression test from atqamz/hand#284: a PR whose head ref is the literal string "HEAD"
+// would fool the pre-fix code (git rev-parse --abbrev-ref HEAD returns that exact sentinel on a
+// detached checkout), so this asserts the caller never sends it to gh at all.
+func TestObservePRNeverSearchesGitHubForTheLiteralSentinelHEAD(t *testing.T) {
+	home := t.TempDir()
+	worktreePath := detachedHeadWorktreeFixture(t, "topic")
+	proj := prDetectionProjectFixture(t, home)
+	logPath := filepath.Join(t.TempDir(), "gh.log")
+	faketool.GH{
+		PRs: []faketool.GHPR{{
+			Number: 1, URL: "https://github.com/" + prDetectionRepo + "/pull/1",
+			Branch: "HEAD", State: "MERGED", Repo: prDetectionRepo,
+		}},
+		Log: logPath,
+	}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: worktreePath}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if observation.Found() {
+		t.Fatalf("observation = %+v, want no PR found: a caller bug would search --head HEAD and wrongly match this trap PR", observation)
+	}
+	if !observation.Unknown() {
+		t.Fatalf("observation = %+v, want unknown when no branch is determinable", observation)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(log), "--head HEAD") {
+		t.Fatalf("gh invocation log = %q, want the literal sentinel HEAD never sent to gh as a branch name", log)
+	}
+}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -105,7 +105,10 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	}
 	worktreePath := lease.Path
 	if req.attempt.Worktree == "" {
-		if err := state.RecordAttemptWorktree(req.home, req.attempt.TaskID, req.attempt.ID, worktreePath, lease.ID); err != nil {
+		// Best-effort: an attempt whose branch cannot be determined here simply has none
+		// durably recorded, and PR detection falls back to a live re-derivation as before.
+		branch, _ := currentBranch(worktreePath)
+		if err := state.RecordAttemptWorktree(req.home, req.attempt.TaskID, req.attempt.ID, worktreePath, branch, lease.ID); err != nil {
 			return "", reportCleanup(fmt.Errorf("record worktree ownership: %w", err), r.deps.worktree.returnLease(lease, true))
 		}
 	}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -532,7 +532,7 @@ func TestReconcileClearsRepairAfterTeardownAndReopenResolvesOldAttempt(t *testin
 		t.Fatal(err)
 	}
 	newWorktree := filepath.Join(home, "reopened-worktree")
-	if err := state.RecordAttemptWorktree(home, "task-1", newAttempt.ID, newWorktree, "lease-new"); err != nil {
+	if err := state.RecordAttemptWorktree(home, "task-1", newAttempt.ID, newWorktree, "", "lease-new"); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.RecordAttemptHerdr(home, "task-1", newAttempt.ID, state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "2026-08-15T00:00:02Z"); err != nil {

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -390,8 +390,8 @@ func TestReopenSchemaV10MigratesOnlyAfterValidRouting(t *testing.T) {
 	if _, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatalf("Reopen() = %v, want schema v10 upgrade after route validation", err)
 	}
-	if got := runtimeStoreSchemaVersion(t, home); got != 15 {
-		t.Fatalf("schema version after valid Reopen = %d, want 15", got)
+	if got, want := runtimeStoreSchemaVersion(t, home), latestRuntimeStoreSchemaVersion(t); got != want {
+		t.Fatalf("schema version after valid Reopen = %d, want %d", got, want)
 	}
 }
 
@@ -414,8 +414,8 @@ func TestPromoteSchemaV10MigratesOnlyAfterValidRouting(t *testing.T) {
 	if _, err := r.Promote(context.Background(), PromoteRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatalf("Promote() = %v, want schema v10 upgrade after route validation", err)
 	}
-	if got := runtimeStoreSchemaVersion(t, home); got != 15 {
-		t.Fatalf("schema version after valid Promote = %d, want 15", got)
+	if got, want := runtimeStoreSchemaVersion(t, home), latestRuntimeStoreSchemaVersion(t); got != want {
+		t.Fatalf("schema version after valid Promote = %d, want %d", got, want)
 	}
 }
 
@@ -530,6 +530,22 @@ func downgradeRuntimeStoreToV10(t *testing.T, home string) {
 	if _, err := db.Exec("PRAGMA user_version = 10"); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// A fresh store always stamps itself at the newest schema version, so reading one back is how a
+// test asserts "fully migrated" without hardcoding a version number that drifts with every
+// unrelated migration added elsewhere in the package.
+func latestRuntimeStoreSchemaVersion(t *testing.T) int {
+	t.Helper()
+	home := t.TempDir()
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return runtimeStoreSchemaVersion(t, home)
 }
 
 func runtimeStoreSchemaVersion(t *testing.T, home string) int {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -697,12 +697,15 @@ func localDefaultBranch(clonePath string) (string, error) {
 	return "", fmt.Errorf("resolve local default branch failed")
 }
 
+// git symbolic-ref, not rev-parse --abbrev-ref: the latter exits 0 and prints the literal string
+// "HEAD" on a detached HEAD instead of failing, which every caller would otherwise have to
+// special-case itself to avoid treating that sentinel as a real branch name.
 func currentBranch(worktreePath string) (string, error) {
-	c := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	c := exec.Command("git", "symbolic-ref", "--short", "-q", "HEAD")
 	c.Dir = worktreePath
 	out, err := c.Output()
 	if err != nil {
-		return "", fmt.Errorf("git rev-parse failed: %w", err)
+		return "", fmt.Errorf("git symbolic-ref failed: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -385,13 +385,13 @@ func ClearTaskRepair(homeDir, id, expectedCode string) error {
 	return db.ClearTaskRepair(id, expectedCode)
 }
 
-func RecordAttemptWorktree(homeDir, taskID string, attemptID int64, worktree, leaseID string) error {
+func RecordAttemptWorktree(homeDir, taskID string, attemptID int64, worktree, branch, leaseID string) error {
 	db, err := store.Open(homeDir)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
-	return db.RecordAttemptWorktree(taskID, attemptID, worktree, leaseID)
+	return db.RecordAttemptWorktree(taskID, attemptID, worktree, branch, leaseID)
 }
 
 func ClearAttemptWorktree(homeDir, taskID string, attemptID int64) error {

--- a/internal/store/attempt_test.go
+++ b/internal/store/attempt_test.go
@@ -67,7 +67,7 @@ func TestAttemptUpdatesPreserveExecutionSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "lease-1"); err != nil {
+	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "", "lease-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.RecordAttemptHerdr("task-1", created.ID, Herdr{PaneID: "pane-1"}, "2026-08-14T00:00:00Z"); err != nil {
@@ -237,7 +237,7 @@ func TestProvisioningEvidenceIsIncrementalAndRequiredBeforeRunning(t *testing.T)
 	if got := read(); got.Worktree != "" || got.Herdr.PaneID != "" || got.LaunchSubmittedAt != "" || got.LaunchConfirmedAt != "" {
 		t.Fatalf("initial provisioning evidence = %+v, want empty boundaries", got)
 	}
-	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "lease-1"); err != nil {
+	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "", "lease-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.RecordAttemptHerdr("task-1", created.ID, Herdr{PaneID: "pane-1"}, "2026-08-14T00:00:01Z"); err != nil {
@@ -267,7 +267,7 @@ func TestReleasedProvisioningResourcesDoNotLeaveStaleOwnershipEvidence(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "lease-1"); err != nil {
+	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "", "lease-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.RecordAttemptHerdr("task-1", created.ID, Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}, "2026-08-14T00:00:01Z"); err != nil {
@@ -503,7 +503,7 @@ func TestAttemptBookkeepingRequiresCurrentActiveOwnership(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.RecordAttemptWorktree("task-1", first.ID, "stale", "stale-lease"); !errors.Is(err, ErrOwnershipConflict) {
+	if err := db.RecordAttemptWorktree("task-1", first.ID, "stale", "", "stale-lease"); !errors.Is(err, ErrOwnershipConflict) {
 		t.Fatalf("historical bookkeeping = %v, want ownership conflict", err)
 	}
 	got, found, err := db.ReadAttempt(second.ID)

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -141,6 +141,10 @@ var migrations = []string{
 	// ensureHoldInferredColumn does the real work below: a database already carrying the
 	// column, unstamped past sendHardeningMigrationVersion, must not fail a plain ALTER TABLE.
 	`SELECT 1;`,
+	// ensureAttemptBranchColumn does the real work below, for the same reason: the base schema
+	// already carries the column, so a plain ALTER TABLE would fail wherever a test or a home
+	// builds its fixture from the current schema before stamping an older version onto it.
+	`SELECT 1;`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -160,6 +164,8 @@ const sendSchemaVersion = repairMetadataVersion + 1
 const sendHardeningMigrationVersion = sendSchemaVersion
 
 const holdInferredVersion = sendHardeningMigrationVersion + 1
+
+const attemptBranchVersion = holdInferredVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -412,6 +418,11 @@ func (db *DB) applyMigration(version int) error {
 			return err
 		}
 	}
+	if version == attemptBranchVersion {
+		if err := ensureAttemptBranchColumn(tx); err != nil {
+			return err
+		}
+	}
 	if err := recordSchemaVersion(tx, version+1); err != nil {
 		return err
 	}
@@ -459,6 +470,20 @@ func ensureHoldInferredColumn(tx *sql.Tx) error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE hold ADD COLUMN inferred INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return fmt.Errorf("add hold inferred column: %w", err)
+	}
+	return nil
+}
+
+func ensureAttemptBranchColumn(tx *sql.Tx) error {
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name = 'branch'`).Scan(&count); err != nil {
+		return fmt.Errorf("inspect attempt branch column: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+	if _, err := tx.Exec(`ALTER TABLE attempt ADD COLUMN branch TEXT NOT NULL DEFAULT ''`); err != nil {
+		return fmt.Errorf("add attempt branch column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/schemaversion_test.go
+++ b/internal/store/schemaversion_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -66,6 +67,58 @@ func TestFreshSchemaIncludesSendAttemptAuthority(t *testing.T) {
 	}
 	if indexes != 1 {
 		t.Fatal("send_attempt pending index is missing")
+	}
+}
+
+func TestFreshSchemaIncludesAttemptBranch(t *testing.T) {
+	db, _ := openTemp(t)
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name = 'branch'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("attempt branch column = %d, want 1", count)
+	}
+}
+
+func TestMigrationAddsEmptyAttemptBranchToAnExistingDatabase(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &DB{sql: sqlDB, home: home}
+	preBranchSchema := strings.Replace(schema, "\tworktree               TEXT NOT NULL DEFAULT '',\n\tbranch                 TEXT NOT NULL DEFAULT '',\n", "\tworktree               TEXT NOT NULL DEFAULT '',\n", 1)
+	if _, err := db.sql.Exec(preBranchSchema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id) VALUES ('legacy')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle, harness, model, effort, worktree) VALUES ('legacy', 1, 'running', 'claude', 'opus', 'high', '/w/legacy')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(len(migrations)-1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = migrated.Close() }()
+	if version, err := migrated.schemaVersion(); err != nil || version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, len(migrations))
+	}
+	history, found, err := migrated.ReadTaskHistory("legacy")
+	if err != nil || !found || len(history.Attempts) != 1 {
+		t.Fatalf("ReadTaskHistory = %+v, %v, %v", history, found, err)
+	}
+	if attempt := history.Attempts[0]; attempt.Worktree != "/w/legacy" || attempt.Branch != "" {
+		t.Fatalf("migrated attempt = %+v, want the pre-existing worktree kept and an empty branch", attempt)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -167,6 +167,7 @@ type Attempt struct {
 	RequestedProfile        string           `json:"requested_profile"`
 	RoutingSource           string           `json:"routing_source"`
 	Worktree                string           `json:"worktree"`
+	Branch                  string           `json:"branch"`
 	LeaseID                 string           `json:"lease_id"`
 	Herdr                   Herdr            `json:"herdr"`
 	CreatedAt               string           `json:"created_at"`
@@ -299,6 +300,7 @@ CREATE TABLE IF NOT EXISTS attempt (
 	requested_profile      TEXT NOT NULL DEFAULT '',
 	routing_source        TEXT NOT NULL DEFAULT '',
 	worktree               TEXT NOT NULL DEFAULT '',
+	branch                 TEXT NOT NULL DEFAULT '',
 	lease_id               TEXT NOT NULL DEFAULT '',
 	herdr_session          TEXT NOT NULL DEFAULT '',
 	herdr_workspace_id    TEXT NOT NULL DEFAULT '',
@@ -613,14 +615,16 @@ var attemptColumnNames = []string{
 	"status_changed_at", "status_changed_for", "done_verified", "last_report_state", "last_report_note",
 	"send_undelivered_message", "send_undelivered_at", "parked_fired_for", "usage_limit_retry_at", "usage_limit_attempts",
 	"teardown_terminal_attempt", "teardown_disposition", "teardown_herdr_state", "teardown_worktree_state", "teardown_completion_state",
-	"usage_limit_episode", "usage_limit_stuck_episode",
+	"usage_limit_episode", "usage_limit_stuck_episode", "branch",
 }
 
 var attemptColumns = strings.Join(attemptColumnNames, ", ")
 
-var attemptColumnsBeforeSend = strings.Join(attemptColumnNames[:len(attemptColumnNames)-2], ", ")
+// -3 excludes usage_limit_episode, usage_limit_stuck_episode and branch: all three were added
+// after the send schema, in that order, at the tail of attemptColumnNames.
+var attemptColumnsBeforeSend = strings.Join(attemptColumnNames[:len(attemptColumnNames)-3], ", ")
 
-var attemptColumnNamesBeforeRouting = append(append([]string{}, attemptColumnNames[:7]...), attemptColumnNames[11:len(attemptColumnNames)-2]...)
+var attemptColumnNamesBeforeRouting = append(append([]string{}, attemptColumnNames[:7]...), attemptColumnNames[11:len(attemptColumnNames)-3]...)
 var attemptColumnsBeforeRouting = strings.Join(attemptColumnNamesBeforeRouting, ", ")
 
 func placeholders(count int) string {
@@ -678,7 +682,7 @@ func attemptValues(a Attempt) []any {
 		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
 		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts,
 		a.TeardownTerminalAttempt, a.TeardownDisposition, a.TeardownHerdrState, a.TeardownWorktreeState, a.TeardownCompletionState,
-		a.UsageLimitEpisode, a.UsageLimitStuckEpisode}
+		a.UsageLimitEpisode, a.UsageLimitStuckEpisode, a.Branch}
 }
 
 func scanAttempt(row interface{ Scan(...any) error }) (Attempt, error) {
@@ -690,7 +694,7 @@ func scanAttempt(row interface{ Scan(...any) error }) (Attempt, error) {
 		&a.StatusChangedAt, &a.StatusChangedFor, &a.DoneVerified, &a.LastReportState, &a.LastReportNote,
 		&a.SendUndeliveredMessage, &a.SendUndeliveredAt, &a.ParkedFiredFor, &a.UsageLimitRetryAt, &a.UsageLimitAttempts,
 		&a.TeardownTerminalAttempt, &a.TeardownDisposition, &a.TeardownHerdrState, &a.TeardownWorktreeState, &a.TeardownCompletionState,
-		&a.UsageLimitEpisode, &a.UsageLimitStuckEpisode)
+		&a.UsageLimitEpisode, &a.UsageLimitStuckEpisode, &a.Branch)
 	return a, err
 }
 
@@ -2008,15 +2012,15 @@ func updateTaskFact(result sql.Result, err error, operation, id string) error {
 	return nil
 }
 
-func (db *DB) RecordAttemptWorktree(taskID string, attemptID int64, worktree, leaseID string) error {
-	result, err := db.sql.Exec(`UPDATE attempt SET worktree = ?, lease_id = ?
+func (db *DB) RecordAttemptWorktree(taskID string, attemptID int64, worktree, branch, leaseID string) error {
+	result, err := db.sql.Exec(`UPDATE attempt SET worktree = ?, branch = ?, lease_id = ?
 		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
-		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, worktree, leaseID, attemptID, taskID, taskID, attemptID)
+		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, worktree, branch, leaseID, attemptID, taskID, taskID, attemptID)
 	return updateAttemptOwnership(result, err, "record worktree", taskID, attemptID)
 }
 
 func (db *DB) ClearAttemptWorktree(taskID string, attemptID int64) error {
-	result, err := db.sql.Exec(`UPDATE attempt SET worktree = '', lease_id = ''
+	result, err := db.sql.Exec(`UPDATE attempt SET worktree = '', branch = '', lease_id = ''
 		WHERE id = ? AND task_id = ? AND lifecycle = 'provisioning'
 		AND EXISTS (SELECT 1 FROM task WHERE id = ? AND lifecycle = 'open' AND active_attempt_id = ?)`, attemptID, taskID, taskID, attemptID)
 	return updateAttemptOwnership(result, err, "clear returned worktree", taskID, attemptID)


### PR DESCRIPTION
## Intent

Fix atqamz/hand#284: PR auto-detection permanently reads absent once a task worktree reaches detached HEAD, because observePR (internal/runtime/pr.go) re-derives which branch to search GitHub for from the worktree's live checked-out ref every call, and currentBranch (git rev-parse --abbrev-ref HEAD) exits 0 with the literal string 'HEAD' on a detached checkout instead of erroring - that sentinel goes straight into a GitHub branch search, which correctly finds zero PRs for a branch literally named 'HEAD' and reports a confident absent. Fix: (1) currentBranch (internal/runtime/teardown.go, duplicated in cmd/git.go) now uses git symbolic-ref --short -q HEAD, which fails cleanly on detached HEAD instead of returning the HEAD sentinel - this also silently fixes the same latent bug in branchIsMerged/localDefaultBranchRef, which route through the same function, as a side effect of fixing the shared root cause once, not scope creep. (2) store.Attempt gains a new durable Branch field (new attempt.branch column) alongside Worktree, captured in internal/runtime/provision.go at the same call site that first records Worktree (RecordAttemptWorktree) - best-effort, empty if undeterminable. The migration is guarded by an idempotent ensureAttemptBranchColumn following the exact pattern ensureHoldInferredColumn already established, because the base schema string already carries the new column, so a plain ALTER TABLE breaks any fixture built from the current schema then stamped to an older version (confirmed by two test failures before I added the guard). (3) observePR now prefers the live currentBranch result when determinable, falls back to active.Branch when the worktree is detached or otherwise undeterminable, and returns ghutil.UnknownPRObservation (never absent) only when neither source yields a branch name. Deliberate scope decision: did NOT add Branch to store.DB.UpdateAttempt's SET clause, because that function already deliberately excludes every other creation-time/execution-identity field (Harness, Model, Effort, ExecutionClass, PlannedAgainst, RequestedProfile, RoutingSource) as immutable once recorded (TestAttemptUpdatesPreserveExecutionSnapshot pins this), and UpdateAttempt has zero production callers today - Branch belongs in that same immutable-once-set family. Coordinated with atqamz/hand#256 (tri-state observation layer) and atqamz/hand#253/#257 (commit-safety evidence ordering) per the brief - confirmed both are distinct, non-overlapping scope, not duplicated. All three required regression tests from the issue are in internal/runtime/pr_test.go, verified to fail against the pre-fix code (git-stashed the fix, reran, confirmed all three fail exactly as expected including the literal-HEAD trap PR, then restored). No new ADR: this is a targeted bug fix with the rationale inline in code comments and the PR body, consistent with how the directly comparable prior fixes in this exact area (#256, #253) were also delivered without one.

## What Changed

- Use `git symbolic-ref` to detect branches cleanly and avoid treating detached `HEAD` as a real branch.
- Persist attempt branches with an idempotent schema migration for detached-worktree PR detection.
- Prefer the live branch, fall back to the recorded branch, and report unknown when neither is available; add regression coverage.

## Risk Assessment

✅ Low: The change correctly replaces the detached-HEAD sentinel path, persists branch identity with an idempotent migration, preserves historical schema projections, and falls back to unknown when no branch is available.

## Testing

Focused end-to-end tests passed in the Nix dev shell, covering merged PR fallback, unknown instead of absent, literal HEAD suppression, durable branch schema and migration, and the shared branch-merge path. Initial direct Go commands were blocked because Go was absent from PATH. No UI surface exists requiring visual evidence.

<details>
<summary>Evidence: Detached HEAD PR validation</summary>

`Targeted runtime, schema migration, and branch-merge tests passed.`

```text
Targeted end-to-end validation

nix develop --command go test ./internal/runtime -run 'TestObservePR(FindsAMergedPRByTheDurablyStoredBranchAfterDetachedHead|ReportsUnknownNotAbsentOnDetachedHeadWithNoBranchHistory|NeverSearchesGitHubForTheLiteralSentinelHEAD)$' -count=1 -v
--- PASS: TestObservePRFindsAMergedPRByTheDurablyStoredBranchAfterDetachedHead
--- PASS: TestObservePRReportsUnknownNotAbsentOnDetachedHeadWithNoBranchHistory
--- PASS: TestObservePRNeverSearchesGitHubForTheLiteralSentinelHEAD
PASS

nix develop --command go test ./internal/store -run 'Test(FreshSchemaIncludesAttemptBranch|MigrationAddsEmptyAttemptBranchToAnExistingDatabase)$' -count=1 -v
--- PASS: TestFreshSchemaIncludesAttemptBranch
--- PASS: TestMigrationAddsEmptyAttemptBranchToAnExistingDatabase
PASS

nix develop --command go test ./internal/runtime -run 'TestBranchIsMergedUsesOriginDefaultBranch$' -count=1 -v
--- PASS: TestBranchIsMergedUsesOriginDefaultBranch
PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c68663224ac536c57baf344a5184955cf073472a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --command go test ./internal/runtime -run 'TestObservePR(FindsAMergedPRByTheDurablyStoredBranchAfterDetachedHead|ReportsUnknownNotAbsentOnDetachedHeadWithNoBranchHistory|NeverSearchesGitHubForTheLiteralSentinelHEAD)$' -count=1 -v`
- `nix develop --command go test ./internal/store -run 'Test(FreshSchemaIncludesAttemptBranch|MigrationAddsEmptyAttemptBranchToAnExistingDatabase)$' -count=1 -v`
- `nix develop --command go test ./internal/runtime -run 'TestBranchIsMergedUsesOriginDefaultBranch$' -count=1 -v`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
