### PR TITLE
feat(orientation): make supervisor orientation stateless and Fleet-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ cd ~/secondhand-fleet
 claude
 ```
 
-The canonical `AGENTS.md` tells the harness to run `hand session start` before responding or acting; that command loads bounded fleet context and reports the first next action, and refuses outright inside a worker's isolated worktree. Any other supported harness reads the same instructions from `AGENTS.md` directly.
+The canonical `AGENTS.md` tells the harness to run `hand session start` before responding or acting; that command loads bounded fleet context, returns Fleet-scoped orientation and monitor currentness, reports the first next action, and refuses outright inside a worker's isolated worktree.
+When it cannot prove a detached watcher, it reports a bounded re-arm and names `hand watch --until-event`.
+Any other supported harness reads the same instructions from `AGENTS.md` directly.
 
 On the first session, the supervisor inspects `hand config`, asks only unresolved configuration policy questions, and persists accepted profile and route choices through the CLI.
 
@@ -534,7 +536,7 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand fleet` | List user-local Fleet homes and their observed identity state. |
 | `hand ack <id> [--reason <text>]` | Record that a supervisor has acknowledged a task's report. |
 | `hand reconcile [id] [--abandon-worktree] [--abandon-pane] [--attempt-never-started]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; given a Task ID, explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, or attest that a running Attempt's worker took no turn so the ordinary release path can end it. |
-| `hand watch` | Wait for actionable fleet events. |
+| `hand watch` | Wait for actionable fleet events and emit Fleet-scoped structured wake hints. |
 | `hand send` | Steer a running worker. |
 | `hand merge` | Merge completed work after authorization. |
 | `hand deliver` | Mark work as handed off when landing is someone else's decision. |

--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/atqamz/hand/internal/attention"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -21,6 +22,9 @@ const (
 	nextActionSendPartial      = "send-partial"
 	nextActionReportUnreadable = "report-unreadable"
 	nextActionUnreported       = "unreported"
+	nextActionRuntimeUnknown   = "runtime-unknown"
+	nextActionUnreachable      = "unreachable"
+	nextActionParked           = "parked"
 	nextActionUnacknowledged   = "unacknowledged"
 	nextActionHold             = "hold"
 	nextActionGate             = "gate"
@@ -40,43 +44,55 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 
 	sorted := sortedByTaskID(views)
 
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.task.RepairCode != "" }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindNeedsRepair) }); ok {
 		return nextAction{Kind: nextActionNeedsRepair, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "resolve its repair ambiguity")}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.latestSend != nil && v.latestSend.State == state.SendUncertain }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindSendUncertain) }); ok {
 		return nextAction{Kind: nextActionSendUncertain, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "confirm whether its uncertain send reached the worker")}
 	}
-	if v, ok := firstView(sorted, isSendPartial); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindSendPartial) }); ok {
 		return nextAction{Kind: nextActionSendPartial, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "confirm whether its send needs to be retried")}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.reportedState == state.ReportNeedsDecision }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindReportDecision) }); ok {
 		return nextAction{Kind: state.ReportNeedsDecision, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "answer the operator decision it is waiting on")}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.reportedState == state.ReportFailed }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindReportFailed) }); ok {
 		return nextAction{Kind: state.ReportFailed, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "investigate why it failed")}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.unreadable }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindReportUnreadable) }); ok {
 		return nextAction{Kind: nextActionReportUnreadable, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "investigate its unreadable report")}
 	}
-	if v, ok := firstView(sorted, unreportedStop); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindUnreported) }); ok {
 		return nextAction{Kind: nextActionUnreported, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: fmt.Sprintf("Run `%s`; it stopped without reporting a terminal state", statusCommand(v.task.ID))}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.reportedState == state.ReportBlocked }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindRuntimeUnknown) }); ok {
+		return nextAction{Kind: nextActionRuntimeUnknown, Task: v.task.ID, Command: statusCommand(v.task.ID),
+			Reason: statusReason(v.task.ID, "investigate why its worker runtime is unknown")}
+	}
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindUnreachable) }); ok {
+		return nextAction{Kind: nextActionUnreachable, Task: v.task.ID, Command: statusCommand(v.task.ID),
+			Reason: statusReason(v.task.ID, "investigate why its worker runtime is unreachable")}
+	}
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindParked) }); ok {
+		return nextAction{Kind: nextActionParked, Task: v.task.ID, Command: statusCommand(v.task.ID),
+			Reason: statusReason(v.task.ID, "investigate why its worker has been silent")}
+	}
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindReportBlocked) }); ok {
 		return nextAction{Kind: state.ReportBlocked, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "resolve what is blocking it")}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.reportedState == state.ReportPaused }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindReportPaused) }); ok {
 		return nextAction{Kind: state.ReportPaused, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "resume or resolve why it is paused")}
 	}
-	if v, ok := firstView(sorted, func(v taskView) bool { return v.unacked }); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindUnacknowledged) }); ok {
 		return nextAction{Kind: nextActionUnacknowledged, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "act on its unacknowledged worker event")}
 	}
@@ -90,7 +106,7 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 		return nextAction{Kind: nextActionHold, Task: h.ID, Command: "none",
 			Reason: "Operator or supervisor judgment is needed to resolve its active hold"}
 	}
-	if v, ok := firstView(sorted, gateProblem); ok {
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindGate) }); ok {
 		return nextAction{Kind: nextActionGate, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "confirm its delivery gate status")}
 	}

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
 	"github.com/spf13/cobra"
@@ -182,6 +183,27 @@ func TestClassifyNextActionIsOrderIndependent(t *testing.T) {
 	}
 	if forward.Task != "a-repair" {
 		t.Fatalf("task = %q, want the needs-repair candidate regardless of input order", forward.Task)
+	}
+}
+
+func TestClassifyNextActionRanksRuntimeAttentionFromSharedDerivation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		view   taskView
+		kind   string
+		reason string
+	}{
+		{name: "unreachable", view: taskView{task: state.Task{ID: "unreachable-task"}, unreachable: true}, kind: nextActionUnreachable, reason: "investigate why its worker runtime is unreachable"},
+		{name: "runtime unknown", view: taskView{task: state.Task{ID: "unknown-task"}, attempt: &state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "pane-1"}}, agentState: string(herdr.StatusUnknown)}, kind: nextActionRuntimeUnknown, reason: "investigate why its worker runtime is unknown"},
+		{name: "parked", view: taskView{task: state.Task{ID: "parked-task"}, parked: true}, kind: nextActionParked, reason: "investigate why its worker has been silent"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := classifyNextAction(configuredWorker, 1, backlogSummary{}, []taskView{test.view}, nil)
+			want := nextAction{Kind: test.kind, Task: test.view.task.ID, Command: statusCommand(test.view.task.ID), Reason: statusReason(test.view.task.ID, test.reason)}
+			if got != want {
+				t.Fatalf("classifyNextAction() = %#v, want %#v", got, want)
+			}
+		})
 	}
 }
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -2,18 +2,23 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/attention"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/shellquote"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/watcher"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +74,8 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	if err != nil {
 		return sessionContextError(fleetHome, backlogPath, err)
 	}
-	if _, err := registry.Preflight(fleetHome, true); err != nil {
+	registryWarnings, err := registry.Preflight(fleetHome, true)
+	if err != nil {
 		return asPrecondition(err)
 	}
 	projects, err := project.ListReadOnly(fleetHome)
@@ -105,6 +111,25 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 		source = "unknown"
 	}
 
+	next := classifyNextAction(cfg, len(projects), backlog, views, holds)
+	oriented, err := buildSessionOrientation(cmd.Context(), fleetHome, views, next, orientation.MonitorStateUnknown, "", registryWarnings)
+	if err != nil {
+		return err
+	}
+	ensure, err := watcher.Ensure(cmd.Context(), watcher.Config{Home: fleetHome}, sessionTargets(oriented, views))
+	if err != nil {
+		return err
+	}
+	views, holds, err = fleetViews(cmd, fleetHome, client, true)
+	if err != nil {
+		return err
+	}
+	next = classifyNextAction(cfg, len(projects), backlog, views, holds)
+	oriented, err = buildSessionOrientation(cmd.Context(), fleetHome, views, next, ensure.State, ensure.Reason, registryWarnings)
+	if err != nil {
+		return err
+	}
+
 	var doc axi.Doc
 	doc.Field("session_bootstrap", "complete")
 	doc.Field("tool", "hand")
@@ -120,13 +145,119 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	axi.Table(&doc, "projects", projects, sessionProjectFields)
 	doc.List("backlog", backlog.Items)
 	appendFleetState(&doc, views, holds, cols)
-	next := classifyNextAction(cfg, len(projects), backlog, views, holds)
+	appendSessionOrientation(&doc, oriented)
 	doc.Field("next_action_kind", next.Kind)
 	doc.Field("next_action_task", orNone(next.Task))
 	doc.Field("next_action_command", orNone(next.Command))
 	doc.Field("next_action_reason", next.Reason)
 	doc.Help(next.Reason)
 	return doc.Render(cmd.OutOrStdout())
+}
+
+func buildSessionOrientation(ctx context.Context, fleetHome string, views []taskView, next nextAction, monitorState orientation.MonitorState, monitorReason string, registryWarnings []string) (orientation.SupervisorOrientation, error) {
+	fleetID, err := state.FleetIDReadOnly(fleetHome)
+	if err != nil {
+		return orientation.SupervisorOrientation{}, fmt.Errorf("read Fleet identity for orientation: %w", err)
+	}
+	provider := orientation.NewProvider(func(context.Context) (orientation.Evidence, error) {
+		evidence := orientation.Evidence{FleetID: fleetID, MonitorState: monitorState}
+		for _, warning := range registryWarnings {
+			evidence.Errors = append(evidence.Errors, orientation.BoundedError{Kind: "registry", Reason: warning})
+		}
+		for _, view := range views {
+			targetEvidence := orientation.TaskTargetEvidence(taskTargetFacts(view))
+			if monitorableView(view) {
+				evidence.Targets = append(evidence.Targets, targetEvidence)
+			}
+			evidence.Work = append(evidence.Work, orientation.WorkEvidence{ID: view.task.ID, Kind: "task", State: view.agentState, Reported: view.reportedState})
+			for _, subject := range attention.Derive(taskAttentionEvidence(view)) {
+				evidence.Actionable = append(evidence.Actionable, orientation.ActionableEvidence{
+					TargetID: view.task.ID, TargetKind: "task", Generation: targetEvidence.Generation,
+					Kind: subject.Kind, Reason: subject.Reason, Provenance: subject.Provenance,
+				})
+			}
+		}
+		if next.Kind != "" {
+			evidence.NextActions = []orientation.NextAction{{Kind: next.Kind, Target: next.Task, Command: next.Command, Reason: next.Reason}}
+		}
+		if monitorState != orientation.MonitorStateAlreadyArmed {
+			evidence.NextActions = append(evidence.NextActions, orientation.NextAction{
+				Kind: "monitor-rearm", Command: "hand watch --until-event",
+				Reason: monitorReason,
+			})
+		}
+		if monitorReason != "" && monitorState != orientation.MonitorStateRearmed {
+			evidence.Errors = append(evidence.Errors, orientation.BoundedError{Kind: "monitor", Reason: monitorReason})
+		}
+		return evidence, nil
+	})
+	return provider.Orientation(ctx)
+}
+
+func sessionTargets(result orientation.SupervisorOrientation, views []taskView) []watcher.TargetBinding {
+	byID := make(map[string]orientation.MonitorTarget, len(result.Monitors))
+	for _, target := range result.Monitors {
+		byID[target.ID] = target
+	}
+	targets := make([]watcher.TargetBinding, 0, len(views))
+	for _, view := range views {
+		if !monitorableView(view) {
+			continue
+		}
+		if target, ok := byID[orientation.TargetFor(result.FleetID, orientation.TargetEvidence{ID: view.task.ID, Kind: "task"}).ID]; ok {
+			targets = append(targets, watcher.TargetBinding{TaskID: view.task.ID, Target: target})
+		}
+	}
+	return targets
+}
+
+func monitorableView(view taskView) bool {
+	return view.task.Lifecycle == state.TaskOpen && view.attempt != nil && view.attempt.Lifecycle == state.AttemptRunning
+}
+
+func taskTargetFacts(view taskView) orientation.TaskTargetFacts {
+	attempt := view.execution()
+	return orientation.TaskTargetFacts{
+		ID: view.task.ID, Kind: "task", CreatedAt: view.task.CreatedAt, Lifecycle: string(view.task.Lifecycle),
+		ActiveAttemptID: view.task.ActiveAttemptID, AttemptID: attempt.ID, AttemptLifecycle: string(attempt.Lifecycle),
+		RuntimeIdentity: []string{attempt.Herdr.Session, attempt.Herdr.WorkspaceID, attempt.Herdr.TabID, attempt.Herdr.PaneID},
+		StatusChangedAt: attempt.StatusChangedAt, StatusChangedFor: attempt.StatusChangedFor, ReportState: view.reportedState,
+		ReportOffset: view.task.ReportOffset, ReportDigest: view.task.ReportDigest, DoneVerified: attempt.DoneVerified,
+		PR: view.task.PR, MergeExecuted: view.task.MergeExecuted, MergeAnnounced: view.task.MergeAnnounced,
+	}
+}
+
+func appendSessionOrientation(doc *axi.Doc, result orientation.SupervisorOrientation) {
+	doc.Field("orientation_schema", result.Schema)
+	doc.Field("fleet_id", result.FleetID)
+	doc.Field("monitor_state", string(result.MonitorState))
+	doc.Bool("orientation_truncated", result.Truncated)
+	doc.Int("orientation_omitted", result.Omitted)
+	monitorRows := make([][]string, 0, len(result.Monitors))
+	for _, target := range result.Monitors {
+		monitorRows = append(monitorRows, []string{target.ID, target.Kind, target.Currentness.String()})
+	}
+	doc.Rows("monitor_targets", []string{"id", "kind", "currentness"}, monitorRows)
+	workRows := make([][]string, 0, len(result.Work))
+	for _, work := range result.Work {
+		workRows = append(workRows, []string{work.ID, work.Kind, work.State, work.Reported, work.Monitor.ID, work.Monitor.Currentness.String()})
+	}
+	doc.Rows("orientation_work", []string{"id", "kind", "state", "reported", "target_id", "currentness"}, workRows)
+	actionRows := make([][]string, 0, len(result.Actionable))
+	for _, subject := range result.Actionable {
+		actionRows = append(actionRows, []string{subject.Target.ID, subject.Kind, subject.Reason, subject.Provenance})
+	}
+	doc.Rows("orientation_actionable", []string{"target_id", "kind", "reason", "provenance"}, actionRows)
+	nextRows := make([][]string, 0, len(result.NextActions))
+	for _, action := range result.NextActions {
+		nextRows = append(nextRows, []string{action.Kind, action.Target, action.Command, action.Reason})
+	}
+	doc.Rows("orientation_next_actions", []string{"kind", "target", "command", "reason"}, nextRows)
+	errorRows := make([][]string, 0, len(result.Errors))
+	for _, failure := range result.Errors {
+		errorRows = append(errorRows, []string{failure.Kind, failure.Reason})
+	}
+	doc.Rows("orientation_errors", []string{"kind", "reason"}, errorRows)
 }
 
 func sessionContextError(fleetHome, path string, err error) error {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -116,7 +116,7 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	if err != nil {
 		return err
 	}
-	ensure, err := watcher.Ensure(cmd.Context(), watcher.Config{Home: fleetHome}, sessionTargets(oriented, views))
+	ensure, err := watcher.Ensure(cmd.Context(), watcher.Config{Home: fleetHome}, sessionTargets(oriented.FleetID, views))
 	if err != nil {
 		return err
 	}
@@ -171,6 +171,9 @@ func buildSessionOrientation(ctx context.Context, fleetHome string, views []task
 			}
 			evidence.Work = append(evidence.Work, orientation.WorkEvidence{ID: view.task.ID, Kind: "task", State: view.agentState, Reported: view.reportedState})
 			for _, subject := range attention.Derive(taskAttentionEvidence(view)) {
+				if !subject.Actionable {
+					continue
+				}
 				evidence.Actionable = append(evidence.Actionable, orientation.ActionableEvidence{
 					TargetID: view.task.ID, TargetKind: "task", Generation: targetEvidence.Generation,
 					Kind: subject.Kind, Reason: subject.Reason, Provenance: subject.Provenance,
@@ -194,19 +197,14 @@ func buildSessionOrientation(ctx context.Context, fleetHome string, views []task
 	return provider.Orientation(ctx)
 }
 
-func sessionTargets(result orientation.SupervisorOrientation, views []taskView) []watcher.TargetBinding {
-	byID := make(map[string]orientation.MonitorTarget, len(result.Monitors))
-	for _, target := range result.Monitors {
-		byID[target.ID] = target
-	}
+func sessionTargets(fleetID string, views []taskView) []watcher.TargetBinding {
 	targets := make([]watcher.TargetBinding, 0, len(views))
 	for _, view := range views {
 		if !monitorableView(view) {
 			continue
 		}
-		if target, ok := byID[orientation.TargetFor(result.FleetID, orientation.TargetEvidence{ID: view.task.ID, Kind: "task"}).ID]; ok {
-			targets = append(targets, watcher.TargetBinding{TaskID: view.task.ID, Target: target})
-		}
+		target := orientation.TaskTarget(fleetID, taskTargetFacts(view))
+		targets = append(targets, watcher.TargetBinding{TaskID: view.task.ID, Target: target})
 	}
 	return targets
 }

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -112,20 +112,11 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	}
 
 	next := classifyNextAction(cfg, len(projects), backlog, views, holds)
-	oriented, err := buildSessionOrientation(cmd.Context(), fleetHome, views, next, orientation.MonitorStateUnknown, "", registryWarnings)
+	monitorState, monitorReason, err := readOnlyMonitorState(fleetHome, monitorTargetCount(views))
 	if err != nil {
 		return err
 	}
-	ensure, err := watcher.Ensure(cmd.Context(), watcher.Config{Home: fleetHome}, sessionTargets(oriented.FleetID, views))
-	if err != nil {
-		return err
-	}
-	views, holds, err = fleetViews(cmd, fleetHome, client, true)
-	if err != nil {
-		return err
-	}
-	next = classifyNextAction(cfg, len(projects), backlog, views, holds)
-	oriented, err = buildSessionOrientation(cmd.Context(), fleetHome, views, next, ensure.State, ensure.Reason, registryWarnings)
+	oriented, err := buildSessionOrientation(cmd.Context(), fleetHome, views, next, monitorState, monitorReason, registryWarnings)
 	if err != nil {
 		return err
 	}
@@ -207,6 +198,30 @@ func sessionTargets(fleetID string, views []taskView) []watcher.TargetBinding {
 		targets = append(targets, watcher.TargetBinding{TaskID: view.task.ID, Target: target})
 	}
 	return targets
+}
+
+func monitorTargetCount(views []taskView) int {
+	count := 0
+	for _, view := range views {
+		if monitorableView(view) {
+			count++
+		}
+	}
+	return count
+}
+
+func readOnlyMonitorState(fleetHome string, targetCount int) (orientation.MonitorState, string, error) {
+	attached, err := watcher.IsAttached(fleetHome)
+	if err != nil {
+		return orientation.MonitorStateUnknown, "watcher ownership is unknown: " + err.Error(), nil
+	}
+	if attached {
+		return orientation.MonitorStateAlreadyArmed, "a watcher already owns this Fleet home", nil
+	}
+	if targetCount == 0 {
+		return orientation.MonitorStateRearmed, "no monitor targets require a bounded arm", nil
+	}
+	return orientation.MonitorStateUnknown, "run `hand watch --until-event` to establish monitoring", nil
 }
 
 func monitorableView(view taskView) bool {

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
 )
 
@@ -88,6 +89,11 @@ func TestSessionStartEmitsCompleteBoundedDigest(t *testing.T) {
 	out := runSessionStartForTest(t)
 	for _, want := range []string{
 		"session_bootstrap: complete\n",
+		"orientation_schema: hand.supervisor.v1\n",
+		"fleet_id: f_",
+		"monitor_state: rearmed\n",
+		"monitor_targets[0]{id,kind,currentness}:\n",
+		"orientation_actionable[0]{target_id,kind,reason,provenance}:\n",
 		"tool: hand\n",
 		"version: test\n",
 		"exec:",
@@ -330,6 +336,34 @@ func TestSessionOverviewsDoNotMutateFleetState(t *testing.T) {
 				t.Fatalf("fleet tree changed:\nbefore: %v\nafter:  %v", before, after)
 			}
 		})
+	}
+}
+
+func TestSessionStartDoesNotAcknowledgeExistingReport(t *testing.T) {
+	home := setupSessionHome(t)
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{
+		ID: "reported-task", Project: "demo", Kind: store.KindShip,
+		AcknowledgedAt: "2026-08-22T00:00:00Z", AcknowledgedOffset: 12, AcknowledgedDigest: "ack-digest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := executeSessionStart(t, nil); err != nil {
+		t.Fatal(err)
+	}
+	after, err := state.ReadHistoryReadOnly(home, "reported-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Task.AcknowledgedAt != "2026-08-22T00:00:00Z" || after.Task.AcknowledgedOffset != 12 || after.Task.AcknowledgedDigest != "ack-digest" {
+		t.Fatalf("acknowledgement changed after session start: %#v", after.Task)
 	}
 }
 

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -19,9 +19,11 @@ import (
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
+	"github.com/atqamz/hand/internal/watcher"
 )
 
 func setupSessionHome(t *testing.T) string {
@@ -119,6 +121,27 @@ func TestSessionStartEmitsCompleteBoundedDigest(t *testing.T) {
 	}
 	if strings.Contains(out, "private implementation body") {
 		t.Fatalf("out = %q, want indented backlog bodies omitted", out)
+	}
+}
+
+func TestSessionTargetsIncludesEveryRunningTaskBeyondOrientationBound(t *testing.T) {
+	views := make([]taskView, 65)
+	for i := range views {
+		views[i] = taskView{
+			task:    state.Task{ID: fmt.Sprintf("task-%02d", i), Lifecycle: state.TaskOpen},
+			attempt: &state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "pane"}},
+		}
+	}
+
+	targets := sessionTargets("fleet-1", views)
+	if len(targets) != len(views) {
+		t.Fatalf("targets = %d, want %d", len(targets), len(views))
+	}
+	for i, target := range targets {
+		want := orientation.TaskTarget("fleet-1", taskTargetFacts(views[i]))
+		if target.Target != want || target.TaskID != views[i].task.ID {
+			t.Fatalf("target %d = %#v, want %#v", i, target, watcher.TargetBinding{TaskID: views[i].task.ID, Target: want})
+		}
 	}
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -892,6 +892,9 @@ func TestStatusFleetFlagsUnreachablePaneAndCountsAttention(t *testing.T) {
 	if got := fleetFlags(t, out.String(), "task-1"); !slices.Contains(got, "unreachable") {
 		t.Fatalf("flags = %v, want unreachable", got)
 	}
+	if got := fleetFlags(t, out.String(), "task-1"); slices.Contains(got, "runtime-unknown") {
+		t.Fatalf("flags = %v, want unreachable without runtime-unknown", got)
+	}
 }
 
 // atqamz/hand#268's disagreement 2: KindParked existed only in hand watch, and atqamz/hand#32's own

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/state"
@@ -1969,6 +1970,28 @@ func TestStatusFlagsPartialSendAfterFreshRead(t *testing.T) {
 			got := latestSendJSON(view.latestSend)
 			if got == nil || got.NeedsAttention != test.wantAttention || got.RetrySafe != test.wantRetrySafe {
 				t.Fatalf("latest send JSON = %+v, want attention=%t retry_safe=%t", got, test.wantAttention, test.wantRetrySafe)
+			}
+		})
+	}
+}
+
+func TestRuntimeUnknownRequiresConcreteExecutionPane(t *testing.T) {
+	tests := []struct {
+		name   string
+		paneID string
+		want   bool
+	}{
+		{name: "synthetic attempt has no pane", want: false},
+		{name: "real attempt pane is unknown", paneID: "pane-1", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			view := taskView{
+				attempt:    &state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: test.paneID}},
+				agentState: string(herdr.StatusUnknown),
+			}
+			if got := runtimeUnknown(view); got != test.want {
+				t.Fatalf("runtimeUnknown() = %t, want %t", got, test.want)
 			}
 		})
 	}

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/atqamz/hand/internal/attention"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
@@ -48,14 +49,6 @@ type taskView struct {
 	// Empty where the gate-run check does not apply to this task, which is neither a finding nor
 	// an absence either: found, absent and unknown are the only three answers it ever gives.
 	gateObserved ghutil.ObservationState
-}
-
-// Reports whether the gate-run check found something an operator should look at: a found run and a
-// check that does not apply are both fine, so only absent and unknown count. watcher.GateKind is the
-// one place that decision is made, shared with hand watch's own gate classifier (atqamz/hand#268).
-func gateProblem(v taskView) bool {
-	_, ok := watcher.GateKind(v.gateObserved)
-	return ok
 }
 
 func (v taskView) execution() state.Attempt {
@@ -104,6 +97,9 @@ func taskFlags(v taskView) []string {
 	if v.unreachable {
 		flags = append(flags, "unreachable")
 	}
+	if runtimeUnknown(v) {
+		flags = append(flags, "runtime-unknown")
+	}
 	if v.parked {
 		flags = append(flags, "parked")
 	}
@@ -138,20 +134,48 @@ func taskFlags(v taskView) []string {
 // every consumer reads (atqamz/hand#268, docs/adr/attention-is-one-derivation-over-three-channels.md).
 // No elapsed-time staleness condition here, matching CatchUpFilter's own deliberate KindStale exclusion.
 func needsAttention(v taskView) bool {
-	if v.unreadable || v.unacked || gateProblem(v) || v.task.RepairCode != "" {
-		return true
+	return attention.NeedsAttention(taskAttentionEvidence(v))
+}
+
+func taskAttentionEvidence(v taskView) attention.Evidence {
+	evidence := attention.Evidence{
+		ID:               v.task.ID,
+		ReportUnreadable: v.unreadable,
+		Unacknowledged:   v.unacked,
+		Unannounced:      v.unannounced,
+		Unreported:       unreportedStop(v),
+		RuntimeUnknown:   runtimeUnknown(v),
+		Unreachable:      v.unreachable,
+		Parked:           v.parked,
+		Repair:           v.task.RepairCode != "",
+		ReportClaim:      v.reportedState != "",
+		ReportedState:    v.reportedState,
 	}
-	if v.unreachable || v.parked {
-		return true
+	if v.latestSend != nil {
+		evidence.SendPending = v.latestSend.State == state.SendPending
+		evidence.SendUncertain = v.latestSend.State == state.SendUncertain
+		evidence.SendPartial = isSendPartial(v)
 	}
-	if v.latestSend != nil && state.SendNeedsAttention(*v.latestSend) {
-		return true
+	if kind, ok := watcher.GateKind(v.gateObserved); ok {
+		evidence.GateProblem = kind
 	}
-	switch v.reportedState {
-	case state.ReportPaused, state.ReportBlocked, state.ReportNeedsDecision, state.ReportFailed:
-		return true
+	return evidence
+}
+
+func runtimeUnknown(v taskView) bool {
+	return v.attempt != nil &&
+		v.attempt.Lifecycle == state.AttemptRunning &&
+		v.execution().Herdr.PaneID != "" &&
+		v.agentState == string(herdr.StatusUnknown)
+}
+
+func hasAttentionKind(v taskView, kind string) bool {
+	for _, subject := range attention.Derive(taskAttentionEvidence(v)) {
+		if subject.Kind == kind {
+			return true
+		}
 	}
-	return unreportedStop(v)
+	return false
 }
 
 // The vocabulary --fields draws from, for both status views. One registry rather than one per view: a

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -166,6 +166,7 @@ func runtimeUnknown(v taskView) bool {
 	return v.attempt != nil &&
 		v.attempt.Lifecycle == state.AttemptRunning &&
 		v.execution().Herdr.PaneID != "" &&
+		!v.unreachable &&
 		v.agentState == string(herdr.StatusUnknown)
 }
 

--- a/docs/adr/arming-a-watch-observes-before-it-waits.md
+++ b/docs/adr/arming-a-watch-observes-before-it-waits.md
@@ -23,6 +23,9 @@ Arming performs a real observation whose events are delivered.
 
 Announcement, not operator acknowledgement, is the idempotence unit here. The acknowledgement model is defined in [the attention record](attention-is-one-derivation-over-three-channels.md).
 
+`hand session start` may run this same two-pass observation as a bounded arm.
+Because that command exits after the bounded pass, it reports `rearmed` rather than claiming a live watcher and names `hand watch --until-event` as the next re-arm action.
+
 ## Rejected alternatives
 
 - Keeping the silent baseline and letting supervisors poll `hand status` between arms restates the missed condition as the supervisor's problem and reintroduces the ad-hoc `sleep; poll` loop the issue rejects.

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -15,6 +15,9 @@ Two decisions already settle pieces of it.
 [Arming a watch observes before it waits](arming-a-watch-observes-before-it-waits.md) made wake level-triggered over durable fleet truth, and deliberately left the acknowledgement model to this record.
 Neither says how many definitions of attention the tool is allowed to have, nor what distinguishes a condition some watcher announced from one a supervisor has taken responsibility for.
 
+The shared evidence-to-actionability adapter now lives in [`internal/attention`](../../internal/attention).
+`internal/orientation` consumes its bounded subjects for supervisor turns, while status and next-action ranking consume the same derivation without merging report claims, runtime evidence, watcher announcements, or acknowledgement.
+
 The listed defects, each mapped to the invariant below that would have prevented it.
 
 - atqamz/hand#65, unbounded worker prose filling a supervising session, is invariant 1.

--- a/docs/adr/fleet-identity-and-user-registry.md
+++ b/docs/adr/fleet-identity-and-user-registry.md
@@ -42,3 +42,6 @@ Copied homes intentionally share an identity, so they must not share an IPC rout
 Operators can discover multiple homes from outside any Fleet while each command remains explicitly bound to its resolved home.
 Copied databases are visible and safe to refuse, but resolving a duplicate remains an operator decision because automatic re-keying would be irreversible and could orphan external resources.
 Herdr supports concurrent Fleet sessions without requiring Hand to stop or delete a named session during normal teardown.
+
+Supervisor monitor targets and currentness tokens include the authoritative Fleet identity, while watcher ownership remains scoped by canonical home and watcher generation.
+This keeps copied homes with colliding human-readable IDs from sharing wake routing or condition currentness.

--- a/docs/adr/stateless-supervisor-orientation-and-opaque-currentness.md
+++ b/docs/adr/stateless-supervisor-orientation-and-opaque-currentness.md
@@ -1,0 +1,44 @@
+# Stateless supervisor orientation and opaque currentness
+
+- Date: 2026-08-22
+- Status: accepted
+- Issue: atqamz/hand#340
+
+## Context
+
+Supervisor turns may begin after a process restart, a missed watcher edge, or a moved Fleet home.
+The existing status, next-action, session, and watcher paths each observe overlapping facts, but none provides one bounded orientation or an exact way to reject a stale wake.
+
+Hand must preserve Fleet identity, report claims, evidence, watcher announcements, and supervisor acknowledgement as separate channels while avoiding a durable supervisor session, event queue, or future Attention/FleetSnapshot schema.
+
+## Decision
+
+`internal/orientation` owns `SupervisorOrientation`, monitor targets, opaque `CurrentnessToken` values, bounded summaries, monitor state, next actions, truncation, and uncertainty.
+Tokens are provider-created values scoped to one Fleet, monitor kind, target identity, and exact current generation.
+Callers may carry, compare, return, or reject them, but never parse or construct their contents.
+
+`hand session start` reads authoritative Fleet identity, derives orientation, checks watcher ownership, performs a bounded two-pass arm when no watcher is live, then re-reads orientation.
+The bounded arm reports `rearmed` or `degraded`; only a lock-proven live watcher reports `already-armed`.
+The command never creates a supervisor-session row and never acknowledges or mutates work.
+
+Watcher wakes carry Fleet identity, monitor kind, opaque target identity, opaque currentness, event kind, and a bounded reason.
+A wake is only a hint: a consumer must read fresh orientation and accept the wake only when Fleet, target, kind, and currentness match exactly.
+
+The watcher keeps its per-home kernel lock, owner-generation takeover route, durable report cursor, and attempt observations.
+Startup and successor ownership retain the existing observe-before-wait two-pass catch-up, so a level already true while no watcher was alive is not lost.
+
+## Rejected alternatives
+
+- A durable supervisor-session or conversation row would couple currentness to one process and create storage ahead of the future read models.
+- A whole-Fleet hash would make an unrelated task invalidate every wake and would not provide exact target scoping.
+- A detached child without a platform-tested liveness contract would claim `armed` after the session command had already lost proof of the watcher.
+- Treating a wake as authoritative would let stale process output steer work without a fresh evidence read.
+
+## Consequences
+
+Repeated session starts converge without taking over a live watcher or clearing acknowledgement.
+Moved homes retain currentness when their authoritative Fleet identity and exact durable generation are unchanged.
+Colliding human-readable task IDs in different Fleets cannot share monitor IDs or tokens.
+The next orientation explicitly names `hand watch --until-event` when the bounded session command cannot prove a detached watcher.
+
+Future Task/Attempt storage and the eventual Attention or FleetSnapshot models can replace the provider adapter without changing the supervisor-facing session or wake contract.

--- a/docs/adr/the-until-event-exit-is-the-delivery.md
+++ b/docs/adr/the-until-event-exit-is-the-delivery.md
@@ -24,3 +24,6 @@ Until-event mode takes a baseline, exits after the first new matching event, and
 ## Consequences
 
 One invocation delivers one wake and must be re-armed. Events consumed during baseline remain in durable channels even though they do not cause that invocation to exit.
+
+Each delivered event can also carry a structured wake hint with Fleet identity, exact monitor target, opaque currentness, and a bounded reason.
+Consumers re-orient before acting and discard a wake whose target or currentness is stale.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -45,6 +45,27 @@ There is no global active Fleet selection to switch.
 The user-local, non-authoritative SQLite index at `~/.secondhand/registry.db` that retains observed Fleet home locators for discovery.
 Registry absence or degradation does not replace the authoritative identity in a Fleet home.
 
+### Supervisor orientation
+
+A bounded, stateless read model returned by `hand session start`.
+It contains Fleet identity, work and actionable summaries, exact monitor targets, monitor state, next actions, truncation, and uncertainty.
+It is not a durable supervisor session, Task-to-Plan record, FleetSnapshot, or Attention table.
+
+### Monitor target
+
+The smallest exact Fleet-scoped condition a watcher can observe and a supervisor can re-check.
+Its ID and currentness are provider-owned opaque values.
+
+### Currentness token
+
+An opaque provider-owned value for one exact monitor target generation.
+Callers may carry, compare, return, or reject it, but never parse it or infer a newer generation from its bytes.
+
+### Wake hint
+
+A bounded watcher message naming Fleet identity, monitor kind, opaque target, opaque currentness, and reason.
+A wake is not authoritative state and cannot directly mutate work; the supervisor must obtain fresh orientation first.
+
 ### Duplicate Fleet
 
 A Fleet identity that is valid at more than one registered home.

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
             vendorHash = "sha256-v84XwEQIPE8kqHDOhWcOS9pwk+ebjRJ/3XFuuwa0+aU=";
             checkFlags = [ "-tags=test" ];
             ldflags = [ "-s" "-w" "-X main.version=v${version}" "-X main.channel=stable" "-X main.commit=" "-X main.distribution=nix" ];
-            nativeCheckInputs = [ pkgs.git ]; # test suite execs git directly
+            nativeCheckInputs = [ pkgs.git pkgs.gh ]; # test suite execs git and gh directly
             meta.mainProgram = "hand";
           };
         }

--- a/internal/attention/attention.go
+++ b/internal/attention/attention.go
@@ -1,0 +1,137 @@
+package attention
+
+import "fmt"
+
+const (
+	KindReportUnreadable = "report-unreadable"
+	KindUnacknowledged   = "unacknowledged"
+	KindUnannounced      = "unannounced"
+	KindUnreported       = "unreported"
+	KindRuntimeUnknown   = "runtime-unknown"
+	KindUnreachable      = "unreachable"
+	KindParked           = "parked"
+	KindNeedsRepair      = "needs-repair"
+	KindSendUncertain    = "send-uncertain"
+	KindSendPartial      = "send-partial"
+	KindReportPaused     = "paused"
+	KindReportBlocked    = "blocked"
+	KindReportDecision   = "needs-decision"
+	KindReportFailed     = "failed"
+	KindReportDone       = "report-done"
+	KindGate             = "gate"
+	KindSendPending      = "send-pending"
+)
+
+const (
+	ProvenanceReport          = "report"
+	ProvenanceAcknowledgement = "acknowledgement"
+	ProvenanceWake            = "wake"
+	ProvenanceEvidence        = "evidence"
+	ProvenanceRuntime         = "runtime"
+	ProvenanceRepair          = "repair"
+	ProvenanceSend            = "send"
+	ProvenanceGate            = "gate"
+)
+
+type Evidence struct {
+	ID               string
+	ReportUnreadable bool
+	Unacknowledged   bool
+	Unannounced      bool
+	Unreported       bool
+	RuntimeUnknown   bool
+	Unreachable      bool
+	Parked           bool
+	Repair           bool
+	SendUncertain    bool
+	SendPending      bool
+	SendPartial      bool
+	ReportedState    string
+	ReportClaim      bool
+	GateProblem      string
+}
+
+type Subject struct {
+	Kind       string
+	Reason     string
+	Provenance string
+	Actionable bool
+}
+
+func Derive(e Evidence) []Subject {
+	var subjects []Subject
+	add := func(kind, reason, provenance string, actionable bool) {
+		subjects = append(subjects, Subject{Kind: kind, Reason: reason, Provenance: provenance, Actionable: actionable})
+	}
+	if e.ReportUnreadable {
+		add(KindReportUnreadable, "report channel is unreadable", ProvenanceReport, true)
+	}
+	if e.Unacknowledged {
+		add(KindUnacknowledged, "worker report is not acknowledged", ProvenanceAcknowledgement, true)
+	}
+	if e.Unannounced {
+		add(KindUnannounced, "terminal report is not announced by a watcher", ProvenanceWake, false)
+	}
+	if e.Unreported {
+		add(KindUnreported, "worker stopped without a terminal report", ProvenanceRuntime, true)
+	}
+	if e.RuntimeUnknown {
+		add(KindRuntimeUnknown, "runtime state is unknown", ProvenanceEvidence, true)
+	}
+	if e.Unreachable {
+		add(KindUnreachable, "worker runtime is unreachable", ProvenanceRuntime, true)
+	}
+	if e.Parked {
+		add(KindParked, "worker has exceeded its report silence bound", ProvenanceRuntime, true)
+	}
+	if e.Repair {
+		add(KindNeedsRepair, "task needs repair", ProvenanceRepair, true)
+	}
+	if e.SendUncertain {
+		add(KindSendUncertain, "send outcome is uncertain", ProvenanceSend, true)
+	}
+	if e.SendPending {
+		add(KindSendPending, "send is still in flight", ProvenanceSend, true)
+	}
+	if e.SendPartial {
+		add(KindSendPartial, "send may have been partially delivered", ProvenanceSend, true)
+	}
+	if e.ReportClaim {
+		switch e.ReportedState {
+		case "done":
+			add(KindReportDone, "worker claims completion; independent evidence is separate", ProvenanceReport, false)
+		case "paused":
+			add(KindReportPaused, "worker reports paused", ProvenanceReport, true)
+		case "blocked":
+			add(KindReportBlocked, "worker reports blocked", ProvenanceReport, true)
+		case "needs-decision":
+			add(KindReportDecision, "worker requests an operator decision", ProvenanceReport, true)
+		case "failed":
+			add(KindReportFailed, "worker reports failure", ProvenanceReport, true)
+		}
+	}
+	if e.GateProblem != "" {
+		add(KindGate, e.GateProblem, ProvenanceGate, true)
+	}
+	return subjects
+}
+
+func NeedsAttention(e Evidence) bool {
+	for _, subject := range Derive(e) {
+		if subject.Actionable {
+			return true
+		}
+	}
+	return false
+}
+
+func UnreportedRuntime(runtimeState, reportedState string) bool {
+	return NeedsAttention(Evidence{Unreported: (runtimeState == "idle" || runtimeState == "done") && (reportedState == "" || reportedState == "working")})
+}
+
+func (s Subject) String() string {
+	if s.Reason == "" {
+		return s.Kind
+	}
+	return fmt.Sprintf("%s: %s", s.Kind, s.Reason)
+}

--- a/internal/attention/attention_test.go
+++ b/internal/attention/attention_test.go
@@ -1,0 +1,73 @@
+package attention
+
+import "testing"
+
+func TestDerivePreservesEvidenceAndAcknowledgementProvenance(t *testing.T) {
+	got := Derive(Evidence{
+		ID:               "task-1",
+		ReportUnreadable: true,
+		Unacknowledged:   true,
+		Unannounced:      true,
+		ReportedState:    "needs-decision",
+		ReportClaim:      true,
+		Unreported:       true,
+	})
+
+	if len(got) != 5 {
+		t.Fatalf("subjects = %#v, want five independent subjects", got)
+	}
+	if got[0].Kind != KindReportUnreadable || got[0].Provenance != ProvenanceReport {
+		t.Fatalf("first subject = %#v, want unreadable report provenance", got[0])
+	}
+	if got[1].Kind != KindUnacknowledged || got[1].Provenance != ProvenanceAcknowledgement {
+		t.Fatalf("second subject = %#v, want acknowledgement provenance", got[1])
+	}
+	if got[2].Kind != KindUnannounced || got[2].Provenance != ProvenanceWake {
+		t.Fatalf("third subject = %#v, want watcher provenance", got[2])
+	}
+	if !NeedsAttention(Evidence{ID: "task-1", Unacknowledged: true}) {
+		t.Fatal("unacknowledged report is not actionable")
+	}
+	if NeedsAttention(Evidence{ID: "task-1", Unannounced: true}) {
+		t.Fatal("unannounced report alone is not supervisor acknowledgement attention")
+	}
+}
+
+func TestDeriveIsDeterministicAndSeparatesUnknownRuntimeFromReportClaim(t *testing.T) {
+	evidence := Evidence{
+		ID:             "task-1",
+		RuntimeUnknown: true,
+		ReportedState:  "done",
+		ReportClaim:    true,
+	}
+	got := Derive(evidence)
+	if len(got) != 2 {
+		t.Fatalf("subjects = %#v, want runtime unknown and report claim", got)
+	}
+	if got[0].Kind != KindRuntimeUnknown || got[0].Provenance != ProvenanceEvidence {
+		t.Fatalf("runtime subject = %#v, want evidence provenance", got[0])
+	}
+	if got[1].Kind != KindReportDone || got[1].Provenance != ProvenanceReport {
+		t.Fatalf("report subject = %#v, want report provenance", got[1])
+	}
+	want := got
+	if again := Derive(evidence); len(again) != len(want) || again[0] != want[0] || again[1] != want[1] {
+		t.Fatalf("second derivation = %#v, want deterministic %#v", again, want)
+	}
+}
+
+func TestUnreportedRuntimeMatchesWatcherCatchUpRule(t *testing.T) {
+	for _, test := range []struct {
+		runtime, reported string
+		want              bool
+	}{
+		{runtime: "done", reported: "", want: true},
+		{runtime: "idle", reported: "working", want: true},
+		{runtime: "done", reported: "done", want: false},
+		{runtime: "working", reported: "", want: false},
+	} {
+		if got := UnreportedRuntime(test.runtime, test.reported); got != test.want {
+			t.Fatalf("UnreportedRuntime(%q, %q) = %t, want %t", test.runtime, test.reported, got, test.want)
+		}
+	}
+}

--- a/internal/integration/catalog.go
+++ b/internal/integration/catalog.go
@@ -69,19 +69,19 @@ func Run(ctx context.Context, id, dir string, args ...string) ([]byte, []byte, e
 	if !ok {
 		return nil, nil, fmt.Errorf("unsupported optional capability %q", id)
 	}
+	// Test builds must use the caller's PATH so per-test fakes cannot be bypassed by a private
+	// integration installed in the developer's SECONDHAND_HOME.
+	if legacyCapabilityFallback {
+		return runExecutable(ctx, capability.Executable, dir, args...)
+	}
 	path, err := DefaultStore().Resolve(id)
 	if err != nil {
-		if legacyCapabilityFallback {
-			cmd := exec.CommandContext(ctx, capability.Executable, args...)
-			cmd.Dir = dir
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-			runErr := cmd.Run()
-			return stdout.Bytes(), stderr.Bytes(), runErr
-		}
 		return nil, nil, err
 	}
+	return runExecutable(ctx, path, dir, args...)
+}
+
+func runExecutable(ctx context.Context, path, dir string, args ...string) ([]byte, []byte, error) {
 	cmd := exec.CommandContext(ctx, path, args...)
 	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer

--- a/internal/integration/fallback_testmode_test.go
+++ b/internal/integration/fallback_testmode_test.go
@@ -1,0 +1,47 @@
+//go:build test
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func TestTestModeRunPrefersPATHFakeOverPrivateCapability(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SECONDHAND_HOME", root)
+
+	privateBin := t.TempDir()
+	faketool.Command{Name: "gh", Stdout: "private\n"}.Install(t, privateBin)
+	privateSource := filepath.Join(privateBin, "gh")
+	if runtime.GOOS == "windows" {
+		privateSource += ".exe"
+	}
+	store := NewStore(root)
+	installed, err := store.Install("github/gh", privateSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateConfig, err := os.ReadFile(filepath.Join(privateBin, ".gh-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(installed), ".gh-config.json"), privateConfig, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pathBin := faketool.Bin(t)
+	faketool.Command{Name: "gh", Stdout: "path\n"}.Install(t, pathBin)
+	stdout, stderr, err := Run(context.Background(), "github/gh", "")
+	if err != nil {
+		t.Fatalf("Run error = %v, stderr = %q", err, stderr)
+	}
+	if string(stdout) != "path\n" {
+		t.Fatalf("Run stdout = %q, want PATH fake output", stdout)
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -5,6 +5,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -28,6 +29,18 @@ var sendTimeout = 10 * time.Second
 // $HAND_MESSAGE, in-process rather than through the hand notify subcommand, and
 // reports whether the template actually ran and succeeded.
 func Send(home, message string) error {
+	return send(home, message, "")
+}
+
+func SendWithWake(home, message string, wake any) error {
+	data, err := json.Marshal(wake)
+	if err != nil {
+		return fmt.Errorf("marshal notification wake: %w", err)
+	}
+	return send(home, message, string(data))
+}
+
+func send(home, message, wake string) error {
 	template, err := os.ReadFile(filepath.Join(home, "config", "notify"))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -50,6 +63,9 @@ func Send(home, message string) error {
 	defer cancel()
 	run := exec.CommandContext(ctx, shell, "-c", command)
 	run.Env = append(os.Environ(), "HAND_MESSAGE="+message)
+	if wake != "" {
+		run.Env = append(run.Env, "HAND_WAKE="+wake)
+	}
 	// Without WaitDelay, a template that backgrounds a child holding the output
 	// pipe keeps CombinedOutput waiting past the kill, defeating the timeout.
 	run.WaitDelay = time.Second

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -114,6 +114,29 @@ func TestSendRunsTheTemplateWithTheMessage(t *testing.T) {
 	}
 }
 
+func TestSendWithWakeProvidesStructuredHintAlongsideMessage(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, "marker.txt")
+	template := "printf '%s\\n%s' \"$HAND_MESSAGE\" \"$HAND_WAKE\" > " + shellquote.Quote(marker)
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte(template), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SendWithWake(home, "blocked task-1", map[string]string{"fleet_id": "f_one", "currentness": "c_one"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "blocked task-1\n{\"currentness\":\"c_one\",\"fleet_id\":\"f_one\"}" {
+		t.Fatalf("marker content = %q, want message and structured wake", got)
+	}
+}
+
 func TestSendReportsTemplateFailureRatherThanSwallowingIt(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {

--- a/internal/orientation/orientation.go
+++ b/internal/orientation/orientation.go
@@ -1,0 +1,401 @@
+package orientation
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const Schema = "hand.supervisor.v1"
+
+const maxOrientationItems = 64
+const maxOrientationText = 256
+
+type MonitorState string
+
+const (
+	MonitorStateArmed        MonitorState = "armed"
+	MonitorStateRearmed      MonitorState = "rearmed"
+	MonitorStateAlreadyArmed MonitorState = "already-armed"
+	MonitorStateDegraded     MonitorState = "degraded"
+	MonitorStateUnknown      MonitorState = "unknown"
+)
+
+type CurrentnessToken struct {
+	value string
+}
+
+func (t CurrentnessToken) String() string {
+	return t.value
+}
+
+func (t CurrentnessToken) IsZero() bool {
+	return t.value == ""
+}
+
+func (t CurrentnessToken) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.value)
+}
+
+type MonitorTarget struct {
+	ID          string           `json:"id"`
+	Kind        string           `json:"kind"`
+	Currentness CurrentnessToken `json:"currentness"`
+}
+
+type WorkSummary struct {
+	ID       string        `json:"id"`
+	Kind     string        `json:"kind"`
+	State    string        `json:"state"`
+	Reported string        `json:"reported,omitempty"`
+	Monitor  MonitorTarget `json:"monitor"`
+}
+
+type ActionableSubject struct {
+	Target     MonitorTarget `json:"target"`
+	Kind       string        `json:"kind"`
+	Reason     string        `json:"reason"`
+	Provenance string        `json:"provenance"`
+}
+
+type NextAction struct {
+	Kind    string `json:"kind"`
+	Target  string `json:"target,omitempty"`
+	Command string `json:"command,omitempty"`
+	Reason  string `json:"reason"`
+}
+
+type BoundedError struct {
+	Kind   string `json:"kind"`
+	Reason string `json:"reason"`
+}
+
+type SupervisorOrientation struct {
+	Schema       string              `json:"schema"`
+	FleetID      string              `json:"fleet_id"`
+	Work         []WorkSummary       `json:"work"`
+	Actionable   []ActionableSubject `json:"actionable"`
+	Monitors     []MonitorTarget     `json:"monitors"`
+	MonitorState MonitorState        `json:"monitor_state"`
+	NextActions  []NextAction        `json:"next_actions"`
+	Truncated    bool                `json:"truncated"`
+	Omitted      int                 `json:"omitted"`
+	Errors       []BoundedError      `json:"errors"`
+}
+
+type TargetEvidence struct {
+	ID         string   `json:"id"`
+	Kind       string   `json:"kind"`
+	Generation []string `json:"generation"`
+}
+
+type TaskTargetFacts struct {
+	ID               string
+	Kind             string
+	CreatedAt        string
+	Lifecycle        string
+	ActiveAttemptID  int64
+	AttemptID        int64
+	AttemptLifecycle string
+	RuntimeIdentity  []string
+	StatusChangedAt  string
+	StatusChangedFor string
+	ReportState      string
+	ReportOffset     int64
+	ReportDigest     string
+	DoneVerified     bool
+	PR               string
+	MergeExecuted    bool
+	MergeAnnounced   bool
+}
+
+type WorkEvidence struct {
+	ID       string `json:"id"`
+	Kind     string `json:"kind"`
+	State    string `json:"state"`
+	Reported string `json:"reported,omitempty"`
+}
+
+type ActionableEvidence struct {
+	TargetID   string   `json:"target_id"`
+	TargetKind string   `json:"target_kind"`
+	Generation []string `json:"generation"`
+	Kind       string   `json:"kind"`
+	Reason     string   `json:"reason"`
+	Provenance string   `json:"provenance"`
+}
+
+type Evidence struct {
+	FleetID      string               `json:"fleet_id"`
+	Work         []WorkEvidence       `json:"work"`
+	Actionable   []ActionableEvidence `json:"actionable"`
+	Targets      []TargetEvidence     `json:"targets"`
+	NextActions  []NextAction         `json:"next_actions"`
+	MonitorState MonitorState         `json:"monitor_state"`
+	Errors       []BoundedError       `json:"errors"`
+}
+
+type Reader func(context.Context) (Evidence, error)
+
+type Provider struct {
+	read Reader
+}
+
+func NewProvider(read Reader) *Provider {
+	return &Provider{read: read}
+}
+
+func (p *Provider) Orientation(ctx context.Context) (SupervisorOrientation, error) {
+	if p == nil || p.read == nil {
+		return SupervisorOrientation{}, errors.New("orientation provider has no evidence reader")
+	}
+	evidence, err := p.read(ctx)
+	if err != nil {
+		return SupervisorOrientation{}, err
+	}
+	return Build(evidence), nil
+}
+
+func Build(evidence Evidence) SupervisorOrientation {
+	result := SupervisorOrientation{Schema: Schema, FleetID: evidence.FleetID, MonitorState: evidence.MonitorState}
+	result.MonitorState = normalizeMonitorState(result.MonitorState)
+	if result.FleetID == "" {
+		result.Errors = append(result.Errors, BoundedError{Kind: "fleet", Reason: "Fleet identity is unavailable"})
+		result.MonitorState = MonitorStateUnknown
+	}
+
+	targets := make(map[string]MonitorTarget, len(evidence.Targets))
+	for _, target := range evidence.Targets {
+		key := targetKey(target.Kind, target.ID)
+		if _, exists := targets[key]; exists {
+			result.Errors = append(result.Errors, BoundedError{Kind: "target", Reason: fmt.Sprintf("duplicate monitor target %q", target.ID)})
+			continue
+		}
+		targets[key] = TargetFor(evidence.FleetID, target)
+	}
+
+	seenTargets := make(map[string]bool, len(evidence.Targets))
+	for _, target := range sortedTargetEvidence(evidence.Targets) {
+		key := targetKey(target.Kind, target.ID)
+		if seenTargets[key] {
+			continue
+		}
+		seenTargets[key] = true
+		if monitor, ok := targets[targetKey(target.Kind, target.ID)]; ok {
+			result.Monitors = append(result.Monitors, monitor)
+		}
+	}
+	for _, work := range sortedWork(evidence.Work) {
+		monitor := targets[targetKey(work.Kind, work.ID)]
+		if monitor.ID == "" {
+			result.Errors = append(result.Errors, BoundedError{Kind: "work", Reason: fmt.Sprintf("work item %q has no monitor target", work.ID)})
+		}
+		result.Work = append(result.Work, WorkSummary{ID: work.ID, Kind: work.Kind, State: work.State, Reported: work.Reported, Monitor: monitor})
+	}
+	for _, item := range sortedActionable(evidence.Actionable) {
+		monitor := targets[targetKey(item.TargetKind, item.TargetID)]
+		if monitor.ID == "" {
+			result.Errors = append(result.Errors, BoundedError{Kind: "actionable", Reason: fmt.Sprintf("actionable item %q has no monitor target", item.TargetID)})
+		}
+		result.Actionable = append(result.Actionable, ActionableSubject{Target: monitor, Kind: item.Kind, Reason: item.Reason, Provenance: item.Provenance})
+	}
+	result.NextActions = sortedNextActions(evidence.NextActions)
+	result.Errors = append(result.Errors, evidence.Errors...)
+	sort.SliceStable(result.Errors, func(i, j int) bool {
+		if result.Errors[i].Kind != result.Errors[j].Kind {
+			return result.Errors[i].Kind < result.Errors[j].Kind
+		}
+		return result.Errors[i].Reason < result.Errors[j].Reason
+	})
+	bound(&result)
+	return result
+}
+
+func normalizeMonitorState(state MonitorState) MonitorState {
+	switch state {
+	case MonitorStateArmed, MonitorStateRearmed, MonitorStateAlreadyArmed, MonitorStateDegraded:
+		return state
+	default:
+		return MonitorStateUnknown
+	}
+}
+
+func TargetFor(fleetID string, target TargetEvidence) MonitorTarget {
+	return MonitorTarget{
+		ID:          targetID(fleetID, target.Kind, target.ID),
+		Kind:        target.Kind,
+		Currentness: currentnessToken(fleetID, target.Kind, target.ID, target.Generation),
+	}
+}
+
+func TaskTarget(fleetID string, facts TaskTargetFacts) MonitorTarget {
+	return TargetFor(fleetID, TaskTargetEvidence(facts))
+}
+
+func TaskTargetEvidence(facts TaskTargetFacts) TargetEvidence {
+	return TargetEvidence{ID: facts.ID, Kind: facts.Kind, Generation: taskGeneration(facts)}
+}
+
+func taskGeneration(facts TaskTargetFacts) []string {
+	runtimeIdentity := append([]string(nil), facts.RuntimeIdentity...)
+	for len(runtimeIdentity) < 4 {
+		runtimeIdentity = append(runtimeIdentity, "")
+	}
+	return []string{
+		facts.CreatedAt,
+		facts.Lifecycle,
+		fmt.Sprintf("active-attempt:%d", facts.ActiveAttemptID),
+		fmt.Sprintf("attempt:%d:%s", facts.AttemptID, facts.AttemptLifecycle),
+		runtimeIdentity[0],
+		runtimeIdentity[1],
+		runtimeIdentity[2],
+		runtimeIdentity[3],
+		facts.StatusChangedAt,
+		facts.StatusChangedFor,
+		facts.ReportState,
+		fmt.Sprintf("report:%d:%s", facts.ReportOffset, facts.ReportDigest),
+		fmt.Sprintf("done-verified:%t", facts.DoneVerified),
+		facts.PR,
+		fmt.Sprintf("merge:%t:%t", facts.MergeExecuted, facts.MergeAnnounced),
+	}
+}
+
+func targetKey(kind, id string) string {
+	return kind + "\x00" + id
+}
+
+func targetID(fleetID, kind, id string) string {
+	return "m_" + digest(fleetID, kind, id)
+}
+
+func currentnessToken(fleetID, kind, id string, generation []string) CurrentnessToken {
+	parts := append([]string{fleetID, kind, id}, generation...)
+	return CurrentnessToken{value: "c_" + digest(parts...)}
+}
+
+func digest(parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = fmt.Fprintf(hash, "%d:", len(part))
+		hash.Write([]byte(part))
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sortedTargetEvidence(items []TargetEvidence) []TargetEvidence {
+	items = append([]TargetEvidence(nil), items...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items
+}
+
+func sortedWork(items []WorkEvidence) []WorkEvidence {
+	items = append([]WorkEvidence(nil), items...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items
+}
+
+func sortedActionable(items []ActionableEvidence) []ActionableEvidence {
+	items = append([]ActionableEvidence(nil), items...)
+	sort.Slice(items, func(i, j int) bool {
+		left := targetKey(items[i].TargetKind, items[i].TargetID)
+		right := targetKey(items[j].TargetKind, items[j].TargetID)
+		if left != right {
+			return left < right
+		}
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].Reason < items[j].Reason
+	})
+	return items
+}
+
+func sortedNextActions(items []NextAction) []NextAction {
+	items = append([]NextAction(nil), items...)
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		if items[i].Target != items[j].Target {
+			return items[i].Target < items[j].Target
+		}
+		if items[i].Command != items[j].Command {
+			return items[i].Command < items[j].Command
+		}
+		return items[i].Reason < items[j].Reason
+	})
+	return items
+}
+
+func bound(result *SupervisorOrientation) {
+	if len(result.Work) > maxOrientationItems {
+		result.Omitted += len(result.Work) - maxOrientationItems
+		result.Work = result.Work[:maxOrientationItems]
+	}
+	if len(result.Actionable) > maxOrientationItems {
+		result.Omitted += len(result.Actionable) - maxOrientationItems
+		result.Actionable = result.Actionable[:maxOrientationItems]
+	}
+	if len(result.Monitors) > maxOrientationItems {
+		result.Omitted += len(result.Monitors) - maxOrientationItems
+		result.Monitors = result.Monitors[:maxOrientationItems]
+	}
+	if len(result.NextActions) > maxOrientationItems {
+		result.Omitted += len(result.NextActions) - maxOrientationItems
+		result.NextActions = result.NextActions[:maxOrientationItems]
+	}
+	if len(result.Errors) > maxOrientationItems {
+		result.Omitted += len(result.Errors) - maxOrientationItems
+		result.Errors = result.Errors[:maxOrientationItems]
+	}
+	if result.Omitted > 0 {
+		result.Truncated = true
+	}
+	result.FleetID, result.Truncated = boundedText(result.FleetID, result.Truncated)
+	for i := range result.Work {
+		result.Work[i].ID, result.Truncated = boundedText(result.Work[i].ID, result.Truncated)
+		result.Work[i].Kind, result.Truncated = boundedText(result.Work[i].Kind, result.Truncated)
+		result.Work[i].State, result.Truncated = boundedText(result.Work[i].State, result.Truncated)
+		result.Work[i].Reported, result.Truncated = boundedText(result.Work[i].Reported, result.Truncated)
+	}
+	for i := range result.Actionable {
+		result.Actionable[i].Kind, result.Truncated = boundedText(result.Actionable[i].Kind, result.Truncated)
+		result.Actionable[i].Reason, result.Truncated = boundedText(result.Actionable[i].Reason, result.Truncated)
+		result.Actionable[i].Provenance, result.Truncated = boundedText(result.Actionable[i].Provenance, result.Truncated)
+	}
+	for i := range result.NextActions {
+		result.NextActions[i].Kind, result.Truncated = boundedText(result.NextActions[i].Kind, result.Truncated)
+		result.NextActions[i].Target, result.Truncated = boundedText(result.NextActions[i].Target, result.Truncated)
+		result.NextActions[i].Command, result.Truncated = boundedText(result.NextActions[i].Command, result.Truncated)
+		result.NextActions[i].Reason, result.Truncated = boundedText(result.NextActions[i].Reason, result.Truncated)
+	}
+	for i := range result.Errors {
+		result.Errors[i].Kind = strings.TrimSpace(result.Errors[i].Kind)
+		result.Errors[i].Reason = strings.TrimSpace(result.Errors[i].Reason)
+		result.Errors[i].Kind, result.Truncated = boundedText(result.Errors[i].Kind, result.Truncated)
+		result.Errors[i].Reason, result.Truncated = boundedText(result.Errors[i].Reason, result.Truncated)
+	}
+}
+
+func boundedText(value string, truncated bool) (string, bool) {
+	runes := []rune(value)
+	if len(runes) <= maxOrientationText {
+		return value, truncated
+	}
+	return string(runes[:maxOrientationText]), true
+}

--- a/internal/orientation/orientation_test.go
+++ b/internal/orientation/orientation_test.go
@@ -1,0 +1,168 @@
+package orientation
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProviderKeepsExactTargetTokenStableAndChangesActiveGeneration(t *testing.T) {
+	provider := NewProvider(func(context.Context) (Evidence, error) {
+		return Evidence{
+			FleetID: "f_one",
+			Targets: []TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"attempt-1", "running"}}},
+		}, nil
+	})
+
+	first, err := provider.Orientation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := provider.Orientation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Monitors[0].Currentness != second.Monitors[0].Currentness {
+		t.Fatalf("unchanged token = %q and %q, want stable", first.Monitors[0].Currentness, second.Monitors[0].Currentness)
+	}
+
+	provider = NewProvider(func(context.Context) (Evidence, error) {
+		return Evidence{
+			FleetID: "f_one",
+			Targets: []TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"attempt-2", "running"}}},
+		}, nil
+	})
+	changed, err := provider.Orientation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Monitors[0].Currentness == changed.Monitors[0].Currentness {
+		t.Fatalf("replaced generation kept token %q", changed.Monitors[0].Currentness)
+	}
+}
+
+func TestProviderScopesCollidingIDsByFleetAndTargetKind(t *testing.T) {
+	makeOrientation := func(fleet string, kind string) SupervisorOrientation {
+		provider := NewProvider(func(context.Context) (Evidence, error) {
+			return Evidence{FleetID: fleet, Targets: []TargetEvidence{{ID: "same", Kind: kind, Generation: []string{"one"}}}}, nil
+		})
+		got, err := provider.Orientation(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	a := makeOrientation("f_one", "task")
+	b := makeOrientation("f_two", "task")
+	c := makeOrientation("f_one", "fleet")
+	if a.Monitors[0].ID == b.Monitors[0].ID || a.Monitors[0].Currentness == b.Monitors[0].Currentness {
+		t.Fatal("colliding task IDs across Fleets share monitor identity or currentness")
+	}
+	if a.Monitors[0].ID == c.Monitors[0].ID || a.Monitors[0].Currentness == c.Monitors[0].Currentness {
+		t.Fatal("different target kinds share monitor identity or currentness")
+	}
+}
+
+func TestProviderKeepsCurrentnessAcrossAHomeMoveWithTheSameFleetIdentity(t *testing.T) {
+	makeOrientation := func(home string) SupervisorOrientation {
+		provider := NewProvider(func(context.Context) (Evidence, error) {
+			return Evidence{
+				FleetID: home,
+				Targets: []TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"attempt-1", "running"}}},
+			}, nil
+		})
+		got, err := provider.Orientation(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	first := makeOrientation("f_same")
+	moved := makeOrientation("f_same")
+	if first.Monitors[0] != moved.Monitors[0] {
+		t.Fatalf("moved-home target = %#v, want unchanged Fleet-scoped target", moved.Monitors[0])
+	}
+}
+
+func TestTaskTargetDoesNotIncludeAcknowledgementChannel(t *testing.T) {
+	facts := TaskTargetFacts{
+		ID: "task-1", Kind: "task", CreatedAt: "created", Lifecycle: "open", RuntimeIdentity: []string{"s", "w", "t", "p"},
+		ReportState: "done", ReportOffset: 12, ReportDigest: "report", DoneVerified: true,
+	}
+	first := TaskTarget("f_one", facts)
+	facts.ReportState = "done"
+	second := TaskTarget("f_one", facts)
+	if first != second {
+		t.Fatalf("unchanged task target = %#v and %#v, want stable when acknowledgement is unchanged", first, second)
+	}
+}
+
+func TestProviderSortsAndBoundsOrientationWithExplicitUncertainty(t *testing.T) {
+	provider := NewProvider(func(context.Context) (Evidence, error) {
+		return Evidence{
+			FleetID: "f_one",
+			Targets: []TargetEvidence{
+				{ID: "z", Kind: "task", Generation: []string{"z"}},
+				{ID: "a", Kind: "task", Generation: []string{"a"}},
+			},
+			Work: []WorkEvidence{
+				{ID: "z", Kind: "task", State: "unknown"},
+				{ID: "a", Kind: "task", State: "working"},
+			},
+			Errors:       []BoundedError{{Kind: "registry", Reason: "unavailable"}},
+			MonitorState: MonitorStateUnknown,
+		}, nil
+	})
+
+	got, err := provider.Orientation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Schema != Schema || got.FleetID != "f_one" {
+		t.Fatalf("header = %#v, want schema and Fleet ID", got)
+	}
+	if len(got.Monitors) != 2 || got.Monitors[0].ID >= got.Monitors[1].ID {
+		t.Fatalf("monitors = %#v, want deterministic ordering", got.Monitors)
+	}
+	if got.MonitorState != MonitorStateUnknown || len(got.Errors) != 1 || got.Errors[0].Kind != "registry" {
+		t.Fatalf("uncertainty = %#v, want explicit unknown registry state", got)
+	}
+}
+
+func TestBuildNormalizesUnknownMonitorStateAndBoundsText(t *testing.T) {
+	got := Build(Evidence{
+		FleetID:      "f_one",
+		MonitorState: "invalid",
+		Actionable: []ActionableEvidence{{
+			TargetID: "task-1", TargetKind: "task", Kind: "blocked", Reason: strings.Repeat("x", 500),
+		}},
+		Targets: []TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"one"}}},
+	})
+	if got.MonitorState != MonitorStateUnknown {
+		t.Fatalf("monitor state = %q, want unknown", got.MonitorState)
+	}
+	if !got.Truncated || len([]rune(got.Actionable[0].Reason)) != 256 {
+		t.Fatalf("bounded actionable = %#v, want 256-rune truncated reason", got.Actionable[0])
+	}
+}
+
+func TestBuildDeduplicatesTargetsAndSortsAllBoundedCollections(t *testing.T) {
+	got := Build(Evidence{
+		FleetID: "f_one",
+		Targets: []TargetEvidence{
+			{ID: "task-1", Kind: "task", Generation: []string{"one"}},
+			{ID: "task-1", Kind: "task", Generation: []string{"two"}},
+		},
+		Work:        []WorkEvidence{{ID: "task-1", Kind: "task"}},
+		NextActions: []NextAction{{Kind: "z", Reason: "later"}, {Kind: "a", Reason: "first"}},
+		Errors:      []BoundedError{{Kind: "z", Reason: "later"}, {Kind: "a", Reason: "first"}},
+	})
+	if len(got.Monitors) != 1 || len(got.Errors) != 3 {
+		t.Fatalf("orientation = %#v, want one monitor and duplicate/missing-target errors", got)
+	}
+	if got.NextActions[0].Kind != "a" || got.Errors[0].Kind != "a" {
+		t.Fatalf("orientation ordering = %#v, want deterministic ordering", got)
+	}
+}

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/age"
+	"github.com/atqamz/hand/internal/attention"
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -129,6 +131,42 @@ type Event struct {
 	Text     string
 	Reason   string
 	Verified bool
+	FleetID  string
+	Target   orientation.MonitorTarget
+}
+
+const MaxWakeReason = 240
+
+type Wake struct {
+	FleetID     string                       `json:"fleet_id"`
+	Kind        string                       `json:"kind"`
+	EventKind   string                       `json:"event_kind"`
+	TargetID    string                       `json:"target_id"`
+	Currentness orientation.CurrentnessToken `json:"currentness"`
+	Reason      string                       `json:"reason"`
+}
+
+func (e Event) Wake() Wake {
+	reason := e.Reason
+	if reason == "" {
+		reason = e.Text
+	}
+	if runes := []rune(reason); len(runes) > MaxWakeReason {
+		reason = string(runes[:MaxWakeReason])
+	}
+	return Wake{FleetID: e.FleetID, Kind: e.Target.Kind, EventKind: e.Kind, TargetID: e.Target.ID, Currentness: e.Target.Currentness, Reason: reason}
+}
+
+func (w Wake) Current(current orientation.SupervisorOrientation) bool {
+	if w.FleetID == "" || w.FleetID != current.FleetID || w.TargetID == "" || w.Currentness.IsZero() {
+		return false
+	}
+	for _, target := range current.Monitors {
+		if target.ID == w.TargetID && target.Kind == w.Kind && target.Currentness == w.Currentness {
+			return true
+		}
+	}
+	return false
 }
 
 // TaskState tracks what's already been observed and announced for one task, so the
@@ -247,7 +285,7 @@ func ClassifyStatus(ts *TaskState, id string, status herdr.Status, probeErr erro
 			// Only when nothing has explained the stop: no report at all, or a last report still
 			// "working". Any other reported state - paused, blocked, needs-decision, done, failed -
 			// already explains the pane going quiet, so the transition is absorbed instead of alarming.
-			if ts.LastReportState == "" || ts.LastReportState == state.ReportWorking {
+			if attention.UnreportedRuntime(string(status), ts.LastReportState) {
 				return &Event{TaskID: id, Kind: KindIdleUnreported, Text: fmt.Sprintf("idle-unreported %s", id)}
 			}
 		}
@@ -279,7 +317,7 @@ func ClassifyCatchUp(ts *TaskState, id string, status herdr.Status, observedFor,
 	switch {
 	case status.NotBusy():
 		// The same question ClassifyStatus asks of its own idle edge: has anything explained the stop.
-		if ts.LastReportState == "" || ts.LastReportState == state.ReportWorking {
+		if attention.UnreportedRuntime(string(status), ts.LastReportState) {
 			return &Event{TaskID: id, Kind: KindIdleUnreported, Text: fmt.Sprintf("idle-unreported %s", id)}
 		}
 	case status == herdr.StatusBlocked:

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -1,16 +1,54 @@
 package watcher
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/state"
 )
+
+func TestEventWakeCarriesFleetAndOpaqueExactTarget(t *testing.T) {
+	provider := orientation.NewProvider(func(context.Context) (orientation.Evidence, error) {
+		return orientation.Evidence{
+			FleetID: "f_one",
+			Targets: []orientation.TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"attempt-1"}}},
+		}, nil
+	})
+	oriented, err := provider.Orientation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := Event{TaskID: "task-1", Kind: KindBlocked, Reason: strings.Repeat("reason ", 100)}
+	event.FleetID = oriented.FleetID
+	event.Target = oriented.Monitors[0]
+	wake := event.Wake()
+	if wake.FleetID != "f_one" || wake.TargetID != oriented.Monitors[0].ID || wake.Currentness != oriented.Monitors[0].Currentness {
+		t.Fatalf("wake = %#v, want exact Fleet target and token", wake)
+	}
+	if len([]rune(wake.Reason)) > MaxWakeReason {
+		t.Fatalf("reason length = %d, want <= %d", len([]rune(wake.Reason)), MaxWakeReason)
+	}
+	if !wake.Current(oriented) {
+		t.Fatal("fresh wake rejected by matching orientation")
+	}
+
+	changed := orientation.Build(orientation.Evidence{
+		FleetID: "f_one",
+		Targets: []orientation.TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"attempt-2"}}},
+	})
+	if wake.Current(changed) {
+		t.Fatal("stale wake accepted after target generation changed")
+	}
+}
 
 // Covers herdr's two spellings of "pane stopped being busy" - see herdr.Status's doc for why idle
 // and done must be classified identically: hand's headless polling model observes done, essentially

--- a/internal/watcher/ownership.go
+++ b/internal/watcher/ownership.go
@@ -57,6 +57,26 @@ func Acquire(homeDir string, takeover bool) (*Ownership, error) {
 	return AcquireContext(context.Background(), homeDir, takeover)
 }
 
+func IsAttached(homeDir string) (bool, error) {
+	home := canonicalHome(homeDir)
+	lockFile, err := os.OpenFile(OwnerPath(home)+".lock", os.O_RDWR, 0o644)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("open watcher lock: %w", err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	if err := lockOwner(lockFile); err == nil {
+		releaseLock(lockFile)
+		return false, nil
+	} else if errors.Is(err, filelock.ErrBusy) {
+		return true, nil
+	} else {
+		return false, fmt.Errorf("inspect watcher lock: %w", err)
+	}
+}
+
 // Context-aware acquisition stops a takeover wait without changing lock authority.
 func AcquireContext(ctx context.Context, homeDir string, takeover bool) (*Ownership, error) {
 	if err := acquisitionContextError(ctx); err != nil {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/notify"
+	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/state"
@@ -30,7 +31,13 @@ var afterWatchTick = func() {}
 var afterArmTick = func() {}
 
 type Config struct {
-	Home           string
+	Home    string
+	FleetID string
+	Targets []TargetBinding
+	// ObserveOnly is used by a bounded session arm: it may classify and persist watcher-owned
+	// observations, but it must not auto-record PRs, recover sends, or steer a worker.
+	ObserveOnly    bool
+	SuppressNotify bool
 	PollInterval   time.Duration
 	StaleThreshold time.Duration
 	// Timeout bounds RunUntilEvent only. Zero blocks until an event arrives.
@@ -44,6 +51,60 @@ type Config struct {
 	// arms. Unexported because it describes this package's own two-tick arming rather than anything a
 	// caller asked for, and nil - matching every kind - on every other tick.
 	catchUp EventFilter
+}
+
+type TargetBinding struct {
+	TaskID string
+	Target orientation.MonitorTarget
+}
+
+type EnsureResult struct {
+	State  orientation.MonitorState
+	Live   bool
+	Reason string
+}
+
+const boundedArmTimeout = 250 * time.Millisecond
+const boundedArmPollInterval = 10 * time.Millisecond
+
+func Ensure(ctx context.Context, cfg Config, targets []TargetBinding) (EnsureResult, error) {
+	fleetID, err := state.FleetIDReadOnly(cfg.Home)
+	if err != nil {
+		return EnsureResult{State: orientation.MonitorStateUnknown, Reason: "Fleet identity is unavailable"}, fmt.Errorf("read Fleet identity for watcher ensure: %w", err)
+	}
+	attached, err := IsAttached(cfg.Home)
+	if err != nil {
+		return EnsureResult{State: orientation.MonitorStateUnknown, Reason: "watcher ownership is unknown"}, err
+	}
+	if attached {
+		return EnsureResult{State: orientation.MonitorStateAlreadyArmed, Live: true, Reason: "a watcher already owns this Fleet home"}, nil
+	}
+	if len(targets) == 0 {
+		return EnsureResult{State: orientation.MonitorStateRearmed, Reason: "no monitor targets require a bounded arm"}, nil
+	}
+
+	armCtx, cancel := withWatchTimeout(ctx, boundedArmTimeout)
+	defer cancel()
+	cfg.FleetID = fleetID
+	cfg.Targets = append([]TargetBinding(nil), targets...)
+	cfg.ObserveOnly = true
+	cfg.SuppressNotify = true
+	cfg.PollInterval = boundedArmPollInterval
+	ownership, err := AcquireContext(armCtx, cfg.Home, false)
+	if errors.Is(err, ErrAttached) {
+		return EnsureResult{State: orientation.MonitorStateAlreadyArmed, Live: true, Reason: "a watcher attached while session start was preparing"}, nil
+	}
+	if err != nil {
+		return EnsureResult{State: orientation.MonitorStateUnknown, Reason: "watcher ownership could not be established"}, err
+	}
+	defer ownership.Release()
+
+	var out, errOut bytes.Buffer
+	err = RunUntilEvent(armCtx, cfg, &out, &errOut)
+	if err == nil || errors.Is(err, ErrNoEvent) {
+		return EnsureResult{State: orientation.MonitorStateRearmed, Reason: "bounded arm completed; run `hand watch --until-event` to keep monitoring"}, nil
+	}
+	return EnsureResult{State: orientation.MonitorStateDegraded, Reason: "bounded arm could not prove monitoring: " + flattenError(err)}, nil
 }
 
 var ErrNoEvent = errors.New("no event")
@@ -96,6 +157,11 @@ func Run(ctx context.Context, cfg Config, out, errOut io.Writer) error {
 		}
 		return err
 	}
+	fleetID, err := state.FleetID(cfg.Home)
+	if err != nil {
+		return fmt.Errorf("read Fleet identity: %w", err)
+	}
+	cfg.FleetID = fleetID
 
 	states := make(map[string]*TaskState)
 	tick(ctx, cfg, client, states, out, errOut)
@@ -146,8 +212,13 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 		}
 		return err
 	}
+	fleetID, err := state.FleetID(cfg.Home)
+	if err != nil {
+		return fmt.Errorf("read Fleet identity: %w", err)
+	}
+	cfg.FleetID = fleetID
 
-	if err := probeAllTasks(ctx, cfg.Home, client); err != nil {
+	if err := probeAllTasks(ctx, cfg.Home, client, cfg.Targets); err != nil {
 		return err
 	}
 
@@ -217,7 +288,7 @@ func connect(ctx context.Context, client *herdr.Client) error {
 
 // Confirms every running task's pane answers before RunUntilEvent arms; provisioning has no pane
 // contract yet and is intentionally left for a later tick after launch confirmation.
-func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error {
+func probeAllTasks(ctx context.Context, home string, client *herdr.Client, targets []TargetBinding) error {
 	histories, err := state.ListOpenHistories(home)
 	if err != nil {
 		return fmt.Errorf("list tasks: %w", err)
@@ -225,6 +296,9 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client) error
 	done := make(chan error, 1)
 	go func() {
 		for _, history := range histories {
+			if targets != nil && !hasTarget(targets, history.Task.ID) {
+				continue
+			}
 			if history.ActiveAttempt == nil {
 				done <- fmt.Errorf("%w: %s has no active attempt", ErrArmFailed, history.Task.ID)
 				return
@@ -288,6 +362,11 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		_, _ = fmt.Fprintf(errOut, "watch: list tasks failed: %v\n", err)
 		return
 	}
+	if cfg.Targets == nil {
+		cfg.Targets = targetBindings(cfg.FleetID, histories)
+	} else {
+		histories = filterHistories(histories, cfg.Targets)
+	}
 
 	seen := make(map[string]bool, len(histories))
 	now := time.Now()
@@ -328,8 +407,10 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 				status = herdr.StatusUnknown
 			}
 			ts = resumeTaskState(t, attempt, status, now)
-			if err := restoreLimitResumeState(cfg.Home, ts, attempt, errOut); err != nil {
-				_, _ = fmt.Fprintf(errOut, "watch: restore usage-limit resume state for %s failed: %v\n", t.ID, err)
+			if !cfg.ObserveOnly {
+				if err := restoreLimitResumeState(cfg.Home, ts, attempt, errOut); err != nil {
+					_, _ = fmt.Fprintf(errOut, "watch: restore usage-limit resume state for %s failed: %v\n", t.ID, err)
+				}
 			}
 			// False starts ClassifyUnreachable's dwell clock immediately, instead of waiting for a second
 			// failed probe to notice this task at all.
@@ -340,7 +421,13 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 
 		forgetPaneScopedCache(ts, t, attempt, now)
 
-		t = tailReport(ctx, cfg, ts, t, out, errOut)
+		t = tailReport(ctx, cfg, ts, t, attempt, out, errOut)
+		cfg.Targets = replaceTarget(cfg.Targets, targetBindingFor(cfg.FleetID, t, attempt, ts.LastReportState, ts.ReportCursor))
+		emit := func(event *Event) {
+			eventCfg := cfg
+			eventCfg.Targets = replaceTarget(cfg.Targets, targetBindingForState(cfg.FleetID, t, attempt, ts))
+			handleEvent(eventCfg, event, out, errOut)
+		}
 
 		// After the report tail, which may be what explains the stop, and before ClassifyStatus, whose
 		// edge would announce the same fact twice. One look per task: nothing this reads can change
@@ -348,7 +435,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		if probeErr == nil && !ts.CaughtUp {
 			ts.CaughtUp = true
 			if e := ClassifyCatchUp(ts, t.ID, status, attempt.StatusChangedFor, attempt.TeardownHerdrState); e != nil {
-				handleEvent(cfg, e, out, errOut)
+				emit(e)
 			}
 		}
 
@@ -357,13 +444,13 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		justStopped := status.NotBusy() && status != ts.Status
 
 		if e := ClassifyStatus(ts, t.ID, status, probeErr, now, attempt.TeardownHerdrState); e != nil {
-			handleEvent(cfg, e, out, errOut)
+			emit(e)
 		}
 		if e := ClassifyUnreachable(ts, t.ID, now, cfg.StaleThreshold, attempt.TeardownHerdrState); e != nil {
-			handleEvent(cfg, e, out, errOut)
+			emit(e)
 		}
 		if e := ClassifyStale(ts, t.ID, t.DeliveredAt, now, cfg.StaleThreshold); e != nil {
-			handleEvent(cfg, e, out, errOut)
+			emit(e)
 		}
 		if t.PR != "" && !ts.PRMerged {
 			ghCtx, ghCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -371,12 +458,12 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 			ghCancel()
 			if err == nil {
 				if e := ClassifyPRMerged(ts, t.ID, merged); e != nil {
-					handleEvent(cfg, e, out, errOut)
+					emit(e)
 				}
 			}
 		}
 		if e := ClassifyDeferredDone(cfg.Home, ts, t); e != nil {
-			handleEvent(cfg, e, out, errOut)
+			emit(e)
 		}
 		// Only shells out to no-mistakes when the check applies and has not already fired: mirrors
 		// !ts.PRMerged above, so an absent gate run does not re-exec no-mistakes on every tick forever.
@@ -386,21 +473,23 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 			ClassifyGateProblem(ts, t.ID, false, "")
 		case !ts.GateProblemFired:
 			if e := ClassifyGateProblem(ts, t.ID, true, gateRunObservation(ctx, cfg.Home, t)); e != nil {
-				handleEvent(cfg, e, out, errOut)
+				emit(e)
 			}
 		}
 		if mtime, err := ReportEvidenceTime(cfg.Home, t, attempt); err != nil {
 			_, _ = fmt.Fprintf(errOut, "watch: stat report %s failed: %v\n", t.ID, err)
 		} else if e := ClassifyParked(ts, t.ID, ts.LastReportState, lastReportLine(ts), mtime, now, cfg.ParkedBounds); e != nil {
-			handleEvent(cfg, e, out, errOut)
+			emit(e)
 		}
-		if e := classifyUsageLimit(cfg, client, ts, t, attempt, pane, status, probeErr, justStopped, now, errOut); e != nil {
-			handleEvent(cfg, e, out, errOut)
+		if !cfg.ObserveOnly {
+			if e := classifyUsageLimit(cfg, client, ts, t, attempt, pane, status, probeErr, justStopped, now, errOut); e != nil {
+				emit(e)
+			}
 		}
 		// Last, after every event this tick produced has been announced: a marker persisted before its
 		// line is emitted would, if the process died in between, suppress an announcement nothing can
 		// re-derive. A duplicate line is a far cheaper failure than a silently dropped one.
-		syncTaskState(cfg.Home, t.ID, ts, now, errOut)
+		syncTaskState(cfg.Home, t.ID, ts, now, errOut, cfg.ObserveOnly)
 	}
 
 	for id := range states {
@@ -612,7 +701,7 @@ func forgetPaneScopedCache(ts *TaskState, t state.Task, a state.Attempt, now tim
 // Classifies whatever report lines have arrived since ts.ReportCursor, before ClassifyStatus runs
 // for this tick, so a report landing in the same poll as a herdr idle transition is already
 // reflected in ts.LastReportState when the idle-vs-idle-unreported decision is made.
-func tailReport(ctx context.Context, cfg Config, ts *TaskState, t state.Task, out, errOut io.Writer) state.Task {
+func tailReport(ctx context.Context, cfg Config, ts *TaskState, t state.Task, attempt state.Attempt, out, errOut io.Writer) state.Task {
 	path := state.ReportPath(cfg.Home, t.ID)
 	lines, cursor, err := state.TailReport(path, ts.ReportCursor)
 	if err != nil {
@@ -620,13 +709,16 @@ func tailReport(ctx context.Context, cfg Config, ts *TaskState, t state.Task, ou
 		return t
 	}
 
+	ts.ReportCursor = cursor
 	for _, line := range lines {
 		if e := ClassifyReportLine(cfg.Home, ts, t, line); e != nil {
-			handleEvent(cfg, e, out, errOut)
+			eventCfg := cfg
+			eventCfg.Targets = replaceTarget(cfg.Targets, targetBindingFor(cfg.FleetID, t, attempt, ts.LastReportState, ts.ReportCursor))
+			handleEvent(eventCfg, e, out, errOut)
 		}
 		// A line carrying exactly one embedded PR URL auto-records it, subject to the same validation
 		// hand pr enforces; more than one URL, or a PR already on record, is left alone.
-		if t.PR == "" {
+		if !cfg.ObserveOnly && t.PR == "" {
 			if urls := state.FindPRURLs(line.Raw); len(urls) == 1 {
 				if err := autoRecordPR(ctx, cfg.Home, t, urls[0]); err != nil {
 					announceAutoRecordFailure(cfg, t, urls[0], err, out, errOut)
@@ -637,7 +729,6 @@ func tailReport(ctx context.Context, cfg Config, ts *TaskState, t state.Task, ou
 		}
 	}
 
-	ts.ReportCursor = cursor
 	return t
 }
 
@@ -839,7 +930,8 @@ func recordedByLockHolder(home, id, url string) error {
 // Writes back the bookkeeping hand watch owns on a task - how far its report file is consumed,
 // whether this watcher's own gh poll announced the PR merged, whether the verified done went out - so
 // a restart neither replays report lines nor re-announces, nor skips, what it cannot re-derive.
-func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writer) {
+func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writer, observeOnly ...bool) {
+	readOnly := len(observeOnly) > 0 && observeOnly[0]
 	if ts.ReportCursor == ts.PersistedCursor && ts.PRMerged == ts.PersistedPRMerged &&
 		ts.DoneVerified == ts.PersistedDoneVerified && ts.ChangedAt.Equal(ts.PersistedChangedAt) &&
 		ts.PersistedChangedFor == string(ts.Status) && ts.ParkedFiredFor.Equal(ts.PersistedParkedFiredFor) &&
@@ -884,19 +976,35 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 		_, _ = fmt.Fprintf(errOut, "watch: read active attempt %s failed: attempt ownership changed\n", id)
 		return
 	}
-	if !ts.LimitRetryAt.IsZero() || ts.LimitResumeBlocked {
-		_ = writeLimitHoldForOwnedAttempt(Config{Home: home}, t, active, ts, errOut)
-	} else if !ts.PersistedLimitRetryAt.IsZero() || ts.PersistedLimitAttempts != 0 {
-		_ = clearLimitHoldForOwnedAttempt(Config{Home: home}, t, active, errOut)
+	if !readOnly {
+		if !ts.LimitRetryAt.IsZero() || ts.LimitResumeBlocked {
+			_ = writeLimitHoldForOwnedAttempt(Config{Home: home}, t, active, ts, errOut)
+		} else if !ts.PersistedLimitRetryAt.IsZero() || ts.PersistedLimitAttempts != 0 {
+			_ = clearLimitHoldForOwnedAttempt(Config{Home: home}, t, active, errOut)
+		}
 	}
 	// A promote may have landed since this tick's state.List. Writing the cached values back would
 	// erase its restamp and leave the disk value matching what this watcher persisted, so no later
 	// tick would find anything to forget either.
 	forgetPaneScopedCache(ts, t, active, now)
+	usageLimitRetryAt := limitRetryStamp(ts.LimitRetryAt)
+	usageLimitAttempts := ts.LimitAttempts
+	usageLimitEpisode := ts.LimitEpisode
+	usageLimitStuckEpisode := ts.LimitStuckEpisode
+	if readOnly {
+		usageLimitRetryAt = active.UsageLimitRetryAt
+		usageLimitAttempts = active.UsageLimitAttempts
+		usageLimitEpisode = active.UsageLimitEpisode
+		usageLimitStuckEpisode = active.UsageLimitStuckEpisode
+		ts.LimitRetryAt = limitRetrySeed(active)
+		ts.LimitAttempts = active.UsageLimitAttempts
+		ts.LimitEpisode = active.UsageLimitEpisode
+		ts.LimitStuckEpisode = active.UsageLimitStuckEpisode
+	}
 	if err := state.UpdateAttemptObservation(home, id, ts.AttemptID, ts.AttemptLifecycle,
 		ts.ChangedAt.UTC().Format(time.RFC3339Nano), string(ts.Status), ts.DoneVerified,
 		ts.LastReportState, ts.LastReportNote, parkedFiredStamp(ts.ParkedFiredFor),
-		limitRetryStamp(ts.LimitRetryAt), ts.LimitAttempts, ts.LimitEpisode, ts.LimitStuckEpisode); err != nil {
+		usageLimitRetryAt, usageLimitAttempts, usageLimitEpisode, usageLimitStuckEpisode); err != nil {
 		_, _ = fmt.Fprintf(errOut, "watch: persist attempt %s failed: %v\n", id, err)
 		return
 	}
@@ -914,6 +1022,13 @@ func syncTaskState(home, id string, ts *TaskState, now time.Time, errOut io.Writ
 // run unconditionally, so narrowing --event never narrows what reaches
 // config/notify.
 func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
+	e.FleetID = cfg.FleetID
+	for _, binding := range cfg.Targets {
+		if binding.TaskID == e.TaskID {
+			e.Target = binding.Target
+			break
+		}
+	}
 	if cfg.EventFilter.Matches(e.Kind) && cfg.catchUp.Matches(e.Kind) {
 		_, _ = fmt.Fprintln(out, e.Text)
 	}
@@ -923,7 +1038,79 @@ func handleEvent(cfg Config, e *Event, out, errOut io.Writer) {
 		_, _ = fmt.Fprintf(errOut, "watch: append events.log failed: %v\n", err)
 	}
 
-	notifyEvent(cfg.Home, e, errOut)
+	if !cfg.SuppressNotify {
+		notifyEvent(cfg.Home, e, errOut)
+	}
+}
+
+func hasTarget(targets []TargetBinding, taskID string) bool {
+	for _, target := range targets {
+		if target.TaskID == taskID {
+			return true
+		}
+	}
+	return false
+}
+
+func filterHistories(histories []state.TaskHistory, targets []TargetBinding) []state.TaskHistory {
+	filtered := make([]state.TaskHistory, 0, len(targets))
+	for _, history := range histories {
+		if hasTarget(targets, history.Task.ID) {
+			filtered = append(filtered, history)
+		}
+	}
+	return filtered
+}
+
+func targetBindings(fleetID string, histories []state.TaskHistory) []TargetBinding {
+	targets := make([]TargetBinding, 0, len(histories))
+	for _, history := range histories {
+		if history.ActiveAttempt == nil {
+			continue
+		}
+		attempt := history.ActiveAttempt
+		targets = append(targets, targetBindingFor(fleetID, history.Task, *attempt, attempt.LastReportState, state.ReportCursor{Offset: history.Task.ReportOffset, Digest: history.Task.ReportDigest}))
+	}
+	return targets
+}
+
+func targetBindingFor(fleetID string, task state.Task, attempt state.Attempt, reportState string, cursor state.ReportCursor) TargetBinding {
+	return TargetBinding{
+		TaskID: task.ID,
+		Target: orientation.TaskTarget(fleetID, orientation.TaskTargetFacts{
+			ID: task.ID, Kind: "task", CreatedAt: task.CreatedAt, Lifecycle: string(task.Lifecycle),
+			ActiveAttemptID: task.ActiveAttemptID, AttemptID: attempt.ID, AttemptLifecycle: string(attempt.Lifecycle),
+			RuntimeIdentity: []string{attempt.Herdr.Session, attempt.Herdr.WorkspaceID, attempt.Herdr.TabID, attempt.Herdr.PaneID},
+			StatusChangedAt: attempt.StatusChangedAt, StatusChangedFor: attempt.StatusChangedFor, ReportState: reportState,
+			ReportOffset: cursor.Offset, ReportDigest: cursor.Digest, DoneVerified: attempt.DoneVerified,
+			PR: task.PR, MergeExecuted: task.MergeExecuted, MergeAnnounced: task.MergeAnnounced,
+		}),
+	}
+}
+
+func targetBindingForState(fleetID string, task state.Task, attempt state.Attempt, tracked *TaskState) TargetBinding {
+	if tracked == nil {
+		return targetBindingFor(fleetID, task, attempt, attempt.LastReportState, state.ReportCursor{Offset: task.ReportOffset, Digest: task.ReportDigest})
+	}
+	updated := attempt
+	updated.StatusChangedAt = tracked.ChangedAt.UTC().Format(time.RFC3339Nano)
+	updated.StatusChangedFor = string(tracked.Status)
+	updated.LastReportState = tracked.LastReportState
+	updated.DoneVerified = tracked.DoneVerified
+	task.MergeAnnounced = tracked.PRMerged
+	task.ReportOffset = tracked.ReportCursor.Offset
+	task.ReportDigest = tracked.ReportCursor.Digest
+	return targetBindingFor(fleetID, task, updated, tracked.LastReportState, tracked.ReportCursor)
+}
+
+func replaceTarget(targets []TargetBinding, replacement TargetBinding) []TargetBinding {
+	for i := range targets {
+		if targets[i].TaskID == replacement.TaskID {
+			targets[i] = replacement
+			return targets
+		}
+	}
+	return append(targets, replacement)
 }
 
 // The unattended hook treats an absent config as disabled, while a configured
@@ -932,7 +1119,7 @@ func notifyEvent(home string, e *Event, errOut io.Writer) {
 	if !NotifyFilter().Matches(e.Kind) {
 		return
 	}
-	if err := notify.Send(home, e.Text); err != nil && !errors.Is(err, notify.ErrNotConfigured) {
+	if err := notify.SendWithWake(home, e.Text, e.Wake()); err != nil && !errors.Is(err, notify.ErrNotConfigured) {
 		_, _ = fmt.Fprintf(errOut, "watch: notify failed: %v\n", err)
 	}
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -16,11 +16,163 @@ import (
 
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
 )
+
+func TestEnsureBoundedArmReleasesOwnershipAndDoesNotClaimLiveWatcher(t *testing.T) {
+	home := t.TempDir()
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.FleetID(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Ensure(context.Background(), Config{Home: home}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != orientation.MonitorStateRearmed || result.Live {
+		t.Fatalf("result = %#v, want bounded rearm without a live watcher", result)
+	}
+	attached, err := IsAttached(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attached {
+		t.Fatal("bounded arm left watcher ownership attached")
+	}
+}
+
+func TestEnsureReportsAlreadyArmedWithoutTakingOverCurrentOwner(t *testing.T) {
+	home := t.TempDir()
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Release()
+
+	target := orientation.TargetFor("f_unused", orientation.TargetEvidence{ID: "task-1", Kind: "task", Generation: []string{"one"}})
+	result, err := Ensure(context.Background(), Config{Home: home}, []TargetBinding{{TaskID: "task-1", Target: target}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != orientation.MonitorStateAlreadyArmed || !result.Live {
+		t.Fatalf("result = %#v, want already-armed live ownership", result)
+	}
+	if got := owner.Generation(); got == "" {
+		t.Fatal("current owner generation was cleared by idempotent ensure")
+	}
+}
+
+func TestEnsureUsesAQuietBoundedArmWithoutAZeroTicker(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	fleetID, err := state.FleetIDReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := orientation.TaskTarget(fleetID, orientation.TaskTargetFacts{ID: "task-1", Kind: "task", Lifecycle: string(state.TaskOpen), RuntimeIdentity: []string{"", "", "", "p1"}})
+
+	result, err := Ensure(context.Background(), Config{Home: home}, []TargetBinding{{TaskID: "task-1", Target: target}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != orientation.MonitorStateRearmed {
+		t.Fatalf("result = %#v, want quiet bounded arm to rearm", result)
+	}
+}
+
+func TestEnsureObserveOnlyArmDoesNotAutoRecordWorkerPRClaim(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: https://github.com/owner/repo/pull/7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(t.TempDir(), "notify")
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "notify"), []byte("printf '%s' \"$HAND_MESSAGE\" > "+shellquote.Quote(marker)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := state.FleetIDReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := orientation.TaskTarget(fleetID, orientation.TaskTargetFacts{ID: "task-1", Kind: "task", Lifecycle: string(state.TaskOpen), RuntimeIdentity: []string{"", "", "", "p1"}})
+
+	if _, err := Ensure(context.Background(), Config{Home: home}, []TargetBinding{{TaskID: "task-1", Target: target}}); err != nil {
+		t.Fatal(err)
+	}
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != "" {
+		t.Fatalf("task PR = %q, want bounded session arm to leave task metadata unchanged", task.PR)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("notify marker stat error = %v, want observe-only arm to suppress notifications", err)
+	}
+}
+
+func TestFilterHistoriesHonorsExplicitMonitorTargets(t *testing.T) {
+	histories := []state.TaskHistory{
+		{Task: state.Task{ID: "task-1"}},
+		{Task: state.Task{ID: "task-2"}},
+	}
+	targets := []TargetBinding{{TaskID: "task-2"}}
+	filtered := filterHistories(histories, targets)
+	if len(filtered) != 1 || filtered[0].Task.ID != "task-2" {
+		t.Fatalf("filtered histories = %#v, want only task-2", filtered)
+	}
+}
+
+func TestObserveOnlySyncPreservesUsageLimitObservation(t *testing.T) {
+	retryAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{
+		Lifecycle:          state.AttemptRunning,
+		UsageLimitRetryAt:  retryAt,
+		UsageLimitAttempts: 2,
+		UsageLimitEpisode:  3,
+	})
+	task, attempt := readTaskAttempt(t, home, "task-1")
+	ts := resumeTaskState(task, attempt, herdr.StatusWorking, time.Now())
+	ts.LimitRetryAt = time.Time{}
+	ts.LimitAttempts = 0
+	ts.LimitEpisode = 0
+	ts.ReportCursor = state.ReportCursor{Offset: 1, Digest: "observed"}
+
+	var errBuf bytes.Buffer
+	syncTaskState(home, task.ID, ts, time.Now(), &errBuf, true)
+	if errBuf.Len() != 0 {
+		t.Fatalf("sync errOut = %q", errBuf.String())
+	}
+	_, after := readTaskAttempt(t, home, task.ID)
+	if after.UsageLimitRetryAt != retryAt || after.UsageLimitAttempts != 2 || after.UsageLimitEpisode != 3 {
+		t.Fatalf("usage-limit observation = %q/%d/%d, want observe-only sync to preserve it", after.UsageLimitRetryAt, after.UsageLimitAttempts, after.UsageLimitEpisode)
+	}
+}
 
 // Drives the fake into herdr's failure shape for `pane get` - an error envelope on stdout with exit 0,
 // the shape the envelope check exists for. Exiting nonzero would reach ClassifyStatus's probeErr

--- a/skills/secondhand/SKILL.md
+++ b/skills/secondhand/SKILL.md
@@ -19,6 +19,9 @@ procedure layer over `hand`, not a second implementation of it: every claim here
 state, dependency state, or task state is something you get by running a `hand` command and
 reading its structured output, never by reconstructing it from panes, files, or memory.
 
+Each supervising turn begins with `hand session start`, whose bounded orientation reports Fleet identity,
+exact monitor currentness, actionable provenance, and whether `hand watch --until-event` must be re-armed.
+
 ```text
 wrong: skill checks PATH itself and decides whether Herdr is installed
 right: skill runs `hand doctor` and interprets structured output

