### PR TITLE
feat(skill): bundle a first-party secondhand Agent Skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ hand.exe
 /projects/
 /config/
 /.claude/
+/.grok/
+/.pi/
+/.agents/
 
 # Go
 coverage.out

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd ~/fleet
 hand init
 ```
 
-`hand init` is non-interactive. It creates the fleet structure and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` before acting, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - a symlink on Unix and an `@AGENTS.md` pointer file on Windows.
+`hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` before acting, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - a symlink on Unix and an `@AGENTS.md` pointer file on Windows.
 
 ### 3. Add a project
 
@@ -261,6 +261,10 @@ A fleet home is deliberately separate from the repositories being worked on.
 ~/fleet/
 ├── AGENTS.md
 ├── CLAUDE.md
+├── .agents/skills/secondhand/
+├── .claude/skills/secondhand/
+├── .grok/skills/secondhand/
+├── .pi/skills/secondhand/
 ├── config/
 ├── data/
 │   ├── backlog.md
@@ -274,6 +278,7 @@ A fleet home is deliberately separate from the repositories being worked on.
 The important pieces are:
 
 - `AGENTS.md` - immutable, Hand-owned supervisor invariants; `hand init` restores it byte-for-byte
+- `.agents/skills/`, `.claude/skills/`, `.grok/skills/`, `.pi/skills/` - bundled `secondhand` Agent Skill copies for supported harnesses
 - `data/operator.md` - your standing constraints and preferences
 - `data/backlog.md` - the supervisor's task queue
 - `data/learnings.md` - durable operational knowledge discovered by the fleet

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,8 +13,14 @@ import (
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/sessionhook"
+	"github.com/atqamz/hand/internal/skill"
 	"github.com/spf13/cobra"
 )
+
+var skillFields = []axi.Column[skill.DestinationResult]{
+	{Name: "dir", Value: func(r skill.DestinationResult) string { return r.Dir }},
+	{Name: "outcome", Value: func(r skill.DestinationResult) string { return string(r.Outcome) }},
+}
 
 var toolCandidates = []string{"treehouse", "herdr", "no-mistakes", "gh"}
 
