### PR TITLE
feat(cmd): hand update hands fleet reconciliation to the new binary

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,14 +3,12 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
+	"os/exec"
 	"strings"
 
-	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/selfupdate"
-	"github.com/atqamz/hand/internal/sessionhook"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +58,7 @@ func newUpdateCmd(info selfupdate.BuildInfo) *cobra.Command {
 			}
 
 			if !newer || checkOnly {
-				doc := updateDoc(info, target, newer, false, "not-applicable", "not-applicable", nil)
+				doc := updateDoc(info, target, newer, false, "not-applicable", nil)
 				if newer {
 					doc.Help(updateHelp(target, requestedChannel != ""))
 				}
@@ -68,7 +66,7 @@ func newUpdateCmd(info selfupdate.BuildInfo) *cobra.Command {
 			}
 
 			if !selfupdate.CanSelfUpdate(info.Distribution) {
-				doc := updateDoc(info, target, true, false, "not-applicable", "not-applicable", nil)
+				doc := updateDoc(info, target, true, false, "not-applicable", nil)
 				doc.Help(ownershipRefusalHelp(info.Distribution))
 				return doc.Render(cmd.OutOrStdout())
 			}
@@ -77,62 +75,22 @@ func newUpdateCmd(info selfupdate.BuildInfo) *cobra.Command {
 				return err
 			}
 
-			// The binary is already replaced by this point, so a failed AGENTS.md refresh or skeleton seed is
-			// reported as a warning rather than an error: exiting nonzero here reads as "the update failed" and
-			// invites a pointless re-run.
-			var refresh agentsmd.RefreshResult
-			var hookRemoved bool
-			var seedErr, hookErr error
-			fleetHome, refreshErr := home.Resolve()
-			switch {
-			case refreshErr == nil:
-				refresh, refreshErr = agentsmd.Refresh(fleetHome)
-				// The refreshed template directs the agent at data files an older home never had, so the command
-				// that installs it also leaves those files in place - directories included, since a home resolves
-				// as one on its state/hand.db marker alone.
-				seedErr = initLayout(fleetHome)
-				// Generated instructions supersede the Claude-only hook, so an
-				// update retires Secondhand's command without touching others.
-				if refreshErr == nil {
-					var exe string
-					if exe, hookErr = os.Executable(); hookErr == nil {
-						hookRemoved, hookErr = sessionhook.Remove(fleetHome, exe)
-					}
-				}
-			case errors.Is(refreshErr, home.ErrNotFound):
-				refreshErr = nil
-			}
-
-			if refreshErr != nil {
-				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: refresh AGENTS.md: %v\n", refreshErr); err != nil {
-					return err
-				}
-			}
-			if hookErr != nil {
-				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: retire the session hook: %v\n", hookErr); err != nil {
-					return err
-				}
-			}
-			if seedErr != nil {
-				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: seed data skeletons: %v\n", seedErr); err != nil {
+			// The binary is already replaced by this point, so a failed handoff is reported as a
+			// warning rather than an error: exiting nonzero here reads as "the update failed" and
+			// invites a pointless re-run of a step that already succeeded.
+			result, homeErr := reconcileFleetHome()
+			if homeErr != nil {
+				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: resolve fleet home for reconciliation: %v\n", homeErr); err != nil {
 					return err
 				}
 			}
 			notes, _ := selfupdate.ReleaseNotes(selfupdate.Repo, target.Tag)
 
-			doc := updateDoc(
-				info,
-				target,
-				true,
-				true,
-				refreshOutcome(fleetHome, refresh.Changed, refreshErr),
-				retirementOutcome(fleetHome, hookRemoved, hookErr),
-				releaseNoteLines(notes),
-			)
-			if refresh.ArchivedPath != "" {
-				doc.Field("agents_md_legacy_archive", refresh.ArchivedPath)
+			doc := updateDoc(info, target, true, true, result.status, releaseNoteLines(notes))
+			if len(result.output) > 0 {
+				doc.List("fleet_reconcile_output", result.output)
 			}
-			doc.Help("Run `hand doctor` to check this home's AGENTS.md against the template " + target.Version + " installed")
+			doc.Help("Run `hand doctor` to check this home's generated surfaces against the template " + target.Version + " installed")
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}
@@ -142,7 +100,51 @@ func newUpdateCmd(info selfupdate.BuildInfo) *cobra.Command {
 	return cmd
 }
 
