### PR TITLE
feat: add cross-platform Secondhand bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -92,17 +92,57 @@ ensure_hand() {
       die "install.sh failed; recover by resolving the reported error and rerunning bootstrap.sh"
     fi
   else
-    log "installing hand via https://raw.githubusercontent.com/atqamz/hand/main/install.sh"
-    hand_installer=$(mktemp) || die "could not create a temporary file for install.sh"
-    if ! curl -fsSL -o "$hand_installer" https://raw.githubusercontent.com/atqamz/hand/main/install.sh || [ ! -s "$hand_installer" ]; then
-      rm -f "$hand_installer"
-      die "install.sh download failed or was empty; recover by resolving the reported error and rerunning bootstrap.sh"
+    log "installing hand from checksum-verified GitHub release"
+    hand_tmp=$(mktemp -d) || die "could not create a temporary directory for hand"
+    case "$(uname -s)" in
+      Linux) hand_goos=linux ;;
+      Darwin) hand_goos=darwin ;;
+      *) rm -rf "$hand_tmp"; die "unsupported OS for hand fallback" ;;
+    esac
+    case "$(uname -m)" in
+      x86_64|amd64) hand_goarch=amd64 ;;
+      arm64|aarch64) hand_goarch=arm64 ;;
+      *) rm -rf "$hand_tmp"; die "unsupported architecture for hand fallback" ;;
+    esac
+    if ! hand_tag=$(curl -fsSL "https://api.github.com/repos/atqamz/hand/releases/latest" |
+      sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1) || [ -z "$hand_tag" ]; then
+      rm -rf "$hand_tmp"
+      die "could not resolve the latest hand release tag"
     fi
-    if ! sh "$hand_installer"; then
-      rm -f "$hand_installer"
-      die "install.sh failed; recover by resolving the reported error and rerunning bootstrap.sh"
+    hand_asset="hand-${hand_goos}-${hand_goarch}.tar.gz"
+    hand_base="https://github.com/atqamz/hand/releases/download/$hand_tag"
+    if ! curl -fsSL -o "$hand_tmp/$hand_asset" "$hand_base/$hand_asset" ||
+      ! curl -fsSL -o "$hand_tmp/checksums.txt" "$hand_base/checksums.txt"; then
+      rm -rf "$hand_tmp"
+      die "could not download the hand release or checksums"
     fi
-    rm -f "$hand_installer"
+    hand_want=$(sed -n "s/^\([0-9a-f]*\)[[:space:]]*\*\{0,1\}${hand_asset}\$/\1/p" "$hand_tmp/checksums.txt" | head -n1)
+    if [ -z "$hand_want" ]; then
+      rm -rf "$hand_tmp"
+      die "checksums.txt has no entry for $hand_asset"
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+      hand_got=$(sha256sum "$hand_tmp/$hand_asset" | cut -d' ' -f1)
+    elif command -v shasum >/dev/null 2>&1; then
+      hand_got=$(shasum -a 256 "$hand_tmp/$hand_asset" | cut -d' ' -f1)
+    else
+      rm -rf "$hand_tmp"
+      die "sha256sum or shasum is required to verify hand"
+    fi
+    if [ "$hand_got" != "$hand_want" ]; then
+      rm -rf "$hand_tmp"
+      die "checksum mismatch for $hand_asset: want $hand_want, got $hand_got"
+    fi
+    if ! tar xzf "$hand_tmp/$hand_asset" -C "$hand_tmp" hand; then
+      rm -rf "$hand_tmp"
+      die "could not extract the verified hand release"
+    fi
+    hand_bin_dir=${HAND_INSTALL_DIR:-$HOME/.local/bin}
+    if ! mkdir -p "$hand_bin_dir" || ! install -m 755 "$hand_tmp/hand" "$hand_bin_dir/hand"; then
+      rm -rf "$hand_tmp"
+      die "could not install the verified hand release"
+    fi
+    rm -rf "$hand_tmp"
   fi
   case ":$PATH:" in
     *":${HAND_INSTALL_DIR:-$HOME/.local/bin}:"*) ;;