--- a/skills/secondhand/references/supervision-loop.md
+++ b/skills/secondhand/references/supervision-loop.md
@@ -56,6 +56,10 @@ still looks the way it did before you acted.
 wrong: keeping your own running list of "what's next" across a long session
 right: re-reading hand session start's next_action_* fields after every action that could have
        changed fleet state
+
+The same output includes a bounded `orientation_*` view with Fleet identity, exact monitor targets,
+currentness, actionable provenance, and `monitor_state`.
+When that state is `rearmed`, follow its `monitor-rearm` action and run `hand watch --until-event` to keep monitoring.
 ```
 
 ## Watching, phase by phase


### PR DESCRIPTION
## Intent

Implement atqamz/hand#340: make supervisor orientation stateless and Fleet-scoped, derive actionability consistently across status, next-action, and watcher channels, and make until-event monitoring re-arm safely with structured stale-rejectable wakes and restart catch-up while preserving intended pending-send behavior. Create a pull request through no-mistakes. Do not merge it.

## What Changed

- Added stateless, Fleet-scoped supervisor orientation with opaque monitor currentness and restart catch-up.
- Centralized attention derivation for status, next-action, and watcher channels, including runtime, reachability, parked, report, send, repair, and gate conditions.
- Made until-event monitoring re-arm safely with structured stale-rejectable wake metadata while preserving pending-send behavior.

## Risk Assessment

🚨 High: The change introduces inconsistent pending-send actionability and can emit malformed or error-laden orientation data for ordinary terminal tasks.

## Testing

Focused unit, command, and end-to-end tests passed for Fleet-scoped stateless orientation, shared actionability, structured stale-rejectable wakes, safe until-event re-arming, restart catch-up, acknowledgement, and watcher takeover behavior.

- Outcome: ⚠️ 1 warning across 1 run (3m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"641dee8e7c0821d8087c799e3ff1023412ca1f81","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `cmd/session.go:173` - The required criterion says actionability must be derived consistently across status, next-action, and watcher channels, but this appends every derived subject, including explicitly non-actionable `unannounced` and `report-done` subjects, to orientation.Actionable. Filter on `subject.Actionable` before appending.
- 🚨 `cmd/session.go:197` - For fleets with more than 64 running tasks, `orientation.Build` truncates `result.Monitors` to 64, and `sessionTargets` derives its watcher bindings only from that truncated list. Session start therefore stops arming tasks after the first 64 even though the source views contain them.
- ⚠️ `cmd/statusview.go:165` - `probePaneStatus` returns `StatusUnknown` with `reachable=false` for every failed pane probe, so an unreachable active pane satisfies both `runtimeUnknown` and `unreachable`. Because next-action checks runtime-unknown first, the new path masks the existing unreachable diagnosis and status emits both flags; preserve the distinction at the probe boundary or avoid classifying failed probes as runtime-unknown.

🔧 Fix: Fix supervisor actionability, target coverage, and outage classification
2 errors still open:
- 🚨 `internal/attention/attention.go:94` - The shared derivation marks `send-pending` as actionable, but the existing contract and `cmd/nextaction.go:134` explicitly treat pending sends as in-flight and non-actionable. This makes status/orientation report attention for a pending send while next-action still skips it, violating the required criterion to preserve intended pending-send behavior.
- 🚨 `cmd/session.go:171` - `buildSessionOrientation` adds work and actionable subjects for every view, but only adds monitor targets for open running attempts. A normal terminal task therefore produces a missing-monitor error, and an unacknowledged terminal report produces an actionable subject with an empty target, so the orientation cannot provide the exact Fleet-scoped target required for that action.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Supervisor bootstrap was unavailable because the isolated worktree is not inside a configured secondhand home.
- `nix develop --command go test -tags=test ./internal/attention ./internal/orientation ./internal/notify ./internal/watcher ./cmd ...`
- `nix develop --command go test -tags=e2e,test ./tests/e2e ... -timeout=6m`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Fixes atqamz/hand#340