### PR TITLE
docs(cmd): make hand init's fleet-reconciler contract explicit

### DIFF
--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -310,7 +310,7 @@ func TestDoctorTreatsMissingManagedMarkersAsViolation(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	// Refresh first so CLAUDE.md (a plain file on Windows, checked separately from
-	// AGENTS.md's markers) is already correct: the overwrite below isolates the one
+	// AGENTS.md's canonical content) is already correct: the overwrite below isolates the one
 	// violation under test rather than also tripping the Windows-only CLAUDE.md check.
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
@@ -384,7 +384,7 @@ func TestDoctorFailsWhenAgentsFileIsDeletedAfterInitialization(t *testing.T) {
 }
 
 // Every drift shape now collapses to one whole-file finding: the canonical AGENTS.md is
-// compared byte-for-byte, so there is no marker structure left for doctor to diagnose.
+// compared byte-for-byte, so doctor reports no partial-drift detail.
 func TestDoctorReportsDriftForMalformedOrForeignContentWithNoLineNumber(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/init_reconciler_test.go
+++ b/cmd/init_reconciler_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/routing"
+	"github.com/atqamz/hand/internal/state"
+)
+
+// hand init restores Hand-owned generated surfaces (AGENTS.md, the bundled skill) and preserves
+// everything else durable. TestInitLeavesExistingDataFilesAlone covers data/** skeleton files;
+// these cover the rest: config/**, project registration, and Task/Attempt history.
+
+func TestInitPreservesExistingProjectRegistration(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	mkFleetDirs(t, dir)
+	if err := project.Add(dir, project.Project{Name: "myproj", URL: "git@example.com:me/myproj.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok, err := project.Find(dir, "myproj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("got project unregistered after hand init, want it preserved")
+	}
+	if p.URL != "git@example.com:me/myproj.git" || p.Mode != project.ModeNoMistakes {
+		t.Fatalf("got %+v, want the registered project's fields unchanged", p)
+	}
+}
+
+func TestInitPreservesExistingConfigProfilesAndRoutes(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	mkFleetDirs(t, dir)
+	mustConfig(t, "profile", "set", "daily", "--harness", harness.Claude, "--model", "claude-opus-5")
+	mustConfig(t, "route", "set", "ship", "deep", "daily")
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := routing.LoadExecutionSnapshot(dir, harness.Claude, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, p := range snapshot.Config.Profiles {
+		if p.Name == "daily" && p.Harness == harness.Claude && p.Model == "claude-opus-5" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("got profiles %+v, want the daily profile preserved unchanged", snapshot.Config.Profiles)
+	}
+	var routeFound bool
+	for _, r := range snapshot.Config.Routes {
+		if r.Kind == routing.TaskKindShip && r.ExecutionClass == routing.ExecutionClassDeep && r.Profile == "daily" {
+			routeFound = true
+		}
+	}
+	if !routeFound {
+		t.Fatalf("got routes %+v, want the ship/deep route to daily preserved", snapshot.Config.Routes)
+	}
+}
+
+func TestInitPreservesExistingTaskAndAttemptHistory(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	mkFleetDirs(t, dir)
+	if err := state.CreateTask(dir, state.Task{
+		ID: "task-1", Project: "myproj", Kind: state.KindShip, Lifecycle: state.TaskOpen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := state.CreateAttempt(dir, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Harness: harness.Claude})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.UpdateTask(dir, state.Task{
+		ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		Lifecycle: state.TaskOpen, ActiveAttemptID: attempt.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := state.Read(dir, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Project != "myproj" || got.Kind != state.KindShip || got.Lifecycle != state.TaskOpen || got.ActiveAttemptID != attempt.ID {
+		t.Fatalf("got task %+v, want it unchanged by hand init", got)
+	}
+	gotAttempt, ok, err := state.ReadAttempt(dir, attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || gotAttempt.Lifecycle != state.AttemptRunning || gotAttempt.Harness != harness.Claude {
+		t.Fatalf("got attempt %+v ok=%v, want it unchanged by hand init", gotAttempt, ok)
+	}
+}
+
+// Repeated init is the reconciler's other half: a second run must reach the identical
+// steady state as the first, not merely avoid an error.
+func TestInitRepeatedRunsConvergeToTheSameSteadyState(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	for i := 0; i < 3; i++ {
+		cmd := newInitCmd()
+		cmd.SetArgs([]string{})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("run %d: %v", i+1, err)
+		}
+	}
+}

--- a/docs/adr/hand-init-is-the-canonical-fleet-reconciler.md
+++ b/docs/adr/hand-init-is-the-canonical-fleet-reconciler.md
@@ -1,0 +1,38 @@
+# hand init is the canonical fleet reconciler
+
+- Date: 2026-08-20
+- Status: accepted
+- Issues: atqamz/hand#218
+- PRs: none
+
+## Context
+
+`hand init` already served as an idempotent initialization and migration boundary before this record: it seeds `data/**` skeleton files that are missing, restores `AGENTS.md` (see [AGENTS.md is fully Hand-owned and immutable](agents-md-is-fully-hand-owned-and-immutable.md)), now installs the bundled `secondhand` Agent Skill (see the skill-bundling PR in atqamz/hand#218's stack), migrates legacy worker settings, and runs `project.Migrate` to open the durable store and apply schema/legacy-registry migration. What it does *not* do had never been written down anywhere as a contract: a fleet home's `data/**` content beyond the skeletons, `config/**` values, registered projects, and Task/Attempt history all already survived every `hand init` call, but only as an emergent property of what the command happened not to touch.
+
+## Decision
+
+`hand init`'s contract is now explicit: initialize a new fleet home, or reconcile an existing one to the canonical layout the running binary expects. Every surface it touches falls into exactly one of two behaviors:
+
+| Surface | Owner | `hand init` behavior |
+|---|---|---|
+| `AGENTS.md` / `CLAUDE.md` reference | Hand | restore canonical, byte-for-byte |
+| bundled `secondhand` skill | Hand | install missing, refresh stale, refuse foreign |
+| `data/operator.md`, `data/backlog.md`, `data/learnings.md`, `data/done-archive.md`, `data/note-archive.md`, `data/projects.md` | Supervisor/operator | create if missing, otherwise preserve |
+| other `data/**` | Fleet | preserve |
+| `config/**` | Operator, via `hand config` | preserve; migrate representation only |
+| project registration | Fleet/runtime | preserve |
+| `state/hand.db` (Task/Attempt history) | Hand runtime | schema-migrate, never reset |
+
+Running `hand init` repeatedly is safe and idempotent: a home already on the canonical layout converges to the identical state on every subsequent call, and nothing durable it did not create is ever reset, regardless of how many times it runs.
+
+This ownership split is enforced by what `hand init` calls, not by a new reconciliation engine: `agentsmd.Refresh` and `skill.Refresh` own the restore column, `initSkeletonFiles` only writes a file that does not already exist, `project.Migrate` opens the store and only imports a legacy registry once, and nothing in the command's `RunE` ever deletes or overwrites a project row, a config value, or a Task/Attempt record.
+
+## Rejected alternatives
+
+- A dedicated `hand reconcile-home` command separate from `init` duplicates the same idempotent-restore logic under a second name, and gives an operator two commands to remember for the same operation `hand init` already owns.
+- Resetting `config/**`, project registration, or Task/Attempt history on `hand init` to guarantee a "clean" reconciliation destroys exactly the durable state the issue this record closes explicitly forbids resetting.
+- Auto-classifying a fleet home's living `data/**` content into a fresh shape on every init treats memory as regenerable, which it is not: only the skeleton's *presence* is Hand's to guarantee, never its content once a human or supervisor has written to it.
+
+## Consequences
+
+An operator or supervisor can always run `hand init` to bring a fleet home's generated surfaces current without fear of losing configuration, project registrations, or task history - the same guarantee `hand update`'s direct self-update path depends on when it hands reconciliation to the newly installed binary. `cmd/init_reconciler_test.go` asserts each preserve-column of the table directly (project registration, config profiles/routes, Task/Attempt history) and that three consecutive `hand init` runs converge to the same steady state, so a regression that started resetting durable state on init fails a focused test instead of only surfacing as a field report.


### PR DESCRIPTION
## Summary

- hand init already preserved config/**, project registration, and Task/Attempt history across every run - true only because nothing in its RunE happened to touch them, never asserted directly and never documented as a contract.
- New ADR `hand-init-is-the-canonical-fleet-reconciler.md` records the ownership matrix explicitly: `AGENTS.md`/`CLAUDE.md` and the bundled skill restore; data/**, config/**, project registration, and Task/Attempt history preserve.
- New tests in `cmd/init_reconciler_test.go` assert each preserve column directly: project registration, config profiles/routes, and Task/Attempt history survive `hand init` unchanged, plus a three-consecutive-runs convergence test.
- No functional code changes: `cmd/init.go` already satisfied this contract correctly.

Part of atqamz/hand#218.

## Stack

Third of the stacked series implementing #218. Base: `218-secondhand-skill-bundling` (#287, second in the stack). Next: update handoff, then doctor expansion, each stacked on the previous. Only the final PR in the series will use `Closes atqamz/hand#218`. Merge order: this PR merges after #287.

## Test plan

- `nix develop -c make lint`, `make test` (`go test -race ./...`), and `make e2e` all pass
- New tests directly exercise the preserve columns of the ownership matrix: register a project / set a config profile+route / create a task+attempt, run `hand init`, assert each is byte-for-byte or field-for-field unchanged