### PR TITLE
feat: add Windows PowerShell bootstrap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,18 @@ jobs:
       - name: End-to-end
         run: go test -tags=e2e -timeout=10m ./tests/e2e/...
 
+  e2e-windows:
+    name: E2E (windows-latest, bootstrap.ps1)
+    runs-on: windows-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: End-to-end (bootstrap.ps1)
+        run: go test -tags=e2e -timeout=10m -run "^TestBootstrapPS1" ./tests/e2e/...
+
   contract:
     name: Contract
     runs-on: ubuntu-latest
@@ -88,7 +100,7 @@ jobs:
 
   edge:
     name: Publish edge
-    needs: [lint, test, e2e, contract, nix-build]
+    needs: [lint, test, e2e, e2e-windows, contract, nix-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -357,6 +357,17 @@ irm https://raw.githubusercontent.com/atqamz/hand/main/install.ps1 | iex
 
 `HAND_INSTALL_DIR` overrides the install directory (`$HOME/.local/bin` on Linux/macOS, `%LOCALAPPDATA%\hand` on Windows); `HAND_INSTALL_VERSION` pins a release tag instead of the latest.
 
+On native Windows, `bootstrap.ps1` optionally installs `hand`, offers to install missing foundational dependencies, initializes a fleet home, and reports readiness from `hand doctor`:
+
+```powershell
+irm https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.ps1 -OutFile bootstrap.ps1
+Set-ExecutionPolicy -Scope Process Bypass
+.\bootstrap.ps1 -Yes
+```
+
+Use `-Check` to inspect the target without making changes.
+The script never installs a coding-agent harness or no-mistakes, and refuses to adopt a non-empty unrecognized directory.
+
 ### Release binary
 
 Release tar archives are available for Linux and macOS on AMD64 and ARM64. A ZIP archive is available for Windows AMD64. Every release includes `checksums.txt`.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -35,7 +35,9 @@ if ($PSCommandPath) {
 
 # ---- step 1: acquire or verify hand ------------------------------------------------------------
 
-$handAvailable = [bool](Get-Command hand -ErrorAction SilentlyContinue)
+$handCommand = Get-Command hand -ErrorAction SilentlyContinue
+$handAvailable = [bool]$handCommand
+$script:handCommandDir = if ($handCommand.Source) { Split-Path -Parent $handCommand.Source } else { $null }
 
 # Install-Hand only ever runs when hand is missing. In check mode it reports and returns without
 # mutating; otherwise it fails with an actionable message on every path that cannot end with hand
@@ -117,6 +119,8 @@ function Install-Hand {
 
 if (-not $handAvailable) {
     Install-Hand
+    $handCommand = Get-Command hand -ErrorAction SilentlyContinue
+    $script:handCommandDir = if ($handCommand.Source) { Split-Path -Parent $handCommand.Source } else { $null }
 }
 
 # ---- step 2: detect/install missing foundational dependencies ---------------------------------
@@ -125,8 +129,11 @@ function Update-ProcessPathFromRegistry {
     $machinePath = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
     $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
     $pathDirs = @($machinePath, $userPath) | ForEach-Object { if ($_){ $_ -split ';' } } | Where-Object { $_ }
-    if ($script:handInstallDir -and -not ($pathDirs | Where-Object { $_ -ieq $script:handInstallDir })) {
-        $pathDirs = @($script:handInstallDir) + @($pathDirs)
+    $handDirs = @($script:handCommandDir, $script:handInstallDir) | Where-Object { $_ }
+    foreach ($handDir in $handDirs) {
+        if (-not ($pathDirs | Where-Object { $_ -ieq $handDir })) {
+            $pathDirs = @($handDir) + @($pathDirs)
+        }
     }
     $env:PATH = $pathDirs -join ';'
 }

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -130,7 +130,15 @@ function Update-ProcessPathFromRegistry {
     param()
     $machinePath = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
     $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
-    $pathDirs = @($machinePath, $userPath) | ForEach-Object { if ($_){ $_ -split ';' } } | Where-Object { $_ }
+    $pathDirs = @()
+    $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($path in @($env:PATH, $machinePath, $userPath)) {
+        foreach ($pathDir in ($path -split ';')) {
+            if ($pathDir -and $seen.Add($pathDir)) {
+                $pathDirs += $pathDir
+            }
+        }
+    }
     $handDirs = @($script:handCommandDir, $script:handInstallDir) | Where-Object { $_ }
     foreach ($handDir in $handDirs) {
         if (-not ($pathDirs | Where-Object { $_ -ieq $handDir })) {

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -308,7 +308,12 @@ function Get-FleetState {
     if ((Test-Path -LiteralPath (Join-Path $Fleet "data\projects.md") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $Fleet "state") -PathType Container)) {
         return 'fleet'
     }
-    if (-not (Get-ChildItem -LiteralPath $Fleet -Force -ErrorAction SilentlyContinue)) {
+    try {
+        $children = @(Get-ChildItem -LiteralPath $Fleet -Force -ErrorAction Stop)
+    } catch {
+        Fail "cannot inspect fleet target $Fleet: $($_.Exception.Message)"
+    }
+    if ($children.Count -eq 0) {
         return 'empty'
     }
     return 'foreign'

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -101,7 +101,7 @@ function Install-Hand {
             }
 
             Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $tmp -Force
-            New-Item -ItemType Directory -LiteralPath $installDir -Force | Out-Null
+            New-Item -ItemType Directory -Path $installDir -Force | Out-Null
             Copy-Item -Path (Join-Path $tmp "hand.exe") -Destination (Join-Path $installDir "hand.exe") -Force
         } finally {
             Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
@@ -126,6 +126,8 @@ if (-not $handAvailable) {
 # ---- step 2: detect/install missing foundational dependencies ---------------------------------
 
 function Update-ProcessPathFromRegistry {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'mutates only this process''s in-memory $env:PATH, not persistent or external state, so a -WhatIf/-Confirm contract would serve no one')]
+    param()
     $machinePath = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
     $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
     $pathDirs = @($machinePath, $userPath) | ForEach-Object { if ($_){ $_ -split ';' } } | Where-Object { $_ }
@@ -311,7 +313,7 @@ function Get-FleetState {
     try {
         $children = @(Get-ChildItem -LiteralPath $Fleet -Force -ErrorAction Stop)
     } catch {
-        Fail "cannot inspect fleet target $Fleet: $($_.Exception.Message)"
+        Fail "cannot inspect fleet target $Fleet`: $($_.Exception.Message)"
     }
     if ($children.Count -eq 0) {
         return 'empty'
@@ -345,7 +347,7 @@ if ($Check) {
 # ---- step 4: hand init, then hand doctor for the authoritative readiness result ----------------
 
 if ($state -eq 'absent') {
-    New-Item -ItemType Directory -LiteralPath $Fleet -Force | Out-Null
+    New-Item -ItemType Directory -Path $Fleet -Force | Out-Null
 }
 
 $initOut = (& hand init $Fleet 2>&1 | Out-String)

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -101,7 +101,7 @@ function Install-Hand {
             }
 
             Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $tmp -Force
-            New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+            New-Item -ItemType Directory -LiteralPath $installDir -Force | Out-Null
             Copy-Item -Path (Join-Path $tmp "hand.exe") -Destination (Join-Path $installDir "hand.exe") -Force
         } finally {
             Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
@@ -340,7 +340,7 @@ if ($Check) {
 # ---- step 4: hand init, then hand doctor for the authoritative readiness result ----------------
 
 if ($state -eq 'absent') {
-    New-Item -ItemType Directory -Path $Fleet -Force | Out-Null
+    New-Item -ItemType Directory -LiteralPath $Fleet -Force | Out-Null
 }
 
 $initOut = (& hand init $Fleet 2>&1 | Out-String)

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -56,6 +56,7 @@ function Install-Hand {
     }
 
     $installDir = if ($env:HAND_INSTALL_DIR) { $env:HAND_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "hand" }
+    $script:handInstallDir = $installDir
     $sibling = if ($scriptDir) { Join-Path $scriptDir "install.ps1" } else { $null }
     if ($sibling -and (Test-Path -LiteralPath $sibling)) {
         Write-BootstrapLog "installing hand via $sibling"
@@ -120,6 +121,16 @@ if (-not $handAvailable) {
 
 # ---- step 2: detect/install missing foundational dependencies ---------------------------------
 
+function Update-ProcessPathFromRegistry {
+    $machinePath = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
+    $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+    $pathDirs = @($machinePath, $userPath) | ForEach-Object { if ($_){ $_ -split ';' } } | Where-Object { $_ }
+    if ($script:handInstallDir -and -not ($pathDirs | Where-Object { $_ -ieq $script:handInstallDir })) {
+        $pathDirs = @($script:handInstallDir) + @($pathDirs)
+    }
+    $env:PATH = $pathDirs -join ';'
+}
+
 # Get-DepSource is the source column the consent prompt shows for a missing foundational
 # dependency.
 function Get-DepSource {
@@ -174,13 +185,7 @@ function Invoke-DepAction {
         'cmd' {
             if (-not $action.Value) { return $false }
             & $action.Value[0] @($action.Value[1..($action.Value.Length - 1)])
-            $ok = $LASTEXITCODE -eq 0
-            if ($Dep -eq 'git') {
-                $machinePath = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
-                $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
-                $env:PATH = (@($machinePath, $userPath) | Where-Object { $_ }) -join ';'
-            }
-            return $ok
+            return $LASTEXITCODE -eq 0
         }
         'url' {
             $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName() + ".ps1")
@@ -267,6 +272,7 @@ function Install-FoundationalDep {
             $installFailed = $true
             continue
         }
+        Update-ProcessPathFromRegistry
         if (-not (Get-Command $dep -ErrorAction SilentlyContinue)) {
             Write-BootstrapLog "$dep`: installed but still not on PATH"
             $installFailed = $true

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,402 @@
+#Requires -Version 5.1
+# Optional, explicitly opt-in Secondhand adoption for native Windows: acquires hand if missing,
+# offers to install missing foundational dependencies (git, treehouse, herdr) with consent,
+# reconciles a fleet home with `hand init`, reads readiness from `hand doctor`, and prints the
+# exact next command. Never installs a coding-agent harness or no-mistakes; never reimplements
+# `hand init` or `hand doctor` validation logic. No WSL: every step below runs as native
+# PowerShell against native Windows tools.
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Yes', Justification = 'read inside Install-Hand and Install-FoundationalDep, which close over this script-scope parameter')]
+param(
+    [string]$Fleet = (Join-Path ([Environment]::GetFolderPath('UserProfile')) "secondhand-fleet"),
+    [switch]$Yes,
+    [switch]$Check
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-BootstrapLog {
+    param([string]$Message)
+    Write-Host $Message
+}
+
+function Fail {
+    param([string]$Message)
+    Write-BootstrapLog "bootstrap.ps1: $Message"
+    exit 1
+}
+
+$interactive = (-not $Check) -and (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
+
+$scriptDir = $null
+if ($PSCommandPath) {
+    $scriptDir = Split-Path -Parent $PSCommandPath
+}
+
+# ---- step 1: acquire or verify hand ------------------------------------------------------------
+
+$handAvailable = [bool](Get-Command hand -ErrorAction SilentlyContinue)
+
+# Install-Hand only ever runs when hand is missing. In check mode it reports and returns without
+# mutating; otherwise it fails with an actionable message on every path that cannot end with hand
+# on PATH, so callers never have to re-check its result.
+function Install-Hand {
+    if ($Check) {
+        Write-BootstrapLog "hand: not installed (check mode: no changes made)"
+        return
+    }
+    if (-not $Yes -and -not $interactive) {
+        Fail "hand is not installed, and bootstrap is not running interactively without -Yes: refusing to install it"
+    }
+    if (-not $Yes) {
+        $reply = Read-Host "hand is not installed. Install it now via install.ps1? [y/N]"
+        if ($reply -notmatch '^(y|yes)$') {
+            Fail "hand install declined; cannot continue"
+        }
+    }
+
+    $installDir = if ($env:HAND_INSTALL_DIR) { $env:HAND_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "hand" }
+    $sibling = if ($scriptDir) { Join-Path $scriptDir "install.ps1" } else { $null }
+    if ($sibling -and (Test-Path $sibling)) {
+        Write-BootstrapLog "installing hand via $sibling"
+        try {
+            & $sibling
+        } catch {
+            Fail "install.ps1 failed: $($_.Exception.Message); recover by resolving the reported error and rerunning bootstrap.ps1"
+        }
+    } else {
+        Write-BootstrapLog "installing hand from checksum-verified GitHub release"
+        $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $tmp | Out-Null
+        try {
+            $repo = "atqamz/hand"
+            $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest"
+            $tag = $release.tag_name
+            if (-not $tag) {
+                Fail "could not resolve the latest hand release tag"
+            }
+            $asset = "hand-windows-amd64.zip"
+            $baseUrl = "https://github.com/$repo/releases/download/$tag"
+            try {
+                Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile (Join-Path $tmp $asset)
+                Invoke-WebRequest -Uri "$baseUrl/checksums.txt" -OutFile (Join-Path $tmp "checksums.txt")
+            } catch {
+                Fail "could not download the hand release or checksums: $($_.Exception.Message)"
+            }
+            if ((Get-Item (Join-Path $tmp $asset)).Length -eq 0) {
+                Fail "downloaded hand release archive is empty"
+            }
+
+            $line = Get-Content (Join-Path $tmp "checksums.txt") | Where-Object { $_ -match [regex]::Escape($asset) + '\s*$' }
+            if (-not $line) {
+                Fail "checksums.txt has no entry for $asset"
+            }
+            $want = (($line | Select-Object -First 1) -split '\s+')[0].ToLower()
+            $got = (Get-FileHash -Algorithm SHA256 (Join-Path $tmp $asset)).Hash.ToLower()
+            if ($got -ne $want) {
+                Fail "checksum mismatch for ${asset}: want $want, got $got"
+            }
+
+            Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $tmp -Force
+            New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+            Copy-Item -Path (Join-Path $tmp "hand.exe") -Destination (Join-Path $installDir "hand.exe") -Force
+        } finally {
+            Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+        }
+    }
+
+    $pathDirs = $env:PATH -split ';'
+    if ($pathDirs -notcontains $installDir) {
+        $env:PATH = "$installDir;$env:PATH"
+    }
+    if (-not (Get-Command hand -ErrorAction SilentlyContinue)) {
+        Fail "hand was installed but is still not on PATH; add $installDir to PATH and rerun bootstrap.ps1"
+    }
+}
+
+if (-not $handAvailable) {
+    Install-Hand
+}
+
+# ---- step 2: detect/install missing foundational dependencies ---------------------------------
+
+# Get-DepSource is the source column the consent prompt shows for a missing foundational
+# dependency.
+function Get-DepSource {
+    param([string]$Dep)
+    switch ($Dep) {
+        'git' { 'winget (or install Git for Windows manually)' }
+        'treehouse' { 'kunchenguid/treehouse' }
+        'herdr' { 'ogulcancelik/herdr' }
+    }
+}
+
+# Resolve-DepAction returns @{ Kind = 'cmd'|'url'; Value = <winget args>|<installer url> } for
+# $Dep. A url is never invoked directly with `irm ... | iex`: Invoke-DepAction downloads to a
+# file first and only runs it once the download itself is confirmed to have succeeded, the same
+# fetch-then-verify-then-run shape bootstrap.sh uses so a failed fetch can never be mistaken for
+# an empty, successful script.
+function Resolve-DepAction {
+    param([string]$Dep)
+    switch ($Dep) {
+        'git' {
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+                @{ Kind = 'cmd'; Value = @('winget', 'install', '--id', 'Git.Git', '-e', '--source', 'winget', '--accept-package-agreements', '--accept-source-agreements') }
+            } else {
+                @{ Kind = 'cmd'; Value = $null }
+            }
+        }
+        'treehouse' {
+            @{ Kind = 'url'; Value = 'https://kunchenguid.github.io/treehouse/install.ps1' }
+        }
+        'herdr' {
+            @{ Kind = 'url'; Value = 'https://herdr.dev/install.ps1' }
+        }
+        default {
+            @{ Kind = 'cmd'; Value = $null }
+        }
+    }
+}
+
+function Get-DepActionDescription {
+    param([string]$Dep)
+    $action = Resolve-DepAction $Dep
+    switch ($action.Kind) {
+        'cmd' { if ($action.Value) { $action.Value -join ' ' } else { $null } }
+        'url' { "download and verify $($action.Value), then run only the completed download" }
+    }
+}
+
+function Invoke-DepAction {
+    param([string]$Dep)
+    $action = Resolve-DepAction $Dep
+    switch ($action.Kind) {
+        'cmd' {
+            if (-not $action.Value) { return $false }
+            & $action.Value[0] @($action.Value[1..($action.Value.Length - 1)])
+            return $LASTEXITCODE -eq 0
+        }
+        'url' {
+            $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName() + ".ps1")
+            try {
+                Invoke-WebRequest -Uri $action.Value -OutFile $tmp
+            } catch {
+                Remove-Item -Force $tmp -ErrorAction SilentlyContinue
+                return $false
+            }
+            if (-not (Test-Path $tmp) -or (Get-Item $tmp).Length -eq 0) {
+                Remove-Item -Force $tmp -ErrorAction SilentlyContinue
+                return $false
+            }
+            $ok = $true
+            try {
+                & $tmp
+            } catch {
+                $ok = $false
+            }
+            Remove-Item -Force $tmp -ErrorAction SilentlyContinue
+            return $ok
+        }
+    }
+}
+
+# Get-MissingFoundationalDep lists, in the same order hand doctor's foundational tools table
+# does, every dependency doctor would also report missing - never a schema bootstrap invents.
+function Get-MissingFoundationalDep {
+    @('git', 'treehouse', 'herdr') | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) }
+}
+
+# Install-FoundationalDep returns $true once every foundational dependency is on PATH, and
+# $false whenever one remains missing - declined, failed, unsupported, or check mode. It never
+# treats that as fatal itself: `hand doctor` is the one place a remaining gap is judged blocking.
+function Install-FoundationalDep {
+    $missing = @(Get-MissingFoundationalDep)
+    if ($missing.Count -eq 0) { return $true }
+
+    if ($Check) {
+        Write-BootstrapLog "missing foundational dependencies (check mode: no changes made):"
+        foreach ($dep in $missing) { Write-BootstrapLog "  $dep" }
+        return $false
+    }
+
+    Write-BootstrapLog "Missing foundational runtime dependencies:"
+    Write-BootstrapLog ""
+    foreach ($dep in $missing) {
+        $desc = Get-DepActionDescription $dep
+        Write-BootstrapLog "  $dep"
+        Write-BootstrapLog "    source: $(Get-DepSource $dep)"
+        if ($desc) {
+            Write-BootstrapLog "    install method: $desc"
+        } else {
+            Write-BootstrapLog "    install method: none detected for this platform; install $dep manually, then rerun bootstrap.ps1"
+        }
+        Write-BootstrapLog ""
+    }
+
+    $proceed = [bool]$Yes
+    if (-not $proceed) {
+        if (-not $interactive) {
+            Write-BootstrapLog "not running interactively and -Yes was not given: declining to install any of the above"
+            return $false
+        }
+        $reply = Read-Host "Install these dependencies? [y/N]"
+        $proceed = $reply -match '^(y|yes)$'
+    }
+    if (-not $proceed) {
+        Write-BootstrapLog "declined: continuing without installing missing foundational dependencies"
+        return $false
+    }
+
+    $installFailed = $false
+    foreach ($dep in $missing) {
+        $desc = Get-DepActionDescription $dep
+        if (-not $desc) {
+            Write-BootstrapLog "$dep`: no supported install method detected on this platform; skipping"
+            $installFailed = $true
+            continue
+        }
+        Write-BootstrapLog "installing $dep`: $desc"
+        if (-not (Invoke-DepAction $dep)) {
+            Write-BootstrapLog "$dep`: install action failed"
+            $installFailed = $true
+            continue
+        }
+        if (-not (Get-Command $dep -ErrorAction SilentlyContinue)) {
+            Write-BootstrapLog "$dep`: installed but still not on PATH"
+            $installFailed = $true
+        }
+    }
+    -not $installFailed
+}
+
+$null = Install-FoundationalDep
+
+# ---- step 3: choose a safe fleet-home target ---------------------------------------------------
+
+# Get-FleetState never duplicates hand doctor's or hand init's own validation: it only decides the
+# one thing bootstrap alone is responsible for before ever invoking hand init - whether this
+# target is safe to hand to it at all.
+function Get-FleetState {
+    if (-not (Test-Path $Fleet)) {
+        return 'absent'
+    }
+    if (-not (Test-Path $Fleet -PathType Container)) {
+        Fail "$Fleet exists and is not a directory"
+    }
+    if ((Test-Path (Join-Path $Fleet "state\hand.db") -PathType Leaf)) {
+        return 'fleet'
+    }
+    if ((Test-Path (Join-Path $Fleet "data\projects.md") -PathType Leaf) -and (Test-Path (Join-Path $Fleet "state") -PathType Container)) {
+        return 'fleet'
+    }
+    if (-not (Get-ChildItem -Force $Fleet -ErrorAction SilentlyContinue)) {
+        return 'empty'
+    }
+    return 'foreign'
+}
+
+$state = Get-FleetState
+if ($state -eq 'foreign') {
+    Fail "$Fleet exists, is not empty, and is not a recognized Secondhand fleet; refusing to adopt it - pass -Fleet with an empty or already-initialized path"
+}
+
+if ($Check) {
+    Write-BootstrapLog ""
+    Write-BootstrapLog "fleet target: $Fleet ($state)"
+    if ($state -ne 'fleet') {
+        Write-BootstrapLog "hand init has not run here yet; check mode makes no changes, so readiness cannot be evaluated further"
+        exit 0
+    }
+    if (-not $handAvailable) {
+        Write-BootstrapLog "hand is not installed; readiness cannot be evaluated further"
+        exit 0
+    }
+    $env:HAND_HOME = $Fleet
+    $doctorOut = (& hand doctor 2>&1 | Out-String)
+    Write-BootstrapLog ""
+    Write-BootstrapLog $doctorOut
+    exit 0
+}
+
+# ---- step 4: hand init, then hand doctor for the authoritative readiness result ----------------
+
+if ($state -eq 'absent') {
+    New-Item -ItemType Directory -Path $Fleet -Force | Out-Null
+}
+
+$initOut = (& hand init $Fleet 2>&1 | Out-String)
+if ($LASTEXITCODE -ne 0) {
+    Write-BootstrapLog $initOut
+    Fail "hand init failed against $Fleet; recover by resolving the reported error, then rerun: bootstrap.ps1 -Fleet $Fleet"
+}
+Write-BootstrapLog $initOut
+
+$env:HAND_HOME = $Fleet
+$doctorOut = (& hand doctor 2>&1 | Out-String)
+Write-BootstrapLog ""
+Write-BootstrapLog $doctorOut
+
+# Get-DoctorField extracts a scalar TOON field ("key: value") from hand doctor's stdout.
+function Get-DoctorField {
+    param([string]$Name, [string]$Text)
+    foreach ($line in ($Text -split "`r?`n")) {
+        if ($line -match "^$Name`: (.*)$") { return $Matches[1] }
+    }
+    return $null
+}
+
+# Get-DoctorList extracts the "  - item" lines under one TOON list block ("name[N]:").
+function Get-DoctorList {
+    param([string]$Name, [string]$Text)
+    $items = @()
+    $inBlock = $false
+    foreach ($line in ($Text -split "`r?`n")) {
+        if ($line -like "$Name[[]*") { $inBlock = $true; continue }
+        if ($inBlock -and $line -match '^  - (.*)$') { $items += $Matches[1]; continue }
+        if ($inBlock) { $inBlock = $false }
+    }
+    return $items
+}
+
+# Get-InstalledHarness reads the harnesses[N]{name,installed} rows hand doctor already
+# computed, in the order hand reports them, so bootstrap never re-detects harnesses on its own.
+function Get-InstalledHarness {
+    param([string]$Text)
+    $names = @()
+    $inBlock = $false
+    foreach ($line in ($Text -split "`r?`n")) {
+        if ($line -like "harnesses[[]*") { $inBlock = $true; continue }
+        if ($inBlock -and $line -match '^  (\w+),(true|false)$') {
+            if ($Matches[2] -eq 'true') { $names += $Matches[1] }
+            continue
+        }
+        if ($inBlock) { $inBlock = $false }
+    }
+    return $names
+}
+
+$ready = Get-DoctorField 'ready' $doctorOut
+if ($ready -ne 'true') {
+    $blocking = Get-DoctorList 'blocking' $doctorOut
+    Write-BootstrapLog ""
+    Write-BootstrapLog "Secondhand is not ready yet. Blocking:"
+    foreach ($item in $blocking) { Write-BootstrapLog "  - $item" }
+    Fail "recover the items above, then rerun: `$env:HAND_HOME='$Fleet'; hand doctor"
+}
+
+$harnesses = @(Get-InstalledHarness $doctorOut)
+
+Write-BootstrapLog ""
+Write-BootstrapLog "Secondhand is ready."
+Write-BootstrapLog ""
+Write-BootstrapLog "Next:"
+Write-BootstrapLog ""
+Write-BootstrapLog "  cd $Fleet"
+if ($harnesses.Count -eq 1) {
+    Write-BootstrapLog "  $($harnesses[0])"
+} elseif ($harnesses.Count -gt 1) {
+    Write-BootstrapLog "  <choose one of the installed harnesses below>"
+    foreach ($h in $harnesses) { Write-BootstrapLog "    $h" }
+} else {
+    Write-BootstrapLog "  <install and authenticate at least one supported coding-agent harness, then run hand doctor>"
+}

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -57,7 +57,7 @@ function Install-Hand {
 
     $installDir = if ($env:HAND_INSTALL_DIR) { $env:HAND_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "hand" }
     $sibling = if ($scriptDir) { Join-Path $scriptDir "install.ps1" } else { $null }
-    if ($sibling -and (Test-Path $sibling)) {
+    if ($sibling -and (Test-Path -LiteralPath $sibling)) {
         Write-BootstrapLog "installing hand via $sibling"
         try {
             & $sibling
@@ -83,7 +83,7 @@ function Install-Hand {
             } catch {
                 Fail "could not download the hand release or checksums: $($_.Exception.Message)"
             }
-            if ((Get-Item (Join-Path $tmp $asset)).Length -eq 0) {
+            if ((Get-Item -LiteralPath (Join-Path $tmp $asset)).Length -eq 0) {
                 Fail "downloaded hand release archive is empty"
             }
 
@@ -174,7 +174,13 @@ function Invoke-DepAction {
         'cmd' {
             if (-not $action.Value) { return $false }
             & $action.Value[0] @($action.Value[1..($action.Value.Length - 1)])
-            return $LASTEXITCODE -eq 0
+            $ok = $LASTEXITCODE -eq 0
+            if ($Dep -eq 'git') {
+                $machinePath = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
+                $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+                $env:PATH = (@($machinePath, $userPath) | Where-Object { $_ }) -join ';'
+            }
+            return $ok
         }
         'url' {
             $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName() + ".ps1")
@@ -184,7 +190,7 @@ function Invoke-DepAction {
                 Remove-Item -Force $tmp -ErrorAction SilentlyContinue
                 return $false
             }
-            if (-not (Test-Path $tmp) -or (Get-Item $tmp).Length -eq 0) {
+            if (-not (Test-Path -LiteralPath $tmp) -or (Get-Item -LiteralPath $tmp).Length -eq 0) {
                 Remove-Item -Force $tmp -ErrorAction SilentlyContinue
                 return $false
             }
@@ -277,19 +283,19 @@ $null = Install-FoundationalDep
 # one thing bootstrap alone is responsible for before ever invoking hand init - whether this
 # target is safe to hand to it at all.
 function Get-FleetState {
-    if (-not (Test-Path $Fleet)) {
+    if (-not (Test-Path -LiteralPath $Fleet)) {
         return 'absent'
     }
-    if (-not (Test-Path $Fleet -PathType Container)) {
+    if (-not (Test-Path -LiteralPath $Fleet -PathType Container)) {
         Fail "$Fleet exists and is not a directory"
     }
-    if ((Test-Path (Join-Path $Fleet "state\hand.db") -PathType Leaf)) {
+    if ((Test-Path -LiteralPath (Join-Path $Fleet "state\hand.db") -PathType Leaf)) {
         return 'fleet'
     }
-    if ((Test-Path (Join-Path $Fleet "data\projects.md") -PathType Leaf) -and (Test-Path (Join-Path $Fleet "state") -PathType Container)) {
+    if ((Test-Path -LiteralPath (Join-Path $Fleet "data\projects.md") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $Fleet "state") -PathType Container)) {
         return 'fleet'
     }
-    if (-not (Get-ChildItem -Force $Fleet -ErrorAction SilentlyContinue)) {
+    if (-not (Get-ChildItem -LiteralPath $Fleet -Force -ErrorAction SilentlyContinue)) {
         return 'empty'
     }
     return 'foreign'

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -181,8 +181,7 @@ func goToolPath() string {
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	//nolint:staticcheck // hermetic test PATHs can hide go, so the running toolchain is the reliable fallback.
-	path := filepath.Join(runtime.GOROOT(), "bin", name)
+	path := filepath.Join(runtime.GOROOT(), "bin", name) //nolint:staticcheck // hermetic test PATHs can hide go, so the running toolchain is the reliable fallback.
 	if _, err := os.Stat(path); err == nil {
 		return path
 	}

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -176,12 +176,13 @@ func helperBinary(t *testing.T) string {
 	return helperBuild.path
 }
 
+//nolint:staticcheck // hermetic test PATHs can hide go, so the running toolchain is the reliable fallback.
 func goToolPath() string {
 	name := "go"
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	path := filepath.Join(runtime.GOROOT(), "bin", name) //nolint:staticcheck // hermetic test PATHs can hide go, so the running toolchain is the reliable fallback.
+	path := filepath.Join(runtime.GOROOT(), "bin", name)
 	if _, err := os.Stat(path); err == nil {
 		return path
 	}

--- a/tests/e2e/bootstrap_windows_test.go
+++ b/tests/e2e/bootstrap_windows_test.go
@@ -27,9 +27,12 @@ var bootstrapPS1Script = func() string {
 func runBootstrapPS1(t *testing.T, home string, extraEnv []string, args ...string) invocation {
 	t.Helper()
 	psArgs := append([]string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", bootstrapPS1Script}, args...)
-	powershell := "powershell.exe"
-	if _, err := exec.LookPath(powershell); err != nil {
-		powershell = "pwsh.exe"
+	powershell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		powershell, err = exec.LookPath("pwsh.exe")
+	}
+	if err != nil {
+		t.Fatalf("find a native PowerShell executable: %v", err)
 	}
 	cmd := exec.Command(powershell, psArgs...)
 	env := append([]string{"PATH=" + os.Getenv("PATH"), "USERPROFILE=" + home, "SystemRoot=" + os.Getenv("SystemRoot")}, extraEnv...)

--- a/tests/e2e/bootstrap_windows_test.go
+++ b/tests/e2e/bootstrap_windows_test.go
@@ -21,13 +21,17 @@ var bootstrapPS1Script = func() string {
 	return abs
 }()
 
-// Runs bootstrap.ps1 under native Windows PowerShell (not pwsh core, not WSL) with an explicit,
+// Runs bootstrap.ps1 under an available native Windows PowerShell executable with an explicit,
 // minimal environment - PATH and USERPROFILE (which [Environment]::GetFolderPath('UserProfile')
 // reads) only - so a test can prove nothing beyond those two ever reaches the script.
 func runBootstrapPS1(t *testing.T, home string, extraEnv []string, args ...string) invocation {
 	t.Helper()
 	psArgs := append([]string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", bootstrapPS1Script}, args...)
-	cmd := exec.Command("powershell.exe", psArgs...)
+	powershell := "powershell.exe"
+	if _, err := exec.LookPath(powershell); err != nil {
+		powershell = "pwsh.exe"
+	}
+	cmd := exec.Command(powershell, psArgs...)
 	env := append([]string{"PATH=" + os.Getenv("PATH"), "USERPROFILE=" + home, "SystemRoot=" + os.Getenv("SystemRoot")}, extraEnv...)
 	cmd.Env = env
 	var stdout, stderr strings.Builder

--- a/tests/e2e/bootstrap_windows_test.go
+++ b/tests/e2e/bootstrap_windows_test.go
@@ -1,0 +1,262 @@
+//go:build e2e && windows
+
+package e2e
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Resolved once, relative to this package, so a test never depends on the working directory
+// `go test` happened to be invoked from.
+var bootstrapPS1Script = func() string {
+	abs, err := filepath.Abs(filepath.Join("..", "..", "bootstrap.ps1"))
+	if err != nil {
+		panic(err)
+	}
+	return abs
+}()
+
+// Runs bootstrap.ps1 under native Windows PowerShell (not pwsh core, not WSL) with an explicit,
+// minimal environment - PATH and USERPROFILE (which [Environment]::GetFolderPath('UserProfile')
+// reads) only - so a test can prove nothing beyond those two ever reaches the script.
+func runBootstrapPS1(t *testing.T, home string, extraEnv []string, args ...string) invocation {
+	t.Helper()
+	psArgs := append([]string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", bootstrapPS1Script}, args...)
+	cmd := exec.Command("powershell.exe", psArgs...)
+	env := append([]string{"PATH=" + os.Getenv("PATH"), "USERPROFILE=" + home, "SystemRoot=" + os.Getenv("SystemRoot")}, extraEnv...)
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	code := 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run bootstrap.ps1 %v: %v", args, err)
+		}
+		code = exitErr.ExitCode()
+	}
+	t.Logf("$ bootstrap.ps1 %s\n  exit %d\n  stdout: %s\n  stderr: %s",
+		strings.Join(args, " "), code, strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()))
+	return invocation{code: code, stdout: stdout.String(), stderr: stderr.String()}
+}
+
+// Puts a copy of the already-built hand binary on dir as hand.exe, the extension native Windows
+// PATH resolution (and a real install.ps1) requires; a bare "hand" is never found by Get-Command.
+func installFakeHandExe(t *testing.T, dir string) {
+	t.Helper()
+	data, err := os.ReadFile(handBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "hand.exe"), data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Drops a no-op .cmd on dir under name, standing in for an installed tool or an installed,
+// authenticated coding-agent harness: bootstrap.ps1 only ever needs Get-Command to find it.
+func installFakeCmdExe(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name+".cmd"), []byte("@exit /b 0\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func isFleetHomeWindows(fleet string) bool {
+	_, err := os.Stat(filepath.Join(fleet, "state", "hand.db"))
+	return err == nil
+}
+
+func TestBootstrapPS1HappyPathReconcilesFleetAndPrintsTheInstalledHarness(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+	installFakeCmdExe(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !isFleetHomeWindows(fleet) {
+		t.Fatalf("%s was not initialized as a fleet home", fleet)
+	}
+	for _, want := range []string{"Secondhand is ready.", "cd " + fleet, "claude", "ready: true"} {
+		if !strings.Contains(got.stdout, want) {
+			t.Fatalf("stdout = %q, want it to contain %q", got.stdout, want)
+		}
+	}
+}
+
+func TestBootstrapPS1RefusesAForeignNonEmptyFleetTarget(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+
+	home := t.TempDir()
+	fleet := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fleet, "unrelated.txt"), []byte("not a fleet\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Yes")
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1 (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "refusing to adopt it") {
+		t.Fatalf("stdout = %q, want a refusal for the foreign non-empty target", got.stdout)
+	}
+	if isFleetHomeWindows(fleet) {
+		t.Fatal("bootstrap.ps1 mutated a foreign non-empty target instead of refusing it")
+	}
+}
+
+func TestBootstrapPS1CheckModeNeverMutatesAnAbsentFleetTarget(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+	installFakeCmdExe(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Check")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 for check mode (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if _, err := os.Stat(fleet); !os.IsNotExist(err) {
+		t.Fatalf("-Check created %s; check mode must never mutate", fleet)
+	}
+}
+
+func TestBootstrapPS1DeclinesMissingDependenciesNonInteractivelyWithoutYesAndFailsClosed(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "herdr")
+	// treehouse deliberately left missing, and PowerShell's stdin is not an interactive console
+	// under exec.Command, so bootstrap must decline installing it rather than hang or guess consent.
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrapPS1(t, home, nil, "-Fleet", fleet)
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1 (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	for _, want := range []string{
+		"declining to install any of the above",
+		"- treehouse",
+		"recover the items above, then rerun",
+	} {
+		if !strings.Contains(got.stdout, want) {
+			t.Fatalf("stdout = %q, want it to contain %q", got.stdout, want)
+		}
+	}
+	if !isFleetHomeWindows(fleet) {
+		t.Fatal("hand init did not run even though only a foundational dependency was missing; a partial setup must still be retained and reconciled")
+	}
+}
+
+func TestBootstrapPS1NeverInstallsAHarnessOrNoMistakesAutomatically(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+	// No coding-agent harness and no no-mistakes on PATH at all.
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	got := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Yes")
+	if got.code != 1 {
+		t.Fatalf("exit = %d, want 1: no harness is installed, so the fleet cannot be ready (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "- harness") {
+		t.Fatalf("stdout = %q, want the missing harness reported as blocking", got.stdout)
+	}
+	for _, name := range []string{"claude", "codex", "grok", "pi", "opencode", "no-mistakes"} {
+		if strings.Contains(got.stdout, "installing "+name) {
+			t.Fatalf("stdout = %q, want bootstrap to never attempt installing a harness or no-mistakes", got.stdout)
+		}
+		if _, err := os.Stat(filepath.Join(dir, name+".cmd")); err == nil {
+			t.Fatalf("%s was created on PATH; bootstrap must only ever detect harnesses, never install one", name)
+		}
+	}
+}
+
+func TestBootstrapPS1AcceptsAFleetTargetPathContainingSpaces(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+	installFakeCmdExe(t, dir, "codex")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "my secondhand fleet")
+
+	got := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 for a fleet path containing spaces (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if !isFleetHomeWindows(fleet) {
+		t.Fatalf("%s was not initialized", fleet)
+	}
+}
+
+func TestBootstrapPS1NeverForwardsAmbientSecretsIntoItsOutput(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+	installFakeCmdExe(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+	const secret = "poison-token-do-not-print-1x2y3z"
+
+	got := runBootstrapPS1(t, home, []string{"GH_TOKEN=" + secret, "ANTHROPIC_API_KEY=" + secret}, "-Fleet", fleet, "-Yes")
+	if got.code != 0 {
+		t.Fatalf("exit = %d, want 0 (stdout %q, stderr %q)", got.code, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stdout, secret) || strings.Contains(got.stderr, secret) {
+		t.Fatal("bootstrap.ps1 leaked an ambient credential into its own output")
+	}
+}
+
+func TestBootstrapPS1ReconcilesAnExistingFleetIdempotently(t *testing.T) {
+	dir := binDir(t)
+	installFakeHandExe(t, dir)
+	installFakeCmdExe(t, dir, "treehouse")
+	installFakeCmdExe(t, dir, "herdr")
+	installFakeCmdExe(t, dir, "claude")
+
+	home := t.TempDir()
+	fleet := filepath.Join(home, "secondhand-fleet")
+
+	first := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Yes")
+	if first.code != 0 {
+		t.Fatalf("first run: exit = %d, want 0 (stdout %q, stderr %q)", first.code, first.stdout, first.stderr)
+	}
+
+	second := runBootstrapPS1(t, home, nil, "-Fleet", fleet, "-Yes")
+	if second.code != 0 {
+		t.Fatalf("second run: exit = %d, want 0 (stdout %q, stderr %q)", second.code, second.stdout, second.stderr)
+	}
+	if !strings.Contains(second.stdout, "agents_md: unchanged") {
+		t.Fatalf("second run stdout = %q, want hand init to report the already-canonical AGENTS.md unchanged", second.stdout)
+	}
+	if !strings.Contains(second.stdout, "Secondhand is ready.") {
+		t.Fatalf("second run stdout = %q, want a ready fleet on a repeat run", second.stdout)
+	}
+}

--- a/tests/e2e/bootstrap_windows_test.go
+++ b/tests/e2e/bootstrap_windows_test.go
@@ -24,13 +24,36 @@ var bootstrapPS1Script = func() string {
 // Runs bootstrap.ps1 under an available native Windows PowerShell executable with an explicit,
 // minimal environment - PATH and USERPROFILE (which [Environment]::GetFolderPath('UserProfile')
 // reads) only - so a test can prove nothing beyond those two ever reaches the script.
+func findPowerShell() (string, error) {
+	names := []string{"powershell.exe", "pwsh.exe"}
+	for _, name := range names {
+		if path, err := exec.LookPath(name); err == nil {
+			return path, nil
+		}
+	}
+
+	candidates := make([]string, 0, 4)
+	if root := os.Getenv("SystemRoot"); root != "" {
+		candidates = append(candidates, filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"))
+	}
+	for _, root := range []string{os.Getenv("ProgramW6432"), os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)")} {
+		if root != "" {
+			candidates = append(candidates, filepath.Join(root, "PowerShell", "7", "pwsh.exe"))
+		}
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", errors.New("PowerShell was not found on PATH or in its standard Windows install locations")
+}
+
 func runBootstrapPS1(t *testing.T, home string, extraEnv []string, args ...string) invocation {
 	t.Helper()
 	psArgs := append([]string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", bootstrapPS1Script}, args...)
-	powershell, err := exec.LookPath("powershell.exe")
-	if err != nil {
-		powershell, err = exec.LookPath("pwsh.exe")
-	}
+	powershell, err := findPowerShell()
 	if err != nil {
 		t.Fatalf("find a native PowerShell executable: %v", err)
 	}

--- a/tests/e2e/bootstrap_windows_test.go
+++ b/tests/e2e/bootstrap_windows_test.go
@@ -21,9 +21,9 @@ var bootstrapPS1Script = func() string {
 	return abs
 }()
 
-// Runs bootstrap.ps1 under an available native Windows PowerShell executable with an explicit,
-// minimal environment - PATH and USERPROFILE (which [Environment]::GetFolderPath('UserProfile')
-// reads) only - so a test can prove nothing beyond those two ever reaches the script.
+// exec.Command resolves a bare name against this process's own PATH at call time, which is not
+// guaranteed to carry either PowerShell edition on every runner, so this also checks each
+// edition's fixed, well-known install location before giving up.
 func findPowerShell() (string, error) {
 	names := []string{"powershell.exe", "pwsh.exe"}
 	for _, name := range names {
@@ -50,16 +50,51 @@ func findPowerShell() (string, error) {
 	return "", errors.New("PowerShell was not found on PATH or in its standard Windows install locations")
 }
 
+// A hand-picked minimal allowlist is the wrong isolation strategy on Windows: PATHEXT,
+// LOCALAPPDATA and TEMP all matter to bootstrap.ps1, so this starts from the real environment
+// and overrides only USERPROFILE and the app-data variables read off of it, redirected under home.
+func windowsIsolatedEnv(home string, extraEnv []string) []string {
+	overridden := map[string]string{
+		"USERPROFILE":  home,
+		"LOCALAPPDATA": filepath.Join(home, "AppData", "Local"),
+		"APPDATA":      filepath.Join(home, "AppData", "Roaming"),
+		"TEMP":         filepath.Join(home, "Temp"),
+		"TMP":          filepath.Join(home, "Temp"),
+	}
+	for _, entry := range extraEnv {
+		if name, value, ok := strings.Cut(entry, "="); ok {
+			overridden[strings.ToUpper(name)] = value
+		}
+	}
+	env := make([]string, 0, len(os.Environ())+len(overridden))
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if _, replaced := overridden[strings.ToUpper(name)]; !replaced {
+			env = append(env, entry)
+		}
+	}
+	for name, value := range overridden {
+		env = append(env, name+"="+value)
+	}
+	return env
+}
+
+// Runs bootstrap.ps1 under native Windows PowerShell against an environment isolated to home,
+// so a test can prove nothing beyond that isolated environment ever reaches the script.
 func runBootstrapPS1(t *testing.T, home string, extraEnv []string, args ...string) invocation {
 	t.Helper()
+	for _, dir := range []string{filepath.Join(home, "AppData", "Local"), filepath.Join(home, "AppData", "Roaming"), filepath.Join(home, "Temp")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
 	psArgs := append([]string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", bootstrapPS1Script}, args...)
 	powershell, err := findPowerShell()
 	if err != nil {
 		t.Fatalf("find a native PowerShell executable: %v", err)
 	}
 	cmd := exec.Command(powershell, psArgs...)
-	env := append([]string{"PATH=" + os.Getenv("PATH"), "USERPROFILE=" + home, "SystemRoot=" + os.Getenv("SystemRoot")}, extraEnv...)
-	cmd.Env = env
+	cmd.Env = windowsIsolatedEnv(home, extraEnv)
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -33,7 +34,11 @@ func buildHermeticPath(dir string) (string, error) {
 		// Each binary is symlinked in individually rather than given its own directory on PATH: on a real
 		// machine git commonly lives in the same directory as real herdr and treehouse, so exposing that
 		// directory would hand the suite straight back the tools it fakes.
-		if err := os.Symlink(resolved, filepath.Join(dir, name)); err != nil {
+		linkName := name
+		if runtime.GOOS == "windows" {
+			linkName += ".exe"
+		}
+		if err := os.Symlink(resolved, filepath.Join(dir, linkName)); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
## Intent

Second follow-up fix on the same atqamz/hand#220 bootstrap.ps1 PR (part of #220, on top of merged #296 and #297). The prior run auto-fixed the PowerShell-executable-resolution bug (converging on a findPowerShell helper that tries LookPath then falls back to fixed known install locations for both editions - I compared it against my own equivalent fix and adopted the pipeline one since it was already pushed, CI-in-flight, and functionally a superset of mine), then CI failed again on every single bootstrap.ps1 test with an identical error: Cannot bind argument to parameter Path because it is null. I diagnosed this myself: it is a test-harness bug, not a bootstrap.ps1 bug. The Go test constructed a minimal three-variable Windows environment (PATH, USERPROFILE, SystemRoot) for the child powershell.exe process. That omitted PATHEXT, so Get-Command could never resolve the fake hand.exe dropped on PATH by its bare name hand (extension-less command resolution on Windows depends on PATHEXT listing .EXE), which made bootstrap.ps1 wrongly conclude hand was not installed even when the test had supplied it; and it omitted LOCALAPPDATA, so bootstrap.ps1 own $installDir = Join-Path $env:LOCALAPPDATA "hand" computation - reached because it incorrectly believed Install-Hand needed to run - received a null path and threw exactly the observed exception, before any of my own log lines could print, which is why every failing test showed empty stdout. The general lesson: a Windows script implicitly depends on far more ambient environment variables than a POSIX shell script does (PATHEXT, LOCALAPPDATA, APPDATA, TEMP/TMP at minimum), so a hand-picked minimal allowlist - which worked fine for the analogous bootstrap.sh Linux/macOS e2e tests, where PATH and HOME are essentially the only load-bearing ambient variables - is the wrong isolation strategy on Windows. I rewrote the test harness to start from the real inherited environment (os.Environ()) and override only what test isolation actually requires: USERPROFILE plus the app-data variables (LOCALAPPDATA, APPDATA, TEMP, TMP) read off of it, all redirected under the test own home directory so nothing touches the CI runner real profile, with those directories created up front since Windows does not auto-create them. I verified this reasoning is internally consistent with the actual failure signature (identical error on every test, zero stdout before the crash, and the one test that does not pre-install a fake hand.exe showing the hand-is-not-installed refusal message instead of reaching the crash at all, which is exactly what you would expect if Get-Command hand was failing to resolve the fake binary due to missing PATHEXT in every other test). I could not reproduce this locally since I only have PowerShell Core on Linux, not a Windows PATHEXT/LOCALAPPDATA-sensitive environment, so this fix is unverified beyond static reasoning and must be confirmed by the e2e-windows CI job itself.

## What Changed

- Added a native Windows PowerShell bootstrap script for installing Hand, offering foundational dependency setup, initializing a fleet home, and reporting `hand doctor` readiness.
- Added Windows end-to-end coverage using the inherited environment with isolated user-data and temporary directories.
- Documented Windows bootstrap usage and added a CI job that runs the Windows tests before edge publishing.

## Risk Assessment

✅ Low: The change is narrowly scoped and correctly preserves Windows ambient command-resolution variables while redirecting test filesystem variables under the isolated home.

## Testing

The focused Windows e2e package compiled successfully for Windows, with no worktree changes or transient artifacts left behind. Native bootstrap.ps1 behavior and reviewer-visible end-to-end evidence require the configured Windows CI job.

- Outcome: ⚠️ 1 warning across 1 run (40m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"183b134becb2dc47d1bf5af6863a05d0ed4b97a1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `/home/atqa/.no-mistakes/worktrees/0b474f2021dd/01M0G406KYS7ZPCJZ2ACT715MB/tests/e2e/bootstrap_windows_test.go:1` - Native Windows PowerShell end-to-end execution was unavailable on this Linux host; the bootstrap harness was only cross-compiled successfully. Confirm the e2e-windows CI job before treating the fix as verified.
- `nix shell nixpkgs#go_1_26 nixpkgs#stdenv.cc -c env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go test -tags=e2e -c -o /tmp/bootstrap-windows.test ./tests/e2e`
- <code>Inspected the changed Windows harness and CI selector `-run &#34;^TestBootstrapPS1&#34;`.</code>
- <code>Attempted native `go test -tags=e2e ./tests/e2e -run &#39;TestBootstrapPS1&#39; -count=1`; execution was unavailable because this host lacks Windows PowerShell.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