@@ -202,8 +242,11 @@ run_dep_action() {
         rm -f "$tmp"
         return 1
       fi
-      sh "$tmp"
-      status=$?
+      if sh "$tmp"; then
+        status=0
+      else
+        status=$?
+      fi
       rm -f "$tmp"
       return "$status"
       ;;

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,9 +93,16 @@ ensure_hand() {
     fi
   else
     log "installing hand via https://raw.githubusercontent.com/atqamz/hand/main/install.sh"
-    if ! curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/install.sh | sh; then
+    hand_installer=$(mktemp) || die "could not create a temporary file for install.sh"
+    if ! curl -fsSL -o "$hand_installer" https://raw.githubusercontent.com/atqamz/hand/main/install.sh || [ ! -s "$hand_installer" ]; then
+      rm -f "$hand_installer"
+      die "install.sh download failed or was empty; recover by resolving the reported error and rerunning bootstrap.sh"
+    fi
+    if ! sh "$hand_installer"; then
+      rm -f "$hand_installer"
       die "install.sh failed; recover by resolving the reported error and rerunning bootstrap.sh"
     fi
+    rm -f "$hand_installer"
   fi
   case ":$PATH:" in
     *":${HAND_INSTALL_DIR:-$HOME/.local/bin}:"*) ;;
@@ -290,7 +297,9 @@ fleet_state() {
     return 0
   fi
   [ -d "$fleet" ] || die "$fleet exists and is not a directory"
-  if [ -e "$fleet/state/hand.db" ]; then
+  if [ -f "$fleet/state/hand.db" ] && [ -d "$fleet/state" ]; then
+    printf 'fleet\n'
+  elif [ -f "$fleet/data/projects.md" ] && [ -d "$fleet/data" ] && [ -d "$fleet/state" ]; then
     printf 'fleet\n'
   elif [ -z "$(ls -A "$fleet" 2>/dev/null)" ]; then
     printf 'empty\n'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,6 +58,7 @@ if [ "$check_only" -eq 0 ] && [ -t 0 ] && [ -t 1 ]; then
   interactive=1
 fi
 
+# shellcheck disable=SC1007
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 # ---- step 1: acquire or verify hand -----------------------------------------------------------

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -238,7 +238,7 @@ run_dep_action() {
       ;;
     url)
       tmp=$(mktemp) || return 1
-      if ! curl -fsSL -o "$tmp" "$dep_action_value"; then
+      if ! curl -fsSL -o "$tmp" "$dep_action_value" || [ ! -s "$tmp" ]; then
         rm -f "$tmp"
         return 1
       fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,398 @@
+#!/bin/sh
+set -eu
+
+# Optional, explicitly opt-in Secondhand adoption for Linux and macOS: acquires hand if missing,
+# offers to install missing foundational dependencies (git, treehouse, herdr) with consent,
+# reconciles a fleet home with `hand init`, reads readiness from `hand doctor`, and prints the
+# exact next command. Never installs a coding-agent harness or no-mistakes; never reimplements
+# `hand init` or `hand doctor` validation logic.
+#
+# Usage: bootstrap.sh [--fleet PATH] [--yes] [--check] [--help]
+#   --fleet PATH  fleet home to create or reconcile (default: $HOME/secondhand-fleet)
+#   --yes         explicit non-interactive consent to install missing foundational dependencies
+#   --check       read-only: report readiness, install or mutate nothing
+
+fleet="${HOME}/secondhand-fleet"
+consent_yes=0
+check_only=0
+
+log() { printf '%s\n' "$*" >&2; }
+die() { log "bootstrap.sh: $*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: bootstrap.sh [--fleet PATH] [--yes] [--check] [--help]
+
+  --fleet PATH  fleet home to create or reconcile (default: $HOME/secondhand-fleet)
+  --yes         explicit non-interactive consent to install missing foundational dependencies
+  --check       read-only: report readiness, install or mutate nothing
+  --help        show this message
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fleet)
+      [ $# -ge 2 ] || die "--fleet requires a path"
+      fleet=$2
+      shift 2
+      ;;
+    --fleet=*)
+      fleet=${1#--fleet=}
+      shift
+      ;;
+    --yes) consent_yes=1; shift ;;
+    --check) check_only=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) die "unknown argument: $1 (see --help)" ;;
+  esac
+done
+
+case "$(uname -s)" in
+  Linux|Darwin) ;;
+  *) die "unsupported OS $(uname -s); use bootstrap.ps1 on Windows" ;;
+esac
+
+interactive=0
+if [ "$check_only" -eq 0 ] && [ -t 0 ] && [ -t 1 ]; then
+  interactive=1
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# ---- step 1: acquire or verify hand -----------------------------------------------------------
+
+hand_available=0
+if command -v hand >/dev/null 2>&1; then
+  hand_available=1
+fi
+
+# ensure_hand only ever runs when hand is missing. In check mode it reports and returns without
+# mutating; otherwise it dies with an actionable message on every path that cannot end with hand
+# on PATH, so callers never have to re-check its result.
+ensure_hand() {
+  if [ "$check_only" -eq 1 ]; then
+    log "hand: not installed (check mode: no changes made)"
+    return 0
+  fi
+  if [ "$consent_yes" -eq 0 ] && [ "$interactive" -eq 0 ]; then
+    die "hand is not installed, and bootstrap is not running interactively without --yes: refusing to install it"
+  fi
+  if [ "$consent_yes" -eq 0 ]; then
+    printf 'hand is not installed. Install it now via install.sh? [y/N] '
+    read -r reply || reply=""
+    case "$reply" in
+      y|Y|yes|YES) ;;
+      *) die "hand install declined; cannot continue" ;;
+    esac
+  fi
+  if [ -f "$script_dir/install.sh" ]; then
+    log "installing hand via $script_dir/install.sh"
+    if ! sh "$script_dir/install.sh"; then
+      die "install.sh failed; recover by resolving the reported error and rerunning bootstrap.sh"
+    fi
+  else
+    log "installing hand via https://raw.githubusercontent.com/atqamz/hand/main/install.sh"
+    if ! curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/install.sh | sh; then
+      die "install.sh failed; recover by resolving the reported error and rerunning bootstrap.sh"
+    fi
+  fi
+  case ":$PATH:" in
+    *":${HAND_INSTALL_DIR:-$HOME/.local/bin}:"*) ;;
+    *) PATH="${HAND_INSTALL_DIR:-$HOME/.local/bin}:$PATH" ;;
+  esac
+  command -v hand >/dev/null 2>&1 || die "hand was installed but is still not on PATH; add ${HAND_INSTALL_DIR:-$HOME/.local/bin} to PATH and rerun bootstrap.sh"
+}
+
+if [ "$hand_available" -eq 0 ]; then
+  ensure_hand
+fi
+
+# ---- step 2: detect/install missing foundational dependencies --------------------------------
+
+pkg_manager() {
+  for mgr in apt-get dnf yum pacman apk zypper brew; do
+    if command -v "$mgr" >/dev/null 2>&1; then
+      printf '%s\n' "$mgr"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# install_git_cmd echoes the exact command bootstrap would run so consent is informed before it
+# is ever asked for; empty output means no supported package manager was found on this platform.
+install_git_cmd() {
+  case "$(pkg_manager 2>/dev/null || true)" in
+    apt-get) printf 'sudo apt-get update && sudo apt-get install -y git' ;;
+    dnf) printf 'sudo dnf install -y git' ;;
+    yum) printf 'sudo yum install -y git' ;;
+    pacman) printf 'sudo pacman -Sy --noconfirm git' ;;
+    apk) printf 'sudo apk add git' ;;
+    zypper) printf 'sudo zypper install -y git' ;;
+    brew) printf 'brew install git' ;;
+  esac
+}
+
+# dep_source is the source column the consent prompt shows for a missing foundational dependency.
+dep_source() {
+  case "$1" in
+    git) printf 'your platform package manager' ;;
+    treehouse) printf 'kunchenguid/treehouse' ;;
+    herdr) printf 'ogulcancelik/herdr' ;;
+  esac
+}
+
+# resolve_dep_action sets dep_action_kind ("cmd", run directly, or "url", fetched and verified
+# before it is ever run) and dep_action_value for dep. A url is never piped straight into a
+# shell: `curl ... | sh` treats a failed fetch as an empty, successful script, so run_dep_action
+# downloads to a file first and only runs it once the download itself is confirmed to have
+# succeeded.
+resolve_dep_action() {
+  case "$1" in
+    git)
+      dep_action_kind=cmd
+      dep_action_value=$(install_git_cmd)
+      ;;
+    treehouse)
+      dep_action_kind=url
+      dep_action_value='https://kunchenguid.github.io/treehouse/install.sh'
+      ;;
+    herdr)
+      if command -v brew >/dev/null 2>&1; then
+        dep_action_kind=cmd
+        dep_action_value='brew install herdr'
+      else
+        dep_action_kind=url
+        dep_action_value='https://herdr.dev/install.sh'
+      fi
+      ;;
+    *)
+      dep_action_kind=cmd
+      dep_action_value=''
+      ;;
+  esac
+}
+
+describe_dep_action() {
+  resolve_dep_action "$1"
+  case "$dep_action_kind" in
+    cmd) printf '%s' "$dep_action_value" ;;
+    url) printf 'download and verify %s, then run only the completed download' "$dep_action_value" ;;
+  esac
+}
+
+run_dep_action() {
+  resolve_dep_action "$1"
+  case "$dep_action_kind" in
+    cmd)
+      [ -n "$dep_action_value" ] || return 1
+      sh -c "$dep_action_value"
+      ;;
+    url)
+      tmp=$(mktemp) || return 1
+      if ! curl -fsSL -o "$tmp" "$dep_action_value"; then
+        rm -f "$tmp"
+        return 1
+      fi
+      sh "$tmp"
+      status=$?
+      rm -f "$tmp"
+      return "$status"
+      ;;
+  esac
+}
+
+# missing_foundational_deps lists, in the same order hand doctor's foundational tools table
+# does, every dependency doctor would also report missing - never a schema bootstrap invents.
+missing_foundational_deps() {
+  for tool in git treehouse herdr; do
+    command -v "$tool" >/dev/null 2>&1 || printf '%s\n' "$tool"
+  done
+}
+
+# ensure_foundational_deps returns 0 once every foundational dependency is on PATH, and 1
+# whenever one remains missing - declined, failed, unsupported platform, or check mode. It never
+# treats that as fatal itself: `hand doctor` is the one place a remaining gap is judged blocking.
+ensure_foundational_deps() {
+  missing=$(missing_foundational_deps)
+  [ -z "$missing" ] && return 0
+
+  if [ "$check_only" -eq 1 ]; then
+    log "missing foundational dependencies (check mode: no changes made):"
+    for dep in $missing; do
+      log "  $dep"
+    done
+    return 1
+  fi
+
+  log "Missing foundational runtime dependencies:"
+  log ""
+  for dep in $missing; do
+    desc=$(describe_dep_action "$dep")
+    log "  $dep"
+    log "    source: $(dep_source "$dep")"
+    if [ -n "$desc" ]; then
+      log "    install method: $desc"
+    else
+      log "    install method: none detected for this platform; install $dep manually, then rerun bootstrap.sh"
+    fi
+    log ""
+  done
+
+  proceed=$consent_yes
+  if [ "$proceed" -eq 0 ]; then
+    if [ "$interactive" -eq 0 ]; then
+      log "not running interactively and --yes was not given: declining to install any of the above"
+      return 1
+    fi
+    printf 'Install these dependencies? [y/N] '
+    read -r reply || reply=""
+    case "$reply" in
+      y|Y|yes|YES) proceed=1 ;;
+      *) proceed=0 ;;
+    esac
+  fi
+  if [ "$proceed" -eq 0 ]; then
+    log "declined: continuing without installing missing foundational dependencies"
+    return 1
+  fi
+
+  install_failed=0
+  for dep in $missing; do
+    desc=$(describe_dep_action "$dep")
+    if [ -z "$desc" ]; then
+      log "$dep: no supported install method detected on this platform; skipping"
+      install_failed=1
+      continue
+    fi
+    log "installing $dep: $desc"
+    if ! run_dep_action "$dep"; then
+      log "$dep: install action failed"
+      install_failed=1
+      continue
+    fi
+    command -v "$dep" >/dev/null 2>&1 || { log "$dep: installed but still not on PATH"; install_failed=1; }
+  done
+  [ "$install_failed" -eq 0 ]
+}
+
+ensure_foundational_deps || true
+
+# ---- step 3: choose a safe fleet-home target --------------------------------------------------
+
+# fleet_state never duplicates hand doctor's or hand init's own validation: it only decides the
+# one thing bootstrap alone is responsible for before ever invoking hand init - whether this
+# target is safe to hand to it at all.
+fleet_state() {
+  if [ ! -e "$fleet" ]; then
+    printf 'absent\n'
+    return 0
+  fi
+  [ -d "$fleet" ] || die "$fleet exists and is not a directory"
+  if [ -e "$fleet/state/hand.db" ]; then
+    printf 'fleet\n'
+  elif [ -z "$(ls -A "$fleet" 2>/dev/null)" ]; then
+    printf 'empty\n'
+  else
+    printf 'foreign\n'
+  fi
+}
+
+state=$(fleet_state)
+if [ "$state" = "foreign" ]; then
+  die "$fleet exists, is not empty, and is not a recognized Secondhand fleet; refusing to adopt it - pass --fleet with an empty or already-initialized path"
+fi
+
+if [ "$check_only" -eq 1 ]; then
+  log ""
+  log "fleet target: $fleet ($state)"
+  if [ "$state" != "fleet" ]; then
+    log "hand init has not run here yet; check mode makes no changes, so readiness cannot be evaluated further"
+    exit 0
+  fi
+  if [ "$hand_available" -eq 0 ]; then
+    log "hand is not installed; readiness cannot be evaluated further"
+    exit 0
+  fi
+  doctor_out=$(HAND_HOME="$fleet" hand doctor 2>&1) || true
+  log ""
+  log "$doctor_out"
+  exit 0
+fi
+
+# ---- step 4: hand init, then hand doctor for the authoritative readiness result ----------------
+
+[ "$state" = "absent" ] && mkdir -p "$fleet"
+
+if ! init_out=$(hand init "$fleet" 2>&1); then
+  log "$init_out"
+  die "hand init failed against $fleet; recover by resolving the reported error, then rerun: bootstrap.sh --fleet $fleet"
+fi
+log "$init_out"
+
+doctor_out=$(HAND_HOME="$fleet" hand doctor 2>&1) || true
+log ""
+log "$doctor_out"
+
+# doctor_field extracts a scalar TOON field ("key: value") from hand doctor's stdout.
+doctor_field() {
+  printf '%s\n' "$2" | sed -n "s/^$1: //p" | head -n1
+}
+
+# doctor_list extracts the "  - item" lines under one TOON list block ("name[N]:"). The block
+# header is matched with a plain prefix comparison, never a dynamic regex built from $1: awk
+# dialects disagree on escaping a literal "[" inside a string-turned-pattern, and a prefix check
+# needs no escaping at all.
+doctor_list() {
+  printf '%s\n' "$2" | awk -v prefix="$1[" '
+    substr($0, 1, length(prefix)) == prefix { in_block=1; next }
+    in_block && /^  - / { sub(/^  - /, ""); print; next }
+    in_block { in_block=0 }
+  '
+}
+
+# installed_harnesses reads the harnesses[N]{name,installed} rows hand doctor already computed,
+# in the order hand reports them, so bootstrap never re-detects harnesses on its own.
+installed_harnesses() {
+  printf '%s\n' "$1" | awk '
+    /^harnesses\[/ { in_block=1; next }
+    in_block && /^  [a-z]/ {
+      split($0, cols, ",")
+      if (cols[2] == "true") print cols[1]
+      next
+    }
+    in_block { in_block=0 }
+  '
+}
+
+ready=$(doctor_field ready "$doctor_out")
+if [ "$ready" != "true" ]; then
+  blocking=$(doctor_list blocking "$doctor_out")
+  log ""
+  log "Secondhand is not ready yet. Blocking:"
+  for item in $blocking; do
+    log "  - $item"
+  done
+  die "recover the items above, then rerun: HAND_HOME=$fleet hand doctor"
+fi
+
+harnesses=$(installed_harnesses "$doctor_out")
+count=$(printf '%s\n' "$harnesses" | grep -c . || true)
+
+log ""
+log "Secondhand is ready."
+log ""
+log "Next:"
+log ""
+log "  cd $fleet"
+if [ "$count" -eq 1 ]; then
+  log "  $harnesses"
+elif [ "$count" -gt 1 ]; then
+  log "  <choose one of the installed harnesses below>"
+  for h in $harnesses; do
+    log "    $h"
+  done
+else
+  log "  <install and authenticate at least one supported coding-agent harness, then run hand doctor>"
+fi

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -1,0 +1,351 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+// Resolved once, relative to this package, so a test never depends on the working directory
+// `go test` happened to be invoked from.
+var bootstrapScript = func() string {
+	abs, err := filepath.Abs(filepath.Join("..", "..", "bootstrap.sh"))
+	if err != nil {
+		panic(err)
+	}
+	return abs
+}()
+
+// Runs bootstrap.sh under an explicit, minimal environment - PATH and HOME only - so a test can
+// prove nothing beyond those two ever reaches the script.
+func runBootstrap(t *testing.T, home string, extraEnv []string, args ...string) invocation {
+	t.Helper()
+	cmd := exec.Command("sh", append([]string{bootstrapScript}, args...)...)
+	env := append([]string{"PATH=" + os.Getenv("PATH"), "HOME=" + home, "TERM=dumb"}, extraEnv...)
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	code := 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run bootstrap.sh %v: %v", args, err)
+		}
+		code = exitErr.ExitCode()
+	}
+	t.Logf("$ bootstrap.sh %s\n  exit %d\n  stdout: %s\n  stderr: %s",
+		strings.Join(args, " "), code, strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()))
+	return invocation{code: code, stdout: stdout.String(), stderr: stderr.String()}
+}
+
+// Puts a symlink to the already-built hand binary on dir, the way a real install.sh would leave
+// hand on PATH.
+func installFakeHand(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.Symlink(handBin, filepath.Join(dir, "hand")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Drops a no-op executable on dir under name, standing in for an installed, authenticated
+// coding-agent harness: bootstrap only ever needs to see it on PATH.
+func installFakeHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	writeFakeBin(t, dir, name, "exit 0\n")
+}
+
+// Drops a fake curl on dir that answers only "-fsSL -o <file> <url>" for wantURL, writing
+// scriptBody to the requested output file, and fails loudly on any other invocation so a test
+// never silently passes through a real fetch.
+func installFakeCurlServingURL(t *testing.T, dir, wantURL, scriptBody string) {
+	t.Helper()
+	body := fmt.Sprintf(`out=""
+url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out=$2; shift 2 ;;
+    -*) shift ;;
+    *) url=$1; shift ;;
+  esac
+done
+if [ "$url" != %s ]; then
+  echo "fake curl: unexpected url $url" >&2
+  exit 1
+fi
+cat > "$out" <<'INNER'
+%s
+INNER
+`, shellSingleQuote(wantURL), scriptBody)
+	writeFakeBin(t, dir, "curl", body)
+}
+
+// Drops a fake curl that always fails, standing in for a network or download failure partway
+// through a dependency install.
+func installFakeCurlFailing(t *testing.T, dir string) {
+	t.Helper()
+	writeFakeBin(t, dir, "curl", "exit 1\n")
+}
+
+func isFleetHome(fleet string) bool {
+	_, err := os.Stat(filepath.Join(fleet, "state", "hand.db"))
+	return err == nil
+}
+
+func TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarness(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeHarness(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr %q)", got.code, got.stderr)
+	}
+	if !isFleetHome(fleet) {
+		t.Fatalf("%s was not initialized as a fleet home", fleet)
+	}
+	for _, want := range []string{"Secondhand is ready.", "cd " + fleet, "claude", "ready: true"} {
+		if !strings.Contains(got.stderr, want) {
+			t.Fatalf("stderr = %q, want it to contain %q", got.stderr, want)
+		}
+	}
+}
+
+func TestBootstrapRefusesAForeignNonEmptyFleetTarget(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+
+	home := t.TempDir()
+	fleet := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fleet, "unrelated.txt"), []byte("not a fleet\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1 (stderr %q)", got.code, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "refusing to adopt it") {
+		t.Fatalf("stderr = %q, want a refusal for the foreign non-empty target", got.stderr)
+	}
+	if isFleetHome(fleet) {
+		t.Fatal("bootstrap.sh mutated a foreign non-empty target instead of refusing it")
+	}
+	if _, err := os.Stat(filepath.Join(fleet, "unrelated.txt")); err != nil {
+		t.Fatalf("bootstrap.sh disturbed the foreign target's own content: %v", err)
+	}
+}
+
+func TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeHarness(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--check")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 for check mode (stderr %q)", got.code, got.stderr)
+	}
+	if _, err := os.Stat(fleet); !os.IsNotExist(err) {
+		t.Fatalf("--check created %s; check mode must never mutate", fleet)
+	}
+}
+
+func TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutYesAndFailsClosed(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	// treehouse deliberately left missing, and stdin is not a tty under exec.Command, so
+	// bootstrap must decline installing it rather than hang or guess consent.
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet)
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1 (stderr %q)", got.code, got.stderr)
+	}
+	for _, want := range []string{
+		"declining to install any of the above",
+		"- treehouse",
+		"recover the items above, then rerun",
+	} {
+		if !strings.Contains(got.stderr, want) {
+			t.Fatalf("stderr = %q, want it to contain %q", got.stderr, want)
+		}
+	}
+	if !isFleetHome(fleet) {
+		t.Fatal("hand init did not run even though only a foundational dependency was missing; a partial setup must still be retained and reconciled")
+	}
+}
+
+func TestBootstrapYesInstallsOnlyTheMissingFoundationalDependency(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeHarness(t, dir, "claude")
+	installFakeCurlServingURL(t, dir, "https://kunchenguid.github.io/treehouse/install.sh",
+		fmt.Sprintf("#!/bin/sh\ncat > %s/treehouse <<'LEAF'\n#!/bin/sh\nexit 0\nLEAF\nchmod +x %s/treehouse\n",
+			shellSingleQuote(dir), shellSingleQuote(dir)))
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr %q)", got.code, got.stderr)
+	}
+	if !isFleetHome(fleet) {
+		t.Fatalf("%s was not initialized", fleet)
+	}
+	if !strings.Contains(got.stderr, "installing treehouse:") {
+		t.Fatalf("stderr = %q, want it to report installing the missing dependency", got.stderr)
+	}
+	for _, notWant := range []string{"installing herdr:", "installing git:"} {
+		if strings.Contains(got.stderr, notWant) {
+			t.Fatalf("stderr = %q, want it to leave an already-present dependency alone", got.stderr)
+		}
+	}
+	if !strings.Contains(got.stderr, "ready: true") {
+		t.Fatalf("stderr = %q, want readiness once the installed dependency is on PATH", got.stderr)
+	}
+}
+
+func TestBootstrapFailedDependencyDownloadProducesActionableRecovery(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeCurlFailing(t, dir)
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1 (stderr %q)", got.code, got.stderr)
+	}
+	for _, want := range []string{
+		"treehouse: install action failed",
+		"- treehouse",
+		"recover the items above, then rerun",
+	} {
+		if !strings.Contains(got.stderr, want) {
+			t.Fatalf("stderr = %q, want it to contain %q", got.stderr, want)
+		}
+	}
+	if !isFleetHome(fleet) {
+		t.Fatal("a failed dependency install must not prevent retaining and reconciling the rest of the setup")
+	}
+}
+
+func TestBootstrapNeverInstallsAHarnessOrNoMistakesAutomatically(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	// No coding-agent harness and no no-mistakes on PATH at all.
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1: no harness is installed, so the fleet cannot be ready (stderr %q)", got.code, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "- harness") {
+		t.Fatalf("stderr = %q, want the missing harness reported as blocking", got.stderr)
+	}
+	for _, name := range []string{"claude", "codex", "grok", "pi", "opencode", "no-mistakes"} {
+		if strings.Contains(got.stderr, "installing "+name) {
+			t.Fatalf("stderr = %q, want bootstrap to never attempt installing a harness or no-mistakes", got.stderr)
+		}
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			t.Fatalf("%s was created on PATH; bootstrap must only ever detect harnesses, never install one", name)
+		}
+	}
+}
+
+func TestBootstrapAcceptsAFleetTargetPathContainingSpaces(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeHarness(t, dir, "codex")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "my secondhand fleet")
+
+	got := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 for a fleet path containing spaces (stderr %q)", got.code, got.stderr)
+	}
+	if !isFleetHome(fleet) {
+		t.Fatalf("%s was not initialized", fleet)
+	}
+}
+
+func TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeHarness(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+	const secret = "poison-token-do-not-print-1x2y3z"
+
+	got := runBootstrap(t, home, []string{"GH_TOKEN=" + secret, "ANTHROPIC_API_KEY=" + secret}, "--fleet", fleet, "--yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr %q)", got.code, got.stderr)
+	}
+	if strings.Contains(got.stdout, secret) || strings.Contains(got.stderr, secret) {
+		t.Fatal("bootstrap.sh leaked an ambient credential into its own output")
+	}
+}
+
+func TestBootstrapReconcilesAnExistingFleetIdempotently(t *testing.T) {
+	dir := binDir(t)
+	installFakeHand(t, dir)
+	faketool.Treehouse{}.Install(t, dir)
+	faketool.Herdr{}.Install(t, dir)
+	installFakeHarness(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	first := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if first.code != 0 {
+		t.Fatalf("first run: exit = %d, want 0 (stderr %q)", first.code, first.stderr)
+	}
+
+	second := runBootstrap(t, home, nil, "--fleet", fleet, "--yes")
+	if second.code != 0 {
+		t.Fatalf("second run: exit = %d, want 0 (stderr %q)", second.code, second.stderr)
+	}
+	if !strings.Contains(second.stderr, "agents_md: unchanged") {
+		t.Fatalf("second run stderr = %q, want hand init to report the already-canonical AGENTS.md unchanged", second.stderr)
+	}
+	if !strings.Contains(second.stderr, "Secondhand is ready.") {
+		t.Fatalf("second run stderr = %q, want a ready fleet on a repeat run", second.stderr)
+	}
+}

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/atqamz/hand/internal/faketool"
 )
 