-func updateDoc(info selfupdate.BuildInfo, target selfupdate.Target, available, updated bool, agentsMD, sessionHook string, notes []string) axi.Doc {
+// Reports what handing reconciliation to the newly installed binary found.
+type fleetReconcileResult struct {
+	status string
+	output []string
+}
+
+// Hands fleet-home reconciliation to the binary selfupdate.Apply just installed: the old binary
+// only knows how to replace itself, the new one owns what a valid fleet home looks like. The
+// returned error is a resolution failure other than "not found", reported as a warning only.
+func reconcileFleetHome() (fleetReconcileResult, error) {
+	fleetHome, err := home.Resolve()
+	switch {
+	case err == nil:
+	case errors.Is(err, home.ErrNotFound):
+		return fleetReconcileResult{status: "no-fleet-home"}, nil
+	default:
+		return fleetReconcileResult{status: "failed", output: []string{err.Error()}}, err
+	}
+
+	// The same override selfupdate.Apply consults, so a test that stages a fake executable
+	// exercises the actual binary the handoff execs, not the real running process's path.
+	exe, err := selfupdate.ExecutableOverride()
+	if err != nil {
+		return fleetReconcileResult{status: "failed", output: []string{err.Error()}}, nil
+	}
+	out, runErr := exec.Command(exe, "init", fleetHome).CombinedOutput()
+	lines := nonEmptyLines(string(out))
+	if runErr != nil {
+		lines = append(lines, runErr.Error())
+		return fleetReconcileResult{status: "failed", output: lines}, nil
+	}
+	return fleetReconcileResult{status: "ok", output: lines}, nil
+}
+
+func nonEmptyLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
+func updateDoc(info selfupdate.BuildInfo, target selfupdate.Target, available, updated bool, fleetReconcile string, notes []string) axi.Doc {
 	var doc axi.Doc
 	doc.Field("current", info.Version)
 	doc.Field("current_channel", info.Channel)
@@ -153,8 +155,7 @@ func updateDoc(info selfupdate.BuildInfo, target selfupdate.Target, available, u
 	doc.Field("latest_commit", selfupdate.DisplayCommit(target.Commit))
 	doc.Bool("update_available", available)
 	doc.Bool("updated", updated)
-	doc.Field("agents_md", agentsMD)
-	doc.Field("session_hook", sessionHook)
+	doc.Field("fleet_reconcile", fleetReconcile)
 	doc.List("notes", notes)
 	return doc
 }
@@ -164,7 +165,7 @@ func updateHelp(target selfupdate.Target, explicit bool) string {
 	if explicit {
 		command += " --channel " + target.Channel
 	}
-	return "Run `" + command + "` to install " + target.Version + ", which also refreshes this home's AGENTS.md template"
+	return "Run `" + command + "` to install " + target.Version + ", which also reconciles this home's generated fleet surfaces via hand init"
 }
 
 // A package manager's install is its own to manage, and a go/source build was never a
@@ -179,40 +180,6 @@ func ownershipRefusalHelp(distribution string) string {
 	}
 }
 
-// The binary is replaced whatever this says, so every outcome is a value of
-// one field rather than a line that appears or does not.
-func refreshOutcome(fleetHome string, changed bool, err error) string {
-	switch {
-	case err != nil:
-		return "failed"
-	case fleetHome == "":
-		return "no-fleet-home"
-	case changed:
-		return "refreshed"
-	default:
-		return "unchanged"
-	}
-}
-
-func retirementOutcome(fleetHome string, changed bool, err error) string {
-	switch {
-	case err != nil:
-		return "failed"
-	case fleetHome == "":
-		return "no-fleet-home"
-	case changed:
-		return "removed"
-	default:
-		return "unchanged"
-	}
-}
-
 func releaseNoteLines(notes string) []string {
-	var lines []string
-	for _, line := range strings.Split(notes, "\n") {
-		if trimmed := strings.TrimSpace(line); trimmed != "" {
-			lines = append(lines, trimmed)
-		}
-	}
-	return lines
+	return nonEmptyLines(notes)
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -96,6 +96,18 @@ func buildUpdateFixture(t *testing.T, binaryContent []byte) string {
 	return dir
 }
 
+// The bytes of the shared fake-tool dispatcher, staged as the "new binary" a release fixture
+// installs. Real once execDir/hand carries both these bytes and a sibling fake config: os.Args[0]
+// resolves to the same path whichever content selfupdate.Apply staged there.
+func newBinaryFixtureBytes(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile(faketool.DispatcherBinaryPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
 func setFakeExecutable(t *testing.T) string {
 	t.Helper()
 	execDir := t.TempDir()
@@ -107,6 +119,34 @@ func setFakeExecutable(t *testing.T) string {
 	selfupdate.ExecutableOverride = func() (string, error) { return execPath, nil }
 	t.Cleanup(func() { selfupdate.ExecutableOverride = restore })
 	return execPath
+}
+
+// Stages a fake "new hand" at execDir: once selfupdate.Apply replaces execPath with the same
+// dispatcher bytes (newBinaryFixtureBytes), invoking it as `init <fleetHome>` writes agentsMD at
+// that path, proving the handoff ran the new binary with the right argv without a real hand init.
+func writeFakeNewBinaryInitBehavior(t *testing.T, execDir, agentsMD string) {
+	t.Helper()
+	faketool.Command{
+		Name: "hand",
+		Args: true,
+		FileAction: &faketool.FileAction{
+			PathArg:  1,
+			Relative: "AGENTS.md",
+			Content:  agentsMD,
+		},
+	}.Install(t, execDir)
+}
+
+// Same as writeFakeNewBinaryInitBehavior, but the fake new binary exits nonzero instead of
+// succeeding, for the failed-handoff path.
+func writeFakeNewBinaryInitFailure(t *testing.T, execDir string, exitCode int, stderr string) {
+	t.Helper()
+	faketool.Command{
+		Name:   "hand",
+		Args:   true,
+		Stderr: stderr,
+		Exit:   exitCode,
+	}.Install(t, execDir)
 }
 
 func writeOwnedSessionHook(t *testing.T, home string) {
@@ -121,36 +161,17 @@ func writeOwnedSessionHook(t *testing.T, home string) {
 	}
 }
 
-// Every outcome renders the same seven fields, so a reader parses one schema
-// rather than a set of lines that appear or do not.
-func appliedUpdateDoc(agentsMD, sessionHook string, notes ...string) string {
-	doc := "current: v0.1.0\n" +
-		"current_channel: stable\n" +
-		"current_commit: unknown\n" +
-		"distribution: \"\"\n" +
-		"latest: v0.5.0\n" +
-		"latest_channel: stable\n" +
-		"latest_commit: unknown\n" +
-		"update_available: true\n" +
-		"updated: true\n" +
-		"agents_md: " + agentsMD + "\n" +
-		"session_hook: " + sessionHook + "\n" +
-		fmt.Sprintf("notes[%d]:\n", len(notes))
-	for _, note := range notes {
-		doc += "  - " + note + "\n"
-	}
-	return doc + "help[1]:\n" +
-		"  - Run `hand doctor` to check this home's AGENTS.md against the template v0.5.0 installed\n"
-}
+const fakeCanonicalAgentsMD = "## Secondhand supervisor bootstrap\n\nBefore responding or acting in a supervising session, run `hand session start`.\n"
 
-func TestUpdateRefreshesWorkspaceAndReportsChanges(t *testing.T) {
-	setFakeExecutable(t)
+func TestUpdateHandsFleetReconciliationToTheNewlyInstalledBinary(t *testing.T) {
+	execPath := setFakeExecutable(t)
+	execDir := filepath.Dir(execPath)
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
-	writeOwnedSessionHook(t, home)
+	writeFakeNewBinaryInitBehavior(t, execDir, fakeCanonicalAgentsMD)
 
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	fixture := buildUpdateFixture(t, newBinaryFixtureBytes(t))
 	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -162,141 +183,34 @@ func TestUpdateRefreshesWorkspaceAndReportsChanges(t *testing.T) {
 	}
 
 	got := out.String()
-	if want := appliedUpdateDoc("refreshed", "removed", "fixed the frobnicator"); got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if !strings.Contains(got, "updated: true\n") || !strings.Contains(got, "fleet_reconcile: ok\n") {
+		t.Fatalf("got %q, want updated=true and fleet_reconcile=ok", got)
+	}
+	if !strings.Contains(got, "fixed the frobnicator") {
+		t.Fatalf("got %q, want the release notes", got)
 	}
 
+	// Proves the new binary ran against this exact fleet home, not merely that some
+	// process exited zero: the fake only writes AGENTS.md when invoked as init <home>.
 	agentsMD, err := os.ReadFile(filepath.Join(home, "AGENTS.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(agentsMD), "## Secondhand supervisor bootstrap") {
-		t.Fatalf("got %q, want AGENTS.md written with the supervisor bootstrap", agentsMD)
-	}
-	settings, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(settings), "/old/path/hand") || !strings.Contains(string(settings), "/usr/bin/custom") {
-		t.Fatalf("settings = %q, want only the unrelated hook preserved", settings)
+	if string(agentsMD) != fakeCanonicalAgentsMD {
+		t.Fatalf("got AGENTS.md %q, want %q", agentsMD, fakeCanonicalAgentsMD)
 	}
 }
 
-// The refreshed template directs the agent at data files a home initialized
-// before them never had, so update seeds whichever are missing.
-func TestUpdateSeedsDataSkeletonsMissingFromAnOlderHome(t *testing.T) {
-	setFakeExecutable(t)
-	home := t.TempDir()
-	t.Chdir(home)
-	mkFleetDirs(t, home)
-
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
-	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
-
-	cmd := newUpdateCmd(stableBuild("v0.1.0"))
-	var out, errOut bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&errOut)
-	cmd.SetArgs(nil)
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-
-	want := map[string]string{
-		"data/backlog.md":      "# Backlog",
-		"data/operator.md":     "## Hard constraints",
-		"data/learnings.md":    "# Learnings",
-		"data/done-archive.md": "# Done archive",
-		"data/note-archive.md": "# Note archive",
-	}
-	for rel, header := range want {
-		got, err := os.ReadFile(filepath.Join(home, rel))
-		if err != nil {
-			t.Fatalf("%s missing after update: %v", rel, err)
-		}
-		if !strings.Contains(string(got), header) {
-			t.Fatalf("%s = %q, want it to contain %q", rel, got, header)
-		}
-	}
-	if errOut.Len() != 0 {
-		t.Fatalf("got stderr %q, want none", errOut.String())
-	}
-}
-
-// A home whose data/ directory is gone still resolves as a home on its
-// state/hand.db marker, so update has to create the directory it seeds into
-// rather than warning about six files it could not write.
-func TestUpdateRecreatesAMissingDataDirectory(t *testing.T) {
-	setFakeExecutable(t)
-	home := t.TempDir()
-	t.Chdir(home)
-	mkFleetDirs(t, home)
-	if err := os.RemoveAll(filepath.Join(home, "data")); err != nil {
-		t.Fatal(err)
-	}
-
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
-	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
-
-	cmd := newUpdateCmd(stableBuild("v0.1.0"))
-	var out, errOut bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&errOut)
-	cmd.SetArgs(nil)
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-
-	if errOut.Len() != 0 {
-		t.Fatalf("got stderr %q, want none", errOut.String())
-	}
-	for _, rel := range []string{"data/backlog.md", "data/projects.md", "data/operator.md", "data/learnings.md", "data/done-archive.md", "data/note-archive.md"} {
-		if _, err := os.Stat(filepath.Join(home, rel)); err != nil {
-			t.Fatalf("%s missing after update: %v", rel, err)
-		}
-	}
-}
-
-func TestUpdateLeavesExistingOperatorContextAlone(t *testing.T) {
-	setFakeExecutable(t)
-	home := t.TempDir()
-	t.Chdir(home)
-	mkFleetDirs(t, home)
-
-	existing := "# Operator\n\n## Authority\n\nMerge without asking.\n"
-	if err := os.WriteFile(filepath.Join(home, "data", "operator.md"), []byte(existing), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
-	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
-
-	cmd := newUpdateCmd(stableBuild("v0.1.0"))
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs(nil)
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(filepath.Join(home, "data", "operator.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != existing {
-		t.Fatalf("data/operator.md = %q, want unchanged %q", got, existing)
-	}
-}
-
-func TestUpdateRefreshesHandHomeRatherThanWorkingDirectory(t *testing.T) {
-	setFakeExecutable(t)
+func TestUpdateHandsOffToTheHandHomeRatherThanTheWorkingDirectory(t *testing.T) {
+	execPath := setFakeExecutable(t)
+	execDir := filepath.Dir(execPath)
 	fleetHome := t.TempDir()
 	mkFleetDirs(t, fleetHome)
-	writeOwnedSessionHook(t, fleetHome)
 	t.Setenv("HAND_HOME", fleetHome)
 	t.Chdir(t.TempDir())
+	writeFakeNewBinaryInitBehavior(t, execDir, fakeCanonicalAgentsMD)
 
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	fixture := buildUpdateFixture(t, newBinaryFixtureBytes(t))
 	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -306,28 +220,26 @@ func TestUpdateRefreshesHandHomeRatherThanWorkingDirectory(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-
-	got := out.String()
-	if want := appliedUpdateDoc("refreshed", "removed", "fixed the frobnicator"); got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if !strings.Contains(out.String(), "fleet_reconcile: ok\n") {
+		t.Fatalf("got %q, want fleet_reconcile=ok", out.String())
 	}
 
-	agentsMD, err := os.ReadFile(filepath.Join(fleetHome, "AGENTS.md"))
-	if err != nil {
-		t.Fatal(err)
+	if _, err := os.ReadFile(filepath.Join(fleetHome, "AGENTS.md")); err != nil {
+		t.Fatalf("got no AGENTS.md written under HAND_HOME: %v", err)
 	}
-	if !strings.Contains(string(agentsMD), "## Secondhand supervisor bootstrap") {
-		t.Fatalf("got %q, want AGENTS.md written with the supervisor bootstrap", agentsMD)
+	if _, err := os.Stat(filepath.Join(t.TempDir(), "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("got AGENTS.md written under the working directory instead of HAND_HOME, err=%v", err)
 	}
 }
 
-func TestUpdateSkipsAgentsRefreshOutsideAFleetHome(t *testing.T) {
+func TestUpdateSkipsFleetReconciliationOutsideAFleetHome(t *testing.T) {
 	setFakeExecutable(t)
 	t.Setenv("HAND_HOME", "")
 	home := t.TempDir()
 	t.Chdir(home)
+	// No fake "init" behavior installed: reaching it at all would be the bug this proves absent.
 
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	fixture := buildUpdateFixture(t, newBinaryFixtureBytes(t))
 	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -339,8 +251,8 @@ func TestUpdateSkipsAgentsRefreshOutsideAFleetHome(t *testing.T) {
 	}
 
 	got := out.String()
-	if want := appliedUpdateDoc("no-fleet-home", "no-fleet-home", "fixed the frobnicator"); got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if !strings.Contains(got, "updated: true\n") || !strings.Contains(got, "fleet_reconcile: no-fleet-home\n") {
+		t.Fatalf("got %q, want updated=true and fleet_reconcile=no-fleet-home", got)
 	}
 	if _, err := os.Stat(filepath.Join(home, "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("got AGENTS.md written outside a fleet home, err=%v", err)
@@ -349,7 +261,7 @@ func TestUpdateSkipsAgentsRefreshOutsideAFleetHome(t *testing.T) {
 
 // "No home here" is the silent skip; "HAND_HOME names something that is not a
 // home" is a misconfiguration, and swallowing it would leave the operator with
-// an unrefreshed AGENTS.md and nothing on stderr saying why.
+// an unreconciled fleet home and nothing on stderr saying why.
 func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
 	setFakeExecutable(t)
 	home := t.TempDir()
@@ -357,7 +269,7 @@ func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
 	notAHome := t.TempDir()
 	t.Setenv("HAND_HOME", notAHome)
 
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	fixture := buildUpdateFixture(t, newBinaryFixtureBytes(t))
 	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -370,22 +282,57 @@ func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
 	}
 
 	got := out.String()
-	if want := appliedUpdateDoc("failed", "no-fleet-home", "fixed the frobnicator"); got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if !strings.Contains(got, "fleet_reconcile: failed\n") {
+		t.Fatalf("got %q, want fleet_reconcile=failed", got)
 	}
 	quotedHome := fmt.Sprintf("%q", notAHome)
-	if !strings.Contains(errOut.String(), "warning: refresh AGENTS.md:") || !strings.Contains(errOut.String(), quotedHome) {
+	if !strings.Contains(errOut.String(), "warning: resolve fleet home for reconciliation:") || !strings.Contains(errOut.String(), quotedHome) {
 		t.Fatalf("got stderr %q, want a warning naming %q", errOut.String(), quotedHome)
 	}
 }
 
-func TestUpdateDegradesGracefullyWithoutReleaseNotes(t *testing.T) {
-	setFakeExecutable(t)
+// The binary is already replaced before the handoff runs, so the new binary exiting nonzero
+// must not turn a successful update into a nonzero exit or pretend the binary swap failed too.
+func TestUpdateReportsFailedFleetReconcileWhenTheNewBinaryExitsNonzero(t *testing.T) {
+	execPath := setFakeExecutable(t)
+	execDir := filepath.Dir(execPath)
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
+	writeFakeNewBinaryInitFailure(t, execDir, 1, "simulated init failure\n")
 
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
+	fixture := buildUpdateFixture(t, newBinaryFixtureBytes(t))
+	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
+
+	cmd := newUpdateCmd(stableBuild("v0.1.0"))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want a successful update despite the new binary's init failing", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "updated: true\n") {
+		t.Fatalf("got %q, want the binary replacement itself still reported as succeeded", got)
+	}
+	if !strings.Contains(got, "fleet_reconcile: failed\n") {
+		t.Fatalf("got %q, want fleet_reconcile=failed", got)
+	}
+	if !strings.Contains(got, "simulated init failure") {
+		t.Fatalf("got %q, want the new binary's own error surfaced", got)
+	}
+}
+
+func TestUpdateDegradesGracefullyWithoutReleaseNotes(t *testing.T) {
+	execPath := setFakeExecutable(t)
+	execDir := filepath.Dir(execPath)
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeNewBinaryInitBehavior(t, execDir, fakeCanonicalAgentsMD)
+
+	fixture := buildUpdateFixture(t, newBinaryFixtureBytes(t))
 	writeFakeGHUpdate(t, "v0.5.0", "", fixture)
 
 	cmd := newUpdateCmd(stableBuild("v0.1.0"))
@@ -397,125 +344,8 @@ func TestUpdateDegradesGracefullyWithoutReleaseNotes(t *testing.T) {
 	}
 
 	got := out.String()
-	if want := appliedUpdateDoc("refreshed", "unchanged"); got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-}
-
-// The binary is already replaced before the refresh runs, so a refresh failure
-// must not turn a successful update into a nonzero exit.
-func TestUpdateReportsVersionsWhenAgentsRefreshFails(t *testing.T) {
-	setFakeExecutable(t)
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "AGENTS.md"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(home)
-	mkFleetDirs(t, home)
-
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
-	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
-
-	cmd := newUpdateCmd(stableBuild("v0.1.0"))
-	var out, errOut bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&errOut)
-	cmd.SetArgs(nil)
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("got %v, want a successful update despite the refresh failure", err)
-	}
-
-	got := out.String()
-	if want := appliedUpdateDoc("failed", "unchanged", "fixed the frobnicator"); got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-	if !strings.Contains(errOut.String(), "warning: refresh AGENTS.md:") {
-		t.Fatalf("got stderr %q, want a refresh warning", errOut.String())
-	}
-}
-
-func TestUpdatePreservesOwnedSessionHookWhenAgentsRefreshFails(t *testing.T) {
-	setFakeExecutable(t)
-	home := t.TempDir()
-	t.Chdir(home)
-	mkFleetDirs(t, home)
-	malformed := "<!-- hand:generated:start -->\n<!-- hand:generated:start -->\n<!-- hand:generated:end -->\n"
-	if err := os.WriteFile(filepath.Join(home, "AGENTS.md"), []byte(malformed), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	writeOwnedSessionHook(t, home)
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	before, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
-	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
-
-	cmd := newUpdateCmd(stableBuild("v0.1.0"))
-	var out, errOut bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&errOut)
-	cmd.SetArgs(nil)
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("got %v, want a successful binary update despite the refresh failure", err)
-	}
-
-	if want := appliedUpdateDoc("failed", "unchanged", "fixed the frobnicator"); out.String() != want {
-		t.Fatalf("got %q, want %q", out.String(), want)
-	}
-	if !strings.Contains(errOut.String(), "warning: refresh AGENTS.md:") {
-		t.Fatalf("stderr = %q, want the refresh warning", errOut.String())
-	}
-	if strings.Contains(errOut.String(), "retire the session hook") {
-		t.Fatalf("stderr = %q, want no retirement attempt after refresh failed", errOut.String())
-	}
-	after, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(after, before) {
-		t.Fatalf("settings changed after refresh failure:\n got %s\nwant %s", after, before)
-	}
-}
-
-// The binary is already replaced before retirement runs, so malformed operator
-// settings produce a warning and a failed field without changing update success.
-func TestUpdateReportsVersionsWhenSessionHookRetirementFails(t *testing.T) {
-	setFakeExecutable(t)
-	home := t.TempDir()
-	t.Chdir(home)
-	mkFleetDirs(t, home)
-	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	path := filepath.Join(home, ".claude", "settings.json")
-	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	fixture := buildUpdateFixture(t, []byte("new binary contents"))
-	writeFakeGHUpdate(t, "v0.5.0", "fixed the frobnicator", fixture)
-
-	cmd := newUpdateCmd(stableBuild("v0.1.0"))
-	var out, errOut bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&errOut)
-	cmd.SetArgs(nil)
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("got %v, want a successful update despite hook retirement failure", err)
-	}
-
-	if want := appliedUpdateDoc("refreshed", "failed", "fixed the frobnicator"); out.String() != want {
-		t.Fatalf("got %q, want %q", out.String(), want)
-	}
-	if !strings.Contains(errOut.String(), "warning: retire the session hook:") {
-		t.Fatalf("got stderr %q, want a retirement warning", errOut.String())
-	}
-	raw, err := os.ReadFile(path)
-	if err != nil || string(raw) != "{not json" {
-		t.Fatalf("settings = %q, %v, want invalid settings untouched", raw, err)
+	if !strings.Contains(got, "fleet_reconcile: ok\n") || !strings.Contains(got, "notes[0]:\n") {
+		t.Fatalf("got %q, want fleet_reconcile=ok and an empty notes list", got)
 	}
 }
 
@@ -533,14 +363,13 @@ func checkedUpdateDoc(current, latest string, available bool) string {
 		"latest_commit: unknown\n" +
 		fmt.Sprintf("update_available: %t\n", available) +
 		"updated: false\n" +
-		"agents_md: not-applicable\n" +
-		"session_hook: not-applicable\n" +
+		"fleet_reconcile: not-applicable\n" +
 		"notes[0]:\n"
 	if !available {
 		return doc
 	}
 	return doc + "help[1]:\n" +
-		"  - Run `hand update` to install " + latest + ", which also refreshes this home's AGENTS.md template\n"
+		"  - Run `hand update` to install " + latest + ", which also reconciles this home's generated fleet surfaces via hand init\n"
 }
 
 func TestUpdateCheckReportsAvailableUpdate(t *testing.T) {

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -143,6 +143,14 @@ func installConfigData(t *testing.T, bin, name string, spec installSpec) {
 	writeFile(t, configPath(bin, name), string(config))
 }
 
+// DispatcherBinaryPath returns the shared fake-tool dispatcher binary's own path, building it once
+// per test process, for a caller that needs its bytes directly - such as staging them as a
+// stand-in for a real executable a test subprocess later replaces - rather than installing it.
+func DispatcherBinaryPath(t *testing.T) string {
+	t.Helper()
+	return helperBinary(t)
+}
+
 func helperBinary(t *testing.T) string {
 	t.Helper()
 	helperBuild.Do(func() {


### PR DESCRIPTION
## Summary

- The direct self-update path no longer calls `agentsmd.Refresh`, `initLayout`, or `sessionhook.Remove` in-process after replacing the binary. Once `selfupdate.Apply` installs the new release, `hand update` execs that same binary as `hand init <fleetHome>` and reports the result as one `fleet_reconcile` field (`ok`/`failed`/`no-fleet-home`/`not-applicable`) plus the subprocess's own captured output.
- The old binary only knows how to replace itself; the new binary owns what a valid fleet home for its own version looks like (generated surfaces, the bundled skill, layout, schema), so none of that knowledge is duplicated in the updater anymore - including the skill-install step PR3's review flagged as missing from the old in-process path.
- Package-manager-owned installs are unaffected: refused before reaching this path, `hand doctor` + `hand init` remain their reconciliation route per atqamz/hand#177.
- Adds `internal/faketool.DispatcherBinaryPath` so a test can stage the shared fake-tool dispatcher as a real, runnable stand-in for the "new" release binary - proving the handoff execs the right binary with the right argv, not merely that some process exited zero.
- Fixed a real bug caught while writing that test: `reconcileFleetHome` now resolves the exec target via `selfupdate.ExecutableOverride` (the same override `Apply` already consults) instead of raw `os.Executable`, which under `go test` resolves to the compiled test binary itself - the first version of this change was silently re-invoking the whole test suite recursively as its own "new binary."

Part of atqamz/hand#218.

## Stack

Fourth of the stacked series implementing #218. Base: `218-init-canonical-reconciler` (#289, third in the stack). Next: doctor expansion, the final PR, which will use `Closes atqamz/hand#218`. Merge order: this PR merges after #289.

## Test plan

- `nix develop -c make lint`, `make test` (`go test -race ./...`), and `make e2e` all pass
- Removed six tests whose premise (independently failing in-process refresh/skeleton-seed/session-hook-retirement steps) no longer exists under the new design; that coverage already lives in `cmd/init_test.go`, which owns those behaviors exclusively now
- New tests in `cmd/update_test.go`: the handoff execs the new binary against the resolved fleet home (not the working directory), `HAND_HOME` is respected over cwd, no fleet home skips the handoff entirely, a misconfigured `HAND_HOME` reports failed with a warning, and the new binary exiting nonzero reports `fleet_reconcile: failed` while `updated: true` still holds (binary replacement isn't undone)