@@ -82,6 +88,10 @@ func newInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			skillResults, err := skill.Refresh(home)
+			if err != nil {
+				return err
+			}
 			exe, err := os.Executable()
 			if err != nil {
 				return fmt.Errorf("resolve the hand executable: %w", err)
@@ -100,6 +110,8 @@ func newInitCmd() *cobra.Command {
 			doc.Field("home", home)
 			doc.Field("agents_md", writtenOrUnchanged(refresh.Changed))
 			doc.Field("agents_md_legacy_archive", noneIfEmpty(refresh.ArchivedPath))
+			axi.Table(&doc, "skill", skillResults, skillFields)
+			doc.Int("skill_conflicts", skillConflictCount(skillResults))
 			doc.Field("session_hook", removedOrUnchanged(hookRemoved))
 			doc.List("migrated", migrated)
 			cfg, err := currentWorkerConfig(home)
@@ -125,6 +137,9 @@ func newInitCmd() *cobra.Command {
 			if refresh.ArchivedPath != "" {
 				help = append(help, fmt.Sprintf("This home's previous AGENTS.md content was archived verbatim at %s; review it and relocate anything still useful yourself", refresh.ArchivedPath))
 			}
+			if n := skillConflictCount(skillResults); n > 0 {
+				help = append(help, fmt.Sprintf("%d bundled-skill destination(s) already hold a foreign file at the managed entry path and were left untouched; move each aside, then run hand init again to install the skill there", n))
+			}
 			doc.Help(help...)
 			return doc.Render(cmd.OutOrStdout())
 		},
@@ -148,6 +163,16 @@ func writtenOrUnchanged(changed bool) string {
 		return "written"
 	}
 	return "unchanged"
+}
+
+func skillConflictCount(results []skill.DestinationResult) int {
+	n := 0
+	for _, r := range results {
+		if r.Outcome == skill.OutcomeConflict {
+			n++
+		}
+	}
+	return n
 }
 
 func noneIfEmpty(path string) string {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -316,3 +316,70 @@ func TestInitRemovesTheSessionHookAndSaysSoOnlyWhenItChangedSettings(t *testing.
 		t.Fatalf("settings = %q, want only the unrelated hook preserved", settings)
 	}
 }
+
+func TestInitInstallsTheBundledSkillIntoEveryDestination(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var out bytes.Buffer
+	cmd := newInitCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "skill_conflicts: 0\n") {
+		t.Fatalf("output = %q, want zero skill conflicts on a fresh home", out.String())
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "skills", "secondhand"),
+		filepath.Join(".grok", "skills", "secondhand"),
+		filepath.Join(".pi", "skills", "secondhand"),
+		filepath.Join(".agents", "skills", "secondhand"),
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel, "SKILL.md")); err != nil {
+			t.Fatalf("%s/SKILL.md missing after init: %v", rel, err)
+		}
+	}
+}
+
+func TestInitReportsASkillDestinationConflictWithoutOverwritingTheForeignFile(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	claudeSkillDir := filepath.Join(dir, ".claude", "skills", "secondhand")
+	if err := os.MkdirAll(claudeSkillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := "# Someone else's skill\n"
+	if err := os.WriteFile(filepath.Join(claudeSkillDir, "SKILL.md"), []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := newInitCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "skill_conflicts: 1\n") {
+		t.Fatalf("output = %q, want one skill conflict reported", out.String())
+	}
+	if !strings.Contains(out.String(), "already hold a foreign file") {
+		t.Fatalf("output = %q, want help text naming the conflict", out.String())
+	}
+	got, err := os.ReadFile(filepath.Join(claudeSkillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != foreign {
+		t.Fatalf("got %q, want the foreign file left exactly as written", got)
+	}
+	// A conflict at one destination must not block the others.
+	if _, err := os.Stat(filepath.Join(dir, ".grok", "skills", "secondhand", "SKILL.md")); err != nil {
+		t.Fatalf("unaffected destination not installed: %v", err)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,193 @@
+// Package skill installs and reconciles the bundled secondhand Agent Skill into a fleet
+// home's supported per-harness project-local destinations, deterministically and without
+// requiring symlink privilege: every copy is a plain file, atomically written.
+package skill
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
+	hskills "github.com/atqamz/hand/skills"
+)
+
+// Name is the skill's directory name at every destination.
+const Name = "secondhand"
+
+// The one file every destination is guaranteed to have, so ownership and staleness checks
+// have a fixed, cheap starting point rather than a directory listing.
+const entryFile = "SKILL.md"
+
+// The frontmatter line the canonical SKILL.md carries. Presence alone distinguishes a
+// Hand-managed copy from a foreign file at the same destination; not a security boundary,
+// only a deterministic ownership signal.
+const managedMarker = "managed-by: hand"
+
+type destination struct {
+	rel string
+}
+
+// One relative root per supported harness, deduplicated where harnesses share a convention:
+// Codex and OpenCode have no distinct Agent Skill directory of their own, so both read the
+// generic .agents/skills root the same way every supported harness already reads AGENTS.md.
+var destinations = []destination{
+	{rel: filepath.Join(".claude", "skills")},
+	{rel: filepath.Join(".grok", "skills")},
+	{rel: filepath.Join(".pi", "skills")},
+	{rel: filepath.Join(".agents", "skills")},
+}
+
+// Kept for tests and callers that want to reason about which harness a destination serves;
+// production code only needs DestinationDirs.
+var harnessRel = map[string]string{
+	harness.Claude:   filepath.Join(".claude", "skills"),
+	harness.Grok:     filepath.Join(".grok", "skills"),
+	harness.Pi:       filepath.Join(".pi", "skills"),
+	harness.Codex:    filepath.Join(".agents", "skills"),
+	harness.OpenCode: filepath.Join(".agents", "skills"),
+}
+
+// DestinationDirs returns every supported harness's skill directory under home, one absolute
+// path per distinct destination root.
+func DestinationDirs(home string) []string {
+	dirs := make([]string, 0, len(destinations))
+	for _, d := range destinations {
+		dirs = append(dirs, filepath.Join(home, d.rel, Name))
+	}
+	return dirs
+}
+
+// Outcome reports what Refresh did, or found, at one destination.
+type Outcome string
+
+const (
+	OutcomeCreated   Outcome = "created"
+	OutcomeRefreshed Outcome = "refreshed"
+	OutcomeUnchanged Outcome = "unchanged"
+	OutcomeConflict  Outcome = "conflict"
+)
+
+// DestinationResult reports Refresh's outcome at one destination directory.
+type DestinationResult struct {
+	Dir     string
+	Outcome Outcome
+}
+
+// Refresh installs or reconciles the bundled skill into every supported destination under a
+// fleet home, independently: create if missing, refresh if stale, refuse a foreign file as a
+// conflict, or leave canonical content untouched. It returns nil if dir is not a fleet home.
+func Refresh(dir string) ([]DestinationResult, error) {
+	isHome, err := home.IsHome(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !isHome {
+		return nil, nil
+	}
+
+	files, err := canonicalFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]DestinationResult, 0, len(destinations))
+	for _, destDir := range DestinationDirs(dir) {
+		outcome, err := refreshOne(destDir, files)
+		if err != nil {
+			return nil, fmt.Errorf("refresh skill at %s: %w", destDir, err)
+		}
+		results = append(results, DestinationResult{Dir: destDir, Outcome: outcome})
+	}
+	return results, nil
+}
+
+func refreshOne(destDir string, files map[string][]byte) (Outcome, error) {
+	entryPath := filepath.Join(destDir, entryFile)
+	existing, err := os.ReadFile(entryPath)
+	switch {
+	case os.IsNotExist(err):
+		if err := writeAll(destDir, files); err != nil {
+			return "", err
+		}
+		return OutcomeCreated, nil
+	case err != nil:
+		return "", fmt.Errorf("read %s: %w", entryPath, err)
+	case !strings.Contains(string(existing), managedMarker):
+		return OutcomeConflict, nil
+	}
+
+	stale, err := isStale(destDir, files)
+	if err != nil {
+		return "", err
+	}
+	if !stale {
+		return OutcomeUnchanged, nil
+	}
+	if err := writeAll(destDir, files); err != nil {
+		return "", err
+	}
+	return OutcomeRefreshed, nil
+}
+
+func isStale(destDir string, files map[string][]byte) (bool, error) {
+	for rel, want := range files {
+		got, err := os.ReadFile(filepath.Join(destDir, rel))
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("read %s: %w", filepath.Join(destDir, rel), err)
+		}
+		if string(got) != string(want) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func writeAll(destDir string, files map[string][]byte) error {
+	for rel, data := range files {
+		path := filepath.Join(destDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create %s: %w", filepath.Dir(rel), err)
+		}
+		if err := atomicfile.Write(path, ".secondhand-skill-", data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+// Walks the embedded skill tree once into a flat relative-path -> content map, so every
+// destination compares and writes against the exact same in-memory snapshot.
+func canonicalFiles() (map[string][]byte, error) {
+	root := Name
+	files := make(map[string][]byte)
+	err := fs.WalkDir(hskills.Secondhand, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, err := fs.ReadFile(hskills.Secondhand, path)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", path, err)
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files[filepath.FromSlash(rel)] = data
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk embedded skill tree: %w", err)
+	}
+	return files, nil
+}

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,0 +1,221 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/harness"
+)
+
+func makeHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state", "hand.db"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func outcomeFor(results []DestinationResult, dir string) (Outcome, bool) {
+	for _, r := range results {
+		if r.Dir == dir {
+			return r.Outcome, true
+		}
+	}
+	return "", false
+}
+
+func TestRefreshSkipsSilentlyWhenNotAFleetHome(t *testing.T) {
+	results, err := Refresh(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results != nil {
+		t.Fatalf("got %v, want nil outside a fleet home", results)
+	}
+}
+
+func TestDestinationDirsCoverEverySupportedHarnessWithNoDuplicates(t *testing.T) {
+	home := t.TempDir()
+	dirs := DestinationDirs(home)
+	seen := make(map[string]bool)
+	for _, d := range dirs {
+		if seen[d] {
+			t.Fatalf("got duplicate destination %q in %v", d, dirs)
+		}
+		seen[d] = true
+	}
+	for _, h := range harness.Names() {
+		rel, ok := harnessRel[h]
+		if !ok {
+			t.Fatalf("harness %q has no mapped skill destination", h)
+		}
+		want := filepath.Join(home, rel, Name)
+		if !seen[want] {
+			t.Fatalf("got %v, want it to include %q for harness %q", dirs, want, h)
+		}
+	}
+}
+
+func TestRefreshCreatesEveryDestinationWhenMissing(t *testing.T) {
+	home := makeHome(t)
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs := DestinationDirs(home)
+	if len(results) != len(dirs) {
+		t.Fatalf("got %d results, want %d", len(results), len(dirs))
+	}
+	for _, dir := range dirs {
+		outcome, ok := outcomeFor(results, dir)
+		if !ok || outcome != OutcomeCreated {
+			t.Fatalf("got outcome %q ok=%v for %s, want created", outcome, ok, dir)
+		}
+		skillMD, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(skillMD) == 0 {
+			t.Fatalf("got empty SKILL.md at %s", dir)
+		}
+		for _, ref := range []string{
+			"setup-doctor.md", "configuration.md", "planning-and-briefs.md",
+			"task-lifecycle.md", "supervision-loop.md", "evaluation.md",
+			"recovery.md", "bug-report.md",
+		} {
+			if _, err := os.Stat(filepath.Join(dir, "references", ref)); err != nil {
+				t.Fatalf("got missing reference %s at %s: %v", ref, dir, err)
+			}
+		}
+	}
+}
+
+func TestRefreshIsUnchangedWhenAlreadyCanonical(t *testing.T) {
+	home := makeHome(t)
+	if _, err := Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	dir := DestinationDirs(home)[0]
+	path := filepath.Join(dir, "SKILL.md")
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Outcome != OutcomeUnchanged {
+			t.Fatalf("got outcome %q for %s on a second run, want unchanged", r.Outcome, r.Dir)
+		}
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("got SKILL.md replaced on an unchanged refresh, want the existing file left untouched")
+	}
+}
+
+func TestRefreshAtomicallyRefreshesAStaleManagedCopy(t *testing.T) {
+	home := makeHome(t)
+	if _, err := Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	dir := DestinationDirs(home)[0]
+	path := filepath.Join(dir, "SKILL.md")
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := string(original) + "\nstray trailing line\n"
+	if err := os.WriteFile(path, []byte(drifted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, ok := outcomeFor(results, dir)
+	if !ok || outcome != OutcomeRefreshed {
+		t.Fatalf("got outcome %q ok=%v, want refreshed", outcome, ok)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("got %q, want the stale copy restored to the canonical body", got)
+	}
+}
+
+func TestRefreshRefusesAForeignFileWithoutOverwritingIt(t *testing.T) {
+	home := makeHome(t)
+	dir := DestinationDirs(home)[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := "# Some unrelated skill\n\nNothing to do with hand.\n"
+	path := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, ok := outcomeFor(results, dir)
+	if !ok || outcome != OutcomeConflict {
+		t.Fatalf("got outcome %q ok=%v, want conflict", outcome, ok)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != foreign {
+		t.Fatalf("got %q, want the foreign file left exactly as written", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "references")); !os.IsNotExist(err) {
+		t.Fatal("got a references directory written alongside a refused foreign file, want none")
+	}
+
+	// A conflict at one destination must not block installing the others.
+	for _, other := range DestinationDirs(home)[1:] {
+		otherOutcome, ok := outcomeFor(results, other)
+		if !ok || otherOutcome != OutcomeCreated {
+			t.Fatalf("got outcome %q ok=%v for unaffected destination %s, want created", otherOutcome, ok, other)
+		}
+	}
+}
+
+func TestRefreshEmbeddedSkillCarriesTheManagedMarkerAndNoBannedCharacters(t *testing.T) {
+	home := makeHome(t)
+	if _, err := Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(DestinationDirs(home)[0], "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, managedMarker) {
+		t.Fatalf("got SKILL.md %q, want the managed-by marker", content)
+	}
+	if !strings.Contains(content, "source: atqamz/hand") {
+		t.Fatalf("got SKILL.md %q, want a source marker naming the project", content)
+	}
+	if strings.ContainsRune(content, '—') {
+		t.Fatal("got an em dash in the canonical SKILL.md, want none")
+	}
+}

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -1,0 +1,9 @@
+// Package skills embeds the first-party secondhand Agent Skill's canonical source tree at
+// build time, so an installed hand binary can install and reconcile it without network access.
+// internal/skill owns installation and ownership logic; this package only owns the embed.
+package skills
+
+import "embed"
+
+//go:embed secondhand
+var Secondhand embed.FS

--- a/skills/secondhand/SKILL.md
+++ b/skills/secondhand/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: secondhand
+description: Use when supervising a Secondhand (hand) fleet - setup and health, profiles and routing, planning and briefs, task lifecycle, the supervision loop, evidence-based evaluation, recovery, and preparing a bug report. Do not use this from inside a worker's own worktree.
+metadata:
+  source: atqamz/hand
+  managed-by: hand
+---
+
+# Secondhand supervisor handbook
+
+This skill teaches how to drive the `hand` CLI as a Secondhand fleet supervisor. It is a
+procedure layer over `hand`, not a second implementation of it: every claim here about fleet
+state, dependency state, or task state is something you get by running a `hand` command and
+reading its structured output, never by reconstructing it from panes, files, or memory.
+
+```text
+wrong: skill checks PATH itself and decides whether Herdr is installed
+right: skill runs `hand doctor` and interprets structured output
+
+wrong: skill edits config files directly
+right: skill uses `hand config profile ...` and `hand config route ...`
+
+wrong: skill reconstructs lifecycle state from terminal panes
+right: skill uses `hand status`, `hand watch`, and hand's own reconciliation results
+```
+
+`AGENTS.md` states the invariants that hold regardless of session; this skill states the
+procedures for acting on them. If the two ever seem to disagree, `AGENTS.md` wins, and that is
+itself worth reporting as a drift signal rather than silently resolving.
+
+## Routing to a reference
+
+Read the reference for the phase of work you are actually in. Do not read all of them up front
+for a routine session; each is designed to be fetched only when its phase applies.
+
+- **references/setup-doctor.md** - first session in a home, or anytime something seems wrong: interpreting `hand doctor`, dependency categories, generated-surface drift.
+- **references/configuration.md** - no Profile/Route exists yet for a task you are about to dispatch, or `hand doctor` reports a routing problem.
+- **references/planning-and-briefs.md** - about to dispatch: choosing scout vs ship, mechanical vs standard vs deep, writing an execution-ready brief.
+- **references/task-lifecycle.md** - normal day-to-day commands: spawn, status, send, hold, deliver, merge, teardown, reopen, promote.
+- **references/supervision-loop.md** - the bounded control loop that ties dispatch, observation, and decision together across a task's life.
+- **references/evaluation.md** - deciding whether a worker's claim of done actually holds up against the brief.
+- **references/recovery.md** - `hand status` or `hand reconcile` shows an ambiguous, ownership-unprovable, or needs-repair condition.
+- **references/bug-report.md** - `hand` itself misbehaves and the operator wants to file or review a report.
+
+## What this skill never introduces
+
+No generic Hand plugin or runtime framework, no marketplace for third-party skills, no
+automatic installation of Herdr, Treehouse, a harness, `gh`, or `no-mistakes`, no hard-coded
+vendor or model policy, no cross-profile model shopping, no provider billing or quota
+introspection, and no `hand judge`, `hand critic`, or generic agent-swarm pattern. Where a
+procedure below needs a decision only Hand's own deterministic state can make, it says to run
+a command and read the result - it does not invent a second, prose-only answer.

--- a/skills/secondhand/references/bug-report.md
+++ b/skills/secondhand/references/bug-report.md
@@ -1,0 +1,50 @@
+# Preparing a bug report
+
+Preparing a report and publishing one are two different steps. Gathering diagnostics never
+implies filing anything; only create a GitHub issue when the operator explicitly asks you to
+publish it.
+
+## What to gather
+
+```text
+hand --version
+hand doctor
+hand config
+hand status <task>          # only when the report is about a specific task
+OS and architecture
+the exact failing command
+its exit kind (from the error document's `kind` field, not just the message text)
+stderr/stdout, as the structured document hand printed
+expected behavior
+actual behavior
+a minimal reproduction
+```
+
+Prefer the exact structured output over a paraphrase: paste the real TOON document (or its
+`error`/`kind`/`exit` fields on failure) rather than describing it in your own words, since a
+paraphrase can drop the one detail that explains the bug.
+
+## Hard privacy rules
+
+- Never dump all environment variables. If an environment variable is genuinely relevant, name
+  that one variable and its value, not the whole environment.
+- Never print tokens or credentials, from any source - environment, config, or a file.
+- Never read arbitrary credential files to "check" something for a report.
+- Never include secrets from a brief or a config file in the report.
+- Redact a sensitive path when it is not necessary to reproduce or diagnose the bug - a fleet
+  home's location is rarely sensitive, but a project's private clone URL or an operator's local
+  username in an unrelated path may be worth redacting.
+
+## Assembling the report
+
+Structure it as: what you expected, what actually happened, the minimal reproduction, and the
+diagnostics gathered above. Do not speculate about root cause beyond what the evidence actually
+shows - a bug report that already contains an unverified guess dressed up as a finding wastes
+the maintainer's time confirming or refuting it.
+
+## Publishing
+
+A prepared report stays local until the operator explicitly asks for it to be published. When
+asked, file it with `gh issue create` against the correct repository, following this fleet's own
+GitHub conventions for issue bodies (`data/operator.md` and the fleet's own `AGENTS.md`/CLAUDE.md
+conventions govern this, not this skill).

--- a/skills/secondhand/references/configuration.md
+++ b/skills/secondhand/references/configuration.md
@@ -1,0 +1,63 @@
+# Profiles and routes
+
+## Read hand config first, always
+
+`hand config` reports the fleet's effective worker configuration: the detected supervisor
+harness, the `harnesses` table (supported harnesses, each with its own `installed`,
+`model`-capable, and `effort`-capable columns), configured `profiles`, configured `routes`, and
+any `problems`.
+
+```text
+wrong: assuming a harness is usable because Hand supports it
+right: reading the harnesses table's own installed column for that harness
+```
+
+`installed` is about this environment's `PATH`, not about Hand's support matrix; a harness can
+be supported and not installed, or installed and not model/effort-capable. Never conflate the
+three.
+
+## Profile and Route, precisely
+
+A **Profile** is an operator-named bundle: a harness, plus an optional model and effort
+override. A **Route** maps one `(kind, execution class)` pair - `scout`/`ship` crossed with
+`mechanical`/`standard`/`deep` - to exactly one Profile. `hand config` reports every route,
+including the ones still `missing`.
+
+Profile names, model identifiers, and which routes exist are entirely operator-defined. Do not
+hard-code a mapping such as "mechanical uses model X, deep uses model Y" anywhere, including in
+a brief: that is a policy decision for the operator to make once, through `hand config`, not a
+default this skill or a supervisor session invents per dispatch.
+
+## When a Profile or Route is missing
+
+Classify the task's execution class first (see `references/planning-and-briefs.md`), then check
+whether a route already covers it. If `hand config`'s `routes` table shows that pair as
+`missing`, or `problems` names it:
+
+```text
+wrong: "I'll just use claude-sonnet-5 for this, that's usually the good default"
+right: propose a structural option - "no route exists for ship/standard; here are the
+       supported, installed harnesses; which should the ship/standard profile use?" - with no
+       claim about which harness or model is better, cheaper, or higher quality
+```
+
+Ask the operator only the genuinely unresolved policy question: which harness, and whether a
+model/effort override is wanted. Do not ask for confirmation on anything routine, and do not
+present entitlement, quality, or cost claims about any harness or model - you do not have
+grounds to make them, and the operator does.
+
+Persist an accepted choice immediately through the CLI, never by writing a config file by hand:
+
+```sh
+hand config profile set <name> --harness <harness> [--model <model>] [--effort <effort>]
+hand config route set <kind> <execution-class> <profile>
+```
+
+Then run `hand config` again to confirm the route now resolves and no new `problems` appeared.
+
+## Routine vs operator-owned
+
+Classifying the task's kind and execution class is routine: do it yourself, every time, without
+asking. Whether a Profile/Route already exists and resolves is a fact you read, not a judgment
+call. The only thing that is genuinely the operator's to decide is *which* harness/model a new
+Profile should use when none of the existing ones fit - ask exactly that, once, and move on.

--- a/skills/secondhand/references/evaluation.md
+++ b/skills/secondhand/references/evaluation.md
@@ -1,0 +1,60 @@
+# Evaluation
+
+Evaluation is a supervisor reasoning procedure over evidence, not a new Hand runtime subsystem.
+Hand does not run a judge or critic agent over a worker's output, and this skill does not ask
+you to build one - it asks you to read the evidence Hand already gives you and reason about it
+yourself, every time, before treating a task as satisfied.
+
+## What "done" never means on its own
+
+```text
+wrong: the worker reported done:, so the task is finished
+right: the worker reported done:, which is a claim - check it against the brief and the actual
+       evidence before treating it as satisfied
+```
+
+A worker's own report is one input, not the verdict. Machine evidence is authoritative over
+model confidence, including the confidence in a worker's own `done:` line.
+
+## What to compare
+
+Hold these side by side before calling anything satisfied:
+
+```text
+brief goal
+brief invariants
+planned_against
+verification commands the brief named
+worker report (state, history, any needs-decision it raised)
+git diff / commits / the PR itself
+tests (did they run, did they pass, do they cover what the brief asked for)
+CI
+the no-mistakes delivery gate, if the project uses one
+Hand's own reconciliation / repair state (references/recovery.md)
+```
+
+Missing any one of these when it is available is a gap in the evaluation, not a shortcut.
+
+## Naming the outcome
+
+Useful outcome classes for your own reasoning - not a state Hand persists, just how to think
+about what you are looking at:
+
+- **satisfied** - every invariant holds, verification passed, and the evidence agrees with the report.
+- **correctable** - a real gap exists but the fix is bounded and safe to steer directly.
+- **stale-plan** - the brief's assumptions no longer hold against current reality; re-plan, do not steer around it.
+- **ambiguous** - the evidence itself does not resolve cleanly; treat as `references/recovery.md`'s territory, not a guess.
+- **operator-decision** - a genuine policy or irreversible choice remains; escalate.
+
+These are guidance for your own reasoning. Do not build a table, a field, or a database around
+them unless a separate, deterministic Hand contract independently requires it - if it does, this
+reference is the wrong place to duplicate it; consume that contract directly instead.
+
+## What this reference explicitly rejects
+
+- `hand judge` or `hand critic` as commands - they do not exist, and nothing here proposes them.
+- Treating "the worker says done" as sufficient without the evidence above.
+- Letting model confidence override deterministic machine evidence - if `hand status` reports
+  an unknown or unprovable condition, that stands even if the worker's own report sounds certain.
+- Nested critic-agent swarms, or any requirement that a Secondhand evaluation involve more than
+  one supervising reasoner. One supervisor, reading real evidence, is the architecture.

--- a/skills/secondhand/references/planning-and-briefs.md
+++ b/skills/secondhand/references/planning-and-briefs.md
@@ -1,0 +1,76 @@
+# Planning and briefs
+
+## Task kind: scout or ship
+
+`scout` and `ship` are Task kinds, not worker roles. Use `scout` when the deliverable is an
+investigation or report; use `ship` when the deliverable is a change that must be landed or
+explicitly delivered. A worker is simply the agent process Hand launches to execute delegated
+work, whichever kind the Task is.
+
+## Execution class: mechanical, standard, or deep
+
+The execution class means how much remaining judgment the executor has *after planning*, never
+task size, line count, or file count.
+
+```text
+wrong: "this is a big refactor across ten files, so it must be deep"
+right: "every file, symbol, and step is already decided; the executor only applies and
+        verifies specified changes" -> mechanical, regardless of file count
+```
+
+- **mechanical** - a decision-complete plan; the executor applies specified changes and verifies.
+- **standard** - architecture is decided; ordinary reversible implementation judgment remains.
+- **deep** - substantial implementation reasoning remains.
+
+Classify routine work yourself; do not ask the operator to classify it. Ask only when a
+genuinely operator-owned tradeoff remains (see `references/configuration.md` for the Profile
+side of that same judgment call).
+
+## Investigate before you commit to a plan
+
+Use a scout first whenever investigation is the cleanest way to remove uncertainty before
+writing a ship brief - especially before a mechanical brief, since mechanical dispatch later
+refuses drift against what the brief assumed.
+
+## What a mechanical ship brief needs
+
+Recommended headings, not syntax Hand parses - they are guidance, not a format the tooling
+enforces:
+
+- Goal
+- Verified current state
+- Locked decisions
+- Exact files/packages/symbols touched
+- Ordered implementation steps
+- Invariants that must hold afterward
+- Tests to add or update
+- Verification commands to run
+- Non-goals
+- Stop/escalate conditions
+
+## planned_against
+
+Immediately before finalizing every new execution-class brief, resolve the registered project's
+verified default branch under `<home>/projects/<project>`, investigate against that exact
+revision, and record its full commit ID as `planned_against` in the brief.
+
+Mechanical dispatch later compares the same local base and refuses on drift: if the project has
+moved since planning, it will not silently execute a plan against a base that no longer exists.
+Standard and deep dispatch retain `planned_against` as provenance only, without that hard
+refusal, since some plan-adjustment judgment is expected of those execution classes.
+
+```text
+wrong: the project advanced past planned_against, so bump the recorded SHA and re-dispatch
+right: the project advanced past planned_against, so re-check every assumption the brief made
+       against the new state, and rewrite or revalidate the plan - not just its provenance line
+```
+
+## Recording and dispatching the task
+
+- Edit `data/backlog.md` to record the task with a unique ID.
+- Write the brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status`
+  and the report vocabulary the worker should append to it (see
+  `references/task-lifecycle.md`).
+- Dispatch with `hand spawn <id> <project> [--scout] [--profile <name>] [--harness ...]
+  [--model ...] [--effort ...]`. Normally omit `--model`/`--effort`: use them only for a genuine
+  task-specific need, never as routine routing - routine routing belongs in a configured Route.

--- a/skills/secondhand/references/recovery.md
+++ b/skills/secondhand/references/recovery.md
@@ -1,0 +1,73 @@
+# Recovery
+
+## The one rule under all of this
+
+Hand never converts ambiguity into guessed success. Where it cannot observe something, it says
+so - `unknown`, `needs-repair`, or an explicit unprovable condition - rather than assuming the
+best case. Read that signal as exactly what it is, and do not resolve it with an assumption of
+your own either.
+
+## `hand status`'s repair fields
+
+A task's `repair`, `repair_code`, `repair_attempt`, `repair_reason`, and `repair_observed_at`
+columns (`hand status <id> --fields ...`) record when Hand itself found a condition it could not
+resolve deterministically. A populated `repair_code` is Hand telling you it hit a boundary, not
+a bug to route around - read `repair_reason` before deciding anything.
+
+## `hand reconcile`
+
+`hand reconcile [id]` converges durable task state with observed external reality: a running
+Attempt whose Herdr pane is observed absent reaches a terminal lifecycle here if it can be
+landed from evidence (an observed merge, a recorded delivery, or a scout report on disk);
+positively observed unlanded work interrupts it instead. Where landing cannot be observed at
+all, the result is `unknown` - no lifecycle value is invented.
+
+Three flags attest to a specific unprovable fact and require an explicit task ID; read
+`hand reconcile --help` in full before using any of them, since each refuses whenever anything
+on record could still prove or disprove the fact it attests to:
+
+- `--abandon-worktree` - Hand relinquishes a Treehouse lease it cannot establish ownership of. It
+  never returns, prunes, or deletes the worktree itself; the operator reclaims it through
+  Treehouse directly.
+- `--abandon-pane` - the same attestation for a Herdr pane identity; it closes no pane, tab, or
+  workspace.
+- `--attempt-never-started` - attests that a running Attempt's worker took no turn at all.
+
+wrong: treat `--abandon-*` as a general "unstick this task" hammer.
+
+right: use exactly the flag matching the specific unprovable fact, only after confirming the
+observation genuinely cannot resolve it - each flag refuses on its own if it can.
+
+None of these flags repair a live worker's resource; an active attempt is only reached through a
+recorded teardown decision. If the task is not actually stuck, `hand reconcile` without any of
+these flags is the right first move, since it may resolve the state from evidence alone.
+
+## Uncertain sends
+
+`hand status`'s `send_state` (for example `submitted`), `send_origin`, and `send_reason` columns
+record what Hand knows about the *delivery* of a message, not what the worker did with it.
+
+```text
+wrong: send_state is submitted, so the worker acknowledged or acted on the message
+right: submitted only means Hand's own delivery mechanism accepted it; observe the worker's next
+       report or state change before assuming it landed
+```
+
+Never blindly resend an uncertain send. A duplicate send into a worker that already acted on
+the first one can compound the confusion rather than resolve it. Observe first (re-read
+`hand status`, consider the pane), and only resend if the evidence genuinely shows the first one
+did not land.
+
+## Crash and restart
+
+Hand's durable state is `state/hand.db`; a supervisor restart does not lose Task/Attempt
+history. On restart, run `hand doctor` then `hand status` before acting on anything - do not
+assume the fleet is in the state you last remember, since a worker's own state can have changed
+while nothing was watching.
+
+## Immutable Attempt execution snapshots
+
+An Attempt's recorded execution details (harness, model, effort, `planned_against`, worktree)
+are fixed at spawn time and describe what actually ran, not a live configuration you can edit in
+place. If a task needs different execution parameters, that is `hand reopen` or `hand promote`
+starting a new Attempt, not an edit to the old one's record.

--- a/skills/secondhand/references/setup-doctor.md
+++ b/skills/secondhand/references/setup-doctor.md
@@ -1,0 +1,63 @@
+# Setup and doctor
+
+## The one command
+
+Run `hand doctor` whenever you start a session, after `hand update`, after a merge that touched
+fleet-generated surfaces, or whenever something feels off. It is report-only: it never repairs
+anything, so every finding it prints is yours to act on, not something it will fix on a later run.
+
+`hand doctor` prints a `findings` table with `line`, `severity`, and `finding` columns.
+Severity `error` means the run fails (nonzero exit); `warning` and `info` do not. Read every
+line, not just the exit code: a clean exit with warnings still means something is worth a look.
+
+## What doctor actually checks today
+
+- `AGENTS.md` against the canonical Hand-owned content, byte for byte. Any difference is one
+  `error` finding naming the exact remedy (`hand init <home>`); there is no partial-drift
+  detail because the whole file is generated, so there is nothing partial to report.
+- Windows only: the `CLAUDE.md` pointer file's presence and exact content.
+- Each registered project's no-mistakes gate state (`gate-absent`, or another gate problem).
+- Routing/configuration validity: missing Profiles or Routes, and whether the fleet is running
+  on explicit configuration or falling back to legacy defaults.
+
+Do not assume categories beyond what a given `hand doctor` build actually reports. If this
+reference and a live run disagree, the live run is right; report the mismatch rather than
+trusting the stale prose.
+
+## Distinguishing what a finding actually means
+
+Doctor's findings distinguish concepts that are easy to blur:
+
+```text
+supported by Hand       - the harness/tool is one Hand knows how to drive
+installed on PATH       - the binary is actually reachable from this environment
+configured              - an operator explicitly persisted a choice through hand config
+required                - this fleet or project cannot proceed without it
+optional                - useful but not blocking (no-mistakes is optional, never assumed)
+```
+
+wrong: treating an optional integration such as `no-mistakes` as though every project must
+have it configured before work can proceed.
+
+right: reading whether a *specific registered project* declared `no-mistakes` mode, and only
+then treating its gate as required for that project.
+
+Doctor never invents local installation state, account entitlement, provider billing state, or
+model availability. If a finding does not name one of those things explicitly, do not infer it.
+
+## Acting on findings
+
+- A generated-surface drift finding always names its own remedy command. Run exactly that
+  command; do not hand-edit the file it names, since it will be overwritten again on the next
+  `hand init` regardless.
+- A project gate finding means that project's no-mistakes state, not the fleet's. Read
+  `references/task-lifecycle.md` before dispatching further into that project.
+- A routing finding means read `references/configuration.md` before dispatching a task whose
+  Profile or Route is missing or invalid; do not guess a Profile to unblock a single dispatch.
+
+## First session in a new home
+
+`hand init` is non-interactive: it never asks a question or invents a worker default. On the
+first supervising session, run `hand config` to see the effective harness/model/effort state,
+then read `references/configuration.md` for how to propose and persist Profiles and Routes
+before the first dispatch.

--- a/skills/secondhand/references/supervision-loop.md
+++ b/skills/secondhand/references/supervision-loop.md
@@ -1,0 +1,81 @@
+# The supervision loop
+
+One bounded loop, not a framework: plan once, dispatch, observe, evaluate, decide exactly one
+next action, re-observe, and stop when the goal is actually satisfied.
+
+```text
+PLAN
+  |
+DISPATCH
+  |
+OBSERVE
+  |
+EVALUATE EVIDENCE AGAINST THE BRIEF   (references/evaluation.md)
+  |
+DECIDE EXACTLY ONE NEXT ACTION
+  |-- steer            (hand send)
+  |-- watch/wait        (hand watch --until-event)
+  |-- re-plan/reopen     (hand reopen, or a rewritten brief)
+  |-- hold               (hand hold set)
+  |-- investigate/reconcile (references/recovery.md)
+  |-- deliver            (hand deliver, hand merge)
+  `-- escalate to operator
+  |
+RE-OBSERVE
+  |
+STOP when the goal/terminal condition is satisfied
+```
+
+## Rules that keep this bounded
+
+- Do not loop merely because more improvement might still be possible. A brief has a stated
+  goal; once evidence satisfies it, stop, do not keep polishing.
+- One targeted correction, then observe its effect, before deciding anything further. Sending
+  three steers before seeing whether the first one landed is not supervision, it is noise into
+  a busy pane.
+- Repeated contradiction between what you expect and what you observe is a signal to re-plan or
+  escalate, not to keep steering around it.
+- A mechanical worker must not redesign stale assumptions; if the brief's `planned_against` has
+  drifted enough that its assumptions no longer hold, that is a re-plan, not a steer (see
+  `references/planning-and-briefs.md`).
+- Ambiguous machine evidence becomes investigation or repair, never guessed success. If
+  `hand status` or `hand reconcile` reports an unknown or unprovable condition, that is
+  `references/recovery.md`'s territory, not a coin flip.
+- Irreversible or genuinely policy-owned choices go to the operator, every time, regardless of
+  how far into a loop you are.
+
+## Deciding the next action
+
+Do not maintain a separate mental precedence table for what to do next: `hand session start`
+already reports one, deterministically, in its `next_action_kind`, `next_action_task`,
+`next_action_command`, and `next_action_reason` fields. Read those, act on the named command,
+and re-run `hand session start` (or `hand status`) after acting rather than assuming the fleet
+still looks the way it did before you acted.
+
+```text
+wrong: keeping your own running list of "what's next" across a long session
+right: re-reading hand session start's next_action_* fields after every action that could have
+       changed fleet state
+```
+
+## Watching, phase by phase
+
+There is no one universal "actionable events" list to filter on; the right `--event` filter
+depends on what phase of the loop you are in.
+
+```text
+wrong: always run hand watch --until-event with no --event filter, every time, at every phase
+right: while confirming a fresh dispatch actually launched, progress evidence may be what you
+       want to see; while waiting for a specific task to reach a terminal state, a narrower
+       terminal/error filter is more appropriate; check `hand watch --help` for the current
+       event kind list rather than assuming this reference's examples are exhaustive
+```
+
+After any wake, re-read fleet state before acting - the event that woke you is one fact, not the
+full current truth. A wake can arrive stale relative to what else has happened since.
+
+## Stop means stop
+
+When the goal is satisfied, or when the loop reaches an operator-escalation point, stop acting.
+Do not spawn a new Task, reopen another one, or pick up unrelated backlog items just because the
+loop is already running and capacity feels available.

--- a/skills/secondhand/references/task-lifecycle.md
+++ b/skills/secondhand/references/task-lifecycle.md
@@ -1,0 +1,66 @@
+# Task lifecycle
+
+## The commands, in normal order
+
+```sh
+hand spawn <id> <project> [--scout] [--profile <name>]     # launch a worker
+hand status [id]                                            # fleet overview, or one task's detail
+hand watch --until-event [--event <kinds>] [--timeout <d>]  # wait for the fleet's next actionable event
+hand send <id> <message>                                    # steer a running worker
+hand hold set <id> --kind operator --reason <text>           # waiting on the operator
+hand hold set <id> --kind blocked --reason <text> --blocked-on <other-id>
+hand hold clear <id>                                          # resolved; resume normal tracking
+hand deliver <id> --reason <text>                            # handed off; landing is someone else's call
+hand merge <id> [--squash|--merge|--rebase|--local]           # land a task's completed work
+hand teardown <id> [--force]                                  # clean up after landing (or --force if abandoned)
+hand reopen <id>                                              # start a new attempt on a terminal task
+hand promote <id>                                             # turn a completed scout into a ship task
+```
+
+## Reading `hand status`
+
+`hand status` with no ID shows the fleet overview; `hand status <id>` shows one task's full
+detail, including its report history. Use `--fields` to pick columns and `--full` for the
+untruncated single-task report line. A worker reports its own state on the `state` column via
+the vocabulary below; `reported` tracks the last report keyword seen; `flags` surfaces anything
+needing attention (for example `gate-absent`, `parked`, `merged-external`).
+
+## The report vocabulary a worker uses
+
+Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.
+`needs-decision:` is reserved for what a worker cannot take back; anything reversible, it
+decides itself and says so in first person - `working: deciding myself: <the call> because
+<reason>`.
+
+wrong: recording your own harness's answer to its own confirmation dialog as an operator
+decision.
+
+right: only a `hand send` message you actually sent counts as an operator decision; if you
+answered your own harness's prompt, that was you deciding, and it is reported that way.
+
+## Watching the fleet
+
+`hand watch --until-event` observes the fleet's already-actionable state first - so a condition
+that arrived while nothing was watching still wakes it - then waits for the next event and
+exits 0. Exit 8 means interruption and exit 9 means takeover replacement; neither is a fleet
+event. Re-arm it after acting on an event, or when intentionally resuming monitoring. See
+`references/supervision-loop.md` for which `--event` filter fits a given phase - there is no one
+universal filter.
+
+## Holds, delivery, and teardown
+
+- Waiting on the operator or on another task is a hold, not a note in a file you maintain
+  yourself: `hand hold set` records it, `hand hold clear` resolves it.
+- `hand deliver <id> --reason <text>` records that work is handed off and landing it is someone
+  else's call - use it before `hand teardown --force`, which is otherwise for work nobody
+  delivered.
+- Never force-teardown without explicit authorization, and never merge without explicit
+  authorization either; both are `AGENTS.md` invariants this skill does not relax.
+- Run `hand teardown <id>` once work has actually landed. `hand reconcile` (see
+  `references/recovery.md`) is the tool for ambiguous or interrupted lifecycle state; teardown
+  itself does not resolve ambiguity.
+
+## Never edit files under `projects/`
+
+Workers make their changes in their own isolated worktrees. Editing a registered project's
+mirror directly bypasses that isolation and is one of `AGENTS.md`'s standing invariants.


### PR DESCRIPTION
## Summary

- Embeds `skills/secondhand` (SKILL.md plus 8 references: setup-doctor, configuration, planning-and-briefs, task-lifecycle, supervision-loop, evaluation, recovery, bug-report) into the binary at build time via a small `skills` package (`go:embed`).
- `internal/skill` installs and reconciles the bundled skill into every supported per-harness project-local destination under a fleet home: `.claude/skills/secondhand`, `.grok/skills/secondhand`, `.pi/skills/secondhand`, and the shared `.agents/skills/secondhand` that Codex and OpenCode read (no distinct convention of their own). Ownership is deterministic per destination: create if missing, atomically refresh a stale Hand-managed copy (byte-for-byte comparison against the embedded canonical tree), refuse a foreign file at the managed entry path as a conflict rather than overwrite it. No symlink privilege required; every copy is a plain file.
- `hand init` now installs/reconciles the skill alongside AGENTS.md and reports each destination's outcome (`created`/`refreshed`/`unchanged`/`conflict`) plus a conflict count, with help text when a conflict needs manual resolution.
- Skill content consumes `hand`'s own CLI/runtime as authoritative throughout (`hand doctor`, `hand config`, `hand status`, `hand session start`'s `next_action_*` fields, `hand watch`, `hand reconcile`, etc.) rather than reimplementing any of that logic in prose, and explicitly rejects `hand judge`/`hand critic`/generic agent-swarm patterns per the issue's addendum.

Part of atqamz/hand#218.

## Stack

Second of the stacked series implementing #218. Base: `218-agents-md-immutable-migration` (#286, first in the stack - AGENTS.md immutability + migration). Next: init-as-reconciler, then update handoff, then doctor expansion, each stacked on the previous. Only the final PR in the series will use `Closes atqamz/hand#218`. Merge order: this PR merges after #286.

## Test plan

- `nix develop -c make lint`, `make test` (`go test -race ./...`), and `make e2e` all pass
- `nix develop -c make build`, then manually verified end to end against a scratch fleet home (HAND_HOME unset): `hand init` creates all four destinations with the exact embedded `SKILL.md` and all 8 references present
- New tests in `internal/skill`: fresh creation at every destination, no-op when already canonical (inode untouched), atomic refresh of a stale Hand-managed copy, refusal of a foreign file at one destination without blocking installation at the others, and that the shipped `SKILL.md` carries the ownership marker and no banned characters
- New tests in `cmd/init_test.go`: skill installed into every destination on a fresh `hand init`, and a foreign file at one destination is reported as a conflict and left untouched while the other destinations still install