### PR TITLE
feat(launch): replace shell-assembled worker launches

### DIFF
--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -133,13 +133,10 @@ func TestPromoteLaunchCarriesWorkerRoleAndResolvedFleetHome(t *testing.T) {
 		t.Fatal(err)
 	}
 	launch := string(calls)
-	env := "HAND_ROLE=worker HAND_HOME='" + home + "'"
-	envAt := strings.Index(launch, env)
-	if envAt < 0 {
-		t.Fatalf("launch = %q, want absolute worker environment %q", launch, env)
-	}
-	if harnessAt := strings.Index(launch, "claude --dangerously"); harnessAt < 0 || envAt > harnessAt {
-		t.Fatalf("launch = %q, want worker environment before harness executable", launch)
+	for _, want := range []string{"--env HAND_HOME=" + home, "--env HAND_ROLE=worker"} {
+		if !strings.Contains(launch, want) {
+			t.Fatalf("launch = %q, want structured worker environment entry %q", launch, want)
+		}
 	}
 }
 

--- a/cmd/reopen_test.go
+++ b/cmd/reopen_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 	herdr := defaultSpawnHerdr(harness.Claude)
+	herdr.ProcessAgents = []string{harness.Claude, harness.Codex}
 	herdr.TabCreates = []faketool.HerdrTab{
 		{ID: "wA:tB", Label: "task-1", Pane: "wA:pC"},
 		{ID: "wA:tC", Label: "task-1", Pane: "wA:pD"},

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -218,13 +218,10 @@ func TestSpawnHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	launch := string(calls)
-	env := "HAND_ROLE=worker HAND_HOME='" + home + "'"
-	envAt := strings.Index(launch, env)
-	if envAt < 0 {
-		t.Fatalf("launch = %q, want absolute worker environment %q", launch, env)
-	}
-	if harnessAt := strings.Index(launch, "claude --dangerously"); harnessAt < 0 || envAt > harnessAt {
-		t.Fatalf("launch = %q, want worker environment before harness executable", launch)
+	for _, want := range []string{"--env HAND_HOME=" + home, "--env HAND_ROLE=worker"} {
+		if !strings.Contains(launch, want) {
+			t.Fatalf("launch = %q, want structured worker environment entry %q", launch, want)
+		}
 	}
 }
 

--- a/docs/adr/harness-templates-launch-interactively.md
+++ b/docs/adr/harness-templates-launch-interactively.md
@@ -8,20 +8,25 @@
 ## Context
 
 Workers must survive multiple steers and gate turns. Interactive launches provide that resident process but expose first-run dialogs. Pane text can outlive a dead process, while herdr can identify a live harness without knowing what dialog blocks it.
+Shell syntax also varies across the pane's actual shell, so a host operating-system guess is not sufficient for a safe launch.
 
 ## Decision
 
-Every harness template launches a resident interactive process with its autonomy flag. Herdr alone answers whether that process is live. Pane text is used only to detect dialogs, and a launch is confirmed only when both signals are clear.
+Every harness template produces a structured launch specification containing its executable, ordered arguments, environment, and working directory.
+Herdr observes the idle pane's shell, renders only the executable and arguments for the supported shell family, and carries environment and working directory through resource creation.
+Herdr process evidence answers whether the expected process is live. Pane text is used only to detect dialogs, and a launch is confirmed only when both signals are clear.
 
-Exact commands and dialog signatures belong to [`internal/harness`](../../internal/harness); confirmation belongs to [`internal/runtime/launch.go`](../../internal/runtime/launch.go). Their tests own supported flags, prompt handling, and failure behavior.
+Launch arguments and dialog signatures belong to [`internal/harness`](../../internal/harness); shell renderers and process observation belong to [`internal/herdr`](../../internal/herdr); confirmation belongs to [`internal/runtime/launch.go`](../../internal/runtime/launch.go). Their tests own supported flags, prompt handling, shell quoting, and failure behavior.
 
 ## Rejected alternatives
 
 - Headless reinvocation has no resident session for `hand send`, watching, or multi-turn gates.
 - A wrapper around headless runs would reimplement harness continuity and make pane state describe the wrapper.
+- Building one opaque POSIX command string cannot preserve process argument boundaries across POSIX and PowerShell.
+- Selecting a renderer from host `GOOS`, `$SHELL`, or a configuration default does not prove which shell owns the pane.
 - Screen text cannot prove liveness because a dead harness leaves text behind.
 - Agent presence alone can confirm a process parked forever on a dialog.
 
 ## Consequences
 
-Dialog wording is an external compatibility surface and may need maintenance as harnesses change. Unknown dialogs fail toward an unconfirmed launch where the harness has a catalogued prompt surface.
+Dialog wording is an external compatibility surface and may need maintenance as harnesses change. Unknown shells and dialogs fail toward an unconfirmed launch. Submission remains separately recorded from confirmation so a lost response cannot trigger an unsafe duplicate launch.

--- a/docs/adr/harness-templates-launch-interactively.md
+++ b/docs/adr/harness-templates-launch-interactively.md
@@ -29,4 +29,6 @@ Launch arguments and dialog signatures belong to [`internal/harness`](../../inte
 
 ## Consequences
 
-Dialog wording is an external compatibility surface and may need maintenance as harnesses change. Unknown shells and dialogs fail toward an unconfirmed launch. Submission remains separately recorded from confirmation so a lost response cannot trigger an unsafe duplicate launch.
+Dialog wording is an external compatibility surface and may need maintenance as harnesses change.
+Unknown shells and dialogs fail toward an unconfirmed launch.
+Submission remains separately recorded from confirmation so a lost response cannot trigger an unsafe duplicate launch.

--- a/internal/faketool/FIDELITY.md
+++ b/internal/faketool/FIDELITY.md
@@ -228,6 +228,22 @@ Exit 0 with the pane, carrying `agent` (the detected harness name, empty when no
 `hand` polls the API and never focuses a client on a worker's pane, so it observes `done` essentially always for this transition and `idle` essentially never.
 Neither value carries task-outcome information for a headless fleet; see `docs/adr/the-report-channel-is-the-only-outcome-signal.md`.
 
+### `herdr pane process-info --pane <id>`
+
+Exit 0 with a JSON envelope carrying `result.process_info`.
+The observed Herdr 0.8.2 shape includes `pane_id`, numeric `shell_pid`, numeric `foreground_process_group_id`, optional `tty`, and `foreground_processes`.
+Each foreground process may carry numeric `pid`, `name`, `argv`, `argv0`, `cmdline`, and `cwd`.
+
+The pane's idle shell must be present in `foreground_processes` with the reported `shell_pid` before Hand submits a worker launch.
+Hand classifies only `sh`, `bash`, `zsh`, `powershell`, `powershell.exe`, `pwsh`, and `pwsh.exe`; missing or unsupported evidence fails before `pane run`.
+The fake models this response separately from `pane get` and `pane read`.
+
+### Structured worker environment
+
+`workspace create` and `tab create` accept repeated `--env KEY=value` entries after their cwd and label arguments.
+Hand merges inherited harness-marker sanitization, the managed runtime PATH overlay, and the validated worker environment with explicit caller precedence, then serializes the entries in sorted key order.
+The fake preserves these argument boundaries rather than reconstructing a shell command.
+
 ### `herdr pane read <id> --source recent --lines <n>`
 
 Exit 0 with bare text, and **empty for a pane whose own shell has not painted yet** - a read taken immediately after `workspace create` returns nothing at all.

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -50,6 +50,8 @@ type Herdr struct {
 	Creates            []HerdrWorkspace
 	TabCreates         []HerdrTab
 	PaneAgent          string
+	ProcessAgent       string
+	ProcessAgents      []string
 	PaneStatus         string
 	PaneStatusSequence []string
 	PaneReadOut        string
@@ -78,6 +80,8 @@ type herdrSpec struct {
 	Creates            []HerdrWorkspace
 	TabCreates         []HerdrTab
 	PaneAgent          string
+	ProcessAgent       string
+	ProcessAgents      []string
 	PaneStatus         string
 	PaneStatusSequence []string
 	PaneReadOut        string
@@ -121,7 +125,7 @@ func (h Herdr) Install(t *testing.T, bin string) {
 	}
 	installConfig(t, bin, "herdr", "herdr", herdrSpec{
 		Workspaces: h.Workspaces, Creates: h.Creates, TabCreates: h.TabCreates,
-		PaneAgent: h.PaneAgent, PaneStatus: h.PaneStatus, PaneReadOut: h.PaneReadOut,
+		PaneAgent: h.PaneAgent, ProcessAgent: h.ProcessAgent, ProcessAgents: h.ProcessAgents, PaneStatus: h.PaneStatus, PaneReadOut: h.PaneReadOut,
 		PaneStatusSequence: h.PaneStatusSequence,
 		PaneStatusFile:     h.PaneStatusFile, Frames: h.Frames, Responses: h.Responses,
 		Hang: h.Hang, Unreachable: h.Unreachable, KeyLog: h.KeyLog, TextLog: h.TextLog,
@@ -286,6 +290,8 @@ func runHerdrState(spec herdrSpec, command string, args []string) int {
 		return herdrTabClose(spec, workspaces, tabs, args)
 	case "pane get":
 		return herdrPaneGet(spec, tabs, args)
+	case "pane process-info":
+		return herdrPaneProcessInfo(spec, tabs, args)
 	case "pane read":
 		return herdrPaneRead(spec, tabs, args)
 	case "pane run", "pane send-text", "pane send-keys":
@@ -496,6 +502,39 @@ func herdrPaneGet(spec herdrSpec, tabs []herdrTabRef, args []string) int {
 	return 0
 }
 
+func herdrPaneProcessInfo(spec herdrSpec, tabs []herdrTabRef, args []string) int {
+	pane := flagValue(args, "--pane")
+	if pane == "" || (herdrPaneRef(spec, tabs, pane).Tab.ID == "" && !spec.AllowUnknownPane) {
+		return herdrError("pane_not_found", "pane "+pane+" not found", "cli:pane:process_info")
+	}
+	agents := append([]string(nil), spec.ProcessAgents...)
+	if len(agents) == 0 {
+		agent := spec.ProcessAgent
+		if agent == "" {
+			agent = spec.PaneAgent
+		}
+		if agent != "" {
+			agents = []string{agent}
+		}
+	}
+	if spec.PaneAgentEnv {
+		agents = []string{os.Getenv("PANE_AGENT")}
+	}
+	if len(spec.Frames) > 0 {
+		index := herdrProcessFrameAdvance(spec.StateDir, len(spec.Frames))
+		agents = []string{spec.Frames[index].Agent}
+	}
+	foreground := `{"pid":1,"name":"bash","argv":["bash"]}`
+	for i, agent := range agents {
+		if agent == "" {
+			continue
+		}
+		foreground += fmt.Sprintf(`,{"pid":%d,"name":%s,"argv":[%s]}`, i+2, jsonQuote(agent), jsonQuote(agent))
+	}
+	_, _ = fmt.Fprintf(os.Stdout, `{"id":"cli:pane:process_info","result":{"process_info":{"pane_id":%s,"shell_pid":1,"foreground_processes":[%s]}}}`+"\n", jsonQuote(pane), foreground)
+	return 0
+}
+
 func herdrPaneRead(spec herdrSpec, tabs []herdrTabRef, args []string) int {
 	if len(args) < 3 {
 		return herdrError("pane_not_found", "pane not found", "cli:pane:read")
@@ -686,6 +725,14 @@ func herdrFrameAdvance(state string, count int) int {
 
 func herdrFrameCurrent(state string, count int) int {
 	return min(max(herdrCounter(state, "frames")-1, 0), count-1)
+}
+
+func herdrProcessFrameAdvance(state string, count int) int {
+	current := herdrCounter(state, "process-frames")
+	if err := atomicWrite(herdrCounterPath(state, "process-frames"), strconv.Itoa(current+1)+"\n"); err != nil {
+		return min(current, count-1)
+	}
+	return min(current, count-1)
 }
 
 func herdrStatusAdvance(state string, count int) int {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,15 +1,14 @@
-// Package harness constructs the per-harness command used to launch a worker agent.
+// Package harness constructs the per-harness process used to launch a worker agent.
 package harness
 
 import (
 	"fmt"
 	"regexp"
 	"slices"
-	"strings"
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/brief"
-	"github.com/atqamz/hand/internal/shellquote"
+	"github.com/atqamz/hand/internal/launch"
 )
 
 const (
@@ -134,7 +133,6 @@ func AgentDetectionVerified(name string) bool {
 type Options struct {
 	Worktree            string
 	Brief               string
-	FleetHome           string
 	Model               string
 	Effort              string
 	ExecutionClass      brief.ExecutionClass
@@ -175,88 +173,85 @@ func CarriesPrompt(name string) bool {
 	return promptCapable[name]
 }
 
-// Build constructs the shell command that cds into the worktree and launches the harness against
-// the brief. Every launch is interactive, never one-shot: hand send steers a running pane, hand
-// watch classifies its lifecycle, and a no-mistakes pipeline drives many turns a one-shot cannot.
-func Build(name string, opts Options) (string, error) {
-	var launch string
+// Build constructs the executable, arguments, environment, and working directory for a harness.
+// Every launch is interactive, never one-shot: hand send steers a running pane, hand watch
+// classifies its lifecycle, and a no-mistakes pipeline drives many turns a one-shot cannot.
+func Build(name string, opts Options) (launch.LaunchSpec, error) {
+	var spec launch.LaunchSpec
 	// Flags for claude, codex, and opencode are verified against the installed CLI's own --help, and
 	// this file is the source of truth for those three.
 	switch name {
 	case Claude:
-		launch = buildClaude(opts)
+		spec = buildClaude(opts)
 	case Codex:
-		launch = buildCodex(opts)
+		spec = buildCodex(opts)
 	case Grok:
-		launch = buildGrok(opts)
+		spec = buildGrok(opts)
 	case Pi:
-		launch = buildPi(opts)
+		spec = buildPi(opts)
 	case OpenCode:
-		launch = buildOpenCode(opts)
+		spec = buildOpenCode(opts)
 	default:
-		return "", fmt.Errorf("harness %q not recognized", name)
+		return launch.LaunchSpec{}, fmt.Errorf("harness %q not recognized", name)
 	}
-	env := ""
-	if opts.FleetHome != "" {
-		env = RoleEnv + "=" + WorkerRole + " " + HomeEnv + "=" + shellQuote(opts.FleetHome) + " "
-	}
-	return fmt.Sprintf("cd %s && %s%s", shellQuote(opts.Worktree), env, launch), nil
+	spec.Cwd = opts.Worktree
+	return launch.NewSpec(spec)
 }
 
 // Launches claude interactively - no --print - so the pane stays resident for hand send and hand
 // watch across a multi-turn no-mistakes pipeline. Verified via `claude --help`: --model, --effort
 // and --dangerously-skip-permissions all apply outside --print.
-func buildClaude(o Options) string {
+func buildClaude(o Options) launch.LaunchSpec {
 	// --dangerously-skip-permissions, or an unattended worker stalls on a permission prompt.
 	// CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false suppresses the dim predicted-next-prompt ghost text,
 	// which a pane-watching supervisor would otherwise read as typed input under an idle worker.
-	args := []string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false", "claude", "--dangerously-skip-permissions"}
+	args := []string{"--dangerously-skip-permissions"}
 	if o.Model != "" {
-		args = append(args, "--model", shellQuote(o.Model))
+		args = append(args, "--model", o.Model)
 	}
 	if o.Effort != "" {
-		args = append(args, "--effort", shellQuote(o.Effort))
+		args = append(args, "--effort", o.Effort)
 	}
-	args = append(args, shellQuote(briefPrompt(o)))
-	return strings.Join(args, " ")
+	args = append(args, briefPrompt(o))
+	return launch.LaunchSpec{Executable: Claude, Args: args, Env: map[string]string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "false"}}
 }
 
 // Launches Codex CLI 0.146.0 interactively with its positional prompt. Its help and config schema
 // expose the flags below; paste-burst buffering otherwise absorbs hand send's immediate Enter, and
 // auto effort means inherit Codex's default rather than pass a literal value.
-func buildCodex(o Options) string {
-	args := []string{"codex", "--dangerously-bypass-approvals-and-sandbox", "-c", shellQuote("disable_paste_burst=true")}
+func buildCodex(o Options) launch.LaunchSpec {
+	args := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true"}
 	if o.Model != "" {
-		args = append(args, "--model", shellQuote(o.Model))
+		args = append(args, "--model", o.Model)
 	}
 	if o.Effort != "" && o.Effort != "auto" {
-		args = append(args, "-c", shellQuote(fmt.Sprintf(`model_reasoning_effort="%s"`, o.Effort)))
+		args = append(args, "-c", fmt.Sprintf(`model_reasoning_effort="%s"`, o.Effort))
 	}
-	args = append(args, shellQuote(briefPrompt(o)))
-	return strings.Join(args, " ")
+	args = append(args, briefPrompt(o))
+	return launch.LaunchSpec{Executable: Codex, Args: args}
 }
 
-func buildGrok(o Options) string {
-	return fmt.Sprintf("grok --trust --file %s", shellQuote(o.Brief))
+func buildGrok(o Options) launch.LaunchSpec {
+	return launch.LaunchSpec{Executable: Grok, Args: []string{"--trust", "--file", o.Brief}}
 }
 
-func buildPi(o Options) string {
-	return fmt.Sprintf("pi %s", shellQuote(o.Brief))
+func buildPi(o Options) launch.LaunchSpec {
+	return launch.LaunchSpec{Executable: Pi, Args: []string{o.Brief}}
 }
 
 // Uses the bare `opencode` command (verified via `opencode --help`), which opens an interactive TUI,
 // rather than `opencode run` - that one is explicitly headless and exits after a single reply.
-func buildOpenCode(o Options) string {
+func buildOpenCode(o Options) launch.LaunchSpec {
 	// OPENCODE_CONFIG_CONTENT grants blanket tool permission so an unattended worker does not stall
 	// on a permission prompt.
-	args := []string{"OPENCODE_CONFIG_CONTENT=" + shellQuote(`{"permission":{"*":"allow"}}`), "opencode"}
+	args := []string{}
 	if o.Model != "" {
-		args = append(args, "--model", shellQuote(o.Model))
+		args = append(args, "--model", o.Model)
 	}
 	// The bare command has no --file flag and no effort or variant flag, so the brief path rides in
 	// the --prompt text and Options.Effort is dropped here rather than passed.
-	args = append(args, "--prompt", shellQuote(briefPrompt(o)))
-	return strings.Join(args, " ")
+	args = append(args, "--prompt", briefPrompt(o))
+	return launch.LaunchSpec{Executable: OpenCode, Args: args, Env: map[string]string{"OPENCODE_CONFIG_CONTENT": `{"permission":{"*":"allow"}}`}}
 }
 
 // Shared so the wording cannot drift between harnesses. It ends with agentsmd.OperatorDecisionRule
@@ -271,8 +266,4 @@ func briefPrompt(o Options) string {
 		prompt += " Verify the named files/symbols and plan assumptions before editing. If materially stale or contradictory, stop and report blocked. Do not redesign the task yourself. Otherwise execute the ordered plan and verification steps."
 	}
 	return prompt + " " + agentsmd.OperatorDecisionRule
-}
-
-func shellQuote(s string) string {
-	return shellquote.Quote(s)
 }

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -1,18 +1,22 @@
 package harness
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/brief"
+	"github.com/atqamz/hand/internal/launch"
 )
 
-// The shell-quoted first message a harness launches with. The operator-decision rule is a paragraph
-// of prose owned by internal/agentsmd, so exact-match wants build the prompt from it instead of
-// restating it here.
-func quotedPrompt(brief string) string {
-	return shellQuote("Read the brief at " + brief + " and carry out the task it describes. " + agentsmd.OperatorDecisionRule)
+func buildSpec(t *testing.T, name string, options Options) launch.LaunchSpec {
+	t.Helper()
+	spec, err := Build(name, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return spec
 }
 
 func TestBuildUnrecognizedHarness(t *testing.T) {
@@ -32,287 +36,166 @@ func TestIsSupported(t *testing.T) {
 	}
 }
 
-func TestBuildAlwaysCdsIntoWorktree(t *testing.T) {
-	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
-		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/wt/brief.md"})
-		if err != nil {
-			t.Fatalf("Build(%q) error: %v", name, err)
-		}
-		if !strings.HasPrefix(got, "cd '/tmp/wt' && ") {
-			t.Errorf("Build(%q) = %q, want cd prefix", name, got)
-		}
-	}
-}
-
-// A worker needs its role and fleet home before every harness-specific setting, so child processes
-// can reliably decline supervisor-only commands while still locating the fleet state.
-func TestBuildCarriesWorkerRoleAndFleetHome(t *testing.T) {
+func TestBuildCarriesStructuredCwdAndNoShellPrefixes(t *testing.T) {
 	for _, name := range Names() {
-		got, err := Build(name, Options{
-			Worktree:  "/tmp/wt",
-			Brief:     "/tmp/brief.md",
-			FleetHome: "/tmp/fleet home",
-		})
-		if err != nil {
-			t.Fatalf("Build(%q): %v", name, err)
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/wt/brief.md"})
+		if spec.Cwd != "/tmp/wt" {
+			t.Errorf("Build(%q).Cwd = %q, want worktree", name, spec.Cwd)
 		}
-		want := "HAND_ROLE=worker HAND_HOME='/tmp/fleet home'"
-		if !strings.Contains(got, want) {
-			t.Fatalf("Build(%q) = %q, want %q", name, got, want)
+		if strings.Contains(spec.Executable, "cd ") {
+			t.Errorf("Build(%q).Executable = %q, contains shell prefix", name, spec.Executable)
+		}
+		for _, arg := range spec.Args {
+			if strings.HasPrefix(arg, "HAND_ROLE=") || strings.HasPrefix(arg, "HAND_HOME=") || strings.HasPrefix(arg, "cd ") {
+				t.Errorf("Build(%q) retained shell launch syntax in arg %q", name, arg)
+			}
 		}
 	}
 }
 
 func TestBuildClaude(t *testing.T) {
-	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/data/fix-login/brief.md"})
-	if err != nil {
-		t.Fatal(err)
+	spec := buildSpec(t, Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/data/fix-login/brief.md"})
+	wantPrompt := briefPrompt(Options{Brief: "/tmp/data/fix-login/brief.md"})
+	want := launch.LaunchSpec{
+		Executable: Claude,
+		Args:       []string{"--dangerously-skip-permissions", wantPrompt},
+		Env:        map[string]string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "false"},
+		Cwd:        "/tmp/wt",
 	}
-	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions " + quotedPrompt("/tmp/data/fix-login/brief.md")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if !reflect.DeepEqual(spec, want) {
+		t.Fatalf("got %+v, want %+v", spec, want)
 	}
 }
 
 func TestBuildClaudeWithModelAndEffort(t *testing.T) {
-	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "sonnet", Effort: "low"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "cd '/tmp/wt' && CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --model 'sonnet' --effort 'low' " + quotedPrompt("/tmp/brief.md")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	spec := buildSpec(t, Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "sonnet", Effort: "low"})
+	if !reflect.DeepEqual(spec.Args[:5], []string{"--dangerously-skip-permissions", "--model", "sonnet", "--effort", "low"}) {
+		t.Fatalf("args = %#v, want ordered model and effort flags", spec.Args)
 	}
 }
 
-// Guards against a silent regression to --print, which would strand hand send and hand watch with
-// no running pane to steer.
 func TestBuildClaudeNeverHeadless(t *testing.T) {
-	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
+	spec := buildSpec(t, Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if contains(spec.Args, "--print") {
+		t.Fatalf("args = %#v, want no --print flag", spec.Args)
 	}
-	if strings.Contains(got, "--print") {
-		t.Fatalf("got %q, want no --print (headless) flag", got)
-	}
-	if !strings.Contains(got, "--dangerously-skip-permissions") {
-		t.Fatalf("got %q, want --dangerously-skip-permissions so an unattended worker never stalls on a permission prompt", got)
+	if !contains(spec.Args, "--dangerously-skip-permissions") {
+		t.Fatalf("args = %#v, want unattended permission flag", spec.Args)
 	}
 }
 
 func TestBuildCodex(t *testing.T) {
-	got, err := Build(Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "cd '/tmp/wt' && codex --dangerously-bypass-approvals-and-sandbox -c 'disable_paste_burst=true' " + quotedPrompt("/tmp/brief.md")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	spec := buildSpec(t, Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	want := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true", briefPrompt(Options{Brief: "/tmp/brief.md"})}
+	if !reflect.DeepEqual(spec.Args, want) {
+		t.Fatalf("args = %#v, want %#v", spec.Args, want)
 	}
 }
 
 func TestBuildCodexWithModelAndEffort(t *testing.T) {
-	got, err := Build(Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "gpt-5.6-codex", Effort: "high"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "cd '/tmp/wt' && codex --dangerously-bypass-approvals-and-sandbox -c 'disable_paste_burst=true' --model 'gpt-5.6-codex' -c 'model_reasoning_effort=\"high\"' " + quotedPrompt("/tmp/brief.md")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	spec := buildSpec(t, Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "gpt-5.6-codex", Effort: "high"})
+	want := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true", "--model", "gpt-5.6-codex", "-c", `model_reasoning_effort="high"`, briefPrompt(Options{Brief: "/tmp/brief.md"})}
+	if !reflect.DeepEqual(spec.Args, want) {
+		t.Fatalf("args = %#v, want %#v", spec.Args, want)
 	}
 }
 
 func TestBuildCodexOmitsAutoEffort(t *testing.T) {
-	got, err := Build(Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "auto"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "cd '/tmp/wt' && codex --dangerously-bypass-approvals-and-sandbox -c 'disable_paste_burst=true' " + quotedPrompt("/tmp/brief.md")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-	if !SupportsEffort(Codex) {
-		t.Fatal("SupportsEffort(Codex) = false, want true for explicit non-auto efforts")
+	spec := buildSpec(t, Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "auto"})
+	if contains(spec.Args, "auto") {
+		t.Fatalf("args = %#v, want auto effort omitted", spec.Args)
 	}
 }
 
 func TestBuildGrok(t *testing.T) {
-	got, err := Build(Grok, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "cd '/tmp/wt' && grok --trust --file '/tmp/brief.md'"
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	spec := buildSpec(t, Grok, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	want := launch.LaunchSpec{Executable: Grok, Args: []string{"--trust", "--file", "/tmp/brief.md"}, Cwd: "/tmp/wt"}
+	if !reflect.DeepEqual(spec, want) {
+		t.Fatalf("got %+v, want %+v", spec, want)
 	}
 }
 
 func TestBuildPi(t *testing.T) {
-	got, err := Build(Pi, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "cd '/tmp/wt' && pi '/tmp/brief.md'"
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	spec := buildSpec(t, Pi, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	want := launch.LaunchSpec{Executable: Pi, Args: []string{"/tmp/brief.md"}, Cwd: "/tmp/wt"}
+	if !reflect.DeepEqual(spec, want) {
+		t.Fatalf("got %+v, want %+v", spec, want)
 	}
 }
 
 func TestBuildOpenCode(t *testing.T) {
-	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
+	spec := buildSpec(t, OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	want := launch.LaunchSpec{
+		Executable: OpenCode,
+		Args:       []string{"--prompt", briefPrompt(Options{Brief: "/tmp/brief.md"})},
+		Env:        map[string]string{"OPENCODE_CONFIG_CONTENT": `{"permission":{"*":"allow"}}`},
+		Cwd:        "/tmp/wt",
 	}
-	want := "cd '/tmp/wt' && OPENCODE_CONFIG_CONTENT='{\"permission\":{\"*\":\"allow\"}}' opencode --prompt " + quotedPrompt("/tmp/brief.md")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-}
-
-func TestBuildClaudeFrontMatterDisclaimer(t *testing.T) {
-	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(got, "dispatch metadata") {
-		t.Fatalf("got %q, want the front matter disclaimed", got)
+	if !reflect.DeepEqual(spec, want) {
+		t.Fatalf("got %+v, want %+v", spec, want)
 	}
 }
 
-func TestBuildClaudeNoFrontMatterUnchanged(t *testing.T) {
-	got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(got, "dispatch metadata") {
-		t.Fatalf("got %q, want no disclaimer for a brief with no front matter", got)
+func TestBuildFrontMatterDisclaimer(t *testing.T) {
+	for _, name := range []string{Claude, Codex, OpenCode} {
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
+		if !containsText(spec.Args, "dispatch metadata") {
+			t.Fatalf("Build(%q) args = %#v, want front matter disclaimer", name, spec.Args)
+		}
 	}
 }
 
 func TestBuildMechanicalExecutionGuidance(t *testing.T) {
 	for _, name := range []string{Claude, Codex, OpenCode} {
-		t.Run(name, func(t *testing.T) {
-			got, err := Build(name, Options{
-				Worktree:       "/tmp/wt",
-				Brief:          "/tmp/brief.md",
-				ExecutionClass: brief.ExecutionClassMechanical,
-			})
-			if err != nil {
-				t.Fatal(err)
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", ExecutionClass: brief.ExecutionClassMechanical})
+		for _, want := range []string{"Verify the named files/symbols and plan assumptions before editing.", "stop and report blocked", "Do not redesign the task yourself.", "execute the ordered plan and verification steps"} {
+			if !containsText(spec.Args, want) {
+				t.Fatalf("Build(%q) args = %#v, want mechanical guidance %q", name, spec.Args, want)
 			}
-			for _, want := range []string{
-				"Verify the named files/symbols and plan assumptions before editing.",
-				"stop and report blocked",
-				"Do not redesign the task yourself.",
-				"execute the ordered plan and verification steps",
-			} {
-				if !strings.Contains(got, want) {
-					t.Fatalf("Build(%q) = %q, want mechanical guidance %q", name, got, want)
-				}
-			}
-		})
+		}
 	}
 }
 
 func TestBuildStandardAndDeepOmitMechanicalExecutionGuidance(t *testing.T) {
 	for _, class := range []brief.ExecutionClass{brief.ExecutionClassStandard, brief.ExecutionClassDeep} {
-		t.Run(string(class), func(t *testing.T) {
-			got, err := Build(Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", ExecutionClass: class})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if strings.Contains(got, "Do not redesign the task yourself.") || strings.Contains(got, "Verify the named files/symbols") {
-				t.Fatalf("Build(%q) = %q, want no mechanical-only guidance", class, got)
-			}
-		})
+		spec := buildSpec(t, Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", ExecutionClass: class})
+		if containsText(spec.Args, "Do not redesign the task yourself.") || containsText(spec.Args, "Verify the named files/symbols") {
+			t.Fatalf("Build(%q) args = %#v, want no mechanical guidance", class, spec.Args)
+		}
 	}
 }
 
 func TestBuildOpenCodeWithModel(t *testing.T) {
-	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "opus"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(got, "--model 'opus'") {
-		t.Fatalf("got %q, want --model flag", got)
+	spec := buildSpec(t, OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "opus"})
+	if !hasPair(spec.Args, "--model", "opus") {
+		t.Fatalf("args = %#v, want --model flag", spec.Args)
 	}
 }
 
-// Guards against a silent regression to `opencode run`, which exits after one reply and leaves no
-// pane to steer.
 func TestBuildOpenCodeNeverHeadless(t *testing.T) {
-	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	if err != nil {
-		t.Fatal(err)
+	spec := buildSpec(t, OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if hasPair(spec.Args, "opencode", "run") || contains(spec.Args, "run") {
+		t.Fatalf("args = %#v, want interactive opencode invocation", spec.Args)
 	}
-	if strings.Contains(got, "opencode run") {
-		t.Fatalf("got %q, want no headless \"opencode run\" invocation", got)
-	}
-	if !strings.Contains(got, `OPENCODE_CONFIG_CONTENT`) {
-		t.Fatalf("got %q, want OPENCODE_CONFIG_CONTENT so an unattended worker never stalls on a permission prompt", got)
+	if spec.Env["OPENCODE_CONFIG_CONTENT"] == "" {
+		t.Fatalf("env = %#v, want OPENCODE_CONFIG_CONTENT", spec.Env)
 	}
 }
 
-func TestBuildOpenCodeFrontMatterDisclaimer(t *testing.T) {
-	got, err := Build(OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(got, "dispatch metadata") {
-		t.Fatalf("got %q, want the front matter disclaimed", got)
-	}
-}
-
-func TestBuildCodexFrontMatterDisclaimer(t *testing.T) {
-	got, err := Build(Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(got, "dispatch metadata") {
-		t.Fatalf("got %q, want the front matter disclaimed", got)
-	}
-}
-
-func TestBuildFrontMatterDisclaimerCoversAllRecognizedDispatchMetadata(t *testing.T) {
-	for _, name := range []string{Claude, Codex, OpenCode} {
-		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, field := range []string{"model", "effort", "execution_class", "planned_against"} {
-			if !strings.Contains(got, field) {
-				t.Fatalf("Build(%q) = %q, want recognized dispatch field %q in disclaimer", name, got, field)
-			}
-		}
-	}
-}
-
-// Pins the only channel that rule has: a worker's worktree is never under the fleet home, so the
-// AGENTS.md copy of it never reaches the worker.
 func TestBuildCarriesOperatorDecisionRule(t *testing.T) {
-	quoted := shellQuote(agentsmd.OperatorDecisionRule)
-	escaped := quoted[1 : len(quoted)-1]
 	for _, name := range []string{Claude, Codex, OpenCode} {
-		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-		if err != nil {
-			t.Fatalf("Build(%q) error: %v", name, err)
-		}
-		if !strings.Contains(got, escaped) {
-			t.Errorf("Build(%q) = %q, want the operator-decision rule %q in the launch prompt", name, got, escaped)
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+		if !containsText(spec.Args, agentsmd.OperatorDecisionRule) {
+			t.Errorf("Build(%q) args = %#v, want operator-decision rule", name, spec.Args)
 		}
 	}
 }
 
-// Pinned against the builders rather than restating the map: a harness reporting true while its
-// command carries no --model is exactly the silent drop being fixed here.
 func TestSupportsModel(t *testing.T) {
 	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
-		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "some-model"})
-		if err != nil {
-			t.Fatalf("Build(%q) error: %v", name, err)
-		}
-		if emits := strings.Contains(got, "--model 'some-model'"); emits != SupportsModel(name) {
-			t.Errorf("SupportsModel(%q) = %v but Build(%q) = %q", name, SupportsModel(name), name, got)
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "some-model"})
+		if hasPair(spec.Args, "--model", "some-model") != SupportsModel(name) {
+			t.Errorf("SupportsModel(%q) = %v but args = %#v", name, SupportsModel(name), spec.Args)
 		}
 	}
 	if SupportsModel("nonexistent") {
@@ -320,17 +203,12 @@ func TestSupportsModel(t *testing.T) {
 	}
 }
 
-// Pinned against the builders for the same reason as TestSupportsModel: a harness reporting true
-// while its command carries no --effort is the silent drop this predicate exists to prevent.
 func TestSupportsEffort(t *testing.T) {
 	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
-		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "some-effort"})
-		if err != nil {
-			t.Fatalf("Build(%q) error: %v", name, err)
-		}
-		emits := strings.Contains(got, "--effort 'some-effort'") || strings.Contains(got, `model_reasoning_effort="some-effort"`)
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "some-effort"})
+		emits := hasPair(spec.Args, "--effort", "some-effort") || contains(spec.Args, `model_reasoning_effort="some-effort"`)
 		if emits != SupportsEffort(name) {
-			t.Errorf("SupportsEffort(%q) = %v but Build(%q) = %q", name, SupportsEffort(name), name, got)
+			t.Errorf("SupportsEffort(%q) = %v but args = %#v", name, SupportsEffort(name), spec.Args)
 		}
 	}
 	if SupportsEffort("nonexistent") {
@@ -338,18 +216,11 @@ func TestSupportsEffort(t *testing.T) {
 	}
 }
 
-// Pinned against the builders for the same reason as TestSupportsModel: a harness reporting true
-// while its command carries no prompt text drops the operator-decision rule in silence.
 func TestCarriesPrompt(t *testing.T) {
-	quoted := shellQuote(agentsmd.OperatorDecisionRule)
-	escaped := quoted[1 : len(quoted)-1]
 	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
-		got, err := Build(name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-		if err != nil {
-			t.Fatalf("Build(%q) error: %v", name, err)
-		}
-		if carries := strings.Contains(got, escaped); carries != CarriesPrompt(name) {
-			t.Errorf("CarriesPrompt(%q) = %v but Build(%q) = %q", name, CarriesPrompt(name), name, got)
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+		if containsText(spec.Args, agentsmd.OperatorDecisionRule) != CarriesPrompt(name) {
+			t.Errorf("CarriesPrompt(%q) = %v but args = %#v", name, CarriesPrompt(name), spec.Args)
 		}
 	}
 	if CarriesPrompt("nonexistent") {
@@ -357,20 +228,6 @@ func TestCarriesPrompt(t *testing.T) {
 	}
 }
 
-func TestShellQuoteEscapesSingleQuotes(t *testing.T) {
-	got, err := Build(Pi, Options{Worktree: "/tmp/wt", Brief: "/tmp/it's/brief.md"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := `cd '/tmp/wt' && pi '/tmp/it'\''s/brief.md'`
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-}
-
-// Pins the shape confirmLaunch depends on: a startup signature for each frame claude settles into,
-// answerable dialogs carrying keys, and the managed-settings dialog catalogued as
-// recognized-but-refused so it fails fast instead of looking uncatalogued.
 func TestFirstRunPromptsClaude(t *testing.T) {
 	prompts := FirstRunPromptsFor(Claude)
 	if prompts.Ready == nil || prompts.Unrecognized == nil {
@@ -381,8 +238,8 @@ func TestFirstRunPromptsClaude(t *testing.T) {
 			t.Errorf("readiness signature does not match claude startup frame %q", frame)
 		}
 	}
-	if prompts.Ready.MatchString("cd '/tmp/wt' && claude --dangerously-skip-permissions 'Read the brief'") {
-		t.Fatal("readiness signature matches the echoed launch command, so a pane that never started reads as ready")
+	if prompts.Ready.MatchString("claude --dangerously-skip-permissions Read the brief") {
+		t.Fatal("readiness signature matches the echoed launch command")
 	}
 
 	byName := map[string]FirstRunPrompt{}
@@ -392,28 +249,18 @@ func TestFirstRunPromptsClaude(t *testing.T) {
 		}
 		byName[prompt.Name] = prompt
 	}
-
-	bypass := byName["bypass permissions"]
-	if !bypass.Match.MatchString("WARNING: Bypass Permissions mode") {
-		t.Fatal("bypass permissions signature does not match the dialog")
-	}
-	if strings.Join(bypass.Keys, ",") != "Down,Enter" {
-		t.Fatalf("bypass permissions keys = %v, want Down before Enter (a bare Enter lands on \"No, exit\" and quits claude)", bypass.Keys)
+	if got := byName["bypass permissions"]; strings.Join(got.Keys, ",") != "Down,Enter" {
+		t.Fatalf("bypass permissions keys = %v", got.Keys)
 	}
 	if got := byName["workspace trust"]; strings.Join(got.Keys, ",") != "Enter" {
-		t.Fatalf("workspace trust keys = %v, want Enter", got.Keys)
+		t.Fatalf("workspace trust keys = %v", got.Keys)
 	}
 	managed := byName["managed settings"]
-	if managed.Refuse == "" {
-		t.Fatal("managed settings must be refused, not answered on the operator's behalf")
-	}
-	if !managed.Match.MatchString("Managed settings require approval") || !managed.Match.MatchString("Yes, I trust these settings") {
-		t.Fatal("managed settings signature does not match the dialog")
+	if managed.Refuse == "" || !managed.Match.MatchString("Managed settings require approval") || !managed.Match.MatchString("Yes, I trust these settings") {
+		t.Fatalf("managed settings prompt = %+v", managed)
 	}
 }
 
-// Pins the harnesses actually run in a real pane and observed being labeled by herdr; the rest must
-// stay false until each is exercised the same way.
 func TestAgentDetectionVerified(t *testing.T) {
 	for _, name := range []string{Claude, Codex, OpenCode} {
 		if !AgentDetectionVerified(name) {
@@ -422,7 +269,7 @@ func TestAgentDetectionVerified(t *testing.T) {
 	}
 	for _, name := range []string{Grok, Pi, "nonexistent"} {
 		if AgentDetectionVerified(name) {
-			t.Errorf("AgentDetectionVerified(%q) = true, want false until herdr detection is exercised against it", name)
+			t.Errorf("AgentDetectionVerified(%q) = true, want false", name)
 		}
 	}
 }
@@ -433,4 +280,31 @@ func TestFirstRunPromptsWithoutVerifiedSignatures(t *testing.T) {
 			t.Errorf("FirstRunPromptsFor(%q) = %+v, want no unverified signatures", name, got)
 		}
 	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsText(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPair(values []string, key, want string) bool {
+	for i := 0; i+1 < len(values); i++ {
+		if values[i] == key && values[i+1] == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/atqamz/hand/internal/launch"
 	"github.com/atqamz/hand/internal/toolchain"
 )
 
@@ -77,25 +79,50 @@ func NewSessionClient(session string) *Client {
 	return &Client{session: session}
 }
 
+func NewManagedSessionClient(session string) *Client {
+	client := NewManagedClient()
+	client.session = session
+	return client
+}
+
+func (c *Client) WorkerEnvironment() map[string]string {
+	result := make(map[string]string)
+	for _, item := range c.childEnv {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			result[key] = value
+		}
+	}
+	return result
+}
+
 // The harness-identity variables a pane must never inherit from the herdr server it is a child of
 // (atqamz/hand#109). A server inside a Claude Code session passes its own session identity
 // down, and CLAUDE_CODE_CHILD_SESSION disables the pane's transcript - a worker's only record.
 var sanitizedEnvKeys = []string{"CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDECODE"}
 
-// Blanking them at creation removes the failure for every pane hand creates, rather than depending
-// on the herdr server's own environment being clean.
-func sanitizedEnvArgs() []string {
-	args := make([]string, 0, len(sanitizedEnvKeys)*2)
+func (c *Client) childEnvArgs(extra map[string]string) []string {
+	values := make(map[string]string, len(sanitizedEnvKeys)+len(c.childEnv)+len(extra))
 	for _, key := range sanitizedEnvKeys {
-		args = append(args, "--env", key+"=")
+		values[key] = ""
 	}
-	return args
-}
-
-func (c *Client) childEnvArgs() []string {
-	args := sanitizedEnvArgs()
 	for _, item := range c.childEnv {
-		args = append(args, "--env", item)
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	for key, value := range extra {
+		values[key] = value
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	args := make([]string, 0, len(keys)*2)
+	for _, key := range keys {
+		args = append(args, "--env", key+"="+values[key])
 	}
 	return args
 }
@@ -340,7 +367,7 @@ func (c *Client) FindWorkspaceByLabel(label string) (Workspace, bool, error) {
 // WorkspaceCreate also returns the root tab and pane herdr creates at cwd as a side effect of
 // creating the workspace - herdr has no way to create an empty workspace - so a caller that
 // discards them leaves a live, unowned shell behind in the workspace.
-func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, Tab, Pane, error) {
+func (c *Client) WorkspaceCreate(cwd string, env map[string]string, label string) (Workspace, Tab, Pane, error) {
 	args := []string{"workspace", "create", "--no-focus"}
 	if cwd != "" {
 		args = append(args, "--cwd", cwd)
@@ -348,7 +375,7 @@ func (c *Client) WorkspaceCreate(cwd, label string) (Workspace, Tab, Pane, error
 	if label != "" {
 		args = append(args, "--label", label)
 	}
-	args = append(args, c.childEnvArgs()...)
+	args = append(args, c.childEnvArgs(env)...)
 	res, err := c.call(args...)
 	if err != nil {
 		return Workspace{}, Tab{}, Pane{}, err
@@ -400,7 +427,7 @@ func (c *Client) TabList(workspaceID string) ([]Tab, error) {
 	return body.Tabs, nil
 }
 
-func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
+func (c *Client) TabCreate(workspaceID, cwd string, env map[string]string, label string) (Tab, Pane, error) {
 	args := []string{"tab", "create", "--workspace", workspaceID, "--no-focus"}
 	if cwd != "" {
 		args = append(args, "--cwd", cwd)
@@ -408,7 +435,7 @@ func (c *Client) TabCreate(workspaceID, cwd, label string) (Tab, Pane, error) {
 	if label != "" {
 		args = append(args, "--label", label)
 	}
-	args = append(args, c.childEnvArgs()...)
+	args = append(args, c.childEnvArgs(env)...)
 	res, err := c.call(args...)
 	if err != nil {
 		return Tab{}, Pane{}, err
@@ -472,9 +499,50 @@ func (c *Client) paneGet(ctx context.Context, paneID string) (Pane, error) {
 	return body.Pane, nil
 }
 
-// PaneRun types command into the pane followed by Enter.
-func (c *Client) PaneRun(paneID, command string) error {
+func (c *Client) PaneProcessInfo(paneID string) (ProcessInfo, error) {
+	res, err := c.call("pane", "process-info", "--pane", paneID)
+	if err != nil {
+		return ProcessInfo{}, err
+	}
+	var body struct {
+		ProcessInfo ProcessInfo `json:"process_info"`
+	}
+	if err := json.Unmarshal(res, &body); err != nil {
+		return ProcessInfo{}, fmt.Errorf("parse pane process info: %w", err)
+	}
+	if body.ProcessInfo.PaneID == "" || body.ProcessInfo.PaneID != paneID || body.ProcessInfo.ShellPID <= 0 {
+		return ProcessInfo{}, fmt.Errorf("parse pane process info: missing or mismatched pane or shell pid")
+	}
+	return body.ProcessInfo, nil
+}
+
+func (c *Client) paneRun(paneID, command string) error {
 	return c.callVoid("pane", "run", paneID, command)
+}
+
+func (c *Client) PaneRunSpec(paneID string, spec launch.LaunchSpec) error {
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("validate launch spec: %w", err)
+	}
+	info, err := c.PaneProcessInfo(paneID)
+	if err != nil {
+		return fmt.Errorf("observe pane shell: %w", err)
+	}
+	shell, err := shellForProcess(info)
+	if err != nil {
+		return err
+	}
+	var command string
+	switch shell {
+	case shellPOSIX:
+		command, err = renderPOSIX(spec.Executable, spec.Args)
+	case shellPowerShell:
+		command, err = renderPowerShell(spec.Executable, spec.Args)
+	}
+	if err != nil {
+		return fmt.Errorf("render launch for %s: %w", shell, err)
+	}
+	return c.paneRun(paneID, command)
 }
 
 func (c *Client) PaneSendText(paneID, text string) error {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/launch"
 )
 
 func writeFakeHerdr(t *testing.T, responses ...faketool.HerdrResponse) {
@@ -83,7 +84,7 @@ func TestFindWorkspaceByLabelNotFound(t *testing.T) {
 func TestWorkspaceCreateParsesRootTabAndPane(t *testing.T) {
 	writeFakeHerdr(t, herdrResponse("workspace create", "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\",\"tab_count\":1},\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\",\"label\":\"1\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\",\"agent_status\":\"idle\"}}}"))
 	c := NewClient()
-	ws, tab, pane, err := c.WorkspaceCreate("/tmp/clone", "proj")
+	ws, tab, pane, err := c.WorkspaceCreate("/tmp/clone", nil, "proj")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +114,7 @@ func TestWorkspaceCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
 	}.Install(t, bin)
 
 	c := NewClient()
-	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err != nil {
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", nil, "proj"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,10 +129,31 @@ func TestWorkspaceCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCreateCarriesSortedStructuredEnvironmentWithCallerPrecedence(t *testing.T) {
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{
+		Command: "workspace create",
+		Args: []string{
+			"--no-focus", "--cwd", "/tmp/clone", "--label", "proj",
+			"--env", "CLAUDECODE=", "--env", "CLAUDE_CODE_CHILD_SESSION=", "--env", "CLAUDE_CODE_SESSION_ID=",
+			"--env", "CUSTOM=literal", "--env", "HAND_ROLE=worker", "--env", "PATH=/managed/bin",
+		},
+		Stdout: "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\"},\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\"}}}",
+	}}}.Install(t, bin)
+
+	if _, _, _, err := NewClient().WorkspaceCreate("/tmp/clone", map[string]string{
+		"CUSTOM":    "literal",
+		"HAND_ROLE": "worker",
+		"PATH":      "/managed/bin",
+	}, "proj"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWorkspaceCreateRejectsMissingRootTabOrPane(t *testing.T) {
 	writeFakeHerdr(t, herdrResponse("workspace create", "{\"id\":\"cli:1\",\"result\":{\"workspace\":{\"workspace_id\":\"wA\",\"label\":\"proj\"}}}"))
 	c := NewClient()
-	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", nil, "proj"); err == nil {
 		t.Fatal("expected an error when the response omits the root tab and pane")
 	}
 }
@@ -151,7 +173,7 @@ func TestWorkspaceCreateClosesWorkspaceOnPartialResponse(t *testing.T) {
 	}.Install(t, bin)
 
 	c := NewClient()
-	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", nil, "proj"); err == nil {
 		t.Fatal("expected an error when the response omits the root tab and pane")
 	}
 
@@ -179,7 +201,7 @@ func TestWorkspaceCreateClosesWorkspaceOnMalformedResponse(t *testing.T) {
 	}.Install(t, bin)
 
 	c := NewClient()
-	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", "proj"); err == nil {
+	if _, _, _, err := c.WorkspaceCreate("/tmp/clone", nil, "proj"); err == nil {
 		t.Fatal("expected an error when the response mistypes the tab field")
 	}
 
@@ -250,15 +272,110 @@ func TestCallRejectsNonObjectResult(t *testing.T) {
 func TestPaneRunSucceedsOnEmptyStdout(t *testing.T) {
 	writeFakeHerdr(t, herdrResponse("pane run", ""))
 	c := NewClient()
-	if err := c.PaneRun("wA:pB", "echo hi"); err != nil {
+	if err := c.paneRun("wA:pB", "echo hi"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPaneProcessInfoParsesShellEvidence(t *testing.T) {
+	writeFakeHerdr(t, herdrResponse("pane process-info", `{"id":"cli:1","result":{"process_info":{"pane_id":"wA:pB","shell_pid":42,"foreground_process_group_id":42,"foreground_processes":[{"pid":42,"name":"bash","argv":["bash","-l"],"argv0":"bash","cmdline":"bash -l","cwd":"/tmp/wt"}]}}}`))
+	info, err := NewClient().PaneProcessInfo("wA:pB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.PaneID != "wA:pB" || info.ShellPID != 42 || len(info.ForegroundProcesses) != 1 || info.ForegroundProcesses[0].Name != "bash" {
+		t.Fatalf("process info = %+v", info)
+	}
+}
+
+func TestPaneProcessInfoRejectsEvidenceForAnotherPane(t *testing.T) {
+	writeFakeHerdr(t, herdrResponse("pane process-info", `{"id":"cli:1","result":{"process_info":{"pane_id":"other-pane","shell_pid":42,"foreground_processes":[{"pid":42,"name":"bash"}]}}}`))
+	if _, err := NewClient().PaneProcessInfo("wA:pB"); err == nil || !strings.Contains(err.Error(), "mismatched pane") {
+		t.Fatalf("PaneProcessInfo() = %v, want mismatched pane error", err)
+	}
+}
+
+func TestPaneRunSpecDetectsPOSIXShellBeforeSubmission(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			herdrResponse("pane process-info", `{"id":"cli:1","result":{"process_info":{"pane_id":"wA:pB","shell_pid":42,"foreground_processes":[{"pid":42,"name":"bash"}]}}}`),
+			herdrResponse("pane run", ""),
+		},
+		Log: callLog,
+	}.Install(t, bin)
+	spec, err := launch.NewSpec(launch.LaunchSpec{Executable: "worker name", Args: []string{"$literal", "has spaces"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewClient().PaneRunSpec("wA:pB", spec); err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "pane process-info --pane wA:pB") || !strings.Contains(string(calls), `pane run wA:pB 'worker name' '$literal' 'has spaces'`) {
+		t.Fatalf("calls = %q, want process evidence before quoted run", calls)
+	}
+}
+
+func TestPaneRunSpecDetectsPowerShell(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			herdrResponse("pane process-info", `{"id":"cli:1","result":{"process_info":{"pane_id":"wA:pB","shell_pid":42,"foreground_processes":[{"pid":42,"name":"pwsh.exe"}]}}}`),
+			herdrResponse("pane run", ""),
+		},
+		Log: callLog,
+	}.Install(t, bin)
+	spec, err := launch.NewSpec(launch.LaunchSpec{Executable: "worker", Args: []string{"it's literal"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewClient().PaneRunSpec("wA:pB", spec); err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), `pane run wA:pB & 'worker' 'it''s literal'`) {
+		t.Fatalf("calls = %q, want PowerShell call operator and literal quoting", calls)
+	}
+}
+
+func TestPaneRunSpecFailsClosedForUnknownShell(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			herdrResponse("pane process-info", `{"id":"cli:1","result":{"process_info":{"pane_id":"wA:pB","shell_pid":42,"foreground_processes":[{"pid":42,"name":"cmd.exe"}]}}}`),
+		},
+		Log: callLog,
+	}.Install(t, bin)
+	spec, err := launch.NewSpec(launch.LaunchSpec{Executable: "worker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewClient().PaneRunSpec("wA:pB", spec); err == nil || !strings.Contains(err.Error(), "unsupported shell") {
+		t.Fatalf("PaneRunSpec() = %v, want unsupported shell error", err)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(calls), "pane run") {
+		t.Fatalf("calls = %q, want no pane run after unknown shell", calls)
 	}
 }
 
 func TestPaneRunSurfacesErrorEnvelopeEvenOnExitZero(t *testing.T) {
 	writeFakeHerdr(t, herdrResponse("pane run", "{\"id\":\"cli:1\",\"error\":{\"code\":\"pane_not_found\",\"message\":\"pane missing\"}}"))
 	c := NewClient()
-	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "pane missing") {
+	if err := c.paneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "pane missing") {
 		t.Fatalf("got err %v, want pane missing", err)
 	}
 }
@@ -330,7 +447,7 @@ func TestPaneSendKeysSucceedsOnEmptyStdout(t *testing.T) {
 func TestCallVoidFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane run", Stderr: "binary crashed\n", Exit: 1})
 	c := NewClient()
-	if err := c.PaneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "binary crashed") {
+	if err := c.paneRun("wA:pB", "echo hi"); err == nil || !strings.Contains(err.Error(), "binary crashed") {
 		t.Fatalf("got err %v, want binary crashed failure", err)
 	}
 }
@@ -338,7 +455,7 @@ func TestCallVoidFailsOnNonZeroExitWithNoStdout(t *testing.T) {
 func TestTabCreateParsesTabAndRootPane(t *testing.T) {
 	writeFakeHerdr(t, herdrResponse("tab create", "{\"id\":\"cli:1\",\"result\":{\"tab\":{\"tab_id\":\"wA:tB\",\"workspace_id\":\"wA\",\"label\":\"task\"},\"root_pane\":{\"pane_id\":\"wA:pC\",\"tab_id\":\"wA:tB\",\"agent_status\":\"idle\"}}}"))
 	c := NewClient()
-	tab, pane, err := c.TabCreate("wA", "/tmp/wt", "task")
+	tab, pane, err := c.TabCreate("wA", "/tmp/wt", nil, "task")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +479,7 @@ func TestTabCreateSanitizesInheritedHarnessMarkers(t *testing.T) {
 	}.Install(t, bin)
 
 	c := NewClient()
-	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err != nil {
+	if _, _, err := c.TabCreate("wA", "/tmp/wt", nil, "task"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -392,7 +509,7 @@ func TestTabCreateClosesTabOnPartialResponse(t *testing.T) {
 	}.Install(t, bin)
 
 	c := NewClient()
-	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err == nil {
+	if _, _, err := c.TabCreate("wA", "/tmp/wt", nil, "task"); err == nil {
 		t.Fatal("expected an error when the response omits the root pane")
 	}
 
@@ -420,7 +537,7 @@ func TestTabCreateClosesTabOnMalformedResponse(t *testing.T) {
 	}.Install(t, bin)
 
 	c := NewClient()
-	if _, _, err := c.TabCreate("wA", "/tmp/wt", "task"); err == nil {
+	if _, _, err := c.TabCreate("wA", "/tmp/wt", nil, "task"); err == nil {
 		t.Fatal("expected an error when the response mistypes the root pane field")
 	}
 
@@ -434,14 +551,14 @@ func TestTabCreateClosesTabOnMalformedResponse(t *testing.T) {
 }
 
 func TestPaneGetParsesAgentStatus(t *testing.T) {
-	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"))
+	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\",\"cwd\":\"/tmp/worktree\",\"foreground_cwd\":\"/tmp/worktree/worker\"}}}"))
 	c := NewClient()
 	pane, err := c.PaneGet("wA:pB")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pane.AgentStatus != StatusWorking {
-		t.Fatalf("got %q, want working", pane.AgentStatus)
+	if pane.AgentStatus != StatusWorking || pane.Cwd != "/tmp/worktree" || pane.ForegroundCwd != "/tmp/worktree/worker" {
+		t.Fatalf("got %+v, want status and cwd evidence", pane)
 	}
 }
 

--- a/internal/herdr/shell.go
+++ b/internal/herdr/shell.go
@@ -1,0 +1,42 @@
+package herdr
+
+import (
+	"fmt"
+	"strings"
+)
+
+type shellFamily string
+
+const (
+	shellPOSIX      shellFamily = "POSIX"
+	shellPowerShell shellFamily = "PowerShell"
+)
+
+func shellForProcess(info ProcessInfo) (shellFamily, error) {
+	if info.ShellPID <= 0 {
+		return "", fmt.Errorf("unknown shell: pane process info has no shell pid")
+	}
+	for _, process := range info.ForegroundProcesses {
+		if process.PID != info.ShellPID {
+			continue
+		}
+		name := process.Name
+		if name == "" {
+			name = process.Argv0
+		}
+		name = shellProcessBase(name)
+		switch name {
+		case "sh", "bash", "zsh":
+			return shellPOSIX, nil
+		case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
+			return shellPowerShell, nil
+		default:
+			return "", fmt.Errorf("unsupported shell %q", name)
+		}
+	}
+	return "", fmt.Errorf("unknown shell: shell pid %d has no matching foreground process", info.ShellPID)
+}
+
+func shellProcessBase(name string) string {
+	return strings.ToLower(processBase(name))
+}

--- a/internal/herdr/shell_posix.go
+++ b/internal/herdr/shell_posix.go
@@ -1,0 +1,46 @@
+package herdr
+
+import (
+	"fmt"
+	"unicode"
+
+	"github.com/atqamz/hand/internal/shellquote"
+)
+
+func renderPOSIX(executable string, args []string) (string, error) {
+	if err := validateShellValue("executable", executable); err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, shellquote.Quote(executable))
+	for i, arg := range args {
+		if err := validateShellValue(fmt.Sprintf("argument %d", i), arg); err != nil {
+			return "", err
+		}
+		parts = append(parts, shellquote.Quote(arg))
+	}
+	return joinShellParts(parts), nil
+}
+
+func validateShellValue(name, value string) error {
+	if value == "" && name == "executable" {
+		return fmt.Errorf("shell %s is empty", name)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("shell %s contains unsupported control character", name)
+		}
+	}
+	return nil
+}
+
+func joinShellParts(parts []string) string {
+	result := ""
+	for i, part := range parts {
+		if i > 0 {
+			result += " "
+		}
+		result += part
+	}
+	return result
+}

--- a/internal/herdr/shell_powershell.go
+++ b/internal/herdr/shell_powershell.go
@@ -1,0 +1,25 @@
+package herdr
+
+import (
+	"fmt"
+	"strings"
+)
+
+func renderPowerShell(executable string, args []string) (string, error) {
+	if err := validateShellValue("executable", executable); err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(args)+2)
+	parts = append(parts, "&", powerShellQuote(executable))
+	for i, arg := range args {
+		if err := validateShellValue(fmt.Sprintf("argument %d", i), arg); err != nil {
+			return "", err
+		}
+		parts = append(parts, powerShellQuote(arg))
+	}
+	return joinShellParts(parts), nil
+}
+
+func powerShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/internal/herdr/shell_test.go
+++ b/internal/herdr/shell_test.go
@@ -1,0 +1,127 @@
+package herdr
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderPOSIXPreservesLiteralArguments(t *testing.T) {
+	got, err := renderPOSIX("worker name", []string{"spaces and 'quotes'", "$HOME; echo unsafe", "--leading", "日本語"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `'worker name' 'spaces and '\''quotes'\''' '$HOME; echo unsafe' '--leading' '日本語'`
+	if got != want {
+		t.Fatalf("renderPOSIX() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderPowerShellPreservesLiteralArguments(t *testing.T) {
+	got, err := renderPowerShell("worker name", []string{"spaces and 'quotes'", "$HOME; echo unsafe", "--leading", "日本語"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `& 'worker name' 'spaces and ''quotes''' '$HOME; echo unsafe' '--leading' '日本語'`
+	if got != want {
+		t.Fatalf("renderPowerShell() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderersRejectControlCharacters(t *testing.T) {
+	for _, render := range []struct {
+		name string
+		fn   func(string, []string) (string, error)
+	}{
+		{name: "posix", fn: renderPOSIX},
+		{name: "powershell", fn: renderPowerShell},
+	} {
+		t.Run(render.name, func(t *testing.T) {
+			for _, input := range []struct {
+				name string
+				exec string
+				args []string
+			}{
+				{name: "executable", exec: "worker\n"},
+				{name: "argument", exec: "worker", args: []string{"value\x00"}},
+			} {
+				t.Run(input.name, func(t *testing.T) {
+					if _, err := render.fn(input.exec, input.args); err == nil {
+						t.Fatal("renderer accepted a control character")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestRenderersDoNotRenderCwdOrEnvironment(t *testing.T) {
+	for _, render := range []struct {
+		name string
+		fn   func(string, []string) (string, error)
+	}{
+		{name: "posix", fn: renderPOSIX},
+		{name: "powershell", fn: renderPowerShell},
+	} {
+		got, err := render.fn("worker", []string{"arg"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(got, "HAND_HOME") || strings.Contains(got, "PATH=") || strings.Contains(got, "cwd") {
+			t.Fatalf("%s renderer included transport metadata: %q", render.name, got)
+		}
+	}
+}
+
+func TestShellForProcessRequiresAuthoritativeShellEvidence(t *testing.T) {
+	tests := []struct {
+		name string
+		info ProcessInfo
+		want shellFamily
+		fail string
+	}{
+		{
+			name: "posix basename",
+			info: ProcessInfo{ShellPID: 7, ForegroundProcesses: []Process{{PID: 7, Name: "/bin/bash"}}},
+			want: shellPOSIX,
+		},
+		{
+			name: "login shell",
+			info: ProcessInfo{ShellPID: 7, ForegroundProcesses: []Process{{PID: 7, Name: "-zsh"}}},
+			want: shellPOSIX,
+		},
+		{
+			name: "powershell argv0 fallback",
+			info: ProcessInfo{ShellPID: 7, ForegroundProcesses: []Process{{PID: 7, Argv0: `C:\\Windows\\System32\\pwsh.exe`}}},
+			want: shellPowerShell,
+		},
+		{
+			name: "missing shell pid",
+			info: ProcessInfo{ForegroundProcesses: []Process{{PID: 7, Name: "bash"}}},
+			fail: "no shell pid",
+		},
+		{
+			name: "shell pid not observed",
+			info: ProcessInfo{ShellPID: 8, ForegroundProcesses: []Process{{PID: 7, Name: "bash"}}},
+			fail: "no matching foreground process",
+		},
+		{
+			name: "unsupported shell",
+			info: ProcessInfo{ShellPID: 7, ForegroundProcesses: []Process{{PID: 7, Name: "cmd.exe"}}},
+			fail: "unsupported shell",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := shellForProcess(test.info)
+			if test.fail != "" {
+				if err == nil || !strings.Contains(err.Error(), test.fail) {
+					t.Fatalf("shellForProcess() = %v, want error containing %q", err, test.fail)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("shellForProcess() = %q, %v, want %q", got, err, test.want)
+			}
+		})
+	}
+}

--- a/internal/herdr/types.go
+++ b/internal/herdr/types.go
@@ -2,6 +2,11 @@
 // client.go and internal/faketool/FIDELITY.md own the calls and observed shapes.
 package herdr
 
+import (
+	"path/filepath"
+	"strings"
+)
+
 // Status is herdr's agent_status value for a pane. The real vocabulary has five values, not four:
 // idle, working, blocked, done, unknown - and idle and done are one signal, "the pane stopped
 // being busy", which NotBusy is the way to test for.
@@ -37,13 +42,50 @@ type Tab struct {
 	Label       string `json:"label"`
 }
 
+type Process struct {
+	PID     int      `json:"pid"`
+	Name    string   `json:"name"`
+	Argv    []string `json:"argv"`
+	Argv0   string   `json:"argv0"`
+	Cmdline string   `json:"cmdline"`
+	Cwd     string   `json:"cwd"`
+}
+
+type ProcessInfo struct {
+	PaneID                   string    `json:"pane_id"`
+	ShellPID                 int       `json:"shell_pid"`
+	ForegroundProcessGroupID int       `json:"foreground_process_group_id"`
+	TTY                      string    `json:"tty"`
+	ForegroundProcesses      []Process `json:"foreground_processes"`
+}
+
+func (p ProcessInfo) HasExecutable(executable string) bool {
+	executable = processBase(executable)
+	for _, process := range p.ForegroundProcesses {
+		if len(process.Argv) > 0 && processBase(process.Argv[0]) == executable {
+			return true
+		}
+		if processBase(process.Name) == executable || processBase(process.Argv0) == executable {
+			return true
+		}
+	}
+	return false
+}
+
+func processBase(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	return strings.TrimPrefix(filepath.Base(value), "-")
+}
+
 // Agent names the harness herdr detects in the pane, empty when the pane holds no agent - a bare
 // shell, or one whose harness exited. AgentStatus is "unknown" then, but also for a pane herdr has
 // not classified yet, so Agent is the field to test for a running harness.
 type Pane struct {
-	PaneID      string `json:"pane_id"`
-	TabID       string `json:"tab_id"`
-	WorkspaceID string `json:"workspace_id"`
-	Agent       string `json:"agent"`
-	AgentStatus Status `json:"agent_status"`
+	PaneID        string `json:"pane_id"`
+	TabID         string `json:"tab_id"`
+	WorkspaceID   string `json:"workspace_id"`
+	Agent         string `json:"agent"`
+	AgentStatus   Status `json:"agent_status"`
+	Cwd           string `json:"cwd"`
+	ForegroundCwd string `json:"foreground_cwd"`
 }

--- a/internal/herdr/types.go
+++ b/internal/herdr/types.go
@@ -74,7 +74,11 @@ func (p ProcessInfo) HasExecutable(executable string) bool {
 
 func processBase(value string) string {
 	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
-	return strings.TrimPrefix(filepath.Base(value), "-")
+	value = strings.TrimPrefix(filepath.Base(value), "-")
+	if len(value) >= len(".exe") && strings.EqualFold(value[len(value)-len(".exe"):], ".exe") {
+		value = value[:len(value)-len(".exe")]
+	}
+	return value
 }
 
 // Agent names the harness herdr detects in the pane, empty when the pane holds no agent - a bare

--- a/internal/herdr/types_test.go
+++ b/internal/herdr/types_test.go
@@ -1,0 +1,14 @@
+package herdr
+
+import "testing"
+
+func TestProcessInfoHasExecutableNormalizesWindowsSuffix(t *testing.T) {
+	info := ProcessInfo{ForegroundProcesses: []Process{{
+		Name:  "claude.exe",
+		Argv0: `C:\Program Files\Claude\claude.exe`,
+	}}}
+
+	if !info.HasExecutable("claude") {
+		t.Fatal("HasExecutable() = false, want true for extensionless executable")
+	}
+}

--- a/internal/launch/spec.go
+++ b/internal/launch/spec.go
@@ -1,0 +1,111 @@
+// Package launch defines the transport-neutral process data used to start a worker.
+package launch
+
+import (
+	"fmt"
+	"unicode"
+)
+
+// LaunchSpec describes one executable invocation without embedding shell syntax or lifecycle data.
+type LaunchSpec struct {
+	Executable string
+	Args       []string
+	Env        map[string]string
+	Cwd        string
+}
+
+// NewSpec validates and copies a launch description so callers can safely reuse their input buffers.
+func NewSpec(spec LaunchSpec) (LaunchSpec, error) {
+	if err := spec.Validate(); err != nil {
+		return LaunchSpec{}, err
+	}
+	return spec.Clone(), nil
+}
+
+// Validate rejects data that cannot be carried safely through process and Herdr argument boundaries.
+func (s LaunchSpec) Validate() error {
+	if s.Executable == "" {
+		return fmt.Errorf("launch executable is empty")
+	}
+	if err := validateText("executable", s.Executable); err != nil {
+		return err
+	}
+	if err := validateText("cwd", s.Cwd); err != nil {
+		return err
+	}
+	for i, arg := range s.Args {
+		if err := validateText(fmt.Sprintf("argument %d", i), arg); err != nil {
+			return err
+		}
+	}
+	for key, value := range s.Env {
+		if !validEnvKey(key) {
+			return fmt.Errorf("invalid launch environment key %q", key)
+		}
+		if err := validateText("environment value for "+key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Clone returns an independent copy of the launch description.
+func (s LaunchSpec) Clone() LaunchSpec {
+	clone := LaunchSpec{
+		Executable: s.Executable,
+		Cwd:        s.Cwd,
+		Args:       append([]string(nil), s.Args...),
+	}
+	if s.Env != nil {
+		clone.Env = make(map[string]string, len(s.Env))
+		for key, value := range s.Env {
+			clone.Env[key] = value
+		}
+	}
+	return clone
+}
+
+// MergeEnv applies overlays in order, with later layers taking precedence.
+func (s LaunchSpec) MergeEnv(overlays ...map[string]string) (LaunchSpec, error) {
+	merged := s.Clone()
+	if merged.Env == nil && len(overlays) > 0 {
+		merged.Env = make(map[string]string)
+	}
+	for _, overlay := range overlays {
+		for key, value := range overlay {
+			merged.Env[key] = value
+		}
+	}
+	return NewSpec(merged)
+}
+
+func validateText(name, value string) error {
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("launch %s contains unsupported control character", name)
+		}
+	}
+	return nil
+}
+
+func validEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		if i == 0 {
+			if !isEnvLetter(r) && r != '_' {
+				return false
+			}
+			continue
+		}
+		if !isEnvLetter(r) && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func isEnvLetter(r rune) bool {
+	return r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z'
+}

--- a/internal/launch/spec_test.go
+++ b/internal/launch/spec_test.go
@@ -1,0 +1,82 @@
+package launch
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewSpecRejectsUnsafeFields(t *testing.T) {
+	tests := []struct {
+		name string
+		spec LaunchSpec
+	}{
+		{name: "empty executable", spec: LaunchSpec{Args: []string{"--help"}}},
+		{name: "empty environment key", spec: LaunchSpec{Executable: "worker", Env: map[string]string{"": "value"}}},
+		{name: "equals in environment key", spec: LaunchSpec{Executable: "worker", Env: map[string]string{"BAD=KEY": "value"}}},
+		{name: "control in executable", spec: LaunchSpec{Executable: "worker\n", Env: map[string]string{}}},
+		{name: "control in environment value", spec: LaunchSpec{Executable: "worker", Env: map[string]string{"KEY": "value\x00"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := NewSpec(test.spec); err == nil {
+				t.Fatal("NewSpec accepted unsafe launch data")
+			}
+		})
+	}
+}
+
+func TestNewSpecDefensivelyCopiesInput(t *testing.T) {
+	args := []string{"--prompt", "literal"}
+	env := map[string]string{"WORKER_FLAG": "one"}
+	spec, err := NewSpec(LaunchSpec{Executable: "worker", Args: args, Env: env, Cwd: "/tmp/worktree"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args[1] = "changed"
+	env["WORKER_FLAG"] = "changed"
+	if spec.Args[1] != "literal" || spec.Env["WORKER_FLAG"] != "one" {
+		t.Fatalf("spec retained mutable input: %+v", spec)
+	}
+}
+
+func TestCloneDefensivelyCopiesSpec(t *testing.T) {
+	spec, err := NewSpec(LaunchSpec{Executable: "worker", Args: []string{"arg"}, Env: map[string]string{"KEY": "value"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clone := spec.Clone()
+	clone.Args[0] = "changed"
+	clone.Env["KEY"] = "changed"
+	if spec.Args[0] != "arg" || spec.Env["KEY"] != "value" {
+		t.Fatalf("clone shares mutable data: original=%+v clone=%+v", spec, clone)
+	}
+}
+
+func TestMergeEnvUsesExplicitLaterLayerPrecedence(t *testing.T) {
+	spec, err := NewSpec(LaunchSpec{
+		Executable: "worker",
+		Env:        map[string]string{"SHARED": "harness", "HARNESS": "yes"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, err := spec.MergeEnv(
+		map[string]string{"SHARED": "hand", "HAND_ROLE": "worker"},
+		map[string]string{"PATH": "/managed/bin", "SHARED": "managed"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := LaunchSpec{
+		Executable: "worker",
+		Env:        map[string]string{"SHARED": "managed", "HARNESS": "yes", "HAND_ROLE": "worker", "PATH": "/managed/bin"},
+	}
+	if !reflect.DeepEqual(merged, want) {
+		t.Fatalf("merged = %+v, want %+v", merged, want)
+	}
+	if strings.Contains(spec.Env["SHARED"], "managed") {
+		t.Fatal("MergeEnv mutated the source spec")
+	}
+}

--- a/internal/runtime/execution_plan_test.go
+++ b/internal/runtime/execution_plan_test.go
@@ -764,9 +764,9 @@ func executionPlanRuntime(t *testing.T, calls *executionPlanCalls, base func(str
 		calls.worktreeReturns++
 		return nil
 	}
-	r.deps.buildHarness = func(string, harness.Options) (string, error) {
+	r.deps.buildHarness = func(string, harness.Options) (launchSpec, error) {
 		calls.harnessBuilds++
-		return "launch", nil
+		return launchSpec{Executable: "launch"}, nil
 	}
 	return r
 }

--- a/internal/runtime/launch.go
+++ b/internal/runtime/launch.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/launch"
 )
 
 type launchPoll struct {
@@ -37,7 +38,7 @@ func ConfigureLaunchPollingForTest(interval, timeout, keySettle time.Duration, q
 
 func SetLaunchTimeoutForTest(timeout time.Duration) { launchPolling.Timeout = timeout }
 
-func confirmLaunch(client herdrClient, paneID, harnessName string) error {
+func confirmLaunch(client herdrClient, paneID, harnessName string, spec launch.LaunchSpec) error {
 	prompts := harness.FirstRunPromptsFor(harnessName)
 	deadline := time.Now().Add(launchPolling.Timeout)
 	quiet := 0
@@ -51,6 +52,11 @@ func confirmLaunch(client herdrClient, paneID, harnessName string) error {
 	var stall string
 
 	for {
+		processInfo, err := client.PaneProcessInfo(paneID)
+		if err != nil {
+			return fmt.Errorf("observe worker process: %w", err)
+		}
+		processPresent := processInfo.HasExecutable(spec.Executable)
 		pane, err := client.PaneGet(paneID)
 		if err != nil {
 			return err
@@ -60,10 +66,10 @@ func confirmLaunch(client herdrClient, paneID, harnessName string) error {
 			return err
 		}
 
-		sawAgent = sawAgent || pane.Agent != ""
+		sawAgent = sawAgent || pane.Agent != "" || processPresent
 		prompt, known := matchFirstRunPrompt(prompts.Known, text)
 		switch {
-		case pane.Agent == "":
+		case !processPresent:
 			quiet = 0
 			switch {
 			case (known || len(answered) > 0) && (sawAgent || detected):

--- a/internal/runtime/launch_test.go
+++ b/internal/runtime/launch_test.go
@@ -210,7 +210,7 @@ func TestConfirmLaunch(t *testing.T) {
 			}
 			keyLog := fakeLaunchPane(t, tt.frames...)
 
-			err := confirmLaunch(herdr.NewClient(), "wA:pC", tt.harness)
+			err := confirmLaunch(herdr.NewClient(), "wA:pC", tt.harness, launchSpec{Executable: tt.harness})
 			switch {
 			case tt.wantErr == "" && err != nil:
 				t.Fatalf("confirmLaunch() = %v, want success", err)

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -10,11 +10,14 @@ import (
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/launch"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
 )
 
 type lifecyclePhase string
+
+type launchSpec = launch.LaunchSpec
 
 const (
 	phaseAttemptCreated        lifecyclePhase = "attempt-created"
@@ -46,8 +49,8 @@ type dependencies struct {
 	herdrFor          func(string) herdrClient
 	worktree          worktreeDependencies
 	projectBaseCommit func(string) (string, error)
-	buildHarness      func(string, harness.Options) (string, error)
-	confirmLaunch     func(herdrClient, string, string) error
+	buildHarness      func(string, harness.Options) (launch.LaunchSpec, error)
+	confirmLaunch     func(herdrClient, string, string, launch.LaunchSpec) error
 	appendCompletion  func(string, completion.Record) error
 	prMerged          func(context.Context, string) ghutil.PRObservation
 	prHead            func(context.Context, string) ghutil.PRObservation
@@ -165,6 +168,14 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		}
 	}
 
+	workerSpec, err := r.deps.buildHarness(req.attempt.Harness, harness.Options{
+		Worktree: worktreePath, Brief: req.briefPath, Model: req.attempt.Model, Effort: req.attempt.Effort,
+		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter,
+	})
+	if err != nil {
+		return "", r.failProvision(req, lease, nil, false, err)
+	}
+
 	session := req.attempt.Herdr.Session
 	if session == "" {
 		fleetID, err := state.FleetID(req.home)
@@ -174,7 +185,11 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		session = herdr.SessionName(fleetID)
 	}
 	client := r.herdrClient(session)
-	workspace, tab, pane, rollback, err := acquireTaskWorkspace(client, worktreePath, req.attempt.TaskID, req.projectName, session)
+	workerSpec, err = composeWorkerSpec(workerSpec, req.home, herdrWorkerEnvironment(client))
+	if err != nil {
+		return "", r.failProvision(req, lease, nil, false, err)
+	}
+	workspace, tab, pane, rollback, err := acquireTaskWorkspace(client, workerSpec.Cwd, workerSpec.Env, req.attempt.TaskID, req.projectName, session)
 	if err != nil {
 		return "", r.failProvision(req, lease, nil, false, err)
 	}
@@ -197,14 +212,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		return fail(err)
 	}
 
-	launchCommand, err := r.deps.buildHarness(req.attempt.Harness, harness.Options{
-		Worktree: worktreePath, Brief: req.briefPath, FleetHome: req.home, Model: req.attempt.Model, Effort: req.attempt.Effort,
-		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter,
-	})
-	if err != nil {
-		return fail(err)
-	}
-	if err := client.PaneRun(pane.PaneID, launchCommand); err != nil {
+	if err := client.PaneRunSpec(pane.PaneID, workerSpec); err != nil {
 		return fail(fmt.Errorf("send launch command failed: %w", err))
 	}
 	if err := state.MarkLaunchSubmitted(req.home, req.attempt.TaskID, req.attempt.ID, r.deps.now().Format(time.RFC3339)); err != nil {
@@ -214,7 +222,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		return fail(err)
 	}
 
-	if err := r.deps.confirmLaunch(client, pane.PaneID, req.attempt.Harness); err != nil {
+	if err := r.deps.confirmLaunch(client, pane.PaneID, req.attempt.Harness, workerSpec); err != nil {
 		return fail(fmt.Errorf("confirm worker started: %w", err))
 	}
 	if err := state.MarkLaunchConfirmed(req.home, req.attempt.TaskID, req.attempt.ID, r.deps.now().Format(time.RFC3339)); err != nil {
@@ -227,6 +235,19 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		return fail(fmt.Errorf("record running attempt: %w", err))
 	}
 	return worktreePath, nil
+}
+
+func composeWorkerSpec(spec launch.LaunchSpec, home string, managed map[string]string) (launch.LaunchSpec, error) {
+	if _, found := managed[harness.RoleEnv]; found {
+		return launch.LaunchSpec{}, fmt.Errorf("managed worker environment cannot override %s", harness.RoleEnv)
+	}
+	if _, found := managed[harness.HomeEnv]; found {
+		return launch.LaunchSpec{}, fmt.Errorf("managed worker environment cannot override %s", harness.HomeEnv)
+	}
+	return spec.MergeEnv(map[string]string{
+		harness.RoleEnv: harness.WorkerRole,
+		harness.HomeEnv: home,
+	}, managed)
 }
 
 func (r *Runtime) afterPhase(phase lifecyclePhase) error { return r.deps.phase(phase) }

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -72,7 +72,8 @@ func TestProvisionFailureAfterWorktreeRecordClearsOnlyReturnedEvidence(t *testin
 func TestProvisionUsesFleetScopedTreehouseLeaseHolder(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	var holder string
-	r := testProvisionRuntime(&provisionHerdr{}, func(lifecyclePhase) error { return nil })
+	fake := &provisionHerdr{}
+	r := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
 	r.deps.worktree.get = func(path, gotHolder string) (worktree.Lease, error) {
 		holder = gotHolder
 		return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
@@ -86,6 +87,13 @@ func TestProvisionUsesFleetScopedTreehouseLeaseHolder(t *testing.T) {
 	}
 	if !strings.HasPrefix(holder, "hand:f_") || !strings.HasSuffix(holder, ":task-1") {
 		t.Fatalf("Treehouse lease holder = %q, want hand:f_<identity>:task-1", holder)
+	}
+	wantWorktree := filepath.Join(home, "projects", "demo", "leased")
+	if fake.tabCwd != wantWorktree || fake.tabEnv[harness.RoleEnv] != harness.WorkerRole || fake.tabEnv[harness.HomeEnv] != home {
+		t.Fatalf("Herdr tab transport = cwd %q env %#v, want worktree cwd and worker identity", fake.tabCwd, fake.tabEnv)
+	}
+	if fake.submitted.Cwd != wantWorktree || fake.submitted.Executable != "launch" {
+		t.Fatalf("submitted launch spec = %+v, want structured worktree and executable", fake.submitted)
 	}
 }
 
@@ -216,6 +224,28 @@ func TestProvisionFailureAfterLaunchSubmissionKeepsSubmissionEvidence(t *testing
 	}
 }
 
+func TestProvisionPaneRunFailureDoesNotRecordSubmission(t *testing.T) {
+	home, attempt := provisioningFixture(t)
+	fake := &provisionHerdr{runErr: errors.New("unsupported shell")}
+	runtime := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
+
+	_, err := runtime.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt,
+	})
+	if err == nil || !strings.Contains(err.Error(), "send launch command failed: unsupported shell") {
+		t.Fatalf("provision() = %v, want pre-submission transport failure", err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := *history.ActiveAttempt
+	if got.LaunchSubmittedAt != "" || got.LaunchConfirmedAt != "" {
+		t.Fatalf("attempt after transport failure = %+v, want no launch timestamps", got)
+	}
+}
+
 func TestProvisionFailureAfterLaunchConfirmationKeepsConfirmationEvidence(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	phaseErr := errors.New("stop after launch confirmation")
@@ -244,6 +274,51 @@ func TestProvisionFailureAfterLaunchConfirmationKeepsConfirmationEvidence(t *tes
 	}
 }
 
+func TestComposeWorkerSpecUsesProtectedPrecedence(t *testing.T) {
+	spec := launchSpec{
+		Executable: "worker",
+		Args:       []string{"--literal"},
+		Cwd:        "/tmp/worktree",
+		Env: map[string]string{
+			"PATH":      "/harness/bin",
+			"HAND_HOME": "harness-home",
+		},
+	}
+	got, err := composeWorkerSpec(spec, "/fleet", map[string]string{
+		"PATH":   "/managed/bin",
+		"CUSTOM": "managed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cwd != spec.Cwd || got.Executable != spec.Executable || strings.Join(got.Args, "\x00") != strings.Join(spec.Args, "\x00") {
+		t.Fatalf("composed launch identity changed: got=%+v want=%+v", got, spec)
+	}
+	want := map[string]string{
+		"PATH":      "/managed/bin",
+		"HAND_HOME": "/fleet",
+		"HAND_ROLE": "worker",
+		"CUSTOM":    "managed",
+	}
+	if len(got.Env) != len(want) {
+		t.Fatalf("composed environment = %#v, want %#v", got.Env, want)
+	}
+	for key, value := range want {
+		if got.Env[key] != value {
+			t.Fatalf("composed environment[%q] = %q, want %q", key, got.Env[key], value)
+		}
+	}
+}
+
+func TestComposeWorkerSpecRejectsManagedIdentityOverride(t *testing.T) {
+	for _, key := range []string{harness.RoleEnv, harness.HomeEnv} {
+		_, err := composeWorkerSpec(launchSpec{Executable: "worker"}, "/fleet", map[string]string{key: "override"})
+		if err == nil || !strings.Contains(err.Error(), "cannot override "+key) {
+			t.Fatalf("composeWorkerSpec managed %s = %v, want protected identity error", key, err)
+		}
+	}
+}
+
 type provisionHerdr struct {
 	closedWorkspace  string
 	createdWorkspace bool
@@ -251,6 +326,12 @@ type provisionHerdr struct {
 	tabCloseErr      error
 	tabs             []herdr.Tab
 	paneStatus       herdr.Status
+	runErr           error
+	workspaceCwd     string
+	workspaceEnv     map[string]string
+	tabCwd           string
+	tabEnv           map[string]string
+	submitted        launchSpec
 }
 
 func (f *provisionHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
@@ -259,8 +340,9 @@ func (f *provisionHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, er
 
 func (f *provisionHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
 
-func (f *provisionHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+func (f *provisionHerdr) WorkspaceCreate(cwd string, env map[string]string, _ string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
 	f.createdWorkspace = true
+	f.workspaceCwd, f.workspaceEnv = cwd, env
 	return herdr.Workspace{WorkspaceID: "ws-1"}, herdr.Tab{TabID: "tab-1"}, herdr.Pane{PaneID: "pane-1"}, nil
 }
 
@@ -273,7 +355,8 @@ func (f *provisionHerdr) TabList(string) ([]herdr.Tab, error) {
 	return []herdr.Tab{{TabID: "tab-1"}}, nil
 }
 
-func (f *provisionHerdr) TabCreate(string, string, string) (herdr.Tab, herdr.Pane, error) {
+func (f *provisionHerdr) TabCreate(_ string, cwd string, env map[string]string, _ string) (herdr.Tab, herdr.Pane, error) {
+	f.tabCwd, f.tabEnv = cwd, env
 	return herdr.Tab{TabID: "tab-1"}, herdr.Pane{PaneID: "pane-1"}, nil
 }
 
@@ -290,6 +373,15 @@ func (f *provisionHerdr) PaneGet(string) (herdr.Pane, error) {
 		status = herdr.StatusDone
 	}
 	return herdr.Pane{PaneID: "pane-1", Agent: "claude", AgentStatus: status}, nil
+}
+
+func (f *provisionHerdr) PaneProcessInfo(string) (herdr.ProcessInfo, error) {
+	return herdr.ProcessInfo{ShellPID: 1, ForegroundProcesses: []herdr.Process{{PID: 1, Name: "bash"}}}, nil
+}
+
+func (f *provisionHerdr) PaneRunSpec(_ string, spec launchSpec) error {
+	f.submitted = spec
+	return f.runErr
 }
 
 func (f *provisionHerdr) PaneRun(string, string) error { return nil }
@@ -312,8 +404,10 @@ func testProvisionRuntime(client herdrClient, phase func(lifecyclePhase) error) 
 			returnWorktree: func(string, bool) error { return nil },
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },
 		},
-		buildHarness:     func(string, harness.Options) (string, error) { return "launch", nil },
-		confirmLaunch:    func(herdrClient, string, string) error { return nil },
+		buildHarness: func(_ string, opts harness.Options) (launchSpec, error) {
+			return launchSpec{Executable: "launch", Cwd: opts.Worktree}, nil
+		},
+		confirmLaunch:    func(herdrClient, string, string, launchSpec) error { return nil },
 		phase:            phase,
 		appendCompletion: completion.Append,
 	}}

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
@@ -1297,7 +1298,19 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 		})
 		return err
 	case reconciliationActionConfirmLaunch:
-		if err := r.deps.confirmLaunch(r.herdrClient(attempt.Herdr.Session), attempt.Herdr.PaneID, attempt.Harness); err != nil {
+		briefPath := filepath.Join(home, task.Brief)
+		_, hasFrontMatter, err := brief.Parse(briefPath)
+		if err != nil {
+			return fmt.Errorf("parse persisted brief for launch confirmation: %w", err)
+		}
+		spec, err := r.deps.buildHarness(attempt.Harness, harness.Options{
+			Worktree: attempt.Worktree, Brief: briefPath, Model: attempt.Model, Effort: attempt.Effort,
+			ExecutionClass: brief.ExecutionClass(attempt.ExecutionClass), BriefHasFrontMatter: hasFrontMatter,
+		})
+		if err != nil {
+			return fmt.Errorf("build persisted launch evidence: %w", err)
+		}
+		if err := r.deps.confirmLaunch(r.herdrClient(attempt.Herdr.Session), attempt.Herdr.PaneID, attempt.Harness, spec); err != nil {
 			return fmt.Errorf("confirm persisted launch: %w", err)
 		}
 		return state.MarkLaunchConfirmed(home, task.ID, attempt.ID, r.deps.now().Format(time.RFC3339))

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -227,18 +227,22 @@ func (f *reconcileHerdrClient) FindWorkspaceByLabel(string) (herdr.Workspace, bo
 	return f.workspace, f.workspace.WorkspaceID != "", nil
 }
 func (f *reconcileHerdrClient) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
-func (f *reconcileHerdrClient) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+func (f *reconcileHerdrClient) WorkspaceCreate(string, map[string]string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
 	return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, errors.New("unused")
 }
 func (f *reconcileHerdrClient) WorkspaceClose(string) error         { return errors.New("unused") }
 func (f *reconcileHerdrClient) TabList(string) ([]herdr.Tab, error) { return f.tabs, nil }
-func (f *reconcileHerdrClient) TabCreate(string, string, string) (herdr.Tab, herdr.Pane, error) {
+func (f *reconcileHerdrClient) TabCreate(string, string, map[string]string, string) (herdr.Tab, herdr.Pane, error) {
 	return herdr.Tab{}, herdr.Pane{}, errors.New("unused")
 }
-func (f *reconcileHerdrClient) TabRename(string, string) error       { return errors.New("unused") }
-func (f *reconcileHerdrClient) TabClose(string) error                { return errors.New("unused") }
-func (f *reconcileHerdrClient) PaneGet(string) (herdr.Pane, error)   { return f.pane, nil }
-func (f *reconcileHerdrClient) PaneRun(string, string) error         { return errors.New("unused") }
+func (f *reconcileHerdrClient) TabRename(string, string) error     { return errors.New("unused") }
+func (f *reconcileHerdrClient) TabClose(string) error              { return errors.New("unused") }
+func (f *reconcileHerdrClient) PaneGet(string) (herdr.Pane, error) { return f.pane, nil }
+func (f *reconcileHerdrClient) PaneRun(string, string) error       { return errors.New("unused") }
+func (f *reconcileHerdrClient) PaneProcessInfo(string) (herdr.ProcessInfo, error) {
+	return herdr.ProcessInfo{ShellPID: 1, ForegroundProcesses: []herdr.Process{{PID: 1, Name: "bash"}}}, nil
+}
+func (f *reconcileHerdrClient) PaneRunSpec(string, launchSpec) error { return errors.New("unused") }
 func (f *reconcileHerdrClient) PaneSendKeys(string, ...string) error { return errors.New("unused") }
 func (f *reconcileHerdrClient) PaneRead(string, int) (string, error) { return "", errors.New("unused") }
 
@@ -299,9 +303,9 @@ func TestReconcileNeverReroutesAnExistingAttempt(t *testing.T) {
 	var gotHarness string
 	var got harness.Options
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.buildHarness = func(name string, options harness.Options) (string, error) {
+	r.deps.buildHarness = func(name string, options harness.Options) (launchSpec, error) {
 		gotHarness, got = name, options
-		return "launch", nil
+		return launchSpec{Executable: "launch"}, nil
 	}
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
@@ -2153,8 +2157,8 @@ func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lea
 			returnWorktree: func(string, bool) error { return nil },
 			returnWithID:   func(string, string, bool) error { return nil },
 		},
-		buildHarness:     func(string, harness.Options) (string, error) { return "launch", nil },
-		confirmLaunch:    func(herdrClient, string, string) error { return nil },
+		buildHarness:     func(string, harness.Options) (launchSpec, error) { return launchSpec{Executable: "launch"}, nil },
+		confirmLaunch:    func(herdrClient, string, string, launchSpec) error { return nil },
 		appendCompletion: completion.Append,
 		phase:            func(lifecyclePhase) error { return nil },
 	}}
@@ -2244,14 +2248,14 @@ func (f *healthyReconcileHerdr) FindWorkspaceByLabel(label string) (herdr.Worksp
 	return herdr.Workspace{WorkspaceID: "ws-1", Label: label}, true, nil
 }
 func (f *healthyReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
-func (f *healthyReconcileHerdr) WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+func (f *healthyReconcileHerdr) WorkspaceCreate(string, map[string]string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
 	return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, errors.New("unused")
 }
 func (f *healthyReconcileHerdr) WorkspaceClose(string) error { f.closed++; return nil }
 func (f *healthyReconcileHerdr) TabList(string) ([]herdr.Tab, error) {
 	return []herdr.Tab{{TabID: "tab-1", WorkspaceID: "ws-1", Label: "task-1"}}, nil
 }
-func (f *healthyReconcileHerdr) TabCreate(string, string, string) (herdr.Tab, herdr.Pane, error) {
+func (f *healthyReconcileHerdr) TabCreate(string, string, map[string]string, string) (herdr.Tab, herdr.Pane, error) {
 	return herdr.Tab{TabID: "tab-1", WorkspaceID: "ws-1", Label: "task-1"}, herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1"}, nil
 }
 func (f *healthyReconcileHerdr) TabRename(string, string) error { return nil }
@@ -2259,6 +2263,10 @@ func (f *healthyReconcileHerdr) TabClose(string) error          { return nil }
 func (f *healthyReconcileHerdr) PaneGet(string) (herdr.Pane, error) {
 	return herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1", Agent: "claude"}, nil
 }
+func (f *healthyReconcileHerdr) PaneProcessInfo(string) (herdr.ProcessInfo, error) {
+	return herdr.ProcessInfo{ShellPID: 1, ForegroundProcesses: []herdr.Process{{PID: 1, Name: "bash"}}}, nil
+}
+func (f *healthyReconcileHerdr) PaneRunSpec(string, launchSpec) error { f.runs++; return nil }
 func (f *healthyReconcileHerdr) PaneRun(string, string) error         { f.runs++; return nil }
 func (f *healthyReconcileHerdr) PaneSendKeys(string, ...string) error { return nil }
 func (f *healthyReconcileHerdr) PaneRead(string, int) (string, error) { return "ready", nil }

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/launch"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
 )
@@ -13,14 +14,15 @@ import (
 type herdrClient interface {
 	FindWorkspaceByLabel(string) (herdr.Workspace, bool, error)
 	WorkspaceList() ([]herdr.Workspace, error)
-	WorkspaceCreate(string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error)
+	WorkspaceCreate(string, map[string]string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error)
 	WorkspaceClose(string) error
 	TabList(string) ([]herdr.Tab, error)
-	TabCreate(string, string, string) (herdr.Tab, herdr.Pane, error)
+	TabCreate(string, string, map[string]string, string) (herdr.Tab, herdr.Pane, error)
 	TabRename(string, string) error
 	TabClose(string) error
 	PaneGet(string) (herdr.Pane, error)
-	PaneRun(string, string) error
+	PaneProcessInfo(string) (herdr.ProcessInfo, error)
+	PaneRunSpec(string, launch.LaunchSpec) error
 	PaneSendKeys(string, ...string) error
 	PaneRead(string, int) (string, error)
 }
@@ -29,9 +31,9 @@ func newHerdrClient() herdrClient { return herdr.NewManagedClient() }
 
 func newHerdrSessionClient(session string) herdrClient {
 	if session == "" || session == "default" {
-		return herdr.NewClient()
+		return herdr.NewManagedClient()
 	}
-	return herdr.NewSessionClient(session)
+	return herdr.NewManagedSessionClient(session)
 }
 
 func (r *Runtime) herdrClient(session string) herdrClient {
@@ -44,6 +46,14 @@ func (r *Runtime) herdrClient(session string) herdrClient {
 	return newHerdrSessionClient(session)
 }
 
+func herdrWorkerEnvironment(client herdrClient) map[string]string {
+	provider, ok := client.(interface{ WorkerEnvironment() map[string]string })
+	if !ok {
+		return nil
+	}
+	return provider.WorkerEnvironment()
+}
+
 func herdrWorkspaceLabelForSession(session, projectName string) string {
 	if session == "" || session == "default" {
 		return herdr.LegacyWorkspaceLabel(projectName)
@@ -51,21 +61,21 @@ func herdrWorkspaceLabelForSession(session, projectName string) string {
 	return herdr.WorkspaceLabel(strings.TrimPrefix(session, "hand-"), projectName)
 }
 
-func acquireTaskWorkspace(client herdrClient, worktreePath, taskID, projectName, session string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
+func acquireTaskWorkspace(client herdrClient, worktreePath string, env map[string]string, taskID, projectName, session string) (herdr.Workspace, herdr.Tab, herdr.Pane, func() error, error) {
 	label := herdrWorkspaceLabelForSession(session, projectName)
 	workspace, found, err := client.FindWorkspaceByLabel(label)
 	createdWorkspace := false
 	var rootTab herdr.Tab
 	var rootPane herdr.Pane
 	if err == nil && !found {
-		workspace, rootTab, rootPane, err = client.WorkspaceCreate(worktreePath, label)
+		workspace, rootTab, rootPane, err = client.WorkspaceCreate(worktreePath, env, label)
 		createdWorkspace = err == nil
 	}
 	if err != nil {
 		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, nil, fmt.Errorf("herdr workspace lookup/create failed: %w", err)
 	}
 
-	tab, pane, err := acquireTaskTab(client, createdWorkspace, workspace.WorkspaceID, worktreePath, taskID, rootTab, rootPane)
+	tab, pane, err := acquireTaskTab(client, createdWorkspace, workspace.WorkspaceID, worktreePath, env, taskID, rootTab, rootPane)
 	if err != nil {
 		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, nil, reportCleanup(err, rollbackHerdr(client, createdWorkspace, workspace.WorkspaceID, ""))
 	}
@@ -75,14 +85,14 @@ func acquireTaskWorkspace(client herdrClient, worktreePath, taskID, projectName,
 	return workspace, tab, pane, rollback, nil
 }
 
-func acquireTaskTab(client herdrClient, createdWorkspace bool, workspaceID, worktreePath, taskID string, rootTab herdr.Tab, rootPane herdr.Pane) (herdr.Tab, herdr.Pane, error) {
+func acquireTaskTab(client herdrClient, createdWorkspace bool, workspaceID, worktreePath string, env map[string]string, taskID string, rootTab herdr.Tab, rootPane herdr.Pane) (herdr.Tab, herdr.Pane, error) {
 	if createdWorkspace {
 		if err := client.TabRename(rootTab.TabID, taskID); err != nil {
 			return herdr.Tab{}, herdr.Pane{}, fmt.Errorf("herdr tab rename failed: %w", err)
 		}
 		return rootTab, rootPane, nil
 	}
-	tab, pane, err := client.TabCreate(workspaceID, worktreePath, taskID)
+	tab, pane, err := client.TabCreate(workspaceID, worktreePath, env, taskID)
 	if err != nil {
 		return herdr.Tab{}, herdr.Pane{}, fmt.Errorf("herdr tab create failed: %w", err)
 	}

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -484,10 +484,10 @@ func TestProvisionBuildsFromPersistedAttemptSnapshot(t *testing.T) {
 	var gotHarness string
 	var gotOptions harness.Options
 	r := testProvisionRuntime(&provisionHerdr{}, func(lifecyclePhase) error { return nil })
-	r.deps.buildHarness = func(name string, options harness.Options) (string, error) {
+	r.deps.buildHarness = func(name string, options harness.Options) (launchSpec, error) {
 		gotHarness = name
 		gotOptions = options
-		return "launch", nil
+		return launchSpec{Executable: "launch"}, nil
 	}
 
 	if _, err := r.provision(context.Background(), provisioningRequest{

--- a/internal/runtime/unwind_test.go
+++ b/internal/runtime/unwind_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
 )
@@ -27,7 +28,7 @@ func fakeSwitchablePane(t *testing.T, agent string) func(string) {
 			{ID: "ws-1", Label: "hand:demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: "1", Pane: "pane-1"}}},
 			{ID: "ws-2", Label: "hand:demo", Tabs: []faketool.HerdrTab{{ID: "tab-2", Label: "1", Pane: "pane-2"}}},
 		},
-		PaneAgentEnv: true, PaneReadFileEnv: true, PaneStatus: "idle",
+		PaneAgent: agent, PaneReadFileEnv: true, PaneStatus: "idle",
 		KeyLog: filepath.Join(dir, "keys.log"),
 	}.Install(t, bin)
 	t.Setenv("PANE_AGENT", agent)
@@ -47,7 +48,8 @@ func unwindRuntime(t *testing.T, returns *int) *Runtime {
 	r := reconcileRuntime(nil, func(string, string) (worktree.Lease, error) {
 		return worktree.Lease{Path: filepath.Join(pool, "slot-1"), ID: "lease-1"}, nil
 	})
-	r.deps.herdr = newHerdrClient
+	r.deps.herdr = func() herdrClient { return herdr.NewClient() }
+	r.deps.buildHarness = harness.Build
 	r.deps.confirmLaunch = confirmLaunch
 	r.deps.worktree.returnWorktree = func(string, bool) error { *returns++; return nil }
 	r.deps.worktree.returnWithID = func(string, string, bool) error { *returns++; return nil }

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -86,8 +86,8 @@ func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 			wantModel:  "claude-opus-5",
 			wantEffort: "high",
 			wantFlags: []string{
-				"--model 'claude-opus-5'",
-				"--effort 'high'",
+				"'--model' 'claude-opus-5'",
+				"'--effort' 'high'",
 				"are dispatch metadata, not task instructions",
 			},
 			denyFlags: []string{"claude-sonnet-5"},
@@ -98,14 +98,14 @@ func TestSpawnHonorsBriefDeclaredTier(t *testing.T) {
 			args:       []string{"--model", "claude-fable-5"},
 			wantModel:  "claude-fable-5",
 			wantEffort: "high",
-			wantFlags:  []string{"--model 'claude-fable-5'", "--effort 'high'"},
+			wantFlags:  []string{"'--model' 'claude-fable-5'", "'--effort' 'high'"},
 			denyFlags:  []string{"claude-opus-5"},
 		},
 		{
 			id:        "task-plain",
 			brief:     plain,
 			wantModel: "claude-sonnet-5",
-			wantFlags: []string{"--model 'claude-sonnet-5'"},
+			wantFlags: []string{"'--model' 'claude-sonnet-5'"},
 			denyFlags: []string{"--effort", "are dispatch metadata, not task instructions"},
 		},
 	}
@@ -202,7 +202,7 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 
 	launch := readLaunchLog(t, launchLog)[0]
 	t.Logf("launch command: %s", launch)
-	if !strings.Contains(launch, "--model 'claude-opus-5' --effort 'max'") {
+	if !strings.Contains(launch, "'--model' 'claude-opus-5' '--effort' 'max'") {
 		t.Fatalf("launch command %q, want the brief's declared tier applied", launch)
 	}
 }
@@ -223,7 +223,7 @@ func TestSpawnWarnsOnEffortIncapableHarness(t *testing.T) {
 	launchLog := filepath.Join(t.TempDir(), "launch.log")
 	dir := binDir(t)
 	writeFakeTreehouse(t, dir, worktree)
-	writeFakeHerdrLaunchLog(t, dir, launchLog, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+	writeFakeHerdrLaunchLog(t, dir, launchLog, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo", Agent: "opencode"})
 
 	spawned := runHand(t, home, "spawn", "task-1", "demo")
 	if spawned.code != 0 {
@@ -235,7 +235,7 @@ func TestSpawnWarnsOnEffortIncapableHarness(t *testing.T) {
 
 	launch := readLaunchLog(t, launchLog)[0]
 	t.Logf("launch command: %s", launch)
-	if !strings.Contains(launch, "--model 'grok-code'") || strings.Contains(launch, "--effort") {
+	if !strings.Contains(launch, "'--model' 'grok-code'") || strings.Contains(launch, "'--effort'") {
 		t.Fatalf("launch command %q, want the declared model applied and no effort flag", launch)
 	}
 }

--- a/tests/e2e/execution_profiles_test.go
+++ b/tests/e2e/execution_profiles_test.go
@@ -27,7 +27,7 @@ func TestExecutionProfilesFreezeExistingAttemptAndRouteFutureTask(t *testing.T) 
 	writeFakeBin(t, dir, "claude", "exit 0\n")
 	writeFakeBin(t, dir, "codex", "exit 0\n")
 	faketool.Treehouse{Slots: []string{worktreeOne, worktreeTwo}}.Install(t, dir)
-	writeFakeHerdrStaticLogged(t, dir, "", herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+	writeFakeHerdrStaticLogged(t, dir, "", herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo", Agents: []string{"claude", "codex"}})
 
 	for _, args := range [][]string{
 		{"config", "profile", "set", "initial", "--harness", "claude", "--model", "initial-model", "--effort", "high"},

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -92,6 +92,8 @@ type herdrIDs struct {
 	PaneID      string
 	Label       string
 	PaneStatus  string // agent_status reported by "pane get"; defaults to "working" if empty
+	Agent       string // harness process reported by pane get and pane process-info; defaults to claude
+	Agents      []string
 }
 
 // The herdr fake for a spawn (or promote) followed by a teardown within one test: no workspace exists
@@ -119,14 +121,20 @@ func writeFakeHerdrStaticLogged(t *testing.T, dir, logPath string, ids herdrIDs)
 			Pane: fmt.Sprintf("%s-%d", ids.PaneID, i+2),
 		}
 	}
+	agent := ids.Agent
+	if agent == "" {
+		agent = "claude"
+	}
 	faketool.Herdr{
 		Creates: []faketool.HerdrWorkspace{{ID: ids.WorkspaceID, Label: ids.Label, Tabs: []faketool.HerdrTab{
 			{ID: ids.TabID, Label: "1", Pane: ids.PaneID},
 		}}},
-		TabCreates: spares,
-		PaneAgent:  "claude",
-		PaneStatus: ids.PaneStatus,
-		Log:        logPath,
+		TabCreates:    spares,
+		PaneAgent:     agent,
+		ProcessAgent:  agent,
+		ProcessAgents: ids.Agents,
+		PaneStatus:    ids.PaneStatus,
+		Log:           logPath,
 	}.Install(t, dir)
 }
 

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -54,6 +54,7 @@ func TestPromoteScoutToShip(t *testing.T) {
 	writeFakeDispatch(t, dir, "herdr", invocationLog, "$1 $2", `  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
   "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-new","label":"demo","tab_count":1},"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"1"},"root_pane":{"pane_id":"pane-new","tab_id":"tab-new","workspace_id":"ws-new","agent_status":"working"}}}' ;;
   "tab rename") echo '{"result":{"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"task-1"}}}' ;;
+  "pane process-info") echo '{"result":{"process_info":{"pane_id":"pane-new","shell_pid":1,"foreground_processes":[{"pid":1,"name":"bash"},{"pid":2,"name":"claude","argv":["claude"]}]}}}' ;;
   "pane run") echo '{"result":{}}' ;;
   "pane read") printf 'Welcome to Claude Code\n> \n  ? for shortcuts\n' ;;
   "tab list")


### PR DESCRIPTION
## Intent

Implement atqamz/hand#338: replace shell-assembled worker launches with a domain-agnostic structured LaunchSpec, explicit runtime environment composition, shell-aware POSIX and PowerShell Herdr transport, and authoritative process confirmation while preserving interactive worker sessions, existing behavior, tests, and boundary documentation. Create a pull request through no-mistakes. Do not merge it.

## What Changed

- Introduced validated, transport-neutral `LaunchSpec` values carrying executable, arguments, environment, and working directory.
- Added shell-aware Herdr process detection and POSIX/PowerShell launch rendering, with explicit worker environment composition and forwarding.
- Updated launch confirmation to require authoritative process evidence while preserving interactive sessions, with corresponding harness, runtime, fake-tool, documentation, unit, and end-to-end test updates.

## Risk Assessment

✅ Low: The Windows executable normalization fix is present, and the reviewed structured launch, shell transport, environment composition, and confirmation paths show no additional material source defects.

## Testing

Validated structured launch specs, POSIX and PowerShell Herdr transport, explicit environment composition, authoritative process confirmation, and an end-to-end worker spawn/teardown flow. Go was supplied through the repository Nix devshell. No reviewer-visible artifact was produced because this is CLI/runtime behavior rather than a rendered UI.

- Outcome: ⚠️ 1 warning across 1 run (6m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3157d542edd6e3de240219c0712ed37c3fc6799a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/herdr/types.go:65` - PowerShell launches can never be authoritatively confirmed on Windows: the LaunchSpec uses extensionless executables such as `claude`, while Herdr process evidence commonly reports `claude.exe`; `HasExecutable` compares these strings without normalizing the optional `.exe` suffix. `PaneRunSpec` submits successfully, but `confirmLaunch` at `internal/runtime/launch.go:59` never sees `processPresent`, times out, and cleans up every worker launched from PowerShell. Normalize executable names before comparison.

🔧 Fix: Normalize Windows executable suffix during launch confirmation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `internal/runtime/pr_test.go:54` - A broader runtime-package run was interrupted after an unrelated GitHub fixture lookup failed for nonexistent repository atqamz/detach-fixture; focused launch tests passed independently.
- `nix develop --command go test -tags=test -count=1 ./internal/launch ./internal/herdr ./internal/harness ./internal/faketool`
- `nix develop --command go test -tags=test -count=1 ./internal/runtime -run '^(TestConfirmLaunch|TestProvision|TestComposeWorkerSpec|TestReconcileSubmittedLaunchConfirmsExistingPaneWithoutRelaunch)$' -timeout=120s`
- `nix develop --command go test -tags=e2e,test -count=1 ./tests/e2e -run '^(TestSpawnTeardownCycle|TestWorkerWorktreeNeverBootstrapsSupervisor|TestRuntimeRouteMatrixPersistsEveryCanonicalCell)$' -timeout=180s`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Fixes atqamz/hand#338