### PR TITLE
feat(project): add local Git project adoption and creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,17 @@ hand init
 
 `hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` before acting, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - a symlink on Unix and an `@AGENTS.md` pointer file on Windows.
 
-### 3. Add a project
+### 3. Add or create a project
 
 ```sh
 hand project add https://github.com/you/project
+hand project add ~/work/project
+hand project create new-project
 ```
 
-Secondhand clones the repository under the fleet home and prepares it for isolated worker worktrees.
+Remote sources are cloned under the fleet home and prepared for isolated worker worktrees.
+Local Git sources are adopted once into a separate Fleet-managed clone; Hand never executes in or synchronizes with the original checkout.
+Created projects start with one empty `main` baseline commit and are also managed locally.
 
 ### 4. Open a supervising session
 
@@ -257,6 +261,20 @@ Choose a mode when registering a project:
 ```sh
 hand project add https://github.com/you/project --mode direct-pr
 ```
+
+Add an existing local Git project or create a new managed project with the local-only mode:
+
+```sh
+hand project add ~/work/project
+hand project add ~/work/project --mode local-only
+hand project create new-project
+```
+
+Local adoption requires a clean, committed, non-detached Git worktree with a resolvable default branch.
+It copies committed state into `projects/<name>` with an independent object store, removes the clone's origin, and leaves the source checkout untouched.
+Local projects do not synchronize with their source later.
+`hand project sync` reports local projects as skipped, and `hand project set-url` is remote-backed-only.
+Use `hand merge --local` to fast-forward local-only work into the canonical managed clone.
 
 For a fork, declare the upstream repository that receives pull requests:
 
@@ -485,8 +503,10 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | Command | Purpose |
 | --- | --- |
 | `hand init` | Create or refresh a fleet home. |
-| `hand project add` | Register a repository with the fleet. |
+| `hand project add <source>` | Clone a remote Git source or adopt a local Git source into the fleet. |
+| `hand project create <name>` | Create a new empty Git-backed local-only project with a real baseline commit. |
 | `hand project set-url <name> <repo-url>` | Recover a registered project after a repository rename or transfer while preserving its local identity and task history. |