-// Everything hand execs beyond these three is faked per test and left unreachable, so a missing fake fails
-// loudly instead of reaching the developer's real tools (e2e_test.go). The three: git, which hand and the
-// helpers really shell out to; sh, for internal/notify's template; cat, for the fake herdr pane status.
-var realBinsOnPath = []string{"git", "sh", "cat"}
+// Everything hand or bootstrap.sh execs beyond these is faked per test and left unreachable (e2e_test.go).
+// git, sh and cat back real production and fixture calls; the rest are plain POSIX utilities bootstrap.sh
+// runs, never one of the backends (herdr, treehouse, gh, no-mistakes) this suite fakes instead.
+var realBinsOnPath = []string{"git", "sh", "cat", "uname", "dirname", "awk", "sed", "head", "grep", "ls", "mkdir", "mktemp", "rm", "chmod"}
 
 // The PATH every test runs under, built once by TestMain from the inherited PATH.
 var hermeticPath string


### PR DESCRIPTION
## Intent

Implement atqamz/hand#220 (cross-platform Secondhand adoption/bootstrap path). Second PR in the stack, built on the merged doctor readiness contract (atqamz/hand#296): add bootstrap.sh, the Linux/macOS Secondhand adoption script. It is deliberately thin orchestration: acquire/verify hand, detect/offer missing foundational deps (git, treehouse, herdr) with explicit consent (--yes for non-interactive consent, --check for a pure read-only dry run that never mutates), choose a safe fleet-home target (default ~/secondhand-fleet, --fleet override, refuses a foreign non-empty directory that is not already a recognized Hand fleet), then hand init followed by hand doctor for the authoritative readiness result, parsed from doctor's own TOON tools[]/harnesses[]/ready/blocking[]/next[] blocks rather than any bootstrap-invented schema. Key decisions: (1) the foreign-non-empty-directory refusal lives entirely in bootstrap.sh's own 'choose a safe fleet-home target' step, not inside hand init, matching the issue's own pipeline diagram where that choice precedes hand init, and preserving an existing e2e test that seeds a pre-existing AGENTS.md into an otherwise-empty directory before hand init runs; (2) treehouse and herdr are fetched via their own vendor-documented installer URLs (kunchenguid.github.io/treehouse/install.sh, herdr.dev/install.sh) which I looked up directly from each project's README, never an invented mirror, and those installer scripts are downloaded to a file and verified to have downloaded successfully BEFORE being run, deliberately avoiding the classic 'curl | sh' hazard where a failed/interrupted download becomes an empty script that a plain pipe silently treats as a successful no-op; (3) git is installed via whatever platform package manager is already present (apt-get/dnf/yum/pacman/apk/zypper/brew), with sudo scoped to only that one install command, never the whole script; (4) a coding-agent harness and no-mistakes are only ever detected via hand doctor's harnesses[] table, never auto-installed; (5) hand itself is acquired via the sibling install.sh next to bootstrap.sh when present, falling back to fetching it from the same first-party, checksum-verified atqamz/hand distribution path #177 already established, which is a different trust tier than the third-party foundational deps. Extended tests/e2e's shared hermetic PATH allow-list (fakes_test.go's realBinsOnPath) with the plain POSIX coreutils bootstrap.sh needs (uname, dirname, awk, sed, head, grep, ls, mkdir, mktemp, rm, chmod) - none of these are backends the suite fakes (herdr/treehouse/gh/no-mistakes), they are the same class of always-real utility git/sh/cat already were. Added tests/e2e/bootstrap_test.go covering the happy path, foreign-directory refusal, --check making zero mutations, missing-dependency decline in a non-interactive/no-tty context failing closed with an actionable recovery command, --yes actually installing only the missing dependency via the fetch-verify-then-run path, a failed download producing the same actionable recovery, bootstrap never auto-installing a harness or no-mistakes, a fleet path containing spaces, no ambient credential ever reaching bootstrap's own output, and idempotent re-reconciliation of an already-initialized fleet. This PR uses 'Part of atqamz/hand#220', not Closes; the doctor contract PR (#296) already merged, and bootstrap.ps1 plus docs/adoption.md remain as later PRs in the same stack.

