### PR TITLE
feat(harness): add worker-only Antigravity support

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -249,14 +249,14 @@ function Get-DoctorList {
     return $items
 }
 
-# Get-InstalledHarness reads the harnesses[N]{name,installed} rows hand doctor already
+# Get-InstalledHarness reads the supervisor_harnesses[N]{name,installed} rows hand doctor already
 # computed, in the order hand reports them, so bootstrap never re-detects harnesses on its own.
 function Get-InstalledHarness {
     param([string]$Text)
     $names = @()
     $inBlock = $false
     foreach ($line in ($Text -split "`r?`n")) {
-        if ($line -like "harnesses[[]*") { $inBlock = $true; continue }
+        if ($line -like "supervisor_harnesses[[]*") { $inBlock = $true; continue }
         if ($inBlock -and $line -match '^  (\w+),(true|false)$') {
             if ($Matches[2] -eq 'true') { $names += $Matches[1] }
             continue
@@ -286,8 +286,8 @@ Write-BootstrapLog "  cd $Fleet"
 if ($harnesses.Count -eq 1) {
     Write-BootstrapLog "  $($harnesses[0])"
 } elseif ($harnesses.Count -gt 1) {
-    Write-BootstrapLog "  <choose one of the installed harnesses below>"
+    Write-BootstrapLog "  <choose one of the installed Supervisor Harnesses below>"
     foreach ($h in $harnesses) { Write-BootstrapLog "    $h" }
 } else {
-    Write-BootstrapLog "  <install and authenticate at least one supported coding-agent harness, then run hand doctor>"
+    Write-BootstrapLog "  <install and authenticate at least one supported Supervisor Harness, then run hand doctor>"
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -265,11 +265,11 @@ doctor_list() {
   '
 }
 
-# installed_harnesses reads the harnesses[N]{name,installed} rows hand doctor already computed,
-# in the order hand reports them, so bootstrap never re-detects harnesses on its own.
+# installed_harnesses reads the supervisor_harnesses[N]{name,installed} rows hand doctor already
+# computed, in the order hand reports them, so bootstrap never re-detects harnesses on its own.
 installed_harnesses() {
   printf '%s\n' "$1" | awk '
-    /^harnesses\[/ { in_block=1; next }
+    /^supervisor_harnesses\[/ { in_block=1; next }
     in_block && /^  [a-z]/ {
       split($0, cols, ",")
       if (cols[2] == "true") print cols[1]
@@ -302,10 +302,10 @@ log "  cd $fleet"
 if [ "$count" -eq 1 ]; then
   log "  $harnesses"
 elif [ "$count" -gt 1 ]; then
-  log "  <choose one of the installed harnesses below>"
+  log "  <choose one of the installed Supervisor Harnesses below>"
   for h in $harnesses; do
     log "    $h"
   done
 else
-  log "  <install and authenticate at least one supported coding-agent harness, then run hand doctor>"
+  log "  <install and authenticate at least one supported Supervisor Harness, then run hand doctor>"
 fi

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -55,7 +55,7 @@ var workerSettingFields = []axi.Column[workerSetting]{
 // claims to know which harness takes a model flag is one that can disagree with the launch command.
 var harnessFields = []axi.Column[string]{
 	{Name: "name", Value: func(name string) string { return name }},
-	{Name: "installed", Value: func(name string) string { return strconv.FormatBool(onPath(name)) }},
+	{Name: "installed", Value: func(name string) string { return strconv.FormatBool(onPath(harness.Executable(name))) }},
 	{Name: "model", Value: func(name string) string { return strconv.FormatBool(harness.SupportsModel(name)) }},
 	{Name: "effort", Value: func(name string) string { return strconv.FormatBool(harness.SupportsEffort(name)) }},
 }
@@ -586,7 +586,7 @@ func harnessCarries(key, harnessName string) bool {
 }
 
 func onPath(name string) bool {
-	_, err := exec.LookPath(name)
+	_, err := exec.LookPath(harness.Executable(name))
 	return err == nil
 }
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 )
 
@@ -144,6 +145,7 @@ func TestConfigApplicabilityFollowsTheHarnessContract(t *testing.T) {
 		{harness.Codex, stateNativeDefault, stateNativeDefault},
 		{harness.Grok, stateUnsupported, stateUnsupported},
 		{harness.Pi, stateUnsupported, stateUnsupported},
+		{harness.Antigravity, stateNativeDefault, stateNativeDefault},
 	} {
 		mustConfigSet(t, settingHarness, tc.harness)
 		if got := settingState(t, home, settingModel); got != tc.model {
@@ -545,7 +547,7 @@ func TestConfigSummaryReportsRoutingConfigurationAndProblems(t *testing.T) {
 	out := mustConfig(t)
 	for _, want := range []string{
 		"supervisor_harness: claude\n",
-		"harnesses[5]{name,installed,model,effort}:\n",
+		"harnesses[6]{name,installed,model,effort}:\n",
 		"config[3]{key,state,value}:\n",
 		"profiles[1]{name,harness,model,effort}:\n",
 		"routes[6]{kind,execution_class,profile,state}:\n",
@@ -562,5 +564,17 @@ func TestConfigSummaryReportsRoutingConfigurationAndProblems(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("config summary = %q, want %q", out, want)
 		}
+	}
+}
+
+func TestConfigHarnessTableUsesAntigravityExecutableMapping(t *testing.T) {
+	setupConfigHome(t)
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: harness.Executable(harness.Antigravity)}.Install(t, bin)
+
+	out := mustConfig(t)
+	if !strings.Contains(out, "  antigravity,true,true,true") {
+		t.Fatalf("config output = %q, want Antigravity installed via agy executable", out)
 	}
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/skill"
+	"github.com/atqamz/hand/internal/supervision"
 	"github.com/atqamz/hand/internal/toolchain"
 	"github.com/spf13/cobra"
 )
@@ -138,7 +139,7 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			doc.Field("herdr_version", valueOrNone(runtimeStatus.HerdrVersion))
 			doc.Field("runtime_reason", valueOrNone(runtimeStatus.Reason))
 			axi.Table(&doc, "tools", tools, toolReadinessFields)
-			axi.Table(&doc, "harnesses", harnesses, harnessReadinessFields)
+			axi.Table(&doc, "supervisor_harnesses", harnesses, harnessReadinessFields)
 			doc.Bool("ready", len(blocking) == 0)
 			doc.List("blocking", blocking)
 			doc.List("next", next)
@@ -326,13 +327,13 @@ func doctorBlockingForRuntime(failing int, runtimeReady bool, tools []toolReadin
 	return blocking
 }
 
-// Every supported coding-agent harness is reported, never a preferred one: bootstrap and doctor
-// both only ever detect, they do not choose.
+// Every registered Supervisor Harness is reported, never a preferred one: bootstrap and doctor
+// both only detect, they do not choose. Worker-only providers must not satisfy Supervisor readiness.
 func doctorHarnesses() []harnessReadiness {
-	names := harness.Names()
+	names := supervision.SupervisorHosts()
 	out := make([]harnessReadiness, 0, len(names))
 	for _, name := range names {
-		out = append(out, harnessReadiness{Name: name, Installed: onPath(name)})
+		out = append(out, harnessReadiness{Name: name, Installed: onPath(harness.Executable(name))})
 	}
 	return out
 }
@@ -374,7 +375,7 @@ func doctorNext(blocking []string) []string {
 		case "fleet-health":
 			next = append(next, "resolve every error finding reported above")
 		case "harness":
-			next = append(next, "install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor")
+			next = append(next, "install and authenticate at least one supported Supervisor Harness (see `supervisor_harnesses` above), then run hand doctor")
 		case "runtime":
 			next = append(next, "run `hand runtime ensure`")
 		default:

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/skill"
+	"github.com/atqamz/hand/internal/supervision"
 )
 
 func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
@@ -691,14 +692,14 @@ func TestDoctorToolsReportsFoundationalAndContextualRequirement(t *testing.T) {
 	}
 }
 
-func TestDoctorHarnessesReportsEverySupportedHarness(t *testing.T) {
+func TestDoctorHarnessesReportsEverySupervisorHarness(t *testing.T) {
 	faketool.NoTools(t)
 	bin := faketool.Bin(t)
 	faketool.Command{Name: harness.Codex}.Install(t, bin)
 
 	got := doctorHarnesses()
-	if len(got) != len(harness.Names()) {
-		t.Fatalf("doctorHarnesses() = %#v, want one entry per %v", got, harness.Names())
+	if len(got) != len(supervision.SupervisorHosts()) {
+		t.Fatalf("doctorHarnesses() = %#v, want one entry per %v", got, supervision.SupervisorHosts())
 	}
 	for _, h := range got {
 		want := h.Name == harness.Codex
@@ -770,7 +771,7 @@ func TestDoctorReportsReadyWhenEveryFoundationalToolAndOneHarnessArePresent(t *t
 		"  treehouse,true,true\n" +
 		"  herdr,true,true\n" +
 		"  gh,false,false\n" +
-		"harnesses[5]{name,installed}:\n" +
+		"supervisor_harnesses[5]{name,installed}:\n" +
 		"  claude,true\n" +
 		"  codex,false\n" +
 		"  grok,false\n" +
@@ -812,7 +813,7 @@ func TestDoctorReportsNotReadyWithBlockingAndNextWhenTreehouseAndEveryHarnessAre
 		"  - harness\n" +
 		"next[2]:\n" +
 		"  - install treehouse\n" +
-		"  - install and authenticate at least one supported coding-agent harness (see `harnesses` above), then run hand doctor\n"
+		"  - install and authenticate at least one supported Supervisor Harness (see `supervisor_harnesses` above), then run hand doctor\n"
 	if !strings.Contains(out.String(), want) {
 		t.Fatalf("stdout = %q, want it to contain %q", out.String(), want)
 	}
@@ -850,5 +851,24 @@ func TestDoctorGHNotRequiredForALocalOnlyProjectDoesNotBlockReadiness(t *testing
 	}
 	if !strings.Contains(out.String(), "ready: true\n") {
 		t.Fatalf("stdout = %q, want ready: true since gh is not required", out.String())
+	}
+}
+
+func TestDoctorDoesNotTreatWorkerOnlyAntigravityAsSupervisorReady(t *testing.T) {
+	faketool.NoTools(t)
+	bin := faketool.Bin(t)
+	faketool.Command{Name: harness.Executable(harness.Antigravity)}.Install(t, bin)
+
+	got := doctorHarnesses()
+	for _, item := range got {
+		if item.Name == harness.Antigravity {
+			t.Fatalf("doctor Supervisor readiness includes worker-only Antigravity: %#v", got)
+		}
+		if item.Installed {
+			t.Fatalf("doctor Supervisor readiness = %#v, want no installed Supervisor Harness", got)
+		}
+	}
+	if anyHarnessInstalled(got) {
+		t.Fatalf("worker-only agy satisfied Supervisor readiness: %#v", got)
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/watcher"
+	"github.com/atqamz/hand/internal/workerobs"
 	"github.com/spf13/cobra"
 )
 
@@ -108,15 +109,22 @@ func reportSummary(id string, lines []state.ReportLine, readErr error, unacked, 
 // Read-only status degrades to "unknown" when herdr or the pane cannot be queried. reachable is false
 // only for a claimed pane that failed to answer, never a task with no pane to probe. Unlike hand
 // watch's dwelled ClassifyUnreachable, one failed probe is enough - a live read has no blink to filter.
-func probePaneStatus(client *herdr.Client, paneID string) (agentState string, reachable bool) {
-	if paneID == "" {
+func probePaneStatus(client *herdr.Client, attempt *state.Attempt) (agentState string, reachable bool) {
+	if attempt == nil || attempt.Herdr.PaneID == "" {
 		return string(herdr.StatusUnknown), true
 	}
-	pane, err := client.PaneGet(paneID)
-	if err != nil || pane.AgentStatus == "" {
+	pane, err := client.PaneGet(attempt.Herdr.PaneID)
+	if err != nil {
 		return string(herdr.StatusUnknown), false
 	}
-	return string(pane.AgentStatus), true
+	normalized, normalizeErr := workerobs.Normalize(*attempt, pane, client)
+	if normalizeErr != nil {
+		return string(herdr.StatusUnknown), true
+	}
+	if normalized.AgentStatus == "" {
+		return string(herdr.StatusUnknown), false
+	}
+	return string(normalized.AgentStatus), true
 }
 
 // Mirrors one classified line from state.ReportLine for JSON output: malformed lines carry their raw text
@@ -525,7 +533,7 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 	if attempt != nil {
 		e = *attempt
 	}
-	agentState, reachable := probePaneStatus(herdrClientForAttempt(attempt, client), e.Herdr.PaneID)
+	agentState, reachable := probePaneStatus(herdrClientForAttempt(attempt, client), attempt)
 	data, readErr := state.ReadReportData(home, t.ID)
 	lines := state.ReportLinesInData(data)
 	reported, reportedOK := state.LastReportedState(lines)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -133,7 +133,7 @@ integrations[4]{id,executable,owner,state,path}:
   gitlab/glab,glab,GitLab,missing,none
   delivery/no-mistakes,no-mistakes,no-mistakes,missing,none
   delivery/witness,witness,Witness,missing,none
-harnesses[5]{name,installed}:
+supervisor_harnesses[5]{name,installed}:
   claude,true
   codex,false
   grok,false
@@ -148,7 +148,7 @@ next[1]:
 
 The private runtime is always required, and its three components are selected together by one runtime ID.
 Optional integrations are missing without blocking readiness until a registered workflow selects one.
-Harnesses are reported purely as installed or not - `hand` never picks one on the operator's behalf.
+Supervisor Supervisor Supervisor Supervisor Supervisor Supervisor Supervisor Harnesses are reported purely as installed or not - `hand` never picks one on the operator's behalf. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness. Worker Harness routing is a separate configuration surface, so a worker-only provider such as Antigravity cannot make bootstrap claim Supervisor readiness.
 
 `hand fleet` is the discovery view for users with more than one Fleet home.
 It reads the user-local registry without selecting an active Fleet or changing any home.

--- a/docs/adr/antigravity-headless-worker-boundary.md
+++ b/docs/adr/antigravity-headless-worker-boundary.md
@@ -1,0 +1,55 @@
+# Antigravity uses one-shot headless worker execution
+
+- Date: 2026-08-23
+- Status: accepted
+- Issues: atqamz/hand#336, atqamz/hand#338, atqamz/hand#353, atqamz/hand#355
+- PRs: atqamz/hand#351, atqamz/hand#356
+
+## Context
+
+Antigravity CLI documents `agy -p` as headless one-shot execution: one prompt runs, emits a response, and the process exits. `--output-format stream-json` emits a typed `init` event before step updates and one terminal `result` event. `--input-format stream-json` is a different persistent-stdin protocol; when it is used, a prompt supplied with `-p` is dropped and prompts must instead be submitted as JSON messages on stdin.
+
+Hand's existing `LaunchSpec` deliberately describes executable, argv, environment, and cwd only. It has no durable stdin-submission transaction. Pretending the persistent-stdin protocol fits that boundary would introduce a new crash window where Hand could not prove whether the initial prompt was submitted, so #351 does not do that.
+
+A one-shot worker also cannot safely consume `hand send` through its pane after exit: the pane has returned to its shell, so arbitrary operator text would become shell input. Process disappearance itself is not success evidence, and Antigravity's provider `result.status` is not Hand task outcome. Hand's report file remains the sole worker outcome channel.
+
+PR #356 separately owns Supervisor Harness qualification and wake/re-entry under `internal/supervision`. Worker process residency must not become a second Supervisor registry.
+
+## Decision
+
+Antigravity remains a worker Harness implemented through the shared structured `LaunchSpec` boundary.
+
+The adapter launches `agy` with:
+
+- `-p <semantic worker prompt>` for one-shot execution;
+- `--output-format stream-json` so startup has typed machine-readable evidence;
+- `--dangerously-skip-permissions` because an unattended worker must not soft-deny required tool actions behind an approval request; this bypasses Antigravity approvals but does **not** enable `--sandbox` or create a Hand isolation boundary;
+- `--print-timeout 24h` to replace Antigravity's five-minute headless default with an explicit finite Worker runtime envelope; timeout is liveness/failure evidence, never task outcome;
+- `--model <slug>` and `--effort <low|medium|high>` only when selected.
+
+Routing qualifies the installed Antigravity runtime before dispatch. The probe requires the executable, supported platform, documented headless/output/permission/timeout flags, and a non-empty `agy models` result. An explicit authentication/configuration error from qualification is unavailable; otherwise successful model discovery is not treated as proof that credentials cannot expire or fail on the later model request. Unknown contract or observation stays unknown and fails closed; Hand does not install the CLI or persist credentials.
+
+Launch confirmation means only that the intended worker initialized. For a resident observation, seeing the intended executable is enough. For a one-shot process that starts and exits between polls, an Antigravity `event: "init"` line is equivalent startup evidence. Merely observing that the process disappeared is never confirmation. A terminal provider `result` is deliberately ignored for Hand outcome semantics.
+
+Before durable launch confirmation, a fast one-shot may be confirmed from a typed `init` event only when its documented `init.cwd` exactly matches the LaunchSpec CWD. After confirmation, pane scrollback is no longer identity evidence: reconciliation, status, and watch normalize one-shot liveness from the persisted Attempt harness plus live process information. A confirmed Attempt with no `agy` process is `done` only in Herdr liveness terms; Hand still requires the report channel for task outcome.
+
+`hand send` refuses a one-shot Antigravity Attempt before creating a SendAttempt or mutating the pane. Follow-up work requires the worker's report to be observed and then a new Attempt; conversation IDs are not canonical Hand state.
+
+Supervisor support is not decided here. `internal/supervision` owns the qualified Supervisor Harness registry and its runtime/wake capabilities. Antigravity may be added there only when that separate contract is qualified; the worker package exposes no `SupportsSupervisor` mirror.
+
+## Consequences
+
+Antigravity stays optional; provider-specific behavior remains isolated behind the Worker Harness adapter and compatible with the shared LaunchSpec -> Session transport architecture.
+
+Hand does not:
+
+- infer success from process exit;
+- infer task success from Antigravity `SUCCESS`;
+- treat permission bypass or the WorktreeBinding CWD as a filesystem sandbox/isolation boundary;
+- send operator text into a shell after a one-shot process exits;
+- persist Antigravity conversation IDs or provider lifecycle state;
+- create a fake resident process;
+- add a second Supervisor capability registry;
+- adopt persistent stdin streaming without a durable submission protocol.
+
+A fast one-shot whose process is never observed and whose typed `init` evidence is unavailable remains unconfirmed rather than being guessed successful. That false negative is intentional: unknown is safer than fabricated launch truth.

--- a/docs/adr/harness-templates-launch-interactively.md
+++ b/docs/adr/harness-templates-launch-interactively.md
@@ -1,4 +1,4 @@
-# Harnesses launch interactively, with liveness owned by herdr
+# Interactive Worker Harnesses launch with liveness owned by herdr
 
 - Date: 2026-08-04
 - Status: accepted
@@ -7,7 +7,8 @@
 
 ## Context
 
-Workers must survive multiple steers and gate turns. Interactive launches provide that resident process but expose first-run dialogs. Pane text can outlive a dead process, while herdr can identify a live harness without knowing what dialog blocks it.
+Interactive workers must survive multiple steers and gate turns. Interactive launches provide that resident process but expose first-run dialogs. Pane text can outlive a dead process, while herdr can identify a live harness without knowing what dialog blocks it.
+One-shot harnesses are a separate qualified contract and do not use this interactive supervision model.
 Shell syntax also varies across the pane's actual shell, so a host operating-system guess is not sufficient for a safe launch.
 
 ## Decision
@@ -20,7 +21,7 @@ Launch arguments and dialog signatures belong to [`internal/harness`](../../inte
 
 ## Rejected alternatives
 
-- Headless reinvocation has no resident session for `hand send`, watching, or multi-turn gates.
+- Treating a headless harness as interactive has no resident session for `hand send`, watching, or multi-turn gates.
 - A wrapper around headless runs would reimplement harness continuity and make pane state describe the wrapper.
 - Building one opaque POSIX command string cannot preserve process argument boundaries across POSIX and PowerShell.
 - Selecting a renderer from host `GOOS`, `$SHELL`, or a configuration default does not prove which shell owns the pane.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -149,10 +149,15 @@ The agent process Hand launches for execution, regardless of Task kind or model.
 `scout` and `ship` do not name Worker roles.
 Compatibility names such as `HAND_ROLE=worker` and `WorkerRole` remain unchanged.
 
-### Harness
+### Worker Harness
 
-The local agent executable or integration Hand launches, such as `codex`, `claude`, `opencode`, `grok`, or `pi`.
-Harness is not synonymous with model provider.
+The local agent executable or integration Hand launches for one Attempt, such as `codex`, `claude`, `opencode`, `grok`, `pi`, or Antigravity's `agy`.
+Worker Harness capability is independent from Supervisor Harness capability and is not synonymous with model provider.
+
+### Supervisor Harness
+
+The user-facing agent host capable of running Supervisor reasoning and, where qualified, Hand's wake/re-entry integration.
+Its registry is owned independently from Worker Harness support. A product may support Worker execution without being a Supervisor Harness, or vice versa; provider identity never implies role.
 
 ## Configuration and delivery
 

--- a/internal/harness/capability.go
+++ b/internal/harness/capability.go
@@ -1,0 +1,225 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+	"time"
+)
+
+type CapabilityState string
+
+const (
+	CapabilityUnavailable CapabilityState = "unavailable"
+	CapabilityUnsupported CapabilityState = "unsupported"
+	CapabilityUnknown     CapabilityState = "unknown"
+	CapabilityReady       CapabilityState = "ready"
+)
+
+type Capability struct {
+	Name       string
+	Executable string
+	State      CapabilityState
+	Reason     string
+	Models     []string
+}
+
+type CapabilityProbe struct {
+	Platform string
+	LookPath func(string) (string, error)
+	Contract func(string) error
+	Models   func(string) ([]string, error)
+}
+
+func Executable(name string) string {
+	if name == Antigravity {
+		return "agy"
+	}
+	return name
+}
+
+func PlatformSupported(name, platform string) bool {
+	if name != Antigravity {
+		return IsSupported(name)
+	}
+	switch platform {
+	case "linux", "darwin", "windows":
+		return true
+	default:
+		return false
+	}
+}
+
+func Inspect(name string, probe CapabilityProbe) Capability {
+	result := Capability{Name: name, Executable: Executable(name)}
+	if !IsSupported(name) {
+		result.State = CapabilityUnsupported
+		result.Reason = "harness is not registered"
+		return result
+	}
+	platform := probe.Platform
+	if platform == "" {
+		platform = runtime.GOOS
+	}
+	if !PlatformSupported(name, platform) {
+		result.State = CapabilityUnsupported
+		result.Reason = fmt.Sprintf("platform %q is unsupported", platform)
+		return result
+	}
+	lookPath := probe.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	path, err := lookPath(result.Executable)
+	if err != nil {
+		result.State = CapabilityUnavailable
+		result.Reason = "executable is unavailable"
+		return result
+	}
+	if name != Antigravity {
+		result.State = CapabilityReady
+		return result
+	}
+
+	contract := probe.Contract
+	if contract == nil {
+		contract = probeAntigravityContract
+	}
+	if err := contract(path); err != nil {
+		result.State = CapabilityUnknown
+		result.Reason = "headless worker contract could not be verified"
+		return result
+	}
+
+	models := probe.Models
+	if models == nil {
+		models = probeAntigravityModels
+	}
+	result.Models, err = models(path)
+	if err != nil {
+		result.State = CapabilityUnknown
+		result.Reason = "model capability could not be verified"
+		if authenticationUnavailable(err) {
+			result.State = CapabilityUnavailable
+			result.Reason = "authentication/configuration unavailable"
+		}
+		return result
+	}
+	if len(result.Models) == 0 {
+		result.State = CapabilityUnknown
+		result.Reason = "model capability could not be verified"
+		return result
+	}
+	result.State = CapabilityReady
+	return result
+}
+
+// ValidateRuntime verifies the installed worker contract even when no explicit model is selected.
+// Routing calls this before any Attempt/worktree/session side effect for Antigravity.
+func ValidateRuntime(name string) error {
+	return ValidateRuntimeWithProbe(name, CapabilityProbe{})
+}
+
+func ValidateRuntimeWithProbe(name string, probe CapabilityProbe) error {
+	if name != Antigravity {
+		return nil
+	}
+	return capabilityError(name, Inspect(name, probe))
+}
+
+func ValidateModel(name, model string) error {
+	return ValidateModelWithProbe(name, model, CapabilityProbe{})
+}
+
+func ValidateModelWithProbe(name, model string, probe CapabilityProbe) error {
+	if name != Antigravity || model == "" {
+		return nil
+	}
+	capability := Inspect(name, probe)
+	if err := capabilityError(name, capability); err != nil {
+		return err
+	}
+	if !slices.Contains(capability.Models, model) {
+		return fmt.Errorf("harness %q does not support model %q", name, model)
+	}
+	return nil
+}
+
+func capabilityError(name string, capability Capability) error {
+	switch capability.State {
+	case CapabilityUnavailable:
+		return fmt.Errorf("harness %q is unavailable: %s", name, capability.Reason)
+	case CapabilityUnsupported:
+		return fmt.Errorf("harness %q is unsupported: %s", name, capability.Reason)
+	case CapabilityUnknown:
+		return fmt.Errorf("harness %q capability is unknown: %s", name, capability.Reason)
+	case CapabilityReady:
+		return nil
+	default:
+		return fmt.Errorf("harness %q capability is unknown", name)
+	}
+}
+
+func ValidateEffort(name, effort string) error {
+	if name != Antigravity || effort == "" {
+		return nil
+	}
+	if slices.Contains([]string{"low", "medium", "high"}, effort) {
+		return nil
+	}
+	return fmt.Errorf("harness %q does not support effort %q; want low, medium, or high", name, effort)
+}
+
+func probeAntigravityContract(executable string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, executable, "--help").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("agy --help failed: %s", strings.TrimSpace(string(output)))
+	}
+	text := string(output)
+	for _, marker := range []string{"--print", "--model", "--effort", "--output-format", "stream-json", "--print-timeout", "--dangerously-skip-permissions"} {
+		if !strings.Contains(text, marker) {
+			return fmt.Errorf("agy --help does not advertise required worker capability %q", marker)
+		}
+	}
+	return nil
+}
+
+func probeAntigravityModels(executable string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, executable, "models").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("agy models failed: %s", strings.TrimSpace(string(output)))
+	}
+	return parseModels(output), nil
+}
+
+var modelSlug = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+func parseModels(output []byte) []string {
+	models := make([]string, 0)
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] == "model" || !modelSlug.MatchString(fields[0]) || slices.Contains(models, fields[0]) {
+			continue
+		}
+		models = append(models, fields[0])
+	}
+	return models
+}
+
+func authenticationUnavailable(err error) bool {
+	text := strings.ToLower(err.Error())
+	for _, marker := range []string{"authentication required", "not authenticated", "sign in", "sign-in", "credentials unavailable", "missing credentials", "configuration required"} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/harness/capability_test.go
+++ b/internal/harness/capability_test.go
@@ -1,0 +1,149 @@
+package harness
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestExecutableMapsAntigravityToAgy(t *testing.T) {
+	if got := Executable(Antigravity); got != "agy" {
+		t.Fatalf("Executable(%q) = %q, want agy", Antigravity, got)
+	}
+	if got := Executable(Claude); got != Claude {
+		t.Fatalf("Executable(%q) = %q, want unchanged name", Claude, got)
+	}
+}
+
+func antigravityProbe(models func(string) ([]string, error)) CapabilityProbe {
+	return CapabilityProbe{
+		Platform: "linux",
+		LookPath: func(string) (string, error) { return "/bin/agy", nil },
+		Contract: func(string) error { return nil },
+		Models:   models,
+	}
+}
+
+func TestInspectAntigravityCapabilityStates(t *testing.T) {
+	tests := []struct {
+		name       string
+		probe      CapabilityProbe
+		wantState  CapabilityState
+		wantReason string
+	}{
+		{
+			name:      "executable missing",
+			probe:     CapabilityProbe{Platform: "linux", LookPath: func(string) (string, error) { return "", errors.New("missing") }},
+			wantState: CapabilityUnavailable,
+		},
+		{
+			name:       "platform unsupported",
+			probe:      CapabilityProbe{Platform: "freebsd"},
+			wantState:  CapabilityUnsupported,
+			wantReason: "platform",
+		},
+		{
+			name: "headless contract unknown",
+			probe: CapabilityProbe{
+				Platform: "linux",
+				LookPath: func(string) (string, error) { return "/bin/agy", nil },
+				Contract: func(string) error { return errors.New("missing stream-json") },
+			},
+			wantState:  CapabilityUnknown,
+			wantReason: "headless worker contract",
+		},
+		{
+			name:       "authentication unavailable",
+			probe:      antigravityProbe(func(string) ([]string, error) { return nil, errors.New("authentication required") }),
+			wantState:  CapabilityUnavailable,
+			wantReason: "authentication/configuration unavailable",
+		},
+		{
+			name:       "unknown capability",
+			probe:      antigravityProbe(func(string) ([]string, error) { return nil, errors.New("provider changed output") }),
+			wantState:  CapabilityUnknown,
+			wantReason: "could not be verified",
+		},
+		{
+			name:      "ready capability",
+			probe:     antigravityProbe(func(string) ([]string, error) { return []string{"gemini-3.5-flash-medium"}, nil }),
+			wantState: CapabilityReady,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Inspect(Antigravity, test.probe)
+			if got.State != test.wantState {
+				t.Fatalf("state = %q, want %q (%+v)", got.State, test.wantState, got)
+			}
+			if test.wantReason != "" && !strings.Contains(got.Reason, test.wantReason) {
+				t.Fatalf("reason = %q, want %q", got.Reason, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestInspectReadyCapabilityPreservesModels(t *testing.T) {
+	models := []string{"gemini-3.5-flash-medium", "claude-sonnet-4-6"}
+	for _, platform := range []string{"linux", "darwin", "windows"} {
+		t.Run(platform, func(t *testing.T) {
+			probe := antigravityProbe(func(string) ([]string, error) { return models, nil })
+			probe.Platform = platform
+			got := Inspect(Antigravity, probe)
+			if got.State != CapabilityReady {
+				t.Fatalf("state = %q, want ready", got.State)
+			}
+			if !reflect.DeepEqual(got.Models, models) {
+				t.Fatalf("models = %#v, want %#v", got.Models, models)
+			}
+		})
+	}
+}
+
+func TestValidateRuntimeRequiresQualifiedAntigravityContract(t *testing.T) {
+	ready := antigravityProbe(func(string) ([]string, error) { return []string{"gemini-3.5-flash-medium"}, nil })
+	if err := ValidateRuntimeWithProbe(Antigravity, ready); err != nil {
+		t.Fatalf("ready runtime rejected: %v", err)
+	}
+	unknown := ready
+	unknown.Contract = func(string) error { return errors.New("old CLI") }
+	if err := ValidateRuntimeWithProbe(Antigravity, unknown); err == nil || !strings.Contains(err.Error(), "capability is unknown") {
+		t.Fatalf("old runtime error = %v, want unknown capability", err)
+	}
+}
+
+func TestValidateAntigravityEffort(t *testing.T) {
+	for _, effort := range []string{"low", "medium", "high"} {
+		if err := ValidateEffort(Antigravity, effort); err != nil {
+			t.Fatalf("ValidateEffort(%q) = %v", effort, err)
+		}
+	}
+	if err := ValidateEffort(Antigravity, "x-high"); err == nil || !strings.Contains(err.Error(), "low, medium, or high") {
+		t.Fatalf("ValidateEffort(%q) = %v, want unsupported effort error", "x-high", err)
+	}
+}
+
+func TestValidateAntigravityModelAgainstProbedCapability(t *testing.T) {
+	probe := antigravityProbe(func(string) ([]string, error) { return []string{"gemini-3.5-flash-medium"}, nil })
+	if err := ValidateModelWithProbe(Antigravity, "gemini-3.5-flash-medium", probe); err != nil {
+		t.Fatalf("supported model rejected: %v", err)
+	}
+	if err := ValidateModelWithProbe(Antigravity, "does-not-exist", probe); err == nil || !strings.Contains(err.Error(), "does not support model") {
+		t.Fatalf("unsupported model error = %v", err)
+	}
+	unknown := probe
+	unknown.Models = func(string) ([]string, error) { return nil, errors.New("unrecognized response") }
+	if err := ValidateModelWithProbe(Antigravity, "gemini-3.5-flash-medium", unknown); err == nil || !strings.Contains(err.Error(), "capability is unknown") {
+		t.Fatalf("unknown model capability error = %v", err)
+	}
+}
+
+func TestParseModelsAcceptsDocumentedSlugDisplayRows(t *testing.T) {
+	got := parseModels([]byte("gemini-3.7-flash-high     Gemini 3.7 Flash (High)\nclaude-sonnet-4-6         Claude Sonnet 4.6 (Thinking)\n"))
+	want := []string{"gemini-3.7-flash-high", "claude-sonnet-4-6"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseModels() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/harness/execution.go
+++ b/internal/harness/execution.go
@@ -1,0 +1,58 @@
+package harness
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// IsOneShot reports whether a Worker Harness exits after one autonomous turn.
+// Supervisor capability is owned independently by internal/supervision.
+func IsOneShot(name string) bool {
+	return name == Antigravity
+}
+
+// SupportsSteering reports whether hand send can safely target the resident Worker.
+// A one-shot pane returns to its shell after exit and therefore must never receive steering text.
+func SupportsSteering(name string) bool {
+	return IsSupported(name) && !IsOneShot(name)
+}
+
+// LaunchEvidenceInOutput recognizes machine-readable evidence that the exact one-shot launch
+// initialized in expectedCwd; unscoped scrollback init cannot prove the current Attempt.
+// Provider terminal result/status never substitutes for Hand's report outcome channel.
+func LaunchEvidenceInOutput(name, text, expectedCwd string) bool {
+	if name != Antigravity || expectedCwd == "" {
+		return false
+	}
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Event string `json:"event"`
+			Init  struct {
+				Cwd string `json:"cwd"`
+			} `json:"init"`
+		}
+		if json.Unmarshal([]byte(line), &event) == nil &&
+			event.Event == "init" &&
+			sameLaunchPath(event.Init.Cwd, expectedCwd) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameLaunchPath(got, want string) bool {
+	if got == "" || want == "" {
+		return false
+	}
+	got, want = filepath.Clean(got), filepath.Clean(want)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(got, want)
+	}
+	return got == want
+}

--- a/internal/harness/execution_test.go
+++ b/internal/harness/execution_test.go
@@ -1,0 +1,46 @@
+package harness
+
+import "testing"
+
+func TestWorkerExecutionShapeIsIndependentFromSupervisorCapability(t *testing.T) {
+	if !IsOneShot(Antigravity) {
+		t.Fatal("Antigravity must remain a one-shot worker")
+	}
+	if SupportsSteering(Antigravity) {
+		t.Fatal("one-shot Antigravity must not expose pane steering")
+	}
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+		if IsOneShot(name) {
+			t.Fatalf("%s unexpectedly classified one-shot", name)
+		}
+		if !SupportsSteering(name) {
+			t.Fatalf("resident worker %s unexpectedly non-steerable", name)
+		}
+	}
+}
+
+func TestAntigravityLaunchEvidenceRequiresTypedInitForExactCwd(t *testing.T) {
+	const cwd = "/tmp/worktree"
+	plain := "agy response\n"
+	if LaunchEvidenceInOutput(Antigravity, plain, cwd) {
+		t.Fatal("plain response text is not launch evidence")
+	}
+	init := "shell noise\n{\"event\":\"init\",\"conversation_id\":\"c1\",\"init\":{\"cwd\":\"/tmp/worktree\"}}\n"
+	if !LaunchEvidenceInOutput(Antigravity, init, cwd) {
+		t.Fatal("typed init event for the exact CWD must prove Antigravity initialized")
+	}
+	if LaunchEvidenceInOutput(Antigravity, init, "/tmp/other-worktree") {
+		t.Fatal("stale init from another CWD must not prove this launch")
+	}
+	missingCwd := "{\"event\":\"init\",\"conversation_id\":\"c1\",\"init\":{}}\n"
+	if LaunchEvidenceInOutput(Antigravity, missingCwd, cwd) {
+		t.Fatal("unscoped init must not prove launch")
+	}
+	resultOnly := "{\"event\":\"result\",\"result\":{\"status\":\"SUCCESS\"}}\n"
+	if LaunchEvidenceInOutput(Antigravity, resultOnly, cwd) {
+		t.Fatal("provider result status must not substitute for launch init evidence")
+	}
+	if LaunchEvidenceInOutput(Antigravity, init, "") {
+		t.Fatal("launch evidence without an expected CWD must fail closed")
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -11,20 +11,24 @@ import (
 	"github.com/atqamz/hand/internal/launch"
 )
 
+const antigravityPrintTimeout = "24h"
+
 const (
-	Claude     = "claude"
-	Codex      = "codex"
-	Grok       = "grok"
-	Pi         = "pi"
-	OpenCode   = "opencode"
-	RoleEnv    = "HAND_ROLE"
-	HomeEnv    = "HAND_HOME"
-	WorkerRole = "worker"
+	Claude      = "claude"
+	Codex       = "codex"
+	Grok        = "grok"
+	Pi          = "pi"
+	OpenCode    = "opencode"
+	Antigravity = "antigravity"
+	RoleEnv     = "HAND_ROLE"
+	HomeEnv     = "HAND_HOME"
+	WorkerRole  = "worker"
 )
 
-// The one list of supported harnesses. Anything that offers a choice of harness derives it from here
-// rather than repeating the names, so a harness added below is offered everywhere at once.
-var names = []string{Claude, Codex, Grok, Pi, OpenCode}
+// The canonical Worker Harness registry. Worker routing/configuration derive their choices from
+// this list. Supervisor turn-delivery capability is independent and owned by internal/supervision;
+// a product appearing here never implies it can host a Supervisor.
+var names = []string{Claude, Codex, Grok, Pi, OpenCode, Antigravity}
 
 func Names() []string {
 	return slices.Clone(names)
@@ -140,20 +144,23 @@ type Options struct {
 }
 
 var modelCapable = map[string]bool{
-	Claude:   true,
-	Codex:    true,
-	OpenCode: true,
+	Claude:      true,
+	Codex:       true,
+	OpenCode:    true,
+	Antigravity: true,
 }
 
 var effortCapable = map[string]bool{
-	Claude: true,
-	Codex:  true,
+	Claude:      true,
+	Codex:       true,
+	Antigravity: true,
 }
 
 var promptCapable = map[string]bool{
-	Claude:   true,
-	Codex:    true,
-	OpenCode: true,
+	Claude:      true,
+	Codex:       true,
+	OpenCode:    true,
+	Antigravity: true,
 }
 
 // False means the caller must warn instead of silently dropping the model.
@@ -173,13 +180,14 @@ func CarriesPrompt(name string) bool {
 	return promptCapable[name]
 }
 
-// Build constructs the executable, arguments, environment, and working directory for a harness.
-// Every launch is interactive, never one-shot: hand send steers a running pane, hand watch
-// classifies its lifecycle, and a no-mistakes pipeline drives many turns a one-shot cannot.
+// Build constructs the executable, arguments, environment, and working directory for a worker
+// harness. Supervisor capability is a separate concern owned by internal/supervision.
 func Build(name string, opts Options) (launch.LaunchSpec, error) {
+	if err := ValidateEffort(name, opts.Effort); err != nil {
+		return launch.LaunchSpec{}, err
+	}
 	var spec launch.LaunchSpec
-	// Flags for claude, codex, and opencode are verified against the installed CLI's own --help, and
-	// this file is the source of truth for those three.
+	// Each builder below uses only flags verified against its documented CLI contract.
 	switch name {
 	case Claude:
 		spec = buildClaude(opts)
@@ -191,11 +199,32 @@ func Build(name string, opts Options) (launch.LaunchSpec, error) {
 		spec = buildPi(opts)
 	case OpenCode:
 		spec = buildOpenCode(opts)
+	case Antigravity:
+		spec = buildAntigravity(opts)
 	default:
 		return launch.LaunchSpec{}, fmt.Errorf("harness %q not recognized", name)
 	}
 	spec.Cwd = opts.Worktree
 	return launch.NewSpec(spec)
+}
+
+func buildAntigravity(o Options) launch.LaunchSpec {
+	// stream-json gives launch confirmation typed init evidence without treating the provider's
+	// terminal result as Hand task outcome. One-shot workers must execute unattended: otherwise a
+	// permission request can soft-deny a required tool action while the headless process still exits.
+	args := []string{
+		"--dangerously-skip-permissions",
+		"--output-format", "stream-json",
+		"--print-timeout", antigravityPrintTimeout,
+	}
+	if o.Model != "" {
+		args = append(args, "--model", o.Model)
+	}
+	if o.Effort != "" {
+		args = append(args, "--effort", o.Effort)
+	}
+	args = append(args, "-p", briefPrompt(o))
+	return launch.LaunchSpec{Executable: Executable(Antigravity), Args: args}
 }
 
 // Launches claude interactively - no --print - so the pane stays resident for hand send and hand

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,13 +27,53 @@ func TestBuildUnrecognizedHarness(t *testing.T) {
 }
 
 func TestIsSupported(t *testing.T) {
-	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode, Antigravity} {
 		if !IsSupported(name) {
 			t.Errorf("IsSupported(%q) = false, want true", name)
 		}
 	}
 	if IsSupported("nonexistent") {
 		t.Error("IsSupported(nonexistent) = true, want false")
+	}
+}
+
+func TestBuildAntigravity(t *testing.T) {
+	options := Options{Worktree: "/tmp/space unicode/wt", Brief: "/tmp/space unicode/wt/brief.md"}
+	spec := buildSpec(t, Antigravity, options)
+	want := launch.LaunchSpec{
+		Executable: "agy",
+		Args:       []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--print-timeout", antigravityPrintTimeout, "-p", briefPrompt(options)},
+		Cwd:        options.Worktree,
+	}
+	if !reflect.DeepEqual(spec, want) {
+		t.Fatalf("got %+v, want %+v", spec, want)
+	}
+	if strings.Contains(spec.Executable, " ") || strings.Contains(spec.Executable, "cd ") {
+		t.Fatalf("executable %q contains shell syntax", spec.Executable)
+	}
+	for _, value := range spec.Args {
+		if strings.HasPrefix(value, "cd ") || strings.HasPrefix(value, "HAND_ROLE=") || strings.HasPrefix(value, "HAND_HOME=") {
+			t.Fatalf("argument %q contains shell launch syntax", value)
+		}
+	}
+	if contains(spec.Args, "--input-format") {
+		t.Fatalf("args = %#v, one-shot -p must not opt into stdin streaming", spec.Args)
+	}
+}
+
+func TestBuildAntigravityWithModelAndEffort(t *testing.T) {
+	options := Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "gemini-3.5-flash-medium", Effort: "high"}
+	spec := buildSpec(t, Antigravity, options)
+	want := []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--print-timeout", antigravityPrintTimeout, "--model", options.Model, "--effort", options.Effort, "-p", briefPrompt(options)}
+	if !reflect.DeepEqual(spec.Args, want) {
+		t.Fatalf("args = %#v, want %#v", spec.Args, want)
+	}
+}
+
+func TestBuildAntigravityRejectsUnsupportedEffort(t *testing.T) {
+	_, err := Build(Antigravity, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "x-high"})
+	if err == nil || !strings.Contains(err.Error(), "low, medium, or high") {
+		t.Fatalf("Build() error = %v, want unsupported effort error", err)
 	}
 }
 
@@ -137,7 +178,7 @@ func TestBuildOpenCode(t *testing.T) {
 }
 
 func TestBuildFrontMatterDisclaimer(t *testing.T) {
-	for _, name := range []string{Claude, Codex, OpenCode} {
+	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
 		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", BriefHasFrontMatter: true})
 		if !containsText(spec.Args, "dispatch metadata") {
 			t.Fatalf("Build(%q) args = %#v, want front matter disclaimer", name, spec.Args)
@@ -146,7 +187,7 @@ func TestBuildFrontMatterDisclaimer(t *testing.T) {
 }
 
 func TestBuildMechanicalExecutionGuidance(t *testing.T) {
-	for _, name := range []string{Claude, Codex, OpenCode} {
+	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
 		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", ExecutionClass: brief.ExecutionClassMechanical})
 		for _, want := range []string{"Verify the named files/symbols and plan assumptions before editing.", "stop and report blocked", "Do not redesign the task yourself.", "execute the ordered plan and verification steps"} {
 			if !containsText(spec.Args, want) {
@@ -183,7 +224,7 @@ func TestBuildOpenCodeNeverHeadless(t *testing.T) {
 }
 
 func TestBuildCarriesOperatorDecisionRule(t *testing.T) {
-	for _, name := range []string{Claude, Codex, OpenCode} {
+	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
 		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
 		if !containsText(spec.Args, agentsmd.OperatorDecisionRule) {
 			t.Errorf("Build(%q) args = %#v, want operator-decision rule", name, spec.Args)
@@ -192,7 +233,7 @@ func TestBuildCarriesOperatorDecisionRule(t *testing.T) {
 }
 
 func TestSupportsModel(t *testing.T) {
-	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode, Antigravity} {
 		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "some-model"})
 		if hasPair(spec.Args, "--model", "some-model") != SupportsModel(name) {
 			t.Errorf("SupportsModel(%q) = %v but args = %#v", name, SupportsModel(name), spec.Args)
@@ -204,9 +245,13 @@ func TestSupportsModel(t *testing.T) {
 }
 
 func TestSupportsEffort(t *testing.T) {
-	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
-		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: "some-effort"})
-		emits := hasPair(spec.Args, "--effort", "some-effort") || contains(spec.Args, `model_reasoning_effort="some-effort"`)
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode, Antigravity} {
+		effort := "some-effort"
+		if name == Antigravity {
+			effort = "high"
+		}
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Effort: effort})
+		emits := hasPair(spec.Args, "--effort", effort) || contains(spec.Args, fmt.Sprintf(`model_reasoning_effort="%s"`, effort))
 		if emits != SupportsEffort(name) {
 			t.Errorf("SupportsEffort(%q) = %v but args = %#v", name, SupportsEffort(name), spec.Args)
 		}
@@ -217,7 +262,7 @@ func TestSupportsEffort(t *testing.T) {
 }
 
 func TestCarriesPrompt(t *testing.T) {
-	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode} {
+	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode, Antigravity} {
 		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
 		if containsText(spec.Args, agentsmd.OperatorDecisionRule) != CarriesPrompt(name) {
 			t.Errorf("CarriesPrompt(%q) = %v but args = %#v", name, CarriesPrompt(name), spec.Args)
@@ -267,7 +312,7 @@ func TestAgentDetectionVerified(t *testing.T) {
 			t.Errorf("AgentDetectionVerified(%q) = false, want true", name)
 		}
 	}
-	for _, name := range []string{Grok, Pi, "nonexistent"} {
+	for _, name := range []string{Grok, Pi, Antigravity, "nonexistent"} {
 		if AgentDetectionVerified(name) {
 			t.Errorf("AgentDetectionVerified(%q) = true, want false", name)
 		}
@@ -275,7 +320,7 @@ func TestAgentDetectionVerified(t *testing.T) {
 }
 
 func TestFirstRunPromptsWithoutVerifiedSignatures(t *testing.T) {
-	for _, name := range []string{Grok, Pi, OpenCode, "nonexistent"} {
+	for _, name := range []string{Grok, Pi, OpenCode, Antigravity, "nonexistent"} {
 		if got := FirstRunPromptsFor(name); got.Ready != nil || got.Known != nil || got.Unrecognized != nil {
 			t.Errorf("FirstRunPromptsFor(%q) = %+v, want no unverified signatures", name, got)
 		}

--- a/internal/harness/usagelimit_test.go
+++ b/internal/harness/usagelimit_test.go
@@ -9,7 +9,7 @@ func TestSupportsUsageLimitOnlyWhereASignatureIsCatalogued(t *testing.T) {
 	if !SupportsUsageLimit(Claude) {
 		t.Fatal("SupportsUsageLimit(claude) = false, want true")
 	}
-	for _, name := range []string{Codex, Grok, Pi, OpenCode, "", "nonesuch"} {
+	for _, name := range []string{Codex, Grok, Pi, OpenCode, Antigravity, "", "nonesuch"} {
 		if SupportsUsageLimit(name) {
 			t.Errorf("SupportsUsageLimit(%q) = true, want false: no signature is catalogued for it", name)
 		}

--- a/internal/routing/antigravity_runtime_test.go
+++ b/internal/routing/antigravity_runtime_test.go
@@ -1,0 +1,36 @@
+package routing
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/brief"
+)
+
+func TestResolveQualifiesRuntimeWithoutExplicitModel(t *testing.T) {
+	called := 0
+	availability := Availability{
+		IsSupported:       func(name string) bool { return name == "antigravity" },
+		PlatformSupported: func(string) bool { return true },
+		OnPath:            func(string) bool { return true },
+		SupportsModel:     func(string) bool { return true },
+		SupportsEffort:    func(string) bool { return true },
+		CarriesPrompt:     func(string) bool { return true },
+		ValidateRuntime: func(name string) error {
+			called++
+			if name != "antigravity" {
+				t.Fatalf("ValidateRuntime(%q), want antigravity", name)
+			}
+			return errors.New("headless contract unknown")
+		},
+	}
+	_, err := Resolve(Request{
+		Kind:        TaskKindShip,
+		Declaration: brief.Declaration{ExecutionClass: brief.ExecutionClassStandard},
+		Profile:     "agy", ProfileFromFlag: true,
+	}, Config{Profiles: []Profile{{Name: "agy", Harness: "antigravity"}}}, LegacyDefaults{}, availability)
+	if err == nil || !strings.Contains(err.Error(), "headless contract unknown") || called != 1 {
+		t.Fatalf("Resolve() err=%v runtime calls=%d, want one pre-dispatch runtime qualification", err, called)
+	}
+}

--- a/internal/routing/config_test.go
+++ b/internal/routing/config_test.go
@@ -250,6 +250,7 @@ func TestLoadDistinguishesUnsupportedProfileCapabilities(t *testing.T) {
 		{Name: "unknown", Harness: "unknown"},
 		{Name: "model", Harness: "pi", Model: "provider/model"},
 		{Name: "effort", Harness: "opencode", Effort: "high"},
+		{Name: "antigravity-effort", Harness: "antigravity", Effort: "x-high"},
 	} {
 		dir := filepath.Join(home, "config", "profiles", profile.Name)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -283,6 +284,7 @@ func TestLoadDistinguishesUnsupportedProfileCapabilities(t *testing.T) {
 		{profile: "unknown", code: ConfigProblemUnsupportedHarness},
 		{profile: "model", code: ConfigProblemUnsupportedModel},
 		{profile: "effort", code: ConfigProblemUnsupportedEffort},
+		{profile: "antigravity-effort", code: ConfigProblemUnsupportedEffort},
 	} {
 		if !hasProblemForProfile(config.Problems, want.profile, want.code) {
 			t.Fatalf("Load().Problems = %+v, want %s for %q", config.Problems, want.code, want.profile)

--- a/internal/routing/resolver.go
+++ b/internal/routing/resolver.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/atqamz/hand/internal/brief"
@@ -38,11 +39,15 @@ type ExecutionSnapshot struct {
 }
 
 type Availability struct {
-	IsSupported    func(string) bool
-	OnPath         func(string) bool
-	SupportsModel  func(string) bool
-	SupportsEffort func(string) bool
-	CarriesPrompt  func(string) bool
+	IsSupported       func(string) bool
+	PlatformSupported func(string) bool
+	OnPath            func(string) bool
+	SupportsModel     func(string) bool
+	SupportsEffort    func(string) bool
+	CarriesPrompt     func(string) bool
+	ValidateRuntime   func(string) error
+	ValidateModel     func(string, string) error
+	ValidateEffort    func(string, string) error
 }
 
 type ResolvedRoute struct {
@@ -59,11 +64,15 @@ type ResolvedRoute struct {
 
 func DefaultAvailability() Availability {
 	return Availability{
-		IsSupported:    harness.IsSupported,
-		OnPath:         harnessOnPath,
-		SupportsModel:  harness.SupportsModel,
-		SupportsEffort: harness.SupportsEffort,
-		CarriesPrompt:  harness.CarriesPrompt,
+		IsSupported:       harness.IsSupported,
+		PlatformSupported: func(name string) bool { return harness.PlatformSupported(name, runtime.GOOS) },
+		OnPath:            harnessOnPath,
+		SupportsModel:     harness.SupportsModel,
+		SupportsEffort:    harness.SupportsEffort,
+		CarriesPrompt:     harness.CarriesPrompt,
+		ValidateRuntime:   harness.ValidateRuntime,
+		ValidateModel:     harness.ValidateModel,
+		ValidateEffort:    harness.ValidateEffort,
 	}
 }
 
@@ -158,6 +167,9 @@ func resolveProfiled(request Request, config Config, legacy LegacyDefaults, avai
 	if !available(availability.IsSupported, result.Harness) {
 		return ResolvedRoute{}, fmt.Errorf("harness %q not recognized", result.Harness)
 	}
+	if availability.PlatformSupported != nil && !availability.PlatformSupported(result.Harness) {
+		return ResolvedRoute{}, fmt.Errorf("harness %q is unsupported on this platform", result.Harness)
+	}
 	if !available(availability.OnPath, result.Harness) {
 		return ResolvedRoute{}, fmt.Errorf("harness %q is not installed on PATH", result.Harness)
 	}
@@ -168,6 +180,9 @@ func resolveProfiled(request Request, config Config, legacy LegacyDefaults, avai
 	}
 	if result.Effort != "" && !available(availability.SupportsEffort, result.Harness) {
 		return ResolvedRoute{}, fmt.Errorf("harness %q takes no effort", result.Harness)
+	}
+	if err := validateCapabilities(result, availability); err != nil {
+		return ResolvedRoute{}, err
 	}
 	if result.ExecutionClass == brief.ExecutionClassMechanical && !available(availability.CarriesPrompt, result.Harness) {
 		return ResolvedRoute{}, fmt.Errorf("mechanical execution requires a prompt-capable harness: harness %q cannot carry the required mechanical worker guidance", result.Harness)
@@ -187,8 +202,14 @@ func resolveLegacy(request Request, legacy LegacyDefaults, availability Availabi
 	if !available(availability.IsSupported, result.Harness) {
 		return ResolvedRoute{}, fmt.Errorf("harness %q not recognized", result.Harness)
 	}
+	if availability.PlatformSupported != nil && !availability.PlatformSupported(result.Harness) {
+		return ResolvedRoute{}, fmt.Errorf("harness %q is unsupported on this platform", result.Harness)
+	}
 	result.Model = firstNonEmpty(flagValue(request.Model, request.ModelFromFlag), request.Declaration.Model, legacy.Models[result.Harness])
 	result.Effort = firstNonEmpty(flagValue(request.Effort, request.EffortFromFlag), request.Declaration.Effort, legacy.Efforts[result.Harness])
+	if err := validateCapabilities(result, availability); err != nil {
+		return ResolvedRoute{}, err
+	}
 	result.Warnings = legacyWarnings(result, availability)
 	return result, nil
 }
@@ -292,8 +313,30 @@ func available(check func(string) bool, name string) bool {
 	return check != nil && check(name)
 }
 
+func validateCapabilities(result ResolvedRoute, availability Availability) error {
+	// A selected model runs the Antigravity capability probe through ValidateModel; without one,
+	// ValidateRuntime still qualifies the installed headless/model-discovery contract. Explicit
+	// auth/config errors fail closed, while successful preflight never promises later credential validity.
+	if result.Model == "" && availability.ValidateRuntime != nil {
+		if err := availability.ValidateRuntime(result.Harness); err != nil {
+			return err
+		}
+	}
+	if result.Model != "" && availability.ValidateModel != nil {
+		if err := availability.ValidateModel(result.Harness, result.Model); err != nil {
+			return err
+		}
+	}
+	if result.Effort != "" && availability.ValidateEffort != nil {
+		if err := availability.ValidateEffort(result.Harness, result.Effort); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func harnessOnPath(name string) bool {
-	_, err := exec.LookPath(name)
+	_, err := exec.LookPath(harness.Executable(name))
 	return err == nil
 }
 

--- a/internal/routing/resolver_test.go
+++ b/internal/routing/resolver_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -304,6 +305,68 @@ func TestResolveProfiledValidation(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Resolve(test.request, test.config, LegacyDefaults{}, test.availability)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Resolve() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveExplicitAntigravityUsesNormalResolver(t *testing.T) {
+	availability := testAvailability()
+	availability.IsSupported = func(name string) bool { return name == "antigravity" }
+	availability.OnPath = func(name string) bool { return name == "antigravity" }
+	availability.SupportsModel = func(name string) bool { return name == "antigravity" }
+	availability.SupportsEffort = func(name string) bool { return name == "antigravity" }
+	availability.CarriesPrompt = func(name string) bool { return name == "antigravity" }
+	config := Config{Profiles: []Profile{{Name: "agy", Harness: "antigravity"}}}
+	got, err := Resolve(Request{
+		Kind:            TaskKindShip,
+		Profile:         "agy",
+		ProfileFromFlag: true,
+		Harness:         "antigravity",
+		HarnessFromFlag: true,
+	}, config, LegacyDefaults{}, availability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Harness != "antigravity" || got.Profile != "agy" || got.Source != RoutingSourceExplicitProfile {
+		t.Fatalf("resolved route = %+v, want normal explicit antigravity route", got)
+	}
+}
+
+func TestResolveAntigravityRejectsCapabilitiesBeforeLaunch(t *testing.T) {
+	availability := testAvailability()
+	availability.IsSupported = func(name string) bool { return name == "antigravity" }
+	availability.OnPath = func(name string) bool { return name == "antigravity" }
+	availability.SupportsModel = func(name string) bool { return name == "antigravity" }
+	availability.SupportsEffort = func(name string) bool { return name == "antigravity" }
+	availability.CarriesPrompt = func(name string) bool { return name == "antigravity" }
+	availability.ValidateModel = func(name, model string) error {
+		return fmt.Errorf("harness %q does not support model %q", name, model)
+	}
+	availability.ValidateEffort = func(name, effort string) error {
+		return fmt.Errorf("harness %q does not support effort %q", name, effort)
+	}
+	config := Config{Profiles: []Profile{{Name: "agy", Harness: "antigravity"}}}
+	for _, test := range []struct {
+		name    string
+		request Request
+		want    string
+	}{
+		{
+			name:    "model",
+			request: Request{Kind: TaskKindShip, Profile: "agy", ProfileFromFlag: true, Model: "bad", ModelFromFlag: true},
+			want:    "does not support model",
+		},
+		{
+			name:    "effort",
+			request: Request{Kind: TaskKindShip, Profile: "agy", ProfileFromFlag: true, Effort: "bad", EffortFromFlag: true},
+			want:    "does not support effort",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Resolve(test.request, config, LegacyDefaults{}, availability)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("Resolve() error = %v, want %q", err, test.want)
 			}

--- a/internal/routing/validation.go
+++ b/internal/routing/validation.go
@@ -99,6 +99,9 @@ func ValidateProfile(profile Profile) error {
 	if profile.Effort != "" && !harness.SupportsEffort(profile.Harness) {
 		return &profileValidationError{code: ConfigProblemUnsupportedEffort, err: fmt.Errorf("harness %q takes no effort", profile.Harness)}
 	}
+	if err := harness.ValidateEffort(profile.Harness, profile.Effort); err != nil {
+		return &profileValidationError{code: ConfigProblemUnsupportedEffort, err: err}
+	}
 	return nil
 }
 

--- a/internal/runtime/antigravity_launch_test.go
+++ b/internal/runtime/antigravity_launch_test.go
@@ -1,0 +1,29 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+func TestConfirmOneShotDoesNotTreatDisappearanceOrPlainResponseAsSuccess(t *testing.T) {
+	useFastLaunchPolling(t)
+	expectLaunchTimeout()
+	fakeLaunchPane(t, exited("agy response without machine-readable init"))
+
+	err := confirmLaunch(herdr.NewClient(), "wA:pC", harness.Antigravity, launchSpec{Executable: "agy", Cwd: "/tmp/worktree"})
+	if err == nil || !strings.Contains(err.Error(), "not confirmed started") {
+		t.Fatalf("confirmLaunch() = %v, want fail-closed unconfirmed launch", err)
+	}
+}
+
+func TestConfirmOneShotRecoversFastExitFromTypedInitEvidence(t *testing.T) {
+	useFastLaunchPolling(t)
+	fakeLaunchPane(t, exited("{\"event\":\"init\",\"conversation_id\":\"c1\",\"init\":{\"cwd\":\"/tmp/worktree\"}}\n{\"event\":\"result\",\"result\":{\"status\":\"ERROR\"}}"))
+
+	if err := confirmLaunch(herdr.NewClient(), "wA:pC", harness.Antigravity, launchSpec{Executable: "agy", Cwd: "/tmp/worktree"}); err != nil {
+		t.Fatalf("confirmLaunch() = %v, typed init must prove startup even though provider outcome is separate", err)
+	}
+}

--- a/internal/runtime/antigravity_reconcile_test.go
+++ b/internal/runtime/antigravity_reconcile_test.go
@@ -1,0 +1,78 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+)
+
+func installOneShotPhysicalObservation(t *testing.T) *herdr.Client {
+	t.Helper()
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{
+			ID:    "wA",
+			Label: herdr.LegacyWorkspaceLabel("project"),
+			Tabs:  []faketool.HerdrTab{{ID: "tA", Label: "task-1", Pane: "pA"}},
+		}},
+		PaneStatus:  "unknown",
+		PaneReadOut: "{\"event\":\"init\",\"conversation_id\":\"stale\",\"init\":{\"cwd\":\"/tmp/old\"}}\n",
+	}.Install(t, bin)
+	return herdr.NewClient()
+}
+
+func TestObserveHerdrOwnershipDoesNotInferWorkerIdentityFromScrollback(t *testing.T) {
+	client := installOneShotPhysicalObservation(t)
+	observation, err := observeHerdrOwnership(client, state.Herdr{
+		Session: "default", WorkspaceID: "wA", TabID: "tA", PaneID: "pA",
+	}, "task-1", "project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.State != herdrOwnershipExact {
+		t.Fatalf("observation = %+v, want exact physical ownership", observation)
+	}
+	if observation.Agent != "" || observation.AgentStatus != herdr.StatusUnknown {
+		t.Fatalf("observation = %+v, pane scrollback must not fabricate worker identity/liveness", observation)
+	}
+}
+
+func TestDecideProvisioningOneShotUsesDedicatedLaunchConfirmation(t *testing.T) {
+	attempt := state.Attempt{
+		Lifecycle: state.AttemptProvisioning,
+		Harness:   harness.Antigravity,
+		Herdr: state.Herdr{
+			Session: "default", WorkspaceID: "wA", TabID: "tA", PaneID: "pA",
+		},
+		LaunchSubmittedAt: "2026-08-24T00:00:00Z",
+	}
+	observation := reconciliationObservation{Herdr: herdrObservation{
+		State: herdrOwnershipExact,
+		Pane:  herdr.Pane{PaneID: "pA", TabID: "tA", WorkspaceID: "wA"},
+	}}
+	decision := decideReconciliation(state.Task{}, attempt, observation)
+	if decision.Action != reconciliationActionConfirmLaunch {
+		t.Fatalf("decision = %+v, want dedicated one-shot launch confirmation", decision)
+	}
+}
+
+func TestDecideProvisioningOneShotRejectsDifferentLiveHarness(t *testing.T) {
+	attempt := state.Attempt{
+		Lifecycle: state.AttemptProvisioning,
+		Harness:   harness.Antigravity,
+		Herdr: state.Herdr{
+			Session: "default", WorkspaceID: "wA", TabID: "tA", PaneID: "pA",
+		},
+		LaunchSubmittedAt: "2026-08-24T00:00:00Z",
+	}
+	observation := reconciliationObservation{Herdr: herdrObservation{
+		State: herdrOwnershipExact, Agent: harness.Claude,
+	}}
+	decision := decideReconciliation(state.Task{}, attempt, observation)
+	if decision.Action != reconciliationActionNeedsRepair || decision.RepairCode != repairCodeLaunchAgentMismatch {
+		t.Fatalf("decision = %+v, want different live harness rejected", decision)
+	}
+}

--- a/internal/runtime/launch.go
+++ b/internal/runtime/launch.go
@@ -69,6 +69,14 @@ func confirmLaunch(client herdrClient, paneID, harnessName string, spec launch.L
 		sawAgent = sawAgent || pane.Agent != "" || processPresent
 		prompt, known := matchFirstRunPrompt(prompts.Known, text)
 		switch {
+		case harness.IsOneShot(harnessName) && processPresent:
+			// Seeing the intended executable is direct start evidence. Do not wait for a one-shot
+			// process to disappear: disappearance says nothing about whether its turn succeeded.
+			return nil
+		case harness.IsOneShot(harnessName) && harness.LaunchEvidenceInOutput(harnessName, text, spec.Cwd):
+			// A very short run can initialize and exit between polls. Its typed init event proves
+			// startup without treating a provider result/status as Hand task outcome.
+			return nil
 		case !processPresent:
 			quiet = 0
 			switch {

--- a/internal/runtime/launch_test.go
+++ b/internal/runtime/launch_test.go
@@ -110,6 +110,11 @@ func TestConfirmLaunch(t *testing.T) {
 			frames:  []launchFrame{{text: "opencode ready", agent: "opencode"}},
 		},
 		{
+			name:    "a one-shot worker is confirmed after its response exits",
+			harness: "antigravity",
+			frames:  []launchFrame{{text: "agy response", agent: "antigravity"}, exited("agy response")},
+		},
+		{
 			// The failure this whole function exists for: the dialog text is still on screen but
 			// the harness behind it is gone, so there is no worker to confirm.
 			name:    "a harness that exited on a dialog is not confirmed",

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/workerobs"
 	"github.com/atqamz/hand/internal/worktree"
 )
 
@@ -89,6 +90,7 @@ type herdrObservation struct {
 	State       herdrOwnershipState
 	Agent       string
 	AgentStatus herdr.Status
+	Pane        herdr.Pane
 }
 
 type reconciliationObservation struct {
@@ -1272,6 +1274,15 @@ func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attemp
 		if observation.Herdr.State == herdrOwnershipAbsent || observation.Herdr.State == herdrOwnershipMismatch {
 			return observation, nil
 		}
+		if observation.Herdr.State == herdrOwnershipExact &&
+			harness.IsOneShot(attempt.Harness) &&
+			attempt.LaunchConfirmedAt != "" {
+			pane, normalizeErr := workerobs.Normalize(attempt, observation.Herdr.Pane, r.herdrClient(attempt.Herdr.Session))
+			if normalizeErr != nil {
+				return observation, fmt.Errorf("observe one-shot worker liveness: %w", normalizeErr)
+			}
+			observation.Herdr.Agent, observation.Herdr.AgentStatus = pane.Agent, pane.AgentStatus
+		}
 	}
 	return observation, nil
 }
@@ -1431,6 +1442,17 @@ func decideProvisioning(attempt state.Attempt, observation reconciliationObserva
 		}
 		if observation.Herdr.State != herdrOwnershipExact {
 			return repairDecision(decision, repairCodeHerdrOwnershipIncomplete, "Herdr ownership for the recorded launch was not proven")
+		}
+		if harness.IsOneShot(attempt.Harness) {
+			if observation.Herdr.Agent != "" && observation.Herdr.Agent != attempt.Harness {
+				return repairDecision(decision, repairCodeLaunchAgentMismatch, "the recorded pane contains a different live harness")
+			}
+			if attempt.LaunchConfirmedAt != "" {
+				decision.Action = reconciliationActionMarkRunning
+				return decision
+			}
+			decision.Action = reconciliationActionConfirmLaunch
+			return decision
 		}
 		if observation.Herdr.Agent != attempt.Harness {
 			return repairDecision(decision, repairCodeLaunchAgentMismatch, "the expected persisted harness is not observed in the recorded pane")

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -229,7 +229,12 @@ func observeHerdrOwnership(client herdrClient, expected state.Herdr, taskID, pro
 	if pane.PaneID != expected.PaneID || pane.TabID != expected.TabID || pane.WorkspaceID != expected.WorkspaceID {
 		return herdrObservation{State: herdrOwnershipMismatch}, nil
 	}
-	return herdrObservation{State: herdrOwnershipExact, Agent: pane.Agent, AgentStatus: pane.AgentStatus}, nil
+
+	// Resource ownership ends here. Worker identity/liveness is normalized separately from the
+	// persisted Attempt; pane scrollback is never promoted into generic ownership evidence.
+	return herdrObservation{
+		State: herdrOwnershipExact, Agent: pane.Agent, AgentStatus: pane.AgentStatus, Pane: pane,
+	}, nil
 }
 
 func isHerdrNotFound(err error) bool {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/supervision"
 )
 
 func makeHome(t *testing.T) string {
@@ -40,7 +40,7 @@ func TestRefreshSkipsSilentlyWhenNotAFleetHome(t *testing.T) {
 	}
 }
 
-func TestDestinationDirsCoverEverySupportedHarnessWithNoDuplicates(t *testing.T) {
+func TestDestinationDirsCoverEverySupervisorHarnessWithNoDuplicates(t *testing.T) {
 	home := t.TempDir()
 	dirs := DestinationDirs(home)
 	seen := make(map[string]bool)
@@ -50,14 +50,19 @@ func TestDestinationDirsCoverEverySupportedHarnessWithNoDuplicates(t *testing.T)
 		}
 		seen[d] = true
 	}
-	for _, h := range harness.Names() {
+	for _, h := range supervision.SupervisorHosts() {
 		rel, ok := harnessRel[h]
 		if !ok {
-			t.Fatalf("harness %q has no mapped skill destination", h)
+			t.Fatalf("Supervisor Harness %q has no mapped skill destination", h)
 		}
 		want := filepath.Join(home, rel, Name)
 		if !seen[want] {
-			t.Fatalf("got %v, want it to include %q for harness %q", dirs, want, h)
+			t.Fatalf("got %v, want it to include %q for Supervisor Harness %q", dirs, want, h)
+		}
+	}
+	for h := range harnessRel {
+		if !supervision.IsSupervisorHost(h) {
+			t.Fatalf("skill mapping %q is not a registered Supervisor Harness", h)
 		}
 	}
 }

--- a/internal/steering/antigravity_test.go
+++ b/internal/steering/antigravity_test.go
@@ -1,0 +1,53 @@
+package steering
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestExecuteRefusesOneShotWorkerBeforeAnySendOrPaneMutation(t *testing.T) {
+	home := t.TempDir()
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(state.Task{ID: "task-1", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := db.CreateAttempt(state.Attempt{
+		TaskID:    "task-1",
+		Lifecycle: state.AttemptRunning,
+		Harness:   harness.Antigravity,
+		Herdr:     state.Herdr{Session: "session-1", WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	pane := &testPane{pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle}}
+	_, err = Execute(Request{Home: home, TaskID: "task-1", Message: "echo this must never reach a shell", Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || !sendErr.Precondition || !strings.Contains(err.Error(), "one-shot worker execution") {
+		t.Fatalf("err = %v, want one-shot precondition refusal", err)
+	}
+	if len(pane.textCalls) != 0 || len(pane.keyCalls) != 0 {
+		t.Fatalf("pane mutations = text %v keys %v, want none", pane.textCalls, pane.keyCalls)
+	}
+	sends, readErr := state.ListSends(home, "task-1")
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(sends) != 0 {
+		t.Fatalf("sends = %+v, want none before refusal", sends)
+	}
+	_ = attempt
+}

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/state"
@@ -113,6 +114,11 @@ func Execute(req Request) (Result, error) {
 	}
 	if active.Lifecycle != state.AttemptRunning {
 		return Result{}, precondition(fmt.Errorf("task %q has no confirmed running attempt", req.TaskID))
+	}
+	if harness.IsOneShot(active.Harness) {
+		// A completed one-shot returns this exact pane to its shell. Reject before a send row or pane
+		// mutation so operator prose can never become shell input merely because the Attempt is active.
+		return Result{}, precondition(fmt.Errorf("harness %q uses one-shot worker execution and cannot accept hand send; wait for its report or start a new Attempt", active.Harness))
 	}
 	pending, found, err := pendingSend(req, active.ID)
 	if err != nil {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -22,6 +22,7 @@ import (
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/workerobs"
 )
 
 const maxEventLogLines = 200
@@ -389,6 +390,16 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 			return
 		}
 		status := pane.AgentStatus
+		if probeErr == nil {
+			normalized, normalizeErr := workerobs.Normalize(attempt, pane, client)
+			if normalizeErr != nil {
+				// The pane itself answered, so this is liveness uncertainty rather than a pane outage.
+				_, _ = fmt.Fprintf(errOut, "watch: observe worker liveness for %s failed: %v\n", t.ID, normalizeErr)
+				status = herdr.StatusUnknown
+			} else {
+				pane, status = normalized, normalized.AgentStatus
+			}
+		}
 
 		// Tracking is keyed by task identity, not by ID: a reopen or a promote gives the same ID a new
 		// attempt, and a new attempt is a new execution identity. Same hazard as a surviving report

--- a/internal/workerobs/observe.go
+++ b/internal/workerobs/observe.go
@@ -1,0 +1,45 @@
+// Package workerobs normalizes worker-process liveness from a persisted Attempt and live Herdr
+// process evidence. It deliberately does not own Herdr resource ownership or task outcome.
+package workerobs
+
+import (
+	"fmt"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+)
+
+// ProcessInspector provides live process evidence for one task-owned pane.
+type ProcessInspector interface {
+	PaneProcessInfo(string) (herdr.ProcessInfo, error)
+}
+
+// Normalize derives Worker identity and liveness without inferring task outcome.
+// For one-shot workers, durable launch confirmation plus process absence means done liveness only.
+func Normalize(attempt state.Attempt, pane herdr.Pane, inspector ProcessInspector) (herdr.Pane, error) {
+	if !harness.IsOneShot(attempt.Harness) {
+		return pane, nil
+	}
+	if pane.Agent != "" && pane.Agent != attempt.Harness {
+		return pane, nil
+	}
+	if pane.PaneID == "" || inspector == nil {
+		return pane, fmt.Errorf("one-shot worker process observation is unavailable")
+	}
+	processInfo, err := inspector.PaneProcessInfo(pane.PaneID)
+	if err != nil {
+		return pane, fmt.Errorf("observe one-shot worker process: %w", err)
+	}
+	if processInfo.HasExecutable(harness.Executable(attempt.Harness)) {
+		pane.Agent = attempt.Harness
+		pane.AgentStatus = herdr.StatusWorking
+		return pane, nil
+	}
+	if attempt.LaunchConfirmedAt != "" {
+		// "done" is Herdr liveness only: the one-shot is no longer resident. It is never task outcome.
+		pane.Agent = attempt.Harness
+		pane.AgentStatus = herdr.StatusDone
+	}
+	return pane, nil
+}

--- a/internal/workerobs/observe_test.go
+++ b/internal/workerobs/observe_test.go
@@ -1,0 +1,97 @@
+package workerobs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+)
+
+type inspectorStub struct {
+	info  herdr.ProcessInfo
+	err   error
+	calls int
+}
+
+func (s *inspectorStub) PaneProcessInfo(string) (herdr.ProcessInfo, error) {
+	s.calls++
+	return s.info, s.err
+}
+
+func TestNormalizeResidentWorkerPassesThroughWithoutProcessProbe(t *testing.T) {
+	in := herdr.Pane{PaneID: "p1", Agent: harness.Claude, AgentStatus: herdr.StatusBlocked}
+	probe := &inspectorStub{err: errors.New("must not be called")}
+	got, err := Normalize(state.Attempt{Harness: harness.Claude}, in, probe)
+	if err != nil || got != in || probe.calls != 0 {
+		t.Fatalf("Normalize() = %+v, %v, calls=%d; want unchanged resident pane", got, err, probe.calls)
+	}
+}
+
+func TestNormalizeOneShotUsesProcessPresenceForWorking(t *testing.T) {
+	probe := &inspectorStub{info: herdr.ProcessInfo{
+		ForegroundProcesses: []herdr.Process{{Name: "agy"}},
+	}}
+	got, err := Normalize(
+		state.Attempt{Harness: harness.Antigravity, LaunchConfirmedAt: "2026-08-24T00:00:00Z"},
+		herdr.Pane{PaneID: "p1", AgentStatus: herdr.StatusUnknown},
+		probe,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Agent != harness.Antigravity || got.AgentStatus != herdr.StatusWorking {
+		t.Fatalf("Normalize() = %+v, want Antigravity working", got)
+	}
+}
+
+func TestNormalizeConfirmedExitedOneShotIsDoneLivenessOnly(t *testing.T) {
+	got, err := Normalize(
+		state.Attempt{Harness: harness.Antigravity, LaunchConfirmedAt: "2026-08-24T00:00:00Z"},
+		herdr.Pane{PaneID: "p1", AgentStatus: herdr.StatusUnknown},
+		&inspectorStub{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Agent != harness.Antigravity || got.AgentStatus != herdr.StatusDone {
+		t.Fatalf("Normalize() = %+v, want confirmed exited Antigravity done-liveness", got)
+	}
+}
+
+func TestNormalizeUnconfirmedExitedOneShotStaysUnknown(t *testing.T) {
+	in := herdr.Pane{PaneID: "p1", AgentStatus: herdr.StatusUnknown}
+	got, err := Normalize(state.Attempt{Harness: harness.Antigravity}, in, &inspectorStub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != in {
+		t.Fatalf("Normalize() = %+v, want no fabricated identity before launch confirmation", got)
+	}
+}
+
+func TestNormalizeDoesNotOverwriteDifferentLiveAgent(t *testing.T) {
+	in := herdr.Pane{PaneID: "p1", Agent: harness.Claude, AgentStatus: herdr.StatusWorking}
+	probe := &inspectorStub{info: herdr.ProcessInfo{ForegroundProcesses: []herdr.Process{{Name: "agy"}}}}
+	got, err := Normalize(
+		state.Attempt{Harness: harness.Antigravity, LaunchConfirmedAt: "2026-08-24T00:00:00Z"},
+		in,
+		probe,
+	)
+	if err != nil || got != in || probe.calls != 0 {
+		t.Fatalf("Normalize() = %+v, %v, calls=%d; want conflicting live identity preserved", got, err, probe.calls)
+	}
+}
+
+func TestNormalizeProcessObservationFailureDoesNotFabricateExit(t *testing.T) {
+	in := herdr.Pane{PaneID: "p1", AgentStatus: herdr.StatusUnknown}
+	got, err := Normalize(
+		state.Attempt{Harness: harness.Antigravity, LaunchConfirmedAt: "2026-08-24T00:00:00Z"},
+		in,
+		&inspectorStub{err: errors.New("process info unavailable")},
+	)
+	if err == nil || got != in {
+		t.Fatalf("Normalize() = %+v, %v; want unchanged pane plus observation error", got, err)
+	}
+}


### PR DESCRIPTION
Fixes #336

## Intent

Add optional Antigravity support as a **Worker Harness** while keeping Supervisor capability independently owned by `internal/supervision`.

Antigravity remains intentionally worker-only in this PR.

## What Changed

- Added `antigravity` to the Worker Harness registry, mapped to the `agy` executable.
- Added model/effort/config/routing support with fail-closed runtime qualification:
  - supported platform and executable checks;
  - documented headless CLI contract verification;
  - `agy models` discovery;
  - authentication/configuration failure classification.
- Launches Antigravity one-shot with `agy -p`, `--output-format stream-json`, `--dangerously-skip-permissions`, and explicit `--print-timeout 24h`.
- Added CWD-scoped typed `event:"init"` launch evidence for workers that initialize and exit between polling intervals.
- Kept provider terminal `result.status` completely separate from Hand task outcome semantics.
- Centralized one-shot liveness normalization from the persisted Attempt plus live process evidence, shared by reconciliation, `hand status`, and `hand watch`.
- Made `hand send` refuse one-shot workers before creating a SendAttempt or mutating the pane.
- Kept `hand doctor` / bootstrap Supervisor readiness based on the qualified Supervisor Harness registry, so worker-only Antigravity cannot satisfy Supervisor readiness.
- Documented the one-shot boundary, permission/isolation semantics, and deferred persistent-stdin design in ADR/docs.

## Invariants

- Process exit is liveness only, never task success.
- Antigravity `result.status == SUCCESS` is never Hand success evidence.
- Fast-exit launch recovery requires typed `init.cwd` matching the exact LaunchSpec CWD.
- After launch confirmation, pane scrollback is not canonical worker identity evidence.
- No Antigravity conversation IDs or provider lifecycle state are persisted.
- No fake resident process is introduced.
- No second Supervisor capability registry is introduced in `internal/harness`.
- Persistent `--input-format stream-json` remains deferred until Hand has durable initial-input submission semantics.

## Testing

CI #685 is fully green on final head `151125bea711e0727ae408d7f406618d3dfe23eb`:

- `go test -tags=test -race ./...` — Ubuntu, macOS, Windows
- `go build` — Ubuntu, macOS, Windows
- gofmt check
- `go vet ./...`
- golangci-lint
- commentlint
- `make contract`
- Nix flake build + built-binary smoke test
- E2E suite on Linux
- bootstrap E2E on macOS (`bootstrap.sh`)
- bootstrap E2E on Windows (`bootstrap.ps1`)

`Publish edge` is correctly skipped for the pull-request event.

## Risk Assessment

**Medium, bounded.** This touches worker launch confirmation and liveness observation across runtime/reconciliation/status/watch surfaces, but the provider-specific semantics stay behind shared Worker Harness boundaries and the final cross-platform race/build/E2E matrix is green.

<details>
<summary>Evidence: Antigravity supervisor refusal</summary>

```text
error: "supervisor mode is unsupported for harness \"antigravity\""
kind: precondition
exit: 3
```

</details>