### PR TITLE
feat(cmd): add doctor readiness contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,12 @@ Every command resolves the fleet home from `HAND_HOME` when set, otherwise from 
 
 `hand` itself is a self-contained Go binary. Operating a fleet relies on a few external tools:
 
+- [git](https://git-scm.com/) - repository operations
 - [herdr](https://github.com/ogulcancelik/herdr) - interactive worker sessions and semantic agent state
 - [treehouse](https://github.com/kunchenguid/treehouse) v2.1.0 or newer - isolated git worktree pools
-- [gh](https://github.com/cli/cli) - GitHub pull-request and release operations
 - at least one supported coding-agent harness
+
+Projects using `direct-pr` or `no-mistakes` delivery also require [gh](https://github.com/cli/cli) for GitHub operations.
 
 Optional:
 
@@ -305,6 +307,7 @@ Optional:
 - [qmd](https://github.com/tobi/qmd) - semantic search over historical fleet context beyond `hand search`
 
 `hand init` reports checked tools it cannot find on `PATH`. `hand doctor` reports fleet health: `AGENTS.md` and bundled-skill drift or conflicts, required tools missing from `PATH`, project no-mistakes gate failures, routing configuration drift, effective routing decisions, and the running binary's version, channel, commit, and distribution.
+Its structured output also exposes the bootstrap readiness contract: foundational tools, contextual `gh` requirements, every supported harness as installed or not installed, and the `ready`, `blocking`, and `next` fields.
 
 Building from source additionally requires Go 1.26.5 or newer.
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -17,10 +17,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// The external tools every ordinary dispatch and delivery path needs regardless of which
-// projects are registered; no-mistakes is checked separately, per project, since it is only
-// required for a project explicitly configured in that delivery mode.
-var requiredTools = []string{"treehouse", "herdr", "gh"}
+// Every fleet needs these regardless of which projects are registered, so bootstrap may install
+// them with consent; gh and a coding-agent harness are checked separately below, since the
+// former is only required by some project delivery modes and hand never picks the latter.
+var foundationalTools = []string{"git", "treehouse", "herdr"}
 
 type doctorSeverity string
 
@@ -48,6 +48,30 @@ var doctorFields = []axi.Column[doctorFinding]{
 }
 
 var doctorDefaultFields = []string{"line", "severity", "finding"}
+
+// This is the readiness contract a bootstrapper, a human and a supervising agent all read off
+// the same `hand doctor` output instead of any of them inventing a second schema.
+type toolReadiness struct {
+	Tool      string
+	Installed bool
+	Required  bool
+}
+
+type harnessReadiness struct {
+	Name      string
+	Installed bool
+}
+
+var toolReadinessFields = []axi.Column[toolReadiness]{
+	{Name: "tool", Value: func(t toolReadiness) string { return t.Tool }},
+	{Name: "installed", Value: func(t toolReadiness) string { return strconv.FormatBool(t.Installed) }},
+	{Name: "required", Value: func(t toolReadiness) string { return strconv.FormatBool(t.Required) }},
+}
+
+var harnessReadinessFields = []axi.Column[harnessReadiness]{
+	{Name: "name", Value: func(h harnessReadiness) string { return h.Name }},
+	{Name: "installed", Value: func(h harnessReadiness) string { return strconv.FormatBool(h.Installed) }},
+}
 
 func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 	var fields []string
@@ -78,6 +102,15 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 				}
 			}
 
+			projects, err := project.ListReadOnly(fleetHome)
+			if err != nil {
+				return err
+			}
+			tools := doctorTools(projects)
+			harnesses := doctorHarnesses()
+			blocking := doctorBlocking(failing, tools, harnesses)
+			next := doctorNext(blocking)
+
 			var doc axi.Doc
 			doc.Field("file", path)
 			doc.Field("version", info.Version)
@@ -86,6 +119,11 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			doc.Field("distribution", info.Distribution)
 			doc.Int("count", len(findings))
 			doc.Int("violations", failing)
+			axi.Table(&doc, "tools", tools, toolReadinessFields)
+			axi.Table(&doc, "harnesses", harnesses, harnessReadinessFields)
+			doc.Bool("ready", len(blocking) == 0)
+			doc.List("blocking", blocking)
+			doc.List("next", next)
 			axi.Table(&doc, "findings", findings, cols)
 			doc.Help(doctorHelp(len(findings), failing)...)
 			if err := doc.Render(cmd.OutOrStdout()); err != nil {
@@ -129,7 +167,7 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 		findings = append(findings, doctorFinding{Severity: severity, Text: violation.Text})
 	}
 
-	for _, tool := range requiredTools {
+	for _, tool := range foundationalTools {
 		if !onPath(tool) {
 			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("required tool %q is not on PATH", tool)})
 		}
@@ -138,6 +176,9 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 	projects, err := project.ListReadOnly(fleetHome)
 	if err != nil {
 		return nil, err
+	}
+	if ghRequired(projects) && !onPath("gh") {
+		findings = append(findings, doctorFinding{Severity: doctorWarning, Text: `required tool "gh" is not on PATH`})
 	}
 	for _, p := range projects {
 		if issue := gateIssue(fleetHome, p); issue != "" {
@@ -178,6 +219,82 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 		}
 	}
 	return findings, nil
+}
+
+// A local-only fleet never needs gh, while a registered project delivering through direct-pr or
+// no-mistakes does.
+func ghRequired(projects []project.Project) bool {
+	for _, p := range projects {
+		if p.Mode == project.ModeDirectPR || p.Mode == project.ModeNoMistakes {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorTools(projects []project.Project) []toolReadiness {
+	tools := make([]toolReadiness, 0, len(foundationalTools)+1)
+	for _, tool := range foundationalTools {
+		tools = append(tools, toolReadiness{Tool: tool, Installed: onPath(tool), Required: true})
+	}
+	tools = append(tools, toolReadiness{Tool: "gh", Installed: onPath("gh"), Required: ghRequired(projects)})
+	return tools
+}
+
+// Every supported coding-agent harness is reported, never a preferred one: bootstrap and doctor
+// both only ever detect, they do not choose.
+func doctorHarnesses() []harnessReadiness {
+	names := harness.Names()
+	out := make([]harnessReadiness, 0, len(names))
+	for _, name := range names {
+		out = append(out, harnessReadiness{Name: name, Installed: onPath(name)})
+	}
+	return out
+}
+
+func anyHarnessInstalled(harnesses []harnessReadiness) bool {
+	for _, h := range harnesses {
+		if h.Installed {
+			return true
+		}
+	}
+	return false
+}
+
+// The one list a bootstrapper needs to decide readiness without re-deriving the rules above: a
+// fleet-health entry stands in for the error findings already detailed in `findings`, a missing
+// required tool names itself, and a fleet with no installed harness cannot be driven.
+func doctorBlocking(failing int, tools []toolReadiness, harnesses []harnessReadiness) []string {
+	blocking := make([]string, 0)
+	if failing > 0 {
+		blocking = append(blocking, "fleet-health")
+	}
+	for _, tool := range tools {
+		if tool.Required && !tool.Installed {
+			blocking = append(blocking, tool.Tool)
+		}
+	}
+	if !anyHarnessInstalled(harnesses) {
+		blocking = append(blocking, "harness")
+	}
+	return blocking
+}
+
+// One exact recovery action per blocking entry, in the same order, so a caller never has to
+// reconcile two lists that could drift apart.
+func doctorNext(blocking []string) []string {
+	next := make([]string, 0, len(blocking))
+	for _, item := range blocking {
+		switch item {
+		case "fleet-health":
+			next = append(next, "resolve every error finding reported above")
+		case "harness":
+			next = append(next, "install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor")
+		default:
+			next = append(next, fmt.Sprintf("install %s", item))
+		}
+	}
+	return next
 }
 
 func onlyMissingRoutes(problems []routing.ConfigProblem) bool {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -213,13 +213,16 @@ func TestDoctorCleanFleetReportsEffectiveRouting(t *testing.T) {
 		"commit: unknown\n" +
 		"distribution: \"\"\n" +
 		"count: 1\n" +
-		"violations: 0\n" +
-		"findings[1]{line,severity,finding}:\n" +
+		"violations: 0\n"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("stdout = %q, want it to contain %q", out.String(), want)
+	}
+	wantFindings := "findings[1]{line,severity,finding}:\n" +
 		"  none,info," + axi.Value(`routing resolves through explicit legacy defaults: harness "claude"`) + "\n" +
 		"help[1]:\n" +
 		"  - No error findings, so this run passed; inspect warnings and info before the next dispatch\n"
-	if out.String() != want {
-		t.Fatalf("stdout = %q, want %q", out.String(), want)
+	if !strings.Contains(out.String(), wantFindings) {
+		t.Fatalf("stdout = %q, want it to contain %q", out.String(), wantFindings)
 	}
 }
 
@@ -637,10 +640,215 @@ func TestDoctorWarnsOnEachMissingRequiredTool(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, tool := range requiredTools {
+	for _, tool := range foundationalTools {
 		want := doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("required tool %q is not on PATH", tool)}
 		if !hasDoctorFinding(findings, want) {
 			t.Fatalf("findings = %#v, want a missing-tool warning for %q", findings, tool)
 		}
+	}
+}
+
+func TestGHRequiredOnlyWhenARegisteredProjectDeliversThroughGitHub(t *testing.T) {
+	tests := []struct {
+		mode string
+		want bool
+	}{
+		{mode: project.ModeLocalOnly, want: false},
+		{mode: project.ModeDirectPR, want: true},
+		{mode: project.ModeNoMistakes, want: true},
+	}
+	for _, tt := range tests {
+		got := ghRequired([]project.Project{{Name: "p", Mode: tt.mode}})
+		if got != tt.want {
+			t.Errorf("ghRequired(mode=%q) = %v, want %v", tt.mode, got, tt.want)
+		}
+	}
+	if ghRequired(nil) {
+		t.Error("ghRequired(nil) = true, want false for a fleet with no registered projects")
+	}
+}
+
+func TestDoctorToolsReportsFoundationalAndContextualRequirement(t *testing.T) {
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: "git"}.Install(t, bin)
+	faketool.Treehouse{}.Install(t, bin)
+
+	got := doctorTools([]project.Project{{Name: "p", Mode: project.ModeDirectPR}})
+	want := []toolReadiness{
+		{Tool: "git", Installed: true, Required: true},
+		{Tool: "treehouse", Installed: true, Required: true},
+		{Tool: "herdr", Installed: false, Required: true},
+		{Tool: "gh", Installed: false, Required: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("doctorTools() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("doctorTools()[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDoctorHarnessesReportsEverySupportedHarness(t *testing.T) {
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: harness.Codex}.Install(t, bin)
+
+	got := doctorHarnesses()
+	if len(got) != len(harness.Names()) {
+		t.Fatalf("doctorHarnesses() = %#v, want one entry per %v", got, harness.Names())
+	}
+	for _, h := range got {
+		want := h.Name == harness.Codex
+		if h.Installed != want {
+			t.Fatalf("doctorHarnesses() entry %q installed = %v, want %v", h.Name, h.Installed, want)
+		}
+	}
+}
+
+func TestDoctorBlockingAndNextStayInStepAndReadyFollowsBlocking(t *testing.T) {
+	tools := []toolReadiness{
+		{Tool: "git", Installed: true, Required: true},
+		{Tool: "treehouse", Installed: false, Required: true},
+		{Tool: "herdr", Installed: true, Required: true},
+		{Tool: "gh", Installed: false, Required: false},
+	}
+	harnesses := []harnessReadiness{{Name: harness.Claude, Installed: false}}
+
+	blocking := doctorBlocking(1, tools, harnesses)
+	want := []string{"fleet-health", "treehouse", "harness"}
+	if len(blocking) != len(want) {
+		t.Fatalf("doctorBlocking() = %v, want %v", blocking, want)
+	}
+	for i := range want {
+		if blocking[i] != want[i] {
+			t.Fatalf("doctorBlocking()[%d] = %q, want %q", i, blocking[i], want[i])
+		}
+	}
+
+	next := doctorNext(blocking)
+	if len(next) != len(blocking) {
+		t.Fatalf("doctorNext() = %v, want one entry per blocking item %v", next, blocking)
+	}
+	if next[1] != "install treehouse" {
+		t.Fatalf("doctorNext()[1] = %q, want %q", next[1], "install treehouse")
+	}
+
+	if doctorBlocking(0, []toolReadiness{{Tool: "git", Installed: true, Required: true}}, []harnessReadiness{{Name: harness.Claude, Installed: true}}) == nil {
+		t.Fatal("doctorBlocking() returned a nil slice for a ready fleet, want an empty non-nil slice so the rendered list still states its count")
+	}
+}
+
+func TestDoctorReportsReadyWhenEveryFoundationalToolAndOneHarnessArePresent(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: "git"}.Install(t, bin)
+	faketool.Treehouse{}.Install(t, bin)
+	faketool.Herdr{}.Install(t, bin)
+	faketool.Command{Name: harness.Claude}.Install(t, bin)
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got error %v, want nil for a ready fleet", err)
+	}
+	want := "tools[4]{tool,installed,required}:\n" +
+		"  git,true,true\n" +
+		"  treehouse,true,true\n" +
+		"  herdr,true,true\n" +
+		"  gh,false,false\n" +
+		"harnesses[5]{name,installed}:\n" +
+		"  claude,true\n" +
+		"  codex,false\n" +
+		"  grok,false\n" +
+		"  pi,false\n" +
+		"  opencode,false\n" +
+		"ready: true\n" +
+		"blocking[0]:\n" +
+		"next[0]:\n"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("stdout = %q, want it to contain %q", out.String(), want)
+	}
+}
+
+func TestDoctorReportsNotReadyWithBlockingAndNextWhenTreehouseAndEveryHarnessAreMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: "git"}.Install(t, bin)
+	faketool.Herdr{}.Install(t, bin)
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got error %v, want nil: a missing foundational tool or harness is a warning, not an error", err)
+	}
+	want := "ready: false\n" +
+		"blocking[2]:\n" +
+		"  - treehouse\n" +
+		"  - harness\n" +
+		"next[2]:\n" +
+		"  - install treehouse\n" +
+		"  - install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor\n"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("stdout = %q, want it to contain %q", out.String(), want)
+	}
+}
+
+func TestDoctorGHNotRequiredForALocalOnlyProjectDoesNotBlockReadiness(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "local", URL: "https://example.com/local.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: "git"}.Install(t, bin)
+	faketool.Treehouse{}.Install(t, bin)
+	faketool.Herdr{}.Install(t, bin)
+	faketool.Command{Name: harness.Claude}.Install(t, bin)
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got error %v, want nil", err)
+	}
+	if !strings.Contains(out.String(), "gh,false,false\n") {
+		t.Fatalf("stdout = %q, want gh reported installed=false, required=false for a local-only project", out.String())
+	}
+	if !strings.Contains(out.String(), "ready: true\n") {
+		t.Fatalf("stdout = %q, want ready: true since gh is not required", out.String())
 	}
 }

--- a/skills/secondhand/references/setup-doctor.md
+++ b/skills/secondhand/references/setup-doctor.md
@@ -6,7 +6,9 @@ Run `hand doctor` whenever you start a session, after `hand update`, after a mer
 fleet-generated surfaces, or whenever something feels off. It is report-only: it never repairs
 anything, so every finding it prints is yours to act on, not something it will fix on a later run.
 
-`hand doctor` prints a `findings` table with `line`, `severity`, and `finding` columns.
+`hand doctor` prints a readiness contract alongside the `findings` table.
+The contract uses flat TOON blocks: `tools`, `harnesses`, `ready`, `blocking`, and `next`.
+The `findings` table has `line`, `severity`, and `finding` columns.
 Severity `error` means the run fails (nonzero exit); `warning` and `info` do not. Read every
 line, not just the exit code: a clean exit with warnings still means something is worth a look.
 
@@ -23,9 +25,14 @@ line, not just the exit code: a clean exit with warnings still means something i
 - Each registered project's no-mistakes gate state (`gate-absent`, or another gate problem).
 - Routing/configuration validity: missing Profiles or Routes, and whether the fleet is running
   on explicit configuration or falling back to legacy defaults.
-- Required external tools (`treehouse`, `herdr`, `gh`) missing from `PATH` (`warning`);
-  `no-mistakes` is checked per project instead, since it is only required for a project
-  explicitly configured in that delivery mode, never a blanket fleet requirement.
+- Foundational external tools (`git`, `treehouse`, `herdr`) missing from `PATH` (`warning`);
+  `gh` is checked only when a registered project uses `direct-pr` or `no-mistakes` delivery.
+  The `tools` block reports each tool's `installed` and `required` state.
+- Every supported coding-agent harness is listed in `harnesses` as installed or not installed.
+  No harness is preferred by this contract.
+- `ready` is false when fleet health has errors, a required tool is missing, or no supported
+  harness is installed.
+  `blocking` names those conditions and `next` gives one corresponding recovery action for each.
 - The running binary's `version`, `channel`, `commit`, and `distribution`, as plain fields
   rather than findings - useful context when comparing a fleet's state against a bug report.
 


### PR DESCRIPTION
## Intent

Implement atqamz/hand#220 (cross-platform Secondhand adoption/bootstrap path). This first PR in the stack lays the shared foundation the bootstrap scripts consume: extend hand doctor's structured output with a readiness contract (tools[] distinguishing foundational deps that are always required from gh which is only contextually required when a registered project's delivery mode is GitHub-backed, harnesses[] listing every supported coding-agent harness purely as detected/not-installed with no preference, ready/blocking[]/next[]). Deliberately followed the existing axi.Doc TOON conventions (flat Field/Rows/List blocks) rather than inventing a nested schema, since the issue is explicit that bootstrap must consume hand doctor's existing structured-output conventions rather than a second schema. Decided NOT to add a hand-init-side 'refuse a foreign non-empty directory' check in this PR: that check belongs to bootstrap's own 'choose a safe fleet-home target' pipeline stage per the issue's own architecture diagram (it precedes 'hand init' in the flow), and an existing e2e test (TestSourceCheckoutDogfoodBootstrap) deliberately seeds a non-empty directory with a pre-existing canonical AGENTS.md before running hand init, which a directory-level refusal inside hand init itself would have broken. Only one pre-existing doctor test used an exact full-string stdout comparison; updated it to Contains-based assertions for the parts it actually covers since the new tools/harnesses/ready/blocking/next blocks are appended to the same output. Part of a stacked PR set for #220 (doctor contract first, then bootstrap.sh, then bootstrap.ps1, then docs) - this PR uses 'Part of atqamz/hand#220', not Closes.

## What Changed

- Extended `hand doctor` structured output with flat TOON readiness blocks for foundational/contextual tools, detected harnesses, readiness status, blocking conditions, and next actions.
- Made `gh` required only for registered `direct-pr` or `no-mistakes` projects, while reporting all supported harnesses without preference.
- Added doctor contract coverage and updated README and setup-doctor documentation.

## Risk Assessment

✅ Low: The readiness contract is bounded, follows existing TOON output conventions, and aligns with the stated delivery-mode and harness-detection requirements.

## Testing

Focused doctor tests passed in the repository Nix dev shell. End-to-end CLI output confirmed the readiness contract and contextual gh requirement. No transient worktree artifacts remain.

<details>
<summary>Evidence: Doctor readiness transcript</summary>

<code>Public `hand doctor` transcript showing `tools[]`, `harnesses[]`, `ready`, `blocking[]`, and `next[]`.</code>

```text
file: /tmp/tmp.4qJRMN2qk7/AGENTS.md
version: dev
channel: dev
commit: unknown
distribution: source
count: 3
violations: 0
tools[4]{tool,installed,required}:
  git,true,true
  treehouse,false,true
  herdr,false,true
  gh,false,false
harnesses[5]{name,installed}:
  claude,false
  codex,false
  grok,false
  pi,false
  opencode,false
ready: false
blocking[3]:
  - treehouse
  - herdr
  - harness
next[3]:
  - install treehouse
  - install herdr
  - install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor
findings[3]{line,severity,finding}:
  none,warning,"required tool \"treehouse\" is not on PATH"
  none,warning,"required tool \"herdr\" is not on PATH"
  none,warning,"routing falls back to legacy defaults without explicit intent: harness \"codex\""
help[1]:
  - No error findings, so this run passed; inspect warnings and info before the next dispatch
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e8658948ff6b7aef2f658dfee3d43113bb2a76a4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --accept-flake-config -c go test ./cmd -run 'TestDoctor|TestGHRequired' -count=1`
- <code>`hand init &lt;temporary fleet home&gt;` then `hand doctor`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