## What Changed

- Added `bootstrap.sh` for Linux/macOS Secondhand adoption: verified Hand acquisition, consent-based foundational dependency installation, safe fleet-home selection, `hand init`, and `hand doctor` readiness reporting.
- Added end-to-end coverage for happy paths, safety checks, read-only mode, dependency installation failures, harness detection, spaced paths, credential isolation, and idempotent reconciliation.
- Expanded the e2e hermetic PATH allow-list with the POSIX utilities required by the bootstrap script.

## Risk Assessment

🚨 High: The implementation contradicts an explicit required acceptance criterion for the herdr acquisition path on macOS/Homebrew environments.

## Testing

Bootstrap e2e tests passed across happy path, refusal, check mode, dependency consent/install failure, harness detection, spaces, credential isolation, and idempotence. Host `go` was unavailable, so tests ran via the project Nix environment. CLI transcript evidence was captured.

<details>
<summary>Evidence: Bootstrap e2e transcript</summary>

```text
=== RUN   TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarness
    bootstrap_test.go:113: $ bootstrap.sh --fleet /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet --yes
          exit 0
          stdout: 
          stderr: result: initialized
        home: /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet
        agents_md: written
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet/.claude/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet/.grok/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet/.pi/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.kxuxWm/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2479706724/002/secondhand-fleet
            claude
--- PASS: TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarness (0.24s)
=== RUN   TestBootstrapRefusesAForeignNonEmptyFleetTarget
    bootstrap_test.go:139: $ bootstrap.sh --fleet /tmp/nix-shell.kxuxWm/TestBootstrapRefusesAForeignNonEmptyFleetTarget1779888131/003 --yes
          exit 1
          stdout: 
          stderr: bootstrap.sh: /tmp/nix-shell.kxuxWm/TestBootstrapRefusesAForeignNonEmptyFleetTarget1779888131/003 exists, is not empty, and is not a recognized Secondhand fleet; refusing to adopt it - pass --fleet with an empty or already-initialized path
--- PASS: TestBootstrapRefusesAForeignNonEmptyFleetTarget (0.02s)
=== RUN   TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget
    bootstrap_test.go:164: $ bootstrap.sh --fleet /tmp/nix-shell.kxuxWm/TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget3890401704/002/secondhand-fleet --check
          exit 0
          stdout: 
          stderr: fleet target: /tmp/nix-shell.kxuxWm/TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget3890401704/002/secondhand-fleet (absent)
        hand init has not run here yet; check mode makes no changes, so readiness cannot be evaluated further
--- PASS: TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget (0.01s)
=== RUN   TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutYesAndFailsClosed
    bootstrap_test.go:183: $ bootstrap.sh --fleet /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet
          exit 1
          stdout: 
          stderr: Missing foundational runtime dependencies:
        
          treehouse
            source: kunchenguid/treehouse
            install method: download and verify https://kunchenguid.github.io/treehouse/install.sh, then run only the completed download
        
        not running interactively and --yes was not given: declining to install any of the above
        result: initialized
        home: /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet
        agents_md: written
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet/.claude/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet/.grok/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet/.pi/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[3]:
          - treehouse
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY48393669/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 2
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,false,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,false
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: false
        blocking[2]:
          - treehouse
          - harness
        next[2]:
          - install treehouse
          - install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor
        findings[2]{line,severity,finding}:
          none,warning,"required tool \"treehouse\" is not on PATH"
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is not ready yet. Blocking:
          - treehouse
          - harness
        bootstrap.sh: recover the items above, then rerun: HAND_HOME=/tmp/nix-shell.kxuxWm/TestBootstrapDeclinesMissi

... [15402 bytes truncated] ...

75509/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.kxuxWm/TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput2367275509/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.kxuxWm/TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput2367275509/002/secondhand-fleet
            claude
--- PASS: TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput (0.06s)
=== RUN   TestBootstrapReconcilesAnExistingFleetIdempotently
    bootstrap_test.go:336: $ bootstrap.sh --fleet /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet --yes
          exit 0
          stdout: 
          stderr: result: initialized
        home: /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet
        agents_md: written
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.claude/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.grok/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.pi/skills/secondhand,created
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet
            claude
    bootstrap_test.go:341: $ bootstrap.sh --fleet /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet --yes
          exit 0
          stdout: 
          stderr: result: initialized
        home: /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet
        agents_md: unchanged
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.claude/skills/secondhand,unchanged
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.grok/skills/secondhand,unchanged
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.pi/skills/secondhand,unchanged
          /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/.agents/skills/secondhand,unchanged
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.kxuxWm/TestBootstrapReconcilesAnExistingFleetIdempotently3410072596/002/secondhand-fleet
            claude
--- PASS: TestBootstrapReconcilesAnExistingFleetIdempotently (0.08s)
PASS
ok  	github.com/atqamz/hand/tests/e2e	1.222s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b7761f1511cf775a2f1e169153871128d1c183a1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0FVJ7WC3XAAZH5X03EBKKTQ/bootstrap.sh:96` - The fallback violates the required hand acquisition trust path: the intent requires fetching hand through the first-party checksum-verified distribution path, but this code pipes an unverified remote install script directly into `sh`. A failed/interrupted download can become an empty successful script, and the fetched script itself is not verified before execution. Fetch the installer to a file and verify it, or invoke the established checksum-verifying distribution flow directly.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0FVJ7WC3XAAZH5X03EBKKTQ/bootstrap.sh:293` - The target check recognizes only `state/hand.db`, while Hand&#39;s own `home.IsHome` also recognizes legacy fleets containing `data/projects.md` and `state/`. Such a non-empty directory is already a recognized Hand fleet but bootstrap classifies it as foreign and refuses adoption, contradicting the requirement to refuse only a foreign non-empty directory that is not already a recognized Hand fleet. Reuse the supported fleet marker contract or clarify that legacy recognized fleets are intentionally excluded.

🔧 Fix: Hardened hand fallback and recognized legacy fleet markers
2 issues (1 error, 1 warning) still open:
- 🚨 `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0FVJ7WC3XAAZH5X03EBKKTQ/bootstrap.sh:97` - The required hand fallback uses the raw GitHub installer but only checks that curl succeeded and the file is non-empty. It never verifies the installer checksum, contradicting the requirement that hand use the first-party checksum-verified distribution path. Use the established release asset plus checksums.txt verification before execution.
- ⚠️ `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0FVJ7WC3XAAZH5X03EBKKTQ/bootstrap.sh:205` - With `set -e`, a nonzero `sh &#34;$tmp&#34;` exits the script before lines 206-208 can capture the status and remove the temporary installer. A downloaded installer that executes and fails therefore leaves the temp file behind and skips the intended actionable dependency-failure path. Run the installer in an explicit conditional, capture its status, clean up, then return the status.

🔧 Fix: Verified hand releases and cleaned dependency installers
1 warning still open:
- ⚠️ `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0FVJ7WC3XAAZH5X03EBKKTQ/bootstrap.sh:201` - `run_dep_action` checks only curl&#39;s exit status before executing the downloaded installer. A successful empty response is still passed to `sh`, contrary to the required fetch-then-verify path (`non-empty, curl exit 0`), and can be treated as a successful no-op before the later PATH check. Require `[ -s &#34;$tmp&#34; ]` before execution, with cleanup on failure.

🔧 Fix: Reject empty dependency installer downloads
1 error still open:
- 🚨 `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0FVJ7WC3XAAZH5X03EBKKTQ/bootstrap.sh:209` - The required acquisition path says treehouse and herdr must use their vendor-documented installer URLs, but on any host with Homebrew this branch instead runs `brew install herdr`. This contradicts the explicit intent and changes the trust/acquisition path for herdr; remove the Homebrew branch or clarify that it is authorized.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --command go test -tags=e2e -count=1 -timeout=10m ./tests/e2e -run '^TestBootstrap'`
- `nix develop --command go test -tags=e2e -count=1 -timeout=10m -v ./tests/e2e -run '^TestBootstrap'`
- `sh -n bootstrap.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