+| `hand project sync [name]` | Fast-forward remote-backed clones; report local-managed projects as skipped. |
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -183,7 +183,7 @@ func newConfigSetCmd() *cobra.Command {
 			appendWorkerConfig(&doc, cfg)
 			help := workerConfigHelp(cfg)
 			if len(help) == 0 {
-				help = append(help, "Every applicable worker default is configured; run `hand project add <repo-url>` to register a project")
+				help = append(help, "Every applicable worker default is configured; run `hand project add <source>` or `hand project create <name>` to register a project")
 			}
 			doc.Help(help...)
 			return doc.Render(cmd.OutOrStdout())

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -1,63 +1,20 @@
 package cmd
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
+	"github.com/atqamz/hand/internal/git"
 )
 
 func hasUncommittedChanges(worktreePath string) (bool, error) {
-	cmd := exec.Command("git", "status", "--porcelain")
-	cmd.Dir = worktreePath
-	out, err := cmd.Output()
-	if err != nil {
-		return false, fmt.Errorf("git status failed: %w", err)
-	}
-	return strings.TrimRight(string(out), "\n") != "", nil
+	return git.HasUncommittedChanges(worktreePath)
 }
 
 // git symbolic-ref, not rev-parse --abbrev-ref: the latter exits 0 and prints the literal string
 // "HEAD" on a detached HEAD instead of failing, which every caller would otherwise have to
 // special-case itself to avoid treating that sentinel as a real branch name.
 func currentBranch(worktreePath string) (string, error) {
-	cmd := exec.Command("git", "symbolic-ref", "--short", "-q", "HEAD")
-	cmd.Dir = worktreePath
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("git symbolic-ref failed: %w", err)
-	}
-	return strings.TrimSpace(string(out)), nil
+	return git.CurrentBranch(worktreePath)
 }
 
 func defaultBranch(clonePath string) (string, error) {
-	cmd := exec.Command("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
-	cmd.Dir = clonePath
-	out, err := cmd.Output()
-	if err == nil {
-		branch := strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")
-		if branch != "" {
-			return branch, nil
-		}
-	}
-
-	cmd = exec.Command("git", "remote", "show", "origin")
-	cmd.Dir = clonePath
-	out, err = cmd.Output()
-	if err == nil {
-		for _, line := range strings.Split(string(out), "\n") {
-			fields := strings.Fields(line)
-			if len(fields) == 3 && fields[0] == "HEAD" && fields[1] == "branch:" && fields[2] != "" {
-				return fields[2], nil
-			}
-		}
-	}
-
-	for _, branch := range []string{"main", "master"} {
-		cmd = exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
-		cmd.Dir = clonePath
-		if err := cmd.Run(); err == nil {
-			return branch, nil
-		}
-	}
-	return "", fmt.Errorf("resolve default branch failed")
+	return git.DefaultBranch(clonePath)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -131,7 +131,7 @@ func newInitCmd() *cobra.Command {
 				effectiveSettingsHelp,
 				"Run `hand config set <key> <value>` only to persist an explicit worker override",
 				"Read AGENTS.md in this home for how a supervising agent is meant to drive it",
-				"Run `hand project add <repo-url>` to register the first project",
+				"Run `hand project add <source>` or `hand project create <name>` to register the first project",
 				"AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses",
 			}
 			if refresh.ArchivedPath != "" {

--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -95,8 +95,8 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 			Reason: statusReason(v.task.ID, "confirm its delivery gate status")}
 	}
 	if projectCount == 0 {
-		return nextAction{Kind: nextActionNeedsProject, Command: "hand project add <repo-url>",
-			Reason: "Run `hand project add <repo-url>` to register the first project"}
+		return nextAction{Kind: nextActionNeedsProject, Command: "hand project add <source>",
+			Reason: "Run `hand project add <source>` or `hand project create <name>` to register the first project"}
 	}
 	if backlog.Queued > 0 {
 		return nextAction{Kind: nextActionQueued, Command: "hand spawn <id> <project>",

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -136,7 +136,7 @@ func TestClassifyNextActionExactPrecedence(t *testing.T) {
 		{
 			"needs-project when nothing is registered",
 			configuredWorker, 0, backlogSummary{}, nil, nil,
-			nextAction{Kind: nextActionNeedsProject, Command: "hand project add <repo-url>", Reason: "Run `hand project add <repo-url>` to register the first project"},
+			nextAction{Kind: nextActionNeedsProject, Command: "hand project add <source>", Reason: "Run `hand project add <source>` or `hand project create <name>` to register the first project"},
 		},
 		{
 			"queued work is selected when nothing stronger exists",

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -27,6 +27,7 @@ func newProjectCmd() *cobra.Command {
 		Short: "Manage the project registry",
 	}
 	cmd.AddCommand(newProjectAddCmd())
+	cmd.AddCommand(newProjectCreateCmd())
 	cmd.AddCommand(newProjectListCmd())
 	cmd.AddCommand(newProjectRemoveCmd())
 	cmd.AddCommand(newProjectSyncCmd())
@@ -51,14 +52,15 @@ var setProjectURL = project.SetURL
 func newProjectSetURLCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-url <name> <repo-url>",
-		Short: "Repoint a registered project at a new repository URL",
+		Short: "Repoint a remote-backed project at a new repository URL",
 		Long: "Repoint a registered project at a new repository URL. The project name and clone path remain unchanged;\n" +
 			"the registry URL and clone origin are updated together, while tasks and history are preserved.\n" +
+			"Local-managed projects do not have a live origin and must remain local-only.\n" +
 			"The command refuses rather than deliberately leaving a registry-only update.",
 		Args: usageArgs(cobra.ExactArgs(2)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name, url := args[0], args[1]
-			if err := validateProjectURL(url); err != nil {
+			if err := validateRemoteProjectURL(url); err != nil {
 				return err
 			}
 			home, err := home.Resolve()
@@ -101,7 +103,10 @@ func repointProject(homeDir, name, url string) (repointResult, error) {
 	if !exists {
 		return repointResult{}, fmt.Errorf("project %q %w", name, project.ErrNotFound)
 	}
-	if err := validateProjectURL(url); err != nil {
+	if project.IsFileLocator(p.URL) {
+		return repointResult{}, fmt.Errorf("project %q is a local-managed project; set-url is supported only for remote-backed projects", name)
+	}
+	if err := validateRemoteProjectURL(url); err != nil {
 		return repointResult{}, err
 	}
 
@@ -207,44 +212,89 @@ func newProjectAddCmd() *cobra.Command {
 	var name string
 
 	cmd := &cobra.Command{
-		Use:   "add <repo-url>",
-		Short: "Clone a git repository and register it",
+		Use:   "add <source>",
+		Short: "Clone or adopt a Git repository and register it",
 		Args:  usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			url := args[0]
-			if err := validateProjectURL(url); err != nil {
+			source, err := classifyProjectSource(args[0])
+			if err != nil {
+				return &ExitError{Err: err, Code: 2}
+			}
+			if err := validateProjectURL(args[0]); err != nil {
 				return err
+			}
+			if source.remote {
+				if err := validateProjectMode(mode); err != nil {
+					return err
+				}
+			} else if cmd.Flags().Changed("mode") && mode != project.ModeLocalOnly {
+				return &ExitError{Err: fmt.Errorf("local Git sources support only --mode local-only"), Code: 2}
+			} else {
+				mode = project.ModeLocalOnly
 			}
 			if err := validateProjectMode(mode); err != nil {
 				return err
 			}
-			home, err := home.Resolve()
+			fleetHome, err := home.Resolve()
 			if err != nil {
 				return asPrecondition(err)
 			}
 
+			if !source.remote {
+				source, err = resolveLocalProjectSource(source)
+				if err != nil {
+					return &ExitError{Err: err, Code: 2}
+				}
+			}
+			if name == "" && source.remote {
+				name = project.DeriveName(source.input)
+			}
 			if name == "" {
-				name = project.DeriveName(url)
+				name = projectNameFromRoot(source.root)
 			}
 			if err := validateProjectName(name); err != nil {
 				return err
 			}
 
-			if _, exists, err := project.Find(home, name); err != nil {
+			release, err := state.Lock(fleetHome, "project:"+name)
+			if err != nil {
+				return fmt.Errorf("lock project %q: %w", name, err)
+			}
+			defer release()
+
+			if !source.remote {
+				managed, err := project.IsManagedPath(fleetHome, source.root)
+				if err != nil {
+					return err
+				}
+				if managed {
+					return &ExitError{Err: fmt.Errorf("local project source %q is already a managed Hand project", source.input), Code: 3}
+				}
+			}
+
+			if _, exists, err := project.Find(fleetHome, name); err != nil {
 				return err
 			} else if exists {
 				return &ExitError{Err: fmt.Errorf("project %q already registered", name), Code: 3}
 			}
 
-			clonePath := filepath.Join(home, "projects", name)
+			clonePath := filepath.Join(fleetHome, "projects", name)
 			if err := reserveCloneDestination(clonePath); err != nil {
 				return err
 			}
-			if err := gitClone(url, clonePath); err != nil {
-				if cleanupErr := os.RemoveAll(clonePath); cleanupErr != nil {
-					return fmt.Errorf("%w; remove incomplete clone: %v", err, cleanupErr)
+			var cloneErr error
+			if source.remote {
+				cloneErr = gitClone(source.input, clonePath)
+			} else {
+				cloneErr = gitCloneLocal(source.root, clonePath)
+			}
+			if cloneErr != nil {
+				return cleanupCloneAfterFailure(clonePath, cloneErr)
+			}
+			if !source.remote {
+				if err := prepareAdoptedClone(source, clonePath); err != nil {
+					return cleanupCloneAfterFailure(clonePath, err)
 				}
-				return err
 			}
 
 			if mode == project.ModeNoMistakes {
@@ -257,7 +307,14 @@ func newProjectAddCmd() *cobra.Command {
 				return cleanupCloneAfterFailure(clonePath, err)
 			}
 
-			if err := project.Add(home, project.Project{Name: name, URL: url, Mode: mode}); err != nil {
+			locator := source.input
+			if !source.remote {
+				locator = source.locator
+			}
+			if err := project.Add(fleetHome, project.Project{Name: name, URL: locator, Mode: mode}); err != nil {
+				if project.IsRegistrationRollbackError(err) {
+					return fmt.Errorf("%w; managed repository retained at %s for registry repair", err, clonePath)
+				}
 				return cleanupCloneAfterFailure(clonePath, err)
 			}
 
@@ -265,8 +322,13 @@ func newProjectAddCmd() *cobra.Command {
 			doc.Field("name", name)
 			doc.Field("result", "added")
 			doc.Field("mode", mode)
-			doc.Field("url", url)
+			doc.Field("url", locator)
 			doc.Field("clone", clonePath)
+			if !source.remote {
+				doc.Field("source", source.input)
+				doc.Field("default_branch", source.defaultBranch)
+				doc.Field("baseline", source.baseline)
+			}
 			doc.Help("Run `hand spawn <id> " + name + "` to dispatch a worker into it")
 			return doc.Render(cmd.OutOrStdout())
 		},
@@ -274,6 +336,67 @@ func newProjectAddCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&mode, "mode", project.ModeDirectPR, "delivery mode: no-mistakes, direct-pr, local-only")
 	cmd.Flags().StringVar(&name, "name", "", "override the project name")
+	return cmd
+}
+
+func newProjectCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new Git-backed project in the fleet",
+		Args:  usageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if err := validateProjectName(name); err != nil {
+				return err
+			}
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			release, err := state.Lock(fleetHome, "project:"+name)
+			if err != nil {
+				return fmt.Errorf("lock project %q: %w", name, err)
+			}
+			defer release()
+			if _, exists, err := project.Find(fleetHome, name); err != nil {
+				return err
+			} else if exists {
+				return &ExitError{Err: fmt.Errorf("project %q already registered", name), Code: 3}
+			}
+
+			clonePath := filepath.Join(fleetHome, "projects", name)
+			if err := reserveCloneDestination(clonePath); err != nil {
+				return err
+			}
+			baseline, err := initCreatedProject(clonePath)
+			if err != nil {
+				return cleanupCloneAfterFailure(clonePath, err)
+			}
+			if err := treehouseInitIfNeeded(clonePath); err != nil {
+				return cleanupCloneAfterFailure(clonePath, err)
+			}
+			locator, err := project.CanonicalFileLocator(clonePath)
+			if err != nil {
+				return cleanupCloneAfterFailure(clonePath, err)
+			}
+			if err := project.Add(fleetHome, project.Project{Name: name, URL: locator, Mode: project.ModeLocalOnly}); err != nil {
+				if project.IsRegistrationRollbackError(err) {
+					return fmt.Errorf("%w; managed repository retained at %s for registry repair", err, clonePath)
+				}
+				return cleanupCloneAfterFailure(clonePath, err)
+			}
+
+			var doc axi.Doc
+			doc.Field("name", name)
+			doc.Field("result", "created")
+			doc.Field("mode", project.ModeLocalOnly)
+			doc.Field("url", locator)
+			doc.Field("clone", clonePath)
+			doc.Field("baseline", baseline)
+			doc.Help("Run `hand spawn <id> " + name + "` to dispatch a worker into it")
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
 	return cmd
 }
 
@@ -320,10 +443,15 @@ func isRegistrySafeName(name string) bool {
 }
 
 func validateProjectURL(url string) error {
-	for _, prefix := range []string{"https://", "git@", "ssh://", "git://"} {
-		if strings.HasPrefix(url, prefix) {
-			return nil
-		}
+	if _, err := classifyProjectSource(url); err != nil {
+		return &ExitError{Err: fmt.Errorf("invalid project source %q: %w", url, err), Code: 2}
+	}
+	return nil
+}
+
+func validateRemoteProjectURL(url string) error {
+	if isRemoteProjectSource(url) {
+		return nil
 	}
 	return &ExitError{Err: fmt.Errorf("invalid project URL %q: must start with https://, git@, ssh://, or git://", url), Code: 2}
 }
@@ -491,7 +619,7 @@ func newProjectListCmd() *cobra.Command {
 
 func projectListHelp(count, ungated int) []string {
 	if count == 0 {
-		return []string{"Run `hand project add <repo-url>` to register the first project"}
+		return []string{"Run `hand project add <source>` or `hand project create <name>` to register the first project"}
 	}
 	help := []string{"Run `hand spawn <id> <project>` to dispatch a worker into one of these"}
 	if ungated > 0 {
@@ -567,7 +695,7 @@ func hasActiveTasksForProject(home, name string) (bool, error) {
 func newProjectSyncCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync [name]",
-		Short: "Fast-forward project clones to their remote default branch",
+		Short: "Fast-forward remote-backed project clones to their default branch",
 		Args:  usageArgs(cobra.MaximumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home, err := home.Resolve()
@@ -660,6 +788,9 @@ func syncOneProject(home string, p project.Project) (syncOutcome, error) {
 
 func syncOneProjectContext(ctx context.Context, home string, p project.Project) (syncOutcome, error) {
 	clonePath := filepath.Join(home, "projects", p.Name)
+	if project.IsFileLocator(p.URL) {
+		return skippedSync(p.Name, "local-managed project; no live origin remote")
+	}
 
 	origin, err := storedOriginURL(clonePath)
 	if err != nil {

--- a/cmd/project_source.go
+++ b/cmd/project_source.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/project"
+)
+
+type projectSource struct {
+	input         string
+	remote        bool
+	root          string
+	locator       string
+	defaultBranch string
+	baseline      string
+}
+
+func isRemoteProjectSource(source string) bool {
+	for _, prefix := range []string{"https://", "git@", "ssh://", "git://"} {
+		if strings.HasPrefix(source, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyProjectSource(source string) (projectSource, error) {
+	if strings.TrimSpace(source) == "" {
+		return projectSource{}, fmt.Errorf("project source is empty")
+	}
+	if isRemoteProjectSource(source) {
+		return projectSource{input: source, remote: true}, nil
+	}
+	if project.IsFileLocator(source) {
+		return projectSource{input: source}, nil
+	}
+	if isWindowsPath(source) {
+		return projectSource{input: source}, nil
+	}
+	u, err := url.Parse(source)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("invalid project source %q: %w", source, err)
+	}
+	if u.Scheme != "" {
+		return projectSource{}, fmt.Errorf("unsupported project source scheme %q", u.Scheme)
+	}
+	return projectSource{input: source}, nil
+}
+
+func resolveLocalProjectSource(source projectSource) (projectSource, error) {
+	path := source.input
+	if project.IsFileLocator(path) {
+		var err error
+		path, err = project.FileLocatorPath(path)
+		if err != nil {
+			return projectSource{}, err
+		}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("local project source %q: %w", source.input, err)
+	}
+	if !info.IsDir() {
+		return projectSource{}, fmt.Errorf("local project source %q is not a directory", source.input)
+	}
+	root, err := git.ResolveRoot(path)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("local project source %q is not a Git worktree: %w", source.input, err)
+	}
+	bare, err := git.IsBare(root)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("inspect local project source %q: %w", source.input, err)
+	}
+	if bare {
+		return projectSource{}, fmt.Errorf("local project source %q is a bare Git repository; Hand requires a non-bare worktree", source.input)
+	}
+	if _, err := git.HeadCommit(root); err != nil {
+		return projectSource{}, fmt.Errorf("local project source %q has no committed HEAD; commit a baseline or use `hand project create <name>`: %w", source.input, err)
+	}
+	if _, err := git.CurrentBranch(root); err != nil {
+		return projectSource{}, fmt.Errorf("local project source %q must have a checked-out branch: %w", source.input, err)
+	}
+	defaultBranch, err := git.DefaultBranch(root)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("local project source %q has no stable default branch: %w", source.input, err)
+	}
+	baseline, err := git.BranchCommit(root, defaultBranch)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("local project source %q default branch %q is not committed: %w", source.input, defaultBranch, err)
+	}
+	dirty, err := git.HasUncommittedChanges(root)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("inspect local project source %q: %w", source.input, err)
+	}
+	if dirty {
+		return projectSource{}, fmt.Errorf("local Git source has uncommitted or untracked changes; Hand adopts committed repository state only; commit, stash, or remove the changes before adding this Project")
+	}
+	locator, err := project.CanonicalFileLocator(root)
+	if err != nil {
+		return projectSource{}, fmt.Errorf("canonicalize local project source %q: %w", source.input, err)
+	}
+	source.root = root
+	source.locator = locator
+	source.defaultBranch = defaultBranch
+	source.baseline = baseline
+	return source, nil
+}
+
+func isWindowsPath(value string) bool {
+	return len(value) >= 2 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':'
+}
+
+func gitCloneLocal(source, dest string) error {
+	cmd := exec.Command("git", "clone", "--no-local", source, dest)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git clone failed: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func prepareAdoptedClone(source projectSource, dest string) error {
+	if err := git.CheckoutBranch(dest, source.defaultBranch); err != nil {
+		return err
+	}
+	if got, err := git.BranchCommit(dest, source.defaultBranch); err != nil || got != source.baseline {
+		if err != nil {
+			return fmt.Errorf("verify adopted default branch %q: %w", source.defaultBranch, err)
+		}
+		return fmt.Errorf("adopted default branch %q commit %s differs from source commit %s", source.defaultBranch, got, source.baseline)
+	}
+	bare, err := git.IsBare(dest)
+	if err != nil {
+		return err
+	}
+	if bare {
+		return fmt.Errorf("adopted project clone %q is bare", dest)
+	}
+	hasAlternates, err := git.HasAlternates(dest)
+	if err != nil {
+		return err
+	}
+	if hasAlternates {
+		return fmt.Errorf("adopted project clone %q uses a shared Git object store", dest)
+	}
+	if err := git.RemoveOrigin(dest); err != nil {
+		return err
+	}
+	if err := git.PreserveDefaultBranch(dest, source.defaultBranch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func initCreatedProject(path string) (string, error) {
+	init := exec.Command("git", "init", "--initial-branch=main", path)
+	if out, err := init.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git init failed: %s", strings.TrimSpace(string(out)))
+	}
+	commit := exec.Command("git", "-C", path, "-c", "user.name=hand", "-c", "user.email=hand@localhost", "commit", "--allow-empty", "-m", "chore: initialize project")
+	if out, err := commit.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("create project baseline commit failed: %s", strings.TrimSpace(string(out)))
+	}
+	baseline, err := git.HeadCommit(path)
+	if err != nil {
+		return "", err
+	}
+	return baseline, nil
+}
+
+func projectNameFromRoot(root string) string {
+	return filepath.Base(filepath.Clean(root))
+}

--- a/cmd/project_source.go
+++ b/cmd/project_source.go
@@ -86,7 +86,7 @@ func resolveLocalProjectSource(source projectSource) (projectSource, error) {
 	if _, err := git.CurrentBranch(root); err != nil {
 		return projectSource{}, fmt.Errorf("local project source %q must have a checked-out branch: %w", source.input, err)
 	}
-	defaultBranch, err := git.DefaultBranch(root)
+	defaultBranch, err := git.LocalDefaultBranch(root)
 	if err != nil {
 		return projectSource{}, fmt.Errorf("local project source %q has no stable default branch: %w", source.input, err)
 	}

--- a/cmd/project_sync_test.go
+++ b/cmd/project_sync_test.go
@@ -389,6 +389,23 @@ func TestSyncOneProjectSkipsWhenNoOriginRemote(t *testing.T) {
 	}
 }
 
+func TestSyncOneProjectSkipsLocalManagedProjectBeforeOriginLookup(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "projects", "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	clonePath := filepath.Join(home, "projects", "myproj")
+	initGitRepo(t, clonePath)
+
+	got, err := syncOneProject(home, project.Project{Name: "myproj", URL: "file:///tmp/myproj", Mode: project.ModeLocalOnly})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Result != "skipped" || got.Detail != "local-managed project; no live origin remote" {
+		t.Fatalf("outcome = %+v, want visible local-managed skip", got)
+	}
+}
+
 func TestPruneGoneBranchesDeletesLocalBranchWithGoneUpstream(t *testing.T) {
 	remotePath := filepath.Join(t.TempDir(), "remote")
 	initGitRepo(t, remotePath)
@@ -449,6 +466,39 @@ func TestProjectSyncCommandFastForwardsTheClone(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(movedClone, "new.txt")); err != nil {
 		t.Fatalf("clone did not fast-forward: %v", err)
+	}
+}
+
+func TestProjectSyncCommandContinuesAcrossRemoteAndLocalProjects(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	remoteClone, remotePath := setupSyncProject(t)
+	remoteManaged := filepath.Join(home, "projects", "remote")
+	if err := os.MkdirAll(filepath.Dir(remoteManaged), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(remoteClone, remoteManaged); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "remote", URL: remotePath, Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	localPath := filepath.Join(home, "projects", "local")
+	initGitRepo(t, localPath)
+	if err := project.Add(home, project.Project{Name: "local", URL: "file:///tmp/local", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newProjectSyncCmd()
+	var output strings.Builder
+	cmd.SetOut(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.Contains(text, "count: 2") || !strings.Contains(text, "failed: 0") || !strings.Contains(text, "local-managed project") {
+		t.Fatalf("sync output = %q, want mixed remote/local results", text)
 	}
 }
 

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -38,15 +38,188 @@ func TestValidateProjectURL(t *testing.T) {
 			t.Errorf("validateProjectURL(%q) failed: %v", url, err)
 		}
 	}
-	for _, url := range []string{"", "local", "/tmp/repo", "file:///tmp/repo", "http://github.com/org/repo"} {
+	for _, url := range []string{".", "..", "local", "/tmp/repo", "file:///tmp/repo", `C:\\work\\repo`} {
+		if err := validateProjectURL(url); err != nil {
+			t.Errorf("validateProjectURL(%q) rejected local source: %v", url, err)
+		}
+	}
+	for _, url := range []string{"", "http://github.com/org/repo", "ftp://example.com/repo", "sshx://example.com/repo"} {
 		err := validateProjectURL(url)
 		if err == nil {
-			t.Errorf("validateProjectURL(%q) accepted invalid URL", url)
+			t.Errorf("validateProjectURL(%q) accepted invalid source", url)
 			continue
 		}
 		if code := exitCodeFor(t, err); code != 2 {
 			t.Errorf("validateProjectURL(%q) code = %d, want 2", url, code)
 		}
+	}
+}
+
+func TestProjectCommandRegistersCreate(t *testing.T) {
+	cmd, _, err := newProjectCmd().Find([]string{"create"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd == nil {
+		t.Fatal("project command does not register create")
+	}
+}
+
+func TestProjectAddAdoptsLocalGitSourceIntoIndependentLocalProject(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(t.TempDir(), "source with space-世界")
+	initGitRepo(t, source)
+	if err := os.Mkdir(filepath.Join(source, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mkFleetDirs(t, home)
+	t.Chdir(home)
+	faketool.Treehouse{}.Install(t, faketool.Bin(t))
+
+	cmd := newProjectAddCmd()
+	cmd.SetArgs([]string{filepath.Join(source, "nested"), "--name", "adopted"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	managed := filepath.Join(home, "projects", "adopted")
+	if _, err := os.Stat(managed); err != nil {
+		t.Fatal(err)
+	}
+	if origin := gitConfigOrigin(t, managed); origin != "" {
+		t.Fatalf("managed origin = %q, want no origin", origin)
+	}
+	if err := os.RemoveAll(source); err != nil {
+		t.Fatal(err)
+	}
+	if got := runGitOutput(t, managed, "log", "-1", "--format=%s"); got != "initial commit\n" {
+		t.Fatalf("managed baseline after source removal = %q", got)
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 || projects[0].Name != "adopted" || projects[0].Mode != project.ModeLocalOnly || !project.IsFileLocator(projects[0].URL) {
+		t.Fatalf("projects = %+v, want one local-only file-locator project", projects)
+	}
+}
+
+func TestProjectAddRefusesExplicitRemoteDeliveryForLocalSource(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(t.TempDir(), "source")
+	initGitRepo(t, source)
+	mkFleetDirs(t, home)
+	t.Chdir(home)
+
+	cmd := newProjectAddCmd()
+	cmd.SetArgs([]string{source, "--mode", project.ModeDirectPR})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "only --mode local-only") {
+		t.Fatalf("error = %v, want explicit local mode refusal", err)
+	}
+}
+
+func TestProjectAddRejectsUnsafeLocalGitStates(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string)
+		want  string
+	}{
+		{name: "dirty", setup: func(t *testing.T, path string) {
+			initGitRepo(t, path)
+			if err := os.WriteFile(filepath.Join(path, "untracked.txt"), []byte("uncommitted"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "uncommitted or untracked"},
+		{name: "detached", setup: func(t *testing.T, path string) {
+			initGitRepo(t, path)
+			runGitIn(t, path, "checkout", "--detach", "HEAD")
+		}, want: "checked-out branch"},
+		{name: "unborn", setup: func(t *testing.T, path string) {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			runGitIn(t, path, "init", "-q", "-b", "main")
+		}, want: "no committed HEAD"},
+		{name: "non-git", setup: func(t *testing.T, path string) {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "not a Git worktree"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			source := filepath.Join(t.TempDir(), test.name)
+			test.setup(t, source)
+			mkFleetDirs(t, home)
+			t.Chdir(home)
+
+			cmd := newProjectAddCmd()
+			cmd.SetArgs([]string{source, "--name", test.name})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestProjectCreateMakesDeterministicLocalBaseline(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	t.Chdir(home)
+	faketool.Treehouse{}.Install(t, faketool.Bin(t))
+
+	cmd := newProjectCreateCmd()
+	cmd.SetArgs([]string{"created"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(home, "projects", "created")
+	if got := runGitOutput(t, path, "symbolic-ref", "--short", "HEAD"); got != "main\n" {
+		t.Fatalf("default branch = %q, want main", got)
+	}
+	if got := runGitOutput(t, path, "log", "-1", "--format=%s"); got != "chore: initialize project\n" {
+		t.Fatalf("baseline message = %q", got)
+	}
+	if got := runGitOutput(t, path, "rev-list", "--count", "HEAD"); got != "1\n" {
+		t.Fatalf("baseline commit count = %q, want one commit", got)
+	}
+	if origin := gitConfigOrigin(t, path); origin != "" {
+		t.Fatalf("created origin = %q, want no origin", origin)
+	}
+	projects, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 || projects[0].Mode != project.ModeLocalOnly || !project.IsFileLocator(projects[0].URL) {
+		t.Fatalf("projects = %+v, want one local-only file-locator project", projects)
+	}
+}
+
+func TestProjectAddPreservesCustomDefaultBranchAfterOriginRemoval(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(t.TempDir(), "custom")
+	initGitRepo(t, source)
+	runGitIn(t, source, "branch", "-m", "trunk")
+	runGitIn(t, source, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/heads/trunk")
+	mkFleetDirs(t, home)
+	t.Chdir(home)
+	faketool.Treehouse{}.Install(t, faketool.Bin(t))
+
+	cmd := newProjectAddCmd()
+	cmd.SetArgs([]string{source, "--name", "custom"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(home, "projects", "custom")
+	if got := runGitOutput(t, managed, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); got != "origin/trunk\n" {
+		t.Fatalf("default marker = %q, want origin/trunk", got)
+	}
+	if got := runGitOutput(t, managed, "rev-parse", "refs/remotes/origin/trunk"); got != runGitOutput(t, managed, "rev-parse", "refs/heads/trunk") {
+		t.Fatalf("preserved origin/trunk ref = %q, want local trunk tip", got)
 	}
 }
 
@@ -138,9 +311,20 @@ func gitConfigOrigin(t *testing.T, clonePath string) string {
 	t.Helper()
 	out, err := exec.Command("git", "-C", clonePath, "config", "--get", "remote.origin.url").Output()
 	if err != nil {
-		t.Fatalf("git config origin: %v", err)
+		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return string(out)
 }
 
 func executeProjectSetURL(t *testing.T, home, url string) error {
@@ -163,6 +347,27 @@ func TestProjectSetURLRejectsInvalidURLBeforeMutation(t *testing.T) {
 	}
 	if projects[0].URL != oldURL || gitConfigOrigin(t, clonePath) != oldURL {
 		t.Fatalf("after invalid URL, project = %+v and origin = %q, want both old", projects[0], gitConfigOrigin(t, clonePath))
+	}
+}
+
+func TestProjectSetURLRefusesLocalManagedProject(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	clonePath := filepath.Join(home, "projects", "local")
+	initGitRepo(t, clonePath)
+	if err := project.Add(home, project.Project{Name: "local", URL: "file:///tmp/local", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newProjectSetURLCmd()
+	cmd.SetArgs([]string{"local", "https://example.com/local"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "local-managed project") {
+		t.Fatalf("error = %v, want local-managed refusal", err)
+	}
+	if got := gitConfigOrigin(t, clonePath); got != "" {
+		t.Fatalf("origin = %q, want no origin after refusal", got)
 	}
 }
 

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -223,6 +223,27 @@ func TestProjectAddPreservesCustomDefaultBranchAfterOriginRemoval(t *testing.T) 
 	}
 }
 
+func TestProjectAddUsesCheckedOutBranchWithoutRemoteDefaultMarker(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(t.TempDir(), "custom")
+	initGitRepo(t, source)
+	runGitIn(t, source, "branch", "-m", "trunk")
+	runGitIn(t, source, "remote", "add", "origin", "file:///does-not-exist")
+	mkFleetDirs(t, home)
+	t.Chdir(home)
+	faketool.Treehouse{}.Install(t, faketool.Bin(t))
+
+	cmd := newProjectAddCmd()
+	cmd.SetArgs([]string{source, "--name", "custom"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(home, "projects", "custom")
+	if got := runGitOutput(t, managed, "symbolic-ref", "--short", "HEAD"); got != "trunk\n" {
+		t.Fatalf("checked-out branch = %q, want trunk", got)
+	}
+}
+
 func TestValidateProjectMode(t *testing.T) {
 	for _, mode := range []string{"no-mistakes", "direct-pr", "local-only"} {
 		if err := validateProjectMode(mode); err != nil {

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -34,7 +34,9 @@ The Projects, Tasks, Attempts, Workers, holds, and context coordinated from one 
 
 ### Project
 
-A repository registered with the Fleet.
+A durable Git-backed body of work registered with the Fleet.
+A Project may enter through a remote clone, one-time adoption of a local Git worktree, or greenfield creation.
+Every Project has one canonical repository under the Fleet and workers never execute directly in an operator-owned source checkout.
 A Project has a delivery mode such as `direct-pr`, `local-only`, or `no-mistakes`.
 
 ### Task

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -182,6 +182,7 @@ func goToolPath() string {
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
+	//nolint:staticcheck // hermetic test PATHs can hide go, so runtime.GOROOT is the reliable fallback.
 	path := filepath.Join(runtime.GOROOT(), "bin", name)
 	if _, err := os.Stat(path); err == nil {
 		return path

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -107,6 +107,11 @@ func LocalDefaultBranch(path string) (string, error) {
 			return branch, nil
 		}
 	}
+	if branch, err := CurrentBranch(path); err == nil {
+		if _, err := BranchCommit(path, branch); err == nil {
+			return branch, nil
+		}
+	}
 	return "", fmt.Errorf("resolve local Git default branch failed")
 }
 

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -1,0 +1,176 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func ResolveRoot(path string) (string, error) {
+	out, err := run(path, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("resolve Git repository root: %w", err)
+	}
+	root, err := filepath.Abs(filepath.FromSlash(strings.TrimSpace(out)))
+	if err != nil {
+		return "", fmt.Errorf("make Git repository root absolute: %w", err)
+	}
+	return filepath.Clean(root), nil
+}
+
+func IsBare(path string) (bool, error) {
+	out, err := run(path, "rev-parse", "--is-bare-repository")
+	if err != nil {
+		return false, fmt.Errorf("inspect Git repository type: %w", err)
+	}
+	return strings.TrimSpace(out) == "true", nil
+}
+
+func HasUncommittedChanges(path string) (bool, error) {
+	out, err := run(path, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("read Git status: %w", err)
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+func CurrentBranch(path string) (string, error) {
+	out, err := run(path, "symbolic-ref", "--short", "-q", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git HEAD is detached or unreadable: %w", err)
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" {
+		return "", fmt.Errorf("git HEAD is detached")
+	}
+	return branch, nil
+}
+
+func HeadCommit(path string) (string, error) {
+	out, err := run(path, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve Git HEAD commit: %w", err)
+	}
+	commit := strings.TrimSpace(out)
+	if commit == "" {
+		return "", fmt.Errorf("git HEAD commit is empty")
+	}
+	return commit, nil
+}
+
+func BranchCommit(path, branch string) (string, error) {
+	out, err := run(path, "rev-parse", "--verify", "refs/heads/"+branch+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve Git branch %q commit: %w", branch, err)
+	}
+	commit := strings.TrimSpace(out)
+	if commit == "" {
+		return "", fmt.Errorf("git branch %q commit is empty", branch)
+	}
+	return commit, nil
+}
+
+func DefaultBranch(path string) (string, error) {
+	if out, err := run(path, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
+		if branch := strings.TrimPrefix(strings.TrimSpace(out), "origin/"); branch != "" {
+			return branch, nil
+		}
+	}
+
+	if out, err := run(path, "remote", "show", "origin"); err == nil {
+		for _, line := range strings.Split(out, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 3 && fields[0] == "HEAD" && fields[1] == "branch:" && fields[2] != "" {
+				return fields[2], nil
+			}
+		}
+	}
+
+	for _, branch := range []string{"main", "master"} {
+		if _, err := run(path, "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
+			return branch, nil
+		}
+	}
+	return "", fmt.Errorf("resolve Git default branch failed")
+}
+
+func LocalDefaultBranch(path string) (string, error) {
+	if out, err := run(path, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD"); err == nil {
+		if branch := strings.TrimPrefix(strings.TrimSpace(out), "origin/"); branch != "" {
+			return branch, nil
+		}
+	}
+	for _, branch := range []string{"main", "master"} {
+		if _, err := run(path, "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
+			return branch, nil
+		}
+	}
+	return "", fmt.Errorf("resolve local Git default branch failed")
+}
+
+func LocalDefaultBranchRef(path string) (string, error) {
+	if out, err := run(path, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD"); err == nil {
+		if ref := strings.TrimSpace(out); ref != "" {
+			return ref, nil
+		}
+	}
+	return LocalDefaultBranch(path)
+}
+
+func RemoveOrigin(path string) error {
+	if _, err := run(path, "remote", "remove", "origin"); err != nil {
+		return fmt.Errorf("remove Git origin: %w", err)
+	}
+	return nil
+}
+
+func CheckoutBranch(path, branch string) error {
+	if _, err := run(path, "checkout", "--quiet", branch); err != nil {
+		return fmt.Errorf("checkout Git branch %q: %w", branch, err)
+	}
+	return nil
+}
+
+func PreserveDefaultBranch(path, branch string) error {
+	if _, err := BranchCommit(path, branch); err != nil {
+		return err
+	}
+	if _, err := run(path, "update-ref", "refs/remotes/origin/"+branch, "refs/heads/"+branch); err != nil {
+		return fmt.Errorf("preserve Git default branch %q: %w", branch, err)
+	}
+	if _, err := run(path, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/"+branch); err != nil {
+		return fmt.Errorf("preserve Git default branch marker %q: %w", branch, err)
+	}
+	return nil
+}
+
+func HasAlternates(path string) (bool, error) {
+	out, err := run(path, "rev-parse", "--git-path", "objects/info/alternates")
+	if err != nil {
+		return false, fmt.Errorf("resolve Git alternates path: %w", err)
+	}
+	alternatePath := strings.TrimSpace(out)
+	if !filepath.IsAbs(alternatePath) {
+		alternatePath = filepath.Join(path, alternatePath)
+	}
+	data, err := os.ReadFile(alternatePath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read Git alternates: %w", err)
+	}
+	return strings.TrimSpace(string(data)) != "", nil
+}
+
+func run(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return string(out), nil
+}

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -1,0 +1,42 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultBranchUsesLocalMarkerWithoutOrigin(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "repo")
+	runGit(t, dir, "init", "-q", "-b", "trunk")
+	runGit(t, dir, "-c", "user.name=git-test", "-c", "user.email=git-test@example.invalid", "commit", "-q", "--allow-empty", "-m", "baseline")
+	runGit(t, dir, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+	runGit(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+
+	got, err := DefaultBranch(dir)
+	if err != nil || got != "trunk" {
+		t.Fatalf("DefaultBranch() = %q, %v, want trunk", got, err)
+	}
+	ref, err := LocalDefaultBranchRef(dir)
+	if err != nil || ref != "origin/trunk" {
+		t.Fatalf("LocalDefaultBranchRef() = %q, %v, want origin/trunk", ref, err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	if len(args) > 1 && args[0] == "init" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}

--- a/internal/project/locator.go
+++ b/internal/project/locator.go
@@ -1,0 +1,96 @@
+package project
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func IsFileLocator(value string) bool {
+	u, err := url.Parse(value)
+	return err == nil && strings.EqualFold(u.Scheme, "file")
+}
+
+func CanonicalFileLocator(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("make path absolute: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", path, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("make resolved path absolute: %w", err)
+	}
+
+	slashPath := filepath.ToSlash(resolved)
+	u := &url.URL{Scheme: "file"}
+	if runtime.GOOS == "windows" && len(slashPath) >= 2 && slashPath[1] == ':' {
+		u.Path = "/" + slashPath
+	} else {
+		u.Path = slashPath
+	}
+	return u.String(), nil
+}
+
+func FileLocatorPath(locator string) (string, error) {
+	u, err := url.Parse(locator)
+	if err != nil || !strings.EqualFold(u.Scheme, "file") {
+		return "", fmt.Errorf("invalid file locator %q", locator)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("file locator %q has query or fragment", locator)
+	}
+	path := u.Path
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
+		path = "//" + u.Host + "/" + strings.TrimPrefix(path, "/")
+	}
+	if path == "" {
+		return "", fmt.Errorf("file locator %q has no path", locator)
+	}
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return filepath.Clean(filepath.FromSlash(path)), nil
+}
+
+func IsManagedPath(homeDir, path string) (bool, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false, fmt.Errorf("resolve managed-path candidate %q: %w", path, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return false, fmt.Errorf("make managed-path candidate absolute: %w", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(homeDir, "projects"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		managed := filepath.Join(homeDir, "projects", entry.Name())
+		managed, err = filepath.EvalSymlinks(managed)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("resolve managed project %q: %w", entry.Name(), err)
+		}
+		managed, err = filepath.Abs(managed)
+		if err != nil {
+			return false, fmt.Errorf("make managed project %q absolute: %w", entry.Name(), err)
+		}
+		if managed == resolved {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -263,6 +263,29 @@ var projectURLUpdater = func(db *store.DB, name, url string) (bool, error) {
 
 var projectURLProjectionWriter = writeProjection
 
+var projectAddProjectionWriter = writeProjection
+
+var projectAddRowRemover = func(db *store.DB, name string) (bool, error) {
+	return db.RemoveProject(name)
+}
+
+type RegistrationRollbackError struct {
+	Name     string
+	Cause    error
+	Rollback error
+}
+
+func (e *RegistrationRollbackError) Error() string {
+	return fmt.Sprintf("register project %q failed: %v; rollback failed: %v", e.Name, e.Cause, e.Rollback)
+}
+
+func (e *RegistrationRollbackError) Unwrap() error { return e.Cause }
+
+func IsRegistrationRollbackError(err error) bool {
+	var target *RegistrationRollbackError
+	return errors.As(err, &target)
+}
+
 // Changes only the registered project's repository URL and its projection.
 func SetURL(homeDir, name, url string) error {
 	unlock, err := lockRegistry(homeDir)
@@ -433,7 +456,17 @@ func Add(homeDir string, p Project) error {
 	if err := db.AddProject(p); err != nil {
 		return err
 	}
-	return writeProjection(db, homeDir)
+	if err := projectAddProjectionWriter(db, homeDir); err != nil {
+		removed, rollbackErr := projectAddRowRemover(db, p.Name)
+		if rollbackErr != nil {
+			return &RegistrationRollbackError{Name: p.Name, Cause: err, Rollback: rollbackErr}
+		}
+		if !removed {
+			return &RegistrationRollbackError{Name: p.Name, Cause: err, Rollback: fmt.Errorf("row was not found")}
+		}
+		return err
+	}
+	return nil
 }
 
 func validMode(mode string) bool {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -198,6 +198,84 @@ func TestSetURLReportsProjectionAndRollbackFailures(t *testing.T) {
 	}
 }
 
+func TestAddRollsBackWhenProjectionWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := projectAddProjectionWriter
+	t.Cleanup(func() { projectAddProjectionWriter = original })
+	projectAddProjectionWriter = func(*store.DB, string) error {
+		return errors.New("projection failed")
+	}
+
+	err := Add(dir, Project{Name: "rollback", URL: "file:///tmp/rollback", Mode: ModeLocalOnly})
+	if err == nil || !strings.Contains(err.Error(), "projection failed") {
+		t.Fatalf("Add error = %v, want projection failure", err)
+	}
+	projects, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("projects after failed Add = %+v, want no durable row", projects)
+	}
+}
+
+func TestAddReportsWhenRegistryRollbackFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalProjection := projectAddProjectionWriter
+	originalRemoval := projectAddRowRemover
+	t.Cleanup(func() {
+		projectAddProjectionWriter = originalProjection
+		projectAddRowRemover = originalRemoval
+	})
+	projectAddProjectionWriter = func(*store.DB, string) error { return errors.New("projection failed") }
+	projectAddRowRemover = func(*store.DB, string) (bool, error) { return false, errors.New("database locked") }
+
+	err := Add(dir, Project{Name: "retained", URL: "file:///tmp/retained", Mode: ModeLocalOnly})
+	if err == nil || !IsRegistrationRollbackError(err) || !strings.Contains(err.Error(), "database locked") {
+		t.Fatalf("Add error = %v, want rollback failure context", err)
+	}
+}
+
+func TestFileLocatorRoundTripsSpacesUnicodeAndWindowsDrivePaths(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "project with space-世界")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	locator, err := CanonicalFileLocator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(locator, "file://") || !strings.Contains(locator, "%20") {
+		t.Fatalf("locator = %q, want canonical file URI with escaped space", locator)
+	}
+	got, err := FileLocatorPath(locator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("FileLocatorPath(%q) = %q, want %q", locator, got, want)
+	}
+	for locator, want := range map[string]string{
+		"file:///C:/work/repo":     "C:/work/repo",
+		"file://server/share/repo": "//server/share/repo",
+	} {
+		got, err := FileLocatorPath(locator)
+		if err != nil || got != filepath.Clean(filepath.FromSlash(want)) {
+			t.Fatalf("FileLocatorPath(%q) = %q, %v, want %q", locator, got, err, want)
+		}
+	}
+}
+
 func TestSetUpstreamNotFound(t *testing.T) {
 	dir := t.TempDir()
 	writeRegistry(t, dir, "# Projects\n\n")

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -258,7 +258,11 @@ func TestFileLocatorRoundTripsSpacesUnicodeAndWindowsDrivePaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want, err := filepath.Abs(dir)
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err = filepath.Abs(want)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/execution_plan_test.go
+++ b/internal/runtime/execution_plan_test.go
@@ -177,6 +177,22 @@ func TestProjectBaseCommitDoesNotQueryRemoteToResolveBranch(t *testing.T) {
 	}
 }
 
+func TestProjectBaseCommitUsesCustomLocalDefaultMarkerWithoutOrigin(t *testing.T) {
+	clonePath := filepath.Join(t.TempDir(), "clone")
+	initRuntimeGitRepo(t, clonePath)
+	runRuntimeGit(t, clonePath, "branch", "-m", "trunk")
+	runRuntimeGit(t, clonePath, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/heads/trunk")
+	want := gitOutput(t, clonePath, "rev-parse", "refs/heads/trunk")
+
+	got, err := projectBaseCommit(clonePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("projectBaseCommit() = %q, want custom trunk commit %q", got, want)
+	}
+}
+
 func TestSpawnMechanicalPlanStopsBeforeAttemptAndExternalProvisioning(t *testing.T) {
 	home := executionPlanHome(t, "---\nexecution_class: mechanical\nplanned_against: "+strings.Repeat("a", 40)+"\n---\nbrief\n")
 	calls := &executionPlanCalls{}

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
@@ -561,33 +562,9 @@ func dirtIsSafeToDiscard(worktreePath, status string) bool {
 	return true
 }
 
-// Resolves the worktree's local knowledge of the default branch without touching the network: a real
-// treehouse worktree shares its refs with the project clone it was leased from, so a prior fetch there
-// already left refs/remotes/origin/HEAD in place for it to read directly.
+// Resolves the worktree's local knowledge of the default branch without touching the network.
 func localDefaultBranchRef(worktreePath string) (string, error) {
-	c := exec.Command("git", "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD")
-	c.Dir = worktreePath
-	if out, err := c.Output(); err == nil {
-		if ref := strings.TrimSpace(string(out)); ref != "" {
-			return ref, nil
-		}
-	}
-
-	current, err := currentBranch(worktreePath)
-	if err != nil {
-		return "", err
-	}
-	for _, branch := range []string{"main", "master"} {
-		if branch == current {
-			continue
-		}
-		c := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
-		c.Dir = worktreePath
-		if err := c.Run(); err == nil {
-			return branch, nil
-		}
-	}
-	return "", fmt.Errorf("cannot resolve a local default branch ref")
+	return git.LocalDefaultBranchRef(worktreePath)
 }
 
 // Reads path's content at ref. An empty ref reads the index's stage-0 blob, which is what
@@ -628,36 +605,7 @@ func branchIsMerged(clonePath, worktreePath string) (bool, error) {
 }
 
 func defaultBranch(clonePath string) (string, error) {
-	c := exec.Command("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
-	c.Dir = clonePath
-	out, err := c.Output()
-	if err == nil {
-		branch := strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")
-		if branch != "" {
-			return branch, nil
-		}
-	}
-
-	c = exec.Command("git", "remote", "show", "origin")
-	c.Dir = clonePath
-	out, err = c.Output()
-	if err == nil {
-		for _, line := range strings.Split(string(out), "\n") {
-			fields := strings.Fields(line)
-			if len(fields) == 3 && fields[0] == "HEAD" && fields[1] == "branch:" && fields[2] != "" {
-				return fields[2], nil
-			}
-		}
-	}
-
-	for _, branch := range []string{"main", "master"} {
-		c = exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
-		c.Dir = clonePath
-		if err := c.Run(); err == nil {
-			return branch, nil
-		}
-	}
-	return "", fmt.Errorf("resolve default branch failed")
+	return git.DefaultBranch(clonePath)
 }
 
 func projectBaseCommit(clonePath string) (string, error) {
@@ -665,47 +613,20 @@ func projectBaseCommit(clonePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ref := "refs/heads/" + branch
-	c := exec.Command("git", "rev-parse", "--verify", ref+"^{commit}")
-	c.Dir = clonePath
-	out, err := c.Output()
+	commit, err := git.BranchCommit(clonePath, branch)
 	if err != nil {
-		return "", fmt.Errorf("resolve local default branch commit %s: %w", ref, err)
-	}
-	commit := strings.TrimSpace(string(out))
-	if commit == "" {
-		return "", fmt.Errorf("resolve local default branch commit %s: empty Git object ID", ref)
+		return "", fmt.Errorf("resolve local default branch commit refs/heads/%s: %w", branch, err)
 	}
 	return commit, nil
 }
 
 func localDefaultBranch(clonePath string) (string, error) {
-	c := exec.Command("git", "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD")
-	c.Dir = clonePath
-	if out, err := c.Output(); err == nil {
-		if branch := strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/"); branch != "" {
-			return branch, nil
-		}
-	}
-	for _, branch := range []string{"main", "master"} {
-		c := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
-		c.Dir = clonePath
-		if err := c.Run(); err == nil {
-			return branch, nil
-		}
-	}
-	return "", fmt.Errorf("resolve local default branch failed")
+	return git.LocalDefaultBranch(clonePath)
 }
 
 // git symbolic-ref, not rev-parse --abbrev-ref: the latter exits 0 and prints the literal string
 // "HEAD" on a detached HEAD instead of failing, which every caller would otherwise have to
 // special-case itself to avoid treating that sentinel as a real branch name.
 func currentBranch(worktreePath string) (string, error) {
-	c := exec.Command("git", "symbolic-ref", "--short", "-q", "HEAD")
-	c.Dir = worktreePath
-	out, err := c.Output()
-	if err != nil {
-		return "", fmt.Errorf("git symbolic-ref failed: %w", err)
-	}
-	return strings.TrimSpace(string(out)), nil
+	return git.CurrentBranch(worktreePath)
 }

--- a/skills/secondhand/SKILL.md
+++ b/skills/secondhand/SKILL.md
@@ -8,6 +8,12 @@ metadata:
 
 # Secondhand supervisor handbook
 
+## Project onboarding
+
+Register an existing remote or local Git project with `hand project add <source>`.
+For greenfield work, use `hand project create <name>`.
+Local adoption is one-time and local-only: Hand copies committed state into its managed clone, never executes in the operator-owned source checkout, and does not synchronize the two repositories later.
+
 This skill teaches how to drive the `hand` CLI as a Secondhand fleet supervisor. It is a
 procedure layer over `hand`, not a second implementation of it: every claim here about fleet
 state, dependency state, or task state is something you get by running a `hand` command and

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -514,7 +514,7 @@ func TestExitCodeTwoOnUsageError(t *testing.T) {
 		{"unknown flag", []string{"spawn", "--bogus", "task-1", "demo"}, "unknown flag: --bogus"},
 		{"conflicting merge methods", []string{"merge", "task-1", "--squash", "--rebase"}, "only one of --squash, --merge, --rebase"},
 		{"merge method with local", []string{"merge", "task-1", "--local", "--squash"}, "cannot be combined with --local"},
-		{"invalid project URL", []string{"project", "add", "not-a-url"}, "invalid project URL"},
+		{"missing local project source", []string{"project", "add", "not-a-url"}, `local project source "not-a-url"`},
 		{"invalid project mode", []string{"project", "add", "https://example.com/demo.git", "--mode", "bogus"}, "invalid project mode"},
 		{"invalid poll interval", []string{"watch", "--poll", "nonsense"}, "invalid poll interval"},
 	}

--- a/tests/e2e/project_test.go
+++ b/tests/e2e/project_test.go
@@ -105,3 +105,40 @@ func TestProjectLifecycle(t *testing.T) {
 		t.Fatalf("clone at %s should survive project remove: %v", clonePath, err)
 	}
 }
+
+func TestLocalProjectLifecycle(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "book with space")
+	initGitRepo(t, source)
+
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, filepath.Join(t.TempDir(), "unused-worktree"))
+	home := newHome(t)
+
+	added := runHand(t, home, "project", "add", source, "--name", "book")
+	if added.code != 0 {
+		t.Fatalf("local project add: exit %d, stderr %q", added.code, added.stderr)
+	}
+	if !strings.Contains(added.stdout, "mode: local-only") || !strings.Contains(added.stdout, "source:") {
+		t.Fatalf("local project add stdout = %q, want adoption fields", added.stdout)
+	}
+	if err := os.RemoveAll(source); err != nil {
+		t.Fatal(err)
+	}
+
+	synced := runHand(t, home, "project", "sync", "book")
+	if synced.code != 0 || !strings.Contains(synced.stdout, "local-managed project") {
+		t.Fatalf("local project sync = %+v, want visible local skip", synced)
+	}
+	repointed := runHand(t, home, "project", "set-url", "book", "https://example.com/book.git")
+	if repointed.code == 0 || !strings.Contains(repointed.stderr, "local-managed project") {
+		t.Fatalf("local project set-url = %+v, want refusal", repointed)
+	}
+
+	created := runHand(t, home, "project", "create", "blank")
+	if created.code != 0 || !strings.Contains(created.stdout, "baseline:") || !strings.Contains(created.stdout, "mode: local-only") {
+		t.Fatalf("project create = %+v, want baseline and local-only output", created)
+	}
+	if got := runGitIn(t, filepath.Join(home, "projects", "blank"), "log", "-1", "--format=%s"); got != "chore: initialize project\n" {
+		t.Fatalf("created baseline = %q", got)
+	}
+}


### PR DESCRIPTION
## Intent

Implement atqamz/hand#330: keep remote project add backward-compatible, add local Git adoption through hand project add <source> with clean committed non-bare validation, independent canonical file:// locator, local-only semantics, no live sync, and safe rollback; add hand project create <name> with deterministic main and one empty baseline commit; preserve Treehouse, spawn, merge --local, teardown, reconcile, sync, set-url, registry, path encoding, docs, skills, and tests. Do not add import, arbitrary non-Git support, live source synchronization, push/publish behavior for local projects, or change delivery semantics.

## What Changed

- Added local Git project adoption through `hand project add <source>` with clean, committed, non-bare validation, canonical `file://` locators, independent managed clones, local-only semantics, and rollback-safe registration.
- Added `hand project create <name>` for deterministic `main` initialization with one empty baseline commit and local-only registration.
- Updated Git/project lifecycle handling, documentation, supervisor skills, and tests for local project onboarding, path encoding, sync skipping, and preserved existing workflows.

## Risk Assessment

✅ Low: The reviewed changes satisfy the stated local-adoption constraints, including local-only default-branch resolution, clean committed non-bare validation, independent file locators, and rollback handling.

## Testing

Focused tests and real CLI verification passed. Evidence demonstrates canonical file:// registration, independent originless managed clone, local-only semantics, deterministic main baseline commit, and safe remote-only set-url refusal. No screenshot applies because this is CLI-only.

<details>
<summary>Evidence: CLI adoption and creation transcript</summary>

```text
result: initialized
home: /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home
agents_md: written
agents_md_legacy_archive: none
skill[4]{dir,outcome}:
  /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/.claude/skills/secondhand,created
  /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/.grok/skills/secondhand,created
  /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/.pi/skills/secondhand,created
  /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/.agents/skills/secondhand,created
skill_conflicts: 0
session_hook: unchanged
migrated[0]:
config_missing: 0
config[3]{key,state,value}:
  harness,detected,codex
  model,native-default,none
  effort,native-default,none
missing_tools[0]:
help[5]:
  - Start a supervising session in this home; it detects the current harness and uses its native model and effort defaults
  - Run `hand config set <key> <value>` only to persist an explicit worker override
  - Read AGENTS.md in this home for how a supervising agent is meant to drive it
  - Run `hand project add <source>` or `hand project create <name>` to register the first project
  - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
name: adopted
result: added
mode: local-only
url: "file:///home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/source"
clone: /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/projects/adopted
source: /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/source
default_branch: main
baseline: e87ae015c23cff6a91bfbb9faf5df1b720888b6f
help[1]:
  - Run `hand spawn <id> adopted` to dispatch a worker into it
name: blank
result: created
mode: local-only
url: "file:///home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/projects/blank"
clone: /home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/.validation-run/home/projects/blank
baseline: 8b24710df385b551306eda8c8702f98865019524
help[1]:
  - Run `hand spawn <id> blank` to dispatch a worker into it
adopted.origin=adopted.branch=main
created.branch=main
created.commits=1
created.commit=chore: initialize project
count: 1
advanced: 0
failed: 0
projects[1]{name,result,detail}:
  adopted,skipped,local-managed project; no live origin remote
error: "project \"adopted\" is a local-managed project; set-url is supported only for remote-backed projects"
kind: general
exit: 1
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"902ad1987d879b8e91033df6780957f48fda4574","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `cmd/project_source.go:89` - Local adoption can perform a live remote query: `resolveLocalProjectSource` calls `git.DefaultBranch` at [cmd/project_source.go:89](/home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/cmd/project_source.go:89), whose fallback runs `git remote show origin` at [internal/git/repository.go:82](/home/atqa/.no-mistakes/worktrees/b12a7d7080cf/01M0JPBJ5M9PA0904HM40YDQVM/internal/git/repository.go:82). For a clean local repository with an origin but no local origin/HEAD marker and a custom default branch, `hand project add &lt;source&gt;` may contact or block on the remote. This contradicts the required criterion: &#34;no live sync&#34;. Resolve the default branch entirely from local refs/HEAD metadata for local adoption.

🔧 Fix: Use local Git metadata for adopted project default branches
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `hand session start` was unavailable because this isolated worktree is not inside a configured Secondhand home; product validation proceeded via the repository dev shell.
- <code>`go test ./cmd -run TestProject... -count=1` via `nix develop`</code>
- <code>`go test ./internal/git ./internal/project -count=1` via `nix develop`</code>
- <code>`go test -tags=e2e ./tests/e2e -run ^Test(ProjectLifecycle|LocalProjectLifecycle)$ -count=1` via `nix develop`</code>
- `Manual CLI flow covering adoption, creation, persisted Git state, local sync skip, and set-url refusal`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
