### PR TITLE
feat(cmd): expand hand doctor into the canonical diagnostic command

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Optional:
 - [no-mistakes](https://github.com/kunchenguid/no-mistakes) - required only by projects using `no-mistakes` mode
 - [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
 
-`hand init` reports checked tools it cannot find on `PATH`. `hand doctor` reports fleet health: generated agent-instruction drift, project no-mistakes gate failures, routing configuration drift, and effective routing decisions.
+`hand init` reports checked tools it cannot find on `PATH`. `hand doctor` reports fleet health: `AGENTS.md` and bundled-skill drift or conflicts, required tools missing from `PATH`, project no-mistakes gate failures, routing configuration drift, effective routing decisions, and the running binary's version, channel, commit, and distribution.
 
 Building from source additionally requires Go 1.26.5 or newer.
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -12,8 +12,15 @@ import (
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/routing"
+	"github.com/atqamz/hand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/skill"
 	"github.com/spf13/cobra"
 )
+
+// The external tools every ordinary dispatch and delivery path needs regardless of which
+// projects are registered; no-mistakes is checked separately, per project, since it is only
+// required for a project explicitly configured in that delivery mode.
+var requiredTools = []string{"treehouse", "herdr", "gh"}
 
 type doctorSeverity string
 
@@ -42,12 +49,12 @@ var doctorFields = []axi.Column[doctorFinding]{
 
 var doctorDefaultFields = []string{"line", "severity", "finding"}
 
-func newDoctorCmd() *cobra.Command {
+func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 	var fields []string
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Check fleet health, including AGENTS.md, project gates, and routing",
+		Short: "Check fleet health: AGENTS.md, the bundled skill, project gates, routing, and tools",
 		Args:  usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fleetHome, err := home.Resolve()
@@ -73,6 +80,10 @@ func newDoctorCmd() *cobra.Command {
 
 			var doc axi.Doc
 			doc.Field("file", path)
+			doc.Field("version", info.Version)
+			doc.Field("channel", info.Channel)
+			doc.Field("commit", selfupdate.DisplayCommit(info.Commit))
+			doc.Field("distribution", info.Distribution)
 			doc.Int("count", len(findings))
 			doc.Int("violations", failing)
 			axi.Table(&doc, "findings", findings, cols)
@@ -92,17 +103,36 @@ func newDoctorCmd() *cobra.Command {
 }
 
 func doctorFindings(fleetHome string) ([]doctorFinding, error) {
-	violations, err := agentsmd.Check(fleetHome)
+	findings := make([]doctorFinding, 0)
+
+	agentsViolations, err := agentsmd.Check(fleetHome)
 	if err != nil {
 		return nil, err
 	}
-	findings := make([]doctorFinding, 0, len(violations))
-	for _, violation := range violations {
+	for _, violation := range agentsViolations {
 		severity := doctorError
 		if violation.Severity == agentsmd.SeverityInfo {
 			severity = doctorInfo
 		}
 		findings = append(findings, doctorFinding{Line: violation.Line, Severity: severity, Text: violation.Text})
+	}
+
+	skillViolations, err := skill.Check(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	for _, violation := range skillViolations {
+		severity := doctorError
+		if violation.Severity == skill.SeverityInfo {
+			severity = doctorInfo
+		}
+		findings = append(findings, doctorFinding{Severity: severity, Text: violation.Text})
+	}
+
+	for _, tool := range requiredTools {
+		if !onPath(tool) {
+			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("required tool %q is not on PATH", tool)})
+		}
 	}
 
 	projects, err := project.ListReadOnly(fleetHome)
@@ -216,6 +246,7 @@ func doctorHelp(count, failing int) []string {
 	}
 	return []string{
 		"Resolve every error finding; hand doctor reports and never rewrites",
-		"Run `hand update` for generated-block drift, or inspect project gates and routing configuration for fleet health findings",
+		"Run `hand init` to restore AGENTS.md or the bundled skill; a foreign file conflict at a skill destination must be moved aside by hand first",
+		"Inspect project gates and routing configuration for the remaining fleet health findings",
 	}
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,9 +11,12 @@ import (
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/routing"
+	"github.com/atqamz/hand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/skill"
 )
 
 func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
@@ -28,6 +32,9 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 				if _, err := agentsmd.Refresh(home); err != nil {
 					t.Fatal(err)
 				}
+				if _, err := skill.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
 				mustConfigSet(t, settingHarness, harness.Claude)
 			},
 			want: []doctorFinding{{Severity: doctorInfo, Text: `routing resolves through explicit legacy defaults: harness "claude"`}},
@@ -37,6 +44,9 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 			setup: func(t *testing.T, home string) {
 				t.Helper()
 				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := skill.Refresh(home); err != nil {
 					t.Fatal(err)
 				}
 				if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
@@ -51,6 +61,9 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 			setup: func(t *testing.T, home string) {
 				t.Helper()
 				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := skill.Refresh(home); err != nil {
 					t.Fatal(err)
 				}
 				if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
@@ -70,6 +83,9 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 				if _, err := agentsmd.Refresh(home); err != nil {
 					t.Fatal(err)
 				}
+				if _, err := skill.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
 				mustConfigSet(t, settingHarness, harness.Claude)
 			},
 			want: []doctorFinding{{Severity: doctorInfo, Text: `routing resolves through explicit legacy defaults: harness "claude"`}},
@@ -81,6 +97,9 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 				if _, err := agentsmd.Refresh(home); err != nil {
 					t.Fatal(err)
 				}
+				if _, err := skill.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
 			},
 			want: []doctorFinding{{Severity: doctorWarning, Text: `routing falls back to legacy defaults without explicit intent: harness "claude"`}},
 		},
@@ -89,6 +108,9 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 			setup: func(t *testing.T, home string) {
 				t.Helper()
 				if _, err := agentsmd.Refresh(home); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := skill.Refresh(home); err != nil {
 					t.Fatal(err)
 				}
 				if err := routing.WriteProfile(home, routing.Profile{Name: "daily", Harness: harness.Claude}); err != nil {
@@ -130,6 +152,9 @@ func TestDoctorIncludesProjectListGateFinding(t *testing.T) {
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	mustConfigSet(t, settingHarness, harness.Claude)
 	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
 		t.Fatal(err)
@@ -163,16 +188,30 @@ func TestDoctorCleanFleetReportsEffectiveRouting(t *testing.T) {
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	mustConfigSet(t, settingHarness, harness.Claude)
+	// Every required tool present, so this run's only finding is the routing decision under
+	// test - onPath only checks PATH presence, never invokes any of these, so zero-valued
+	// fakes are enough.
+	bin := faketool.Bin(t)
+	faketool.Treehouse{}.Install(t, bin)
+	faketool.Herdr{}.Install(t, bin)
+	faketool.GH{}.Install(t, bin)
 
 	var out bytes.Buffer
-	cmd := newDoctorCmd()
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
 	cmd.SetOut(&out)
 	cmd.SetArgs(nil)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("got error %v, want nil for a clean AGENTS.md", err)
 	}
 	want := "file: " + axi.Value(filepath.Join(home, "AGENTS.md")) + "\n" +
+		"version: v0.1.0\n" +
+		"channel: stable\n" +
+		"commit: unknown\n" +
+		"distribution: \"\"\n" +
 		"count: 1\n" +
 		"violations: 0\n" +
 		"findings[1]{line,severity,finding}:\n" +
@@ -189,6 +228,9 @@ func TestDoctorReportsConfiguredRoutingDecision(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
 	if err := routing.WriteProfile(home, routing.Profile{Name: "daily", Harness: harness.Claude, Model: "opus", Effort: "high"}); err != nil {
@@ -216,6 +258,9 @@ func TestDoctorReportsUnresolvedConfiguredRoutingDecision(t *testing.T) {
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(home, "config", "routes"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -239,6 +284,9 @@ func TestDoctorReportsMalformedRoutingBeforeEffectiveFallback(t *testing.T) {
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
 	profileDir := filepath.Join(home, "config", "profiles", "broken")
@@ -276,6 +324,9 @@ func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	path := filepath.Join(home, "AGENTS.md")
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
@@ -289,7 +340,7 @@ func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	cmd := newDoctorCmd()
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
 	cmd.SetOut(&out)
 	cmd.SetArgs(nil)
 	err = cmd.Execute()
@@ -315,13 +366,16 @@ func TestDoctorTreatsMissingManagedMarkersAsViolation(t *testing.T) {
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(home, "AGENTS.md"),
 		[]byte("# Hand-authored, no generated markers\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	var out bytes.Buffer
-	cmd := newDoctorCmd()
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
 	cmd.SetOut(&out)
 	cmd.SetArgs(nil)
 	if err := cmd.Execute(); err == nil {
@@ -343,12 +397,15 @@ func TestDoctorFailsWhenManagedMarkersAreRemovedAfterInitialization(t *testing.T
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(path, []byte("# Hand-authored, no generated markers\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	var out bytes.Buffer
-	cmd := newDoctorCmd()
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
 	cmd.SetOut(&out)
 	cmd.SetArgs(nil)
 	if err := cmd.Execute(); err == nil {
@@ -367,12 +424,15 @@ func TestDoctorFailsWhenAgentsFileIsDeletedAfterInitialization(t *testing.T) {
 	if _, err := agentsmd.Refresh(home); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Remove(path); err != nil {
 		t.Fatal(err)
 	}
 
 	var out bytes.Buffer
-	cmd := newDoctorCmd()
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
 	cmd.SetOut(&out)
 	cmd.SetArgs(nil)
 	if err := cmd.Execute(); err == nil {
@@ -404,7 +464,7 @@ func TestDoctorReportsDriftForMalformedOrForeignContentWithNoLineNumber(t *testi
 			}
 
 			var out bytes.Buffer
-			cmd := newDoctorCmd()
+			cmd := newDoctorCmd(stableBuild("v0.1.0"))
 			cmd.SetOut(&out)
 			cmd.SetArgs(nil)
 			if err := cmd.Execute(); err == nil {
@@ -422,7 +482,7 @@ func TestDoctorOutsideFleetHomeIsPrecondition(t *testing.T) {
 	t.Chdir(dir)
 	t.Setenv("HAND_HOME", "")
 
-	cmd := newDoctorCmd()
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetArgs(nil)
 	err := cmd.Execute()
@@ -432,5 +492,155 @@ func TestDoctorOutsideFleetHomeIsPrecondition(t *testing.T) {
 	var exitErr *ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
 		t.Fatalf("got %v, want an ExitError with code 3", err)
+	}
+}
+
+func TestDoctorReportsBinaryVersionChannelCommitAndDistribution(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+
+	var out bytes.Buffer
+	info := selfupdate.BuildInfo{Version: "v0.6.0", Channel: selfupdate.ChannelEdge, Commit: "abcdef1234567890", Distribution: selfupdate.DistributionBrew}
+	cmd := newDoctorCmd(info)
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"version: v0.6.0\n",
+		"channel: edge\n",
+		"commit: " + selfupdate.DisplayCommit("abcdef1234567890") + "\n",
+		"distribution: " + selfupdate.DistributionBrew + "\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestDoctorFlagsEveryMissingBundledSkillDestination(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	// No skill.Refresh: every destination is missing.
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, f := range findings {
+		if strings.Contains(f.Text, "bundled skill is missing") {
+			if f.Severity != doctorError {
+				t.Fatalf("got severity %v for a missing-skill finding, want error", f.Severity)
+			}
+			n++
+		}
+	}
+	if n != len(skill.DestinationDirs(home)) {
+		t.Fatalf("got %d missing-skill findings, want one per destination (%d): %#v", n, len(skill.DestinationDirs(home)), findings)
+	}
+}
+
+func TestDoctorFlagsADriftedBundledSkillFile(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	dir := skill.DestinationDirs(home)[0]
+	path := filepath.Join(dir, "SKILL.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(content, []byte("\nstray\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDoctorFinding(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("bundled skill at %s has drifted from the canonical content: run hand init '%s' to refresh it", dir, home)}) {
+		t.Fatalf("findings = %#v, want a drift finding naming %s", findings, dir)
+	}
+}
+
+func TestDoctorFlagsAForeignFileAtASkillDestinationAsAConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	dir := skill.DestinationDirs(home)[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# unrelated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, f := range findings {
+		if strings.Contains(f.Text, "foreign, unmanaged file") {
+			found = true
+			if f.Severity != doctorError {
+				t.Fatalf("got severity %v for a skill conflict finding, want error", f.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("findings = %#v, want a foreign-file conflict finding for %s", findings, dir)
+	}
+}
+
+func TestDoctorWarnsOnEachMissingRequiredTool(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	faketool.NoTools(t)
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range requiredTools {
+		want := doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("required tool %q is not on PATH", tool)}
+		if !hasDoctorFinding(findings, want) {
+			t.Fatalf("findings = %#v, want a missing-tool warning for %q", findings, tool)
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.AddCommand(newReopenCmd())
 	root.AddCommand(newNotifyCmd())
 	root.AddCommand(newSearchCmd())
-	root.AddCommand(newDoctorCmd())
+	root.AddCommand(newDoctorCmd(info))
 	root.AddCommand(newUpdateCmd(info))
 	// ExecuteC would add the completion group later, too late for the guard below.
 	root.InitDefaultCompletionCmd()

--- a/cmd/smoke_test.go
+++ b/cmd/smoke_test.go
@@ -42,7 +42,7 @@ func TestSmokeInitProjectAddDoctorLifecycle(t *testing.T) {
 		t.Fatalf("clone missing treehouse.toml: %v", err)
 	}
 
-	if err := newDoctorCmd().Execute(); err != nil {
+	if err := newDoctorCmd(stableBuild("v0.1.0")).Execute(); err != nil {
 		t.Fatalf("doctor: %v", err)
 	}
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -13,6 +13,7 @@ import (
 	"github.com/atqamz/hand/internal/atomicfile"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/shellquote"
 	hskills "github.com/atqamz/hand/skills"
 )
 
@@ -23,10 +24,39 @@ const Name = "secondhand"
 // have a fixed, cheap starting point rather than a directory listing.
 const entryFile = "SKILL.md"
 
-// The frontmatter line the canonical SKILL.md carries. Presence alone distinguishes a
-// Hand-managed copy from a foreign file at the same destination; not a security boundary,
-// only a deterministic ownership signal.
+// The frontmatter field the canonical SKILL.md's metadata block carries. Presence as an actual
+// frontmatter line, not merely a substring anywhere in the file, distinguishes a Hand-managed
+// copy from a foreign file at the same destination; not a security boundary.
 const managedMarker = "managed-by: hand"
+
+// The frontmatter delimiter Agent Skill files use to bound their YAML metadata block.
+const frontmatterDelimiter = "---"
+
+// Reports whether content's frontmatter block - the span between its first two lines that are
+// exactly "---" - contains managedMarker as one of its own lines, so a foreign file that merely
+// mentions the marker in prose is never mistaken for a Hand-managed copy.
+func isManaged(content string) bool {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != frontmatterDelimiter {
+		return false
+	}
+	closeAt := -1
+	for i, line := range lines[1:] {
+		if strings.TrimSpace(line) == frontmatterDelimiter {
+			closeAt = i
+			break
+		}
+	}
+	if closeAt < 0 {
+		return false
+	}
+	for _, line := range lines[1 : 1+closeAt] {
+		if strings.TrimSpace(line) == managedMarker {
+			return true
+		}
+	}
+	return false
+}
 
 type destination struct {
 	rel string
@@ -111,13 +141,23 @@ func refreshOne(destDir string, files map[string][]byte) (Outcome, error) {
 	existing, err := os.ReadFile(entryPath)
 	switch {
 	case os.IsNotExist(err):
+		occupied, err := destDirHasAnyEntry(destDir)
+		if err != nil {
+			return "", err
+		}
+		if occupied {
+			// SKILL.md is absent, but something else already occupies this destination: a
+			// partial or foreign install with no ownership marker to trust. Refuse rather
+			// than let writeAll silently overwrite whatever is already there.
+			return OutcomeConflict, nil
+		}
 		if err := writeAll(destDir, files); err != nil {
 			return "", err
 		}
 		return OutcomeCreated, nil
 	case err != nil:
 		return "", fmt.Errorf("read %s: %w", entryPath, err)
-	case !strings.Contains(string(existing), managedMarker):
+	case !isManaged(string(existing)):
 		return OutcomeConflict, nil
 	}
 
@@ -132,6 +172,19 @@ func refreshOne(destDir string, files map[string][]byte) (Outcome, error) {
 		return "", err
 	}
 	return OutcomeRefreshed, nil
+}
+
+// Reports whether destDir exists and already contains at least one entry, so a missing SKILL.md
+// is trusted as "genuinely empty destination" only when nothing else backs that assumption up.
+func destDirHasAnyEntry(destDir string) (bool, error) {
+	entries, err := os.ReadDir(destDir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", destDir, err)
+	}
+	return len(entries) > 0, nil
 }
 
 func isStale(destDir string, files map[string][]byte) (bool, error) {
@@ -161,6 +214,78 @@ func writeAll(destDir string, files map[string][]byte) error {
 		}
 	}
 	return nil
+}
+
+// Severity distinguishes a Violation that fails hand doctor from one that is informational.
+type Severity int
+
+const (
+	SeverityViolation Severity = iota
+	SeverityInfo
+)
+
+// Violation is one drift, missing-file, or conflict finding Check found at one destination.
+type Violation struct {
+	Dir      string
+	Text     string
+	Severity Severity
+}
+
+// Check reports whether every supported destination's bundled skill matches the canonical
+// content, without fixing anything, the same report/restore split agentsmd.Check draws for
+// AGENTS.md. A nil result with no error means dir is not a fleet home.
+func Check(dir string) ([]Violation, error) {
+	isHome, err := home.IsHome(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !isHome {
+		return nil, nil
+	}
+
+	files, err := canonicalFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	var violations []Violation
+	for _, destDir := range DestinationDirs(dir) {
+		v, err := checkOne(dir, destDir, files)
+		if err != nil {
+			return nil, fmt.Errorf("check skill at %s: %w", destDir, err)
+		}
+		violations = append(violations, v...)
+	}
+	return violations, nil
+}
+
+func checkOne(fleetHome, destDir string, files map[string][]byte) ([]Violation, error) {
+	entryPath := filepath.Join(destDir, entryFile)
+	existing, err := os.ReadFile(entryPath)
+	switch {
+	case os.IsNotExist(err):
+		occupied, occErr := destDirHasAnyEntry(destDir)
+		if occErr != nil {
+			return nil, occErr
+		}
+		if occupied {
+			return []Violation{{Dir: destDir, Text: fmt.Sprintf("bundled skill at %s has unmanaged content with no SKILL.md to identify it: move it aside, then run hand init %s to install the skill there", destDir, shellquote.Quote(fleetHome))}}, nil
+		}
+		return []Violation{{Dir: destDir, Text: fmt.Sprintf("bundled skill is missing at %s: run hand init %s to install it", destDir, shellquote.Quote(fleetHome))}}, nil
+	case err != nil:
+		return nil, fmt.Errorf("read %s: %w", entryPath, err)
+	case !isManaged(string(existing)):
+		return []Violation{{Dir: destDir, Text: fmt.Sprintf("bundled skill at %s is a foreign, unmanaged file: move it aside, then run hand init %s to install the skill there", destDir, shellquote.Quote(fleetHome))}}, nil
+	}
+
+	stale, err := isStale(destDir, files)
+	if err != nil {
+		return nil, err
+	}
+	if !stale {
+		return nil, nil
+	}
+	return []Violation{{Dir: destDir, Text: fmt.Sprintf("bundled skill at %s has drifted from the canonical content: run hand init %s to refresh it", destDir, shellquote.Quote(fleetHome))}}, nil
 }
 
 // Walks the embedded skill tree once into a flat relative-path -> content map, so every

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -199,6 +199,123 @@ func TestRefreshRefusesAForeignFileWithoutOverwritingIt(t *testing.T) {
 	}
 }
 
+// A destination can be missing SKILL.md while still holding other files: a partial install left
+// over from a prior failed write, or content a user created without ever adding a SKILL.md.
+// Refresh must not treat "no SKILL.md" as "safe to write" in that case.
+func TestRefreshRefusesToWriteOverUnmarkedContentWhenSkillMdIsMissing(t *testing.T) {
+	home := makeHome(t)
+	dir := DestinationDirs(home)[0]
+	if err := os.MkdirAll(filepath.Join(dir, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := "# Someone else's notes\n"
+	foreignPath := filepath.Join(dir, "references", "recovery.md")
+	if err := os.WriteFile(foreignPath, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, ok := outcomeFor(results, dir)
+	if !ok || outcome != OutcomeConflict {
+		t.Fatalf("got outcome %q ok=%v, want conflict when unmarked content already occupies the destination", outcome, ok)
+	}
+	got, err := os.ReadFile(foreignPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != foreign {
+		t.Fatalf("got %q, want the pre-existing file left exactly as written", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatalf("got SKILL.md written into an occupied, unmarked destination, err=%v", err)
+	}
+}
+
+func TestCheckFlagsUnmarkedContentAtAMissingDestinationAsAConflict(t *testing.T) {
+	home := makeHome(t)
+	dir := DestinationDirs(home)[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	violations, err := Check(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "unmanaged content with no SKILL.md") {
+		t.Fatalf("got %v, want an unmanaged-content violation for %s", violations, dir)
+	}
+	if hasViolation(violations, "bundled skill is missing at "+dir+":") {
+		t.Fatalf("got %v, want the occupied-destination wording, not the plain missing wording", violations)
+	}
+}
+
+// The marker must be an actual frontmatter line, not merely a substring anywhere in the file:
+// a foreign skill that happens to mention it in prose must still be refused as a conflict.
+func TestRefreshTreatsAMarkerMentionedOutsideFrontmatterAsForeign(t *testing.T) {
+	home := makeHome(t)
+	dir := DestinationDirs(home)[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := "# Someone else's skill\n\nThis document mentions managed-by: hand in passing, not as frontmatter.\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, ok := outcomeFor(results, dir)
+	if !ok || outcome != OutcomeConflict {
+		t.Fatalf("got outcome %q ok=%v, want conflict for a marker mentioned outside frontmatter", outcome, ok)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != foreign {
+		t.Fatalf("got %q, want the foreign file left exactly as written", got)
+	}
+}
+
+// The marker only counts inside a properly closed frontmatter block: an unclosed "---" must not
+// let the rest of the file be scanned as if it were still frontmatter.
+func TestRefreshTreatsAnUnclosedFrontmatterAsForeignEvenIfTheMarkerAppears(t *testing.T) {
+	home := makeHome(t)
+	dir := DestinationDirs(home)[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := "---\nmanaged-by: hand\n\n# The frontmatter above never closes.\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Refresh(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, ok := outcomeFor(results, dir)
+	if !ok || outcome != OutcomeConflict {
+		t.Fatalf("got outcome %q ok=%v, want conflict for an unclosed frontmatter block", outcome, ok)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != foreign {
+		t.Fatalf("got %q, want the foreign file left exactly as written", got)
+	}
+}
+
 func TestRefreshEmbeddedSkillCarriesTheManagedMarkerAndNoBannedCharacters(t *testing.T) {
 	home := makeHome(t)
 	if _, err := Refresh(home); err != nil {
@@ -217,5 +334,105 @@ func TestRefreshEmbeddedSkillCarriesTheManagedMarkerAndNoBannedCharacters(t *tes
 	}
 	if strings.ContainsRune(content, '—') {
 		t.Fatal("got an em dash in the canonical SKILL.md, want none")
+	}
+}
+
+func hasViolation(violations []Violation, substr string) bool {
+	for _, v := range violations {
+		if strings.Contains(v.Text, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCheckSkipsNonFleetHome(t *testing.T) {
+	violations, err := Check(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if violations != nil {
+		t.Fatalf("got %v, want nil outside a fleet home", violations)
+	}
+}
+
+func TestCheckFlagsMissingDestinationsBeforeAnyRefresh(t *testing.T) {
+	home := makeHome(t)
+	violations, err := Check(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != len(DestinationDirs(home)) {
+		t.Fatalf("got %d violations, want one per destination: %v", len(violations), violations)
+	}
+	if !hasViolation(violations, "bundled skill is missing") {
+		t.Fatalf("got %v, want a missing-skill violation", violations)
+	}
+}
+
+func TestCheckCleanRightAfterRefresh(t *testing.T) {
+	home := makeHome(t)
+	if _, err := Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	violations, err := Check(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("got %v, want no violations right after Refresh", violations)
+	}
+}
+
+func TestCheckFlagsDriftedSkillContent(t *testing.T) {
+	home := makeHome(t)
+	if _, err := Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	dir := DestinationDirs(home)[0]
+	path := filepath.Join(dir, "SKILL.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(content, []byte("\nstray line\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	violations, err := Check(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 1 || violations[0].Dir != dir {
+		t.Fatalf("got %v, want exactly one violation naming %s", violations, dir)
+	}
+	if !hasViolation(violations, "has drifted from the canonical content") {
+		t.Fatalf("got %v, want a drift violation", violations)
+	}
+	if !hasViolation(violations, "run hand init '"+home+"'") {
+		t.Fatalf("got %v, want the remedy to name the resolved home", violations)
+	}
+}
+
+func TestCheckFlagsAForeignFileAsAConflict(t *testing.T) {
+	home := makeHome(t)
+	dir := DestinationDirs(home)[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# unrelated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	violations, err := Check(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasViolation(violations, "foreign, unmanaged file") {
+		t.Fatalf("got %v, want a foreign-file violation for %s", violations, dir)
+	}
+	// The other destinations are still genuinely missing, distinct from this conflict.
+	if n := len(violations); n != len(DestinationDirs(home)) {
+		t.Fatalf("got %d violations, want one per destination (one conflict, the rest missing): %v", n, violations)
 	}
 }

--- a/skills/secondhand/references/setup-doctor.md
+++ b/skills/secondhand/references/setup-doctor.md
@@ -15,10 +15,19 @@ line, not just the exit code: a clean exit with warnings still means something i
 - `AGENTS.md` against the canonical Hand-owned content, byte for byte. Any difference is one
   `error` finding naming the exact remedy (`hand init <home>`); there is no partial-drift
   detail because the whole file is generated, so there is nothing partial to report.
+- The bundled `secondhand` skill at every supported destination: missing (`error`), drifted from
+  the canonical content (`error`), or a foreign/unmanaged file occupying the destination
+  (`error`, refuse-to-overwrite) - each names its own remedy, and a collision is distinguished
+  from ordinary drift because a collision needs a human to move something aside first.
 - Windows only: the `CLAUDE.md` pointer file's presence and exact content.
 - Each registered project's no-mistakes gate state (`gate-absent`, or another gate problem).
 - Routing/configuration validity: missing Profiles or Routes, and whether the fleet is running
   on explicit configuration or falling back to legacy defaults.
+- Required external tools (`treehouse`, `herdr`, `gh`) missing from `PATH` (`warning`);
+  `no-mistakes` is checked per project instead, since it is only required for a project
+  explicitly configured in that delivery mode, never a blanket fleet requirement.
+- The running binary's `version`, `channel`, `commit`, and `distribution`, as plain fields
+  rather than findings - useful context when comparing a fleet's state against a bug report.
 
 Do not assume categories beyond what a given `hand doctor` build actually reports. If this
 reference and a live run disagree, the live run is right; report the mismatch rather than


### PR DESCRIPTION
## Summary

- Adds `internal/skill.Check`, mirroring `agentsmd.Check`'s report-only byte-for-byte comparison: missing, drifted, and foreign/conflict findings per supported skill destination, distinguishing a collision `hand init` must refuse to overwrite from ordinary drift it will fix on the next run.
- `hand doctor` now reports the running binary's `version`, `channel`, `commit`, and `distribution`, and flags each required external tool (`treehouse`, `herdr`, `gh`) missing from `PATH` as a warning finding. `no-mistakes` stays a per-project check (already existed), since it is only required for a project explicitly configured in that delivery mode - not a blanket fleet requirement.
- No provider subscription, quota, or model-catalog scraping introduced; nothing here invents local installation state or account entitlement beyond a deterministic `PATH` lookup.
- `hand doctor` remains report-only throughout: every new finding names its own remedy (`hand init <home>` or "move it aside"), and doctor never rewrites anything itself.

Part of atqamz/hand#218.

## Stack

Fifth and final PR of the stacked series implementing #218. Base: `218-update-init-handoff` (#291, fourth in the stack). Merge order: this PR merges last, after #291.

Closes atqamz/hand#218

## Test plan

- `nix develop -c make lint`, `make test` (`go test -race ./...`), and `make e2e` all pass
- New tests in `internal/skill`: `Check` is clean right after `Refresh`, flags every destination missing before any refresh, flags drift with the correct remedy naming the resolved home, and distinguishes a foreign/conflict file from an ordinarily-missing destination
- New tests in `cmd/doctor_test.go`: binary version/channel/commit/distribution fields render correctly, every missing skill destination is flagged at error severity, a drifted skill file is flagged with the right remedy, a foreign file at a skill destination is flagged as a conflict, and each missing required tool produces its own warning finding
- Existing doctor tests updated to install the bundled skill in their "clean fleet" setup, since a doctor run genuinely reports skill findings now (this is real new coverage, not something the old tests were failing to check)
- Manually verified end to end against a scratch fleet home (`HAND_HOME` unset): a fresh `hand init` followed by `hand doctor` is clean; removing `.claude/skills` produces exactly the missing-skill error and remedy, and exit code 1