### PR TITLE
feat(runtime): add fleet identity and registry isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,21 @@ SQLite is durable intent and history, while Git, treehouse, herdr, and worker pr
 The [deterministic reconciliation decision record](docs/adr/deterministic-reconciliation-observes-before-mutating.md) owns the recovery invariants.
 `hand status` remains read-only and displays repair markers without attempting cleanup.
 
+Each Fleet home has one opaque, durable Fleet identity in `state/hand.db`.
+The identity survives restarts, moving the home, and deleting the user-local registry.
+It is never derived from the path, project names, or the current machine.
+
+One OS user may have multiple independent Fleet homes.
+`hand fleet` lists homes discovered through the user-local `~/.secondhand/registry.db` registry, including missing homes, identity mismatches, and duplicate copied identities.
+The registry is discovery metadata rather than Fleet authority, so a missing registry is a warning and does not become a global active-Fleet switch.
+
+Copied Fleet databases retain their identity by design.
+When the registry can prove that one identity is valid at more than one home, runtime and mutating commands fail closed until the duplicate is resolved by the operator.
+This boundary prevents accidental cross-Fleet ownership but is logical isolation, not an OS security boundary.
+
+New Herdr workspaces use a Fleet-scoped named session and label.
+Legacy Attempts with an empty or `default` session remain in the legacy Herdr session and are cleaned up only through their exact persisted workspace, tab, and pane identities.
+
 ### Safe lifecycle boundaries
 
 `hand` fails closed around destructive or irreversible transitions. Teardown refuses unlanded work unless it was explicitly delivered, and the generated supervisor rules prohibit merging without operator authorization.
@@ -349,6 +364,7 @@ The important pieces are:
 - `data/learnings.md` - durable operational knowledge discovered by the fleet
 - `projects/` - registered project clones
 - `state/hand.db` - authoritative machine state
+- `state/index.db` - local full-text index of Fleet prose
 
 You normally do not manage these by hand. The supervisor and `hand` own the workflow.
 
@@ -510,6 +526,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand spawn` | Dispatch a worker into an isolated worktree. |
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
+| `hand fleet` | List user-local Fleet homes and their observed identity state. |
 | `hand ack <id> [--reason <text>]` | Record that a supervisor has acknowledged a task's report. |
 | `hand reconcile [id] [--abandon-worktree] [--abandon-pane] [--attempt-never-started]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; given a Task ID, explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, or attest that a running Attempt's worker took no turn so the ordinary release path can end it. |
 | `hand watch` | Wait for actionable fleet events. |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ It is never derived from the path, project names, or the current machine.
 
 One OS user may have multiple independent Fleet homes.
 `hand fleet` lists homes discovered through the user-local `~/.secondhand/registry.db` registry, including missing homes, identity mismatches, and duplicate copied identities.
-The registry is discovery metadata rather than Fleet authority, so a missing registry is a warning and does not become a global active-Fleet switch.
+The registry is discovery metadata rather than Fleet authority, so a missing registry leaves discovery empty and does not become a global active-Fleet switch.
 
 Copied Fleet databases retain their identity by design.
 When the registry can prove that one identity is valid at more than one home, runtime and mutating commands fail closed until the duplicate is resolved by the operator.

