### PR TITLE
docs: add cross-platform adoption and macOS bootstrap coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,18 @@ jobs:
       - name: End-to-end (bootstrap.ps1)
         run: go test -tags=e2e -timeout=10m -run "^TestBootstrapPS1" ./tests/e2e/...
 
+  e2e-macos:
+    name: E2E (macos-latest, bootstrap.sh)
+    runs-on: macos-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: End-to-end (bootstrap.sh)
+        run: go test -tags=e2e -timeout=10m -run "^TestBootstrap" ./tests/e2e/...
+
   contract:
     name: Contract
     runs-on: ubuntu-latest
@@ -100,7 +112,7 @@ jobs:
 
   edge:
     name: Publish edge
-    needs: [lint, test, e2e, e2e-windows, contract, nix-build]
+    needs: [lint, test, e2e, e2e-windows, e2e-macos, contract, nix-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -42,6 +42,53 @@ Someone still has to:
 
 Secondhand splits those responsibilities cleanly: **the supervisor handles judgment; `hand` handles mechanics.**
 
+## Adoption
+
+### Fastest path
+
+```sh
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.sh | sh
+```
+
+```powershell
+# Windows
+irm https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.ps1 -OutFile bootstrap.ps1
+Set-ExecutionPolicy -Scope Process Bypass
+.\bootstrap.ps1
+```
+
+Optional and explicitly opt-in: acquires `hand` if missing, offers to install missing foundational dependencies (Git, Treehouse, Herdr) with consent, initializes a fleet home (default `~/secondhand-fleet`), and reports readiness from `hand doctor`.
+It never installs a coding-agent harness or no-mistakes, and refuses to adopt a non-empty directory that is not already a recognized fleet.
+Use `--check`/`-Check` for a read-only dry run, `--yes`/`-Yes` for non-interactive consent.
+See [docs/adoption.md](docs/adoption.md) for the full walkthrough, the consent model, and the readiness contract.
+
+### Install `hand` only
+
+Already have Git, Treehouse, Herdr, and a coding-agent harness? See [Installation](#installation) below.
+
+### Manual adoption
+
+```sh
+mkdir -p ~/secondhand-fleet
+cd ~/secondhand-fleet
+hand init
+hand doctor
+```
+
+See [Quick start](#quick-start) for the full walkthrough.
+
+### Agent-assisted adoption
+
+Already have a capable coding agent and prefer to delegate setup:
+
+```text
+Set up Secondhand from atqamz/hand on this machine using its documented
+bootstrap workflow. Inspect first, explain any third-party installations
+before performing them, preserve existing credentials/configuration, and
+finish by running hand doctor.
+```
+
 ## Quick start
 
 ### 1. Install `hand`
@@ -67,8 +114,8 @@ See [Installation](#installation) for every supported option.
 A fleet home is the directory where the supervising agent lives and where Secondhand keeps fleet state.
 
 ```sh
-mkdir ~/fleet
-cd ~/fleet
+mkdir ~/secondhand-fleet
+cd ~/secondhand-fleet
 hand init
 ```
 
@@ -87,7 +134,7 @@ Secondhand clones the repository under the fleet home and prepares it for isolat
 For Claude Code:
 
 ```sh
-cd ~/fleet
+cd ~/secondhand-fleet
 claude
 ```
 
@@ -258,7 +305,7 @@ Use those values as explicit overrides only for a genuine task-specific need; ex
 A fleet home is deliberately separate from the repositories being worked on.
 
 ```text
-~/fleet/
+~/secondhand-fleet/
 ├── AGENTS.md
 ├── CLAUDE.md
 ├── .agents/skills/secondhand/
@@ -357,16 +404,7 @@ irm https://raw.githubusercontent.com/atqamz/hand/main/install.ps1 | iex
 
 `HAND_INSTALL_DIR` overrides the install directory (`$HOME/.local/bin` on Linux/macOS, `%LOCALAPPDATA%\hand` on Windows); `HAND_INSTALL_VERSION` pins a release tag instead of the latest.
 
-On native Windows, `bootstrap.ps1` optionally installs `hand`, offers to install missing foundational dependencies, initializes a fleet home, and reports readiness from `hand doctor`:
-
-```powershell
-irm https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.ps1 -OutFile bootstrap.ps1
-Set-ExecutionPolicy -Scope Process Bypass
-.\bootstrap.ps1 -Yes
-```
-
-Use `-Check` to inspect the target without making changes.
-The script never installs a coding-agent harness or no-mistakes, and refuses to adopt a non-empty unrecognized directory.
+To also initialize a fleet home in one step, see [Adoption](#adoption) above.
 
 ### Release binary
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Secondhand splits those responsibilities cleanly: **the supervisor handles judgm
 
 ```sh
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.sh | sh
+curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.sh | sh -s -- --yes
 ```
 
 ```powershell

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,147 @@
+# Secondhand adoption
+
+How to get from a machine with a coding-agent harness to a ready-to-use Hand fleet, and the boundary between the surfaces that make that possible.
+
+## Architectural boundary
+
+Four surfaces, four questions, never blurred together:
+
+```text
+install.sh / install.ps1   -> "How do I install the hand binary?"
+bootstrap.sh / bootstrap.ps1 -> "How do I make this machine ready to use Secondhand?"
+hand init                  -> "Initialize or reconcile a fleet home."
+hand doctor                -> "Is this fleet ready, and what is blocking it?"
+```
+
+`install.*` (owned by [atqamz/hand#177](https://github.com/atqamz/hand/issues/177)) installs `hand` only.
+It never installs Treehouse, Herdr, `gh`, a coding-agent harness, or no-mistakes.
+
+`bootstrap.*` is optional and explicitly opt-in.
+It may install missing foundational dependencies (Git, Treehouse, Herdr) with consent, because the operator explicitly chose an adoption workflow by running it.
+It never installs a coding-agent harness or no-mistakes: those require account, provider, and authentication choices only the operator can make.
+
+`hand init` is the only fleet initialize/reconcile operation.
+Bootstrap calls it; it never reimplements fleet setup in shell or PowerShell.
+
+`hand doctor` is the only readiness and diagnostic authority.
+Bootstrap, a human, and a supervising agent all read the same structured output rather than a second schema invented in a script.
+
+## Fastest path
+
+```sh
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.sh | sh
+```
+
+```powershell
+# Windows
+irm https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.ps1 -OutFile bootstrap.ps1
+Set-ExecutionPolicy -Scope Process Bypass
+.\bootstrap.ps1
+```
+
+Both scripts acquire `hand` if it is missing, detect and offer to install missing foundational dependencies, choose a safe fleet-home target (default `~/secondhand-fleet`), run `hand init` and `hand doctor`, and print the exact next command:
+
+```text
+Secondhand is ready.
+
+Next:
+
+  cd ~/secondhand-fleet
+  claude
+```
+
+If no supported coding-agent harness is installed, the printed next step says so instead of guessing one.
+
+Flags, identical in effect on both platforms:
+
+| Shell | PowerShell | Effect |
+| --- | --- | --- |
+| `--fleet PATH` | `-Fleet PATH` | fleet home to create or reconcile (default `~/secondhand-fleet`) |
+| `--yes` | `-Yes` | explicit non-interactive consent to install missing foundational dependencies |
+| `--check` | `-Check` | read-only: report readiness, install or mutate nothing |
+
+A target that already exists, is non-empty, and is not a recognized Hand fleet is refused rather than silently adopted.
+
+## Install `hand` only
+
+Already have Git, Treehouse, Herdr, and a coding-agent harness, and only want the binary?
+See [Installation](../README.md#installation) in the README for Homebrew, Nix, `go install`, the install script, and release binaries.
+
+## Manual adoption
+
+For operators who prefer to run each step themselves, using whichever package manager they already trust:
+
+```sh
+# install git, treehouse, herdr, and a coding-agent harness with your preferred package managers
+mkdir -p ~/secondhand-fleet
+cd ~/secondhand-fleet
+hand init
+hand doctor
+```
+
+## Agent-assisted adoption
+
+For an operator who already has a capable coding agent and prefers to delegate setup, a small prompt is enough - the immutable, Hand-owned `AGENTS.md` and bundled `secondhand` skill that `hand init` installs teach the newly opened supervisor how to operate Hand from there:
+
+```text
+Set up Secondhand from atqamz/hand on this machine using its documented
+bootstrap workflow. Inspect first, explain any third-party installations
+before performing them, preserve existing credentials/configuration, and
+finish by running hand doctor.
+```
+
+If adoption ever needs a longer, more specialized prompt than this, that is a signal to improve the bootstrap scripts or `hand` itself, not to grow the prompt.
+
+## Consent and security model
+
+Bootstrap runs at a high-trust boundary and is deliberately conservative:
+
+- Every missing foundational dependency is listed with its source and install method before anything runs; `--yes` is explicit non-interactive consent, and a non-interactive invocation without it declines rather than guessing.
+- `--check` is a pure read-only dry run; it never installs or mutates anything, including the fleet target.
+- A dependency fetched from a URL is downloaded to a file and its download verified before that file is ever run - never `curl | sh` or `irm | iex` piped directly, which would treat a failed or interrupted fetch as an empty, successful script.
+- `hand` itself, when bootstrap must acquire it, is verified against the same checksummed GitHub release artifact `install.sh`/`install.ps1` use.
+- No step escalates privilege for the whole run; a package-manager action that needs it is scoped to that action alone.
+- Bootstrap never asks for provider tokens, never prints an existing token, and never dumps the environment.
+- A coding-agent harness and no-mistakes are only ever detected, never installed - account, provider, and authentication choices stay the operator's.
+
+## Readiness contract
+
+`hand doctor` exposes the same readiness contract bootstrap reads, so a human or a supervising agent gets identical answers:
+
+```text
+tools[4]{tool,installed,required}:
+  git,true,true
+  treehouse,false,true
+  herdr,true,true
+  gh,false,false
+harnesses[5]{name,installed}:
+  claude,true
+  codex,false
+  grok,false
+  pi,false
+  opencode,false
+ready: false
+blocking[1]:
+  - treehouse
+next[1]:
+  - install treehouse
+```
+
+`git`, `treehouse`, and `herdr` are always required; `gh` is required only when a registered project's delivery mode is `direct-pr` or `no-mistakes`.
+Harnesses are reported purely as installed or not - `hand` never picks one on the operator's behalf.
+
+## Idempotency and recovery
+
+Repeated bootstrap runs are safe:
+
+| Fleet target state | Bootstrap behavior |
+| --- | --- |
+| absent | created and initialized |
+| empty directory | initialized |
+| existing valid Hand fleet | reconciled by `hand init`, no destructive rewrite |
+| existing, non-empty, not a recognized fleet | refused |
+| already healthy | reports ready, mutates nothing |
+
+A partial failure is never reported as success.
+If a dependency install fails or `hand init`/`hand doctor` reports a blocker, bootstrap exits non-zero with the exact recovery command - typically resolving the reported blocker, then rerunning `hand doctor` or the bootstrap script itself.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -30,7 +30,7 @@ Bootstrap, a human, and a supervising agent all read the same structured output 
 
 ```sh
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.sh | sh
+curl -fsSL https://raw.githubusercontent.com/atqamz/hand/main/bootstrap.sh | sh -s -- --yes
 ```
 
 ```powershell


### PR DESCRIPTION
## Intent

Implement atqamz/hand#220 (cross-platform Secondhand adoption/bootstrap path). Fourth and final PR in the stack, built on the merged doctor readiness contract (#296), bootstrap.sh (#297), and bootstrap.ps1 (#298). Adds docs/adoption.md and restructures the README per the issue's explicit documentation UX requirements: a Fastest path (bootstrap one-liner), Install hand only (pointer to the existing Installation section for #177 methods), Manual adoption (mkdir/cd/hand-init/hand-doctor), and Agent-assisted adoption (the small delegation prompt) - all four exactly as the issue specifies, added as a new Adoption section ahead of Quick start rather than folded into the existing Hand-only Installation section, since mixing those would repeat the exact install-vs-adoption conflation the issue explicitly warns against. Updated the Quick start fleet-home example and the Fleet home layout diagram from the old generic ~/fleet to the product-specific ~/secondhand-fleet default this issue establishes, for internal consistency with the new Adoption section and with what bootstrap.sh/bootstrap.ps1 actually default to. Removed a bootstrap.ps1 paragraph that had been auto-added into the Hand-only "Install script" subsection during an earlier PR in this stack, since it blurred the same install-vs-adoption boundary; that content now lives in the new Adoption section and in docs/adoption.md instead. Also closed one remaining gap noticed while finishing out this stack: this repository CI never ran the bootstrap.sh e2e tests on macOS at all (only on ubuntu-latest), so the earlier PR (#298) work that added a Windows-only e2e job left macOS as the one platform in the issue acceptance criteria (Linux/macOS/Windows behavior is tested) without any actual CI execution. Added a scoped e2e-macos job (macos-latest, -run ^TestBootstrap, needs test) mirroring the existing e2e-windows job approach of testing only the relevant subset rather than widening the broad, never-validated-on-that-OS main e2e job. This is the final PR in the stack, so it uses Closes atqamz/hand#220, not Part of.

## What Changed

- Added a cross-platform adoption guide covering bootstrap, installation, manual adoption, and agent-assisted adoption paths.
- Restructured the README with a dedicated Adoption section, updated the default fleet-home examples and layout diagram, and removed misplaced bootstrap guidance from Hand-only installation.
- Added a scoped macOS bootstrap end-to-end CI job and included it in the edge publishing prerequisites.

## Risk Assessment

✅ Low: The documentation updates satisfy the stated adoption requirements, and the macOS workflow runs the Unix bootstrap E2E subset and gates delivery appropriately.

## Testing

The focused bootstrap E2E suite passed in the project Nix environment, verbose end-user behavior was captured as evidence, and the workflow semantically confirms the macOS bootstrap job is wired into CI; no source or transient worktree artifacts were created.

<details>
<summary>Evidence: Bootstrap E2E transcript</summary>

`Verbose bootstrap E2E transcript demonstrating initialization, readiness, safety, consent, recovery, secret isolation, and idempotency behavior.`

```text
=== RUN   TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarness
    bootstrap_test.go:113: $ bootstrap.sh --fleet /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet --yes
          exit 0
          stdout: 
          stderr: result: initialized
        home: /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet
        agents_md: written
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet/.claude/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet/.grok/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet/.pi/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.lJZcHA/TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarnes2732650065/002/secondhand-fleet
            claude
--- PASS: TestBootstrapHappyPathReconcilesFleetAndPrintsTheInstalledHarness (0.31s)
=== RUN   TestBootstrapRefusesAForeignNonEmptyFleetTarget
    bootstrap_test.go:139: $ bootstrap.sh --fleet /tmp/nix-shell.lJZcHA/TestBootstrapRefusesAForeignNonEmptyFleetTarget346593024/003 --yes
          exit 1
          stdout: 
          stderr: bootstrap.sh: /tmp/nix-shell.lJZcHA/TestBootstrapRefusesAForeignNonEmptyFleetTarget346593024/003 exists, is not empty, and is not a recognized Secondhand fleet; refusing to adopt it - pass --fleet with an empty or already-initialized path
--- PASS: TestBootstrapRefusesAForeignNonEmptyFleetTarget (0.02s)
=== RUN   TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget
    bootstrap_test.go:164: $ bootstrap.sh --fleet /tmp/nix-shell.lJZcHA/TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget2028705753/002/secondhand-fleet --check
          exit 0
          stdout: 
          stderr: fleet target: /tmp/nix-shell.lJZcHA/TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget2028705753/002/secondhand-fleet (absent)
        hand init has not run here yet; check mode makes no changes, so readiness cannot be evaluated further
--- PASS: TestBootstrapCheckModeNeverMutatesAnAbsentFleetTarget (0.02s)
=== RUN   TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutYesAndFailsClosed
    bootstrap_test.go:183: $ bootstrap.sh --fleet /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet
          exit 1
          stdout: 
          stderr: Missing foundational runtime dependencies:
        
          treehouse
            source: kunchenguid/treehouse
            install method: download and verify https://kunchenguid.github.io/treehouse/install.sh, then run only the completed download
        
        not running interactively and --yes was not given: declining to install any of the above
        result: initialized
        home: /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet
        agents_md: written
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet/.claude/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet/.grok/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet/.pi/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[3]:
          - treehouse
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.lJZcHA/TestBootstrapDeclinesMissingDependenciesNonInteractivelyWithoutY1697879678/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 2
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,false,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,false
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: false
        blocking[2]:
          - treehouse
          - harness
        next[2]:
          - install treehouse
          - install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor
        findings[2]{line,severity,finding}:
          none,warning,"required tool \"treehouse\" is not on PATH"
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is not ready yet. Blocking:
          - treehouse
          - harness
        bootstrap.sh: recover the items above, then rerun: HAND_HOME=/tmp/nix-shell.lJZcHA/TestBootstrapD

... [15416 bytes truncated] ...

95697/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.lJZcHA/TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput1058095697/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.lJZcHA/TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput1058095697/002/secondhand-fleet
            claude
--- PASS: TestBootstrapNeverForwardsAmbientSecretsIntoItsOutput (0.06s)
=== RUN   TestBootstrapReconcilesAnExistingFleetIdempotently
    bootstrap_test.go:336: $ bootstrap.sh --fleet /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet --yes
          exit 0
          stdout: 
          stderr: result: initialized
        home: /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet
        agents_md: written
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.claude/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.grok/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.pi/skills/secondhand,created
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.agents/skills/secondhand,created
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet
            claude
    bootstrap_test.go:341: $ bootstrap.sh --fleet /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet --yes
          exit 0
          stdout: 
          stderr: result: initialized
        home: /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet
        agents_md: unchanged
        agents_md_legacy_archive: none
        skill[4]{dir,outcome}:
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.claude/skills/secondhand,unchanged
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.grok/skills/secondhand,unchanged
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.pi/skills/secondhand,unchanged
          /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/.agents/skills/secondhand,unchanged
        skill_conflicts: 0
        session_hook: unchanged
        migrated[0]:
        config_missing: 1
        config[3]{key,state,value}:
          harness,missing,none
          model,pending-harness,none
          effort,pending-harness,none
        missing_tools[2]:
          - no-mistakes
          - gh
        help[5]:
          - Start a supervising session in this home; no supported worker harness is configured or detected, so it reports the unanswered harness choice
          - Run `hand config set <key> <value>` only to persist an explicit worker override
          - Read AGENTS.md in this home for how a supervising agent is meant to drive it
          - Run `hand project add <repo-url>` to register the first project
          - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
        
        file: /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet/AGENTS.md
        version: dev
        channel: dev
        commit: unknown
        distribution: source
        count: 1
        violations: 0
        tools[4]{tool,installed,required}:
          git,true,true
          treehouse,true,true
          herdr,true,true
          gh,false,false
        harnesses[5]{name,installed}:
          claude,true
          codex,false
          grok,false
          pi,false
          opencode,false
        ready: true
        blocking[0]:
        next[0]:
        findings[1]{line,severity,finding}:
          none,warning,"routing falls back to legacy defaults without explicit intent: harness \"\""
        help[1]:
          - No error findings, so this run passed; inspect warnings and info before the next dispatch
        
        Secondhand is ready.
        
        Next:
        
          cd /tmp/nix-shell.lJZcHA/TestBootstrapReconcilesAnExistingFleetIdempotently1796000183/002/secondhand-fleet
            claude
--- PASS: TestBootstrapReconcilesAnExistingFleetIdempotently (0.10s)
PASS
ok  	github.com/atqamz/hand/tests/e2e	1.432s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0564fbc3deaf0a7b6730f7a8e1a4b8843ea1f23d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `README.md:51` - The required fastest-path bootstrap one-liner cannot complete fresh Unix adoption: piping through `sh` makes stdin non-interactive, and `bootstrap.sh` refuses to install missing `hand` unless `--yes` is supplied. The documented command therefore exits before initializing the fleet on a machine without `hand`, contradicting the required “Fastest path (bootstrap one-liner)” behavior. The same command is duplicated in `docs/adoption.md`.

🔧 Fix: Pass non-interactive consent to documented bootstrap commands
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `nix develop --command go test -tags=e2e -timeout=10m -run '^TestBootstrap' ./tests/e2e/...`
- `nix develop --command bash -o pipefail -c 'go test -tags=e2e -timeout=10m -run "^TestBootstrap" -v ./tests/e2e/...'`
- <code>Semantic YAML validation of `.github/workflows/ci.yaml`: macOS runner, dependency, focused test command, and edge dependency verified.</code>

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 `/home/atqa/.codex/skills/.system/using-superpowers/SKILL.md` - Required setup instructions could not be read because /home/atqa/.codex/skills/.system/using-superpowers/SKILL.md is unavailable.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