--- a/cmd/fleet.go
+++ b/cmd/fleet.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/registry"
+	"github.com/spf13/cobra"
+)
+
+func newFleetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fleet",
+		Short: "List known Fleet homes for this user",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registryPath, err := registry.Path()
+			if err != nil {
+				return err
+			}
+			currentHome, currentErr := home.Resolve()
+			var fleets []registry.Fleet
+			registryDB, err := registry.OpenReadOnlyAt(registryPath)
+			switch {
+			case errors.Is(err, registry.ErrRegistryMissing):
+			case err != nil:
+				return err
+			default:
+				defer func() { _ = registryDB.Close() }()
+				fleets, err = registryDB.List(currentHome)
+				if err != nil {
+					return err
+				}
+			}
+
+			doc := axi.Doc{}
+			doc.Field("registry", registryPath)
+			doc.Field("current_home", orNone(currentHome))
+			if currentErr != nil {
+				doc.Field("current_error", currentErr.Error())
+			} else {
+				doc.Field("current_error", "none")
+			}
+			rows := make([][]string, 0, len(fleets))
+			for _, fleet := range fleets {
+				rows = append(rows, []string{
+					fleet.ID,
+					fleet.Home,
+					string(fleet.State),
+					boolString(fleet.Current),
+					strings.Join(fleet.Locations, "\n"),
+				})
+			}
+			doc.Rows("fleets", []string{"id", "home", "state", "current", "locations"}, rows)
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/cmd/fleet_test.go
+++ b/cmd/fleet_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestFleetListsKnownHomesOutsideFleetContext(t *testing.T) {
 	userHome := t.TempDir()
-	t.Setenv("HOME", userHome)
-	t.Setenv("USERPROFILE", userHome)
+	setTestUserHome(t, userHome)
 	t.Setenv("HAND_HOME", "")
 	t.Chdir(t.TempDir())
 	firstHome := filepath.Join(t.TempDir(), "first")
@@ -58,8 +57,7 @@ func TestFleetListsKnownHomesOutsideFleetContext(t *testing.T) {
 
 func TestFleetListsHomesWhenExplicitContextIsInvalid(t *testing.T) {
 	userHome := t.TempDir()
-	t.Setenv("HOME", userHome)
-	t.Setenv("USERPROFILE", userHome)
+	setTestUserHome(t, userHome)
 	badHome := filepath.Join(t.TempDir(), "not-a-fleet")
 	t.Setenv("HAND_HOME", badHome)
 	t.Chdir(t.TempDir())

--- a/cmd/fleet_test.go
+++ b/cmd/fleet_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/registry"
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestFleetListsKnownHomesOutsideFleetContext(t *testing.T) {
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	t.Setenv("USERPROFILE", userHome)
+	t.Setenv("HAND_HOME", "")
+	t.Chdir(t.TempDir())
+	firstHome := filepath.Join(t.TempDir(), "first")
+	secondHome := filepath.Join(t.TempDir(), "second")
+	registryDB, err := registry.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	for _, home := range []string{firstHome, secondHome} {
+		db, err := store.Open(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fleetID, err := db.FleetID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := registryDB.Register(home, fleetID, testNow()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	root := newRootCmd(devBuild("test"))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"fleet"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"fleets[2]{id,home,state,current,locations}:", "ready,false", "current_home: none"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("fleet output = %q, want %q", out.String(), want)
+		}
+	}
+}
+
+func TestFleetListsHomesWhenExplicitContextIsInvalid(t *testing.T) {
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	t.Setenv("USERPROFILE", userHome)
+	badHome := filepath.Join(t.TempDir(), "not-a-fleet")
+	t.Setenv("HAND_HOME", badHome)
+	t.Chdir(t.TempDir())
+	registryDB, err := registry.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	home := filepath.Join(t.TempDir(), "fleet")
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(home, fleetID, testNow()); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd(devBuild("test"))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"fleet"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "current_error:") || !strings.Contains(out.String(), "HAND_HOME") || !strings.Contains(out.String(), "fleets[1]") {
+		t.Fatalf("fleet output = %q, want context error and listing", out.String())
+	}
+}
+
+func testNow() (now time.Time) {
+	return time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC)
+}

--- a/cmd/herdr.go
+++ b/cmd/herdr.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
+)
+
+func currentHerdrClient(home string) (*herdr.Client, error) {
+	fleetID, err := state.FleetIDReadOnly(home)
+	if err != nil {
+		if errors.Is(err, store.ErrFleetIdentityMissing) {
+			return herdr.NewClient(), nil
+		}
+		return nil, fmt.Errorf("read Fleet identity: %w", err)
+	}
+	return herdr.NewSessionClient(herdr.SessionName(fleetID)), nil
+}
+
+func herdrClientForAttempt(attempt *state.Attempt, current *herdr.Client) *herdr.Client {
+	if attempt == nil || attempt.Herdr.Session == "" || attempt.Herdr.Session == "default" {
+		return herdr.NewClient()
+	}
+	return herdr.NewSessionClient(attempt.Herdr.Session)
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,13 +7,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/sessionhook"
 	"github.com/atqamz/hand/internal/skill"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 
@@ -80,6 +83,11 @@ func newInitCmd() *cobra.Command {
 			if err := initMarker(home); err != nil {
 				return err
 			}
+			fleetID, err := state.FleetID(home)
+			if err != nil {
+				return fmt.Errorf("read Fleet identity after initialization: %w", err)
+			}
+			registryOutcome, registryErr := registerFleet(home, fleetID)
 			migrated, err := migrateWorkerSettings(home)
 			if err != nil {
 				return err
@@ -108,6 +116,8 @@ func newInitCmd() *cobra.Command {
 			var doc axi.Doc
 			doc.Field("result", "initialized")
 			doc.Field("home", home)
+			doc.Field("fleet_id", fleetID)
+			doc.Field("registry", registryOutcome)
 			doc.Field("agents_md", writtenOrUnchanged(refresh.Changed))
 			doc.Field("agents_md_legacy_archive", noneIfEmpty(refresh.ArchivedPath))
 			axi.Table(&doc, "skill", skillResults, skillFields)
@@ -141,9 +151,36 @@ func newInitCmd() *cobra.Command {
 				help = append(help, fmt.Sprintf("%d bundled-skill destination(s) already hold a foreign file at the managed entry path and were left untouched; move each aside, then run hand init again to install the skill there", n))
 			}
 			doc.Help(help...)
-			return doc.Render(cmd.OutOrStdout())
+			if err := doc.Render(cmd.OutOrStdout()); err != nil {
+				return err
+			}
+			if registryErr != nil {
+				return fmt.Errorf("fleet initialized at %s with fleet_id %s, but registry discovery update failed: %w", home, fleetID, registryErr)
+			}
+			return nil
 		},
 	}
+}
+
+func registerFleet(home, fleetID string) (string, error) {
+	db, err := registry.Open()
+	if err != nil {
+		return "failed", err
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Register(home, fleetID, time.Now().UTC()); err != nil {
+		return "failed", err
+	}
+	fleets, err := db.List(home)
+	if err != nil {
+		return "failed", err
+	}
+	for _, fleet := range fleets {
+		if fleet.ID == fleetID && fleet.State == registry.StateDuplicate {
+			return string(fleet.State), nil
+		}
+	}
+	return "registered", nil
 }
 
 // Reported rather than resolved: a missing tool is a diagnostic the first session explains in context,

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -40,7 +40,7 @@ func TestInitCreatesTheHandDbMarker(t *testing.T) {
 func TestInitRegistersDurableFleetIdentity(t *testing.T) {
 	t.Setenv("HAND_HOME", "")
 	userHome := t.TempDir()
-	t.Setenv("HOME", userHome)
+	setTestUserHome(t, userHome)
 	dir := t.TempDir()
 	t.Chdir(dir)
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/registry"
+	"github.com/atqamz/hand/internal/store"
 )
 
 func TestInitCreatesTheHandDbMarker(t *testing.T) {
@@ -32,6 +34,49 @@ func TestInitCreatesTheHandDbMarker(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("got IsHome false right after init, want true")
+	}
+}
+
+func TestInitRegistersDurableFleetIdentity(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newInitCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "fleet_id: "+fleetID+"\n") || !strings.Contains(out.String(), "registry: registered\n") {
+		t.Fatalf("init output = %q, want identity and registry outcome", out.String())
+	}
+
+	registryDB, err := registry.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	fleets, err := registryDB.List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fleets) != 1 || fleets[0].ID != fleetID || fleets[0].State != registry.StateReady {
+		t.Fatalf("registered fleets = %+v, want ready %s", fleets, fleetID)
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -57,11 +58,12 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 	bin := faketool.Bin(t)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
 	t.Setenv("HERDR_CALL_LOG", callLog)
-	herdr.Log = callLog
-	herdr.Install(t, bin)
 	faketool.Treehouse{Slots: []string{newWorktree, oldWorktree}, Log: callLog}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
+	herdr = scopeHerdrForFleet(t, home, herdr)
+	herdr.Log = callLog
+	herdr.Install(t, bin)
 	return home
 }
 
@@ -249,7 +251,11 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	if got.Worktree != newWt || got.LeaseID != "lease-1" {
 		t.Fatalf("worktree/lease = %q/%q, want the new ship execution identity", got.Worktree, got.LeaseID)
 	}
-	if got.Herdr.Session != "default" || got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tNew" || got.Herdr.PaneID != "wA:pNew" {
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Herdr.Session != herdr.SessionName(fleetID) || got.Herdr.WorkspaceID != "wA" || got.Herdr.TabID != "wA:tNew" || got.Herdr.PaneID != "wA:pNew" {
 		t.Fatalf("herdr = %+v, want the new ship execution identity", got.Herdr)
 	}
 	if history.Task.ReportOffset != 42 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/store"
 	"github.com/spf13/cobra"
@@ -22,6 +23,9 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 		Short:   "You lead. hand runs the crew.",
 		Version: info.Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Name() == "fleet" {
+				return nil
+			}
 			if fleetHome, err := home.Resolve(); err == nil {
 				startupOverview := cmd.Name() == "hand" || cmd.CommandPath() == "hand session start"
 				if cmd.Name() != "init" && !startupOverview && cmd.Name() != "status" {
@@ -39,6 +43,17 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 				if cmd.Name() != "update" && !startupOverview {
 					if notice := selfupdate.CheckNoticeForBuild(fleetHome, selfupdate.Repo, info); notice != "" {
 						_, _ = fmt.Fprintln(cmd.ErrOrStderr(), notice)
+					}
+				}
+				if shouldGuardFleet(cmd) {
+					warnings, err := registry.Preflight(fleetHome, cmd.Name() == "status" || startupOverview)
+					if err != nil {
+						return asPrecondition(err)
+					}
+					for _, warning := range warnings {
+						if _, err := fmt.Fprintln(cmd.ErrOrStderr(), warning); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -61,6 +76,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.AddCommand(newProjectCmd())
 	root.AddCommand(newSpawnCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(newFleetCmd())
 	root.AddCommand(newReconcileCmd())
 	root.AddCommand(newSessionCmd(info.Version))
 	root.AddCommand(newSendCmd())
@@ -81,6 +97,10 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.InitDefaultCompletionCmd()
 	guardSubcommandGroups(root)
 	return root
+}
+
+func shouldGuardFleet(cmd *cobra.Command) bool {
+	return cmd.Name() != "init" && cmd.Name() != "fleet" && cmd.CommandPath() != "hand" && cmd.CommandPath() != "hand session start"
 }
 
 // Makes every subcommand-only group below c reject an unknown subcommand with exit code 2.

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/axi"
-	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/steering"
@@ -56,7 +55,15 @@ func newSendCmd() *cobra.Command {
 				return usageValue(waitFromFlag, fmt.Errorf("invalid wait duration %q: %w", wait, err))
 			}
 
-			client := herdr.NewClient()
+			history, err := state.ReadHistoryReadOnly(fleetHome, args[0])
+			if err != nil {
+				return asPrecondition(err)
+			}
+			var attempt *state.Attempt
+			if history.ActiveAttempt != nil {
+				attempt = history.ActiveAttempt
+			}
+			client := herdrClientForAttempt(attempt, nil)
 			result, err := steering.Execute(steering.Request{
 				Home: fleetHome, TaskID: args[0], Message: message, Origin: steeringOperator,
 				Client: client, Wait: waitDuration, WaitComposer: client.WaitComposerEmpty, TryTaskLock: true,

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -10,9 +10,9 @@ import (
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/harness"
-	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/spf13/cobra"
 )
@@ -69,6 +69,9 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	if err != nil {
 		return sessionContextError(fleetHome, backlogPath, err)
 	}
+	if _, err := registry.Preflight(fleetHome, true); err != nil {
+		return asPrecondition(err)
+	}
 	projects, err := project.ListReadOnly(fleetHome)
 	if err != nil {
 		return err
@@ -81,7 +84,11 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	if err != nil {
 		return err
 	}
-	views, holds, err := fleetViews(cmd, fleetHome, herdr.NewClient(), true)
+	client, err := currentHerdrClient(fleetHome)
+	if err != nil {
+		return err
+	}
+	views, holds, err := fleetViews(cmd, fleetHome, client, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -48,13 +48,14 @@ func setupSpawnHome(t *testing.T, worktreePath string, herdr faketool.Herdr) str
 	bin := faketool.Bin(t)
 	callLog := filepath.Join(t.TempDir(), "calls.log")
 	t.Setenv("HERDR_CALL_LOG", callLog)
-	herdr.Log = callLog
-	herdr.Install(t, bin)
 	treehouseLog := filepath.Join(t.TempDir(), "treehouse.log")
 	t.Setenv("TREEHOUSE_CALL_LOG", treehouseLog)
 	faketool.Treehouse{Slots: []string{worktreePath}, Log: treehouseLog}.Install(t, bin)
 	t.Chdir(home)
 	mkFleetDirs(t, home)
+	herdr = scopeHerdrForFleet(t, home, herdr)
+	herdr.Log = callLog
+	herdr.Install(t, bin)
 	return home
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -45,7 +45,10 @@ func newStatusCmd() *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
-			client := herdr.NewClient()
+			client, err := currentHerdrClient(home)
+			if err != nil {
+				return err
+			}
 
 			if len(args) == 1 {
 				return runStatusSingle(cmd, home, client, args[0], asJSON, full, cols)
@@ -521,7 +524,7 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 	if attempt != nil {
 		e = *attempt
 	}
-	agentState, reachable := probePaneStatus(client, e.Herdr.PaneID)
+	agentState, reachable := probePaneStatus(herdrClientForAttempt(attempt, client), e.Herdr.PaneID)
 	data, readErr := state.ReadReportData(home, t.ID)
 	lines := state.ReportLinesInData(data)
 	reported, reportedOK := state.LastReportedState(lines)

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -32,6 +32,12 @@ func readTaskAttempt(t *testing.T, home, id string) state.Attempt {
 	return attempt
 }
 
+func setTestUserHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
 func scopeHerdrForFleet(t *testing.T, home string, h faketool.Herdr) faketool.Herdr {
 	t.Helper()
 	fleetID, err := state.FleetID(home)

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -3,8 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -29,7 +32,27 @@ func readTaskAttempt(t *testing.T, home, id string) state.Attempt {
 	return attempt
 }
 
+func scopeHerdrForFleet(t *testing.T, home string, h faketool.Herdr) faketool.Herdr {
+	t.Helper()
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range h.Workspaces {
+		project := strings.TrimPrefix(h.Workspaces[i].Label, "hand:")
+		if project != h.Workspaces[i].Label && !strings.HasPrefix(project, "f_") {
+			h.Workspaces[i].Label = herdr.WorkspaceLabel(fleetID, project)
+		}
+	}
+	return h
+}
+
 func TestMain(m *testing.M) {
+	testUserHome, err := os.MkdirTemp("", "hand-cmd-home-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	for _, tc := range []struct {
 		name  string
 		value string
@@ -43,7 +66,17 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 	}
-	os.Exit(m.Run())
+	if err := os.Setenv("HOME", testUserHome); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("USERPROFILE", testUserHome); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(testUserHome)
+	os.Exit(code)
 }
 
 func TestCommandPackageStartsWithNeutralEnvironment(t *testing.T) {

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -172,7 +172,7 @@ func TestWatchMapsContextCancelToInterruption(t *testing.T) {
 	deadline := time.Now().Add(budget)
 	for time.Now().Before(deadline) {
 		calls, err := os.ReadFile(os.Getenv("HERDR_CALL_LOG"))
-		if err == nil && bytes.Contains(calls, []byte("herdr workspace list\n")) {
+		if err == nil && bytes.Contains(calls, []byte(" workspace list\n")) {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -155,7 +155,7 @@ Repeated bootstrap runs are safe:
 | already healthy | reports ready, mutates nothing |
 
 The registry is discovery metadata, not a second source of Fleet state.
-Deleting or temporarily losing it does not change a Fleet identity; rerun `hand init` in each known home to register it again.
+Deleting or temporarily losing it does not change a Fleet identity; discovery remains empty until `hand init` registers each known home again.
 
 A partial failure is never reported as success.
 If a dependency install fails or `hand init`/`hand doctor` reports a blocker, bootstrap exits non-zero with the exact recovery command - typically resolving the reported blocker, then rerunning `hand doctor` or the bootstrap script itself.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -26,6 +26,13 @@ Bootstrap calls it; it never reimplements fleet setup in shell or PowerShell.
 `hand doctor` is the only readiness and diagnostic authority.
 Bootstrap, a human, and a supervising agent all read the same structured output rather than a second schema invented in a script.
 
+`hand init` gives each home one durable opaque Fleet identity and registers its canonical path in the user-local registry.
+Repeat initialization keeps the same identity and refreshes that home's locator.
+Moving a home keeps the identity because it moves with `state/hand.db`.
+Copying a home also keeps the identity, so the registry reports a duplicate and Fleet-bound runtime or mutation commands refuse to proceed until the operator resolves the copied state.
+Use `hand fleet` outside any Fleet home to inspect the discovered homes.
+There is intentionally no `hand fleet switch` command or global active-Fleet setting.
+
 ## Fastest path
 
 ```sh
@@ -131,6 +138,10 @@ next[1]:
 `git`, `treehouse`, and `herdr` are always required; `gh` is required only when a registered project's delivery mode is `direct-pr` or `no-mistakes`.
 Harnesses are reported purely as installed or not - `hand` never picks one on the operator's behalf.
 
+`hand fleet` is the discovery view for users with more than one Fleet home.
+It reads the user-local registry without selecting an active Fleet or changing any home.
+Read a `duplicate`, `identity-mismatch`, `ambiguous`, or `unreadable` state as an ownership boundary, not as permission to choose a path yourself.
+
 ## Idempotency and recovery
 
 Repeated bootstrap runs are safe:
@@ -142,6 +153,9 @@ Repeated bootstrap runs are safe:
 | existing valid Hand fleet | reconciled by `hand init`, no destructive rewrite |
 | existing, non-empty, not a recognized fleet | refused |
 | already healthy | reports ready, mutates nothing |
+
+The registry is discovery metadata, not a second source of Fleet state.
+Deleting or temporarily losing it does not change a Fleet identity; rerun `hand init` in each known home to register it again.
 
 A partial failure is never reported as success.
 If a dependency install fails or `hand init`/`hand doctor` reports a blocker, bootstrap exits non-zero with the exact recovery command - typically resolving the reported blocker, then rerunning `hand doctor` or the bootstrap script itself.

--- a/docs/adr/fleet-identity-and-user-registry.md
+++ b/docs/adr/fleet-identity-and-user-registry.md
@@ -1,0 +1,44 @@
+# Fleet identity and user-local registry
+
+- Date: 2026-08-22
+- Status: accepted
+- Issue: atqamz/hand#331
+- Pull requests: none
+
+## Context
+
+One OS user can run several independent Hand Fleet homes.
+Paths are movable and copied databases preserve durable state, so a path-derived identity or a global active-Fleet setting cannot safely identify external Herdr and Treehouse ownership.
+Discovery also needs to retain missing and duplicate home evidence without becoming a second authority for Fleet state.
+
+## Decision
+
+Each Fleet home stores one immutable opaque Fleet identity in `state/hand.db`.
+The identity is generated under the Fleet-local identity lock and is stable across restarts, moves, and registry loss.
+The user-local `~/.secondhand/registry.db` stores canonical observed locators and timestamps only.
+It is non-authoritative and has no Tasks, Attempts, Projects, configuration, reports, or runtime state.
+
+`hand fleet` reads registry discovery without changing the current invocation context.
+There is no global active Fleet switch.
+Positive duplicate or identity-mismatch evidence fails closed before runtime or mutation side effects, while registry absence or degradation is reported as a warning because it cannot prove a duplicate.
+
+New Herdr resources use the Fleet identity in a named session and workspace label.
+Legacy Attempts with empty or `default` sessions use the legacy session and require exact persisted workspace, tab, and pane identities for observation and cleanup.
+Treehouse lease-holder text is Fleet-scoped diagnostic metadata, while persisted lease IDs and exact path observations remain the ownership proof.
+
+Watcher takeover endpoints remain derived from canonical Fleet home plus generation rather than Fleet identity alone.
+Copied homes intentionally share an identity, so they must not share an IPC route.
+
+## Rejected alternatives
+
+- Path-derived identity: moves and symlinks would change identity, while copied databases would be misclassified as new Fleets.
+- Registry as authority: a deleted, stale, or corrupt user-local database must not change Fleet state or authorize ownership.
+- Global active Fleet: it would make commands depend on ambient mutable user state and make concurrent supervisors ambiguous.
+- Fleet-ID-only watcher IPC: duplicate copied homes would route takeover requests to one another.
+- Label-only legacy cleanup: a project label cannot prove ownership of a particular workspace or pane.
+
+## Consequences
+
+Operators can discover multiple homes from outside any Fleet while each command remains explicitly bound to its resolved home.
+Copied databases are visible and safe to refuse, but resolving a duplicate remains an operator decision because automatic re-keying would be irreversible and could orphan external resources.
+Herdr supports concurrent Fleet sessions without requiring Hand to stop or delete a named session during normal teardown.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -26,9 +26,34 @@ Hand owns lifecycle, durable state, isolation, process supervision, routing reso
 
 The directory containing one Hand Fleet's durable context and state.
 
+### Fleet identity
+
+The opaque immutable identifier stored authoritatively in a Fleet home's `state/hand.db`.
+It is stable across restarts and home moves and is not derived from a path, host, user, project, or timestamp.
+
 ### Fleet
 
 The Projects, Tasks, Attempts, Workers, holds, and context coordinated from one Fleet home.
+
+### Current invocation context
+
+The Fleet home selected for one command by `HAND_HOME`, the current directory, or nearest-ancestor discovery.
+There is no global active Fleet selection to switch.
+
+### Fleet registry
+
+The user-local, non-authoritative SQLite index at `~/.secondhand/registry.db` that retains observed Fleet home locators for discovery.
+Registry absence or degradation does not replace the authoritative identity in a Fleet home.
+
+### Duplicate Fleet
+
+A Fleet identity that is valid at more than one registered home.
+Runtime and mutating commands refuse positive duplicate evidence rather than guessing which home owns external resources.
+
+### Legacy Herdr namespace
+
+The global or `default` Herdr session used by Attempts written before Fleet-scoped sessions.
+Legacy cleanup requires the exact persisted workspace, tab, and pane identities and never adopts a workspace by project label alone.
 
 ## Work model
 

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -7,7 +7,7 @@ Only the calls `hand` makes are recorded, plus the release writes `.github/scrip
 A behaviour no test exercises does not belong here.
 
 Every entry was observed by running the real binary, not read off its documentation.
-Versions probed: `treehouse v2.1.0`, `herdr 0.7.5`, `gh 2.97.0`.
+Versions probed: `treehouse v2.1.0`, `herdr 0.8.2`, `gh 2.97.0`.
 
 `make contract-live` re-runs reversible calls against the real tools under the `contractlive` build tag, skipping where a binary is absent, so a record that has gone stale against a newer tool is discoverable without making the default suite depend on installed tools or the network.
 `make contract` exercises shared fake fixtures only.
@@ -35,6 +35,7 @@ A version banner goes to **stderr**, the JSON payload to **stdout**, which is wh
 
 `lease_id` is fresh on every acquisition, including a slot that was just returned and handed straight back out.
 `lease_holder` and `leased_at` are read by nothing in `hand`, so only `path` and `lease_id` are load-bearing.
+Hand runtime acquisitions identify the diagnostic holder as `hand:<fleet_id>:<task_id>`; direct worktree and contract fixtures may use another explicit holder because Treehouse ownership proof remains the persisted lease ID.
 An update-available notice shares stderr with the banner when one is due, which is the second reason nothing may read this call's output as a whole.
 A treehouse older than v2.1.0 reports `path` alone with no identity, which stays a usable lease: `worktree.CheckCollision` falls back to comparing paths for it.
 
@@ -168,6 +169,9 @@ For the single `Enter` key invocation used by Hand steering, `pane_send_failed` 
 Herdr processes encoded key sequences incrementally, so a `pane send-keys` failure for a multi-key invocation does not prove that no earlier key was accepted.
 That typed rejection is distinct from a process, transport or protocol failure, which does not prove whether the bytes were accepted.
 `pane read` is the one command whose success is bare text on stdout rather than an envelope.
+
+Hand's named-session calls prepend `--session <name>` before the command.
+The same response and side-effect contracts apply within that session, and a named session does not authorize Hand to stop or delete another session during normal cleanup.
 
 Identifiers are assigned by herdr: workspaces `wX`, their tabs `wX:t1`, their panes `wX:p1`.
 

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -137,14 +137,20 @@ func runHerdrFromPayload(payload json.RawMessage, args []string) int {
 	if err := json.Unmarshal(payload, &spec); err != nil {
 		return fail("decode herdr config: %v", err)
 	}
-	if len(args) < 2 {
+	stateDir, err := herdrStateDirForSession(spec.StateDir, args)
+	if err != nil {
+		return fail("prepare Herdr session state: %v", err)
+	}
+	spec.StateDir = stateDir
+	logicalArgs := herdrLogicalArgs(args)
+	if len(logicalArgs) < 2 {
 		return fail("unexpected herdr invocation: %s", strings.Join(args, " "))
 	}
-	command := args[0] + " " + args[1]
+	command := logicalArgs[0] + " " + logicalArgs[1]
 	for _, blocked := range spec.Hang {
 		if blocked == command {
 			if spec.MutateBeforeHang {
-				if exit := runHerdrState(spec, command, args); exit != 0 {
+				if exit := runHerdrState(spec, command, logicalArgs); exit != 0 {
 					return exit
 				}
 			}
@@ -163,9 +169,9 @@ func runHerdrFromPayload(payload json.RawMessage, args []string) int {
 		return 1
 	}
 	for _, response := range spec.Responses {
-		if response.Command == command && (response.Args == nil || sameArgs(response.Args, args[2:])) {
+		if response.Command == command && (response.Args == nil || sameArgs(response.Args, logicalArgs[2:])) {
 			if response.MutateBeforeResponse {
-				if exit := runHerdrState(spec, command, args); exit != 0 {
+				if exit := runHerdrState(spec, command, logicalArgs); exit != 0 {
 					return exit
 				}
 			}
@@ -177,11 +183,63 @@ func runHerdrFromPayload(payload json.RawMessage, args []string) int {
 			return response.Exit
 		}
 	}
-	exit := runHerdrState(spec, command, args)
+	exit := runHerdrState(spec, command, logicalArgs)
 	if err := logHerdrInvocation(spec, args); err != nil {
 		return fail("log herdr invocation: %v", err)
 	}
 	return exit
+}
+
+func herdrStateDirForSession(base string, args []string) (string, error) {
+	session := herdrSession(args)
+	if session == "" || session == "default" {
+		return base, nil
+	}
+	safe := strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(session)
+	dir := filepath.Join(base, "sessions", safe)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	ready := filepath.Join(dir, ".ready")
+	if _, err := os.Stat(ready); err == nil {
+		return dir, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "sessions" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(base, entry.Name()))
+		if err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(filepath.Join(dir, entry.Name()), data, 0o600); err != nil {
+			return "", err
+		}
+	}
+	if err := os.WriteFile(ready, nil, 0o600); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+	return dir, nil
+}
+
+func herdrSession(args []string) string {
+	if len(args) >= 2 && args[0] == "--session" {
+		return args[1]
+	}
+	return ""
+}
+
+func herdrLogicalArgs(args []string) []string {
+	if len(args) >= 2 && args[0] == "--session" {
+		return args[2:]
+	}
+	return args
 }
 
 func logHerdrInvocation(spec herdrSpec, args []string) error {
@@ -192,6 +250,7 @@ func logHerdrInvocation(spec herdrSpec, args []string) error {
 }
 
 func commandName(args []string) string {
+	args = herdrLogicalArgs(args)
 	if len(args) < 2 {
 		return strings.Join(args, " ")
 	}

--- a/internal/faketool/herdr_test.go
+++ b/internal/faketool/herdr_test.go
@@ -148,6 +148,30 @@ func TestHerdrWorkspaceCreateAddsAWorkspaceToTheListing(t *testing.T) {
 	}
 }
 
+func TestHerdrNamedSessionsKeepWorkspaceStateSeparate(t *testing.T) {
+	Herdr{Creates: []HerdrWorkspace{
+		{ID: "wN", Tabs: []HerdrTab{{ID: "wN:t1", Pane: "wN:p1"}}},
+	}}.Install(t, Bin(t))
+
+	for session, label := range map[string]string{"hand-a": "fleet-a", "hand-b": "fleet-b"} {
+		if _, errOut, code := runHerdr(t, "--session", session, "workspace", "create", "--cwd", "/tmp/wt", "--label", label); code != 0 {
+			t.Fatalf("workspace create for %s = exit %d (%q)", session, code, errOut)
+		}
+	}
+	for session, labels := range map[string][2]string{
+		"hand-a": [2]string{"fleet-a", "fleet-b"},
+		"hand-b": [2]string{"fleet-b", "fleet-a"},
+	} {
+		list, errOut, code := runHerdr(t, "--session", session, "workspace", "list")
+		if code != 0 {
+			t.Fatalf("workspace list for %s = exit %d (%q)", session, code, errOut)
+		}
+		if !strings.Contains(list, `"label":"`+labels[0]+`"`) || strings.Contains(list, `"label":"`+labels[1]+`"`) {
+			t.Fatalf("workspace list for %s = %q, want only %s", session, list, labels[0])
+		}
+	}
+}
+
 func TestHerdrTabCreateAttachesToTheWorkspaceAskedFor(t *testing.T) {
 	h := twoTabWorkspace()
 	h.TabCreates = []HerdrTab{{ID: "wA:t3", Pane: "wA:p3"}}

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -17,10 +17,16 @@ import (
 // transient and worth retrying, a pane that stopped answering will never answer a retry.
 var ErrComposerBusyTimeout = errors.New("composer still busy")
 
-type Client struct{}
+type Client struct {
+	session string
+}
 
 func NewClient() *Client {
 	return &Client{}
+}
+
+func NewSessionClient(session string) *Client {
+	return &Client{session: session}
 }
 
 // The harness-identity variables a pane must never inherit from the herdr server it is a child of
@@ -99,7 +105,7 @@ func (c *Client) run(args ...string) ([]byte, string, error) {
 }
 
 func (c *Client) runContext(ctx context.Context, args ...string) ([]byte, string, error) {
-	cmd := exec.CommandContext(ctx, "herdr", args...)
+	cmd := exec.CommandContext(ctx, "herdr", c.wireArgs(args...)...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -108,6 +114,15 @@ func (c *Client) runContext(ctx context.Context, args ...string) ([]byte, string
 		runErr = &ExecError{Started: cmd.ProcessState != nil, Err: runErr}
 	}
 	return bytes.TrimSpace(stdout.Bytes()), strings.TrimSpace(stderr.String()), runErr
+}
+
+func (c *Client) wireArgs(args ...string) []string {
+	if c.session == "" {
+		return args
+	}
+	wire := make([]string, 0, len(args)+2)
+	wire = append(wire, "--session", c.session)
+	return append(wire, args...)
 }
 
 func parseEnvelope(args []string, trimmed []byte) (envelope, error) {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -33,6 +33,26 @@ func TestWorkspaceListParsesResult(t *testing.T) {
 	}
 }
 
+func TestNamedSessionPrefixesHerdrInvocation(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{herdrResponse("workspace list", "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[]}}")},
+		Log:       callLog,
+	}.Install(t, bin)
+
+	if _, err := NewSessionClient("hand-f-fleet").WorkspaceList(); err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "--session hand-f-fleet workspace list") {
+		t.Fatalf("calls = %q, want named session before command", calls)
+	}
+}
+
 func TestFindWorkspaceByLabelFound(t *testing.T) {
 	writeFakeHerdr(t, herdrResponse("workspace list", "{\"id\":\"cli:1\",\"result\":{\"workspaces\":[{\"workspace_id\":\"wA\",\"label\":\"proj\"}]}}"))
 	c := NewClient()

--- a/internal/herdr/namespaces.go
+++ b/internal/herdr/namespaces.go
@@ -1,0 +1,13 @@
+package herdr
+
+func SessionName(fleetID string) string {
+	return "hand-" + fleetID
+}
+
+func WorkspaceLabel(fleetID, projectName string) string {
+	return "hand:" + fleetID + ":" + projectName
+}
+
+func LegacyWorkspaceLabel(projectName string) string {
+	return "hand:" + projectName
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -183,7 +183,8 @@ func open(path string, readOnly bool) (*sql.DB, error) {
 	if readOnly {
 		query = "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_pragma=query_only(1)"
 	}
-	db, err := sql.Open("sqlite", "file:"+(&url.URL{Path: path}).EscapedPath()+query)
+	uriPath := filepath.ToSlash(path)
+	db, err := sql.Open("sqlite", "file:"+(&url.URL{Path: uriPath}).EscapedPath()+query)
 	if err != nil {
 		return nil, fmt.Errorf("open registry %s: %w", path, err)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,506 @@
+// Package registry stores the per-user, non-authoritative index of Fleet homes.
+package registry
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/atqamz/hand/internal/filelock"
+	"github.com/atqamz/hand/internal/store"
+	_ "modernc.org/sqlite"
+)
+
+var ErrRegistryMissing = errors.New("fleet registry missing")
+
+type State string
+
+const (
+	StateReady            State = "ready"
+	StateMissing          State = "missing"
+	StateIdentityMismatch State = "identity-mismatch"
+	StateDuplicate        State = "duplicate"
+	StateAmbiguous        State = "ambiguous"
+	StateUnreadable       State = "unreadable"
+)
+
+type Fleet struct {
+	ID        string
+	Home      string
+	Locations []string
+	State     State
+	Current   bool
+	Reason    string
+}
+
+type Locator struct {
+	FleetID     string
+	Home        string
+	FirstSeenAt string
+	LastSeenAt  string
+}
+
+type Registry struct {
+	path string
+	sql  *sql.DB
+}
+
+func Preflight(home string, readOnly bool) ([]string, error) {
+	var fleetID string
+	if readOnly {
+		var err error
+		fleetID, err = store.FleetIDReadOnly(home)
+		if err != nil {
+			if strings.Contains(err.Error(), "no such table: fleet_identity") {
+				return nil, nil
+			}
+			return nil, err
+		}
+	} else {
+		db, err := store.Open(home)
+		if err != nil {
+			return nil, err
+		}
+		fleetID, err = db.FleetID()
+		_ = db.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	path, err := Path()
+	if err != nil {
+		return []string{"warning: Fleet registry unavailable: " + err.Error()}, nil
+	}
+	registry, err := OpenReadOnlyAt(path)
+	if errors.Is(err, ErrRegistryMissing) {
+		return nil, nil
+	}
+	if err != nil {
+		return []string{fmt.Sprintf("warning: Fleet registry %s unavailable: %v", path, err)}, nil
+	}
+	defer func() { _ = registry.Close() }()
+	if err := registry.Check(home, fleetID); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+const schema = `
+CREATE TABLE IF NOT EXISTS fleet_registry (
+	fleet_id TEXT PRIMARY KEY,
+	last_known_home TEXT NOT NULL,
+	first_seen_at TEXT NOT NULL,
+	last_seen_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS fleet_locator (
+	fleet_id TEXT NOT NULL REFERENCES fleet_registry(fleet_id),
+	home TEXT NOT NULL,
+	first_seen_at TEXT NOT NULL,
+	last_seen_at TEXT NOT NULL,
+	PRIMARY KEY (fleet_id, home)
+);
+CREATE INDEX IF NOT EXISTS fleet_locator_by_id ON fleet_locator(fleet_id, home);
+`
+
+func Path() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	if home == "" {
+		return "", errors.New("resolve user home: empty path")
+	}
+	return filepath.Join(home, ".secondhand", "registry.db"), nil
+}
+
+func Open() (*Registry, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	return OpenAt(path)
+}
+
+func OpenAt(path string) (*Registry, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve registry path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create registry directory: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil && runtime.GOOS != "windows" {
+		return nil, fmt.Errorf("protect registry directory: %w", err)
+	}
+	db, err := open(path, false)
+	if err != nil {
+		return nil, err
+	}
+	registry := &Registry{path: path, sql: db}
+	if err := registry.withWriteLock(func() error {
+		if _, err := db.Exec(schema); err != nil {
+			return fmt.Errorf("create registry schema: %w", err)
+		}
+		return nil
+	}); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := os.Chmod(path, 0o600); err != nil && runtime.GOOS != "windows" {
+		_ = db.Close()
+		return nil, fmt.Errorf("protect registry database: %w", err)
+	}
+	return registry, nil
+}
+
+func OpenReadOnlyAt(path string) (*Registry, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve registry path: %w", err)
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, ErrRegistryMissing
+	} else if err != nil {
+		return nil, fmt.Errorf("inspect registry: %w", err)
+	}
+	db, err := open(path, true)
+	if err != nil {
+		return nil, err
+	}
+	return &Registry{path: path, sql: db}, nil
+}
+
+func open(path string, readOnly bool) (*sql.DB, error) {
+	query := "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate"
+	if readOnly {
+		query = "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_pragma=query_only(1)"
+	}
+	db, err := sql.Open("sqlite", "file:"+(&url.URL{Path: path}).EscapedPath()+query)
+	if err != nil {
+		return nil, fmt.Errorf("open registry %s: %w", path, err)
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
+}
+
+func (r *Registry) Close() error {
+	return r.sql.Close()
+}
+
+func (r *Registry) Register(home, fleetID string, now time.Time) error {
+	if err := store.ValidateFleetID(fleetID); err != nil {
+		return err
+	}
+	home, err := canonicalPath(home)
+	if err != nil {
+		return fmt.Errorf("canonicalize Fleet home: %w", err)
+	}
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	if stamp == "0001-01-01T00:00:00Z" {
+		stamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	return r.withWriteLock(func() error {
+		tx, err := r.sql.Begin()
+		if err != nil {
+			return fmt.Errorf("begin registry registration: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		if _, err := tx.Exec(`
+INSERT INTO fleet_registry (fleet_id, last_known_home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(fleet_id) DO UPDATE SET last_known_home = excluded.last_known_home, last_seen_at = excluded.last_seen_at`, fleetID, home, stamp, stamp); err != nil {
+			return fmt.Errorf("write Fleet registry row: %w", err)
+		}
+		if _, err := tx.Exec(`
+INSERT INTO fleet_locator (fleet_id, home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(fleet_id, home) DO UPDATE SET last_seen_at = excluded.last_seen_at`, fleetID, home, stamp, stamp); err != nil {
+			return fmt.Errorf("write Fleet locator: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit Fleet registration: %w", err)
+		}
+		return nil
+	})
+}
+
+func (r *Registry) Locators() ([]Locator, error) {
+	rows, err := r.sql.Query(`SELECT fleet_id, home, first_seen_at, last_seen_at FROM fleet_locator ORDER BY fleet_id, home`)
+	if err != nil {
+		return nil, fmt.Errorf("list Fleet locators: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var locators []Locator
+	for rows.Next() {
+		var locator Locator
+		if err := rows.Scan(&locator.FleetID, &locator.Home, &locator.FirstSeenAt, &locator.LastSeenAt); err != nil {
+			return nil, fmt.Errorf("read Fleet locator: %w", err)
+		}
+		locators = append(locators, locator)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list Fleet locators: %w", err)
+	}
+	return locators, nil
+}
+
+func (r *Registry) List(currentHome string) ([]Fleet, error) {
+	locators, err := r.Locators()
+	if err != nil {
+		return nil, err
+	}
+	current, _ := canonicalPath(currentHome)
+	byID := make(map[string][]Locator)
+	claims := make(map[string]map[string]bool)
+	for _, locator := range locators {
+		byID[locator.FleetID] = append(byID[locator.FleetID], locator)
+		key, _ := pathKey(locator.Home)
+		if claims[key] == nil {
+			claims[key] = make(map[string]bool)
+		}
+		claims[key][locator.FleetID] = true
+	}
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	result := make([]Fleet, 0, len(ids))
+	for _, id := range ids {
+		fleet := Fleet{ID: id}
+		observations := make([]observation, 0, len(byID[id]))
+		for _, locator := range byID[id] {
+			fleet.Locations = append(fleet.Locations, locator.Home)
+			observations = append(observations, observe(locator))
+		}
+		sort.Strings(fleet.Locations)
+		fleet.Home = lastKnownHome(r.sql, id, fleet.Locations)
+		fleet.State, fleet.Reason = classify(observations, claims)
+		for _, observed := range observations {
+			if observed.valid && samePath(observed.locator.Home, current) {
+				fleet.Current = true
+				break
+			}
+		}
+		result = append(result, fleet)
+	}
+	return result, nil
+}
+
+type observation struct {
+	locator Locator
+	valid   bool
+	state   State
+	reason  string
+}
+
+func observe(locator Locator) observation {
+	info, err := os.Stat(locator.Home)
+	if os.IsNotExist(err) {
+		return observation{locator: locator, state: StateMissing}
+	}
+	if err != nil {
+		return observation{locator: locator, state: StateUnreadable, reason: err.Error()}
+	}
+	if !info.IsDir() {
+		return observation{locator: locator, state: StateUnreadable, reason: "Fleet home is not a directory"}
+	}
+	if _, err := os.Stat(store.Path(locator.Home)); err != nil {
+		if os.IsNotExist(err) {
+			return observation{locator: locator, state: StateUnreadable, reason: "state/hand.db is missing"}
+		}
+		return observation{locator: locator, state: StateUnreadable, reason: err.Error()}
+	}
+	db, err := store.OpenReadOnly(locator.Home)
+	if err != nil {
+		return observation{locator: locator, state: StateUnreadable, reason: err.Error()}
+	}
+	defer func() { _ = db.Close() }()
+	observedID, err := db.FleetID()
+	if err != nil {
+		return observation{locator: locator, state: StateIdentityMismatch, reason: err.Error()}
+	}
+	if observedID != locator.FleetID {
+		return observation{locator: locator, state: StateIdentityMismatch, reason: fmt.Sprintf("authoritative identity is %s", observedID)}
+	}
+	return observation{locator: locator, valid: true, state: StateReady}
+}
+
+func classify(observations []observation, claims map[string]map[string]bool) (State, string) {
+	valid := 0
+	missing := 0
+	var mismatch, unreadable []string
+	for _, observed := range observations {
+		switch {
+		case observed.valid:
+			valid++
+		case observed.state == StateMissing:
+			missing++
+		case observed.state == StateIdentityMismatch:
+			mismatch = append(mismatch, observed.locator.Home+": "+observed.reason)
+		case observed.state == StateUnreadable:
+			unreadable = append(unreadable, observed.locator.Home+": "+observed.reason)
+		}
+	}
+	if valid > 1 {
+		return StateDuplicate, "the same Fleet identity is valid at multiple homes"
+	}
+	for _, ids := range claims {
+		if len(ids) > 1 {
+			return StateAmbiguous, "one home is registered for multiple Fleet identities"
+		}
+	}
+	if len(mismatch) > 0 {
+		return StateIdentityMismatch, strings.Join(mismatch, "; ")
+	}
+	if valid == 1 {
+		return StateReady, ""
+	}
+	if len(unreadable) > 0 {
+		return StateUnreadable, strings.Join(unreadable, "; ")
+	}
+	if missing == len(observations) {
+		return StateMissing, "all known Fleet homes are missing"
+	}
+	return StateUnreadable, "Fleet identity could not be observed"
+}
+
+func lastKnownHome(db *sql.DB, id string, locations []string) string {
+	var home string
+	if err := db.QueryRow(`SELECT last_known_home FROM fleet_registry WHERE fleet_id = ?`, id).Scan(&home); err == nil && home != "" {
+		return home
+	}
+	if len(locations) > 0 {
+		return locations[0]
+	}
+	return ""
+}
+
+type DuplicateError struct {
+	FleetID string
+	Current string
+	Other   []string
+}
+
+func (e *DuplicateError) Error() string {
+	return fmt.Sprintf("Fleet %s is also valid at %s; copying a Fleet directory does not create a new Fleet identity, so operation refused for %s", e.FleetID, strings.Join(e.Other, ", "), e.Current)
+}
+
+type AmbiguousError struct {
+	Current string
+	Reason  string
+}
+
+func (e *AmbiguousError) Error() string {
+	return fmt.Sprintf("Fleet home %s has ambiguous registry identity: %s", e.Current, e.Reason)
+}
+
+func (r *Registry) Check(home, fleetID string) error {
+	if err := store.ValidateFleetID(fleetID); err != nil {
+		return err
+	}
+	current, err := canonicalPath(home)
+	if err != nil {
+		return err
+	}
+	locators, err := r.Locators()
+	if err != nil {
+		return err
+	}
+	var other []string
+	var claims []string
+	for _, locator := range locators {
+		if samePath(locator.Home, current) {
+			if locator.FleetID != fleetID {
+				claims = append(claims, locator.FleetID)
+			}
+			continue
+		}
+		if locator.FleetID != fleetID {
+			continue
+		}
+		observed := observe(locator)
+		if observed.valid {
+			other = append(other, locator.Home)
+		}
+	}
+	if len(claims) > 0 {
+		return &AmbiguousError{Current: current, Reason: "registered as " + strings.Join(claims, ", ") + " and does not match its authoritative Fleet identity"}
+	}
+	if len(other) > 0 {
+		slices.Sort(other)
+		return &DuplicateError{FleetID: fleetID, Current: current, Other: other}
+	}
+	return nil
+}
+
+func canonicalPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	real, err := filepath.EvalSymlinks(abs)
+	if err == nil {
+		return filepath.Clean(real), nil
+	}
+	if os.IsNotExist(err) {
+		return abs, nil
+	}
+	return "", err
+}
+
+func pathKey(path string) (string, error) {
+	canonical, err := canonicalPath(path)
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(canonical), nil
+	}
+	return canonical, nil
+}
+
+func samePath(left, right string) bool {
+	if left == "" || right == "" {
+		return left == right
+	}
+	leftKey, err := pathKey(left)
+	if err != nil {
+		return false
+	}
+	rightKey, err := pathKey(right)
+	if err != nil {
+		return false
+	}
+	return leftKey == rightKey
+}
+
+func (r *Registry) withWriteLock(fn func() error) error {
+	path := r.path + ".lock"
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open registry lock: %w", err)
+	}
+	if err := filelock.Lock(file, true); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("lock registry: %w", err)
+	}
+	defer func() {
+		_ = filelock.Unlock(file)
+		_ = file.Close()
+	}()
+	return fn()
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -59,7 +59,7 @@ func Preflight(home string, readOnly bool) ([]string, error) {
 		var err error
 		fleetID, err = store.FleetIDReadOnly(home)
 		if err != nil {
-			if strings.Contains(err.Error(), "no such table: fleet_identity") {
+			if errors.Is(err, store.ErrFleetIdentityMissing) {
 				return nil, nil
 			}
 			return nil, err

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,211 @@
+package registry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestRegisterAndListReadyFleet(t *testing.T) {
+	root := t.TempDir()
+	registryPath := filepath.Join(root, ".secondhand", "registry.db")
+	home := filepath.Join(root, "fleet")
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	registry, err := OpenAt(registryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registry.Close() }()
+	if err := registry.Register(home, fleetID, time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
+
+	fleets, err := registry.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fleets) != 1 {
+		t.Fatalf("fleets = %+v, want one fleet", fleets)
+	}
+	if fleets[0].ID != fleetID || fleets[0].State != StateReady || !fleets[0].Current {
+		t.Fatalf("fleet = %+v, want ready current %s", fleets[0], fleetID)
+	}
+	if len(fleets[0].Locations) != 1 || fleets[0].Locations[0] != home {
+		t.Fatalf("locations = %+v, want %q", fleets[0].Locations, home)
+	}
+}
+
+func TestListReportsCopiedFleetIdentityAsDuplicate(t *testing.T) {
+	root := t.TempDir()
+	registryPath := filepath.Join(root, ".secondhand", "registry.db")
+	firstHome := filepath.Join(root, "first")
+	secondHome := filepath.Join(root, "second")
+
+	db, err := store.Open(firstHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(store.Path(secondHome)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	database, err := os.ReadFile(store.Path(firstHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path(secondHome), database, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	registry, err := OpenAt(registryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registry.Close() }()
+	for _, home := range []string{firstHome, secondHome} {
+		if err := registry.Register(home, fleetID, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fleets, err := registry.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fleets) != 1 || fleets[0].State != StateDuplicate || len(fleets[0].Locations) != 2 {
+		t.Fatalf("fleets = %+v, want one duplicate with two locations", fleets)
+	}
+	var duplicate *DuplicateError
+	if err := registry.Check(secondHome, fleetID); !errors.As(err, &duplicate) {
+		t.Fatalf("Check error = %v, want DuplicateError", err)
+	}
+	if duplicate.Current == "" || len(duplicate.Other) != 1 {
+		t.Fatalf("duplicate = %+v, want current and one other home", duplicate)
+	}
+}
+
+func TestReadOnlyMissingRegistryDoesNotCreateDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".secondhand", "registry.db")
+	if _, err := OpenReadOnlyAt(path); !errors.Is(err, ErrRegistryMissing) {
+		t.Fatalf("OpenReadOnlyAt error = %v, want ErrRegistryMissing", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("registry stat error = %v, want no file", err)
+	}
+}
+
+func TestListReportsAmbiguousHomeClaims(t *testing.T) {
+	root := t.TempDir()
+	registryPath := filepath.Join(root, ".secondhand", "registry.db")
+	home := filepath.Join(root, "fleet")
+	first, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	secondHome := filepath.Join(root, "other")
+	second, err := store.Open(secondHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := second.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	registryDB, err := OpenAt(registryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	if err := registryDB.Register(home, firstID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(home, secondID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	fleets, err := registryDB.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fleets) != 2 || fleets[0].State != StateAmbiguous || fleets[1].State != StateAmbiguous {
+		t.Fatalf("fleets = %+v, want both identities ambiguous", fleets)
+	}
+}
+
+func TestPreflightRefusesARegisteredDuplicateBeforeRuntime(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("USERPROFILE", root)
+	firstHome := filepath.Join(root, "first")
+	secondHome := filepath.Join(root, "second")
+	first, err := store.Open(firstHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(store.Path(secondHome)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	database, err := os.ReadFile(store.Path(firstHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path(secondHome), database, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registryDB, err := Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(firstHome, fleetID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(secondHome, fleetID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var duplicate *DuplicateError
+	if _, err := Preflight(secondHome, false); !errors.As(err, &duplicate) {
+		t.Fatalf("Preflight() = %v, want DuplicateError", err)
+	}
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -45,8 +45,12 @@ func TestRegisterAndListReadyFleet(t *testing.T) {
 	if fleets[0].ID != fleetID || fleets[0].State != StateReady || !fleets[0].Current {
 		t.Fatalf("fleet = %+v, want ready current %s", fleets[0], fleetID)
 	}
-	if len(fleets[0].Locations) != 1 || fleets[0].Locations[0] != home {
-		t.Fatalf("locations = %+v, want %q", fleets[0].Locations, home)
+	canonicalHome, err := canonicalPath(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fleets[0].Locations) != 1 || fleets[0].Locations[0] != canonicalHome {
+		t.Fatalf("locations = %+v, want %q", fleets[0].Locations, canonicalHome)
 	}
 }
 

--- a/internal/runtime/fleet.go
+++ b/internal/runtime/fleet.go
@@ -1,0 +1,13 @@
+package runtime
+
+import "github.com/atqamz/hand/internal/registry"
+
+func fleetPreflight(home string) error {
+	_, err := registry.Preflight(home, false)
+	return err
+}
+
+func fleetPreflightReadOnly(home string) error {
+	_, err := registry.Preflight(home, true)
+	return err
+}

--- a/internal/runtime/liveness.go
+++ b/internal/runtime/liveness.go
@@ -100,7 +100,7 @@ func (r *Runtime) recordAttemptLiveness(home string, task state.Task, attempt st
 // per-harness capability internal/harness/usagelimit.go catalogues. This never steers the pane -
 // reconcile does not implement the send protocol - it only leaves the fact durable for the next observer.
 func (r *Runtime) probeUsageLimit(attempt state.Attempt) (time.Time, bool) {
-	text, err := r.deps.herdr().PaneRead(attempt.Herdr.PaneID, usageLimitReadLines)
+	text, err := r.herdrClient(attempt.Herdr.Session).PaneRead(attempt.Herdr.PaneID, usageLimitReadLines)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/internal/runtime/promote.go
+++ b/internal/runtime/promote.go
@@ -16,6 +16,9 @@ import (
 )
 
 func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, error) {
+	if err := fleetPreflightReadOnly(req.Home); err != nil {
+		return Result{}, Precondition(err)
+	}
 	history, err := state.ReadHistoryReadOnly(req.Home, req.ID)
 	if err != nil {
 		if errors.Is(err, state.ErrTaskNotFound) {
@@ -35,7 +38,7 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 	if _, err := os.Stat(filepath.Join(req.Home, reportRel)); err != nil {
 		return Result{}, Precondition(fmt.Errorf("scout report not found at %s", reportRel))
 	}
-	client := r.deps.herdr()
+	client := r.herdrClient(scout.Herdr.Session)
 	status := herdr.StatusUnknown
 	if scout.Herdr.PaneID != "" {
 		if pane, err := client.PaneGet(scout.Herdr.PaneID); err == nil && pane.AgentStatus != "" {
@@ -45,7 +48,6 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 	if !status.NotBusy() && status != herdr.StatusUnknown {
 		return Result{}, Precondition(fmt.Errorf("task %q is not a completed scout (agent state: %s)", req.ID, status))
 	}
-
 	briefRel := filepath.Join("data", req.ID, "brief.md")
 	briefPath := filepath.Join(req.Home, briefRel)
 	if _, err := os.Stat(briefPath); err != nil {
@@ -84,6 +86,9 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 	}
 	if !exists {
 		return fail(Precondition(fmt.Errorf("project %q not registered", task.Project)))
+	}
+	if err := fleetPreflight(req.Home); err != nil {
+		return fail(Precondition(err))
 	}
 	release, err := state.Lock(req.Home, "task:"+req.ID)
 	if err != nil {
@@ -163,7 +168,7 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 }
 
 func (r *Runtime) cleanupScout(homeDir, taskID string, scout state.Attempt) ([]string, error) {
-	client := r.deps.herdr()
+	client := r.herdrClient(scout.Herdr.Session)
 	var warnings []string
 	setState := func(resource, next string) error {
 		if scout.ID == 0 {

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
 )
@@ -42,6 +43,7 @@ type worktreeDependencies struct {
 type dependencies struct {
 	now               func() time.Time
 	herdr             func() herdrClient
+	herdrFor          func(string) herdrClient
 	worktree          worktreeDependencies
 	projectBaseCommit func(string) (string, error)
 	buildHarness      func(string, harness.Options) (string, error)
@@ -55,7 +57,11 @@ type dependencies struct {
 
 type Runtime struct{ deps dependencies }
 
-func New() *Runtime { return &Runtime{deps: defaultDependencies()} }
+func New() *Runtime {
+	deps := defaultDependencies()
+	deps.herdrFor = newHerdrSessionClient
+	return &Runtime{deps: deps}
+}
 
 func defaultDependencies() dependencies {
 	return dependencies{
@@ -98,7 +104,11 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	lease := worktree.Lease{Path: req.attempt.Worktree, ID: req.attempt.LeaseID}
 	var err error
 	if lease.Path == "" {
-		lease, err = r.deps.worktree.get(req.clonePath, "hand:"+req.attempt.TaskID)
+		fleetID, err := state.FleetID(req.home)
+		if err != nil {
+			return "", fmt.Errorf("read Fleet identity for Treehouse lease holder: %w", err)
+		}
+		lease, err = r.deps.worktree.get(req.clonePath, "hand:"+fleetID+":"+req.attempt.TaskID)
 		if err != nil {
 			return "", fmt.Errorf("acquire treehouse worktree: %w", err)
 		}
@@ -155,8 +165,16 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		}
 	}
 
-	client := r.deps.herdr()
-	workspace, tab, pane, rollback, err := acquireTaskWorkspace(client, worktreePath, req.attempt.TaskID, req.projectName)
+	session := req.attempt.Herdr.Session
+	if session == "" {
+		fleetID, err := state.FleetID(req.home)
+		if err != nil {
+			return "", r.failProvision(req, lease, nil, false, fmt.Errorf("read Fleet identity for Herdr session: %w", err))
+		}
+		session = herdr.SessionName(fleetID)
+	}
+	client := r.herdrClient(session)
+	workspace, tab, pane, rollback, err := acquireTaskWorkspace(client, worktreePath, req.attempt.TaskID, req.projectName, session)
 	if err != nil {
 		return "", r.failProvision(req, lease, nil, false, err)
 	}
@@ -170,7 +188,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		startedAt = r.deps.now().Format(time.RFC3339)
 	}
 	if err := state.RecordAttemptHerdr(req.home, req.attempt.TaskID, req.attempt.ID, state.Herdr{
-		Session: "default", WorkspaceID: workspace.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID,
+		Session: session, WorkspaceID: workspace.WorkspaceID, TabID: tab.TabID, PaneID: pane.PaneID,
 	}, startedAt); err != nil {
 		return fail(fmt.Errorf("record Herdr ownership: %w", err))
 	}

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +66,26 @@ func TestProvisionFailureAfterWorktreeRecordClearsOnlyReturnedEvidence(t *testin
 	}
 	if got.Lifecycle != state.AttemptProvisioning {
 		t.Fatalf("attempt lifecycle = %q, want provisioning", got.Lifecycle)
+	}
+}
+
+func TestProvisionUsesFleetScopedTreehouseLeaseHolder(t *testing.T) {
+	home, attempt := provisioningFixture(t)
+	var holder string
+	r := testProvisionRuntime(&provisionHerdr{}, func(lifecyclePhase) error { return nil })
+	r.deps.worktree.get = func(path, gotHolder string) (worktree.Lease, error) {
+		holder = gotHolder
+		return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
+	}
+
+	if _, err := r.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(holder, "hand:f_") || !strings.HasSuffix(holder, ":task-1") {
+		t.Fatalf("Treehouse lease holder = %q, want hand:f_<identity>:task-1", holder)
 	}
 }
 

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -182,6 +182,9 @@ const (
 const reconcileIterationLimit = 8
 
 func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
+	if err := fleetPreflightReadOnly(req.Home); err != nil {
+		return ReconcileReport{}, Precondition(err)
+	}
 	ctx := req.Context
 	if ctx == nil {
 		ctx = context.Background()
@@ -607,12 +610,17 @@ func mergeWorktreeAttempt(history state.TaskHistory) (*state.Attempt, error) {
 }
 
 func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
-	client := r.deps.herdr()
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		return nil, err
+	}
+	client := r.herdrClient(herdr.SessionName(fleetID))
 	ownerships, err := state.ListHerdrOwnerships(home)
 	if err != nil {
 		return nil, err
 	}
 	ownershipCandidates := make(map[string][]string, len(ownerships))
+	legacyWorkspaces := make(map[string]bool)
 	for _, ownership := range ownerships {
 		if ownership.WorkspaceID != "" && ownership.TabID != "" {
 			key := ownership.WorkspaceID + "\x00" + ownership.TabID
@@ -620,40 +628,65 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 				ownershipCandidates[key] = append(ownershipCandidates[key], ownership.TaskID)
 			}
 		}
+		if (ownership.Session == "" || ownership.Session == "default") && ownership.WorkspaceID != "" {
+			legacyWorkspaces[ownership.WorkspaceID] = true
+		}
 	}
 	workspaces, err := client.WorkspaceList()
 	if err != nil {
 		return nil, fmt.Errorf("list Herdr workspaces: %w", err)
 	}
-	sort.Slice(workspaces, func(i, j int) bool {
-		if workspaces[i].Label != workspaces[j].Label {
-			return workspaces[i].Label < workspaces[j].Label
-		}
-		return workspaces[i].WorkspaceID < workspaces[j].WorkspaceID
-	})
 	var anomalies []ReconcileAnomaly
-	for _, workspace := range workspaces {
-		if !strings.HasPrefix(workspace.Label, "hand:") {
-			continue
-		}
-		tabs, err := client.TabList(workspace.WorkspaceID)
-		if err != nil {
-			return nil, fmt.Errorf("list Herdr tabs for workspace %s: %w", workspace.WorkspaceID, err)
-		}
-		sort.Slice(tabs, func(i, j int) bool {
-			if tabs[i].TabID != tabs[j].TabID {
-				return tabs[i].TabID < tabs[j].TabID
+	inspect := func(inventory herdrClient, candidates []herdr.Workspace, skip map[string]bool) error {
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].Label != candidates[j].Label {
+				return candidates[i].Label < candidates[j].Label
 			}
-			return tabs[i].Label < tabs[j].Label
+			return candidates[i].WorkspaceID < candidates[j].WorkspaceID
 		})
-		for _, tab := range tabs {
-			anomaly, err := r.classifyHerdrTab(home, client, workspace, tab, ownershipCandidates)
+		for _, workspace := range candidates {
+			if !strings.HasPrefix(workspace.Label, "hand:") || skip[workspace.WorkspaceID] {
+				continue
+			}
+			tabs, err := inventory.TabList(workspace.WorkspaceID)
 			if err != nil {
-				return nil, err
+				return fmt.Errorf("list Herdr tabs for workspace %s: %w", workspace.WorkspaceID, err)
 			}
-			if anomaly != nil {
-				anomalies = append(anomalies, *anomaly)
+			sort.Slice(tabs, func(i, j int) bool {
+				if tabs[i].TabID != tabs[j].TabID {
+					return tabs[i].TabID < tabs[j].TabID
+				}
+				return tabs[i].Label < tabs[j].Label
+			})
+			for _, tab := range tabs {
+				anomaly, err := r.classifyHerdrTab(home, inventory, workspace, tab, ownershipCandidates)
+				if err != nil {
+					return err
+				}
+				if anomaly != nil {
+					anomalies = append(anomalies, *anomaly)
+				}
 			}
+		}
+		return nil
+	}
+	if err := inspect(client, workspaces, legacyWorkspaces); err != nil {
+		return nil, err
+	}
+	if len(legacyWorkspaces) > 0 {
+		legacyClient := r.herdrClient("default")
+		workspaces, err := legacyClient.WorkspaceList()
+		if err != nil {
+			return nil, fmt.Errorf("list legacy Herdr workspaces: %w", err)
+		}
+		selected := make([]herdr.Workspace, 0, len(workspaces))
+		for _, workspace := range workspaces {
+			if legacyWorkspaces[workspace.WorkspaceID] {
+				selected = append(selected, workspace)
+			}
+		}
+		if err := inspect(legacyClient, selected, nil); err != nil {
+			return nil, err
 		}
 	}
 	return anomalies, nil
@@ -819,7 +852,7 @@ func (r *Runtime) pendingHistoricalAttempt(_ string, history state.TaskHistory) 
 
 func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, task state.Task, attempt state.Attempt, attest reconcileAttestations) (bool, reconciliationDecision, error) {
 	if hasHerdrIdentity(attempt.Herdr) && !herdrCleanupSettled(attempt.TeardownHerdrState) {
-		observation, err := observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
+		observation, err := observeHerdrOwnership(r.herdrClient(attempt.Herdr.Session), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
 			return false, reconciliationDecision{}, err
 		}
@@ -855,7 +888,7 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 					return false, reconciliationDecision{}, err
 				}
 			}
-			if err := closeTaskTab(r.deps.herdr(), attempt.Herdr.WorkspaceID, attempt.Herdr.TabID); err != nil {
+			if err := closeTaskTab(r.herdrClient(attempt.Herdr.Session), attempt.Herdr.WorkspaceID, attempt.Herdr.TabID); err != nil {
 				_ = state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceAmbiguous)
 				return false, reconciliationDecision{}, fmt.Errorf("close historical Herdr resource: %w", err)
 			}
@@ -1206,7 +1239,7 @@ func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attemp
 	}
 	if hasHerdrIdentity(attempt.Herdr) && !skipHerdrObservation {
 		var err error
-		observation.Herdr, err = observeHerdrOwnership(r.deps.herdr(), attempt.Herdr, task.ID, task.Project)
+		observation.Herdr, err = observeHerdrOwnership(r.herdrClient(attempt.Herdr.Session), attempt.Herdr, task.ID, task.Project)
 		if err != nil {
 			return observation, err
 		}
@@ -1245,7 +1278,7 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 		})
 		return err
 	case reconciliationActionConfirmLaunch:
-		if err := r.deps.confirmLaunch(r.deps.herdr(), attempt.Herdr.PaneID, attempt.Harness); err != nil {
+		if err := r.deps.confirmLaunch(r.herdrClient(attempt.Herdr.Session), attempt.Herdr.PaneID, attempt.Harness); err != nil {
 			return fmt.Errorf("confirm persisted launch: %w", err)
 		}
 		return state.MarkLaunchConfirmed(home, task.ID, attempt.ID, r.deps.now().Format(time.RFC3339))

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -623,13 +623,13 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 	legacyWorkspaces := make(map[string]bool)
 	for _, ownership := range ownerships {
 		if ownership.WorkspaceID != "" && ownership.TabID != "" {
-			key := ownership.WorkspaceID + "\x00" + ownership.TabID
+			key := herdrIdentityKey(herdrSession(ownership.Session), ownership.WorkspaceID, ownership.TabID)
 			if !containsString(ownershipCandidates[key], ownership.TaskID) {
 				ownershipCandidates[key] = append(ownershipCandidates[key], ownership.TaskID)
 			}
 		}
 		if (ownership.Session == "" || ownership.Session == "default") && ownership.WorkspaceID != "" {
-			legacyWorkspaces[ownership.WorkspaceID] = true
+			legacyWorkspaces[herdrIdentityKey("default", ownership.WorkspaceID, "")] = true
 		}
 	}
 	workspaces, err := client.WorkspaceList()
@@ -637,7 +637,15 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 		return nil, fmt.Errorf("list Herdr workspaces: %w", err)
 	}
 	var anomalies []ReconcileAnomaly
-	inspect := func(inventory herdrClient, candidates []herdr.Workspace, skip map[string]bool) error {
+	currentSession := herdr.SessionName(fleetID)
+	if r.deps.herdrFor == nil {
+		currentSession = "default"
+	}
+	currentSkip := legacyWorkspaces
+	if currentSession == "default" {
+		currentSkip = nil
+	}
+	inspect := func(inventory herdrClient, session string, candidates []herdr.Workspace, skip map[string]bool) error {
 		sort.Slice(candidates, func(i, j int) bool {
 			if candidates[i].Label != candidates[j].Label {
 				return candidates[i].Label < candidates[j].Label
@@ -645,7 +653,7 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 			return candidates[i].WorkspaceID < candidates[j].WorkspaceID
 		})
 		for _, workspace := range candidates {
-			if !strings.HasPrefix(workspace.Label, "hand:") || skip[workspace.WorkspaceID] {
+			if !strings.HasPrefix(workspace.Label, "hand:") || skip[herdrIdentityKey(session, workspace.WorkspaceID, "")] {
 				continue
 			}
 			tabs, err := inventory.TabList(workspace.WorkspaceID)
@@ -659,7 +667,7 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 				return tabs[i].Label < tabs[j].Label
 			})
 			for _, tab := range tabs {
-				anomaly, err := r.classifyHerdrTab(home, inventory, workspace, tab, ownershipCandidates)
+				anomaly, err := r.classifyHerdrTab(home, inventory, session, workspace, tab, ownershipCandidates)
 				if err != nil {
 					return err
 				}
@@ -670,10 +678,10 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 		}
 		return nil
 	}
-	if err := inspect(client, workspaces, legacyWorkspaces); err != nil {
+	if err := inspect(client, currentSession, workspaces, currentSkip); err != nil {
 		return nil, err
 	}
-	if len(legacyWorkspaces) > 0 {
+	if len(legacyWorkspaces) > 0 && r.deps.herdrFor != nil {
 		legacyClient := r.herdrClient("default")
 		workspaces, err := legacyClient.WorkspaceList()
 		if err != nil {
@@ -681,19 +689,30 @@ func (r *Runtime) observeHerdrOrphans(home string) ([]ReconcileAnomaly, error) {
 		}
 		selected := make([]herdr.Workspace, 0, len(workspaces))
 		for _, workspace := range workspaces {
-			if legacyWorkspaces[workspace.WorkspaceID] {
+			if legacyWorkspaces[herdrIdentityKey("default", workspace.WorkspaceID, "")] {
 				selected = append(selected, workspace)
 			}
 		}
-		if err := inspect(legacyClient, selected, nil); err != nil {
+		if err := inspect(legacyClient, "default", selected, nil); err != nil {
 			return nil, err
 		}
 	}
 	return anomalies, nil
 }
 
-func (r *Runtime) classifyHerdrTab(home string, client herdrClient, workspace herdr.Workspace, tab herdr.Tab, ownershipCandidates map[string][]string) (*ReconcileAnomaly, error) {
-	candidates := append([]string(nil), ownershipCandidates[workspace.WorkspaceID+"\x00"+tab.TabID]...)
+func herdrSession(session string) string {
+	if session == "" {
+		return "default"
+	}
+	return session
+}
+
+func herdrIdentityKey(session, workspaceID, tabID string) string {
+	return herdrSession(session) + "\x00" + workspaceID + "\x00" + tabID
+}
+
+func (r *Runtime) classifyHerdrTab(home string, client herdrClient, session string, workspace herdr.Workspace, tab herdr.Tab, ownershipCandidates map[string][]string) (*ReconcileAnomaly, error) {
+	candidates := append([]string(nil), ownershipCandidates[herdrIdentityKey(session, workspace.WorkspaceID, tab.TabID)]...)
 	if state.ValidateID(tab.Label) == nil && !containsString(candidates, tab.Label) {
 		candidates = append(candidates, tab.Label)
 	}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -2240,8 +2240,8 @@ func (*missingReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, boo
 	return herdr.Workspace{}, false, nil
 }
 
-func (f *healthyReconcileHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
-	return herdr.Workspace{WorkspaceID: "ws-1", Label: "hand:demo"}, true, nil
+func (f *healthyReconcileHerdr) FindWorkspaceByLabel(label string) (herdr.Workspace, bool, error) {
+	return herdr.Workspace{WorkspaceID: "ws-1", Label: label}, true, nil
 }
 func (f *healthyReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
 func (f *healthyReconcileHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {

--- a/internal/runtime/reopen.go
+++ b/internal/runtime/reopen.go
@@ -69,6 +69,9 @@ func (r *Runtime) Reopen(ctx context.Context, req ReopenRequest) (Result, error)
 	if !exists {
 		return fail(Precondition(fmt.Errorf("project %q not registered", task.Project)))
 	}
+	if err := fleetPreflight(req.Home); err != nil {
+		return fail(Precondition(err))
+	}
 	release, err := state.Lock(req.Home, "task:"+req.ID)
 	if err != nil {
 		return Result{}, fmt.Errorf("lock task %q: %w", req.ID, err)

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
@@ -24,12 +25,36 @@ type herdrClient interface {
 	PaneRead(string, int) (string, error)
 }
 
-func newHerdrClient() herdrClient { return herdr.NewClient() }
+func newHerdrClient() herdrClient {
+	return herdr.NewClient()
+}
 
-func herdrWorkspaceLabel(projectName string) string { return "hand:" + projectName }
+func newHerdrSessionClient(session string) herdrClient {
+	if session == "" || session == "default" {
+		return herdr.NewClient()
+	}
+	return herdr.NewSessionClient(session)
+}
 
-func acquireTaskWorkspace(client herdrClient, worktreePath, taskID, projectName string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
-	label := herdrWorkspaceLabel(projectName)
+func (r *Runtime) herdrClient(session string) herdrClient {
+	if r.deps.herdrFor != nil {
+		return r.deps.herdrFor(session)
+	}
+	if r.deps.herdr != nil {
+		return r.deps.herdr()
+	}
+	return newHerdrSessionClient(session)
+}
+
+func herdrWorkspaceLabelForSession(session, projectName string) string {
+	if session == "" || session == "default" {
+		return herdr.LegacyWorkspaceLabel(projectName)
+	}
+	return herdr.WorkspaceLabel(strings.TrimPrefix(session, "hand-"), projectName)
+}
+
+func acquireTaskWorkspace(client herdrClient, worktreePath, taskID, projectName, session string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
+	label := herdrWorkspaceLabelForSession(session, projectName)
 	workspace, found, err := client.FindWorkspaceByLabel(label)
 	createdWorkspace := false
 	var rootTab herdr.Tab
@@ -139,14 +164,32 @@ func observeHerdrOwnership(client herdrClient, expected state.Herdr, taskID, pro
 	if expected.WorkspaceID == "" && expected.TabID == "" && expected.PaneID == "" {
 		return herdrObservation{State: herdrOwnershipUnobserved}, nil
 	}
-	workspace, found, err := client.FindWorkspaceByLabel(herdrWorkspaceLabel(projectName))
+	label := herdrWorkspaceLabelForSession(expected.Session, projectName)
+	var workspace herdr.Workspace
+	var found bool
+	var err error
+	if expected.Session == "" || expected.Session == "default" {
+		workspace, found, err = client.FindWorkspaceByLabel(label)
+		if err == nil && !found {
+			var workspaces []herdr.Workspace
+			workspaces, err = client.WorkspaceList()
+			for _, candidate := range workspaces {
+				if candidate.WorkspaceID == expected.WorkspaceID {
+					workspace, found = candidate, true
+					break
+				}
+			}
+		}
+	} else {
+		workspace, found, err = client.FindWorkspaceByLabel(label)
+	}
 	if err != nil {
 		return herdrObservation{}, fmt.Errorf("find Herdr workspace: %w", err)
 	}
 	if !found {
 		return herdrObservation{State: herdrOwnershipAbsent}, nil
 	}
-	if workspace.WorkspaceID != expected.WorkspaceID || workspace.Label != herdrWorkspaceLabel(projectName) {
+	if workspace.WorkspaceID != expected.WorkspaceID || workspace.Label != label {
 		return herdrObservation{State: herdrOwnershipMismatch}, nil
 	}
 	tabs, err := client.TabList(workspace.WorkspaceID)

--- a/internal/runtime/spawn.go
+++ b/internal/runtime/spawn.go
@@ -47,6 +47,9 @@ func (r *Runtime) Spawn(ctx context.Context, req SpawnRequest) (Result, error) {
 	if !exists {
 		return fail(Precondition(fmt.Errorf("project %q not registered", req.Project)))
 	}
+	if err := fleetPreflight(req.Home); err != nil {
+		return fail(Precondition(err))
+	}
 
 	releaseClaim, err := state.Claim(req.Home, req.ID)
 	if err != nil {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -96,6 +96,9 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 	}
 	defer releaseProject()
 
+	if err := fleetPreflight(req.Home); err != nil {
+		return fail(Precondition(err))
+	}
 	if err := r.releaseHerdr(req.Home, req.ID, active, &warnings); err != nil {
 		return fail(err)
 	}
@@ -190,7 +193,7 @@ func (r *Runtime) releaseHerdr(home, taskID string, attempt state.Attempt, warni
 	if err := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceReleasing); err != nil {
 		return fmt.Errorf("record Herdr release phase: %w", err)
 	}
-	if err := closeTaskTab(r.deps.herdr(), attempt.Herdr.WorkspaceID, attempt.Herdr.TabID); err != nil {
+	if err := closeTaskTab(r.herdrClient(attempt.Herdr.Session), attempt.Herdr.WorkspaceID, attempt.Herdr.TabID); err != nil {
 		if stateErr := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "herdr", state.TeardownResourceAmbiguous); stateErr != nil {
 			return fmt.Errorf("record failed Herdr release: %w", stateErr)
 		}

--- a/internal/state/fleet.go
+++ b/internal/state/fleet.go
@@ -1,0 +1,16 @@
+package state
+
+import "github.com/atqamz/hand/internal/store"
+
+func FleetID(homeDir string) (string, error) {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = db.Close() }()
+	return db.FleetID()
+}
+
+func FleetIDReadOnly(homeDir string) (string, error) {
+	return store.FleetIDReadOnly(homeDir)
+}

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -79,6 +80,9 @@ func (e *Error) SendFields() (int64, int64, string, string, bool, bool) {
 }
 
 func Execute(req Request) (Result, error) {
+	if _, err := registry.Preflight(req.Home, false); err != nil {
+		return Result{}, &Error{Cause: err, Precondition: true}
+	}
 	if req.Client == nil {
 		return Result{}, &Error{Cause: errors.New("steering client is required"), Precondition: true}
 	}

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const FleetIdentityLock = "fleet-identity"
@@ -21,7 +22,7 @@ func (db *DB) FleetID() (string, error) {
 	}
 	var id string
 	if err := db.sql.QueryRow(`SELECT fleet_id FROM fleet_identity WHERE singleton = 1`).Scan(&id); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "no such table: fleet_identity") {
 			return "", ErrFleetIdentityMissing
 		}
 		return "", fmt.Errorf("read fleet identity: %w", err)

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+const FleetIdentityLock = "fleet-identity"
+
+var (
+	ErrFleetIdentityMissing = errors.New("fleet identity missing")
+	ErrFleetIdentityInvalid = errors.New("invalid fleet identity")
+)
+
+func (db *DB) FleetID() (string, error) {
+	if db.empty {
+		return "", ErrFleetIdentityMissing
+	}
+	var id string
+	if err := db.sql.QueryRow(`SELECT fleet_id FROM fleet_identity WHERE singleton = 1`).Scan(&id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrFleetIdentityMissing
+		}
+		return "", fmt.Errorf("read fleet identity: %w", err)
+	}
+	if err := validateFleetID(id); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func FleetIDReadOnly(homeDir string) (string, error) {
+	db, _, err := openReadOnlyForLifecycle(homeDir)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = db.Close() }()
+	return db.FleetID()
+}
+
+func ensureFleetIdentityTx(tx *sql.Tx) error {
+	var id string
+	err := tx.QueryRow(`SELECT fleet_id FROM fleet_identity WHERE singleton = 1`).Scan(&id)
+	if err == nil {
+		return validateFleetID(id)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("read fleet identity: %w", err)
+	}
+	id, err = newFleetID()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO fleet_identity (singleton, fleet_id) VALUES (1, ?)`, id); err != nil {
+		return fmt.Errorf("insert fleet identity: %w", err)
+	}
+	return nil
+}
+
+func newFleetID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate fleet identity: %w", err)
+	}
+	return "f_" + hex.EncodeToString(raw[:]), nil
+}
+
+func validateFleetID(id string) error {
+	if len(id) != 34 || id[:2] != "f_" {
+		return fmt.Errorf("%w: %q", ErrFleetIdentityInvalid, id)
+	}
+	for _, char := range id[2:] {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return fmt.Errorf("%w: %q", ErrFleetIdentityInvalid, id)
+		}
+	}
+	return nil
+}
+
+func ValidateFleetID(id string) error {
+	return validateFleetID(id)
+}

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -34,6 +35,11 @@ func (db *DB) FleetID() (string, error) {
 }
 
 func FleetIDReadOnly(homeDir string) (string, error) {
+	if _, err := os.Stat(Path(homeDir)); os.IsNotExist(err) {
+		return "", ErrFleetIdentityMissing
+	} else if err != nil {
+		return "", fmt.Errorf("check %s: %w", Path(homeDir), err)
+	}
 	db, _, err := openReadOnlyForLifecycle(homeDir)
 	if err != nil {
 		return "", err

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOpenGeneratesAndPreservesFleetIdentity(t *testing.T) {
+	home := t.TempDir()
+
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err = Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	second, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("FleetID changed across reopen: first=%q second=%q", first, second)
+	}
+	if len(first) != len("f_")+32 || first[:2] != "f_" {
+		t.Fatalf("FleetID = %q, want f_ plus 32 hexadecimal characters", first)
+	}
+}
+
+func TestCurrentSchemaWithoutFleetIdentityFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`DELETE FROM fleet_identity`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	readOnly, err := OpenReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readOnly.Close() }()
+	if _, err := readOnly.FleetID(); !errors.Is(err, ErrFleetIdentityMissing) {
+		t.Fatalf("FleetID error = %v, want ErrFleetIdentityMissing", err)
+	}
+
+	if _, err := Open(home); !errors.Is(err, ErrFleetIdentityMissing) {
+		t.Fatalf("Open error = %v, want ErrFleetIdentityMissing", err)
+	}
+}
+
+func TestMigrationGeneratesFleetIdentityOnce(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacySchema := strings.Replace(schema, `CREATE TABLE IF NOT EXISTS fleet_identity (
+	singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+	fleet_id TEXT NOT NULL UNIQUE
+);
+`, "", 1)
+	if _, err := sqlDB.Exec(legacySchema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`PRAGMA user_version = 17`); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	first, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version, err := db.schemaVersion(); err != nil || version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, len(migrations))
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err = Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	second, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("migrated FleetID changed across reopen: first=%q second=%q", first, second)
+	}
+}
+
+func TestMalformedFleetIdentityFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE fleet_identity SET fleet_id = 'copied-from-somewhere' WHERE singleton = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(home); !errors.Is(err, ErrFleetIdentityInvalid) {
+		t.Fatalf("Open error = %v, want ErrFleetIdentityInvalid", err)
+	}
+}

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -83,6 +83,14 @@ func TestReadOnlyLegacySchemaReportsMissingFleetIdentity(t *testing.T) {
 	}
 }
 
+func TestReadOnlyMissingDatabaseReportsMissingFleetIdentity(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := FleetIDReadOnly(home); !errors.Is(err, ErrFleetIdentityMissing) {
+		t.Fatalf("FleetIDReadOnly error = %v, want ErrFleetIdentityMissing", err)
+	}
+}
+
 func TestMigrationGeneratesFleetIdentityOnce(t *testing.T) {
 	home := t.TempDir()
 	sqlDB, err := open(Path(home))

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -65,6 +65,24 @@ func TestCurrentSchemaWithoutFleetIdentityFailsClosed(t *testing.T) {
 	}
 }
 
+func TestReadOnlyLegacySchemaReportsMissingFleetIdentity(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`DROP TABLE fleet_identity`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := FleetIDReadOnly(home); !errors.Is(err, ErrFleetIdentityMissing) {
+		t.Fatalf("FleetIDReadOnly error = %v, want ErrFleetIdentityMissing", err)
+	}
+}
+
 func TestMigrationGeneratesFleetIdentityOnce(t *testing.T) {
 	home := t.TempDir()
 	sqlDB, err := open(Path(home))

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -149,6 +149,10 @@ var migrations = []string{
 	// like ensureUsageLimitEpisodeColumns: a home already carrying the current schema.Task layout when
 	// its version is forced backward must replay this step without a duplicate-column error.
 	`SELECT 1;`,
+	`CREATE TABLE IF NOT EXISTS fleet_identity (
+		singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+		fleet_id TEXT NOT NULL UNIQUE
+	);`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -175,6 +179,8 @@ const attemptBranchVersion = holdInferredVersion + 1
 const preAcknowledgementVersion = attemptBranchVersion + 1
 
 const acknowledgedMetadataVersion = preAcknowledgementVersion + 1
+
+const fleetIdentityVersion = acknowledgedMetadataVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -411,6 +417,9 @@ func (db *DB) createSchema(isNew bool, latest int) error {
 		if _, err := tx.Exec(sendSchema); err != nil {
 			return fmt.Errorf("create send schema: %w", err)
 		}
+		if err := ensureFleetIdentityTx(tx); err != nil {
+			return err
+		}
 		if err := recordSchemaVersion(tx, latest); err != nil {
 			return err
 		}
@@ -479,6 +488,11 @@ func (db *DB) applyMigration(version int) error {
 	}
 	if version == preAcknowledgementVersion {
 		if err := ensureAcknowledgementColumns(tx); err != nil {
+			return err
+		}
+	}
+	if version == fleetIdentityVersion-1 {
+		if err := ensureFleetIdentityTx(tx); err != nil {
 			return err
 		}
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -465,7 +465,6 @@ func OpenReadOnly(homeDir string) (*DB, error) {
 			_ = sqlDB.Close()
 			return nil, err
 		}
-		db.empty = false
 		if _, err := sqlDB.Exec("PRAGMA query_only = 1"); err != nil {
 			_ = sqlDB.Close()
 			return nil, fmt.Errorf("set read-only state: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -353,6 +353,10 @@ CREATE TABLE IF NOT EXISTS meta (
 	key   TEXT PRIMARY KEY,
 	value TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS fleet_identity (
+	singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+	fleet_id TEXT NOT NULL UNIQUE
+);
 CREATE TABLE IF NOT EXISTS hold (
 	id         TEXT PRIMARY KEY,
 	kind       TEXT NOT NULL DEFAULT '',
@@ -422,6 +426,12 @@ func Open(homeDir string) (*DB, error) {
 	if err := db.migrateLegacy(true); err != nil {
 		_ = sqlDB.Close()
 		return nil, err
+	}
+	if len(migrations) >= fleetIdentityVersion {
+		if _, err := db.FleetID(); err != nil {
+			_ = sqlDB.Close()
+			return nil, err
+		}
 	}
 	return db, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -465,6 +465,7 @@ func OpenReadOnly(homeDir string) (*DB, error) {
 			_ = sqlDB.Close()
 			return nil, err
 		}
+		db.empty = false
 		if _, err := sqlDB.Exec("PRAGMA query_only = 1"); err != nil {
 			_ = sqlDB.Close()
 			return nil, fmt.Errorf("set read-only state: %w", err)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -19,6 +19,7 @@ import (
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/notify"
 	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -85,8 +86,11 @@ func contextLifecycleError(ctx context.Context) error {
 // typed lifecycle result for cancellation or an error if herdr is unreachable at startup. out
 // receives the actionable event stream, while errOut receives internal diagnostics.
 func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
-	client, err := connect(ctx)
+	client, err := prepareClient(cfg.Home)
 	if err != nil {
+		return err
+	}
+	if err := connect(ctx, client); err != nil {
 		if lifecycleErr := contextLifecycleError(ctx); lifecycleErr != nil {
 			return lifecycleErr
 		}
@@ -108,6 +112,17 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 	}
 }
 
+func prepareClient(home string) (*herdr.Client, error) {
+	if _, err := registry.Preflight(home, false); err != nil {
+		return nil, err
+	}
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		return nil, fmt.Errorf("read Fleet identity: %w", err)
+	}
+	return herdr.NewSessionClient(herdr.SessionName(fleetID)), nil
+}
+
 // RunUntilEvent observes what is already actionable, then blocks until a tick produces events, writes
 // them to out and returns nil - the exit is the delivery, since it is the one signal a supervisory
 // agent's background-task runner already honors.
@@ -118,8 +133,14 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 		defer cancel()
 	}
 
-	client, err := connect(ctx)
+	client, err := prepareClient(cfg.Home)
 	if err != nil {
+		if errors.Is(err, ErrNoEvent) {
+			return fmt.Errorf("%w within %s: %w", ErrNoEvent, cfg.Timeout, err)
+		}
+		return err
+	}
+	if err := connect(ctx, client); err != nil {
 		if errors.Is(err, ErrNoEvent) {
 			return fmt.Errorf("%w within %s: %w", ErrNoEvent, cfg.Timeout, err)
 		}
@@ -175,23 +196,22 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 
 // Races the reachability probe against ctx because unbounded, a wedged herdr daemon blocks
 // RunUntilEvent's --timeout from ever starting to count.
-func connect(ctx context.Context) (*herdr.Client, error) {
-	client := herdr.NewClient()
+func connect(ctx context.Context, client *herdr.Client) error {
 	done := make(chan error, 1)
 	go func() { _, err := client.WorkspaceListContext(ctx); done <- err }()
 	select {
 	// Recheck lifecycle cause after the operation: a configured until-event timeout is ErrNoEvent,
 	// while generic cancellation and proven takeover retain their own typed results.
 	case <-ctx.Done():
-		return nil, connectContextError(ctx)
+		return connectContextError(ctx)
 	case err := <-done:
 		if ctxErr := contextLifecycleError(ctx); ctxErr != nil {
-			return nil, connectContextError(ctx)
+			return connectContextError(ctx)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("herdr unreachable: %w", err)
+			return fmt.Errorf("herdr unreachable: %w", err)
 		}
-		return client, nil
+		return nil
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -136,7 +136,7 @@ func waitForPaneGets(t *testing.T, callLog string, want int) {
 func waitForHerdrCalls(t *testing.T, callLog, command string, want int) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
-	prefix := []byte("herdr " + command)
+	needle := []byte(" " + command)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(callLog)
 		if err != nil && !os.IsNotExist(err) {
@@ -144,7 +144,7 @@ func waitForHerdrCalls(t *testing.T, callLog, command string, want int) {
 		}
 		calls := 0
 		for _, line := range bytes.Split(data, []byte("\n")) {
-			if bytes.HasPrefix(line, prefix) {
+			if bytes.Contains(line, needle) {
 				calls++
 			}
 		}
@@ -2281,6 +2281,49 @@ func TestRunFailsWhenHerdrUnreachable(t *testing.T) {
 	err := Run(context.Background(), Config{Home: home, PollInterval: time.Second, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "herdr unreachable") {
 		t.Fatalf("got err %v, want herdr unreachable", err)
+	}
+}
+
+func TestRunUsesTheFleetScopedHerdrSession(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "herdr-calls")
+	faketool.Herdr{Log: callLog, LogCommands: []string{"workspace list"}}.Install(t, faketool.Bin(t))
+	home := setupWatcherHome(t, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptProvisioning})
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Minute}, &bytes.Buffer{}, io.Discard)
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, readErr := os.ReadFile(callLog); readErr == nil && strings.Contains(string(data), "workspace list") {
+			break
+		}
+		select {
+		case runErr := <-done:
+			t.Fatalf("Run returned before Herdr connection: %v", runErr)
+		default:
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if data, readErr := os.ReadFile(callLog); readErr != nil || !strings.Contains(string(data), "workspace list") {
+		t.Fatalf("Herdr call log = %q, read error = %v", data, readErr)
+	}
+	cancel()
+	if err := <-done; !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("Run returned %v, want ErrInterrupted", err)
+	}
+	data, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "--session " + herdr.SessionName(fleetID) + " workspace list"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("Herdr calls = %q, want %q", data, want)
 	}
 }
 

--- a/skills/secondhand/SKILL.md
+++ b/skills/secondhand/SKILL.md
@@ -30,6 +30,11 @@ wrong: skill reconstructs lifecycle state from terminal panes
 right: skill uses `hand status`, `hand watch`, and hand's own reconciliation results
 ```
 
+Every home has an opaque durable Fleet identity.
+Use `hand fleet` to inspect user-local discovery when the current invocation context is unclear; do not invent a global active Fleet or look for a `fleet switch` command.
+If Hand reports a duplicate or identity mismatch, stop runtime and mutation commands and resolve the home evidence before acting.
+New workers use Fleet-scoped Herdr sessions, while legacy Attempts are observed and cleaned up only through their exact persisted Herdr identities.
+
 `AGENTS.md` states the invariants that hold regardless of session; this skill states the
 procedures for acting on them. If the two ever seem to disagree, `AGENTS.md` wins, and that is
 itself worth reporting as a drift signal rather than silently resolving.

--- a/skills/secondhand/references/recovery.md
+++ b/skills/secondhand/references/recovery.md
@@ -7,6 +7,12 @@ so - `unknown`, `needs-repair`, or an explicit unprovable condition - rather tha
 best case. Read that signal as exactly what it is, and do not resolve it with an assumption of
 your own either.
 
+### Duplicate Fleet identity
+
+`hand fleet` reports a duplicate when the same authoritative Fleet identity is valid at more than one registered home.
+Do not delete a locator, re-key a database, or choose a home by path as a shortcut.
+Runtime and mutation commands fail closed until the operator has resolved the copied-home evidence and rerun `hand fleet`.
+
 ## `hand status`'s repair fields
 
 A task's `repair`, `repair_code`, `repair_attempt`, `repair_reason`, and `repair_observed_at`

--- a/skills/secondhand/references/setup-doctor.md
+++ b/skills/secondhand/references/setup-doctor.md
@@ -40,6 +40,10 @@ Do not assume categories beyond what a given `hand doctor` build actually report
 reference and a live run disagree, the live run is right; report the mismatch rather than
 trusting the stale prose.
 
+`hand fleet` is the discovery view for users with more than one Fleet home.
+It reads the user-local registry without selecting an active Fleet or changing any home.
+Read a `duplicate`, `identity-mismatch`, `ambiguous`, or `unreadable` state as an ownership boundary, not as permission to choose a path yourself.
+
 ## Distinguishing what a finding actually means
 
 Doctor's findings distinguish concepts that are easy to blur:

--- a/tests/contract/herdr_test.go
+++ b/tests/contract/herdr_test.go
@@ -127,6 +127,31 @@ func TestHerdrClosingTheSoleTabTakesTheWorkspaceWithIt(t *testing.T) {
 	}
 }
 
+func TestHerdrNamedSessionsKeepWorkspaceInventoriesSeparate(t *testing.T) {
+	requireBin(t, "herdr")
+	cwd := t.TempDir()
+	sessions := []string{"hand-contract-a", "hand-contract-b"}
+	ids := make(map[string]string, len(sessions))
+	for _, session := range sessions {
+		created := envelope(t, run(t, cwd, "herdr", "--session", session, "workspace", "create",
+			"--no-focus", "--cwd", cwd, "--label", session).requireCode(t, 0))
+		id := created.Result.Workspace.WorkspaceID
+		if id == "" {
+			t.Fatalf("session %s workspace create returned no id", session)
+		}
+		ids[session] = id
+		t.Cleanup(func() {
+			run(t, cwd, "herdr", "--session", session, "workspace", "close", id)
+		})
+	}
+	for _, session := range sessions {
+		listed := envelope(t, run(t, cwd, "herdr", "--session", session, "workspace", "list").requireCode(t, 0))
+		if len(listed.Result.Workspaces) != 1 || listed.Result.Workspaces[0].WorkspaceID != ids[session] {
+			t.Fatalf("session %s workspace list = %+v, want only %s", session, listed.Result.Workspaces, ids[session])
+		}
+	}
+}
+
 // Bare text on success, unlike every other command, so an envelope here would
 // be read as pane content.
 func readPane(t *testing.T, cwd, pane, source string) string {

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -41,7 +42,7 @@ func readLaunchLog(t *testing.T, path string) []string {
 	}
 	var launches []string
 	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
-		if strings.HasPrefix(line, "herdr pane run ") {
+		if strings.Contains(line, " pane run ") {
 			launches = append(launches, line)
 		}
 	}
@@ -173,8 +174,12 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 	launchLog := filepath.Join(t.TempDir(), "launch.log")
 	dir := binDir(t)
 	writeFakeTreehouse(t, dir, filepath.Join(home, "wt-ship-new"), filepath.Join(home, "wt-scout-old"))
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		t.Fatal(err)
+	}
 	faketool.Herdr{
-		Workspaces: []faketool.HerdrWorkspace{{ID: "ws-old", Label: "hand:demo", Tabs: []faketool.HerdrTab{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "ws-old", Label: herdr.WorkspaceLabel(fleetID, "demo"), Tabs: []faketool.HerdrTab{
 			{ID: "tab-old", Label: "task-1", Pane: "pane-old"},
 			{ID: "tab-other", Label: "other", Pane: "pane-other"},
 		}}},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -311,7 +311,11 @@ func waitForInvocations(t *testing.T, logPath, substr string, want int, timeout 
 		if err != nil && !os.IsNotExist(err) {
 			t.Fatalf("read invocation log %s: %v", logPath, err)
 		}
-		if strings.Count(string(data), substr) >= want {
+		count := strings.Count(string(data), substr)
+		if strings.HasPrefix(substr, "herdr ") {
+			count = max(count, strings.Count(string(data), " "+strings.TrimPrefix(substr, "herdr ")))
+		}
+		if count >= want {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)

--- a/tests/e2e/execution_class_test.go
+++ b/tests/e2e/execution_class_test.go
@@ -28,7 +28,7 @@ func TestMechanicalPlanDispatchesAgainstTheRegisteredBase(t *testing.T) {
 	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") {
 		t.Fatalf("treehouse log = %q, want acquisition", log)
 	}
-	if log := readOptionalLog(t, herdrLog); !strings.Contains(log, "herdr pane run") {
+	if log := readOptionalLog(t, herdrLog); !strings.Contains(log, " pane run") {
 		t.Fatalf("herdr log = %q, want launch", log)
 	}
 	if current := strings.TrimSpace(runGitIn(t, clonePath, "rev-parse", "refs/heads/main^{commit}")); current != base {
@@ -122,7 +122,7 @@ func TestStandardAndDeepPlansDoNotUseMechanicalStaleRefusal(t *testing.T) {
 			if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") {
 				t.Fatalf("treehouse log = %q, want acquisition", log)
 			}
-			if log := readOptionalLog(t, herdrLog); !strings.Contains(log, "herdr pane run") {
+			if log := readOptionalLog(t, herdrLog); !strings.Contains(log, " pane run") {
 				t.Fatalf("herdr log = %q, want launch", log)
 			}
 		})
@@ -144,7 +144,7 @@ func TestLegacyBriefStillDispatchesWithoutExecutionPlanPreflight(t *testing.T) {
 	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") {
 		t.Fatalf("treehouse log = %q, want acquisition", log)
 	}
-	if log := readOptionalLog(t, herdrLog); !strings.Contains(log, "herdr pane run") {
+	if log := readOptionalLog(t, herdrLog); !strings.Contains(log, " pane run") {
 		t.Fatalf("herdr log = %q, want launch", log)
 	}
 }

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -74,6 +74,7 @@ func writeFakeDispatch(t *testing.T, dir, name, logPath, selector, caseBody stri
 	if logPath != "" {
 		script = fmt.Sprintf("echo \"%s $@\" >> %s\n", name, shellSingleQuote(logPath))
 	}
+	script += "if [ \"$1\" = \"--session\" ]; then shift 2; fi\n"
 	script += fmt.Sprintf("case \"%s\" in\n%s\n  *) echo \"unexpected %s invocation: $@\" >&2; exit 1 ;;\nesac\n",
 		selector, caseBody, name)
 	writeFakeBin(t, dir, name, script)

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -95,8 +96,12 @@ func TestPromoteScoutToShip(t *testing.T) {
 	if attempt.Herdr.WorkspaceID != "ws-new" || attempt.Herdr.TabID != "tab-new" || attempt.Herdr.PaneID != "pane-new" {
 		t.Fatalf("attempt.Herdr = %+v, want the new ws-new/tab-new/pane-new identifiers", attempt.Herdr)
 	}
-	if attempt.Herdr.Session != "default" {
-		t.Fatalf("attempt.Herdr.Session = %q, want %q", attempt.Herdr.Session, "default")
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.Herdr.Session != herdr.SessionName(fleetID) {
+		t.Fatalf("attempt.Herdr.Session = %q, want %q", attempt.Herdr.Session, herdr.SessionName(fleetID))
 	}
 	if attempt.Harness != "claude" {
 		t.Fatalf("attempt.Harness = %q, want the default harness recorded", attempt.Harness)
@@ -110,19 +115,19 @@ func TestPromoteScoutToShip(t *testing.T) {
 		t.Fatal(err)
 	}
 	log := string(logData)
-	if !strings.Contains(log, "herdr tab list --workspace ws-old") {
+	if !strings.Contains(log, " tab list --workspace ws-old") {
 		t.Fatalf("invocation log = %q, want promote to have queried the OLD workspace's tabs to release them", log)
 	}
-	if !strings.Contains(log, "herdr tab close tab-old") {
+	if !strings.Contains(log, " tab close tab-old") {
 		t.Fatalf("invocation log = %q, want promote to have actually closed the OLD tab, not just listed it", log)
 	}
-	if strings.Contains(log, "herdr tab close tab-new") || strings.Contains(log, "herdr workspace close ws-new") {
+	if strings.Contains(log, " tab close tab-new") || strings.Contains(log, " workspace close ws-new") {
 		t.Fatalf("invocation log = %q, want promote to leave the NEW ship tab open", log)
 	}
-	if !strings.Contains(log, "herdr tab rename tab-new task-1") {
+	if !strings.Contains(log, " tab rename tab-new task-1") {
 		t.Fatalf("invocation log = %q, want promote to rename the new workspace's own root tab to the task id", log)
 	}
-	if strings.Contains(log, "herdr tab create --workspace ws-new") {
+	if strings.Contains(log, " tab create --workspace ws-new") {
 		t.Fatalf("invocation log = %q, want promote to reuse the new workspace's root tab instead of creating a second one", log)
 	}
 	if !strings.Contains(log, "treehouse return --force --if-lease-id lease-old "+oldWorktree) {

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -213,8 +213,12 @@ func countInvocations(t *testing.T, logPath, substr string) int {
 		t.Fatal(err)
 	}
 	count := 0
+	suffix := ""
+	if strings.HasPrefix(substr, "herdr ") {
+		suffix = " " + strings.TrimPrefix(substr, "herdr ")
+	}
 	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
-		if line == substr {
+		if line == substr || (suffix != "" && strings.HasSuffix(line, suffix)) {
 			count++
 		}
 	}

--- a/tests/e2e/spawn_teardown_test.go
+++ b/tests/e2e/spawn_teardown_test.go
@@ -52,10 +52,10 @@ func TestSpawnTeardownCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(spawnLog), "herdr tab rename tab-1 task-1") {
+	if !strings.Contains(string(spawnLog), " tab rename tab-1 task-1") {
 		t.Fatalf("invocation log = %q, want spawn to rename the fresh workspace's root tab to the task id", spawnLog)
 	}
-	if strings.Contains(string(spawnLog), "herdr tab create") {
+	if strings.Contains(string(spawnLog), " tab create") {
 		t.Fatalf("invocation log = %q, want spawn to reuse the root tab instead of creating a second one", spawnLog)
 	}
 
@@ -95,10 +95,10 @@ func TestSpawnTeardownCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(finalLog), "herdr workspace close ws-1") {
+	if !strings.Contains(string(finalLog), " workspace close ws-1") {
 		t.Fatalf("invocation log = %q, want teardown to close the now-empty workspace", finalLog)
 	}
-	if strings.Contains(string(finalLog), "herdr tab close tab-1") {
+	if strings.Contains(string(finalLog), " tab close tab-1") {
 		t.Fatalf("invocation log = %q, want teardown to close the workspace, not just the sole tab in it", finalLog)
 	}
 }


### PR DESCRIPTION
## Intent

Implement atqamz/hand#331: add durable opaque Fleet identity in state/hand.db, per-user ~/.secondhand/registry.db discovery, read-only hand fleet listing, duplicate and identity-mismatch fail-closed preflight, Fleet-scoped Herdr named sessions and labels, exact legacy Attempt cleanup, watcher and Treehouse integration, docs, ADR, and adversarial tests. Preserve current one-context resolution and no global active Fleet, no re-keying or hosted registry, and do not change unrelated Task or Project semantics. Verify the full repository gate and open a PR targeting main.

## What Changed

- Added durable Fleet identities, per-user registry discovery, and read-only `hand fleet` listing with duplicate and identity-mismatch preflight checks.
- Scoped Herdr named sessions and labels, runtime reconciliation, watcher integration, and exact legacy Attempt cleanup to Fleet identity.
- Added Fleet initialization and command support, documentation, ADRs, and registry, identity, Herdr, watcher, and end-to-end test coverage.

## Risk Assessment

⚠️ Medium: The change is a broad cross-cutting Fleet identity and Herdr namespace update, but the reviewed source paths consistently enforce scoped identities and fail-closed duplicate or mismatch checks.

## Testing

Focused tests and selected end-to-end tests passed. Direct CLI verification showed durable Fleet registration and read-only listing of two Fleet homes outside any current context. No linters or full-suite tests were run.

<details>
<summary>Evidence: CLI fleet initialization</summary>

<code>result: initialized&#10;fleet_id: f_37ce09c6963fa079e86bfa2e55483dac&#10;registry: registered</code>

```text
result: initialized
home: /tmp/tmp.ctCGOx6zzr/fleet-one
fleet_id: f_37ce09c6963fa079e86bfa2e55483dac
registry: registered
agents_md: written
agents_md_legacy_archive: none
skill[4]{dir,outcome}:
  /tmp/tmp.ctCGOx6zzr/fleet-one/.claude/skills/secondhand,created
  /tmp/tmp.ctCGOx6zzr/fleet-one/.grok/skills/secondhand,created
  /tmp/tmp.ctCGOx6zzr/fleet-one/.pi/skills/secondhand,created
  /tmp/tmp.ctCGOx6zzr/fleet-one/.agents/skills/secondhand,created
skill_conflicts: 0
session_hook: unchanged
migrated[0]:
config_missing: 0
config[3]{key,state,value}:
  harness,detected,codex
  model,native-default,none
  effort,native-default,none
missing_tools[0]:
help[5]:
  - Start a supervising session in this home; it detects the current harness and uses its native model and effort defaults
  - Run `hand config set <key> <value>` only to persist an explicit worker override
  - Read AGENTS.md in this home for how a supervising agent is meant to drive it
  - Run `hand project add <source>` or `hand project create <name>` to register the first project
  - AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses
```
</details>
<details>
<summary>Evidence: Read-only fleet listing</summary>

<code>current_home: none&#10;fleets[2]{id,home,state,current,locations}:&#10;f_37ce09c6963fa079e86bfa2e55483dac,/tmp/tmp.ctCGOx6zzr/fleet-one,ready,false,/tmp/tmp.ctCGOx6zzr/fleet-one&#10;f_b69fa2211d9ae3e3720eede2cbb34e3e,/tmp/tmp.ctCGOx6zzr/fleet-two,ready,false,/tmp/tmp.ctCGOx6zzr/fleet-two</code>

```text
registry: /tmp/tmp.hVlzSy27Nc/.secondhand/registry.db
current_home: none
current_error: not inside a secondhand home; run `hand init` or set HAND_HOME
fleets[2]{id,home,state,current,locations}:
  f_37ce09c6963fa079e86bfa2e55483dac,/tmp/tmp.ctCGOx6zzr/fleet-one,ready,false,/tmp/tmp.ctCGOx6zzr/fleet-one
  f_b69fa2211d9ae3e3720eede2cbb34e3e,/tmp/tmp.ctCGOx6zzr/fleet-two,ready,false,/tmp/tmp.ctCGOx6zzr/fleet-two
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"896b88870b594182372849376e3bcc3ed485f28a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `internal/runtime/reconcile.go:631` - Legacy workspace tracking is keyed only by workspace ID, even though named Herdr sessions have independent namespaces and can reuse IDs. If a legacy `default` workspace and the current Fleet-scoped workspace both use `ws-1`, `legacyWorkspaces[&#34;ws-1&#34;]` causes the scoped workspace to be skipped entirely, so its orphaned tabs are never inspected. Key the skip and ownership candidates by session plus workspace/tab identity.

🔧 Fix: Fix session-qualified Herdr orphan reconciliation
1 warning still open:
- ⚠️ `internal/store/identity.go:35` - Read-only Fleet identity lookup does not consistently represent a legacy or missing identity as `store.ErrFleetIdentityMissing`. `FleetIDReadOnly` delegates to `DB.FleetID`, which returns a wrapped `no such table: fleet_identity` for an existing pre-Fleet database, while `cmd/herdr.go:15-18` only falls back to the legacy default Herdr session for `ErrFleetIdentityMissing`. Thus `hand session start` passes `Preflight` but then fails instead of preserving the existing default-session context. Normalize this case at the store boundary and avoid generating a random Fleet session for an in-memory read-only database without durable state.

🔧 Fix: Normalize missing legacy Fleet identities read-only
2 errors still open:
- 🚨 `internal/store/identity.go:42` - Read-only access to a missing state database builds an in-memory schema, then clears `db.empty` before `FleetIDReadOnly` reads it, generating a fresh random Fleet ID. Commands can therefore select a non-durable Herdr session for an uninitialized home. Preserve the empty marker and return `store.ErrFleetIdentityMissing` without inventing an identity.
- 🚨 `cmd/session.go:72` - `renderSessionOverview` now calls `registry.Preflight(fleetHome, true)` and propagates `ErrFleetIdentityMissing`, so an existing pre-Fleet home with legacy state but no `fleet_identity` table fails `hand session start` before `currentHerdrClient` can fall back to the legacy default Herdr session. Allow the documented legacy read-only path while retaining fail-closed handling for actual identity conflicts.

🔧 Fix: Preserve missing-state marker and legacy preflight fallback
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`nix develop -c go test ./internal/store ./internal/registry ./internal/herdr ./internal/faketool ./cmd ./internal/watcher` with focused Fleet and identity test selection</code>
- `nix develop -c go test -tags=e2e -count=1 -timeout=10m ./tests/e2e -run 'TestBareCommandNamesItselfAndReportsTheFleet|TestExitCodeThreeOutsideAnyFleetHome|TestExitCodeThreeWhenHandHomeIsNotAFleetHome|TestWatchIsASingletonPerFleetHome'`
- <code>Built the CLI and ran isolated `init` twice plus read-only `fleet`; outputs captured in evidence artifacts</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Fixes atqamz/hand#331

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->