### PR TITLE
feat(supervision): autonomously re-enter supported Supervisor Harnesses without operator prompts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 AGENTS.md text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.json text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
 ## Secondhand supervisor bootstrap
 
-Before responding or acting in a supervising session, run `hand session start`.
-Do not run supervisor bootstrap when `HAND_ROLE=worker`.
+At the beginning of a new Supervisor runtime/session, run `hand session start` once.
+Before reasoning or acting in every Supervisor turn, run `hand orient`.
+After an automatic wake/re-entry, run `hand orient` before any action.
+Do not run supervisor commands when `HAND_ROLE=worker`.
 
 This file is Hand-owned and immutable: `hand init` restores it byte-for-byte, and
 nobody edits it by hand, including the supervisor. The same rule covers every other

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cd ~/secondhand-fleet
 hand init
 ```
 
-`hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` before acting, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - a symlink on Unix and an `@AGENTS.md` pointer file on Windows.
+`hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, installs or refreshes the Hand-owned supervisor wake bridges (the Claude Stop hook entry, the OpenCode plugin, and the Pi extension), and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` once per runtime and `hand orient` every turn, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - the `@AGENTS.md` pointer file on every platform.
 
 ### 3. Add or create a project
 
@@ -142,8 +142,9 @@ cd ~/secondhand-fleet
 claude
 ```
 
-The canonical `AGENTS.md` tells the harness to run `hand session start` before responding or acting; that command loads bounded fleet context, returns Fleet-scoped orientation and monitor currentness, reports the first next action, and refuses outright inside a worker's isolated worktree.
-When it cannot prove a detached watcher, it reports a bounded re-arm and names `hand watch --until-event`.
+The canonical `AGENTS.md` tells the harness to run `hand session start` once at the beginning of a new Supervisor runtime - one-time bootstrap that identifies the Supervisor Harness, qualifies whether unattended wake delivery is supported, degraded, or unsupported on it, and installs or validates the host bridge - and `hand orient` before reasoning or acting in every turn, including a turn an automatic wake re-enters.
+Both commands refuse outright inside a worker's isolated worktree (`HAND_ROLE=worker`).
+Unattended wake delivery is host-specific: each supported harness gets its next reasoning opportunity through its own bridge (Claude Stop hook, Codex same-thread queue, OpenCode persistent plugin with the synchronous prompt API, Pi extension follow-up, Grok host-owned background completion), never through a watcher process exit alone.
 Any other supported harness reads the same instructions from `AGENTS.md` directly.
 
 On the first session, the supervisor inspects `hand config`, asks only unresolved configuration policy questions, and persists accepted profile and route choices through the CLI.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cd ~/secondhand-fleet
 hand init
 ```
 
-`hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, installs or refreshes the Hand-owned supervisor wake bridges (the Claude Stop hook entry, the OpenCode plugin, and the Pi extension), and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` once per runtime and `hand orient` every turn, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - the `@AGENTS.md` pointer file on every platform.
+`hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, installs or refreshes the Hand-owned supervisor wake bridges (the Claude Stop hook entry in `.claude/settings.json`, the OpenCode plugin, the Pi extension, and the Codex project-scope Stop hook in `.codex/hooks.json`), and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` once per runtime and `hand orient` every turn, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - the `@AGENTS.md` pointer file on every platform.
 
 ### 3. Add or create a project
 
@@ -142,9 +142,9 @@ cd ~/secondhand-fleet
 claude
 ```
 
-The canonical `AGENTS.md` tells the harness to run `hand session start` once at the beginning of a new Supervisor runtime - one-time bootstrap that identifies the Supervisor Harness, qualifies whether unattended wake delivery is supported, degraded, or unsupported on it, and installs or validates the host bridge - and `hand orient` before reasoning or acting in every turn, including a turn an automatic wake re-enters.
+The canonical `AGENTS.md` tells the harness to run `hand session start` once at the beginning of a new Supervisor runtime - one-time read-only bootstrap that identifies the Supervisor Harness, qualifies whether unattended wake delivery is supported, degraded, or unsupported on it, and reports the installed integration state without touching any static byte (only `hand init` installs or repairs those) - and `hand orient` before reasoning or acting in every turn, including a turn an automatic wake re-enters.
 Both commands refuse outright inside a worker's isolated worktree (`HAND_ROLE=worker`).
-Unattended wake delivery is host-specific: each supported harness gets its next reasoning opportunity through its own bridge (Claude Stop hook, Codex same-thread queue, OpenCode persistent plugin with the synchronous prompt API, Pi extension follow-up, Grok host-owned background completion), never through a watcher process exit alone.
+Unattended wake delivery is host-specific: each supported harness gets its next reasoning opportunity through its own bridge (Claude Stop hook asyncRewake, Codex project-scope Stop hook driving the same-thread queue, OpenCode persistent plugin with the synchronous prompt API, Pi extension follow-up, Grok host-owned background completion), never through a watcher process exit alone.
 Any other supported harness reads the same instructions from `AGENTS.md` directly.
 
 On the first session, the supervisor inspects `hand config`, asks only unresolved configuration policy questions, and persists accepted profile and route choices through the CLI.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -143,6 +143,7 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			doc.List("blocking", blocking)
 			doc.List("next", next)
 			axi.Table(&doc, "integrations", integrations, integrationFields)
+			appendSupervisionDiagnostics(&doc, cmd.Context(), fleetHome)
 			axi.Table(&doc, "findings", findings, cols)
 			doc.Help(doctorHelp(len(findings), failing)...)
 			if err := doc.Render(cmd.OutOrStdout()); err != nil {

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/atqamz/hand/internal/attention"
+	"github.com/atqamz/hand/internal/orientation"
+	"github.com/atqamz/hand/internal/project"
+	"github.com/atqamz/hand/internal/registry"
+	"github.com/atqamz/hand/internal/state"
+)
+
+// Everything the orientation evidence builder derives from, loaded once per
+// invocation. hand orient and the supervision wait read through it so every
+// consumer reasons over exactly the same authoritative level.
+type fleetSnapshot struct {
+	fleetID          string
+	registryWarnings []string
+	projects         []project.Project
+	backlog          backlogSummary
+	cfg              workerConfig
+	views            []taskView
+	holds            []state.Hold
+	next             nextAction
+	monitorState     orientation.MonitorState
+	monitorReason    string
+}
+
+// Performs the one read-only sweep of durable Fleet state the orientation
+// path is allowed. Every fault propagates: a partially read Fleet must never
+// render as a quiet one.
+func loadFleetSnapshot(ctx context.Context, warnOut io.Writer, fleetHome string) (*fleetSnapshot, error) {
+	snapshot := &fleetSnapshot{}
+	fleetID, err := state.FleetIDReadOnly(fleetHome)
+	if err != nil {
+		return nil, fmt.Errorf("read Fleet identity for orientation: %w", err)
+	}
+	snapshot.fleetID = fleetID
+	warnings, err := registry.Preflight(fleetHome, true)
+	if err != nil {
+		return nil, asPrecondition(err)
+	}
+	snapshot.registryWarnings = warnings
+	projects, err := project.ListReadOnly(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.projects = projects
+	cfg, err := currentWorkerConfig(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.cfg = cfg
+	backlogPath := filepath.Join(fleetHome, "data", "backlog.md")
+	backlog, err := readBacklogSummary(backlogPath, sessionBacklogLimit)
+	if err != nil {
+		return nil, sessionContextError(fleetHome, backlogPath, err)
+	}
+	snapshot.backlog = backlog
+	client, err := currentHerdrClient(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	views, holds, err := fleetViews(ctx, warnOut, fleetHome, client, true)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.views = views
+	snapshot.holds = holds
+	snapshot.next = classifyNextAction(cfg, len(projects), backlog, views, holds)
+	snapshot.monitorState, snapshot.monitorReason, err = readOnlyMonitorState(fleetHome, monitorTargetCount(views))
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+// Assembles the unbounded underlying orientation evidence. Wake eligibility
+// consumes this directly; only rendered orientation applies bounds afterwards.
+func (s *fleetSnapshot) evidence() orientation.Evidence {
+	evidence := orientation.Evidence{FleetID: s.fleetID, MonitorState: s.monitorState}
+	for _, warning := range s.registryWarnings {
+		evidence.Errors = append(evidence.Errors, orientation.BoundedError{Kind: "registry", Reason: warning})
+	}
+	for _, view := range s.views {
+		targetEvidence := orientation.TaskTargetEvidence(taskTargetFacts(view))
+		if monitorableView(view) {
+			evidence.Targets = append(evidence.Targets, targetEvidence)
+		}
+		evidence.Work = append(evidence.Work, orientation.WorkEvidence{ID: view.task.ID, Kind: "task", State: view.agentState, Reported: view.reportedState})
+		for _, subject := range attention.Derive(taskAttentionEvidence(view)) {
+			if !subject.Actionable {
+				continue
+			}
+			evidence.Actionable = append(evidence.Actionable, orientation.ActionableEvidence{
+				TargetID: view.task.ID, TargetKind: "task", Generation: targetEvidence.Generation,
+				Kind: subject.Kind, Reason: subject.Reason, Provenance: subject.Provenance,
+			})
+		}
+	}
+	if s.next.Kind != "" {
+		evidence.NextActions = append(evidence.NextActions, orientation.NextAction{Kind: s.next.Kind, Target: s.next.Task, Command: s.next.Command, Reason: s.next.Reason})
+	}
+	if s.monitorState != orientation.MonitorStateAlreadyArmed {
+		evidence.NextActions = append(evidence.NextActions, orientation.NextAction{
+			Kind: "monitor-rearm", Command: "hand watch --until-event",
+			Reason: s.monitorReason,
+		})
+	}
+	if s.monitorReason != "" && s.monitorState != orientation.MonitorStateRearmed {
+		evidence.Errors = append(evidence.Errors, orientation.BoundedError{Kind: "monitor", Reason: s.monitorReason})
+	}
+	return evidence
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -107,6 +107,7 @@ func newInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			supervisionInstalls, supervisionConflicts := installSupervisorBridgesForInit(home, exe)
 
 			if err := warnHandHomeMismatch(cmd.ErrOrStderr(), home); err != nil {
 				return err
@@ -126,6 +127,8 @@ func newInitCmd() *cobra.Command {
 			axi.Table(&doc, "skill", skillResults, skillFields)
 			doc.Int("skill_conflicts", skillConflictCount(skillResults))
 			doc.Field("session_hook", removedOrUnchanged(hookRemoved))
+			axi.Table(&doc, "supervision_integration", supervisionInstalls, supervisionInstallFields)
+			doc.Int("supervision_conflicts", len(supervisionConflicts))
 			doc.Bool("runtime_ready", runtimeStatus.Ready)
 			doc.Field("runtime_target", runtimeStatus.Target)
 			doc.Field("runtime_id", valueOrNone(runtimeStatus.RuntimeID))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -160,12 +160,18 @@ func newInitCmd() *cobra.Command {
 			if n := skillConflictCount(skillResults); n > 0 {
 				help = append(help, fmt.Sprintf("%d bundled-skill destination(s) already hold a foreign file at the managed entry path and were left untouched; move each aside, then run hand init again to install the skill there", n))
 			}
+			if len(supervisionConflicts) > 0 {
+				help = append(help, fmt.Sprintf("%d supervisor wake integration surface(s) hold foreign content at Hand-managed paths and were left untouched; move each aside, then run hand init again", len(supervisionConflicts)))
+			}
 			doc.Help(help...)
 			if err := doc.Render(cmd.OutOrStdout()); err != nil {
 				return err
 			}
 			if registryErr != nil {
 				return fmt.Errorf("fleet initialized at %s with fleet_id %s, but registry discovery update failed: %w", home, fleetID, registryErr)
+			}
+			if len(supervisionConflicts) > 0 {
+				return &ExitError{Err: fmt.Errorf("initialized %s, but %d supervisor wake integration surface(s) are conflicted and were left untouched; unattended turn delivery stays degraded until they are resolved", home, len(supervisionConflicts)), Code: 3}
 			}
 			return nil
 		},

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"io"
 	"reflect"
 	"testing"
 
@@ -9,7 +11,6 @@ import (
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -244,7 +245,7 @@ func TestClassifyNextActionFieldNamesArePinned(t *testing.T) {
 
 func observeNextAction(t *testing.T, home string) nextAction {
 	t.Helper()
-	views, holds, err := fleetViews(&cobra.Command{}, home, nil, true)
+	views, holds, err := fleetViews(context.Background(), io.Discard, home, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/orient.go
+++ b/cmd/orient.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/orientation"
+	"github.com/atqamz/hand/internal/supervision"
+	"github.com/spf13/cobra"
+)
+
+// hand orient is the one observation every Supervisor reasoning turn begins
+// with, including the turn an automatic wake re-enters. Read-mostly: the only
+// thing it records is that this turn actually oriented the current episodes.
+func newOrientCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "orient",
+		Short: "Observe current bounded Supervisor orientation for this reasoning turn",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
+				return &ExitError{Err: fmt.Errorf("hand orient is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
+			}
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			snapshot, err := loadFleetSnapshot(cmd.Context(), cmd.ErrOrStderr(), fleetHome)
+			if err != nil {
+				return err
+			}
+			evidence := snapshot.evidence()
+
+			ledger := supervision.OpenLedger(fleetHome)
+			if err := ledger.MarkOriented(supervision.FromEvidence(evidence)); err != nil {
+				return err
+			}
+
+			result := orientation.Build(evidence)
+			var doc axi.Doc
+			appendSessionOrientation(&doc, result)
+			doc.Field("next_action_kind", snapshot.next.Kind)
+			doc.Field("next_action_task", orNone(snapshot.next.Task))
+			doc.Field("next_action_command", orNone(snapshot.next.Command))
+			doc.Field("next_action_reason", snapshot.next.Reason)
+			appendSupervisionProgress(&doc, ledger)
+			doc.Help("Reason and act on this observation; run `hand orient` again after every automatic wake")
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+}
+
+// Renders the mechanism-progress diagnostics that must stay distinguishable
+// from canonical truth: acceptance without a later orientation stamp means a
+// host took the wake but no reasoning turn returned.
+func appendSupervisionProgress(doc *axi.Doc, ledger *supervision.Ledger) {
+	lastAccepted, lastOriented := ledger.Progress()
+	doc.Field("wake_delivery_last_accepted", timestampOrNone(lastAccepted))
+	doc.Field("orientation_progress", timestampOrNone(lastOriented))
+}
+
+func timestampOrNone(t *time.Time) string {
+	if t == nil {
+		return "none"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// Answers, separately: harness identity, runtime addressability, integration
+// currency, unattended turn capability, bridge attachment, wake acceptance,
+// orient progress, and watcher liveness. No one field proves autonomy.
+func appendSupervisionDiagnostics(doc *axi.Doc, ctx context.Context, fleetHome string) {
+	detection, err := harness.DetectCurrent()
+	if err != nil {
+		doc.Field("supervisor_harness", "unknown")
+		doc.Field("supervisor_diagnosis_error", err.Error())
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		exe = "unknown"
+	}
+	status, err := supervision.IntegrationStatus(ctx, supervision.StatusInput{
+		Home:      fleetHome,
+		Detection: detection,
+		Exe:       exe,
+	})
+	if err != nil {
+		doc.Field("supervisor_harness", orNone(detection.Name))
+		doc.Field("supervisor_diagnosis_error", err.Error())
+		return
+	}
+	doc.Field("supervisor_harness", orNone(status.Harness))
+	doc.Field("runtime_identity_status", orNone(status.RuntimeIdentity))
+	doc.Field("bootstrap_integration_status", orNone(status.Integration))
+	doc.Field("wake_delivery_capability", status.WakeDelivery)
+	doc.Field("wake_delivery_reason", orNone(status.WakeDeliveryReason))
+	doc.Field("wake_delivery_attachment_status", orNone(status.Attachment))
+	lastAccepted, lastOriented := supervision.OpenLedger(fleetHome).Progress()
+	doc.Field("wake_delivery_last_accepted", timestampOrNone(lastAccepted))
+	doc.Field("orientation_progress", timestampOrNone(lastOriented))
+	doc.Field("watcher_observer_liveness", orNone(status.WatcherLiveness))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,8 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 	root.AddCommand(newFleetCmd())
 	root.AddCommand(newReconcileCmd())
 	root.AddCommand(newSessionCmd(info.Version))
+	root.AddCommand(newOrientCmd())
+	root.AddCommand(newSupervisionCmd())
 	root.AddCommand(newSendCmd())
 	root.AddCommand(newHoldCmd())
 	root.AddCommand(newDeliverCmd())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -196,11 +196,30 @@ func TestBareInvocationReportsConfigurationStateAndAsksTheOperator(t *testing.T)
 	}
 }
 
-func TestBareInvocationInHomeUsesTheSessionStartRenderer(t *testing.T) {
+// Since the #353 split, bare hand keeps the ordinary fleet overview while
+// `hand session start` is one-time runtime bootstrap: the two documents are
+// deliberately different answers to different questions.
+func TestBareInvocationInHomeRendersTheFleetOverviewNotBootstrap(t *testing.T) {
 	setupSessionHome(t)
-	want := runSessionStartForTest(t)
-	if got := runBareRoot(t); got != want {
-		t.Fatalf("bare hand = %q, want the exact hand session start overview %q", got, want)
+	out := runBareRoot(t)
+	for _, want := range []string{
+		"orientation_schema: hand.supervisor.v1\n",
+		"tasks[0]{id,state,reported,age,flags}:\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("out = %q, want the fleet overview to contain %q", out, want)
+		}
+	}
+	if strings.Contains(out, "next_command: hand orient\n") {
+		t.Fatalf("out = %q, want the overview not to answer the bootstrap question", out)
+	}
+
+	started := runSessionStartForTest(t)
+	if !strings.Contains(started, "session_bootstrap: complete\n") || !strings.Contains(started, "next_command: hand orient\n") {
+		t.Fatalf("session start = %q, want the bootstrap contract", started)
+	}
+	if started == out {
+		t.Fatal("bare hand rendered the same document as hand session start")
 	}
 }
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/supervision"
 	"github.com/atqamz/hand/internal/watcher"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +54,9 @@ func newSessionCmd(version string) *cobra.Command {
 	return cmd
 }
 
+// One-time runtime bootstrap: resolve the Fleet, validate the role, identify
+// the harness and its runtime, install or validate the host bridge. Not the
+// ordinary current-work read; turns observe through `hand orient` instead.
 func runSessionStart(cmd *cobra.Command, version string) error {
 	if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
 		return &ExitError{Err: fmt.Errorf("supervisor session bootstrap is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
@@ -60,7 +65,102 @@ func runSessionStart(cmd *cobra.Command, version string) error {
 	if err != nil {
 		return asPrecondition(err)
 	}
-	return renderSessionOverview(cmd, version, fleetHome)
+	if _, err := state.FleetIDReadOnly(fleetHome); err != nil {
+		// A home without fleet identity is a bootstrap precondition: the
+		// remedy is init. Any other store fault stays the owning reader's
+		// general error rather than being reclassified.
+		if errors.Is(err, state.ErrFleetIdentityMissing) {
+			return &ExitError{Err: fmt.Errorf("read Fleet identity for supervisor bootstrap: %w; run `hand init %s` to restore it", err, shellquote.Quote(fleetHome)), Code: 3}
+		}
+		return fmt.Errorf("read Fleet identity for supervisor bootstrap: %w", err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		exe = "unknown"
+	}
+	detection, err := harness.DetectCurrent()
+	if err != nil {
+		return err
+	}
+
+	installs, installErrs := installSupervisorBridge(fleetHome, detection.Name, exe)
+	status, err := supervision.IntegrationStatus(cmd.Context(), supervision.StatusInput{
+		Home:      fleetHome,
+		Detection: detection,
+		Exe:       exe,
+	})
+	if err != nil {
+		return err
+	}
+
+	var doc axi.Doc
+	doc.Field("session_bootstrap", "complete")
+	doc.Field("tool", "hand")
+	doc.Field("version", version)
+	doc.Field("exec", tildePath(exe))
+	doc.Field("home", tildePath(fleetHome))
+	doc.Field("supervisor_harness", orNone(status.Harness))
+	doc.Field("supervisor_harness_source", orNone(status.HarnessSource))
+	doc.Field("runtime_identity_status", orNone(status.RuntimeIdentity))
+	doc.Field("runtime_identity_detail", orNone(status.RuntimeDetail))
+	doc.Field("bootstrap_integration_status", orNone(status.Integration))
+	doc.Field("bootstrap_integration_detail", orNone(status.IntegrationDetail))
+	doc.Rows("integration", []string{"host", "path", "state", "detail"}, installRows(installs))
+	doc.Field("wake_delivery_capability", status.WakeDelivery)
+	doc.Field("wake_delivery_reason", orNone(status.WakeDeliveryReason))
+	doc.Field("wake_delivery_attachment_status", orNone(status.Attachment))
+	doc.Field("watcher_observer_liveness", orNone(status.WatcherLiveness))
+	lastAccepted, lastOriented := supervision.OpenLedger(fleetHome).Progress()
+	doc.Field("wake_delivery_last_accepted", timestampOrNone(lastAccepted))
+	doc.Field("orientation_progress", timestampOrNone(lastOriented))
+	doc.Field("next_command", "hand orient")
+	help := []string{
+		"Before reasoning or acting in every Supervisor turn, run `hand orient`",
+		"After an automatic wake/re-entry, run `hand orient` before any action",
+	}
+	if status.WakeDelivery != supervision.CapabilitySupported {
+		help = append(help, "Unattended Supervisor turn delivery is "+status.WakeDelivery+" here: "+status.WakeDeliveryReason)
+	}
+	help = append(help, installErrs...)
+	doc.Help(help...)
+	return doc.Render(cmd.OutOrStdout())
+}
+
+// Installs or refreshes the detected host's Hand-owned wait-to-turn bridge.
+// Conflicts are diagnostics, not bootstrap failures: hand init and doctor are
+// the repair paths, and a foreign managed-path file is the operator's to move.
+func installSupervisorBridge(fleetHome, host, exe string) ([]supervision.InstallResult, []string) {
+	var results []supervision.InstallResult
+	var errs []string
+	switch host {
+	case harness.Claude:
+		result, err := supervision.InstallClaudeStopHook(fleetHome, exe)
+		results = append(results, result)
+		if err != nil {
+			errs = append(errs, result.Detail)
+		}
+	case harness.OpenCode, harness.Pi:
+		assetResults, err := supervision.InstallHostAssets(fleetHome, host, exe)
+		if err != nil {
+			errs = append(errs, err.Error())
+			break
+		}
+		results = assetResults
+		for _, result := range assetResults {
+			if result.State == "conflict" {
+				errs = append(errs, result.Path+": "+result.Detail)
+			}
+		}
+	}
+	return results, errs
+}
+
+func installRows(results []supervision.InstallResult) [][]string {
+	rows := make([][]string, 0, len(results))
+	for _, result := range results {
+		rows = append(rows, []string{result.Host, result.Path, result.State, result.Detail})
+	}
+	return rows
 }
 
 func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error {
@@ -94,7 +194,7 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	if err != nil {
 		return err
 	}
-	views, holds, err := fleetViews(cmd, fleetHome, client, true)
+	views, holds, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), fleetHome, client, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -55,8 +55,8 @@ func newSessionCmd(version string) *cobra.Command {
 }
 
 // One-time runtime bootstrap: resolve the Fleet, validate the role, identify
-// the harness and its runtime, install or validate the host bridge. Not the
-// ordinary current-work read; turns observe through `hand orient` instead.
+// the harness and its runtime, qualify the installed bridge. Read-only against
+// static integration (init owns those bytes) and not a current-work read.
 func runSessionStart(cmd *cobra.Command, version string) error {
 	if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
 		return &ExitError{Err: fmt.Errorf("supervisor session bootstrap is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
@@ -83,7 +83,6 @@ func runSessionStart(cmd *cobra.Command, version string) error {
 		return err
 	}
 
-	installs, installErrs := installSupervisorBridge(fleetHome, detection.Name, exe)
 	status, err := supervision.IntegrationStatus(cmd.Context(), supervision.StatusInput{
 		Home:      fleetHome,
 		Detection: detection,
@@ -105,7 +104,6 @@ func runSessionStart(cmd *cobra.Command, version string) error {
 	doc.Field("runtime_identity_detail", orNone(status.RuntimeDetail))
 	doc.Field("bootstrap_integration_status", orNone(status.Integration))
 	doc.Field("bootstrap_integration_detail", orNone(status.IntegrationDetail))
-	doc.Rows("integration", []string{"host", "path", "state", "detail"}, installRows(installs))
 	doc.Field("wake_delivery_capability", status.WakeDelivery)
 	doc.Field("wake_delivery_reason", orNone(status.WakeDeliveryReason))
 	doc.Field("wake_delivery_attachment_status", orNone(status.Attachment))
@@ -118,49 +116,19 @@ func runSessionStart(cmd *cobra.Command, version string) error {
 		"Before reasoning or acting in every Supervisor turn, run `hand orient`",
 		"After an automatic wake/re-entry, run `hand orient` before any action",
 	}
-	if status.WakeDelivery != supervision.CapabilitySupported {
-		help = append(help, "Unattended Supervisor turn delivery is "+status.WakeDelivery+" here: "+status.WakeDeliveryReason)
+	switch status.WakeDelivery {
+	case supervision.CapabilityDegraded:
+		help = append(help, "Unattended Supervisor turn delivery is degraded here: "+status.WakeDeliveryReason)
+	case supervision.CapabilityUnsupported:
+		help = append(help, "Unattended Supervisor turn delivery is unsupported here: "+status.WakeDeliveryReason)
+	case supervision.CapabilityUnqualified:
+		help = append(help, "Wake delivery is available but not yet live-qualified on this build: "+status.WakeDeliveryReason)
 	}
-	help = append(help, installErrs...)
+	if status.Integration == "stale" || status.Integration == "absent" || status.Integration == "conflict" {
+		help = append(help, "Repair Hand-owned integration with `hand init "+shellquote.Quote(fleetHome)+"`; then restart or reload this harness if it caches configuration at startup")
+	}
 	doc.Help(help...)
 	return doc.Render(cmd.OutOrStdout())
-}
-
-// Installs or refreshes the detected host's Hand-owned wait-to-turn bridge.
-// Conflicts are diagnostics, not bootstrap failures: hand init and doctor are
-// the repair paths, and a foreign managed-path file is the operator's to move.
-func installSupervisorBridge(fleetHome, host, exe string) ([]supervision.InstallResult, []string) {
-	var results []supervision.InstallResult
-	var errs []string
-	switch host {
-	case harness.Claude:
-		result, err := supervision.InstallClaudeStopHook(fleetHome, exe)
-		results = append(results, result)
-		if err != nil {
-			errs = append(errs, result.Detail)
-		}
-	case harness.OpenCode, harness.Pi:
-		assetResults, err := supervision.InstallHostAssets(fleetHome, host, exe)
-		if err != nil {
-			errs = append(errs, err.Error())
-			break
-		}
-		results = assetResults
-		for _, result := range assetResults {
-			if result.State == "conflict" {
-				errs = append(errs, result.Path+": "+result.Detail)
-			}
-		}
-	}
-	return results, errs
-}
-
-func installRows(results []supervision.InstallResult) [][]string {
-	rows := make([][]string, 0, len(results))
-	for _, result := range results {
-		rows = append(rows, []string{result.Host, result.Path, result.State, result.Detail})
-	}
-	return rows
 }
 
 func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error {

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -17,10 +16,10 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/axi"
-	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/selfupdate"
+	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
 	"github.com/atqamz/hand/internal/watcher"
@@ -91,36 +90,39 @@ func TestSessionStartEmitsCompleteBoundedDigest(t *testing.T) {
 	out := runSessionStartForTest(t)
 	for _, want := range []string{
 		"session_bootstrap: complete\n",
-		"orientation_schema: hand.supervisor.v1\n",
-		"fleet_id: f_",
-		"monitor_state: rearmed\n",
-		"monitor_targets[0]{id,kind,currentness}:\n",
-		"orientation_actionable[0]{target_id,kind,reason,provenance}:\n",
 		"tool: hand\n",
 		"version: test\n",
 		"exec:",
 		"home: " + axi.Value(home) + "\n",
 		"supervisor_harness: codex\n",
 		"supervisor_harness_source: override\n",
-		"harness,detected,codex",
-		"model,native-default,none",
-		"operator: \"## Hard constraints\\nKeep every line.\\nIncluding: punctuation.\"\n",
-		"instructions[",
-		"projects[0]{name,mode,url,upstream}:\n",
-		"backlog[2]:\n",
-		"count: 0\n",
-		"attention: 0\n",
-		"held: 0\n",
-		"tasks[0]{id,state,reported,age,flags}:\n",
-		"holds[0]{id,kind,detail,age}:\n",
-		"help[1]:\n",
+		"runtime_identity_status: unidentified\n",
+		"bootstrap_integration_status: not-required\n",
+		"wake_delivery_capability:",
+		"wake_delivery_attachment_status:",
+		"watcher_observer_liveness:",
+		"next_command: hand orient\n",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("out = %q, want %q", out, want)
 		}
 	}
-	if strings.Contains(out, "private implementation body") {
-		t.Fatalf("out = %q, want indented backlog bodies omitted", out)
+	// Bootstrap is not the ordinary current-work read: no orientation dump, no
+	// project/backlog/operator context, no instruction list. Every reasoning
+	// turn observes through hand orient instead.
+	for _, banned := range []string{
+		"orientation_schema:",
+		"orientation_actionable",
+		"projects[0]{name,mode,url,upstream}:",
+		"backlog[",
+		"operator: ",
+		"instructions[",
+		"tasks[0]{id,state,reported,age,flags}:",
+		"private implementation body",
+	} {
+		if strings.Contains(out, banned) {
+			t.Fatalf("out = %q, want bootstrap output without %q", out, banned)
+		}
 	}
 }
 
@@ -172,32 +174,32 @@ func TestSessionStartRefusesOutsideFleetHome(t *testing.T) {
 	}
 }
 
-func TestSessionStartMissingRequiredContextNamesPathAndRecovery(t *testing.T) {
+// data/operator.md and data/backlog.md are the supervisor's own reading list,
+// not bootstrap inputs: one-time runtime qualification must complete without
+// them and leave their absence to the generated instructions to surface.
+func TestSessionStartCompletesWithoutOperatorOrBacklogContext(t *testing.T) {
+	home := setupSessionHome(t)
 	for _, name := range []string{"operator.md", "backlog.md"} {
-		t.Run(name, func(t *testing.T) {
-			home := setupSessionHome(t)
-			path := filepath.Join(home, "data", name)
-			if err := os.Remove(path); err != nil {
-				t.Fatal(err)
-			}
+		if err := os.Remove(filepath.Join(home, "data", name)); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-			_, err := executeSessionStart(t, nil)
-			assertExitCode(t, err, 3)
-			for _, want := range []string{path, "hand init '" + home + "'"} {
-				if !strings.Contains(err.Error(), want) {
-					t.Fatalf("err = %q, want %q", err, want)
-				}
-			}
-		})
+	out, err := executeSessionStart(t, nil)
+	if err != nil {
+		t.Fatalf("session start = %v, want a completed bootstrap", err)
+	}
+	if !strings.Contains(out, "session_bootstrap: complete\n") || !strings.Contains(out, "next_command: hand orient\n") {
+		t.Fatalf("out = %q, want the bootstrap contract", out)
 	}
 }
 
-func TestSessionStartRecoveryCommandQuotesFleetHomeForPOSIXShell(t *testing.T) {
+func TestSessionStartResolvesFleetIdentityBeforeQualifyingTheRuntime(t *testing.T) {
 	parent := t.TempDir()
 	home := filepath.Join(parent, "fleet path's `printf injected`;printf injected")
 	mkFleetDirs(t, home)
 	writeSessionContext(t, home, "operator", "# Backlog\n")
-	if err := os.Remove(filepath.Join(home, "data", "operator.md")); err != nil {
+	if err := os.Remove(filepath.Join(home, "state", "hand.db")); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HAND_HOME", home)
@@ -205,25 +207,12 @@ func TestSessionStartRecoveryCommandQuotesFleetHomeForPOSIXShell(t *testing.T) {
 	t.Setenv(harness.RoleEnv, "")
 	t.Chdir(parent)
 
-	bin := faketool.Bin(t)
-	faketool.Command{Name: "hand", Args: true}.Install(t, bin)
-
 	_, err := executeSessionStart(t, nil)
 	assertExitCode(t, err, 3)
-	message := err.Error()
-	start := strings.LastIndex(message, "; run `")
-	end := strings.LastIndex(message, "` to restore it")
-	if start < 0 || end <= start {
-		t.Fatalf("err = %q, want an executable recovery command", message)
-	}
-	recovery := message[start+len("; run `") : end]
-	got, runErr := exec.Command("sh", "-c", recovery).CombinedOutput()
-	if runErr != nil {
-		t.Fatalf("run recovery %q: %v: %s", recovery, runErr, got)
-	}
-	want := "2\ninit\n" + home + "\n"
-	if string(got) != want {
-		t.Fatalf("recovery argv = %q, want %q", got, want)
+	for _, want := range []string{"fleet identity missing", "run `hand init " + shellquote.Quote(home)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %q, want it to name %q", err, want)
+		}
 	}
 }
 
@@ -349,10 +338,16 @@ func TestSessionOverviewsDoNotMutateFleetState(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			for _, want := range []string{"sqlite-project", "sqlite-task", "sqlite-hold"} {
-				if !strings.Contains(out, want) {
-					t.Fatalf("out = %q, want current SQLite-backed %q", out, want)
+			// Bootstrap qualifies the runtime without rendering current work;
+			// the bare overview is the surface that reports SQLite-backed state.
+			if len(test.args) == 0 {
+				for _, want := range []string{"sqlite-project", "sqlite-task", "sqlite-hold"} {
+					if !strings.Contains(out, want) {
+						t.Fatalf("out = %q, want current SQLite-backed %q", out, want)
+					}
 				}
+			} else if !strings.Contains(out, "session_bootstrap: complete\n") {
+				t.Fatalf("out = %q, want a completed bootstrap", out)
 			}
 			after := snapshotFleetTree(t, home)
 			if !slices.Equal(after, before) {
@@ -443,10 +438,18 @@ func TestOldFleetRequiresExplicitRecoveryBeforeReadOnlyOverview(t *testing.T) {
 		if err != nil {
 			t.Fatalf("overview %d: %v", i+1, err)
 		}
-		for _, want := range []string{"legacy-project", "legacy-task"} {
-			if !strings.Contains(out, want) {
-				t.Fatalf("overview %d = %q, want migrated %q", i+1, out, want)
+		// Bootstrap qualifies the runtime without rendering current work; the
+		// bare overview is the surface that reports migrated tasks.
+		if len(args) == 0 {
+			for _, want := range []string{"legacy-project", "legacy-task"} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("overview %d = %q, want migrated %q", i+1, out, want)
+				}
 			}
+			continue
+		}
+		if !strings.Contains(out, "session_bootstrap: complete\n") {
+			t.Fatalf("overview %d = %q, want a completed bootstrap", i+1, out)
 		}
 		if afterOverview := snapshotFleetTree(t, home); !slices.Equal(afterOverview, afterRecovery) {
 			t.Fatalf("overview %d mutated the recovered fleet:\nbefore: %v\nafter:  %v", i+1, afterRecovery, afterOverview)
@@ -584,10 +587,10 @@ func TestReadBacklogSummaryBoundsIdentityLinesAndCountsTheWholeQueue(t *testing.
 	}
 }
 
-// classifyNextAction's own precedence and determinism coverage lives in cmd/nextaction_test.go; this
-// test is the session start integration boundary: the fleet-state-derived next_action_* fields and
-// help line actually reach the rendered document atqamz/hand#234 asks a supervisor to consume.
-func TestSessionStartRendersNextActionFromFleetState(t *testing.T) {
+// classifyNextAction precedence coverage lives in cmd/nextaction_test.go; this
+// is the orient integration boundary: fleet-state-derived fields, the bounded
+// orientation view, and the progress receipt reach one rendered document.
+func TestOrientRendersNextActionFromFleetState(t *testing.T) {
 	home := setupSessionHome(t)
 	db, err := store.Open(home)
 	if err != nil {
@@ -604,16 +607,61 @@ func TestSessionStartRendersNextActionFromFleetState(t *testing.T) {
 	}
 	writeSessionContext(t, home, "operator", "# Backlog\n\n## Queue\n- queued-task\n")
 
-	out := runSessionStartForTest(t)
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"orient"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(new(bytes.Buffer))
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
 	for _, want := range []string{
+		"orientation_schema: hand.supervisor.v1\n",
+		"fleet_id: f_",
+		"orientation_actionable[",
 		"next_action_kind: needs-repair\n",
 		"next_action_task: needs-repair-task\n",
 		"next_action_command: hand status needs-repair-task\n",
 		"next_action_reason: Run `hand status needs-repair-task` and resolve its repair ambiguity\n",
-		"help[1]:\n  - Run `hand status needs-repair-task` and resolve its repair ambiguity\n",
+		"wake_delivery_last_accepted: none\n",
 	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("out = %q, want %q", out, want)
+		if !strings.Contains(got, want) {
+			t.Fatalf("out = %q, want %q", got, want)
 		}
+	}
+
+	// The reasoning re-entry is recorded only as disposable mechanism progress:
+	// state/runtime/supervision-wake.json exists and carries oriented stamps,
+	// while canonical task truth stays untouched.
+	raw, err := os.ReadFile(filepath.Join(home, "state", "runtime", "supervision-wake.json"))
+	if err != nil {
+		t.Fatalf("read wake ledger: %v", err)
+	}
+	if !strings.Contains(string(raw), `"oriented":`) || !strings.Contains(string(raw), "hand.supervision.wake.v1") {
+		t.Fatalf("ledger = %q, want oriented stamps under the wake schema", raw)
+	}
+	after, err := state.ReadHistoryReadOnly(home, "needs-repair-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Task.RepairCode != "E_ORPHAN" {
+		t.Fatalf("task mutated by orient: %#v", after.Task)
+	}
+}
+
+func TestOrientRefusesWorkerRole(t *testing.T) {
+	setupSessionHome(t)
+	t.Setenv(harness.RoleEnv, harness.WorkerRole)
+
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"orient"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(new(bytes.Buffer))
+	_, err := root.ExecuteC()
+	assertExitCode(t, err, 3)
+	if want := "hand orient is unavailable when HAND_ROLE=worker"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %q, want %q", err, want)
 	}
 }

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -97,8 +97,10 @@ func TestSessionStartEmitsCompleteBoundedDigest(t *testing.T) {
 		"supervisor_harness: codex\n",
 		"supervisor_harness_source: override\n",
 		"runtime_identity_status: unidentified\n",
-		"bootstrap_integration_status: not-required\n",
-		"wake_delivery_capability:",
+		// Session start never installs; an un-integrated home reports the
+		// absence and degrades honestly instead of repairing silently.
+		"bootstrap_integration_status: absent\n",
+		"wake_delivery_capability: degraded\n",
 		"wake_delivery_attachment_status:",
 		"watcher_observer_liveness:",
 		"next_command: hand orient\n",

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 	"time"
@@ -337,7 +338,7 @@ func gateRunObservation(home string, t state.Task, reportedDone bool, p project.
 }
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool, cols []axi.Column[taskView]) error {
-	views, holds, err := fleetViews(cmd, home, client, true)
+	views, holds, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), home, client, true)
 	if err != nil {
 		return err
 	}
@@ -386,7 +387,7 @@ func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, cols [
 	return attention
 }
 
-func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, error) {
+func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, error) {
 	listHistories := state.ListReconciliationHistories
 	listHolds := state.ListHolds
 	listProjects := project.List
@@ -414,7 +415,7 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 	if projectsErr != nil {
 		// Named on stderr all the same - silently dropping every (gate: ...) marker fleet-wide would render
 		// an ungated PR as clean, the false all-clear this feature exists to avoid.
-		if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: project registry unreadable, gate-run checks skipped: %v\n", projectsErr); err != nil {
+		if _, err := fmt.Fprintf(warnOut, "warning: project registry unreadable, gate-run checks skipped: %v\n", projectsErr); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -422,7 +423,7 @@ func fleetViews(cmd *cobra.Command, home string, client *herdr.Client, readOnly 
 	for _, p := range projects {
 		projectByName[p.Name] = p
 	}
-	runPRs := newGateRunReader(cmd.Context())
+	runPRs := newGateRunReader(ctx)
 	bounds, err := parkedBoundsFromConfig(home)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/supervision.go
+++ b/cmd/supervision.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/orientation"
+	"github.com/atqamz/hand/internal/supervision"
+	"github.com/atqamz/hand/internal/watcher"
+	"github.com/spf13/cobra"
+)
+
+// The default bound for the Claude Stop hook's single wait cycle: long enough
+// to hold through a normal work stretch, bounded so a turn can always end.
+const defaultStopHookTimeout = 10 * time.Minute
+
+// The cooldown that keeps a deterministic bridge failure from becoming a
+// per-turn feedback loop.
+const bridgeFailureCooldown = time.Hour
+
+func newSupervisionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "supervision",
+		Short:  "Supervisor wake coordination internals",
+		Hidden: true,
+	}
+	cmd.AddCommand(newSupervisionWaitCmd())
+	cmd.AddCommand(newClaudeStopCmd())
+	return cmd
+}
+
+// The provider-neutral wait primitive host bridges call. Hidden, but its
+// structured output and typed exits are a contract: 0 eligible wake, 4
+// checkpoint, 5 monitoring failure, 8 interrupted, 9 replaced.
+func newSupervisionWaitCmd() *cobra.Command {
+	var host string
+	var timeout time.Duration
+	var deliver bool
+
+	cmd := &cobra.Command{
+		Use:   "wait --host <claude|codex|opencode|pi|grok>",
+		Short: "Block until current actionable work is wake-eligible, then emit one coalesced wake",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
+				return &ExitError{Err: fmt.Errorf("supervision wait is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
+			}
+			if !harness.IsSupported(host) {
+				return &ExitError{Err: fmt.Errorf("invalid --host %q: want one of %s", host, joinHarnesses()), Code: 2}
+			}
+			if cmd.Flags().Changed("timeout") && timeout <= 0 {
+				return &ExitError{Err: fmt.Errorf("invalid timeout %s: must be positive", timeout), Code: 2}
+			}
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			pollInterval, staleThreshold, parkedBounds, err := watchConfigFromFleet(fleetHome)
+			if err != nil {
+				return err
+			}
+
+			wake, err := supervision.Wait(cmd.Context(), supervision.Waiter{
+				Home:         fleetHome,
+				ReadEvidence: fleetEvidenceReader(cmd, fleetHome),
+				Ledger:       supervision.OpenLedger(fleetHome),
+			}, supervision.WaitConfig{
+				Host:           host,
+				PollInterval:   pollInterval,
+				StaleThreshold: staleThreshold,
+				ParkedBounds:   parkedBounds,
+				Timeout:        timeout,
+			})
+			if err != nil {
+				return mapWatchResult(err)
+			}
+
+			var doc axi.Doc
+			doc.Field("woke", "true")
+			doc.Field("host", wake.Host)
+			doc.Field("fleet_id", wake.FleetID)
+			doc.Int("episodes", len(wake.Episodes))
+			rows := make([][]string, 0, len(wake.Episodes))
+			for _, episode := range wake.Episodes {
+				rows = append(rows, []string{episode.TargetID, episode.TargetKind, episode.Currentness.String(), episode.Kind})
+			}
+			doc.Rows("wake_episodes", []string{"target_id", "kind", "currentness", "action"}, rows)
+			doc.Field("text", wake.Text)
+			if deliver && host == harness.Codex {
+				appendCodexDelivery(&doc, cmd.Context(), wake)
+			}
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "the Supervisor Harness runtime arming this wait")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "give up after this long and exit 4 (default: no timeout)")
+	cmd.Flags().BoolVar(&deliver, "deliver", false, "with --host codex, enqueue the wake on the live thread via codex queue after eligibility")
+	return cmd
+}
+
+// The Hand-owned Claude Stop hook entry point. Exit 2 with one bounded stderr
+// line is the Stop-hook rewake: it becomes a follow-up turn whose first Hand
+// read is `hand orient`. Silence lets the turn end when nothing is eligible.
+func newClaudeStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "claude-stop",
+		Short:  "One bounded wait cycle behind the Claude Stop hook",
+		Hidden: true,
+		Args:   usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
+				return &ExitError{Err: fmt.Errorf("supervision claude-stop is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
+			}
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			timeout := defaultStopHookTimeout
+			if raw := os.Getenv("HAND_SUPERVISION_WAIT_TIMEOUT"); raw != "" {
+				parsed, parseErr := time.ParseDuration(raw)
+				if parseErr != nil {
+					return fmt.Errorf("parse HAND_SUPERVISION_WAIT_TIMEOUT %q: %w", raw, parseErr)
+				}
+				timeout = parsed
+			}
+			pollInterval, staleThreshold, parkedBounds, err := watchConfigFromFleet(fleetHome)
+			if err != nil {
+				return err
+			}
+			ledger := supervision.OpenLedger(fleetHome)
+
+			wake, waitErr := supervision.Wait(cmd.Context(), supervision.Waiter{
+				Home:         fleetHome,
+				ReadEvidence: fleetEvidenceReader(cmd, fleetHome),
+				Ledger:       ledger,
+			}, supervision.WaitConfig{
+				Host:           harness.Claude,
+				PollInterval:   pollInterval,
+				StaleThreshold: staleThreshold,
+				ParkedBounds:   parkedBounds,
+				Timeout:        timeout,
+			})
+			switch {
+			case waitErr == nil:
+				// Requesting the rewake here is acceptance by this bridge; the
+				// resulting turn running hand orient remains the only progress
+				// witness, recorded by orient itself.
+				if err := ledger.MarkAccepted(supervision.Keys(wake.Episodes)); err != nil {
+					return err
+				}
+				return &ExitError{Err: errors.New(wake.Text), Code: 2}
+			case errors.Is(waitErr, watcher.ErrNoEvent), errors.Is(waitErr, watcher.ErrInterrupted), errors.Is(waitErr, watcher.ErrReplaced):
+				return nil
+			case errors.Is(waitErr, watcher.ErrArmFailed):
+				if !ledger.BridgeErroredBefore(harness.Claude, bridgeFailureCooldown) {
+					return nil
+				}
+				if markErr := ledger.MarkBridgeError(harness.Claude, waitErr.Error()); markErr != nil {
+					return markErr
+				}
+				return &ExitError{Err: fmt.Errorf("hand supervisor wake bridge failed monitoring: %v; run `hand doctor` in the fleet home", waitErr), Code: 2}
+			default:
+				return waitErr
+			}
+		},
+	}
+}
+
+// Builds the fresh unbounded actionable-evidence reader every wait cycle
+// re-derives from authoritative Fleet state.
+func fleetEvidenceReader(cmd *cobra.Command, fleetHome string) supervision.EvidenceReader {
+	warnOut := cmd.ErrOrStderr()
+	return func(ctx context.Context) (orientation.Evidence, error) {
+		snapshot, err := loadFleetSnapshot(ctx, warnOut, fleetHome)
+		if err != nil {
+			return orientation.Evidence{}, err
+		}
+		return snapshot.evidence(), nil
+	}
+}
+
+func appendCodexDelivery(doc *axi.Doc, ctx context.Context, wake supervision.Wake) {
+	threadID := os.Getenv(supervision.CodexThreadEnv)
+	deliverErr := supervision.DeliverCodexQueue(ctx, supervision.RunCommand, threadID, wake.Text)
+	switch {
+	case deliverErr == nil:
+		doc.Field("delivery", "accepted")
+		doc.Field("runtime_thread", threadID)
+	case errors.Is(deliverErr, supervision.ErrUnsupported):
+		doc.Field("delivery", "unsupported")
+		doc.Field("delivery_reason", deliverErr.Error())
+	default:
+		doc.Field("delivery", "rejected")
+		doc.Field("delivery_reason", deliverErr.Error())
+	}
+}
+
+func joinHarnesses() string {
+	out := ""
+	for i, name := range harness.Names() {
+		if i > 0 {
+			out += ", "
+		}
+		out += name
+	}
+	return out
+}
+
+func watchConfigFromFleet(fleetHome string) (time.Duration, time.Duration, watcher.ParkedBounds, error) {
+	pollInterval, err := time.ParseDuration(configDefault(fleetHome, "watch-interval", "5s"))
+	if err != nil {
+		return 0, 0, watcher.ParkedBounds{}, fmt.Errorf("invalid watch-interval %q: %w", pollInterval, err)
+	}
+	staleThreshold, err := configSeconds(fleetHome, "stale-threshold", defaultStaleThreshold)
+	if err != nil {
+		return 0, 0, watcher.ParkedBounds{}, err
+	}
+	bounds, err := parkedBoundsFromConfig(fleetHome)
+	if err != nil {
+		return 0, 0, watcher.ParkedBounds{}, err
+	}
+	return pollInterval, staleThreshold, bounds, nil
+}
+
+var supervisionInstallFields = []axi.Column[supervision.InstallResult]{
+	{Name: "host", Value: func(r supervision.InstallResult) string { return r.Host }},
+	{Name: "path", Value: func(r supervision.InstallResult) string { return r.Path }},
+	{Name: "state", Value: func(r supervision.InstallResult) string { return r.State }},
+	{Name: "detail", Value: func(r supervision.InstallResult) string { return r.Detail }},
+}
+
+// Installs every host bridge hand manages, so whichever harness a supervisor
+// later runs in this home just works without hand-copying glue. Foreign
+// content at an exact managed path is a surfaced conflict, never an overwrite.
+func installSupervisorBridgesForInit(fleetHome, exe string) ([]supervision.InstallResult, []string) {
+	var results []supervision.InstallResult
+	var conflicts []string
+	claudeResult, err := supervision.InstallClaudeStopHook(fleetHome, exe)
+	if err != nil {
+		conflicts = append(conflicts, fmt.Sprintf("%s: %s", claudeResult.Path, err.Error()))
+	}
+	results = append(results, claudeResult)
+	for _, host := range []string{harness.OpenCode, harness.Pi} {
+		assetResults, err := supervision.InstallHostAssets(fleetHome, host, exe)
+		if err != nil {
+			conflicts = append(conflicts, err.Error())
+			continue
+		}
+		results = append(results, assetResults...)
+		for _, result := range assetResults {
+			if result.State == "conflict" {
+				conflicts = append(conflicts, result.Path+": "+result.Detail)
+			}
+		}
+	}
+	return results, conflicts
+}

--- a/cmd/supervision.go
+++ b/cmd/supervision.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/atqamz/hand/internal/axi"
@@ -16,13 +19,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// The default bound for the Claude Stop hook's single wait cycle: long enough
-// to hold through a normal work stretch, bounded so a turn can always end.
-const defaultStopHookTimeout = 10 * time.Minute
+// The default bound for a Stop-hook wait cycle: long enough to hold through a
+// normal work stretch, bounded so the hook lifecycle always gets its child
+// back. The upstream hook timeout must stay above it.
+const defaultStopHookTimeout = 30 * time.Minute
 
 // The cooldown that keeps a deterministic bridge failure from becoming a
 // per-turn feedback loop.
-const bridgeFailureCooldown = time.Hour
+const bridgeFailureCooldown = supervision.BridgeFailureCooldown
 
 func newSupervisionCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -32,16 +36,19 @@ func newSupervisionCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newSupervisionWaitCmd())
 	cmd.AddCommand(newClaudeStopCmd())
+	cmd.AddCommand(newCodexStopCmd())
+	cmd.AddCommand(newSupervisionReceiptCmd())
 	return cmd
 }
 
-// The provider-neutral wait primitive host bridges call. Hidden, but its
-// structured output and typed exits are a contract: 0 eligible wake, 4
-// checkpoint, 5 monitoring failure, 8 interrupted, 9 replaced.
+// The provider-neutral wait primitive host bridges call. Hidden and
+// internal-facing, but its structured output and typed exits are a contract:
+// 0 wake, 4 checkpoint, 3 owned elsewhere, 5 failure, 8 interrupted, 9 replaced.
 func newSupervisionWaitCmd() *cobra.Command {
 	var host string
 	var timeout time.Duration
 	var deliver bool
+	var format string
 
 	cmd := &cobra.Command{
 		Use:   "wait --host <claude|codex|opencode|pi|grok>",
@@ -51,11 +58,16 @@ func newSupervisionWaitCmd() *cobra.Command {
 			if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
 				return &ExitError{Err: fmt.Errorf("supervision wait is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
 			}
-			if !harness.IsSupported(host) {
-				return &ExitError{Err: fmt.Errorf("invalid --host %q: want one of %s", host, joinHarnesses()), Code: 2}
+			if !supervision.IsSupervisorHost(host) {
+				return &ExitError{Err: fmt.Errorf("invalid --host %q: want one of %s", host, strings.Join(supervision.SupervisorHosts(), ", ")), Code: 2}
 			}
 			if cmd.Flags().Changed("timeout") && timeout <= 0 {
 				return &ExitError{Err: fmt.Errorf("invalid timeout %s: must be positive", timeout), Code: 2}
+			}
+			switch format {
+			case "", "toon", "json":
+			default:
+				return &ExitError{Err: fmt.Errorf("invalid --format %q: want toon or json", format), Code: 2}
 			}
 			fleetHome, err := home.Resolve()
 			if err != nil {
@@ -72,13 +84,39 @@ func newSupervisionWaitCmd() *cobra.Command {
 				Ledger:       supervision.OpenLedger(fleetHome),
 			}, supervision.WaitConfig{
 				Host:           host,
+				RuntimeSession: os.Getenv("HAND_RUNTIME_SESSION"),
 				PollInterval:   pollInterval,
 				StaleThreshold: staleThreshold,
 				ParkedBounds:   parkedBounds,
 				Timeout:        timeout,
 			})
+			if errors.Is(err, supervision.ErrBridgeOwned) {
+				return &ExitError{Err: err, Code: 3}
+			}
 			if err != nil {
 				return mapWatchResult(err)
+			}
+
+			if format == "json" {
+				doc := struct {
+					Schema   string                       `json:"schema"`
+					FleetID  string                       `json:"fleet_id"`
+					Host     string                       `json:"host"`
+					Message  string                       `json:"message"`
+					Episodes []supervision.EpisodePayload `json:"episodes"`
+				}{
+					Schema:   supervision.WakeSchema,
+					FleetID:  wake.FleetID,
+					Host:     wake.Host,
+					Message:  wake.Message,
+					Episodes: supervision.EpisodePayloads(wake.Episodes),
+				}
+				encoded, encodeErr := json.MarshalIndent(doc, "", "  ")
+				if encodeErr != nil {
+					return encodeErr
+				}
+				_, writeErr := fmt.Fprintln(cmd.OutOrStdout(), string(encoded))
+				return writeErr
 			}
 
 			var doc axi.Doc
@@ -91,7 +129,7 @@ func newSupervisionWaitCmd() *cobra.Command {
 				rows = append(rows, []string{episode.TargetID, episode.TargetKind, episode.Currentness.String(), episode.Kind})
 			}
 			doc.Rows("wake_episodes", []string{"target_id", "kind", "currentness", "action"}, rows)
-			doc.Field("text", wake.Text)
+			doc.Field("text", wake.Message)
 			if deliver && host == harness.Codex {
 				appendCodexDelivery(&doc, cmd.Context(), wake)
 			}
@@ -102,16 +140,17 @@ func newSupervisionWaitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&host, "host", "", "the Supervisor Harness runtime arming this wait")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "give up after this long and exit 4 (default: no timeout)")
 	cmd.Flags().BoolVar(&deliver, "deliver", false, "with --host codex, enqueue the wake on the live thread via codex queue after eligibility")
+	cmd.Flags().StringVar(&format, "format", "", "output protocol: toon (human) or json (versioned machine contract)")
 	return cmd
 }
 
-// The Hand-owned Claude Stop hook entry point. Exit 2 with one bounded stderr
-// line is the Stop-hook rewake: it becomes a follow-up turn whose first Hand
-// read is `hand orient`. Silence lets the turn end when nothing is eligible.
+// The Hand-owned Claude Stop entry point, run with asyncRewake so Claude
+// executes it in the background at turn end without blocking Stop. Exit 2
+// with bounded stderr is the rewake into a follow-up `hand orient` turn.
 func newClaudeStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:    "claude-stop",
-		Short:  "One bounded wait cycle behind the Claude Stop hook",
+		Short:  "One background wait cycle behind the Claude Stop hook (asyncRewake)",
 		Hidden: true,
 		Args:   usageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -122,14 +161,7 @@ func newClaudeStopCmd() *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
-			timeout := defaultStopHookTimeout
-			if raw := os.Getenv("HAND_SUPERVISION_WAIT_TIMEOUT"); raw != "" {
-				parsed, parseErr := time.ParseDuration(raw)
-				if parseErr != nil {
-					return fmt.Errorf("parse HAND_SUPERVISION_WAIT_TIMEOUT %q: %w", raw, parseErr)
-				}
-				timeout = parsed
-			}
+			timeout := stopHookTimeoutFromEnv(defaultStopHookTimeout)
 			pollInterval, staleThreshold, parkedBounds, err := watchConfigFromFleet(fleetHome)
 			if err != nil {
 				return err
@@ -142,6 +174,7 @@ func newClaudeStopCmd() *cobra.Command {
 				Ledger:       ledger,
 			}, supervision.WaitConfig{
 				Host:           harness.Claude,
+				RuntimeSession: hookSessionID(cmd.InOrStdin()),
 				PollInterval:   pollInterval,
 				StaleThreshold: staleThreshold,
 				ParkedBounds:   parkedBounds,
@@ -155,8 +188,11 @@ func newClaudeStopCmd() *cobra.Command {
 				if err := ledger.MarkAccepted(supervision.Keys(wake.Episodes)); err != nil {
 					return err
 				}
-				return &ExitError{Err: errors.New(wake.Text), Code: 2}
+				fmt.Fprintln(os.Stderr, wake.Message)
+				return &ExitError{Err: errors.New(wake.Message), Code: 2}
 			case errors.Is(waitErr, watcher.ErrNoEvent), errors.Is(waitErr, watcher.ErrInterrupted), errors.Is(waitErr, watcher.ErrReplaced):
+				return nil
+			case errors.Is(waitErr, supervision.ErrBridgeOwned):
 				return nil
 			case errors.Is(waitErr, watcher.ErrArmFailed):
 				if !ledger.BridgeErroredBefore(harness.Claude, bridgeFailureCooldown) {
@@ -173,6 +209,159 @@ func newClaudeStopCmd() *cobra.Command {
 	}
 }
 
+// The Hand-owned Codex Stop entry, installed Fleet-locally as an async
+// background handler. Codex's hook lifecycle runs it at every turn end, so it
+// owns the post-turn wait and enqueues the wake on the exact live thread.
+func newCodexStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "codex-stop",
+		Short:  "Background wait-and-queue cycle behind the Codex project Stop hook",
+		Hidden: true,
+		Args:   usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
+				return &ExitError{Err: fmt.Errorf("supervision codex-stop is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
+			}
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			threadID := hookSessionID(cmd.InOrStdin())
+			if threadID == "" {
+				threadID = os.Getenv(supervision.CodexThreadEnv)
+			}
+			if strings.TrimSpace(threadID) == "" {
+				return nil
+			}
+			timeout := stopHookTimeoutFromEnv(defaultStopHookTimeout)
+			pollInterval, staleThreshold, parkedBounds, err := watchConfigFromFleet(fleetHome)
+			if err != nil {
+				return err
+			}
+			ledger := supervision.OpenLedger(fleetHome)
+
+			wake, waitErr := supervision.Wait(cmd.Context(), supervision.Waiter{
+				Home:         fleetHome,
+				ReadEvidence: fleetEvidenceReader(cmd, fleetHome),
+				Ledger:       ledger,
+			}, supervision.WaitConfig{
+				Host:           harness.Codex,
+				RuntimeSession: threadID,
+				PollInterval:   pollInterval,
+				StaleThreshold: staleThreshold,
+				ParkedBounds:   parkedBounds,
+				Timeout:        timeout,
+			})
+			switch {
+			case waitErr == nil:
+				if deliverErr := supervision.DeliverCodexQueue(cmd.Context(), supervision.RunCommand, threadID, wake.Message); deliverErr != nil {
+					_ = ledger.MarkBridgeError(harness.Codex, deliverErr.Error())
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "hand supervisor wake:", deliverErr.Error())
+					return nil
+				}
+				// Queue acceptance is enqueued-only; the resulting turn's hand
+				// orient records the reasoning progress.
+				return ledger.MarkAccepted(supervision.Keys(wake.Episodes))
+			case errors.Is(waitErr, watcher.ErrNoEvent), errors.Is(waitErr, watcher.ErrInterrupted),
+				errors.Is(waitErr, watcher.ErrReplaced), errors.Is(waitErr, supervision.ErrBridgeOwned):
+				return nil
+			default:
+				if !ledger.BridgeErroredBefore(harness.Codex, bridgeFailureCooldown) {
+					return nil
+				}
+				_ = ledger.MarkBridgeError(harness.Codex, waitErr.Error())
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "hand supervisor wake: monitoring failed:", waitErr.Error())
+				return nil
+			}
+		},
+	}
+}
+
+// receipt records a host adapter's delivery evidence against episodes in the
+// disposable mechanism ledger. Acceptance means the host took the wake;
+// neither stage ever implies reasoning - only hand orient does.
+func newSupervisionReceiptCmd() *cobra.Command {
+	var host, stage, detail string
+	var episodes []string
+	cmd := &cobra.Command{
+		Use:    "receipt --host <h> --stage accepted|delivery-failed --episode <key>...",
+		Short:  "Record one host adapter's delivery receipt",
+		Hidden: true,
+		Args:   usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getenv(harness.RoleEnv) == harness.WorkerRole {
+				return &ExitError{Err: fmt.Errorf("supervision receipt is unavailable when %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
+			}
+			if !supervision.IsSupervisorHost(host) {
+				return &ExitError{Err: fmt.Errorf("invalid --host %q", host), Code: 2}
+			}
+			fleetHome, err := home.Resolve()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			ledger := supervision.OpenLedger(fleetHome)
+			switch stage {
+			case "accepted":
+				return ledger.MarkAccepted(episodes)
+			case "delivery-failed":
+				if len(episodes) == 0 {
+					return ledger.MarkBridgeError(host, orDash(detail))
+				}
+				return ledger.MarkErrorByKeys(episodes, detail)
+			default:
+				return &ExitError{Err: fmt.Errorf("invalid --stage %q: want accepted or delivery-failed", stage), Code: 2}
+			}
+		},
+	}
+	cmd.Flags().StringVar(&host, "host", "", "host whose adapter produced this receipt")
+	cmd.Flags().StringVar(&stage, "stage", "", "accepted or delivery-failed")
+	cmd.Flags().StringSliceVar(&episodes, "episode", nil, "claimed episode keys this receipt covers")
+	cmd.Flags().StringVar(&detail, "detail", "", "bounded failure evidence")
+	return cmd
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "host reported delivery failure"
+	}
+	return s
+}
+
+// Reads the hook stdin payload's session identifier without requiring it:
+// both Claude and Codex pass hook context as JSON on stdin.
+func hookSessionID(in io.Reader) string {
+	if in == nil {
+		return ""
+	}
+	data, err := io.ReadAll(io.LimitReader(in, 1<<20))
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	var payload struct {
+		SessionID string `json:"session_id"`
+		ThreadID  string `json:"thread_id"`
+	}
+	if json.Unmarshal(data, &payload) != nil {
+		return ""
+	}
+	if payload.SessionID != "" {
+		return payload.SessionID
+	}
+	return payload.ThreadID
+}
+
+func stopHookTimeoutFromEnv(fallback time.Duration) time.Duration {
+	raw := os.Getenv("HAND_SUPERVISION_WAIT_TIMEOUT")
+	if raw == "" {
+		return fallback
+	}
+	parsed, parseErr := time.ParseDuration(raw)
+	if parseErr != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
 // Builds the fresh unbounded actionable-evidence reader every wait cycle
 // re-derives from authoritative Fleet state.
 func fleetEvidenceReader(cmd *cobra.Command, fleetHome string) supervision.EvidenceReader {
@@ -187,46 +376,17 @@ func fleetEvidenceReader(cmd *cobra.Command, fleetHome string) supervision.Evide
 }
 
 func appendCodexDelivery(doc *axi.Doc, ctx context.Context, wake supervision.Wake) {
-	threadID := os.Getenv(supervision.CodexThreadEnv)
-	deliverErr := supervision.DeliverCodexQueue(ctx, supervision.RunCommand, threadID, wake.Text)
+	err := supervision.DeliverCodexQueue(ctx, supervision.RunCommand, os.Getenv(supervision.CodexThreadEnv), wake.Message)
 	switch {
-	case deliverErr == nil:
+	case err == nil:
 		doc.Field("delivery", "accepted")
-		doc.Field("runtime_thread", threadID)
-	case errors.Is(deliverErr, supervision.ErrUnsupported):
+	case errors.Is(err, supervision.ErrUnsupported):
 		doc.Field("delivery", "unsupported")
-		doc.Field("delivery_reason", deliverErr.Error())
+		doc.Field("delivery_reason", err.Error())
 	default:
 		doc.Field("delivery", "rejected")
-		doc.Field("delivery_reason", deliverErr.Error())
+		doc.Field("delivery_reason", err.Error())
 	}
-}
-
-func joinHarnesses() string {
-	out := ""
-	for i, name := range harness.Names() {
-		if i > 0 {
-			out += ", "
-		}
-		out += name
-	}
-	return out
-}
-
-func watchConfigFromFleet(fleetHome string) (time.Duration, time.Duration, watcher.ParkedBounds, error) {
-	pollInterval, err := time.ParseDuration(configDefault(fleetHome, "watch-interval", "5s"))
-	if err != nil {
-		return 0, 0, watcher.ParkedBounds{}, fmt.Errorf("invalid watch-interval %q: %w", pollInterval, err)
-	}
-	staleThreshold, err := configSeconds(fleetHome, "stale-threshold", defaultStaleThreshold)
-	if err != nil {
-		return 0, 0, watcher.ParkedBounds{}, err
-	}
-	bounds, err := parkedBoundsFromConfig(fleetHome)
-	if err != nil {
-		return 0, 0, watcher.ParkedBounds{}, err
-	}
-	return pollInterval, staleThreshold, bounds, nil
 }
 
 var supervisionInstallFields = []axi.Column[supervision.InstallResult]{
@@ -247,7 +407,7 @@ func installSupervisorBridgesForInit(fleetHome, exe string) ([]supervision.Insta
 		conflicts = append(conflicts, fmt.Sprintf("%s: %s", claudeResult.Path, err.Error()))
 	}
 	results = append(results, claudeResult)
-	for _, host := range []string{harness.OpenCode, harness.Pi} {
+	for _, host := range supervision.ManagedAssetHosts() {
 		assetResults, err := supervision.InstallHostAssets(fleetHome, host, exe)
 		if err != nil {
 			conflicts = append(conflicts, err.Error())
@@ -261,4 +421,20 @@ func installSupervisorBridgesForInit(fleetHome, exe string) ([]supervision.Insta
 		}
 	}
 	return results, conflicts
+}
+
+func watchConfigFromFleet(fleetHome string) (time.Duration, time.Duration, watcher.ParkedBounds, error) {
+	pollInterval, err := time.ParseDuration(configDefault(fleetHome, "watch-interval", "5s"))
+	if err != nil {
+		return 0, 0, watcher.ParkedBounds{}, fmt.Errorf("invalid watch-interval: %w", err)
+	}
+	staleThreshold, err := configSeconds(fleetHome, "stale-threshold", defaultStaleThreshold)
+	if err != nil {
+		return 0, 0, watcher.ParkedBounds{}, err
+	}
+	bounds, err := parkedBoundsFromConfig(fleetHome)
+	if err != nil {
+		return 0, 0, watcher.ParkedBounds{}, err
+	}
+	return pollInterval, staleThreshold, bounds, nil
 }

--- a/cmd/supervision_test.go
+++ b/cmd/supervision_test.go
@@ -1,6 +1,13 @@
 package cmd
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -67,6 +74,7 @@ func TestSupervisionWaitValidatesHostAndTimeout(t *testing.T) {
 		want string
 	}{
 		{"unknown host", []string{"wait", "--host", "bogus"}, 2, `invalid --host "bogus"`},
+		{"worker-capable name outside the supervisor registry", []string{"wait", "--host", "antigravity"}, 2, `invalid --host "antigravity"`},
 		{"missing host", []string{"wait"}, 2, `invalid --host ""`},
 		{"non-positive timeout", []string{"wait", "--host", "codex", "--timeout", "0s"}, 2, "must be positive"},
 	} {
@@ -92,5 +100,155 @@ func TestSupervisionWaitIsHiddenFromTheCommandReference(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "supervision") {
 		t.Fatalf("help = %q, want the internal-facing group hidden", out.String())
+	}
+}
+
+// hand init owns every static integration byte; session start is read-only
+// qualification. A home with foreign content at managed paths reports the
+// conflict and degradation without touching a single byte.
+func TestSessionStartNeverMutatesStaticIntegration(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		harness    string
+		wantStatus string
+	}{
+		{"codex without integration", harness.Codex, "bootstrap_integration_status: absent\n"},
+		{"opencode with foreign plugin", harness.OpenCode, "bootstrap_integration_status: conflict\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := setupSupervisionHome(t)
+			t.Setenv("HAND_HARNESS", test.harness)
+			foreign := "// an operator's own plugin\n"
+			writeFile(t, filepath.Join(home, ".opencode", "plugins", "hand-supervisor-wake.js"), foreign)
+			writeFile(t, filepath.Join(home, ".pi", "extensions", "hand-supervisor-wake.ts"), "// operator extension\n")
+			writeFile(t, filepath.Join(home, ".claude", "settings.json"), "{custom: true}\n")
+			writeFile(t, filepath.Join(home, ".codex", "hooks.json"), "{\"hooks\":{}}\n")
+			before := snapshotDir(t, home)
+
+			out, err := executeSessionStart(t, nil)
+			if err != nil {
+				t.Fatalf("session start = %v, want a completed read-only bootstrap", err)
+			}
+			if !strings.Contains(out, "session_bootstrap: complete\n") || !strings.Contains(out, test.wantStatus) {
+				t.Fatalf("out = %q, want honest non-mutating qualification", out)
+			}
+			if after := snapshotDir(t, home); !slices.Equal(after, before) {
+				t.Fatalf("session start mutated static integration:\nbefore: %v\nafter:  %v", before, after)
+			}
+			if !strings.Contains(out, "hand init") {
+				t.Fatalf("out = %q, want the init recovery action", out)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func snapshotDir(t *testing.T, root string) []string {
+	t.Helper()
+	var snapshot []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		entry := rel
+		if info.Mode().IsRegular() {
+			body, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			entry += " " + fmt.Sprintf("%x", sha256.Sum256(body))
+		}
+		snapshot = append(snapshot, entry)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+// hand init is the exclusive repair path: a Hand-owned stale asset is
+// replaced, while a foreign file at the exact managed path fails init with a
+// precondition and stays byte-for-byte untouched.
+func TestInitExclusivelyOwnsStaticIntegrationRepair(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	if err := initMarker(home); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HAND_HOME", home)
+	t.Setenv("HAND_HARNESS", harness.Codex)
+	t.Setenv(harness.RoleEnv, "")
+
+	stale := "// Hand-owned supervisor wake integration (stale)\noutdated body\n"
+	writeFile(t, filepath.Join(home, ".pi", "extensions", "hand-supervisor-wake.ts"), stale)
+
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"init", home})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(new(bytes.Buffer))
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("init over owned-stale asset: %v", err)
+	}
+	repaired, err := os.ReadFile(filepath.Join(home, ".pi", "extensions", "hand-supervisor-wake.ts"))
+	if err != nil || !bytes.Contains(repaired, []byte("hand.supervision.wake.v1")) {
+		t.Fatalf("stale asset not replaced with the canonical extension: %q, %v", repaired, err)
+	}
+
+	foreign := "// an operator's own extension; do not touch\n"
+	writeFile(t, filepath.Join(home, ".opencode", "plugins", "hand-supervisor-wake.js"), foreign)
+
+	root = newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"init", home})
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	_, initErr := root.ExecuteC()
+	assertExitCode(t, initErr, 3)
+	kept, readErr := os.ReadFile(filepath.Join(home, ".opencode", "plugins", "hand-supervisor-wake.js"))
+	if readErr != nil || string(kept) != foreign {
+		t.Fatalf("foreign file changed by refused init: %q, %v", kept, readErr)
+	}
+}
+
+// Hand integration is Fleet-local by construction: initializing a fleet home
+// must leave no hook, plugin, or extension in any global harness directory.
+func TestInitWritesNoGlobalHarnessConfiguration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME isolation asserted on unix runners")
+	}
+	globalHome := t.TempDir()
+	fleet := t.TempDir()
+	t.Setenv("HOME", globalHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(globalHome, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(globalHome, ".local", "state"))
+	t.Setenv("HAND_HARNESS", harness.Codex)
+	t.Setenv(harness.RoleEnv, "")
+	t.Chdir(fleet)
+
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"init"})
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	for _, banned := range []string{".claude/settings.json", ".opencode", ".pi", ".codex/hooks.json"} {
+		if _, err := os.Stat(filepath.Join(globalHome, filepath.Dir(banned), filepath.Base(banned))); !os.IsNotExist(err) {
+			t.Fatalf("global surface %s exists under the isolated HOME (%v); integration leaked out of the fleet home", banned, err)
+		}
 	}
 }

--- a/cmd/supervision_test.go
+++ b/cmd/supervision_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/harness"
+)
+
+func setupSupervisionHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	if err := initMarker(home); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HAND_HOME", home)
+	t.Setenv("HAND_HARNESS", harness.Codex)
+	t.Setenv(harness.RoleEnv, "")
+	return home
+}
+
+func executeSupervision(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	_, _, err := executeRootForTest(t, devBuild("test"), nil, append([]string{"supervision"}, args...)...)
+	return "", err
+}
+
+func TestSupervisorCommandsRejectWorkerRole(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"wait", []string{"wait", "--host", "codex"}, "supervision wait is unavailable when HAND_ROLE=worker"},
+		{"claude-stop", []string{"claude-stop"}, "supervision claude-stop is unavailable when HAND_ROLE=worker"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			setupSupervisionHome(t)
+			t.Setenv(harness.RoleEnv, harness.WorkerRole)
+
+			_, _, err := executeRootForTest(t, devBuild("test"), nil, append([]string{"supervision"}, test.args...)...)
+			assertExitCode(t, err, 3)
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("err = %q, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestOrientRejectsWorkerRoleBeforeReadingTheFleet(t *testing.T) {
+	setupSupervisionHome(t)
+	t.Setenv(harness.RoleEnv, harness.WorkerRole)
+
+	_, _, err := executeRootForTest(t, devBuild("test"), nil, "orient")
+	assertExitCode(t, err, 3)
+	if want := "hand orient is unavailable when HAND_ROLE=worker"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %q, want %q", err, want)
+	}
+}
+
+func TestSupervisionWaitValidatesHostAndTimeout(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		code int
+		want string
+	}{
+		{"unknown host", []string{"wait", "--host", "bogus"}, 2, `invalid --host "bogus"`},
+		{"missing host", []string{"wait"}, 2, `invalid --host ""`},
+		{"non-positive timeout", []string{"wait", "--host", "codex", "--timeout", "0s"}, 2, "must be positive"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			setupSupervisionHome(t)
+
+			_, err := executeSupervision(t, test.args...)
+			assertExitCode(t, err, test.code)
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("err = %q, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSupervisionWaitIsHiddenFromTheCommandReference(t *testing.T) {
+	root := newRootCmd(devBuild("test"))
+	var out strings.Builder
+	root.SetOut(&out)
+	root.SetErr(new(strings.Builder))
+	if err := root.Help(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "supervision") {
+		t.Fatalf("help = %q, want the internal-facing group hidden", out.String())
+	}
+}

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -122,9 +122,9 @@ func newWatchCmd() *cobra.Command {
 				return mapWatchResult(watcher.Run(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr()))
 			}
 
-			// The exit code is the delivery, so a watcher that stopped without an
-			// event must not exit 0: a caller re-arming on 0 would read it as fleet
-			// news, and one distinguishing it from a crash needs its own code.
+			// The exit code is delivery only where an owning host converts it into
+			// another Supervisor reasoning turn (docs/adr/supervisor-turn-delivery-is-host-specific.md).
+			// No-event stops must not exit 0: re-arming on 0 would misread silence as fleet news.
 			return mapWatchResult(watcher.RunUntilEvent(ctx, cfg, cmd.OutOrStdout(), cmd.ErrOrStderr()))
 		},
 	}

--- a/docs/adr/agents-md-is-fully-hand-owned-and-immutable.md
+++ b/docs/adr/agents-md-is-fully-hand-owned-and-immutable.md
@@ -19,6 +19,8 @@ The first time `hand init` finds a fleet home's `AGENTS.md` predating this model
 
 `hand doctor`'s drift check now compares the whole file against the canonical body byte-for-byte instead of scanning for perishable content or marker damage, since there is no longer a span within the file that legitimately differs.
 
+`CLAUDE.md`, the reference Claude reads when the name is otherwise absent, is the regular `@AGENTS.md` pointer file on every platform (2026-08-23, operator decision). One shape everywhere removes the Windows symlink-creation privilege dependency and gives stat/copy tooling nothing to special-case; a Hand-era Unix symlink to `AGENTS.md` upgrades to the pointer file on the next refresh, while any other pre-existing `CLAUDE.md` stays untouched as operator-owned content.
+
 ## Rejected alternatives
 
 - Keeping the marked-span model and only shrinking its content leaves every cost this decision removes: merge logic, drift heuristics for content the span cannot own, and an unsettled boundary between `AGENTS.md` and the fleet home's own notes.

--- a/docs/adr/supervisor-turn-delivery-is-host-specific.md
+++ b/docs/adr/supervisor-turn-delivery-is-host-specific.md
@@ -1,0 +1,54 @@
+# Supervisor turn delivery is host-specific
+
+- Date: 2026-08-23
+- Status: accepted
+- Issues: atqamz/hand#355
+- PRs: none
+
+## Context
+
+`hand watch --until-event` detects, prints, and exits correctly, but a process exit is only a
+delivered wake where an owning host converts that exit into another Supervisor reasoning
+opportunity. After the outer Supervisor turn has ended, nothing starts another turn and the
+operator must nudge the harness by hand. Detection is not delivery; an accepted request is not
+reasoning.
+
+There is no universal "wake an LLM" primitive. Each supported host exposes its own mechanism,
+and Hand's cross-platform semantic logic stays in Go rather than porting any shell/PID
+machinery.
+
+## Decision
+
+Hand owns actionability, currentness, wake episode identity (fleet + target + currentness +
+actionable kind, never rendered reason, PIDs, or wall-clock), level catch-up, dedupe/retry, the
+bounded wait primitive (`hand supervision wait --host <harness>`), disposable mechanism
+progress bookkeeping under `state/runtime/`, and integration installation/qualification. The
+Supervisor host owns converting one coalesced Hand wake into exactly one reasoning opportunity,
+whose first Hand read is `hand orient`.
+
+Per host:
+
+```text
+claude    -> Hand-owned Stop hook in project .claude/settings.json; eligible wake = exit 2 feedback = follow-up turn
+codex     -> codex queue --thread $CODEX_THREAD_ID --message <wake>, capability-probed, not foreground polling
+opencode  -> persistent TUI plugin; synchronous prompt API only; promptAsync/204 is not delivery
+pi        -> extension followUp message with turn trigger; session generations retire stale callbacks
+grok      -> host-owned background task completion notification re-enters the model
+```
+
+`hand orient` marks currently actionable episodes oriented in a disposable ledger so an
+unchanged condition cannot storm turns; changed currentness is a new episode and wakes normally.
+Wake eligibility reads unbounded actionable evidence - never the 64-item bounded rendered
+orientation - so a full display slice cannot starve newer subjects.
+
+Rejected: a detached universal Hand supervisor daemon (still needs per-host integration plus
+orphan/lifetime complexity across three platforms); treating notification delivery as reasoning
+progress; one generic supervision healthy boolean; canonicalizing runtime/conversation IDs.
+
+## Consequences
+
+Every harness carries an explicit qualified outcome - supported, degraded, or unsupported with
+the exact reason - surfaced separately through `hand doctor`, `hand session start`, and
+`hand orient` diagnostics. A provider whose host lacks the required primitive is reported as
+not unattended-supervision capable instead of silently healthy. Live no-operator-input dogfood
+per claimed host remains the release gate for the 0.7 support matrix.

--- a/docs/adr/supervisor-turn-delivery-is-host-specific.md
+++ b/docs/adr/supervisor-turn-delivery-is-host-specific.md
@@ -30,7 +30,7 @@ Per host:
 
 ```text
 claude    -> Hand-owned Stop hook in project .claude/settings.json; eligible wake = exit 2 feedback = follow-up turn
-codex     -> codex queue --thread $CODEX_THREAD_ID --message <wake>, capability-probed, not foreground polling
+codex     -> Fleet-local .codex/hooks.json async Stop hook owns the post-turn wait; it reads the thread from the Stop payload and enqueues codex queue on that exact thread
 opencode  -> persistent TUI plugin; synchronous prompt API only; promptAsync/204 is not delivery
 pi        -> extension followUp message with turn trigger; session generations retire stale callbacks
 grok      -> host-owned background task completion notification re-enters the model
@@ -47,8 +47,9 @@ progress; one generic supervision healthy boolean; canonicalizing runtime/conver
 
 ## Consequences
 
-Every harness carries an explicit qualified outcome - supported, degraded, or unsupported with
-the exact reason - surfaced separately through `hand doctor`, `hand session start`, and
-`hand orient` diagnostics. A provider whose host lacks the required primitive is reported as
-not unattended-supervision capable instead of silently healthy. Live no-operator-input dogfood
-per claimed host remains the release gate for the 0.7 support matrix.
+Every harness carries an explicit qualified outcome - supported (live-proven only), available-unqualified
+(static preconditions hold, live proof pending), degraded, or unsupported, always with the exact reason -
+surfaced separately through `hand doctor`, `hand session start`, and `hand orient` diagnostics. A provider
+whose host lacks the required primitive is reported as not unattended-supervision capable instead of silently
+healthy. Live no-operator-input dogfood per claimed host remains the release gate for the 0.7 support matrix;
+until then every host reports available-unqualified at best.

--- a/docs/adr/the-until-event-exit-is-the-delivery.md
+++ b/docs/adr/the-until-event-exit-is-the-delivery.md
@@ -1,7 +1,7 @@
 # Process exit delivers watcher events to the supervisor
 
 - Date: 2026-08-04
-- Status: accepted, with its silent baseline superseded by [Arming a watch observes before it waits](arming-a-watch-observes-before-it-waits.md)
+- Status: accepted, with its silent baseline superseded by [Arming a watch observes before it waits](arming-a-watch-observes-before-it-waits.md), and its delivery claim narrowed by [Supervisor turn delivery is host-specific](supervisor-turn-delivery-is-host-specific.md)
 - Issues: none
 - PRs: atqamz/hand#125
 
@@ -27,3 +27,6 @@ One invocation delivers one wake and must be re-armed. Events consumed during ba
 
 Each delivered event can also carry a structured wake hint with Fleet identity, exact monitor target, opaque currentness, and a bounded reason.
 Consumers re-orient before acting and discard a wake whose target or currentness is stale.
+
+Narrowed by [Supervisor turn delivery is host-specific](supervisor-turn-delivery-is-host-specific.md): a process exit is a usable delivery primitive only where an owning host is guaranteed to convert it into another Supervisor reasoning opportunity.
+Once the outer Supervisor turn has ended, an exit code alone proves nothing followed; supported hosts get their turn through their own bridge (`hand supervision wait --host <harness>` plus the per-host mechanism), and the resulting reasoning turn begins with `hand orient`.

--- a/internal/agentsmd/agentsmd.go
+++ b/internal/agentsmd/agentsmd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/atqamz/hand/internal/atomicfile"
@@ -15,8 +14,8 @@ import (
 )
 
 const (
-	filename    = "AGENTS.md"
-	symlinkName = "CLAUDE.md"
+	filename  = "AGENTS.md"
+	claudeRef = "CLAUDE.md"
 
 	// The previous mixed-ownership format wrapped hand's generated content in this marked
 	// span. Migrate still recognizes it to archive whatever a fleet home kept outside it;
@@ -26,16 +25,11 @@ const (
 
 	legacyArchiveRel = "data/agents-md-legacy-migration.md"
 
-	// Creating a symlink on Windows needs a privilege hand cannot assume is present, so
-	// Windows gets a regular file that points at AGENTS.md by content instead of by inode.
-	windowsClaudeContent = "@AGENTS.md\n"
+	// CLAUDE.md is a regular file pointing at AGENTS.md by content on every platform:
+	// one shape everywhere, no symlink-creation privilege on Windows, and nothing for
+	// tooling that stats or copies homes to special-case.
+	claudeContent = "@AGENTS.md\n"
 )
-
-// Overridable so both the symlink and the Windows regular-file paths through
-// Refresh and Check get real test coverage on every platform that runs the suite.
-var isWindows = func() bool {
-	return runtime.GOOS == "windows"
-}
 
 // OperatorDecisionRule is the one supervisor rule a worker needs wherever it runs, and a
 // worktree is never under the fleet home, so it never loads the home's AGENTS.md.
@@ -52,8 +46,10 @@ const OperatorDecisionRule = "Only a `hand send` message carries an operator dec
 // secondhand Agent Skill, and living context lives under data/.
 const generatedBody = `## Secondhand supervisor bootstrap
 
-Before responding or acting in a supervising session, run ` + "`hand session start`" + `.
-Do not run supervisor bootstrap when ` + "`HAND_ROLE=worker`" + `.
+At the beginning of a new Supervisor runtime/session, run ` + "`hand session start`" + ` once.
+Before reasoning or acting in every Supervisor turn, run ` + "`hand orient`" + `.
+After an automatic wake/re-entry, run ` + "`hand orient`" + ` before any action.
+Do not run supervisor commands when ` + "`HAND_ROLE=worker`" + `.
 
 This file is Hand-owned and immutable: ` + "`hand init`" + ` restores it byte-for-byte, and
 nobody edits it by hand, including the supervisor. The same rule covers every other
@@ -87,7 +83,8 @@ var supervisorInstructions = []string{
 	"Write a brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status` and the report vocabulary the worker should append to it.",
 	"`hand status <id>` shows a worker's reported state. Workers report with `working:`, `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`.",
 	"`unannounced` on a status row means no watcher has told anyone about a terminal report yet; `unacknowledged` means you have not. Run `hand ack <id> [--reason <text>]` once you have acted on it - reading `hand status` never clears it on its own.",
-	"Run `hand watch --until-event` as a background task to monitor the fleet. Arming observes the fleet's already-actionable state first, so a condition that arrived while nothing was watching still wakes it; after that it exits on the first fleet event. Exit 8 means interruption and exit 9 means takeover replacement, neither of which is a fleet event. A supervisor should re-arm it after acting on an event or when intentionally resuming monitoring.",
+	"Run `hand orient` as the first Hand read of every reasoning turn, including a turn an automatic wake re-enters: it reports the bounded current orientation and records disposable mechanism progress only.",
+	"Unattended wake delivery is host-specific: a supported host bridge arms `hand supervision wait --host <harness>`, which blocks until current actionable work is wake-eligible, emits one coalesced wake hint that becomes your next reasoning opportunity, and re-arms without model memory after each wake. A watcher process exit alone is delivery only where an owning host guarantees that conversion; never treat an exit code, a notification, or an accepted request as proof you reasoned.",
 	"Never merge without explicit authorization.",
 	"Run `hand teardown <id>` after work is landed. Work that is handed off but whose landing is someone else's call is recorded with `hand deliver <id> --reason <text>` first.",
 	"Never edit files under `projects/`. Workers do that in worktrees.",
@@ -180,19 +177,30 @@ func Refresh(dir string) (RefreshResult, error) {
 		result.ArchivedPath = archived
 	}
 
-	symlinkPath := filepath.Join(dir, symlinkName)
-	if isWindows() {
-		if err := writeWindowsClaudeFile(symlinkPath); err != nil {
+	claudePath := filepath.Join(dir, claudeRef)
+	info, err := os.Lstat(claudePath)
+	switch {
+	case os.IsNotExist(err):
+		if err := writeClaudePointer(claudePath); err != nil {
 			return RefreshResult{}, err
 		}
-		return result, nil
-	}
-	if _, err := os.Lstat(symlinkPath); os.IsNotExist(err) {
-		if err := os.Symlink(filename, symlinkPath); err != nil {
-			return RefreshResult{}, fmt.Errorf("create %s symlink: %w", symlinkName, err)
+	case err != nil:
+		return RefreshResult{}, fmt.Errorf("check %s: %w", claudeRef, err)
+	case info.Mode()&os.ModeSymlink != 0:
+		// A Hand-era symlink to AGENTS.md upgrades to the pointer file every
+		// platform now uses; any other target is foreign and stays untouched.
+		target, linkErr := os.Readlink(claudePath)
+		if linkErr != nil {
+			return RefreshResult{}, fmt.Errorf("read %s symlink: %w", claudeRef, linkErr)
 		}
-	} else if err != nil {
-		return RefreshResult{}, fmt.Errorf("check %s: %w", symlinkName, err)
+		if target == filename {
+			if err := writeClaudePointer(claudePath); err != nil {
+				return RefreshResult{}, err
+			}
+		}
+	default:
+		// An existing regular CLAUDE.md the operator owns stays untouched; only
+		// drift from the canonical pointer content is a Check violation.
 	}
 
 	return result, nil
@@ -277,16 +285,11 @@ func legacyContent(content string) (string, error) {
 	return content[:start] + content[end:], nil
 }
 
-// A CLAUDE.md that already exists, in any form, is left alone: the same rule
-// Refresh applies to an existing CLAUDE.md symlink on every other platform.
-func writeWindowsClaudeFile(path string) error {
-	if _, err := os.Lstat(path); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("check %s: %w", symlinkName, err)
-	}
-	if err := atomicfile.Write(path, ".claude.md-", []byte(windowsClaudeContent), 0o644); err != nil {
-		return fmt.Errorf("create %s: %w", symlinkName, err)
+// Creates the CLAUDE.md pointer file. Refresh resolves any pre-existing entry
+// before calling this, so it only ever writes when the name is free.
+func writeClaudePointer(path string) error {
+	if err := atomicfile.Write(path, ".claude.md-", []byte(claudeContent), 0o644); err != nil {
+		return fmt.Errorf("create %s: %w", claudeRef, err)
 	}
 	return nil
 }
@@ -334,25 +337,23 @@ func Check(dir string) ([]Violation, error) {
 		violations = append(violations, Violation{Text: fmt.Sprintf("AGENTS.md has drifted from the canonical Hand-owned content: run hand init %s to restore it", shellquote.Quote(dir))})
 	}
 
-	if isWindows() {
-		violations = append(violations, checkWindowsClaudeFile(dir)...)
-	}
+	violations = append(violations, checkClaudeFile(dir)...)
 
 	return violations, nil
 }
 
-// Unix's CLAUDE.md is a symlink the filesystem itself keeps honest, so Check has never
-// had to look at it; Windows's copy is ordinary file content that can drift or go missing.
-func checkWindowsClaudeFile(dir string) []Violation {
-	path := filepath.Join(dir, symlinkName)
+// CLAUDE.md is ordinary file content on every platform now, so Check reads and
+// compares it everywhere the same way.
+func checkClaudeFile(dir string) []Violation {
+	path := filepath.Join(dir, claudeRef)
 	data, err := os.ReadFile(path)
 	switch {
 	case os.IsNotExist(err):
 		return []Violation{{Text: fmt.Sprintf("CLAUDE.md is missing: run hand init %s to restore it", shellquote.Quote(dir))}}
 	case err != nil:
-		return []Violation{{Text: fmt.Sprintf("read %s: %v", symlinkName, err)}}
-	case string(data) != windowsClaudeContent:
-		return []Violation{{Text: fmt.Sprintf("CLAUDE.md is not the Windows @AGENTS.md pointer: run hand init %s to restore it", shellquote.Quote(dir))}}
+		return []Violation{{Text: fmt.Sprintf("read %s: %v", claudeRef, err)}}
+	case string(data) != claudeContent:
+		return []Violation{{Text: fmt.Sprintf("CLAUDE.md is not the @AGENTS.md pointer: run hand init %s to restore it", shellquote.Quote(dir))}}
 	}
 	return nil
 }

--- a/internal/agentsmd/agentsmd_test.go
+++ b/internal/agentsmd/agentsmd_test.go
@@ -8,13 +8,6 @@ import (
 	"testing"
 )
 
-func withWindows(t *testing.T) {
-	t.Helper()
-	restore := isWindows
-	isWindows = func() bool { return true }
-	t.Cleanup(func() { isWindows = restore })
-}
-
 func makeWorkspace(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -76,23 +69,19 @@ func TestRefreshWritesCanonicalAgentsMdAndClaudeReferenceWhenMissing(t *testing.
 		t.Fatalf("got archive %q, want the migration sentinel", archive)
 	}
 
-	claudePath := filepath.Join(dir, "CLAUDE.md")
-	if runtime.GOOS == "windows" {
-		got, err := os.ReadFile(claudePath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(got) != windowsClaudeContent {
-			t.Fatalf("got CLAUDE.md content %q, want %q", got, windowsClaudeContent)
-		}
-	} else {
-		link, err := os.Readlink(claudePath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if link != "AGENTS.md" {
-			t.Fatalf("got CLAUDE.md -> %q, want AGENTS.md", link)
-		}
+	got, err = os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != claudeContent {
+		t.Fatalf("got CLAUDE.md content %q, want the %q pointer file", got, claudeContent)
+	}
+	info, err := os.Lstat(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("got CLAUDE.md as a symlink, want a regular pointer file on every platform")
 	}
 }
 
@@ -339,8 +328,38 @@ func TestRefreshDoesNotOverwriteExistingClaudeSymlink(t *testing.T) {
 	}
 }
 
-func TestRefreshWritesWindowsClaudeFileWhenMissing(t *testing.T) {
-	withWindows(t)
+// The Hand-era Unix symlink to AGENTS.md upgrades to the pointer file every
+// platform now uses; a foreign target never does.
+func TestRefreshMigratesHandOwnedSymlinkToPointerFile(t *testing.T) {
+	dir := makeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(generatedBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("AGENTS.md", filepath.Join(dir, "CLAUDE.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Refresh(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Lstat(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("got the old symlink left in place, want it migrated to the pointer file")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != claudeContent {
+		t.Fatalf("got CLAUDE.md content %q, want %q", got, claudeContent)
+	}
+}
+
+func TestRefreshWritesClaudePointerWhenMissing(t *testing.T) {
 	dir := makeWorkspace(t)
 
 	if _, err := Refresh(dir); err != nil {
@@ -352,20 +371,22 @@ func TestRefreshWritesWindowsClaudeFileWhenMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		t.Fatal("got CLAUDE.md as a symlink, want a regular file on Windows")
+		t.Fatal("got CLAUDE.md as a symlink, want a regular pointer file")
 	}
 	got, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != windowsClaudeContent {
-		t.Fatalf("got CLAUDE.md content %q, want %q", got, windowsClaudeContent)
+	if string(got) != claudeContent {
+		t.Fatalf("got CLAUDE.md content %q, want %q", got, claudeContent)
 	}
 }
 
-func TestRefreshDoesNotOverwriteExistingWindowsClaudeFile(t *testing.T) {
-	withWindows(t)
+func TestRefreshDoesNotOverwriteExistingClaudeFile(t *testing.T) {
 	dir := makeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(generatedBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("custom\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -480,8 +501,7 @@ func TestCheckCleanRightAfterRefresh(t *testing.T) {
 	}
 }
 
-func TestCheckCleanForWindowsClaudeFileRightAfterRefresh(t *testing.T) {
-	withWindows(t)
+func TestCheckCleanForClaudePointerRightAfterRefresh(t *testing.T) {
 	dir := makeWorkspace(t)
 	if _, err := Refresh(dir); err != nil {
 		t.Fatal(err)
@@ -496,8 +516,7 @@ func TestCheckCleanForWindowsClaudeFileRightAfterRefresh(t *testing.T) {
 	}
 }
 
-func TestCheckFlagsMissingWindowsClaudeFile(t *testing.T) {
-	withWindows(t)
+func TestCheckFlagsMissingClaudePointer(t *testing.T) {
 	dir := makeWorkspace(t)
 	if _, err := Refresh(dir); err != nil {
 		t.Fatal(err)
@@ -515,8 +534,7 @@ func TestCheckFlagsMissingWindowsClaudeFile(t *testing.T) {
 	}
 }
 
-func TestCheckFlagsDriftedWindowsClaudeFile(t *testing.T) {
-	withWindows(t)
+func TestCheckFlagsDriftedClaudePointer(t *testing.T) {
 	dir := makeWorkspace(t)
 	if _, err := Refresh(dir); err != nil {
 		t.Fatal(err)
@@ -529,7 +547,7 @@ func TestCheckFlagsDriftedWindowsClaudeFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !hasViolation(violations, "CLAUDE.md is not the Windows") {
+	if !hasViolation(violations, "CLAUDE.md is not the @AGENTS.md pointer") {
 		t.Fatalf("got %v, want a drifted CLAUDE.md violation", violations)
 	}
 }

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -41,19 +41,19 @@ func Write(path, tempPrefix string, data []byte, mode os.FileMode) error {
 		removeTemp()
 		return fmt.Errorf("close temp file: %w", err)
 	}
-	// Windows refuses Rename onto a target a reader still holds open without
-	// share-delete, turning concurrent reads into transient "Access is denied".
-	// A short bounded retry rides it out; Unix never hits this path.
+	// Windows denies Rename while a reader or scanner holds the new file
+	// open (concurrent reads, first-write AV sweeps); the swap retries on an
+	// exponential curve to a ~2s ceiling. Unix never hits this path.
 	var renameErr error
-	for attempt := range 5 {
+	for attempt := range 8 {
 		renameErr = os.Rename(tmpName, path)
 		if renameErr == nil {
 			return nil
 		}
-		if !isTransientRenameDenied(renameErr) {
+		if !isTransientRenameDenied(renameErr) || attempt == 7 {
 			break
 		}
-		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+		time.Sleep((time.Duration(1) << uint(attempt)) * 15 * time.Millisecond)
 	}
 	if renameErr != nil {
 		removeTemp()

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -8,9 +8,13 @@
 package atomicfile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"syscall"
+	"time"
 )
 
 // Write creates or replaces path with data and mode. tempPrefix names the
@@ -37,9 +41,36 @@ func Write(path, tempPrefix string, data []byte, mode os.FileMode) error {
 		removeTemp()
 		return fmt.Errorf("close temp file: %w", err)
 	}
-	if err := os.Rename(tmpName, path); err != nil {
+	// Windows refuses Rename onto a target a reader still holds open without
+	// share-delete, turning concurrent reads into transient "Access is denied".
+	// A short bounded retry rides it out; Unix never hits this path.
+	var renameErr error
+	for attempt := range 5 {
+		renameErr = os.Rename(tmpName, path)
+		if renameErr == nil {
+			return nil
+		}
+		if !isTransientRenameDenied(renameErr) {
+			break
+		}
+		time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+	}
+	if renameErr != nil {
 		removeTemp()
-		return fmt.Errorf("rename temp file: %w", err)
+		return fmt.Errorf("rename temp file: %w", renameErr)
 	}
 	return nil
+}
+
+func isTransientRenameDenied(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	// 32 = ERROR_ACCESS_DENIED, 33 = ERROR_SHARING_VIOLATION; the Win32
+	// constants live in x/sys, which this tiny helper must not pull in.
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == 32 || errno == 33
+	}
+	return false
 }

--- a/internal/sessionhook/sessionhook.go
+++ b/internal/sessionhook/sessionhook.go
@@ -1,4 +1,6 @@
-// Package sessionhook retires Secondhand-owned Claude Code SessionStart hooks.
+// Package sessionhook merges and retires Hand-owned Claude Code hooks in a
+// project settings.json, preserving every unrelated operator entry byte for
+// byte and refusing any shape it cannot carry through losslessly.
 package sessionhook
 
 import (
@@ -11,54 +13,209 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/shellquote"
 )
 
 const (
 	settingsDir  = ".claude"
 	settingsFile = "settings.json"
-	event        = "SessionStart"
+	legacyEvent  = "SessionStart"
 	toolName     = "hand"
 	toolNameExe  = "hand.exe"
 )
 
-// Removes owned hooks from dir/.claude/settings.json and reports whether the
-// file changed. A missing settings file is already retired.
+// Removes owned SessionStart hooks from dir/.claude/settings.json and reports
+// whether the file changed. A missing settings file is already retired.
 func Remove(dir, exe string) (bool, error) {
-	path := filepath.Join(dir, settingsDir, settingsFile)
-	existing, err := os.ReadFile(path)
+	return mutate(dir, legacyEvent, func(matchers []any, _ string) ([]any, bool, error) {
+		return filterOwned(matchers, exe, legacyEvent)
+	})
+}
+
+// Ensure merges exactly one Hand-owned command hook under hooks.<event>,
+// replacing any earlier Hand-owned entry for that event and preserving every
+// unrelated matcher, hook, and setting. Repeated calls are idempotent.
+func Ensure(dir, exe, event, args string) (bool, error) {
+	command := shellquote.Quote(exe)
+	if args != "" {
+		command += " " + args
+	}
+	changed, err := mutate(dir, event, func(matchers []any, _ string) ([]any, bool, error) {
+		filtered, _, err := filterOwned(matchers, exe, event)
+		if err != nil {
+			return nil, false, err
+		}
+		if exactPresent, ownedCount := scanOwned(matchers, exe, command); exactPresent && ownedCount == 1 {
+			return filtered, false, nil
+		}
+		return append(filtered, map[string]any{
+			"matcher": "",
+			"hooks":   []any{map[string]any{"type": "command", "command": command}},
+		}), true, nil
+	})
+	return changed, err
+}
+
+// Counts Hand-owned entries under the matchers and reports whether one of
+// them already runs exactly this command line.
+func scanOwned(matchers []any, exe, command string) (exactPresent bool, owned int) {
+	for _, matcher := range matchers {
+		entry, ok := matcher.(map[string]any)
+		if !ok {
+			continue
+		}
+		commands, err := array(entry, "hooks", "hooks")
+		if err != nil {
+			continue
+		}
+		for _, hook := range commands {
+			hookMap, ok := hook.(map[string]any)
+			if !ok {
+				continue
+			}
+			line, ok := hookMap["command"].(string)
+			if !ok {
+				continue
+			}
+			args, ownedEntry := handArgs(line, exe)
+			if !ownedEntry {
+				continue
+			}
+			owned++
+			if strings.TrimSpace(exe)+args == strings.TrimSpace(command) || strings.TrimSpace(line) == strings.TrimSpace(command) {
+				exactPresent = true
+			}
+		}
+	}
+	return exactPresent, owned
+}
+
+// State reports whether hooks.<event> carries a Hand-owned entry running this
+// binary with the expected args: installed, stale, or absent. An unparseable
+// settings file is malformed - an actionable diagnostic, never overwritten.
+func State(dir, exe, event, args string) (string, error) {
+	settings, err := read(dir)
+	if err != nil {
+		return "", err
+	}
+	if settings == nil {
+		return "absent", nil
+	}
+	hooks, err := object(settings, "hooks", "hooks")
+	if err != nil {
+		return "", err
+	}
+	matchers, err := array(hooks, event, "hooks."+event)
+	if err != nil {
+		return "", err
+	}
+	command := shellquote.Quote(exe)
+	if args != "" {
+		command += " " + args
+	}
+	state := "absent"
+	for _, matcher := range matchers {
+		entry, ok := matcher.(map[string]any)
+		if !ok {
+			continue
+		}
+		commands, err := array(entry, "hooks", "hooks."+event)
+		if err != nil {
+			return "", err
+		}
+		for _, hook := range commands {
+			command0, ok := hook.(map[string]any)
+			if !ok {
+				continue
+			}
+			line, ok := command0["command"].(string)
+			if !ok {
+				continue
+			}
+			if _, owned := handArgs(line, exe); !owned {
+				continue
+			}
+			if strings.TrimSpace(line) == strings.TrimSpace(command) {
+				return "installed", nil
+			}
+			state = "stale"
+		}
+	}
+	return state, nil
+}
+
+// Parses dir/.claude/settings.json into a settings map. A missing file is nil
+// with no error; anything unparseable or non-object is an error the caller
+// must surface instead of overwriting.
+func read(dir string) (map[string]any, error) {
+	existing, err := os.ReadFile(filepath.Join(dir, settingsDir, settingsFile))
 	if os.IsNotExist(err) {
-		return false, nil
+		return nil, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("read %s: %w", relPath(), err)
+		return nil, fmt.Errorf("read %s: %w", relPath(), err)
 	}
-
 	var settings map[string]any
 	decoder := json.NewDecoder(bytes.NewReader(existing))
 	decoder.UseNumber()
 	if err := decoder.Decode(&settings); err != nil {
-		return false, fmt.Errorf("parse %s: %w", relPath(), err)
+		return nil, fmt.Errorf("parse %s: %w", relPath(), err)
 	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		if err == nil {
 			err = fmt.Errorf("multiple JSON values")
 		}
-		return false, fmt.Errorf("parse %s: %w", relPath(), err)
+		return nil, fmt.Errorf("parse %s: %w", relPath(), err)
 	}
 	if settings == nil {
-		return false, fmt.Errorf("%s: settings is not an object, refusing to overwrite it", relPath())
+		return nil, fmt.Errorf("%s: settings is not an object, refusing to overwrite it", relPath())
 	}
-	changed, err := remove(settings, exe)
+	return settings, nil
+}
+
+// Loads settings (starting an empty object when the file does not exist yet),
+// applies change to the matchers under hooks.<event>, and writes atomically
+// only when something changed.
+func mutate(dir, event string, change func(matchers []any, event string) ([]any, bool, error)) (bool, error) {
+	settings, err := read(dir)
+	if err != nil {
+		return false, err
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	hooks, err := object(settings, "hooks", "hooks")
+	if err != nil {
+		return false, err
+	}
+	// object hands back an empty stand-in when the key is absent; attach it so
+	// a merge into a fresh settings file actually lands.
+	if existing, ok := settings["hooks"]; !ok || existing == nil {
+		settings["hooks"] = hooks
+	}
+	matchers, err := array(hooks, event, "hooks."+event)
+	if err != nil {
+		return false, err
+	}
+	updated, changed, err := change(matchers, event)
 	if err != nil || !changed {
 		return false, err
 	}
-
+	if len(updated) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = updated
+	}
 	encoded, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
 		return false, err
 	}
 	encoded = append(encoded, '\n')
+	path := filepath.Join(dir, settingsDir, settingsFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, fmt.Errorf("create %s: %w", settingsDir, err)
+	}
 	if err := atomicfile.Write(path, ".settings.json-", encoded, 0o644); err != nil {
 		return false, fmt.Errorf("write %s: %w", relPath(), err)
 	}
@@ -69,35 +226,27 @@ func relPath() string {
 	return filepath.Join(settingsDir, settingsFile)
 }
 
-// Edits settings in place while carrying every unrelated matcher, hook, and
-// setting through untouched.
-func remove(settings map[string]any, exe string) (bool, error) {
-	hooks, err := object(settings, "hooks", "hooks")
-	if err != nil {
-		return false, err
-	}
-	matchers, err := array(hooks, event, "hooks."+event)
-	if err != nil {
-		return false, err
-	}
-
+// Strips every Hand-owned command entry from the matchers, carrying every
+// unrelated matcher, hook, and setting through untouched. Reports whether
+// anything was removed.
+func filterOwned(matchers []any, exe, event string) ([]any, bool, error) {
 	filteredMatchers := make([]any, 0, len(matchers))
 	changed := false
 	for i, matcher := range matchers {
 		entry, ok := matcher.(map[string]any)
 		if !ok {
-			return false, fmt.Errorf("%s: hooks.%s[%d] is not an object, refusing to overwrite it", relPath(), event, i)
+			return nil, false, fmt.Errorf("%s: hooks.%s[%d] is not an object, refusing to overwrite it", relPath(), event, i)
 		}
 		commands, err := array(entry, "hooks", fmt.Sprintf("hooks.%s[%d].hooks", event, i))
 		if err != nil {
-			return false, err
+			return nil, false, err
 		}
 		filteredCommands := make([]any, 0, len(commands))
 		matcherChanged := false
 		for j, hook := range commands {
 			command, ok := hook.(map[string]any)
 			if !ok {
-				return false, fmt.Errorf("%s: hooks.%s[%d].hooks[%d] is not an object, refusing to overwrite it", relPath(), event, i, j)
+				return nil, false, fmt.Errorf("%s: hooks.%s[%d].hooks[%d] is not an object, refusing to overwrite it", relPath(), event, i, j)
 			}
 			rawType, exists := command["type"]
 			if !exists {
@@ -106,7 +255,7 @@ func remove(settings map[string]any, exe string) (bool, error) {
 			}
 			hookType, ok := rawType.(string)
 			if !ok {
-				return false, fmt.Errorf("%s: hooks.%s[%d].hooks[%d].type is not a string, refusing to overwrite it", relPath(), event, i, j)
+				return nil, false, fmt.Errorf("%s: hooks.%s[%d].hooks[%d].type is not a string, refusing to overwrite it", relPath(), event, i, j)
 			}
 			if hookType != "command" {
 				filteredCommands = append(filteredCommands, hook)
@@ -119,7 +268,7 @@ func remove(settings map[string]any, exe string) (bool, error) {
 			}
 			line, ok := raw.(string)
 			if !ok {
-				return false, fmt.Errorf("%s: hooks.%s[%d].hooks[%d].command is not a string, refusing to overwrite it", relPath(), event, i, j)
+				return nil, false, fmt.Errorf("%s: hooks.%s[%d].hooks[%d].command is not a string, refusing to overwrite it", relPath(), event, i, j)
 			}
 			if _, owned := handArgs(line, exe); owned {
 				matcherChanged = true
@@ -137,15 +286,7 @@ func remove(settings map[string]any, exe string) (bool, error) {
 			filteredMatchers = append(filteredMatchers, matcher)
 		}
 	}
-	if !changed {
-		return false, nil
-	}
-	if len(filteredMatchers) == 0 {
-		delete(hooks, event)
-	} else {
-		hooks[event] = filteredMatchers
-	}
-	return true, nil
+	return filteredMatchers, changed, nil
 }
 
 // A key whose value is not the shape hand merges into is the operator's, the
@@ -176,16 +317,25 @@ func array(m map[string]any, key, path string) ([]any, error) {
 }
 
 // Splits a hook command into whatever follows the binary it runs. An entry is
-// ours when it names this binary, or any binary called hand or hand.exe.
+// ours when it names this binary, or any binary called hand or hand.exe. The
+// binary may be shell-quoted, so a path with spaces still resolves.
 func handArgs(line, exe string) (string, bool) {
 	trimmed := strings.TrimLeft(line, " \t")
-	first := trimmed
-	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+	first, rest := trimmed, ""
+	if len(trimmed) > 0 && (trimmed[0] == '"' || trimmed[0] == '\'') {
+		end := strings.IndexByte(trimmed[1:], trimmed[0])
+		if end < 0 {
+			return "", false
+		}
+		first = strings.Trim(trimmed[:end+2], string(trimmed[0]))
+		rest = strings.TrimLeft(trimmed[end+2:], " \t")
+	} else if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
 		first = trimmed[:i]
+		rest = strings.TrimPrefix(trimmed[i:], " ")
 	}
 	base := filepath.Base(first)
 	if first == "" || (first != exe && base != toolName && base != toolNameExe) {
 		return "", false
 	}
-	return strings.TrimPrefix(trimmed, first), true
+	return rest, true
 }

--- a/internal/sessionhook/sessionhook_test.go
+++ b/internal/sessionhook/sessionhook_test.go
@@ -41,9 +41,9 @@ func hookCommands(t *testing.T, settings map[string]any) []string {
 	if !ok {
 		t.Fatalf("settings = %+v, want a hooks object", settings)
 	}
-	matchers, ok := hooks[event].([]any)
+	matchers, ok := hooks[legacyEvent].([]any)
 	if !ok {
-		t.Fatalf("hooks = %+v, want a %s array", hooks, event)
+		t.Fatalf("hooks = %+v, want a %s array", hooks, legacyEvent)
 	}
 	var lines []string
 	for _, matcher := range matchers {
@@ -60,7 +60,7 @@ func hookCommands(t *testing.T, settings map[string]any) []string {
 func TestRemoveDeletesOnlyOwnedHandHook(t *testing.T) {
 	dir := mkHome(t)
 	writeSettings(t, dir, map[string]any{"hooks": map[string]any{
-		event: []any{
+		legacyEvent: []any{
 			map[string]any{"matcher": "startup", "hooks": []any{
 				map[string]any{"type": "command", "command": "/old/path/hand"},
 				map[string]any{"type": "command", "command": "/usr/bin/custom"},
@@ -80,7 +80,7 @@ func TestRemoveDeletesOnlyOwnedHandHook(t *testing.T) {
 func TestRemovePreservesNonCommandHooksWithAHandCommandField(t *testing.T) {
 	dir := mkHome(t)
 	prompt := map[string]any{"type": "prompt", "command": "hand session start", "prompt": "summarize"}
-	writeSettings(t, dir, map[string]any{"hooks": map[string]any{event: []any{map[string]any{"hooks": []any{
+	writeSettings(t, dir, map[string]any{"hooks": map[string]any{legacyEvent: []any{map[string]any{"hooks": []any{
 		prompt,
 		map[string]any{"type": "command", "command": "/old/path/hand"},
 	}}}}})
@@ -90,7 +90,7 @@ func TestRemovePreservesNonCommandHooksWithAHandCommandField(t *testing.T) {
 		t.Fatalf("Remove = %v, %v, want only the command hook removed", changed, err)
 	}
 	events := readSettings(t, dir)["hooks"].(map[string]any)
-	matchers, ok := events[event].([]any)
+	matchers, ok := events[legacyEvent].([]any)
 	if !ok || len(matchers) != 1 {
 		t.Fatalf("hooks = %+v, want the matcher containing the prompt hook preserved", events)
 	}
@@ -180,7 +180,7 @@ func TestRemoveDeletesOwnedOnlyMatcherAndPreservesUnrelatedMatchers(t *testing.T
 	writeSettings(t, dir, map[string]any{
 		"permissions": map[string]any{},
 		"hooks": map[string]any{
-			event: []any{
+			legacyEvent: []any{
 				map[string]any{"matcher": "owned", "hooks": []any{map[string]any{"type": "command", "command": "hand session start"}}},
 				empty,
 				custom,
@@ -195,12 +195,12 @@ func TestRemoveDeletesOwnedOnlyMatcherAndPreservesUnrelatedMatchers(t *testing.T
 	}
 	settings := readSettings(t, dir)
 	hooks := settings["hooks"].(map[string]any)
-	matchers := hooks[event].([]any)
+	matchers := hooks[legacyEvent].([]any)
 	if len(matchers) != 2 || matchers[0].(map[string]any)["matcher"] != "already-empty" || matchers[1].(map[string]any)["matcher"] != "custom" {
 		t.Fatalf("matchers = %+v, want the unrelated empty and custom matchers", matchers)
 	}
 	if _, ok := hooks["PreToolUse"]; !ok {
-		t.Fatalf("hooks = %+v, want unrelated empty event preserved", hooks)
+		t.Fatalf("hooks = %+v, want unrelated empty legacyEvent preserved", hooks)
 	}
 	if _, ok := settings["permissions"]; !ok {
 		t.Fatalf("settings = %+v, want unrelated empty permissions preserved", settings)
@@ -210,26 +210,26 @@ func TestRemoveDeletesOwnedOnlyMatcherAndPreservesUnrelatedMatchers(t *testing.T
 func TestRemoveDeletesSessionStartOnlyWhenNoMatchersRemain(t *testing.T) {
 	dir := mkHome(t)
 	writeSettings(t, dir, map[string]any{"hooks": map[string]any{
-		event:        []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/old/path/hand --version"}}}},
+		legacyEvent:  []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "/old/path/hand --version"}}}},
 		"PreToolUse": []any{},
 	}})
 
 	changed, err := Remove(dir, "/current/path/hand")
 	if err != nil || !changed {
-		t.Fatalf("Remove = %v, %v, want the event removed", changed, err)
+		t.Fatalf("Remove = %v, %v, want the legacyEvent removed", changed, err)
 	}
 	hooks := readSettings(t, dir)["hooks"].(map[string]any)
-	if _, ok := hooks[event]; ok {
-		t.Fatalf("hooks = %+v, want empty %s removed", hooks, event)
+	if _, ok := hooks[legacyEvent]; ok {
+		t.Fatalf("hooks = %+v, want empty %s removed", hooks, legacyEvent)
 	}
 	if _, ok := hooks["PreToolUse"]; !ok {
-		t.Fatalf("hooks = %+v, want unrelated empty event preserved", hooks)
+		t.Fatalf("hooks = %+v, want unrelated empty legacyEvent preserved", hooks)
 	}
 }
 
 func TestRemoveRecognizesMovedHandAndCurrentExecutableNames(t *testing.T) {
 	dir := mkHome(t)
-	writeSettings(t, dir, map[string]any{"hooks": map[string]any{event: []any{map[string]any{"hooks": []any{
+	writeSettings(t, dir, map[string]any{"hooks": map[string]any{legacyEvent: []any{map[string]any{"hooks": []any{
 		map[string]any{"type": "command", "command": "  /old/path/hand status"},
 		map[string]any{"type": "command", "command": "/tmp/hand.test session start"},
 		map[string]any{"type": "command", "command": "/somewhere/hand.test session start"},
@@ -246,7 +246,7 @@ func TestRemoveRecognizesMovedHandAndCurrentExecutableNames(t *testing.T) {
 
 func TestRemoveRecognizesHandExeSuffix(t *testing.T) {
 	dir := mkHome(t)
-	writeSettings(t, dir, map[string]any{"hooks": map[string]any{event: []any{map[string]any{"hooks": []any{
+	writeSettings(t, dir, map[string]any{"hooks": map[string]any{legacyEvent: []any{map[string]any{"hooks": []any{
 		map[string]any{"type": "command", "command": "/old/path/hand.exe status"},
 		map[string]any{"type": "command", "command": "/usr/bin/custom"},
 	}}}}})
@@ -262,7 +262,7 @@ func TestRemoveRecognizesHandExeSuffix(t *testing.T) {
 
 func TestRemoveIsIdempotent(t *testing.T) {
 	dir := mkHome(t)
-	writeSettings(t, dir, map[string]any{"hooks": map[string]any{event: []any{map[string]any{"hooks": []any{
+	writeSettings(t, dir, map[string]any{"hooks": map[string]any{legacyEvent: []any{map[string]any{"hooks": []any{
 		map[string]any{"type": "command", "command": "/old/path/hand"},
 		map[string]any{"type": "command", "command": "/usr/bin/custom"},
 	}}}}})
@@ -322,7 +322,7 @@ func TestRemoveRefusesSettingsOfAnUnexpectedShape(t *testing.T) {
 	}{
 		{"settings is not an object", `null`},
 		{"hooks is not an object", `{"hooks": "SessionStart"}`},
-		{"the event is not an array", `{"hooks": {"SessionStart": {"command": "/usr/bin/tea"}}}`},
+		{"the legacyEvent is not an array", `{"hooks": {"SessionStart": {"command": "/usr/bin/tea"}}}`},
 		{"a matcher is not an object", `{"hooks": {"SessionStart": ["startup"]}}`},
 		{"matcher hooks is not an array", `{"hooks": {"SessionStart": [{"hooks": {"command": "hand"}}]}}`},
 		{"a nested hook is not an object", `{"hooks": {"SessionStart": [{"hooks": ["hand"]}]}}`},

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -38,6 +38,7 @@ var (
 	ErrSendOwnershipConflict = store.ErrSendOwnershipConflict
 	ErrSendInFlight          = store.ErrSendInFlight
 	ErrInvalidSendTransition = store.ErrInvalidSendTransition
+	ErrFleetIdentityMissing  = store.ErrFleetIdentityMissing
 )
 
 const (

--- a/internal/supervision/assets.go
+++ b/internal/supervision/assets.go
@@ -1,19 +1,24 @@
 package supervision
 
-import "embed"
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+)
 
 //go:embed assets
 var assetsFS embed.FS
 
-// Asset describes one managed host-integration file rendered into its
-// destination with install-time substitutions applied.
+// One managed host-integration file. Script assets carry a template body
+// whose path placeholders are substituted as JSON string literals; structured
+// documents carry a Render function producing their full bytes.
 type Asset struct {
 	// RelPath is the destination path relative to the fleet home.
 	RelPath string
-	// Body is the canonical template. The __HAND_EXECUTABLE__ and
-	// __HAND_HOME__ placeholders are replaced with quoted absolute paths at
-	// render time, so doctor can compare exact bytes to detect staleness.
+	// Body is the canonical template for placeholder substitution.
 	Body []byte
+	// Render, when set, produces the entire file and Body is unused.
+	Render func(exe string) []byte
 }
 
 func asset(name string) []byte {
@@ -24,9 +29,9 @@ func asset(name string) []byte {
 	return data
 }
 
-// HostAssets returns the managed files for one host. Grok needs none: its
-// bridge is the host's own background-task lifecycle, established through the
-// generated Supervisor instructions rather than an installed file.
+// HostAssets returns the managed script-template files for one host. Grok
+// needs none: its bridge is instruction-established. Codex is absent too: its
+// Fleet-local hooks.json is merged through InstallCodexHooks instead.
 func HostAssets(host string) []Asset {
 	switch host {
 	case "opencode":
@@ -44,14 +49,31 @@ func HostAssets(host string) []Asset {
 	}
 }
 
-// AllManagedAssets maps every host with installed assets to them, in the
-// stable harness-name order used by init and doctor.
-func AllManagedAssets() map[string][]Asset {
-	hosts := map[string][]Asset{}
-	for _, host := range []string{"opencode", "pi"} {
-		if list := HostAssets(host); len(list) > 0 {
-			hosts[host] = list
-		}
+// ManagedAssetHosts lists every host whose bridge installs through the
+// template pipeline, in the stable order used by init.
+func ManagedAssetHosts() []string {
+	return []string{"opencode", "pi"}
+}
+
+// CodexHooksRelPath is the Fleet-local hooks document hand owns a Stop group
+// inside.
+const CodexHooksRelPath = ".codex/hooks.json"
+
+// Produces one asset's final bytes with install-time substitutions applied.
+func renderAsset(a Asset, exe, home string) []byte {
+	if a.Render != nil {
+		return a.Render(exe)
 	}
-	return hosts
+	body := bytes.ReplaceAll(a.Body, []byte("__HAND_EXECUTABLE__"), mustJSONString(exe))
+	return bytes.ReplaceAll(body, []byte("__HAND_HOME__"), mustJSONString(home))
+}
+
+// Yields a complete JSON string literal: encoding/json owns
+// the escaping grammar, so no path byte can survive misquoted.
+func mustJSONString(value string) []byte {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic("supervision: json string marshal failed: " + err.Error())
+	}
+	return encoded
 }

--- a/internal/supervision/assets.go
+++ b/internal/supervision/assets.go
@@ -59,12 +59,15 @@ func ManagedAssetHosts() []string {
 // inside.
 const CodexHooksRelPath = ".codex/hooks.json"
 
-// Produces one asset's final bytes with install-time substitutions applied.
+// Produces one asset's final bytes with substitutions applied. Templates are
+// normalized to LF first: a Windows checkout may hand the embed CRLF content,
+// and idempotent byte-compare must not depend on the checkout platform.
 func renderAsset(a Asset, exe, home string) []byte {
+	body := bytes.ReplaceAll(a.Body, []byte("\r\n"), []byte("\n"))
 	if a.Render != nil {
 		return a.Render(exe)
 	}
-	body := bytes.ReplaceAll(a.Body, []byte("__HAND_EXECUTABLE__"), mustJSONString(exe))
+	body = bytes.ReplaceAll(body, []byte("__HAND_EXECUTABLE__"), mustJSONString(exe))
 	return bytes.ReplaceAll(body, []byte("__HAND_HOME__"), mustJSONString(home))
 }
 

--- a/internal/supervision/assets.go
+++ b/internal/supervision/assets.go
@@ -1,0 +1,57 @@
+package supervision
+
+import "embed"
+
+//go:embed assets
+var assetsFS embed.FS
+
+// Asset describes one managed host-integration file rendered into its
+// destination with install-time substitutions applied.
+type Asset struct {
+	// RelPath is the destination path relative to the fleet home.
+	RelPath string
+	// Body is the canonical template. The __HAND_EXECUTABLE__ and
+	// __HAND_HOME__ placeholders are replaced with quoted absolute paths at
+	// render time, so doctor can compare exact bytes to detect staleness.
+	Body []byte
+}
+
+func asset(name string) []byte {
+	data, err := assetsFS.ReadFile("assets/" + name)
+	if err != nil {
+		panic("supervision: embedded asset missing: " + name)
+	}
+	return data
+}
+
+// HostAssets returns the managed files for one host. Grok needs none: its
+// bridge is the host's own background-task lifecycle, established through the
+// generated Supervisor instructions rather than an installed file.
+func HostAssets(host string) []Asset {
+	switch host {
+	case "opencode":
+		return []Asset{{
+			RelPath: ".opencode/plugins/hand-supervisor-wake.js",
+			Body:    asset("opencode/hand-supervisor-wake.js"),
+		}}
+	case "pi":
+		return []Asset{{
+			RelPath: ".pi/extensions/hand-supervisor-wake.ts",
+			Body:    asset("pi/hand-supervisor-wake.ts"),
+		}}
+	default:
+		return nil
+	}
+}
+
+// AllManagedAssets maps every host with installed assets to them, in the
+// stable harness-name order used by init and doctor.
+func AllManagedAssets() map[string][]Asset {
+	hosts := map[string][]Asset{}
+	for _, host := range []string{"opencode", "pi"} {
+		if list := HostAssets(host); len(list) > 0 {
+			hosts[host] = list
+		}
+	}
+	return hosts
+}

--- a/internal/supervision/assets/codex/hooks.json
+++ b/internal/supervision/assets/codex/hooks.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          __HAND_CODEX_STOP__
+        ]
+      }
+    ]
+  }
+}

--- a/internal/supervision/assets/opencode/hand-supervisor-wake.js
+++ b/internal/supervision/assets/opencode/hand-supervisor-wake.js
@@ -1,125 +1,192 @@
 // Hand-owned supervisor wake integration (hand supervision). Managed by hand
 // init; edits are replaced on the next init. Placeholders __HAND_EXECUTABLE__
-// and __HAND_HOME__ are substituted at install time.
+// and __HAND_HOME__ are substituted as JSON string literals at install time.
 //
-// Converts one Hand wake into exactly one OpenCode reasoning turn: after the
-// primary session goes idle, this plugin arms at most one `hand supervision
-// wait --host opencode` child; an eligible wake is delivered through the
-// synchronous session prompt, so acceptance means real assistant activity,
-// never a fire-and-forget enqueue. Stale session generations become no-ops.
+// Converts one Hand wake into exactly one OpenCode reasoning turn for the
+// primary Fleet supervisor session: after it goes idle this plugin arms at
+// most one `hand supervision wait` child; an eligible wake is delivered
+// through the synchronous session prompt, so acceptance means real assistant
+// activity. Subagent sessions (parentID set) and sessions outside the Fleet
+// home never own the bridge, and a live wait owned by another runtime is not
+// stolen.
 
 import { spawn } from "node:child_process";
 
-const HAND_EXE = "__HAND_EXECUTABLE__";
-const HAND_HOME = "__HAND_HOME__";
-const COORDINATOR_KEY = "__handSupervisorWake";
-const WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+const HAND_EXE = __HAND_EXECUTABLE__;
+const HAND_HOME = __HAND_HOME__;
+const WAKE_SCHEMA = "hand.supervision.wake.v1";
 
 export const HandSupervisorWake = async ({ client }) => {
-  const coordinator = {
-    generation: 0,
-    armedFor: null,
-    child: null,
-    timer: null,
-  };
-  globalThis[COORDINATOR_KEY] = coordinator;
+  let generation = 0;
+  let primary = null;
+  let child = null;
+  let timer = null;
 
   const stopChild = () => {
-    if (coordinator.timer) {
-      clearTimeout(coordinator.timer);
-      coordinator.timer = null;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
     }
-    if (coordinator.child) {
-      coordinator.child.kill();
-      coordinator.child = null;
+    if (child) {
+      child.kill();
+      child = null;
     }
-    coordinator.armedFor = null;
   };
 
-  const wakeText = (stdout) => {
-    for (const line of stdout.split("\n")) {
-      if (line.startsWith("text: ")) return line.slice(6).trim();
+  // parseWake accepts only the versioned machine protocol. Rendered human
+  // output is never a contract: an unexpected schema fails closed.
+  const parseWake = (stdout) => {
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      return null;
     }
-    return "";
+    if (!parsed || parsed.schema !== WAKE_SCHEMA || typeof parsed.fleet_id !== "string") {
+      return null;
+    }
+    return parsed;
   };
 
-  const deliver = async (sessionID, text) => {
-    const prompt =
-      text ||
-      "Hand has current actionable work. Run `hand orient` before reasoning or acting.";
-    // Synchronous prompt semantics only: awaiting the response is what makes
-    // delivery progressed evidence. promptAsync/204 is explicitly not proof a
-    // model turn started.
+  const receipt = (stage, episodes, detail) => {
+    const argv = ["supervision", "receipt", "--host", "opencode", "--stage", stage];
+    for (const episode of episodes || []) {
+      argv.push("--episode", episode);
+    }
+    if (detail) {
+      argv.push("--detail", String(detail).slice(0, 200));
+    }
+    try {
+      spawn(HAND_EXE, argv, {
+        cwd: HAND_HOME,
+        env: { ...process.env, HAND_HOME: HAND_HOME },
+        stdio: "ignore",
+      });
+    } catch {}
+  };
+
+  const deliver = async (sessionID, payload) => {
+    const text =
+      payload && typeof payload.message === "string" && payload.message.trim() !== ""
+        ? payload.message
+        : "Hand has current actionable work. Run `hand orient` before reasoning or acting.";
+    // Synchronous prompt semantics: awaiting the response is what makes
+    // delivery progressed evidence. promptAsync/204 proves nothing.
     await client.session.prompt({
       path: { id: sessionID },
-      body: { parts: [{ type: "text", text: prompt }] },
+      body: { parts: [{ type: "text", text }] },
     });
+    receipt(
+      "accepted",
+      payload && Array.isArray(payload.episodes) ? payload.episodes.map((e) => e.key) : [],
+    );
+  };
+
+  const sessionInfo = async (sessionID) => {
+    try {
+      const res = await client.session.get({ path: { id: sessionID } });
+      return (res && res.data) || res;
+    } catch {
+      return null;
+    }
   };
 
   const arm = (sessionID) => {
-    if (coordinator.armedFor === sessionID && coordinator.child) return;
-    if (coordinator.armedFor !== null) stopChild();
-    coordinator.armedFor = sessionID;
-
-    const child = spawn(
+    if (child) return;
+    const started = generation;
+    child = spawn(
       HAND_EXE,
-      ["supervision", "wait", "--host", "opencode", "--timeout", "30m"],
-      { cwd: HAND_HOME, env: { ...process.env, HAND_HOME: HAND_HOME }, stdio: ["ignore", "pipe", "pipe"] },
+      [
+        "supervision",
+        "wait",
+        "--host",
+        "opencode",
+        "--format",
+        "json",
+        "--runtime-session",
+        sessionID,
+        "--timeout",
+        "30m",
+      ],
+      {
+        cwd: HAND_HOME,
+        env: { ...process.env, HAND_HOME: HAND_HOME },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
     );
-    coordinator.child = child;
 
     let stdout = "";
+    let stderr = "";
     child.stdout.on("data", (chunk) => {
       stdout += chunk;
     });
-
-    const generation = coordinator.generation;
-    child.on("close", (code, signal) => {
-      if (coordinator.generation !== generation || coordinator.child !== child) return;
-      coordinator.child = null;
-      if (coordinator.timer) {
-        clearTimeout(coordinator.timer);
-        coordinator.timer = null;
-      }
-      // 0 eligible wake, 4 checkpoint with no wake: both re-arm on the next
-      // idle event. 8 interrupted and 9 replaced mean another Hand process now
-      // owns coordination; arming again here would fight it.
-      if (code === 0 || code === 4) {
-        if (code === 0) {
-          deliver(sessionID, wakeText(stdout)).catch((err) => {
-            process.stderr.write("hand supervisor wake: prompt failed: " + err + "\n");
-          });
-        }
-        coordinator.armedFor = null;
-        return;
-      }
-      if (code === 5) {
-        process.stderr.write(
-          "hand supervisor wake: monitoring failed; run `hand doctor` in " + HAND_HOME + "\n",
-        );
-      }
-      coordinator.armedFor = null;
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
     });
 
-    coordinator.timer = setTimeout(() => {
-      if (coordinator.child === child) child.kill();
-    }, WAIT_TIMEOUT_MS);
+    child.on("close", (code) => {
+      if (generation !== started) return;
+      child = null;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      // 0 eligible wake, 4 checkpoint without one: both re-arm on the next
+      // idle. 3 means another live runtime owns the bridge; never steal it.
+      // 8 interrupted and 9 replaced mean another Hand process took over.
+      if (code === 0) {
+        const payload = parseWake(stdout);
+        if (!payload) {
+          process.stderr.write(
+            "hand supervisor wake: unexpected wait output schema; run `hand init " +
+              HAND_HOME +
+              "` to refresh this integration\n",
+          );
+        } else {
+          deliver(sessionID, payload).catch((err) => {
+            process.stderr.write("hand supervisor wake: prompt failed: " + err + "\n");
+            receipt("delivery-failed", [], err);
+          });
+        }
+      } else if (code === 5 && stderr.trim() !== "") {
+        process.stderr.write("hand supervisor wake: " + stderr.trim().split("\n")[0] + "\n");
+      }
+    });
+
+    timer = setTimeout(() => {
+      if (child) child.kill();
+    }, 31 * 60 * 1000);
   };
 
   return {
     event: async ({ event }) => {
       if (event.type !== "session.idle") return;
-      const sessionID = event.properties?.sessionID;
+      const sessionID = event.properties && event.properties.sessionID;
       if (!sessionID) return;
-      // A different session ID is a successor generation (/new, switch,
-      // replacement): its callbacks retire the previous arm instead of
-      // targeting it.
-      if (coordinator.armedFor !== null && coordinator.armedFor !== sessionID) {
-        coordinator.generation += 1;
+
+      // Ownership: only a top-level session rooted in the Fleet home may hold
+      // the bridge. Subagent sessions carry parentID and are never candidates;
+      // sessions in any other directory are not this Fleet's supervisor.
+      const info = await sessionInfo(sessionID);
+      if (!qualifiesSession(info, HAND_HOME)) return;
+
+      if (primary !== null && primary !== sessionID) {
+        // A successor top-level Fleet-home session (/new, switch) retires the
+        // previous generation; stale callbacks become no-ops.
+        generation += 1;
         stopChild();
       }
-      if (coordinator.child) return;
+      primary = sessionID;
+      if (child) return;
       arm(sessionID);
     },
   };
 };
+
+// qualifiesSession is the exact primary-supervisor predicate, exported so the
+// generated artifact itself can be executed by tests.
+export function qualifiesSession(info, fleetHome) {
+  if (!info || typeof info !== "object") return false;
+  if (typeof info.parentID === "string" && info.parentID !== "") return false;
+  return info.directory === fleetHome;
+}

--- a/internal/supervision/assets/opencode/hand-supervisor-wake.js
+++ b/internal/supervision/assets/opencode/hand-supervisor-wake.js
@@ -1,0 +1,125 @@
+// Hand-owned supervisor wake integration (hand supervision). Managed by hand
+// init; edits are replaced on the next init. Placeholders __HAND_EXECUTABLE__
+// and __HAND_HOME__ are substituted at install time.
+//
+// Converts one Hand wake into exactly one OpenCode reasoning turn: after the
+// primary session goes idle, this plugin arms at most one `hand supervision
+// wait --host opencode` child; an eligible wake is delivered through the
+// synchronous session prompt, so acceptance means real assistant activity,
+// never a fire-and-forget enqueue. Stale session generations become no-ops.
+
+import { spawn } from "node:child_process";
+
+const HAND_EXE = "__HAND_EXECUTABLE__";
+const HAND_HOME = "__HAND_HOME__";
+const COORDINATOR_KEY = "__handSupervisorWake";
+const WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+
+export const HandSupervisorWake = async ({ client }) => {
+  const coordinator = {
+    generation: 0,
+    armedFor: null,
+    child: null,
+    timer: null,
+  };
+  globalThis[COORDINATOR_KEY] = coordinator;
+
+  const stopChild = () => {
+    if (coordinator.timer) {
+      clearTimeout(coordinator.timer);
+      coordinator.timer = null;
+    }
+    if (coordinator.child) {
+      coordinator.child.kill();
+      coordinator.child = null;
+    }
+    coordinator.armedFor = null;
+  };
+
+  const wakeText = (stdout) => {
+    for (const line of stdout.split("\n")) {
+      if (line.startsWith("text: ")) return line.slice(6).trim();
+    }
+    return "";
+  };
+
+  const deliver = async (sessionID, text) => {
+    const prompt =
+      text ||
+      "Hand has current actionable work. Run `hand orient` before reasoning or acting.";
+    // Synchronous prompt semantics only: awaiting the response is what makes
+    // delivery progressed evidence. promptAsync/204 is explicitly not proof a
+    // model turn started.
+    await client.session.prompt({
+      path: { id: sessionID },
+      body: { parts: [{ type: "text", text: prompt }] },
+    });
+  };
+
+  const arm = (sessionID) => {
+    if (coordinator.armedFor === sessionID && coordinator.child) return;
+    if (coordinator.armedFor !== null) stopChild();
+    coordinator.armedFor = sessionID;
+
+    const child = spawn(
+      HAND_EXE,
+      ["supervision", "wait", "--host", "opencode", "--timeout", "30m"],
+      { cwd: HAND_HOME, env: { ...process.env, HAND_HOME: HAND_HOME }, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    coordinator.child = child;
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+
+    const generation = coordinator.generation;
+    child.on("close", (code, signal) => {
+      if (coordinator.generation !== generation || coordinator.child !== child) return;
+      coordinator.child = null;
+      if (coordinator.timer) {
+        clearTimeout(coordinator.timer);
+        coordinator.timer = null;
+      }
+      // 0 eligible wake, 4 checkpoint with no wake: both re-arm on the next
+      // idle event. 8 interrupted and 9 replaced mean another Hand process now
+      // owns coordination; arming again here would fight it.
+      if (code === 0 || code === 4) {
+        if (code === 0) {
+          deliver(sessionID, wakeText(stdout)).catch((err) => {
+            process.stderr.write("hand supervisor wake: prompt failed: " + err + "\n");
+          });
+        }
+        coordinator.armedFor = null;
+        return;
+      }
+      if (code === 5) {
+        process.stderr.write(
+          "hand supervisor wake: monitoring failed; run `hand doctor` in " + HAND_HOME + "\n",
+        );
+      }
+      coordinator.armedFor = null;
+    });
+
+    coordinator.timer = setTimeout(() => {
+      if (coordinator.child === child) child.kill();
+    }, WAIT_TIMEOUT_MS);
+  };
+
+  return {
+    event: async ({ event }) => {
+      if (event.type !== "session.idle") return;
+      const sessionID = event.properties?.sessionID;
+      if (!sessionID) return;
+      // A different session ID is a successor generation (/new, switch,
+      // replacement): its callbacks retire the previous arm instead of
+      // targeting it.
+      if (coordinator.armedFor !== null && coordinator.armedFor !== sessionID) {
+        coordinator.generation += 1;
+        stopChild();
+      }
+      if (coordinator.child) return;
+      arm(sessionID);
+    },
+  };
+};

--- a/internal/supervision/assets/pi/hand-supervisor-wake.ts
+++ b/internal/supervision/assets/pi/hand-supervisor-wake.ts
@@ -1,20 +1,40 @@
 // Hand-owned supervisor wake integration (hand supervision). Managed by hand
 // init; edits are replaced on the next init. Placeholders __HAND_EXECUTABLE__
-// and __HAND_HOME__ are substituted at install time.
+// and __HAND_HOME__ are substituted as JSON string literals at install time.
 //
-// Converts one Hand wake into exactly one Pi reasoning turn: while the primary
-// session is settled, this extension arms at most one `hand supervision wait
-// --host pi` child; an eligible wake is delivered as a mechanism follow-up
-// message that triggers a turn, never as a fabricated operator answer.
-// session_shutdown covers ordinary same-process replacements (/new, /resume,
-// /fork, reload), so a retired generation's callbacks are no-ops.
+// Converts one Hand wake into exactly one Pi reasoning turn, forever while the
+// session lives: the extension arms one `hand supervision wait` child whenever
+// the agent is settled, delivers an eligible wake as a mechanism message that
+// triggers a turn (never a fabricated operator/user message), and the settled
+// event after the resulting turn re-arms the next cycle. session_start and
+// session_shutdown carry generation ownership, so /new, /resume, /fork, reload,
+// and quit retire stale callbacks instead of letting a retired wait deliver
+// into a successor session.
 
 import { spawn } from "node:child_process";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-const HAND_EXE = "__HAND_EXECUTABLE__";
-const HAND_HOME = "__HAND_HOME__";
-const WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+const HAND_EXE = __HAND_EXECUTABLE__;
+const HAND_HOME = __HAND_HOME__;
+const WAKE_SCHEMA = "hand.supervision.wake.v1";
+
+// parseWake accepts only the versioned machine protocol; anything else fails
+// closed rather than improvising on rendered human output.
+export function parseWake(
+  stdout: string,
+): { schema: string; fleet_id: string; message?: string; episodes?: Array<{ key: string }> } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  const record = parsed as { schema?: unknown; fleet_id?: unknown };
+  if (!record || typeof record !== "object" || record.schema !== WAKE_SCHEMA || typeof record.fleet_id !== "string") {
+    return null;
+  }
+  return parsed as { schema: string; fleet_id: string; message?: string; episodes?: Array<{ key: string }> };
+}
 
 export default function (pi: ExtensionAPI) {
   let generation = 0;
@@ -32,58 +52,91 @@ export default function (pi: ExtensionAPI) {
     }
   };
 
-  const wakeText = (stdout: string): string => {
-    for (const line of stdout.split("\n")) {
-      if (line.startsWith("text: ")) return line.slice(6).trim();
+  const receipt = (stage: string, episodes: Array<{ key: string }>, detail?: string) => {
+    const argv = ["supervision", "receipt", "--host", "pi", "--stage", stage];
+    for (const episode of episodes || []) {
+      argv.push("--episode", episode.key);
     }
-    return "";
+    if (detail) {
+      argv.push("--detail", String(detail).slice(0, 200));
+    }
+    try {
+      spawn(HAND_EXE, argv, {
+        cwd: HAND_HOME,
+        env: { ...process.env, HAND_HOME: HAND_HOME },
+        stdio: "ignore",
+      });
+    } catch {}
   };
 
   const arm = () => {
     if (child) return;
-    const current = generation;
-    const started = spawn(
+    const started = generation;
+    const startedChild = spawn(
       HAND_EXE,
-      ["supervision", "wait", "--host", "pi", "--timeout", "30m"],
-      { cwd: HAND_HOME, env: { ...process.env, HAND_HOME: HAND_HOME }, stdio: ["ignore", "pipe", "pipe"] },
+      ["supervision", "wait", "--host", "pi", "--format", "json", "--timeout", "30m"],
+      {
+        cwd: HAND_HOME,
+        env: { ...process.env, HAND_HOME: HAND_HOME },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
     );
-    child = started;
+    child = startedChild;
 
     let stdout = "";
-    started.stdout?.on("data", (chunk: Buffer) => {
+    let stderr = "";
+    startedChild.stdout?.on("data", (chunk: Buffer) => {
       stdout += chunk;
     });
+    startedChild.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk;
+    });
 
-    started.on("close", (code) => {
-      if (generation !== current || child !== started) return;
+    startedChild.on("close", (code) => {
+      if (generation !== started || child !== startedChild) return;
       child = null;
       if (timer) {
         clearTimeout(timer);
         timer = null;
       }
-      // 0 eligible wake, 4 checkpoint with no wake: both re-arm via
-      // session_start/turn-end arming. 8 interrupted and 9 replaced mean
-      // another Hand process owns coordination now; do not fight it.
+      // 0 eligible wake, 4 checkpoint without one: the next agent_settled
+      // re-arms either way. 3 means another live runtime owns the bridge.
+      // 8 interrupted / 9 replaced mean another Hand process took over.
       if (code === 0) {
+        const payload = parseWake(stdout);
+        if (!payload) {
+          process.stderr.write(
+            "hand supervisor wake: unexpected wait output schema; run `hand init " +
+              HAND_HOME +
+              "` to refresh this integration\n",
+          );
+          return;
+        }
         void pi
-          .sendUserMessage(
-            wakeText(stdout) ||
-              "Hand has current actionable work. Run `hand orient` before reasoning or acting.",
-            { deliverAs: "followUp" },
+          .sendMessage(
+            {
+              customType: "hand-supervisor-wake",
+              content:
+                payload.message && payload.message.trim() !== ""
+                  ? payload.message
+                  : "Hand has current actionable work. Run `hand orient` before reasoning or acting.",
+              display: true,
+            },
+            { triggerTurn: true, deliverAs: "followUp" },
           )
+          .then(() => receipt("accepted", payload.episodes ?? []))
           .catch((err) => {
-            process.stderr.write("hand supervisor wake: follow-up failed: " + err + "\n");
+            process.stderr.write("hand supervisor wake: mechanism message failed: " + err + "\n");
+            receipt("delivery-failed", [], err);
           });
-      } else if (code === 5) {
-        process.stderr.write(
-          "hand supervisor wake: monitoring failed; run `hand doctor` in " + HAND_HOME + "\n",
-        );
+      } else if (code === 5 && stderr.trim() !== "") {
+        process.stderr.write("hand supervisor wake: " + stderr.trim().split("\n")[0] + "\n");
       }
     });
 
     timer = setTimeout(() => {
-      if (child === started) started.kill();
-    }, WAIT_TIMEOUT_MS);
+      if (child === startedChild) startedChild.kill();
+    }, 31 * 60 * 1000);
   };
 
   pi.on?.("session_start", () => {
@@ -94,5 +147,12 @@ export default function (pi: ExtensionAPI) {
   pi.on?.("session_shutdown", () => {
     generation += 1;
     stopChild();
+  });
+
+  // The settled signal is what makes supervision continuous instead of
+  // one-shot: after every turn - including the turn a wake triggered - the
+  // next wait is armed here without model memory.
+  pi.on?.("agent_settled", () => {
+    arm();
   });
 }

--- a/internal/supervision/assets/pi/hand-supervisor-wake.ts
+++ b/internal/supervision/assets/pi/hand-supervisor-wake.ts
@@ -1,0 +1,98 @@
+// Hand-owned supervisor wake integration (hand supervision). Managed by hand
+// init; edits are replaced on the next init. Placeholders __HAND_EXECUTABLE__
+// and __HAND_HOME__ are substituted at install time.
+//
+// Converts one Hand wake into exactly one Pi reasoning turn: while the primary
+// session is settled, this extension arms at most one `hand supervision wait
+// --host pi` child; an eligible wake is delivered as a mechanism follow-up
+// message that triggers a turn, never as a fabricated operator answer.
+// session_shutdown covers ordinary same-process replacements (/new, /resume,
+// /fork, reload), so a retired generation's callbacks are no-ops.
+
+import { spawn } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const HAND_EXE = "__HAND_EXECUTABLE__";
+const HAND_HOME = "__HAND_HOME__";
+const WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+
+export default function (pi: ExtensionAPI) {
+  let generation = 0;
+  let child: ReturnType<typeof spawn> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const stopChild = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (child) {
+      child.kill();
+      child = null;
+    }
+  };
+
+  const wakeText = (stdout: string): string => {
+    for (const line of stdout.split("\n")) {
+      if (line.startsWith("text: ")) return line.slice(6).trim();
+    }
+    return "";
+  };
+
+  const arm = () => {
+    if (child) return;
+    const current = generation;
+    const started = spawn(
+      HAND_EXE,
+      ["supervision", "wait", "--host", "pi", "--timeout", "30m"],
+      { cwd: HAND_HOME, env: { ...process.env, HAND_HOME: HAND_HOME }, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    child = started;
+
+    let stdout = "";
+    started.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk;
+    });
+
+    started.on("close", (code) => {
+      if (generation !== current || child !== started) return;
+      child = null;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      // 0 eligible wake, 4 checkpoint with no wake: both re-arm via
+      // session_start/turn-end arming. 8 interrupted and 9 replaced mean
+      // another Hand process owns coordination now; do not fight it.
+      if (code === 0) {
+        void pi
+          .sendUserMessage(
+            wakeText(stdout) ||
+              "Hand has current actionable work. Run `hand orient` before reasoning or acting.",
+            { deliverAs: "followUp" },
+          )
+          .catch((err) => {
+            process.stderr.write("hand supervisor wake: follow-up failed: " + err + "\n");
+          });
+      } else if (code === 5) {
+        process.stderr.write(
+          "hand supervisor wake: monitoring failed; run `hand doctor` in " + HAND_HOME + "\n",
+        );
+      }
+    });
+
+    timer = setTimeout(() => {
+      if (child === started) started.kill();
+    }, WAIT_TIMEOUT_MS);
+  };
+
+  pi.on?.("session_start", () => {
+    generation += 1;
+    arm();
+  });
+
+  pi.on?.("session_shutdown", () => {
+    generation += 1;
+    stopChild();
+  });
+}

--- a/internal/supervision/assets_artifacts_test.go
+++ b/internal/supervision/assets_artifacts_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,10 +29,7 @@ func TestGeneratedOpenCodePluginParsesAsESM(t *testing.T) {
 func TestGeneratedPiExtensionTranspiles(t *testing.T) {
 	bunPath, err := exec.LookPath("bun")
 	if err != nil {
-		bunPath, err = exec.LookPath("npx")
-		if err != nil {
-			t.Skip("neither bun nor npx is available for artifact transpiling")
-		}
+		t.Skip("bun is not available for artifact transpiling")
 	}
 	rendered := renderAsset(HostAssets("pi")[0], `/opt/my hand\bin`, "/fleet home")
 	dir := t.TempDir()
@@ -41,13 +37,24 @@ func TestGeneratedPiExtensionTranspiles(t *testing.T) {
 	if err := os.WriteFile(path, rendered, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	var cmd *exec.Cmd
-	if strings.HasSuffix(bunPath, "bun") {
-		cmd = exec.Command(bunPath, "build", path, "--outfile", filepath.Join(dir, "out.js"))
-	} else {
-		cmd = exec.Command(bunPath, "--yes", "esbuild@latest", path, "--loader=ts", "--outfile="+filepath.Join(dir, "out.js"))
+	// Stub the host's extension module so bundling resolves offline; only
+	// syntax and type-stripping of the generated artifact are under test.
+	stub := filepath.Join(dir, "node_modules", "@earendil-works", "pi-coding-agent")
+	if err := os.MkdirAll(stub, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	out, err := cmd.CombinedOutput()
+	pkg := `{"name":"@earendil-works/pi-coding-agent","version":"0.0.0","types":"./index.d.ts","main":"./index.js"}`
+	if err := os.WriteFile(filepath.Join(stub, "package.json"), []byte(pkg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stub, "index.d.ts"), []byte("export type ExtensionAPI = any;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stub, "index.js"), []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command(bunPath, "build", path, "--outdir", filepath.Join(dir, "out")).CombinedOutput()
 	if err != nil {
 		t.Fatalf("transpiler rejected the generated extension: %v\n%s", err, out)
 	}
@@ -101,9 +108,6 @@ console.log("ok");
 // Executes the generated Pi extension's protocol parser in bun when present:
 // only the versioned machine protocol parses; human rendering never does.
 func TestGeneratedPiProtocolParserExecutes(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bun execution path verified on unix runners")
-	}
 	bunPath, err := exec.LookPath("bun")
 	if err != nil {
 		t.Skip("bun is not available to execute the generated extension")

--- a/internal/supervision/assets_artifacts_test.go
+++ b/internal/supervision/assets_artifacts_test.go
@@ -1,0 +1,129 @@
+package supervision
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The generated host artifacts must be executable syntax, not plausible
+// substrings: node parses the OpenCode plugin and bun transpiles the Pi
+// extension whenever those toolchains run this suite.
+func TestGeneratedOpenCodePluginParsesAsESM(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is not available for artifact parsing")
+	}
+	rendered := renderAsset(HostAssets("opencode")[0], "/opt/bin/hand", "/fleet home")
+	path := filepath.Join(t.TempDir(), "hand-supervisor-wake.mjs")
+	if err := os.WriteFile(path, rendered, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("node", "--check", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("node --check rejected the generated plugin: %v\n%s", err, out)
+	}
+}
+
+func TestGeneratedPiExtensionTranspiles(t *testing.T) {
+	bunPath, err := exec.LookPath("bun")
+	if err != nil {
+		bunPath, err = exec.LookPath("npx")
+		if err != nil {
+			t.Skip("neither bun nor npx is available for artifact transpiling")
+		}
+	}
+	rendered := renderAsset(HostAssets("pi")[0], `/opt/my hand\bin`, "/fleet home")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hand-supervisor-wake.ts")
+	if err := os.WriteFile(path, rendered, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bunPath, "bun") {
+		cmd = exec.Command(bunPath, "build", path, "--outfile", filepath.Join(dir, "out.js"))
+	} else {
+		cmd = exec.Command(bunPath, "--yes", "esbuild@latest", path, "--loader=ts", "--outfile="+filepath.Join(dir, "out.js"))
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("transpiler rejected the generated extension: %v\n%s", err, out)
+	}
+}
+
+// The protocol schema constant and both generated adapters must agree; a
+// drifted literal would fail closed at runtime instead of delivering.
+func TestWakeSchemaMatchesGeneratedAdapters(t *testing.T) {
+	for _, asset := range []Asset{HostAssets("opencode")[0], HostAssets("pi")[0]} {
+		body := string(asset.Body)
+		if !strings.Contains(body, `"`+WakeSchema+`"`) && !strings.Contains(body, WakeSchema) {
+			t.Fatalf("%s does not carry the wake schema constant %q", asset.RelPath, WakeSchema)
+		}
+	}
+}
+
+// Executes the generated OpenCode plugin's ownership predicate inside its own
+// runtime: subagents (parentID) and sessions outside the Fleet home can never
+// qualify as the primary supervisor.
+func TestGeneratedOpenCodeOwnershipPredicateExecutes(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is not available to execute the generated plugin")
+	}
+	rendered := string(renderAsset(HostAssets("opencode")[0], "/opt/bin/hand", "/fleet/home"))
+	script := `
+const { qualifiesSession } = await import(process.env.HAND_PLUGIN_PATH);
+const assert = (cond, msg) => { if (!cond) { console.error(msg); process.exit(1); } };
+assert(qualifiesSession({ directory: "/fleet/home" }, "/fleet/home") === true, "primary session must qualify");
+assert(qualifiesSession({ directory: "/fleet/home", parentID: "p1" }, "/fleet/home") === false, "subagent must not qualify");
+assert(qualifiesSession({ directory: "/other/project" }, "/fleet/home") === false, "foreign project must not qualify");
+assert(qualifiesSession(null, "/fleet/home") === false, "missing info must not qualify");
+console.log("ok");
+`
+	tmp := t.TempDir()
+	pluginPath := filepath.Join(tmp, "plugin.mjs")
+	if err := os.WriteFile(pluginPath, []byte(rendered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testPath := filepath.Join(tmp, "ownership.test.mjs")
+	if err := os.WriteFile(testPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("node", testPath)
+	cmd.Env = append(os.Environ(), "HAND_PLUGIN_PATH="+pluginPath, "HAND_HOME=")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated plugin failed its executed contract: %v\n%s", err, out)
+	}
+}
+
+// Executes the generated Pi extension's protocol parser in bun when present:
+// only the versioned machine protocol parses; human rendering never does.
+func TestGeneratedPiProtocolParserExecutes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bun execution path verified on unix runners")
+	}
+	bunPath, err := exec.LookPath("bun")
+	if err != nil {
+		t.Skip("bun is not available to execute the generated extension")
+	}
+	rendered := string(renderAsset(HostAssets("pi")[0], "/opt/bin/hand", "/fleet/home"))
+	script := rendered + `
+const assert = (cond, msg) => { if (!cond) { console.error(msg); process.exit(1); } };
+const good = parseWake(JSON.stringify({ schema: "hand.supervision.wake.v1", fleet_id: "f_1", message: "m", episodes: [{ key: "k" }] }));
+assert(good !== null && good.fleet_id === "f_1" && good.episodes[0].key === "k", "valid protocol must parse");
+assert(parseWake("text: hand has work") === null, "rendered TOON must not parse");
+assert(parseWake("{\"schema\":\"other.v9\"}") === null, "unknown schema must fail closed");
+assert(parseWake("not json") === null, "garbage must fail closed");
+console.log("ok");
+`
+	path := filepath.Join(t.TempDir(), "extension.test.ts")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(bunPath, "run", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated extension failed its executed contract: %v\n%s", err, out)
+	}
+}

--- a/internal/supervision/assets_artifacts_test.go
+++ b/internal/supervision/assets_artifacts_test.go
@@ -80,7 +80,8 @@ func TestGeneratedOpenCodeOwnershipPredicateExecutes(t *testing.T) {
 	}
 	rendered := string(renderAsset(HostAssets("opencode")[0], "/opt/bin/hand", "/fleet/home"))
 	script := `
-const { qualifiesSession } = await import(process.env.HAND_PLUGIN_PATH);
+import { pathToFileURL } from "node:url";
+const { qualifiesSession } = await import(pathToFileURL(process.env.HAND_PLUGIN_PATH));
 const assert = (cond, msg) => { if (!cond) { console.error(msg); process.exit(1); } };
 assert(qualifiesSession({ directory: "/fleet/home" }, "/fleet/home") === true, "primary session must qualify");
 assert(qualifiesSession({ directory: "/fleet/home", parentID: "p1" }, "/fleet/home") === false, "subagent must not qualify");

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -164,34 +164,27 @@ func ClearAttachment(home, host, runtime string) {
 	})
 }
 
-// ReadAttachment returns the current record for diagnostics, or nil when
-// none exists or the file is unreadable/corrupt. Diagnostics tolerate the
-// race; ownership decisions never rely on this unlocked read.
+// Diagnostics read of the current record under the attachment lock: Windows
+// rename-vs-read races would otherwise tear it. Nil when absent or corrupt.
 func ReadAttachment(home string) *AttachmentRecord {
-	data, err := os.ReadFile(attachmentPath(home))
-	if err != nil {
-		return nil
-	}
-	var record AttachmentRecord
-	if json.Unmarshal(data, &record) != nil {
-		return nil
-	}
-	return &record
+	var record *AttachmentRecord
+	_ = mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
+		record = existing
+		return nil, false, nil
+	})
+	return record
 }
 
 // BridgeOwner reports the live runtime holding host's bridge, or empty when
-// no fresh record exists for that host.
+// no fresh record exists for that host. Locked like every other ownership
+// decision path.
 func BridgeOwner(home string, host string, now time.Time) string {
-	data, err := os.ReadFile(attachmentPath(home))
-	if err != nil {
-		return ""
-	}
-	var record AttachmentRecord
-	if json.Unmarshal(data, &record) != nil {
-		return ""
-	}
-	if !record.Fresh(now) || record.Host != host {
-		return ""
-	}
-	return record.Runtime
+	var owner string
+	_ = mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
+		if existing != nil && existing.Fresh(now) && existing.Host == host {
+			owner = existing.Runtime
+		}
+		return nil, false, nil
+	})
+	return owner
 }

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -165,9 +165,25 @@ func ClearAttachment(home, host, runtime string) {
 }
 
 // Diagnostics read of the current record, or nil when absent or corrupt.
-// Deliberately lock-free: diagnostics must not litter the observed home with
-// lock files, and POSIX rename never tears an unlocked read.
+// Never creates a lock file: with no writer lock on disk nothing can race,
+// and once one exists the read takes it so Windows renames never starve.
 func ReadAttachment(home string) *AttachmentRecord {
+	if _, err := os.Stat(attachmentLockPath(home)); os.IsNotExist(err) {
+		return readAttachmentFile(home)
+	}
+	lock, err := os.OpenFile(attachmentLockPath(home), os.O_RDWR, 0o644)
+	if err != nil {
+		return readAttachmentFile(home)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := filelock.Lock(lock, true); err != nil {
+		return readAttachmentFile(home)
+	}
+	defer func() { _ = filelock.Unlock(lock) }()
+	return readAttachmentFile(home)
+}
+
+func readAttachmentFile(home string) *AttachmentRecord {
 	data, err := os.ReadFile(attachmentPath(home))
 	if err != nil {
 		return nil

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -105,14 +105,20 @@ func mutateAttachment(home string, change func(existing *AttachmentRecord) (*Att
 	return nil
 }
 
-// Claims host's bridge for rec's runtime under the file lock. Returns false
-// when a fresh record shows another live runtime still holds it; stale,
-// foreign-schema, and absent records never block a takeover.
+// The exact bridge-owner identity combines harness AND runtime: the harness
+// selects the delivery mechanism, never an ownership domain - a Fleet holds
+// one live Supervisor bridge regardless of provider.
+func ownerKey(rec AttachmentRecord) string {
+	return rec.Host + "\x00" + rec.Runtime
+}
+
+// Claims THE Fleet bridge for rec's owner under the file lock, exclusive
+// across every harness: false means a fresh record shows another live owner
+// still holding it. Stale or absent records never block a takeover.
 func AcquireAttachment(home string, rec AttachmentRecord) (bool, error) {
 	acquired := false
 	err := mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
-		if existing != nil && existing.Fresh(time.Now()) &&
-			existing.Host == rec.Host && existing.Runtime != "" && existing.Runtime != rec.Runtime {
+		if existing != nil && existing.Fresh(time.Now()) && ownerKey(*existing) != ownerKey(rec) {
 			return nil, false, nil
 		}
 		acquired = true
@@ -124,22 +130,20 @@ func AcquireAttachment(home string, rec AttachmentRecord) (bool, error) {
 	return acquired, nil
 }
 
-// Re-stamps the heartbeat when the record still belongs to rec's runtime.
+// Re-stamps the heartbeat when the record still belongs to rec's exact owner,
+// preserving the original StartedAt and advancing the lease explicitly.
 // False means ownership moved elsewhere: stop claiming the bridge.
-func RefreshAttachment(home string, rec AttachmentRecord) (bool, error) {
+func RefreshAttachment(home string, rec AttachmentRecord, lease time.Duration) (bool, error) {
 	ours := false
 	err := mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
-		if existing == nil || existing.Runtime != rec.Runtime || existing.Host != rec.Host {
+		if existing == nil || ownerKey(*existing) != ownerKey(rec) {
 			return nil, false, nil
 		}
 		now := time.Now()
 		fresh := rec
 		fresh.StartedAt = existing.StartedAt
 		fresh.HeartbeatAt = now
-		fresh.ExpiresAt = now.Add(time.Until(rec.ExpiresAt))
-		if fresh.ExpiresAt.Before(now) {
-			fresh.ExpiresAt = now.Add(time.Minute)
-		}
+		fresh.ExpiresAt = now.Add(lease)
 		ours = true
 		return &fresh, true, nil
 	})

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -2,13 +2,14 @@ package supervision
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/filelock"
 )
 
 // AttachmentSchema versions the bridge-attachment record. It is mechanism
@@ -16,7 +17,10 @@ import (
 // bridge for one runtime, never workflow authority of any kind.
 const AttachmentSchema = "hand.supervision.attachment.v1"
 
-const attachmentRel = "state/runtime/supervision-attachment.json"
+const (
+	attachmentRel        = "state/runtime/supervision-attachment.json"
+	attachmentLockSuffix = ".lock"
+)
 
 // AttachmentRecord is one running wait's claim on its host's wake bridge.
 // HeartbeatAt/ExpiresAt make staleness mechanical: a dead child stops
@@ -40,33 +44,125 @@ func (r AttachmentRecord) Fresh(now time.Time) bool {
 	return now.Before(r.ExpiresAt)
 }
 
-// ErrBridgeOwned is Wait's result when another live runtime already holds
-// this host's bridge. A secondary session must defer, not steal.
-var ErrBridgeOwned = fmt.Errorf("wake bridge is owned by another live runtime")
-
-var attachmentMu sync.Mutex
+// ErrBridgeOwned is the result when another live runtime already holds this
+// host's bridge. A secondary session must defer, not steal.
+var ErrBridgeOwned = errors.New("wake bridge is owned by another live runtime")
 
 func attachmentPath(home string) string { return filepath.Join(home, attachmentRel) }
 
-// WriteAttachment atomically replaces the fleet home's bridge-attachment
-// record; it runs under one process-wide mutex because each wait child owns
-// exactly one record and children never share one.
-func WriteAttachment(home string, record AttachmentRecord) error {
-	attachmentMu.Lock()
-	defer attachmentMu.Unlock()
+func attachmentLockPath(home string) string {
+	return filepath.Join(home, attachmentRel+attachmentLockSuffix)
+}
+
+// Runs change under the attachment's advisory file lock, so acquire, refresh,
+// and clear decisions are atomic across processes, not just goroutines.
+func mutateAttachment(home string, change func(existing *AttachmentRecord) (*AttachmentRecord, bool, error)) error {
 	if err := os.MkdirAll(filepath.Dir(attachmentPath(home)), 0o755); err != nil {
 		return fmt.Errorf("create %s: %w", filepath.Dir(attachmentRel), err)
 	}
-	record.Schema = AttachmentSchema
-	encoded, err := json.MarshalIndent(record, "", "  ")
+	lock, err := os.OpenFile(attachmentLockPath(home), os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
+		return fmt.Errorf("open %s: %w", attachmentRel+attachmentLockSuffix, err)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := filelock.Lock(lock, true); err != nil {
+		return fmt.Errorf("lock %s: %w", attachmentRel+attachmentLockSuffix, err)
+	}
+	defer func() { _ = filelock.Unlock(lock) }()
+
+	existing, err := os.ReadFile(attachmentPath(home))
+	var record *AttachmentRecord
+	switch {
+	case err == nil:
+		record = &AttachmentRecord{}
+		if json.Unmarshal(existing, record) != nil || record.Schema != AttachmentSchema {
+			record = nil
+		}
+	case os.IsNotExist(err):
+	default:
+		return fmt.Errorf("read %s: %w", attachmentRel, err)
+	}
+
+	next, write, err := change(record)
+	if err != nil || !write {
 		return err
 	}
-	return atomicfile.Write(attachmentPath(home), ".supervision-attachment-", append(encoded, '\n'), 0o644)
+	if next == nil {
+		// Removal verdict: drop the record so nothing reads as attached.
+		if rmErr := os.Remove(attachmentPath(home)); rmErr != nil && !os.IsNotExist(rmErr) {
+			return fmt.Errorf("remove %s: %w", attachmentRel, rmErr)
+		}
+		return nil
+	}
+	next.Schema = AttachmentSchema
+	encoded, encodeErr := json.MarshalIndent(next, "", "  ")
+	if encodeErr != nil {
+		return encodeErr
+	}
+	if writeErr := atomicfile.Write(attachmentPath(home), ".supervision-attachment-", append(encoded, '\n'), 0o644); writeErr != nil {
+		return fmt.Errorf("write %s: %w", attachmentRel, writeErr)
+	}
+	return nil
 }
 
-// ReadAttachment returns the current record, or nil when none exists or the
-// file is unreadable or corrupt - all three mean "nothing attached".
+// Claims host's bridge for rec's runtime under the file lock. Returns false
+// when a fresh record shows another live runtime still holds it; stale,
+// foreign-schema, and absent records never block a takeover.
+func AcquireAttachment(home string, rec AttachmentRecord) (bool, error) {
+	acquired := false
+	err := mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
+		if existing != nil && existing.Fresh(time.Now()) &&
+			existing.Host == rec.Host && existing.Runtime != "" && existing.Runtime != rec.Runtime {
+			return nil, false, nil
+		}
+		acquired = true
+		return &rec, true, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
+}
+
+// Re-stamps the heartbeat when the record still belongs to rec's runtime.
+// False means ownership moved elsewhere: stop claiming the bridge.
+func RefreshAttachment(home string, rec AttachmentRecord) (bool, error) {
+	ours := false
+	err := mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
+		if existing == nil || existing.Runtime != rec.Runtime || existing.Host != rec.Host {
+			return nil, false, nil
+		}
+		now := time.Now()
+		fresh := rec
+		fresh.StartedAt = existing.StartedAt
+		fresh.HeartbeatAt = now
+		fresh.ExpiresAt = now.Add(time.Until(rec.ExpiresAt))
+		if fresh.ExpiresAt.Before(now) {
+			fresh.ExpiresAt = now.Add(time.Minute)
+		}
+		ours = true
+		return &fresh, true, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return ours, nil
+}
+
+// Removes the record only when it still belongs to this runtime, so a
+// replaced child cannot revoke its successor's claim.
+func ClearAttachment(home, host, runtime string) {
+	_ = mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
+		if existing == nil || existing.Host != host || existing.Runtime != runtime {
+			return nil, false, nil
+		}
+		return nil, true, nil
+	})
+}
+
+// ReadAttachment returns the current record for diagnostics, or nil when
+// none exists or the file is unreadable/corrupt. Diagnostics tolerate the
+// race; ownership decisions never rely on this unlocked read.
 func ReadAttachment(home string) *AttachmentRecord {
 	data, err := os.ReadFile(attachmentPath(home))
 	if err != nil {
@@ -79,30 +175,18 @@ func ReadAttachment(home string) *AttachmentRecord {
 	return &record
 }
 
-// ClearAttachment removes the record when it still belongs to this runtime,
-// so a replaced child cannot revoke its successor's claim.
-func ClearAttachment(home, host, runtime string) {
-	attachmentMu.Lock()
-	defer attachmentMu.Unlock()
-	data, err := os.ReadFile(attachmentPath(home))
-	if err != nil {
-		return
-	}
-	var record AttachmentRecord
-	if json.Unmarshal(data, &record) != nil {
-		_ = os.Remove(attachmentPath(home))
-		return
-	}
-	if record.Host == host && record.Runtime == runtime {
-		_ = os.Remove(attachmentPath(home))
-	}
-}
-
 // BridgeOwner reports the live runtime holding host's bridge, or empty when
 // no fresh record exists for that host.
 func BridgeOwner(home string, host string, now time.Time) string {
-	record := ReadAttachment(home)
-	if record == nil || !record.Fresh(now) || record.Host != host {
+	data, err := os.ReadFile(attachmentPath(home))
+	if err != nil {
+		return ""
+	}
+	var record AttachmentRecord
+	if json.Unmarshal(data, &record) != nil {
+		return ""
+	}
+	if !record.Fresh(now) || record.Host != host {
 		return ""
 	}
 	return record.Runtime

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -164,27 +164,30 @@ func ClearAttachment(home, host, runtime string) {
 	})
 }
 
-// Diagnostics read of the current record under the attachment lock: Windows
-// rename-vs-read races would otherwise tear it. Nil when absent or corrupt.
+// ReadAttachment returns the current record for diagnostics, or nil when
+// none exists or the file is unreadable/corrupt. Deliberately lock-free:
+// diagnostics must not create lock files in the home they only observe, and
+// POSIX rename keeps an unlocked read from ever tearing.
 func ReadAttachment(home string) *AttachmentRecord {
-	var record *AttachmentRecord
-	_ = mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
-		record = existing
-		return nil, false, nil
-	})
-	return record
+	data, err := os.ReadFile(attachmentPath(home))
+	if err != nil {
+		return nil
+	}
+	var record AttachmentRecord
+	if json.Unmarshal(data, &record) != nil || record.Schema != AttachmentSchema {
+		return nil
+	}
+	return &record
 }
 
 // BridgeOwner reports the live runtime holding host's bridge, or empty when
-// no fresh record exists for that host. Locked like every other ownership
-// decision path.
+// no fresh record exists for that host. Ownership DECISIONS still go through
+// the locked acquire/refresh paths; this read only informs diagnostics and
+// deferral checks, where a just-expired record is a safe false negative.
 func BridgeOwner(home string, host string, now time.Time) string {
-	var owner string
-	_ = mutateAttachment(home, func(existing *AttachmentRecord) (*AttachmentRecord, bool, error) {
-		if existing != nil && existing.Fresh(now) && existing.Host == host {
-			owner = existing.Runtime
-		}
-		return nil, false, nil
-	})
-	return owner
+	record := ReadAttachment(home)
+	if record == nil || !record.Fresh(now) || record.Host != host {
+		return ""
+	}
+	return record.Runtime
 }

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -164,10 +164,9 @@ func ClearAttachment(home, host, runtime string) {
 	})
 }
 
-// ReadAttachment returns the current record for diagnostics, or nil when
-// none exists or the file is unreadable/corrupt. Deliberately lock-free:
-// diagnostics must not create lock files in the home they only observe, and
-// POSIX rename keeps an unlocked read from ever tearing.
+// Diagnostics read of the current record, or nil when absent or corrupt.
+// Deliberately lock-free: diagnostics must not litter the observed home with
+// lock files, and POSIX rename never tears an unlocked read.
 func ReadAttachment(home string) *AttachmentRecord {
 	data, err := os.ReadFile(attachmentPath(home))
 	if err != nil {
@@ -180,10 +179,9 @@ func ReadAttachment(home string) *AttachmentRecord {
 	return &record
 }
 
-// BridgeOwner reports the live runtime holding host's bridge, or empty when
-// no fresh record exists for that host. Ownership DECISIONS still go through
-// the locked acquire/refresh paths; this read only informs diagnostics and
-// deferral checks, where a just-expired record is a safe false negative.
+// Reports the live runtime holding host's bridge, or empty when none. Real
+// ownership decisions run through locked acquire/refresh; this read only
+// informs diagnostics and deferral checks.
 func BridgeOwner(home string, host string, now time.Time) string {
 	record := ReadAttachment(home)
 	if record == nil || !record.Fresh(now) || record.Host != host {

--- a/internal/supervision/attachment.go
+++ b/internal/supervision/attachment.go
@@ -1,0 +1,109 @@
+package supervision
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/atqamz/hand/internal/atomicfile"
+)
+
+// AttachmentSchema versions the bridge-attachment record. It is mechanism
+// evidence only: a fresh record proves a live wait child claimed this host's
+// bridge for one runtime, never workflow authority of any kind.
+const AttachmentSchema = "hand.supervision.attachment.v1"
+
+const attachmentRel = "state/runtime/supervision-attachment.json"
+
+// AttachmentRecord is one running wait's claim on its host's wake bridge.
+// HeartbeatAt/ExpiresAt make staleness mechanical: a dead child stops
+// beating, and an expired record can never read as attached.
+type AttachmentRecord struct {
+	Schema      string    `json:"schema"`
+	Host        string    `json:"host"`
+	Runtime     string    `json:"runtime,omitempty"`
+	PID         int       `json:"pid"`
+	FleetID     string    `json:"fleet_id"`
+	StartedAt   time.Time `json:"started_at"`
+	HeartbeatAt time.Time `json:"heartbeat_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+// Fresh reports whether the record still describes a live wait.
+func (r AttachmentRecord) Fresh(now time.Time) bool {
+	if r.Schema != AttachmentSchema || r.Host == "" {
+		return false
+	}
+	return now.Before(r.ExpiresAt)
+}
+
+// ErrBridgeOwned is Wait's result when another live runtime already holds
+// this host's bridge. A secondary session must defer, not steal.
+var ErrBridgeOwned = fmt.Errorf("wake bridge is owned by another live runtime")
+
+var attachmentMu sync.Mutex
+
+func attachmentPath(home string) string { return filepath.Join(home, attachmentRel) }
+
+// WriteAttachment atomically replaces the fleet home's bridge-attachment
+// record; it runs under one process-wide mutex because each wait child owns
+// exactly one record and children never share one.
+func WriteAttachment(home string, record AttachmentRecord) error {
+	attachmentMu.Lock()
+	defer attachmentMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(attachmentPath(home)), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(attachmentRel), err)
+	}
+	record.Schema = AttachmentSchema
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicfile.Write(attachmentPath(home), ".supervision-attachment-", append(encoded, '\n'), 0o644)
+}
+
+// ReadAttachment returns the current record, or nil when none exists or the
+// file is unreadable or corrupt - all three mean "nothing attached".
+func ReadAttachment(home string) *AttachmentRecord {
+	data, err := os.ReadFile(attachmentPath(home))
+	if err != nil {
+		return nil
+	}
+	var record AttachmentRecord
+	if json.Unmarshal(data, &record) != nil {
+		return nil
+	}
+	return &record
+}
+
+// ClearAttachment removes the record when it still belongs to this runtime,
+// so a replaced child cannot revoke its successor's claim.
+func ClearAttachment(home, host, runtime string) {
+	attachmentMu.Lock()
+	defer attachmentMu.Unlock()
+	data, err := os.ReadFile(attachmentPath(home))
+	if err != nil {
+		return
+	}
+	var record AttachmentRecord
+	if json.Unmarshal(data, &record) != nil {
+		_ = os.Remove(attachmentPath(home))
+		return
+	}
+	if record.Host == host && record.Runtime == runtime {
+		_ = os.Remove(attachmentPath(home))
+	}
+}
+
+// BridgeOwner reports the live runtime holding host's bridge, or empty when
+// no fresh record exists for that host.
+func BridgeOwner(home string, host string, now time.Time) string {
+	record := ReadAttachment(home)
+	if record == nil || !record.Fresh(now) || record.Host != host {
+		return ""
+	}
+	return record.Runtime
+}

--- a/internal/supervision/correctness_test.go
+++ b/internal/supervision/correctness_test.go
@@ -2,8 +2,12 @@ package supervision
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,8 +19,8 @@ import (
 )
 
 // Two concurrent waiters racing on the same exact episode must produce
-// exactly one successful claim overall: eligibility and the requested stamp
-// happen inside one ledger transaction.
+// exactly ONE successful non-empty wake overall; every loser keeps waiting
+// until its checkpoint and never answers an empty success.
 func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
 	ledger := OpenLedger(t.TempDir())
 	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "blocked")}}
@@ -24,7 +28,7 @@ func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
 	stub, restore := newWatcherStub(t, false, nil)
 	defer restore()
 
-	var total atomic.Int64
+	var wakes, empties, checkpoints atomic.Int64
 	var wg sync.WaitGroup
 	for i := range 10 {
 		wg.Add(1)
@@ -35,16 +39,31 @@ func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
 				PollInterval: time.Millisecond,
 				Timeout:      150 * time.Millisecond,
 			})
-			if err != nil && !errors.Is(err, watcher.ErrNoEvent) {
+			switch {
+			case err != nil && errors.Is(err, watcher.ErrNoEvent):
+				checkpoints.Add(1)
+				if len(wake.Episodes) != 0 {
+					t.Errorf("waiter %d: checkpoint carried episodes", i)
+				}
+			case err != nil:
 				t.Errorf("waiter %d: %v", i, err)
-				return
+			case len(wake.Episodes) == 0:
+				t.Errorf("waiter %d answered an empty successful wake", i)
+				empties.Add(1)
+			default:
+				wakes.Add(1)
 			}
-			total.Add(int64(len(wake.Episodes)))
 		}(i)
 	}
 	wg.Wait()
-	if total.Load() != 1 {
-		t.Fatalf("claims = %d across 10 concurrent waiters, want exactly one", total.Load())
+	if wakes.Load() != 1 {
+		t.Fatalf("successful wakes = %d across 10 concurrent waiters, want exactly one", wakes.Load())
+	}
+	if empties.Load() != 0 {
+		t.Fatalf("empty successful wakes = %d, want zero", empties.Load())
+	}
+	if checkpoints.Load() != 9 {
+		t.Fatalf("losers that waited to checkpoint = %d, want all nine losers", checkpoints.Load())
 	}
 	if stub.acquired.Load() > 9 {
 		t.Fatalf("ownership acquisitions = %d, want one per losing waiter at most", stub.acquired.Load())
@@ -93,8 +112,8 @@ func TestSixteenDistinctEpisodesEachWakeOnce(t *testing.T) {
 			t.Fatal(err)
 		}
 		// The unchanged episode never re-claims afterwards.
-		if again := ledger.ClaimEligible(FromEvidence(evidence)); len(again) != 0 {
-			t.Fatalf("episode %d re-claimed after orient: %d", i, len(again))
+		if again, claimErr := ledger.ClaimEligible(FromEvidence(evidence)); claimErr != nil || len(again) != 0 {
+			t.Fatalf("episode %d re-claimed after orient: %d, %v", i, len(again), claimErr)
 		}
 	}
 }
@@ -104,12 +123,10 @@ func TestSixteenDistinctEpisodesEachWakeOnce(t *testing.T) {
 func TestAttachmentIsIndependentFromWatcherLiveness(t *testing.T) {
 	home := t.TempDir()
 	now := time.Now()
-	if err := WriteAttachment(home, AttachmentRecord{
+	writeAttachmentRecord(t, home, AttachmentRecord{
 		Host: "opencode", Runtime: "ses-1", PID: 1, FleetID: "f_1",
 		StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
 	status := Status{Harness: harness.OpenCode}
 	status.finishIndependentFields(StatusInput{Home: home})
 	if status.Attachment != "attached:ses-1" {
@@ -121,12 +138,10 @@ func TestAttachmentIsIndependentFromWatcherLiveness(t *testing.T) {
 
 	expired := home
 	status2 := Status{Harness: harness.OpenCode}
-	if err := WriteAttachment(expired, AttachmentRecord{
+	writeAttachmentRecord(t, expired, AttachmentRecord{
 		Host: "opencode", Runtime: "ses-9", PID: 1, FleetID: "f_1",
 		StartedAt: now.Add(-time.Hour), HeartbeatAt: now.Add(-time.Hour), ExpiresAt: now.Add(-time.Minute),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
 	status2.finishIndependentFields(StatusInput{Home: expired})
 	if status2.Attachment != "detached" {
 		t.Fatalf("expired heartbeat reads %q, want detached", status2.Attachment)
@@ -138,12 +153,10 @@ func TestAttachmentIsIndependentFromWatcherLiveness(t *testing.T) {
 func TestSecondaryRuntimeCannotStealAnAttachedBridge(t *testing.T) {
 	home := t.TempDir()
 	now := time.Now()
-	if err := WriteAttachment(home, AttachmentRecord{
+	writeAttachmentRecord(t, home, AttachmentRecord{
 		Host: "opencode", Runtime: "primary-session", PID: 424242, FleetID: "f_1",
 		StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
 	evidence := orientation.Evidence{FleetID: "f_1"}
 	stub, restore := newWatcherStub(t, true, nil)
 	defer restore()
@@ -224,9 +237,9 @@ func TestAcceptedThenCrashRecoversBounded(t *testing.T) {
 	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "unacknowledged")}}
 	episodes := FromEvidence(evidence)
 
-	claimed := ledger.ClaimEligible(episodes)
-	if len(claimed) != 1 {
-		t.Fatalf("claim = %d, want the episode", len(claimed))
+	claimed, claimErr := ledger.ClaimEligible(episodes)
+	if claimErr != nil || len(claimed) != 1 {
+		t.Fatalf("claim = %d, %v; want the episode", len(claimed), claimErr)
 	}
 	if err := ledger.MarkAccepted(Keys(claimed)); err != nil {
 		t.Fatal(err)
@@ -238,5 +251,189 @@ func TestAcceptedThenCrashRecoversBounded(t *testing.T) {
 	now = now.Add(2 * DefaultPolicy().ProgressTimeout)
 	if eligible := ledger.Eligible(episodes); len(eligible) != 1 {
 		t.Fatal("past the window bounded recovery re-eligibles the episode")
+	}
+}
+
+// The one deterministic episode cross-process children and parent both
+// derive, so their keys always agree.
+func fixedClaimEpisode() Episode {
+	return Episode{
+		FleetID: "f_fix", TargetID: "t_fix", TargetKind: "task",
+		Currentness: orientation.TargetFor("f_fix", orientation.TargetEvidence{ID: "t_fix", Kind: "task", Generation: []string{"gfix"}}).Currentness,
+		Kind:        "blocked",
+	}
+}
+
+// Child body for the cross-process tests: performs exactly one operation and
+// writes a JSON verdict, so the parent can count winners across real process
+// boundaries where flock - not a mutex - is the only coordination.
+func runSupervisionChild(op string) int {
+	home := os.Getenv("HAND_SUPERVISION_CHILD_HOME")
+	switch op {
+	case "claim":
+		claimed, err := OpenLedger(home).ClaimEligible([]Episode{fixedClaimEpisode()})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "child claim:", err)
+			return 3
+		}
+		return writeChildVerdict(len(claimed))
+	case "acquire":
+		now := time.Now()
+		acquired, err := AcquireAttachment(home, AttachmentRecord{
+			Host: "opencode", Runtime: os.Getenv("HAND_SUPERVISION_CHILD_RUNTIME"), PID: os.Getpid(),
+			FleetID: "f_fix", StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "child acquire:", err)
+			return 3
+		}
+		return writeChildVerdict(map[bool]int{true: 1, false: 0}[acquired])
+	}
+	fmt.Fprintln(os.Stderr, "unknown child op")
+	return 2
+}
+
+func writeChildVerdict(won int) int {
+	out := os.Getenv("HAND_SUPERVISION_CHILD_OUT")
+	if out == "" {
+		return 4
+	}
+	if err := os.WriteFile(out, []byte(fmt.Sprintf(`{"won":%d}`, won)), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "child verdict:", err)
+		return 4
+	}
+	return 0
+}
+
+// Spawns eight real processes that each attempt the same single-episode wake
+// claim simultaneously. Exactly one may win; the file lock is the only thing
+// coordinating them.
+func TestClaimIsAtomicAcrossProcesses(t *testing.T) {
+	if os.Getenv("HAND_SUPERVISION_CHILD_OP") != "" {
+		t.Skip("child mode")
+	}
+	home := t.TempDir()
+	wins := spawnSupervisionChildren(t, home, "claim", 8)
+	if wins != 1 {
+		t.Fatalf("winning claims across 8 processes = %d, want exactly one", wins)
+	}
+}
+
+// Two runtimes racing to acquire the same host bridge across process
+// boundaries: exactly one holds it, the other is told it is owned.
+func TestAttachmentAcquireIsAtomicAcrossProcesses(t *testing.T) {
+	if os.Getenv("HAND_SUPERVISION_CHILD_OP") != "" {
+		t.Skip("child mode")
+	}
+	home := t.TempDir()
+	wins := spawnSupervisionChildren(t, home, "acquire", 2)
+	if wins != 1 {
+		t.Fatalf("winning acquisitions across 2 processes = %d, want exactly one holder", wins)
+	}
+}
+
+func spawnSupervisionChildren(t *testing.T, home, op string, n int) int {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outs := make([]string, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range n {
+		out := filepath.Join(t.TempDir(), fmt.Sprintf("verdict-%d.json", i))
+		outs[i] = out
+		cmd := exec.Command(exe, "-test.run=TestSupervisionChildProcess$", "-test.timeout=60s")
+		cmd.Env = append(os.Environ(),
+			"HAND_SUPERVISION_CHILD_OP="+op,
+			"HAND_SUPERVISION_CHILD_HOME="+home,
+			"HAND_SUPERVISION_CHILD_RUNTIME="+fmt.Sprintf("runtime-%d", i),
+			"HAND_SUPERVISION_CHILD_OUT="+out,
+		)
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if runErr := cmd.Run(); runErr != nil {
+				t.Errorf("child %d exited %v", i, runErr)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	won := 0
+	for _, out := range outs {
+		data, readErr := os.ReadFile(out)
+		if readErr != nil {
+			t.Fatalf("child verdict %s: %v", out, readErr)
+		}
+		var v struct {
+			Won int `json:"won"`
+		}
+		if json.Unmarshal(data, &v) != nil {
+			t.Fatalf("verdict %s unparsable: %s", out, data)
+		}
+		won += v.Won
+	}
+	return won
+}
+
+// Guarded entry point the parent re-executes as a child process.
+func TestSupervisionChildProcess(t *testing.T) {
+	op := os.Getenv("HAND_SUPERVISION_CHILD_OP")
+	if op == "" {
+		t.Skip("parent mode")
+	}
+	code := runSupervisionChild(op)
+	if code != 0 {
+		t.Fatalf("child failed with code %d", code)
+	}
+}
+
+// In-process twin of the cross-process acquisition proof.
+func TestAttachmentAcquireAllowsExactlyOneHolderConcurrently(t *testing.T) {
+	home := t.TempDir()
+	mkRecord := func(runtimeName string) AttachmentRecord {
+		now := time.Now()
+		return AttachmentRecord{Host: "pi", Runtime: runtimeName, PID: os.Getpid(), FleetID: "f_1",
+			StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute)}
+	}
+	var holders atomic.Int64
+	var wg sync.WaitGroup
+	for i := range 6 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			acquired, err := AcquireAttachment(home, mkRecord(fmt.Sprintf("runtime-%d", i)))
+			if err != nil {
+				t.Errorf("runtime-%d: %v", i, err)
+				return
+			}
+			if acquired {
+				holders.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if holders.Load() != 1 {
+		t.Fatalf("holders = %d across 6 concurrent acquirers, want exactly one", holders.Load())
+	}
+}
+
+func writeAttachmentRecord(t *testing.T, home string, record AttachmentRecord) {
+	t.Helper()
+	record.Schema = AttachmentSchema
+	if err := os.MkdirAll(filepath.Join(home, "state", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, "state", "runtime", "supervision-attachment.json")
+	if err := os.WriteFile(path, append(encoded, '\n'), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/supervision/correctness_test.go
+++ b/internal/supervision/correctness_test.go
@@ -36,7 +36,7 @@ func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
 	stub, restore := newWatcherStub(t, false, nil)
 	defer restore()
 
-	var wakes, empties, checkpoints atomic.Int64
+	var wakes, empties, noEventLosers atomic.Int64
 	var wg sync.WaitGroup
 	for i := range 10 {
 		wg.Add(1)
@@ -45,11 +45,11 @@ func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
 			wake, err := Wait(context.Background(), Waiter{Home: t.TempDir(), ReadEvidence: reader, Ledger: ledger}, WaitConfig{
 				Host:         "opencode",
 				PollInterval: time.Millisecond,
-				Timeout:      150 * time.Millisecond,
+				Timeout:      250 * time.Millisecond,
 			})
 			switch {
 			case err != nil && errors.Is(err, watcher.ErrNoEvent):
-				checkpoints.Add(1)
+				noEventLosers.Add(1)
 				if len(wake.Episodes) != 0 {
 					t.Errorf("waiter %d: checkpoint carried episodes", i)
 				}
@@ -70,8 +70,8 @@ func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
 	if empties.Load() != 0 {
 		t.Fatalf("empty successful wakes = %d, want zero", empties.Load())
 	}
-	if checkpoints.Load() != 9 {
-		t.Fatalf("losers that waited to checkpoint = %d, want all nine losers", checkpoints.Load())
+	if noEventLosers.Load() != 9 {
+		t.Fatalf("losers ending in a clean checkpoint = %d, want all nine", noEventLosers.Load())
 	}
 	if stub.acquired.Load() > 9 {
 		t.Fatalf("ownership acquisitions = %d, want one per losing waiter at most", stub.acquired.Load())

--- a/internal/supervision/correctness_test.go
+++ b/internal/supervision/correctness_test.go
@@ -1,0 +1,242 @@
+package supervision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/orientation"
+	"github.com/atqamz/hand/internal/watcher"
+)
+
+// Two concurrent waiters racing on the same exact episode must produce
+// exactly one successful claim overall: eligibility and the requested stamp
+// happen inside one ledger transaction.
+func TestConcurrentWaitersClaimExactlyOnce(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "blocked")}}
+	reader := fixedReader(evidence)
+	stub, restore := newWatcherStub(t, false, nil)
+	defer restore()
+
+	var total atomic.Int64
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			wake, err := Wait(context.Background(), Waiter{Home: t.TempDir(), ReadEvidence: reader, Ledger: ledger}, WaitConfig{
+				Host:         "opencode",
+				PollInterval: time.Millisecond,
+				Timeout:      150 * time.Millisecond,
+			})
+			if err != nil && !errors.Is(err, watcher.ErrNoEvent) {
+				t.Errorf("waiter %d: %v", i, err)
+				return
+			}
+			total.Add(int64(len(wake.Episodes)))
+		}(i)
+	}
+	wg.Wait()
+	if total.Load() != 1 {
+		t.Fatalf("claims = %d across 10 concurrent waiters, want exactly one", total.Load())
+	}
+	if stub.acquired.Load() > 9 {
+		t.Fatalf("ownership acquisitions = %d, want one per losing waiter at most", stub.acquired.Load())
+	}
+}
+
+// Different exact episodes may coalesce into one wake; changed currentness is
+// independently claimable again.
+func TestClaimCoalescesDistinctEpisodesAndNewnessReclaims(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{
+		actionableEvidence("t1", "g1", "blocked"),
+		actionableEvidence("t2", "g1", "failed"),
+		actionableEvidence("t3", "g1", "parked"),
+	}}
+	wake, err := Wait(context.Background(), Waiter{Home: t.TempDir(), ReadEvidence: fixedReader(evidence), Ledger: ledger}, WaitConfig{Host: "pi"})
+	if err != nil || len(wake.Episodes) != 3 {
+		t.Fatalf("wake = %#v, %v; want three coalesced subjects in ONE wake", wake, err)
+	}
+
+	next := evidence
+	next.Actionable = []orientation.ActionableEvidence{actionableEvidence("t1", "g2", "blocked")}
+	retry, err := Wait(context.Background(), Waiter{Home: t.TempDir(), ReadEvidence: fixedReader(next), Ledger: ledger}, WaitConfig{Host: "pi"})
+	if err != nil || len(retry.Episodes) != 1 {
+		t.Fatalf("changed-currentness wake = %#v, %v; want independently eligible", retry, err)
+	}
+}
+
+// Sixteen distinct legitimate episodes each wake exactly once - the storm and
+// permanent-disable guard for Stop-hook recursion limits.
+func TestSixteenDistinctEpisodesEachWakeOnce(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	ctx := context.Background()
+	for i := range 16 {
+		evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{
+			actionableEvidence(fmt.Sprintf("t%02d", i), fmt.Sprintf("gen%d", i), "blocked"),
+		}}
+		wake, err := Wait(ctx, Waiter{Home: t.TempDir(), ReadEvidence: fixedReader(evidence), Ledger: ledger}, WaitConfig{Host: "claude"})
+		if err != nil || len(wake.Episodes) != 1 {
+			t.Fatalf("episode %d: wake = %#v, %v; want exactly one legitimate rewake", i, wake, err)
+		}
+		if err := ledger.MarkAccepted(Keys(wake.Episodes)); err != nil {
+			t.Fatal(err)
+		}
+		if err := ledger.MarkOriented(wake.Episodes); err != nil {
+			t.Fatal(err)
+		}
+		// The unchanged episode never re-claims afterwards.
+		if again := ledger.ClaimEligible(FromEvidence(evidence)); len(again) != 0 {
+			t.Fatalf("episode %d re-claimed after orient: %d", i, len(again))
+		}
+	}
+}
+
+// Attachment comes from this runtime's heartbeat record, watcher liveness from
+// fleet-home ownership; neither field may imply the other.
+func TestAttachmentIsIndependentFromWatcherLiveness(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+	if err := WriteAttachment(home, AttachmentRecord{
+		Host: "opencode", Runtime: "ses-1", PID: 1, FleetID: "f_1",
+		StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	status := Status{Harness: harness.OpenCode}
+	status.finishIndependentFields(StatusInput{Home: home})
+	if status.Attachment != "attached:ses-1" {
+		t.Fatalf("attachment = %q, want attached to the live runtime record", status.Attachment)
+	}
+	if status.WatcherLiveness != "idle" {
+		t.Fatalf("liveness = %q on a home no watcher owns; the two fields are independent answers", status.WatcherLiveness)
+	}
+
+	expired := home
+	status2 := Status{Harness: harness.OpenCode}
+	if err := WriteAttachment(expired, AttachmentRecord{
+		Host: "opencode", Runtime: "ses-9", PID: 1, FleetID: "f_1",
+		StartedAt: now.Add(-time.Hour), HeartbeatAt: now.Add(-time.Hour), ExpiresAt: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	status2.finishIndependentFields(StatusInput{Home: expired})
+	if status2.Attachment != "detached" {
+		t.Fatalf("expired heartbeat reads %q, want detached", status2.Attachment)
+	}
+}
+
+// A secondary runtime defers instead of stealing a bridge another live
+// runtime already holds.
+func TestSecondaryRuntimeCannotStealAnAttachedBridge(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+	if err := WriteAttachment(home, AttachmentRecord{
+		Host: "opencode", Runtime: "primary-session", PID: 424242, FleetID: "f_1",
+		StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	evidence := orientation.Evidence{FleetID: "f_1"}
+	stub, restore := newWatcherStub(t, true, nil)
+	defer restore()
+
+	_, err := Wait(context.Background(), Waiter{
+		Home:         home,
+		ReadEvidence: func(context.Context) (orientation.Evidence, error) { return evidence, nil },
+		Ledger:       OpenLedger(t.TempDir()),
+	}, WaitConfig{Host: "opencode", RuntimeSession: "secondary-session", PollInterval: time.Millisecond})
+	if !errors.Is(err, ErrBridgeOwned) {
+		t.Fatalf("err = %v, want ErrBridgeOwned for the secondary runtime", err)
+	}
+	if stub.acquired.Load() != 0 {
+		t.Fatal("a deferring waiter must not touch watcher ownership either")
+	}
+}
+
+// Capability honesty: nothing claims supported before live qualification,
+// instruction-only bridges included, and non-supervisor harness names are
+// outside the registry even if they build workers.
+func TestCapabilityVocabularyStaysHonestBeforeLiveQualification(t *testing.T) {
+	if qualifiedHosts[harness.Grok] || qualifiedHosts[harness.Codex] {
+		t.Fatal("live qualification flags must start empty")
+	}
+	home := t.TempDir()
+	exe := "/opt/bin/hand"
+	if _, err := InstallClaudeStopHook(home, exe); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallCodexHooks(home, exe); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallHostAssets(home, harness.OpenCode, exe); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallHostAssets(home, harness.Pi, exe); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(CodexThreadEnv, "thr_live")
+	for _, name := range SupervisorHosts() {
+		status, err := IntegrationStatus(context.Background(), StatusInput{Home: home, Detection: harness.Detection{Name: name, Source: "override"}, Exe: exe})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if status.WakeDelivery == CapabilitySupported {
+			t.Fatalf("%s claimed supported without any live qualification", name)
+		}
+		if status.WakeDelivery != CapabilityUnqualified && status.WakeDelivery != CapabilityDegraded {
+			t.Fatalf("%s = %q with full static integration installed; want available-unqualified or degraded with reason", name, status.WakeDelivery)
+		}
+	}
+	grok, err := IntegrationStatus(context.Background(), StatusInput{Home: home, Detection: harness.Detection{Name: harness.Grok, Source: "override"}, Exe: exe})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grok.Integration != "not-required" && grok.WakeDelivery == CapabilitySupported {
+		t.Fatal("grok must not become supported from instructions alone")
+	}
+}
+
+func TestWorkerCapableNameOutsideRegistryIsRejected(t *testing.T) {
+	if IsSupervisorHost("antigravity") {
+		t.Fatal("antigravity is worker-execution support only; it must never enter the supervisor registry implicitly")
+	}
+	for _, name := range []string{"antigravity", "", "claude-code"} {
+		if IsSupervisorHost(name) {
+			t.Fatalf("%q must not resolve as a supervisor host", name)
+		}
+	}
+}
+
+// Crash after host acceptance but before orient: suppressed through the
+// progress window, then bounded recovery makes it eligible again.
+func TestAcceptedThenCrashRecoversBounded(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	now := time.Date(2026, 8, 23, 18, 0, 0, 0, time.UTC)
+	ledger.now = func() time.Time { return now }
+	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "unacknowledged")}}
+	episodes := FromEvidence(evidence)
+
+	claimed := ledger.ClaimEligible(episodes)
+	if len(claimed) != 1 {
+		t.Fatalf("claim = %d, want the episode", len(claimed))
+	}
+	if err := ledger.MarkAccepted(Keys(claimed)); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(DefaultPolicy().ProgressTimeout / 2)
+	if eligible := ledger.Eligible(episodes); len(eligible) != 0 {
+		t.Fatal("inside the window a crashed delivery is still awaited")
+	}
+	now = now.Add(2 * DefaultPolicy().ProgressTimeout)
+	if eligible := ledger.Eligible(episodes); len(eligible) != 1 {
+		t.Fatal("past the window bounded recovery re-eligibles the episode")
+	}
+}

--- a/internal/supervision/correctness_test.go
+++ b/internal/supervision/correctness_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,6 +19,12 @@ import (
 	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/watcher"
 )
+
+// Carries one Wait outcome from a goroutine back to its test.
+type waitResult struct {
+	wake Wake
+	err  error
+}
 
 // Two concurrent waiters racing on the same exact episode must produce
 // exactly ONE successful non-empty wake overall; every loser keeps waiting
@@ -280,7 +288,8 @@ func runSupervisionChild(op string) int {
 	case "acquire":
 		now := time.Now()
 		acquired, err := AcquireAttachment(home, AttachmentRecord{
-			Host: "opencode", Runtime: os.Getenv("HAND_SUPERVISION_CHILD_RUNTIME"), PID: os.Getpid(),
+			Host:    os.Getenv("HAND_SUPERVISION_CHILD_HOST"),
+			Runtime: os.Getenv("HAND_SUPERVISION_CHILD_RUNTIME"), PID: os.Getpid(),
 			FleetID: "f_fix", StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
 		})
 		if err != nil {
@@ -313,7 +322,7 @@ func TestClaimIsAtomicAcrossProcesses(t *testing.T) {
 		t.Skip("child mode")
 	}
 	home := t.TempDir()
-	wins := spawnSupervisionChildren(t, home, "claim", 8)
+	wins := spawnSupervisionChildren(t, home, "claim", []string{"opencode", "opencode", "opencode", "opencode", "opencode", "opencode", "opencode", "opencode"})
 	if wins != 1 {
 		t.Fatalf("winning claims across 8 processes = %d, want exactly one", wins)
 	}
@@ -326,14 +335,38 @@ func TestAttachmentAcquireIsAtomicAcrossProcesses(t *testing.T) {
 		t.Skip("child mode")
 	}
 	home := t.TempDir()
-	wins := spawnSupervisionChildren(t, home, "acquire", 2)
+	wins := spawnSupervisionChildren(t, home, "acquire", []string{"opencode", "opencode"})
 	if wins != 1 {
 		t.Fatalf("winning acquisitions across 2 processes = %d, want exactly one holder", wins)
 	}
 }
 
-func spawnSupervisionChildren(t *testing.T, home, op string, n int) int {
+// Harness name selects a delivery mechanism, never an ownership domain: every
+// representative pair contends for the SAME Fleet bridge, proven with real
+// subprocesses where flock is the only coordination.
+func TestAttachmentAcquireIsFleetExclusiveAcrossHosts(t *testing.T) {
+	if os.Getenv("HAND_SUPERVISION_CHILD_OP") != "" {
+		t.Skip("child mode")
+	}
+	for _, pair := range [][2]string{
+		{"opencode", "claude"},
+		{"claude", "codex"},
+		{"pi", "grok"},
+		{"grok", "opencode"},
+	} {
+		t.Run(pair[0]+"-vs-"+pair[1], func(t *testing.T) {
+			home := t.TempDir()
+			wins := spawnSupervisionChildren(t, home, "acquire", pair[:])
+			if wins != 1 {
+				t.Fatalf("holders for %s vs %s = %d, want exactly ONE Fleet bridge owner", pair[0], pair[1], wins)
+			}
+		})
+	}
+}
+
+func spawnSupervisionChildren(t *testing.T, home, op string, hosts []string) int {
 	t.Helper()
+	n := len(hosts)
 	exe, err := os.Executable()
 	if err != nil {
 		t.Fatal(err)
@@ -348,6 +381,7 @@ func spawnSupervisionChildren(t *testing.T, home, op string, n int) int {
 		cmd.Env = append(os.Environ(),
 			"HAND_SUPERVISION_CHILD_OP="+op,
 			"HAND_SUPERVISION_CHILD_HOME="+home,
+			"HAND_SUPERVISION_CHILD_HOST="+hosts[i],
 			"HAND_SUPERVISION_CHILD_RUNTIME="+fmt.Sprintf("runtime-%d", i),
 			"HAND_SUPERVISION_CHILD_OUT="+out,
 		)
@@ -435,5 +469,229 @@ func writeAttachmentRecord(t *testing.T, home string, record AttachmentRecord) {
 	path := filepath.Join(home, "state", "runtime", "supervision-attachment.json")
 	if err := os.WriteFile(path, append(encoded, '\n'), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// Harness name changes HOW a runtime is woken, never WHO owns the Fleet
+// bridge: every fresh different-owner combination is rejected, expired
+// owners are takeover-eligible, and only the exact owner may refresh.
+func TestAttachmentOwnershipIsFleetExclusiveAcrossHosts(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+	writeAttachmentRecord(t, home, AttachmentRecord{
+		Host: "opencode", Runtime: "session-a", PID: 1, FleetID: "f_1",
+		StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
+	})
+
+	incoming := func(host, runtimeName string) AttachmentRecord {
+		return AttachmentRecord{Host: host, Runtime: runtimeName, PID: 2, FleetID: "f_1",
+			StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute)}
+	}
+
+	if acquired, err := AcquireAttachment(home, incoming("claude", "session-b")); err != nil || acquired {
+		t.Fatalf("claude over fresh opencode owner = %v, %v; want rejected", acquired, err)
+	}
+	if owner := BridgeOwner(home, "opencode", now); owner != "session-a" {
+		t.Fatalf("owner = %q after foreign attempt, want the original untouched", owner)
+	}
+
+	if acquired, err := AcquireAttachment(home, incoming("codex", "thr-a")); err != nil || acquired {
+		t.Fatalf("codex over fresh opencode owner = %v, %v; want rejected", acquired, err)
+	}
+
+	if _, err := AcquireAttachment(home, incoming("opencode", "session-a")); err != nil {
+		t.Fatal(err)
+	}
+	ours, err := RefreshAttachment(home, incoming("opencode", "session-a"), time.Minute)
+	if err != nil || !ours {
+		t.Fatalf("exact-owner refresh = %v, %v; want allowed", ours, err)
+	}
+	foreignOurs, err := RefreshAttachment(home, incoming("codex", "thr-a"), time.Minute)
+	if err != nil || foreignOurs {
+		t.Fatalf("foreign-host refresh = %v, %v; want refused", foreignOurs, err)
+	}
+}
+
+func TestAttachmentExpiredOwnerAllowsCrossHostTakeover(t *testing.T) {
+	home := t.TempDir()
+	now := time.Now()
+	writeAttachmentRecord(t, home, AttachmentRecord{
+		Host: "pi", Runtime: "pi-a", PID: 1, FleetID: "f_1",
+		StartedAt: now.Add(-time.Hour), HeartbeatAt: now.Add(-time.Hour), ExpiresAt: now.Add(-time.Second),
+	})
+
+	acquired, err := AcquireAttachment(home, AttachmentRecord{
+		Host: "claude", Runtime: "claude-b", PID: 2, FleetID: "f_1",
+		StartedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(time.Minute),
+	})
+	if err != nil || !acquired {
+		t.Fatalf("takeover over expired owner = %v, %v; want allowed", acquired, err)
+	}
+	if owner := BridgeOwner(home, "claude", now); owner != "claude-b" {
+		t.Fatalf("owner = %q, want the successor", owner)
+	}
+}
+
+func TestRefreshPreservesStartedAtAndAdvancesLeaseExplicitly(t *testing.T) {
+	home := t.TempDir()
+	started := time.Now().Add(-time.Hour)
+	writeAttachmentRecord(t, home, AttachmentRecord{
+		Host: "pi", Runtime: "pi-a", PID: 1, FleetID: "f_1",
+		StartedAt: started, HeartbeatAt: started, ExpiresAt: started.Add(3 * time.Second),
+	})
+	rec := AttachmentRecord{Host: "pi", Runtime: "pi-a", PID: 1, FleetID: "f_1"}
+
+	before := ReadAttachment(home)
+	lease := time.Minute
+	ours, err := RefreshAttachment(home, rec, lease)
+	if err != nil || !ours {
+		t.Fatalf("refresh = %v, %v; want owned", ours, err)
+	}
+	after := ReadAttachment(home)
+	if !after.StartedAt.Equal(before.StartedAt) {
+		t.Fatalf("StartedAt moved from %v to %v; refresh must preserve it", before.StartedAt, after.StartedAt)
+	}
+	if remaining := time.Until(after.ExpiresAt); remaining > lease || remaining < lease-time.Second {
+		t.Fatalf("lease after refresh = %v, want ~%v regardless of prior staleness", remaining, lease)
+	}
+}
+
+// Losing bridge ownership mid-wait cancels the active watcher wait and
+// forbids any claim: the retired runtime must not deliver as if it still
+// owned delivery.
+func TestOwnershipLossCancelsActiveWaitAndForbidsClaim(t *testing.T) {
+	home := t.TempDir()
+	ledger := OpenLedger(home)
+
+	origRun := runWatcherUntilEvent
+	stolen := make(chan struct{})
+	runWatcherUntilEvent = func(ctx context.Context, cfg watcher.Config, out, errOut io.Writer) error {
+		<-ctx.Done() // blocks exactly like a live watcher wait; only guard cancellation ends it
+		return context.Cause(ctx)
+	}
+	origAcquire := acquireWatcherOwnership
+	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) { return nil, nil }
+	restore := func() {
+		runWatcherUntilEvent = origRun
+		acquireWatcherOwnership = origAcquire
+		watcherAttached = func(string) (bool, error) { return false, nil }
+	}
+	watcherAttached = func(string) (bool, error) { return false, nil }
+	defer restore()
+
+	results := make(chan waitResult, 1)
+	go func() {
+		wake, err := Wait(context.Background(), Waiter{
+			Home:         home,
+			ReadEvidence: fixedReader(orientation.Evidence{FleetID: "f_1"}),
+			Ledger:       ledger,
+		}, WaitConfig{Host: "claude", RuntimeSession: "runtime-old", PollInterval: time.Millisecond})
+		results <- waitResult{wake, err}
+	}()
+
+	waitForAttachmentRuntime(t, home, "runtime-old")
+	// Successor takes the Fleet bridge while the old waiter sits blocked.
+	writeAttachmentRecord(t, home, AttachmentRecord{
+		Host: "claude", Runtime: "runtime-new", PID: 999999, FleetID: "f_1",
+		StartedAt: time.Now(), HeartbeatAt: time.Now(), ExpiresAt: time.Now().Add(time.Minute),
+	})
+	close(stolen)
+
+	select {
+	case got := <-results:
+		if !errors.Is(got.err, ErrBridgeOwned) {
+			t.Fatalf("err = %v, want ErrBridgeOwned from ownership loss", got.err)
+		}
+		if len(got.wake.Episodes) != 0 {
+			t.Fatalf("episodes = %d, want zero claimed by the retired runtime", len(got.wake.Episodes))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait was not cancelled after ownership loss; it kept blocking on the watcher")
+	}
+
+	// The episode stays available to the true owner: no requested stamp was
+	// written by the retired runtime.
+	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "blocked")}}
+	claimed, claimErr := ledger.ClaimEligible(FromEvidence(evidence))
+	if claimErr != nil || len(claimed) != 1 {
+		t.Fatalf("true owner claim = %d, %v; want the episode unsuppressed", len(claimed), claimErr)
+	}
+}
+
+func waitForAttachmentRuntime(t *testing.T, home, runtimeName string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if record := ReadAttachment(home); record != nil && record.Runtime == runtimeName && record.Fresh(time.Now()) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("attachment for %q never appeared", runtimeName)
+}
+
+// Takeover racing the watcher event: the stale runtime fails its pre-claim
+// proof, consumes nothing, and the episode stays claimable by the new owner.
+func TestClaimBoundaryTakeoverKeepsEpisodeAvailable(t *testing.T) {
+	home := t.TempDir()
+	ledger := OpenLedger(home)
+	evidence := orientation.Evidence{FleetID: "f_1"}
+	eventReady := make(chan struct{})
+	release := make(chan struct{})
+
+	origRun := runWatcherUntilEvent
+	var once sync.Once
+	runWatcherUntilEvent = func(ctx context.Context, cfg watcher.Config, out, errOut io.Writer) error {
+		once.Do(func() {
+			evidence.Actionable = append(evidence.Actionable, actionableEvidence("t9", "g1", "parked"))
+			close(eventReady)
+		})
+		<-release
+		return nil
+	}
+	origAcquire := acquireWatcherOwnership
+	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) { return nil, nil }
+	watcherAttached = func(string) (bool, error) { return false, nil }
+	defer func() {
+		runWatcherUntilEvent = origRun
+		acquireWatcherOwnership = origAcquire
+	}()
+
+	results := make(chan waitResult, 1)
+	go func() {
+		wake, err := Wait(context.Background(), Waiter{
+			Home:         home,
+			ReadEvidence: fixedReader(evidence),
+			Ledger:       ledger,
+		}, WaitConfig{Host: "claude", RuntimeSession: "runtime-old", PollInterval: time.Millisecond})
+		results <- waitResult{wake, err}
+	}()
+
+	<-eventReady
+	writeAttachmentRecord(t, home, AttachmentRecord{
+		Host: "claude", Runtime: "runtime-new", PID: 999999, FleetID: "f_1",
+		StartedAt: time.Now(), HeartbeatAt: time.Now(), ExpiresAt: time.Now().Add(time.Minute),
+	})
+	close(release)
+
+	select {
+	case got := <-results:
+		if !errors.Is(got.err, ErrBridgeOwned) {
+			t.Fatalf("err = %v, want the pre-claim ownership proof to reject the stale runtime", got.err)
+		}
+		if len(got.wake.Episodes) != 0 {
+			t.Fatalf("stale runtime claimed %d episodes across the handover", len(got.wake.Episodes))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait did not return after the handover")
+	}
+
+	raw, readErr := os.ReadFile(filepath.Join(home, "state", "runtime", "supervision-wake.json"))
+	if readErr == nil && strings.Contains(string(raw), `"delivery_requested"`) {
+		t.Fatal("episode was durably consumed by the stale runtime; it must stay available to the new owner")
+	}
+	claimed, claimErr := ledger.ClaimEligible(FromEvidence(evidence))
+	if claimErr != nil || len(claimed) != 1 {
+		t.Fatalf("new-owner claim = %d, %v; want the episode fully available", len(claimed), claimErr)
 	}
 }

--- a/internal/supervision/deliver_codex.go
+++ b/internal/supervision/deliver_codex.go
@@ -1,0 +1,73 @@
+package supervision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// CodexThreadEnv is where a live Codex runtime exposes the exact current
+// thread. It is routing evidence only, never workflow currentness.
+const CodexThreadEnv = "CODEX_THREAD_ID"
+
+// ErrUnsupported names a host whose installed build lacks the primitive its
+// unattended turn delivery needs. Callers must report it as unsupported or
+// degraded, never as healthy.
+var ErrUnsupported = errors.New("unsupported host integration")
+
+// CommandRunner executes one structured argv with env additions and returns
+// combined output. exec.CommandContext with an argv slice is the only allowed
+// shape: no shell concatenation anywhere in a delivery path.
+type CommandRunner func(ctx context.Context, exe string, argv []string, env []string) (string, error)
+
+// RunCommand is the production CommandRunner.
+func RunCommand(ctx context.Context, exe string, argv []string, env []string) (string, error) {
+	cmd := exec.CommandContext(ctx, exe, argv...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// ProbeCodexQueue capability-probes behavior, not product name: only an
+// installed `codex queue` that accepts --thread/--message qualifies for
+// unattended same-thread turn delivery.
+func ProbeCodexQueue(ctx context.Context, run CommandRunner) error {
+	out, err := run(ctx, "codex", []string{"queue", "--help"}, nil)
+	if err != nil {
+		return fmt.Errorf("%w: codex queue is unavailable: %s", ErrUnsupported, firstLine(out))
+	}
+	for _, flag := range []string{"--thread", "--message"} {
+		if !strings.Contains(out, flag) {
+			return fmt.Errorf("%w: codex queue does not accept %s", ErrUnsupported, flag)
+		}
+	}
+	return nil
+}
+
+// DeliverCodexQueue enqueues one bounded wake on the exact live thread.
+// Acceptance means enqueued only; the resulting turn running `hand orient` is
+// the stronger progress witness, recorded by orient itself.
+func DeliverCodexQueue(ctx context.Context, run CommandRunner, threadID, message string) error {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return fmt.Errorf("%w: %s is not set, so no live Codex thread can be addressed", ErrUnsupported, CodexThreadEnv)
+	}
+	out, err := run(ctx, "codex", []string{"queue", "--thread", threadID, "--message", message}, nil)
+	if err != nil {
+		return fmt.Errorf("codex queue rejected the wake on thread %s: %s: %w", threadID, firstLine(out), err)
+	}
+	return nil
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}

--- a/internal/supervision/deliver_codex_test.go
+++ b/internal/supervision/deliver_codex_test.go
@@ -1,0 +1,63 @@
+package supervision
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestProbeCodexQueueAcceptsOnlyTheRealPrimitive(t *testing.T) {
+	help := "usage: codex queue --thread <THREAD> --message <TEXT>"
+	if err := ProbeCodexQueue(context.Background(), func(context.Context, string, []string, []string) (string, error) {
+		return help, nil
+	}); err != nil {
+		t.Fatalf("probe = %v, want a queue that names both flags accepted", err)
+	}
+	for _, broken := range []string{
+		"usage: codex queue", // older build: no flags named
+		"usage: codex queue --message <TEXT>",
+		"usage: codex queue --thread <THREAD>",
+	} {
+		if err := ProbeCodexQueue(context.Background(), func(context.Context, string, []string, []string) (string, error) {
+			return broken, nil
+		}); !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("probe(%q) = %v, want ErrUnsupported", broken, err)
+		}
+	}
+	if err := ProbeCodexQueue(context.Background(), func(context.Context, string, []string, []string) (string, error) {
+		return "", errors.New("exec: not found")
+	}); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("probe of a missing binary = %v, want ErrUnsupported", err)
+	}
+}
+
+func TestDeliverCodexQueueUsesStructuredArgv(t *testing.T) {
+	var gotExe string
+	var gotArgv []string
+	err := DeliverCodexQueue(context.Background(), func(_ context.Context, exe string, argv []string, _ []string) (string, error) {
+		gotExe, gotArgv = exe, argv
+		return "", nil
+	}, " thread-9 ", "wake text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotExe != "codex" || !reflect.DeepEqual(gotArgv, []string{"queue", "--thread", "thread-9", "--message", "wake text"}) {
+		t.Fatalf("delivery = %s %v, want one argv array, never a shell string", gotExe, gotArgv)
+	}
+
+	if err := DeliverCodexQueue(context.Background(), func(context.Context, string, []string, []string) (string, error) {
+		t.Fatal("must not spawn without a thread")
+		return "", nil
+	}, "  ", "wake"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("empty thread = %v, want ErrUnsupported", err)
+	}
+
+	err = DeliverCodexQueue(context.Background(), func(context.Context, string, []string, []string) (string, error) {
+		return "error: no such thread", errors.New("exit status 1")
+	}, "thread-9", "wake")
+	if err == nil || !strings.Contains(err.Error(), "no such thread") {
+		t.Fatalf("rejected queue = %v, want the bounded host line carried", err)
+	}
+}

--- a/internal/supervision/install.go
+++ b/internal/supervision/install.go
@@ -2,69 +2,552 @@ package supervision
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/atqamz/hand/internal/atomicfile"
-	"github.com/atqamz/hand/internal/sessionhook"
 )
 
-// OwnershipMarker is the first line every managed host asset starts with. A
-// destination file without it is foreign content at a Hand-managed path, which
-// is a conflict to surface, never permission to overwrite.
+// OwnershipMarker is the first line every managed host script asset starts
+// with. A destination file without it is foreign content at a Hand-managed
+// path, which is a conflict to surface, never permission to overwrite.
 const OwnershipMarker = "// Hand-owned supervisor wake integration"
 
-// ClaudeStopHookArgs is the argv after the executable that the Hand-owned
-// Claude Stop hook runs.
-const ClaudeStopHookArgs = "supervision claude-stop"
+// ClaudeStopArgs is the argv after the executable that the Hand-owned Claude
+// Stop hook runs, in upstream exec form: no shell anywhere.
+var ClaudeStopArgs = []string{"supervision", "claude-stop"}
 
 // InstallResult is one managed surface's outcome.
 type InstallResult struct {
 	Host   string
 	Path   string
-	State  string // installed, unchanged, replaced, conflict, absent
+	State  string // installed, unchanged, replaced, conflict, absent, stale
 	Detail string
 }
 
-// InstallClaudeStopHook merges the Hand-owned Stop hook into the fleet home's
-// .claude/settings.json through the conflict-safe sessionhook posture, then
-// reports the resulting state.
+func claudeStopHandler(exe string) map[string]any {
+	return map[string]any{
+		"type":        "command",
+		"command":     exe,
+		"args":        append([]string(nil), ClaudeStopArgs...),
+		"asyncRewake": true,
+		"timeout":     1800,
+	}
+}
+
+// Classifies an existing Stop handler: exact matches the canonical handler,
+// owned is a superseded Hand version (including earlier shell-form entries),
+// and neither means foreign content.
+func claudeOwned(handler map[string]any, exe string) (exact bool, owned bool) {
+	if handler["type"] != "command" {
+		return false, false
+	}
+	rawArgs, hasArgs := handler["args"].([]any)
+	command, _ := handler["command"].(string)
+	if hasArgs {
+		args := make([]string, 0, len(rawArgs))
+		for _, arg := range rawArgs {
+			s, ok := arg.(string)
+			if !ok {
+				return false, false
+			}
+			args = append(args, s)
+		}
+		if !sameStrings(args, ClaudeStopArgs) {
+			return false, false
+		}
+		if command != exe {
+			return false, false
+		}
+		return sameHandler(handler, claudeStopHandler(exe)), true
+	}
+	// Legacy shell form from earlier integration generations: ownership means
+	// this binary followed by our subcommand tokens in the command string.
+	first, rest := splitFirstToken(command)
+	unquoted := unquoteToken(first)
+	base := filepath.Base(unquoted)
+	if first == "" || rest == "" || (unquoted != exe && base != "hand" && base != "hand.exe") {
+		return false, false
+	}
+	if strings.HasPrefix(rest, "supervision claude-stop") {
+		return false, true
+	}
+	return false, false
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameHandler(a, b map[string]any) bool {
+	encodedA, errA := json.Marshal(a)
+	encodedB, errB := json.Marshal(b)
+	return errA == nil && errB == nil && bytes.Equal(encodedA, encodedB)
+}
+
+func splitFirstToken(command string) (first, rest string) {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return "", ""
+	}
+	if trimmed[0] == '"' || trimmed[0] == '\'' {
+		end := strings.IndexByte(trimmed[1:], trimmed[0])
+		if end < 0 {
+			return trimmed, ""
+		}
+		return trimmed[:end+2], strings.TrimLeft(trimmed[end+2:], " \t")
+	}
+	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+		return trimmed[:i], strings.TrimSpace(trimmed[i+1:])
+	}
+	return trimmed, ""
+}
+
+// Strips one matching layer of surrounding shell quotes so quoted-path
+// ownership checks compare real paths.
+func unquoteToken(token string) string {
+	if len(token) >= 2 && (token[0] == '"' || token[0] == '\'') && token[len(token)-1] == token[0] {
+		return token[1 : len(token)-1]
+	}
+	return token
+}
+
+// InstallClaudeStopHook merges the Hand-owned Stop handler into the fleet
+// home's .claude/settings.json: unrelated hooks pass through, owned stale
+// versions are replaced, uncarryable shapes refused. Exec form + asyncRewake.
 func InstallClaudeStopHook(home, exe string) (InstallResult, error) {
-	changed, err := sessionhook.Ensure(home, exe, "Stop", ClaudeStopHookArgs)
-	if err != nil {
-		return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: "conflict", Detail: err.Error()}, err
-	}
-	state, err := sessionhook.State(home, exe, "Stop", ClaudeStopHookArgs)
-	if err != nil {
-		return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json")}, err
-	}
-	if changed {
-		return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: "installed"}, nil
-	}
-	return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: "unchanged", Detail: state}, nil
+	path := filepath.Join(home, ".claude", "settings.json")
+	state, err := mergeClaudeSettings(path, exe)
+	return InstallResult{Host: "claude", Path: path, State: state.State, Detail: state.Detail}, err
 }
 
 // CheckClaudeStopHook reports the Stop hook state without writing anything.
 func CheckClaudeStopHook(home, exe string) (InstallResult, error) {
-	state, err := sessionhook.State(home, exe, "Stop", ClaudeStopHookArgs)
-	if err != nil {
-		return InstallResult{Host: "claude", State: "conflict", Detail: err.Error()}, err
+	path := filepath.Join(home, ".claude", "settings.json")
+	state := checkClaudeSettings(filepath.Join(home, ".claude", "settings.json"), exe)
+	return InstallResult{Host: "claude", Path: path, State: state.State, Detail: state.Detail}, nil
+}
+
+type mergeState struct {
+	State  string
+	Detail string
+}
+
+func readJSONSettings(path string) (map[string]any, error) {
+	existing, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
 	}
-	return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: state}, nil
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var settings map[string]any
+	if json.Unmarshal(existing, &settings) != nil || settings == nil {
+		return nil, fmt.Errorf("%s is not a JSON object, refusing to overwrite it", path)
+	}
+	return settings, nil
 }
 
-// Substitutes install-time paths into an asset template. Both are JSON-quoted
-// so the generated JS/TS stays syntactically valid for any path, including
-// spaces and Unicode.
-func renderAsset(a Asset, exe, home string) []byte {
-	body := bytes.ReplaceAll(a.Body, []byte("__HAND_EXECUTABLE__"), []byte(quoteJS(exe)))
-	return bytes.ReplaceAll(body, []byte("__HAND_HOME__"), []byte(quoteJS(home)))
+func writeJSONSettings(path string, settings map[string]any) error {
+	encoded, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	if err := atomicfile.Write(path, ".settings.json-", append(encoded, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
 }
 
-func quoteJS(value string) string {
-	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`).Replace(value) + `"`
+// Walks hooks.Stop groups only. Stop has no matcher support upstream, so the
+// generated group carries none; foreign groups keep theirs verbatim.
+func mergeClaudeSettings(path, exe string) (mergeState, error) {
+	settings, err := readJSONSettings(path)
+	if err != nil {
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok && settings["hooks"] != nil {
+		err := fmt.Errorf("%s: hooks is not an object, refusing to overwrite it", path)
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+	if hooks == nil {
+		hooks = map[string]any{}
+		settings["hooks"] = hooks
+	}
+	groups, ok := hooks["Stop"].([]any)
+	if !ok && hooks["Stop"] != nil {
+		err := fmt.Errorf("%s: hooks.Stop is not an array, refusing to overwrite it", path)
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+
+	canonical := claudeStopHandler(exe)
+	filtered := make([]any, 0, len(groups))
+	replaced := false
+	for i, group := range groups {
+		entry, ok := group.(map[string]any)
+		if !ok {
+			err := fmt.Errorf("%s: hooks.Stop[%d] is not an object, refusing to overwrite it", path, i)
+			return mergeState{State: "conflict", Detail: err.Error()}, err
+		}
+		handlers, ok := entry["hooks"].([]any)
+		if entry["hooks"] != nil && !ok {
+			err := fmt.Errorf("%s: hooks.Stop[%d].hooks is not an array, refusing to overwrite it", path, i)
+			return mergeState{State: "conflict", Detail: err.Error()}, err
+		}
+		kept := make([]any, 0, len(handlers))
+		groupChanged := false
+		for j, raw := range handlers {
+			handler, ok := raw.(map[string]any)
+			if !ok {
+				err := fmt.Errorf("%s: hooks.Stop[%d].hooks[%d] is not an object, refusing to overwrite it", path, i, j)
+				return mergeState{State: "conflict", Detail: err.Error()}, err
+			}
+			exact, owned := claudeOwned(handler, exe)
+			if !owned {
+				kept = append(kept, handler)
+				continue
+			}
+			groupChanged = true
+			replaced = true
+			if exact {
+				replaced = false
+			}
+		}
+		if groupChanged {
+			if len(kept) > 0 {
+				entry["hooks"] = kept
+				filtered = append(filtered, entry)
+			}
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	if !replaced {
+		state := checkClaudeSettings(path, exe)
+		if state.State == "installed" {
+			return mergeState{State: "unchanged", Detail: state.Detail}, nil
+		}
+		filtered = append(filtered, map[string]any{"hooks": []any{canonical}})
+	} else {
+		filtered = append(filtered, map[string]any{"hooks": []any{canonical}})
+	}
+	hooks["Stop"] = filtered
+	if err := writeJSONSettings(path, settings); err != nil {
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+	if replaced {
+		return mergeState{State: "replaced"}, nil
+	}
+	return mergeState{State: "installed"}, nil
+}
+
+// Inspects hooks.Stop for a Hand-owned handler running this binary: installed
+// when canonical, stale for a superseded owned version, absent otherwise.
+// Malformed config is conflict - actionable, never overwritten blind.
+func checkClaudeSettings(path, exe string) mergeState {
+	settings, err := readJSONSettings(path)
+	if err != nil {
+		return mergeState{State: "conflict", Detail: err.Error()}
+	}
+	if settings == nil {
+		return mergeState{State: "absent"}
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		if settings["hooks"] != nil {
+			return mergeState{State: "conflict", Detail: "hooks is not an object"}
+		}
+		return mergeState{State: "absent"}
+	}
+	groups, ok := hooks["Stop"].([]any)
+	if !ok {
+		if hooks["Stop"] != nil {
+			return mergeState{State: "conflict", Detail: "hooks.Stop is not an array"}
+		}
+		return mergeState{State: "absent"}
+	}
+	found := "absent"
+	for _, group := range groups {
+		entry, ok := group.(map[string]any)
+		if !ok {
+			continue
+		}
+		handlers, ok := entry["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, raw := range handlers {
+			handler, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			exact, owned := claudeOwned(handler, exe)
+			if !owned {
+				continue
+			}
+			if exact {
+				return mergeState{State: "installed"}
+			}
+			found = "stale"
+		}
+	}
+	return mergeState{State: found}
+}
+
+// The canonical Codex Stop group entry: upstream embeds arguments in the
+// command string, so both platform variants are shell-quoted here; async
+// keeps it background work owned by the Codex hook lifecycle.
+func codexStopHandler(exe string) map[string]any {
+	return map[string]any{
+		"type":           "command",
+		"command":        shellquoteQuote(exe) + " supervision codex-stop",
+		"commandWindows": windowsQuote(exe) + " supervision codex-stop",
+		"async":          true,
+		"timeout":        1860,
+	}
+}
+
+func shellquoteQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func windowsQuote(value string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+func codexHooksPath(home string) string { return filepath.Join(home, ".codex", "hooks.json") }
+
+// Classifies one existing Stop handler against this binary's codex-stop
+// entrypoint.
+func codexOwned(handler map[string]any, exe string) (exact bool, owned bool) {
+	if handler["type"] != "command" {
+		return false, false
+	}
+	canonical := codexStopHandler(exe)
+	command, _ := handler["command"].(string)
+	if !codexCommandTokens(command, exe) {
+		return false, false
+	}
+	if windows, _ := handler["commandWindows"].(string); windows != "" && !codexCommandTokens(windows, exe) {
+		return false, false
+	}
+	if _, isAsync := handler["async"].(bool); !isAsync {
+		return false, true
+	}
+	return sameHandler(handler, canonical), true
+}
+
+func codexCommandTokens(command, exe string) bool {
+	first, rest := splitFirstToken(command)
+	if first == "" || rest != "supervision codex-stop" {
+		return false
+	}
+	unquoted := unquoteToken(first)
+	base := filepath.Base(unquoted)
+	return unquoted == exe || base == "hand" || base == "hand.exe"
+}
+
+// InstallCodexHooks merges the Hand-owned async Stop group into the
+// Fleet-local .codex/hooks.json: foreign events and handlers pass through,
+// an owned superseded version is replaced, anything unparseable is refused.
+func InstallCodexHooks(home, exe string) (InstallResult, error) {
+	path := codexHooksPath(home)
+	state, err := mergeCodexHooks(path, exe)
+	return InstallResult{Host: "codex", Path: path, State: state.State, Detail: state.Detail}, err
+}
+
+// CheckCodexHooks reports the Fleet-local codex hook state without writing.
+func CheckCodexHooks(home, exe string) (InstallResult, error) {
+	path := codexHooksPath(home)
+	state := inspectCodexHooks(path, exe)
+	return InstallResult{Host: "codex", Path: path, State: state.State, Detail: state.Detail}, nil
+}
+
+func mergeCodexHooks(path, exe string) (mergeState, error) {
+	settings, err := readJSONSettings(path)
+	if err != nil {
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+	if settings == nil {
+		if err := writeJSONSettings(path, renderCodexJSON(exe)); err != nil {
+			return mergeState{State: "conflict", Detail: err.Error()}, err
+		}
+		return mergeState{State: "installed"}, nil
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok && settings["hooks"] != nil {
+		err := fmt.Errorf("%s: hooks is not an object, refusing to overwrite it", path)
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+	if hooks == nil {
+		hooks = map[string]any{}
+		settings["hooks"] = hooks
+	}
+	groups, ok := hooks["Stop"].([]any)
+	if !ok && hooks["Stop"] != nil {
+		err := fmt.Errorf("%s: hooks.Stop is not an array, refusing to overwrite it", path)
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+
+	replaced := false
+	filtered := make([]any, 0, len(groups)+1)
+	for i, group := range groups {
+		entry, ok := group.(map[string]any)
+		if !ok {
+			err := fmt.Errorf("%s: hooks.Stop[%d] is not an object, refusing to overwrite it", path, i)
+			return mergeState{State: "conflict", Detail: err.Error()}, err
+		}
+		handlers, ok := entry["hooks"].([]any)
+		if entry["hooks"] != nil && !ok {
+			err := fmt.Errorf("%s: hooks.Stop[%d].hooks is not an array, refusing to overwrite it", path, i)
+			return mergeState{State: "conflict", Detail: err.Error()}, err
+		}
+		kept := make([]any, 0, len(handlers))
+		groupChanged := false
+		for j, raw := range handlers {
+			handler, ok := raw.(map[string]any)
+			if !ok {
+				err := fmt.Errorf("%s: hooks.Stop[%d].hooks[%d] is not an object, refusing to overwrite it", path, i, j)
+				return mergeState{State: "conflict", Detail: err.Error()}, err
+			}
+			exact, owned := codexOwned(handler, exe)
+			if !owned {
+				kept = append(kept, handler)
+				continue
+			}
+			groupChanged = true
+			replaced = true
+			if exact {
+				replaced = false
+			}
+		}
+		switch {
+		case !groupChanged:
+			filtered = append(filtered, entry)
+		case len(kept) > 0:
+			entry["hooks"] = kept
+			filtered = append(filtered, entry)
+		}
+	}
+
+	if !replaced {
+		if inspectCodexHandlers(groups, exe) == "installed" {
+			return mergeState{State: "unchanged"}, nil
+		}
+	}
+	filtered = append(filtered, map[string]any{"hooks": []any{codexStopHandler(exe)}})
+	hooks["Stop"] = filtered
+	if err := writeJSONSettings(path, settings); err != nil {
+		return mergeState{State: "conflict", Detail: err.Error()}, err
+	}
+	if replaced {
+		return mergeState{State: "replaced"}, nil
+	}
+	return mergeState{State: "installed"}, nil
+}
+
+func renderCodexJSON(exe string) map[string]any {
+	return map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{
+				map[string]any{"hooks": []any{codexStopHandler(exe)}},
+			},
+		},
+	}
+}
+
+func inspectCodexHooks(path, exe string) mergeState {
+	settings, err := readJSONSettings(path)
+	if err != nil {
+		return mergeState{State: "conflict", Detail: err.Error()}
+	}
+	if settings == nil {
+		return mergeState{State: "absent"}
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		if settings["hooks"] != nil {
+			return mergeState{State: "conflict", Detail: "hooks is not an object"}
+		}
+		return mergeState{State: "absent"}
+	}
+	groups, ok := hooks["Stop"].([]any)
+	if !ok {
+		if hooks["Stop"] != nil {
+			return mergeState{State: "conflict", Detail: "hooks.Stop is not an array"}
+		}
+		return mergeState{State: "absent"}
+	}
+	state := "absent"
+	for _, group := range groups {
+		entry, ok := group.(map[string]any)
+		if !ok {
+			continue
+		}
+		handlers, ok := entry["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, raw := range handlers {
+			handler, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			exact, owned := codexOwned(handler, exe)
+			if !owned {
+				continue
+			}
+			if exact {
+				return mergeState{State: "installed"}
+			}
+			state = "stale"
+		}
+	}
+	return mergeState{State: state}
+}
+
+func inspectCodexHandlers(groups []any, exe string) string {
+	state := "absent"
+	for _, group := range groups {
+		entry, ok := group.(map[string]any)
+		if !ok {
+			continue
+		}
+		handlers, _ := entry["hooks"].([]any)
+		for _, raw := range handlers {
+			handler, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			exact, owned := codexOwned(handler, exe)
+			if exact {
+				return "installed"
+			}
+			if owned {
+				state = "stale"
+			}
+		}
+	}
+	return state
 }
 
 // CheckHostAssets reports managed asset states for one host without writing.
@@ -87,9 +570,9 @@ func CheckHostAssets(home, host, exe string) ([]InstallResult, error) {
 	return results, nil
 }
 
-// Compares existing bytes to the canonical rendered shape, with the ownership
-// marker as the ownership proof: a marked file that no longer matches is a
-// stale Hand version, an unmarked file is foreign content.
+// Compares existing bytes to the canonical rendered shape; the ownership
+// marker proves ownership: a marked mismatch is a stale Hand version, an
+// unmarked file is foreign content.
 func assetState(existing, canonical []byte) string {
 	if !bytes.HasPrefix(bytes.TrimSpace(existing), []byte(OwnershipMarker)) {
 		return "conflict"

--- a/internal/supervision/install.go
+++ b/internal/supervision/install.go
@@ -1,0 +1,141 @@
+package supervision
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/sessionhook"
+)
+
+// OwnershipMarker is the first line every managed host asset starts with. A
+// destination file without it is foreign content at a Hand-managed path, which
+// is a conflict to surface, never permission to overwrite.
+const OwnershipMarker = "// Hand-owned supervisor wake integration"
+
+// ClaudeStopHookArgs is the argv after the executable that the Hand-owned
+// Claude Stop hook runs.
+const ClaudeStopHookArgs = "supervision claude-stop"
+
+// InstallResult is one managed surface's outcome.
+type InstallResult struct {
+	Host   string
+	Path   string
+	State  string // installed, unchanged, replaced, conflict, absent
+	Detail string
+}
+
+// InstallClaudeStopHook merges the Hand-owned Stop hook into the fleet home's
+// .claude/settings.json through the conflict-safe sessionhook posture, then
+// reports the resulting state.
+func InstallClaudeStopHook(home, exe string) (InstallResult, error) {
+	changed, err := sessionhook.Ensure(home, exe, "Stop", ClaudeStopHookArgs)
+	if err != nil {
+		return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: "conflict", Detail: err.Error()}, err
+	}
+	state, err := sessionhook.State(home, exe, "Stop", ClaudeStopHookArgs)
+	if err != nil {
+		return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json")}, err
+	}
+	if changed {
+		return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: "installed"}, nil
+	}
+	return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: "unchanged", Detail: state}, nil
+}
+
+// CheckClaudeStopHook reports the Stop hook state without writing anything.
+func CheckClaudeStopHook(home, exe string) (InstallResult, error) {
+	state, err := sessionhook.State(home, exe, "Stop", ClaudeStopHookArgs)
+	if err != nil {
+		return InstallResult{Host: "claude", State: "conflict", Detail: err.Error()}, err
+	}
+	return InstallResult{Host: "claude", Path: filepath.Join(home, ".claude", "settings.json"), State: state}, nil
+}
+
+// Substitutes install-time paths into an asset template. Both are JSON-quoted
+// so the generated JS/TS stays syntactically valid for any path, including
+// spaces and Unicode.
+func renderAsset(a Asset, exe, home string) []byte {
+	body := bytes.ReplaceAll(a.Body, []byte("__HAND_EXECUTABLE__"), []byte(quoteJS(exe)))
+	return bytes.ReplaceAll(body, []byte("__HAND_HOME__"), []byte(quoteJS(home)))
+}
+
+func quoteJS(value string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`).Replace(value) + `"`
+}
+
+// CheckHostAssets reports managed asset states for one host without writing.
+// exe and home are the install-time substitutions canonical bytes are judged
+// against.
+func CheckHostAssets(home, host, exe string) ([]InstallResult, error) {
+	var results []InstallResult
+	for _, a := range HostAssets(host) {
+		path := filepath.Join(home, a.RelPath)
+		existing, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			results = append(results, InstallResult{Host: host, Path: path, State: "absent"})
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", a.RelPath, err)
+		}
+		results = append(results, InstallResult{Host: host, Path: path, State: assetState(existing, renderAsset(a, exe, home))})
+	}
+	return results, nil
+}
+
+// Compares existing bytes to the canonical rendered shape, with the ownership
+// marker as the ownership proof: a marked file that no longer matches is a
+// stale Hand version, an unmarked file is foreign content.
+func assetState(existing, canonical []byte) string {
+	if !bytes.HasPrefix(bytes.TrimSpace(existing), []byte(OwnershipMarker)) {
+		return "conflict"
+	}
+	if bytes.Equal(existing, canonical) {
+		return "unchanged"
+	}
+	return "stale"
+}
+
+// InstallHostAssets writes the managed assets for one host, replacing only
+// Hand-owned stale versions and refusing foreign content at exact managed
+// paths. Canonical files stay untouched, so repeated init changes no bytes.
+func InstallHostAssets(home, host, exe string) ([]InstallResult, error) {
+	var results []InstallResult
+	for _, a := range HostAssets(host) {
+		path := filepath.Join(home, a.RelPath)
+		result := InstallResult{Host: host, Path: path}
+		existing, err := os.ReadFile(path)
+		switch {
+		case os.IsNotExist(err):
+			result.State = "installed"
+		case err != nil:
+			return nil, fmt.Errorf("read %s: %w", a.RelPath, err)
+		default:
+			switch assetState(existing, renderAsset(a, exe, home)) {
+			case "conflict":
+				result.State = "conflict"
+				result.Detail = "a foreign file occupies the Hand-managed path; move it aside, then run hand init again"
+				results = append(results, result)
+				continue
+			case "unchanged":
+				result.State = "unchanged"
+				results = append(results, result)
+				continue
+			default:
+				result.State = "replaced"
+			}
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, fmt.Errorf("create %s: %w", filepath.Dir(a.RelPath), err)
+		}
+		if err := atomicfile.Write(path, ".hand-supervisor-wake-", renderAsset(a, exe, home), 0o644); err != nil {
+			return nil, fmt.Errorf("write %s: %w", a.RelPath, err)
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}

--- a/internal/supervision/install_test.go
+++ b/internal/supervision/install_test.go
@@ -1,0 +1,147 @@
+package supervision
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/sessionhook"
+)
+
+func TestRenderAssetQuotesPathsForTheHostLanguage(t *testing.T) {
+	rendered := string(renderAsset(HostAssets("opencode")[0], `/opt/my hand\bin`, `/fleet home "quoted"`))
+	for _, banned := range []string{"__HAND_EXECUTABLE__", "__HAND_HOME__"} {
+		if strings.Contains(rendered, banned) {
+			t.Fatalf("rendered asset still contains %s", banned)
+		}
+	}
+	for _, want := range []string{`"/opt/my hand\\bin"`, `"/fleet home \"quoted\""`, `"supervision", "wait", "--host", "opencode"`} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered asset = %q, want it to contain %q", rendered, want)
+		}
+	}
+}
+
+func TestInstallHostAssetsIdempotentStaleAndConflict(t *testing.T) {
+	home := t.TempDir()
+	exe := "/opt/bin/hand"
+
+	first, err := InstallHostAssets(home, "pi", exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 1 || first[0].State != "installed" {
+		t.Fatalf("first install = %#v, want installed", first)
+	}
+
+	second, err := InstallHostAssets(home, "pi", exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second[0].State != "unchanged" {
+		t.Fatalf("second install = %#v, want a byte-level no-op", second)
+	}
+
+	path := filepath.Join(home, HostAssets("pi")[0].RelPath)
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := append([]byte("// Hand-owned supervisor wake integration (old version)\n"), body[len(body)-10:]...)
+	if err := os.WriteFile(path, stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	replaced, err := InstallHostAssets(home, "pi", exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced[0].State != "replaced" {
+		t.Fatalf("stale install = %#v, want the Hand-owned stale version replaced", replaced)
+	}
+
+	foreign := "// an operator's own extension content\n"
+	if err := os.WriteFile(path, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	conflicted, err := InstallHostAssets(home, "pi", exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflicted[0].State != "conflict" || conflicted[0].Detail == "" {
+		t.Fatalf("foreign install = %#v, want a surfaced conflict", conflicted)
+	}
+	kept, err := os.ReadFile(path)
+	if err != nil || string(kept) != foreign {
+		t.Fatalf("foreign file changed: %q, %v; conflicts are never overwrites", kept, err)
+	}
+}
+
+func TestClaudeStopHookMergeIsConflictSafeAndIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	first, err := InstallClaudeStopHook(home, "/opt/my tools/hand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.State != "installed" {
+		t.Fatalf("install = %#v, want created", first)
+	}
+
+	again, err := InstallClaudeStopHook(home, "/opt/my tools/hand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.State != "unchanged" {
+		t.Fatalf("re-install = %#v, want idempotent", again)
+	}
+
+	settings := filepath.Join(home, ".claude", "settings.json")
+	raw, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "'/opt/my tools/hand' supervision claude-stop") {
+		t.Fatalf("settings = %q, want the quoted spaced path hook command", raw)
+	}
+
+	// A pre-existing unrelated operator entry survives byte-for-byte.
+	before, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := sessionhook.State(home, "/opt/my tools/hand", "Stop", ClaudeStopHookArgs)
+	if err != nil || state != "installed" {
+		t.Fatalf("state = %q, %v; want installed", state, err)
+	}
+	if _, err := InstallClaudeStopHook(home, "/opt/my tools/hand"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(settings)
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("idempotent install rewrote settings: before %q after %q (%v)", before, after, err)
+	}
+}
+
+func TestClaudeStopHookRefusesMalformedSettings(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	malformed := "{not an object"
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := InstallClaudeStopHook(home, "/opt/bin/hand")
+	if err == nil {
+		t.Fatal("got nil, want the malformed-settings refusal")
+	}
+	if result.State != "conflict" {
+		t.Fatalf("result = %#v, want conflict state carrying the diagnostic", result)
+	}
+	raw, readErr := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if readErr != nil || string(raw) != malformed {
+		t.Fatalf("malformed settings were overwritten: %q, %v", raw, readErr)
+	}
+}

--- a/internal/supervision/install_test.go
+++ b/internal/supervision/install_test.go
@@ -19,14 +19,14 @@ func TestRenderAssetSubstitutesExactJSONStringLiterals(t *testing.T) {
 		}
 	}
 	var gotExe string
-	if err := json.Unmarshal([]byte(strBetween(rendered, "const HAND_EXE = ", ";\n")), &gotExe); err != nil {
+	if err := json.Unmarshal([]byte(strBetween(rendered, "const HAND_EXE = ", ";")), &gotExe); err != nil {
 		t.Fatalf("HAND_EXE is not a valid JSON string literal: %v\n%s", err, rendered)
 	}
 	if gotExe != exe {
 		t.Fatalf("HAND_EXE = %q, want the exact original path %q", gotExe, exe)
 	}
 	var gotHome string
-	if err := json.Unmarshal([]byte(strBetween(rendered, "const HAND_HOME = ", ";\n")), &gotHome); err != nil {
+	if err := json.Unmarshal([]byte(strBetween(rendered, "const HAND_HOME = ", ";")), &gotHome); err != nil {
 		t.Fatalf("HAND_HOME is not a valid JSON string literal: %v", err)
 	}
 	if gotHome != home {
@@ -43,7 +43,8 @@ func strBetween(s, start, end string) string {
 	if j < 0 {
 		return ""
 	}
-	return s[i+len(start) : i+len(start)+j]
+	trimmed := s[i+len(start) : i+len(start)+j]
+	return strings.TrimSuffix(trimmed, "\r")
 }
 
 func TestInstallHostAssetsIdempotentStaleAndConflict(t *testing.T) {

--- a/internal/supervision/install_test.go
+++ b/internal/supervision/install_test.go
@@ -1,26 +1,49 @@
 package supervision
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/atqamz/hand/internal/sessionhook"
 )
 
-func TestRenderAssetQuotesPathsForTheHostLanguage(t *testing.T) {
-	rendered := string(renderAsset(HostAssets("opencode")[0], `/opt/my hand\bin`, `/fleet home "quoted"`))
-	for _, banned := range []string{"__HAND_EXECUTABLE__", "__HAND_HOME__"} {
+func TestRenderAssetSubstitutesExactJSONStringLiterals(t *testing.T) {
+	exe := `C:\Program Files\my "hand"\hånd.exe`
+	home := `/fleet home's "quoted" path`
+	rendered := string(renderAsset(HostAssets("opencode")[0], exe, home))
+	for _, banned := range []string{"__HAND_EXECUTABLE__", "__HAND_HOME__", `const HAND_EXE = ""`, `const HAND_HOME = ""`} {
 		if strings.Contains(rendered, banned) {
-			t.Fatalf("rendered asset still contains %s", banned)
+			t.Fatalf("rendered asset contains %s:\n%s", banned, rendered)
 		}
 	}
-	for _, want := range []string{`"/opt/my hand\\bin"`, `"/fleet home \"quoted\""`, `"supervision", "wait", "--host", "opencode"`} {
-		if !strings.Contains(rendered, want) {
-			t.Fatalf("rendered asset = %q, want it to contain %q", rendered, want)
-		}
+	var gotExe string
+	if err := json.Unmarshal([]byte(strBetween(rendered, "const HAND_EXE = ", ";\n")), &gotExe); err != nil {
+		t.Fatalf("HAND_EXE is not a valid JSON string literal: %v\n%s", err, rendered)
 	}
+	if gotExe != exe {
+		t.Fatalf("HAND_EXE = %q, want the exact original path %q", gotExe, exe)
+	}
+	var gotHome string
+	if err := json.Unmarshal([]byte(strBetween(rendered, "const HAND_HOME = ", ";\n")), &gotHome); err != nil {
+		t.Fatalf("HAND_HOME is not a valid JSON string literal: %v", err)
+	}
+	if gotHome != home {
+		t.Fatalf("HAND_HOME = %q, want the exact original %q", gotHome, home)
+	}
+}
+
+func strBetween(s, start, end string) string {
+	i := strings.Index(s, start)
+	if i < 0 {
+		return ""
+	}
+	j := strings.Index(s[i+len(start):], end)
+	if j < 0 {
+		return ""
+	}
+	return s[i+len(start) : i+len(start)+j]
 }
 
 func TestInstallHostAssetsIdempotentStaleAndConflict(t *testing.T) {
@@ -77,49 +100,99 @@ func TestInstallHostAssetsIdempotentStaleAndConflict(t *testing.T) {
 	}
 }
 
-func TestClaudeStopHookMergeIsConflictSafeAndIdempotent(t *testing.T) {
+func TestClaudeStopHookUsesExecFormAsyncRewake(t *testing.T) {
 	home := t.TempDir()
+	exe := "/opt/my tools/hand"
 
-	first, err := InstallClaudeStopHook(home, "/opt/my tools/hand")
+	first, err := InstallClaudeStopHook(home, exe)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if first.State != "installed" {
 		t.Fatalf("install = %#v, want created", first)
 	}
-
-	again, err := InstallClaudeStopHook(home, "/opt/my tools/hand")
+	raw, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if again.State != "unchanged" {
-		t.Fatalf("re-install = %#v, want idempotent", again)
+	var settings struct {
+		Hooks struct {
+			Stop []struct {
+				Hooks []map[string]any `json:"hooks"`
+			} `json:"Stop"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		t.Fatalf("settings are not valid JSON: %v", err)
+	}
+	handlers := settings.Hooks.Stop
+	if len(handlers) != 1 || len(handlers[0].Hooks) != 1 {
+		t.Fatalf("hooks.Stop = %+v, want exactly one group with one handler", handlers)
+	}
+	handler := handlers[0].Hooks[0]
+	if handler["type"] != "command" || handler["command"] != exe {
+		t.Fatalf("handler = %+v, want exec form naming this binary only", handler)
+	}
+	args, _ := handler["args"].([]any)
+	if !reflect.DeepEqual(args, []any{"supervision", "claude-stop"}) {
+		t.Fatalf("args = %+v, want structured argv with no shell anywhere", args)
+	}
+	if handler["asyncRewake"] != true {
+		t.Fatalf("asyncRewake = %+v, want the upstream background rewake primitive enabled", handler["asyncRewake"])
 	}
 
-	settings := filepath.Join(home, ".claude", "settings.json")
-	raw, err := os.ReadFile(settings)
+	again, err := InstallClaudeStopHook(home, exe)
+	if err != nil || again.State != "unchanged" {
+		t.Fatalf("re-install = %#v, %v; want idempotent", again, err)
+	}
+	before, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if _, err := InstallClaudeStopHook(home, exe); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if string(before) != string(after) {
+		t.Fatal("idempotent install rewrote settings bytes")
+	}
+}
+
+func TestClaudeStopHookPreservesForeignAndUpgradesOwnedLegacy(t *testing.T) {
+	home := t.TempDir()
+	foreign := map[string]any{
+		"type":    "command",
+		"command": "/usr/bin/operator-own-tool --flag",
+	}
+	legacy := map[string]any{
+		"type":    "command",
+		"command": "'/old/path/hand' supervision claude-stop",
+	}
+	writeSettingsJSON(t, filepath.Join(home, ".claude", "settings.json"), map[string]any{
+		"permissions": map[string]any{"allow": []string{"Bash(ls*)"}},
+		"hooks": map[string]any{
+			"PreToolUse": []any{map[string]any{"matcher": "Bash", "hooks": []any{foreign}}},
+			"Stop":       []any{map[string]any{"hooks": []any{legacy}}},
+		},
+	})
+
+	result, err := InstallClaudeStopHook(home, "/new/install/hand")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(raw), "'/opt/my tools/hand' supervision claude-stop") {
-		t.Fatalf("settings = %q, want the quoted spaced path hook command", raw)
+	if result.State != "replaced" {
+		t.Fatalf("install = %#v, want the owned legacy entry replaced", result)
 	}
-
-	// A pre-existing unrelated operator entry survives byte-for-byte.
-	before, err := os.ReadFile(settings)
+	raw, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	state, err := sessionhook.State(home, "/opt/my tools/hand", "Stop", ClaudeStopHookArgs)
-	if err != nil || state != "installed" {
-		t.Fatalf("state = %q, %v; want installed", state, err)
+	text := string(raw)
+	if !strings.Contains(text, "/usr/bin/operator-own-tool --flag") || !strings.Contains(text, `"PreToolUse"`) {
+		t.Fatalf("settings lost foreign operator content:\n%s", text)
 	}
-	if _, err := InstallClaudeStopHook(home, "/opt/my tools/hand"); err != nil {
-		t.Fatal(err)
+	if strings.Contains(text, "/old/path/hand") {
+		t.Fatalf("stale Hand-owned entry survived:\n%s", text)
 	}
-	after, err := os.ReadFile(settings)
-	if err != nil || string(after) != string(before) {
-		t.Fatalf("idempotent install rewrote settings: before %q after %q (%v)", before, after, err)
+	if !strings.Contains(text, `"asyncRewake": true`) {
+		t.Fatalf("settings missing asyncRewake on the new handler:\n%s", text)
 	}
 }
 
@@ -129,7 +202,8 @@ func TestClaudeStopHookRefusesMalformedSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	malformed := "{not an object"
-	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(malformed), 0o644); err != nil {
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.WriteFile(path, []byte(malformed), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -140,8 +214,95 @@ func TestClaudeStopHookRefusesMalformedSettings(t *testing.T) {
 	if result.State != "conflict" {
 		t.Fatalf("result = %#v, want conflict state carrying the diagnostic", result)
 	}
-	raw, readErr := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	raw, readErr := os.ReadFile(path)
 	if readErr != nil || string(raw) != malformed {
 		t.Fatalf("malformed settings were overwritten: %q, %v", raw, readErr)
+	}
+}
+
+func TestCodexHooksMergeIsFleetLocalIdempotentAndForeignSafe(t *testing.T) {
+	home := t.TempDir()
+	exe := "/opt/bin hand/hand"
+
+	first, err := InstallCodexHooks(home, exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.State != "installed" {
+		t.Fatalf("first install = %#v, want installed", first)
+	}
+	second, err := InstallCodexHooks(home, exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.State != "unchanged" {
+		t.Fatalf("second install = %#v, want idempotent", second)
+	}
+	raw, err := os.ReadFile(filepath.Join(home, CodexHooksRelPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Hooks struct {
+			Stop []struct {
+				Hooks []map[string]any `json:"hooks"`
+			} `json:"Stop"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("hooks.json invalid: %v", err)
+	}
+	if len(doc.Hooks.Stop) != 1 || doc.Hooks.Stop[0].Hooks[0]["async"] != true {
+		t.Fatalf("hooks.Stop = %+v, want one async background Stop group", doc.Hooks.Stop)
+	}
+
+	// A foreign-only document gains our group without losing anything.
+	path := filepath.Join(home, CodexHooksRelPath)
+	theirs := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "operator-own"}}}},
+		},
+	}
+	theirBytes, _ := json.MarshalIndent(theirs, "", "  ")
+	if err := os.WriteFile(path, theirBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	merged, err := InstallCodexHooks(home, exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged.State != "installed" {
+		t.Fatalf("merge into foreign doc = %#v, want our group appended", merged)
+	}
+	text, _ := os.ReadFile(path)
+	if !strings.Contains(string(text), "operator-own") {
+		t.Fatalf("foreign codex hook content lost:\n%s", text)
+	}
+
+	malformed := "{broken"
+	if err := os.WriteFile(path, []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refused, err := InstallCodexHooks(home, exe)
+	if err == nil || refused.State != "conflict" {
+		t.Fatalf("malformed merge = %#v, %v; want refusal", refused, err)
+	}
+	kept, _ := os.ReadFile(path)
+	if string(kept) != malformed {
+		t.Fatalf("malformed hooks.json overwritten: %q", kept)
+	}
+}
+
+func writeSettingsJSON(t *testing.T, path string, body map[string]any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -77,9 +77,34 @@ func OpenLedger(home string) *Ledger {
 
 func (l *Ledger) lockPath() string { return l.path + ledgerLockSuffix }
 
-// Filters current episodes down to the ones a wake may be requested for now:
-// unseen, requested-but-unaccepted past the delivery window, or accepted-
-// but-never-oriented past the progress window. Aged memory re-eligibles.
+// ClaimEligible atomically decides which current episodes may wake AND stamps
+// their delivery request inside one locked transaction: two concurrent
+// waiters can never both claim the same exact episode.
+func (l *Ledger) ClaimEligible(episodes []Episode) []Episode {
+	var claimed []Episode
+	_ = l.update(func(file *ledgerFile, now time.Time) {
+		for _, episode := range episodes {
+			record, exists := file.Episodes[episode.Key()]
+			if !exists || l.eligibleRecord(record) {
+				stamp := now
+				if !exists {
+					record = &episodeRecord{Key: episode.Key(), FirstSeen: now}
+					file.Episodes[episode.Key()] = record
+				}
+				record.SeenAt = now
+				record.DeliveryRequested = &stamp
+				record.HostAccepted = nil
+				record.Oriented = nil
+				claimed = append(claimed, episode)
+			}
+		}
+	})
+	return claimed
+}
+
+// Eligible filters current episodes down to the ones a wake may be requested
+// for now. Read-only: claiming goes through ClaimEligible so the stamp lands
+// atomically.
 func (l *Ledger) Eligible(episodes []Episode) []Episode {
 	file := l.read()
 	var eligible []Episode
@@ -172,6 +197,20 @@ func (l *Ledger) LastErrorBefore(keys []string, window time.Duration) bool {
 		}
 	}
 	return false
+}
+
+// MarkErrorByKeys records bounded mechanism failure evidence against claimed
+// episode keys, so a failed host delivery can retry boundedly later without
+// fabricating Episode values it never held.
+func (l *Ledger) MarkErrorByKeys(keys []string, reason string) error {
+	return l.update(func(file *ledgerFile, now time.Time) {
+		for _, key := range keys {
+			record := ensureKey(file, key, now)
+			record.LastError = reason
+			stamp := now
+			record.LastErrorAt = &stamp
+		}
+	})
 }
 
 // BridgeErrorKey namespaces a host bridge's own failure evidence, which is

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -1,0 +1,319 @@
+package supervision
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/filelock"
+)
+
+const (
+	ledgerSchema     = "hand.supervision.wake.v1"
+	ledgerRel        = "state/runtime/supervision-wake.json"
+	ledgerLockSuffix = ".lock"
+
+	// MaxLedgerAge bounds one episode's mechanism memory; entries older than it
+	// are pruned whatever their stage. The ledger is disposable evidence, not
+	// historical product truth.
+	MaxLedgerAge = 24 * time.Hour
+	// MaxLedgerEntries caps storm memory; pruning drops the least recently
+	// seen entries first.
+	MaxLedgerEntries = 512
+	// BridgeFailureCooldown bounds how often a deterministic bridge failure
+	// surfaces a notice, so a broken mechanism never becomes a per-turn loop.
+	BridgeFailureCooldown = time.Hour
+)
+
+// Bounded retry windows keeping one unchanged episode from unlimited wake
+// attempts while still recovering a wake whose delivery or progress never
+// arrived. Neither timeout proves failure; both only allow one more attempt.
+type Policy struct {
+	// DeliveryTimeout is how long after delivery was requested a bridge has to
+	// accept it before another request may be made.
+	DeliveryTimeout time.Duration
+	// ProgressTimeout is how long after host acceptance `hand orient` progress
+	// is awaited before a retry may be requested.
+	ProgressTimeout time.Duration
+}
+
+func DefaultPolicy() Policy {
+	return Policy{DeliveryTimeout: 2 * time.Minute, ProgressTimeout: 15 * time.Minute}
+}
+
+type episodeRecord struct {
+	Key               string     `json:"key"`
+	FirstSeen         time.Time  `json:"first_seen"`
+	SeenAt            time.Time  `json:"seen_at"`
+	DeliveryRequested *time.Time `json:"delivery_requested,omitempty"`
+	HostAccepted      *time.Time `json:"host_accepted,omitempty"`
+	Oriented          *time.Time `json:"oriented,omitempty"`
+	LastError         string     `json:"last_error,omitempty"`
+	LastErrorAt       *time.Time `json:"last_error_at,omitempty"`
+}
+
+type ledgerFile struct {
+	Schema   string                    `json:"schema"`
+	Episodes map[string]*episodeRecord `json:"episodes"`
+}
+
+// The disposable mechanism store behind wake dedupe and progress
+// classification, under state/runtime/ and never canonical hand.db: deleting
+// or corrupting it causes bounded duplicate wakes, never workflow-truth harm.
+type Ledger struct {
+	path   string
+	policy Policy
+	now    func() time.Time
+}
+
+// OpenLedger opens (lazily creating) the fleet home's wake ledger.
+func OpenLedger(home string) *Ledger {
+	return &Ledger{path: filepath.Join(home, ledgerRel), policy: DefaultPolicy(), now: time.Now}
+}
+
+func (l *Ledger) lockPath() string { return l.path + ledgerLockSuffix }
+
+// Filters current episodes down to the ones a wake may be requested for now:
+// unseen, requested-but-unaccepted past the delivery window, or accepted-
+// but-never-oriented past the progress window. Aged memory re-eligibles.
+func (l *Ledger) Eligible(episodes []Episode) []Episode {
+	file := l.read()
+	var eligible []Episode
+	for _, episode := range episodes {
+		record, exists := file.Episodes[episode.Key()]
+		if !exists || l.eligibleRecord(record) {
+			eligible = append(eligible, episode)
+		}
+	}
+	return eligible
+}
+
+func (l *Ledger) eligibleRecord(record *episodeRecord) bool {
+	if record.Oriented != nil {
+		return false
+	}
+	now := l.now()
+	if record.HostAccepted != nil {
+		return now.Sub(*record.HostAccepted) >= l.policy.ProgressTimeout
+	}
+	if record.DeliveryRequested != nil {
+		return now.Sub(*record.DeliveryRequested) >= l.policy.DeliveryTimeout
+	}
+	return true
+}
+
+// MarkRequested records that a wake for these episodes was handed to a host
+// bridge, so repeated observation of the same episode does not spam parallel
+// wake attempts.
+func (l *Ledger) MarkRequested(episodes []Episode) error {
+	return l.update(func(file *ledgerFile, now time.Time) {
+		for _, episode := range episodes {
+			record := ensureRecord(file, episode.Key(), now)
+			stamp := now
+			record.DeliveryRequested = &stamp
+			record.HostAccepted = nil
+			record.Oriented = nil
+		}
+	})
+}
+
+// MarkAccepted records host-side acceptance (queue enqueued, prompt submitted,
+// rewake armed). Acceptance alone is never reasoning progress: only orient is.
+func (l *Ledger) MarkAccepted(keys []string) error {
+	return l.update(func(file *ledgerFile, now time.Time) {
+		for _, key := range keys {
+			record := ensureKey(file, key, now)
+			stamp := now
+			record.HostAccepted = &stamp
+		}
+	})
+}
+
+// MarkOriented records that a Supervisor reasoning turn re-entered and ran
+// `hand orient` while these exact episodes were current. This is the strongest
+// progress witness and what stops an unchanged condition from waking forever.
+func (l *Ledger) MarkOriented(episodes []Episode) error {
+	return l.update(func(file *ledgerFile, now time.Time) {
+		for _, episode := range episodes {
+			record := ensureRecord(file, episode.Key(), now)
+			stamp := now
+			record.Oriented = &stamp
+		}
+	})
+}
+
+// MarkError records bounded mechanism failure evidence against episodes, so a
+// bridge can avoid turning a deterministic failure into a per-turn loop.
+func (l *Ledger) MarkError(episodes []Episode, reason string) error {
+	return l.update(func(file *ledgerFile, now time.Time) {
+		for _, episode := range episodes {
+			record := ensureRecord(file, episode.Key(), now)
+			record.LastError = reason
+			stamp := now
+			record.LastErrorAt = &stamp
+		}
+	})
+}
+
+// LastErrorBefore reports whether every named episode's last recorded error is
+// older than window, so a failing bridge may surface one bounded failure
+// notice instead of one per turn end. It is true when nothing errored yet.
+func (l *Ledger) LastErrorBefore(keys []string, window time.Duration) bool {
+	file := l.read()
+	cutoff := l.now().Add(-window)
+	for _, key := range keys {
+		record, exists := file.Episodes[key]
+		if !exists || record.LastErrorAt == nil || record.LastErrorAt.Before(cutoff) {
+			return true
+		}
+	}
+	return false
+}
+
+// BridgeErrorKey namespaces a host bridge's own failure evidence, which is
+// not attached to any episode.
+func BridgeErrorKey(host string) string {
+	return "bridge:" + host
+}
+
+// MarkBridgeError stamps one bridge-level mechanism failure (arm failed,
+// delivery path broken) without touching any episode record.
+func (l *Ledger) MarkBridgeError(host string, reason string) error {
+	return l.update(func(f *ledgerFile, now time.Time) {
+		record := ensureKey(f, BridgeErrorKey(host), now)
+		record.LastError = reason
+		stamp := now
+		record.LastErrorAt = &stamp
+	})
+}
+
+// BridgeErroredBefore reports whether the bridge's last recorded failure for
+// host is older than window, so a deterministic failure surfaces one bounded
+// notice instead of one per turn end. True when nothing has errored yet.
+func (l *Ledger) BridgeErroredBefore(host string, window time.Duration) bool {
+	return l.LastErrorBefore([]string{BridgeErrorKey(host)}, window)
+}
+
+// Progress reports the latest acceptance and orientation stamps across the
+// ledger, for the typed diagnostics that must distinguish "a wake was
+// accepted" from "a Supervisor actually re-entered and oriented".
+func (l *Ledger) Progress() (lastAccepted, lastOriented *time.Time) {
+	file := l.read()
+	for _, record := range file.Episodes {
+		if record.HostAccepted != nil && (lastAccepted == nil || record.HostAccepted.After(*lastAccepted)) {
+			stamp := *record.HostAccepted
+			lastAccepted = &stamp
+		}
+		if record.Oriented != nil && (lastOriented == nil || record.Oriented.After(*lastOriented)) {
+			stamp := *record.Oriented
+			lastOriented = &stamp
+		}
+	}
+	return lastAccepted, lastOriented
+}
+
+func ensureRecord(file *ledgerFile, key string, now time.Time) *episodeRecord {
+	record, exists := file.Episodes[key]
+	if !exists {
+		record = &episodeRecord{Key: key, FirstSeen: now}
+		file.Episodes[key] = record
+	}
+	record.SeenAt = now
+	return record
+}
+
+func ensureKey(file *ledgerFile, key string, now time.Time) *episodeRecord {
+	record, exists := file.Episodes[key]
+	if !exists {
+		record = &episodeRecord{Key: key, FirstSeen: now}
+		file.Episodes[key] = record
+	}
+	return record
+}
+
+func (l *Ledger) read() ledgerFile {
+	file := ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}
+	data, err := os.ReadFile(l.path)
+	if err != nil {
+		return file
+	}
+	var parsed ledgerFile
+	if json.Unmarshal(data, &parsed) != nil || parsed.Schema != ledgerSchema || parsed.Episodes == nil {
+		// Corruption is the disposable case: bounded duplicate wakes replace
+		// canonical-truth risk, and the next write replaces the file wholesale.
+		return ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}
+	}
+	now := l.now()
+	for key, record := range parsed.Episodes {
+		reference := record.SeenAt
+		if reference.IsZero() {
+			reference = record.FirstSeen
+		}
+		if now.Sub(reference) > MaxLedgerAge {
+			delete(parsed.Episodes, key)
+		}
+	}
+	return parsed
+}
+
+// Mutates the ledger under its advisory lock and replaces the file atomically,
+// then prunes to the age and count bounds.
+func (l *Ledger) update(mutate func(*ledgerFile, time.Time)) error {
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(ledgerRel), err)
+	}
+	lock, err := os.OpenFile(l.lockPath(), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", ledgerRel+ledgerLockSuffix, err)
+	}
+	defer func() { _ = lock.Close() }()
+	if err := filelock.Lock(lock, true); err != nil {
+		return fmt.Errorf("lock %s: %w", ledgerRel+ledgerLockSuffix, err)
+	}
+	defer func() { _ = filelock.Unlock(lock) }()
+
+	now := l.now()
+	file := l.read()
+	mutate(&file, now)
+	prune(file.Episodes, now)
+	file.Schema = ledgerSchema
+
+	encoded, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.Write(l.path, ".supervision-wake-", append(encoded, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", ledgerRel, err)
+	}
+	return nil
+}
+
+func prune(episodes map[string]*episodeRecord, now time.Time) {
+	for key, record := range episodes {
+		reference := record.SeenAt
+		if reference.IsZero() {
+			reference = record.FirstSeen
+		}
+		if now.Sub(reference) > MaxLedgerAge {
+			delete(episodes, key)
+		}
+	}
+	if len(episodes) <= MaxLedgerEntries {
+		return
+	}
+	keys := make([]string, 0, len(episodes))
+	for key := range episodes {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left, right := episodes[keys[i]], episodes[keys[j]]
+		return left.SeenAt.Before(right.SeenAt)
+	})
+	for _, key := range keys[:len(episodes)-MaxLedgerEntries] {
+		delete(episodes, key)
+	}
+}

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -277,30 +277,20 @@ func ensureKey(file *ledgerFile, key string, now time.Time) *episodeRecord {
 	return record
 }
 
-// Same advisory lock as writers before touching the file: on Windows an atomic
-// replacement fails while any reader holds the target open, so unlocked reads
-// turn every write into a rename race.
+// read stays lock-free on purpose: POSIX rename is atomic so a concurrent
+// swap never tears this read, and taking the writer's lock here would litter
+// every read-only command with lock files. Writer-side retries absorb the one
+// platform (Windows) where rename can fail against an open reader.
 func (l *Ledger) read() ledgerFile {
-	file := ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}
-	lock, err := os.OpenFile(l.lockPath(), os.O_CREATE|os.O_RDWR, 0o644)
-	if err != nil {
-		return file
-	}
-	defer func() { _ = lock.Close() }()
-	if err := filelock.Lock(lock, true); err != nil {
-		return file
-	}
-	defer func() { _ = filelock.Unlock(lock) }()
-
 	data, err := os.ReadFile(l.path)
 	if err != nil {
-		return file
+		return ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}
 	}
 	return l.parse(data)
 }
 
-// Decodes already-read ledger bytes; locked callers use this to avoid
-// re-entering the lock.
+// Decodes already-read ledger bytes; update uses this inside the lock to
+// avoid re-entering it.
 func (l *Ledger) parse(data []byte) ledgerFile {
 	var parsed ledgerFile
 	if json.Unmarshal(data, &parsed) != nil || parsed.Schema != ledgerSchema || parsed.Episodes == nil {

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -277,10 +277,26 @@ func ensureKey(file *ledgerFile, key string, now time.Time) *episodeRecord {
 	return record
 }
 
-// Stays lock-free on purpose: POSIX rename is atomic so a concurrent swap
-// never tears this read, and the writer's lock here would litter read-only
-// commands with lock files. Writer retries absorb Windows rename races.
+// Reads the ledger without ever creating a lock file: with no writer lock on
+// disk nothing can race the raw read, and once one exists readers take it, so
+// a Windows rename never competes with an open reader under poll traffic.
 func (l *Ledger) read() ledgerFile {
+	if _, err := os.Stat(l.lockPath()); os.IsNotExist(err) {
+		return l.parseFile()
+	}
+	lock, err := os.OpenFile(l.lockPath(), os.O_RDWR, 0o644)
+	if err != nil {
+		return l.parseFile()
+	}
+	defer func() { _ = lock.Close() }()
+	if err := filelock.Lock(lock, true); err != nil {
+		return l.parseFile()
+	}
+	defer func() { _ = filelock.Unlock(lock) }()
+	return l.parseFile()
+}
+
+func (l *Ledger) parseFile() ledgerFile {
 	data, err := os.ReadFile(l.path)
 	if err != nil {
 		return ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -277,12 +277,31 @@ func ensureKey(file *ledgerFile, key string, now time.Time) *episodeRecord {
 	return record
 }
 
+// Same advisory lock as writers before touching the file: on Windows an atomic
+// replacement fails while any reader holds the target open, so unlocked reads
+// turn every write into a rename race.
 func (l *Ledger) read() ledgerFile {
 	file := ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}
+	lock, err := os.OpenFile(l.lockPath(), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return file
+	}
+	defer func() { _ = lock.Close() }()
+	if err := filelock.Lock(lock, true); err != nil {
+		return file
+	}
+	defer func() { _ = filelock.Unlock(lock) }()
+
 	data, err := os.ReadFile(l.path)
 	if err != nil {
 		return file
 	}
+	return l.parse(data)
+}
+
+// Decodes already-read ledger bytes; locked callers use this to avoid
+// re-entering the lock.
+func (l *Ledger) parse(data []byte) ledgerFile {
 	var parsed ledgerFile
 	if json.Unmarshal(data, &parsed) != nil || parsed.Schema != ledgerSchema || parsed.Episodes == nil {
 		// Corruption is the disposable case: bounded duplicate wakes replace
@@ -319,7 +338,13 @@ func (l *Ledger) update(mutate func(*ledgerFile, time.Time)) error {
 	defer func() { _ = filelock.Unlock(lock) }()
 
 	now := l.now()
-	file := l.read()
+	data, readErr := os.ReadFile(l.path)
+	var file ledgerFile
+	if readErr == nil {
+		file = l.parse(data)
+	} else {
+		file = ledgerFile{Schema: ledgerSchema, Episodes: map[string]*episodeRecord{}}
+	}
 	mutate(&file, now)
 	prune(file.Episodes, now)
 	file.Schema = ledgerSchema

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -77,12 +77,12 @@ func OpenLedger(home string) *Ledger {
 
 func (l *Ledger) lockPath() string { return l.path + ledgerLockSuffix }
 
-// ClaimEligible atomically decides which current episodes may wake AND stamps
-// their delivery request inside one locked transaction: two concurrent
-// waiters can never both claim the same exact episode.
-func (l *Ledger) ClaimEligible(episodes []Episode) []Episode {
+// Atomically decides which current episodes may wake and stamps their delivery
+// request in one locked transaction: two waiters can never both claim the same
+// exact episode. Transaction faults return as errors, never empty claims.
+func (l *Ledger) ClaimEligible(episodes []Episode) ([]Episode, error) {
 	var claimed []Episode
-	_ = l.update(func(file *ledgerFile, now time.Time) {
+	err := l.update(func(file *ledgerFile, now time.Time) {
 		for _, episode := range episodes {
 			record, exists := file.Episodes[episode.Key()]
 			if !exists || l.eligibleRecord(record) {
@@ -99,7 +99,10 @@ func (l *Ledger) ClaimEligible(episodes []Episode) []Episode {
 			}
 		}
 	})
-	return claimed
+	if err != nil {
+		return nil, err
+	}
+	return claimed, nil
 }
 
 // Eligible filters current episodes down to the ones a wake may be requested

--- a/internal/supervision/ledger.go
+++ b/internal/supervision/ledger.go
@@ -277,10 +277,9 @@ func ensureKey(file *ledgerFile, key string, now time.Time) *episodeRecord {
 	return record
 }
 
-// read stays lock-free on purpose: POSIX rename is atomic so a concurrent
-// swap never tears this read, and taking the writer's lock here would litter
-// every read-only command with lock files. Writer-side retries absorb the one
-// platform (Windows) where rename can fail against an open reader.
+// Stays lock-free on purpose: POSIX rename is atomic so a concurrent swap
+// never tears this read, and the writer's lock here would litter read-only
+// commands with lock files. Writer retries absorb Windows rename races.
 func (l *Ledger) read() ledgerFile {
 	data, err := os.ReadFile(l.path)
 	if err != nil {

--- a/internal/supervision/ledger_test.go
+++ b/internal/supervision/ledger_test.go
@@ -1,0 +1,219 @@
+package supervision
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testLedger(t *testing.T) (*Ledger, *time.Time) {
+	t.Helper()
+	home := t.TempDir()
+	ledger := OpenLedger(home)
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	ledger.now = func() time.Time { return now }
+	t.Cleanup(func() { ledger.now = time.Now })
+	return ledger, &now
+}
+
+func episode(id, generation string) Episode {
+	return Episode{
+		FleetID: "f_1", TargetID: id, TargetKind: "task",
+		Currentness: currentnessOf("f_1", generation), Kind: "blocked",
+	}
+}
+
+func TestUnseenEpisodeIsEligibleOnceThenDeduped(t *testing.T) {
+	ledger, _ := testLedger(t)
+	e := episode("t1", "g1")
+
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatalf("eligible = %d, want the unseen episode eligible", len(eligible))
+	}
+	if err := ledger.MarkRequested([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 0 {
+		t.Fatal("a requested wake must not spam parallel attempts")
+	}
+}
+
+func TestRequestedWakeRetriesAfterDeliveryWindow(t *testing.T) {
+	ledger, now := testLedger(t)
+	e := episode("t1", "g1")
+	if err := ledger.MarkRequested([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	*now = now.Add(DefaultPolicy().DeliveryTimeout)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatal("a delivery that never got accepted becomes retry-eligible after the bounded window")
+	}
+}
+
+func TestAcceptedWakeAwaitsOrientProgressBeforeRetry(t *testing.T) {
+	ledger, now := testLedger(t)
+	e := episode("t1", "g1")
+	if err := ledger.MarkRequested([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.MarkAccepted(Keys([]Episode{e})); err != nil {
+		t.Fatal(err)
+	}
+	*now = now.Add(DefaultPolicy().DeliveryTimeout)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 0 {
+		t.Fatal("accepted delivery inside the progress window is not a failure")
+	}
+	*now = now.Add(DefaultPolicy().ProgressTimeout + DefaultPolicy().DeliveryTimeout)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatal("acceptance without any orient progress becomes retry-eligible after the bounded window")
+	}
+}
+
+func TestOrientedEpisodeNeverRewakesUntilCurrentnessChanges(t *testing.T) {
+	ledger, now := testLedger(t)
+	e := episode("t1", "g1")
+	if err := ledger.MarkRequested([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.MarkOriented([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	*now = now.Add(MaxLedgerAge / 2)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 0 {
+		t.Fatal("an unchanged oriented condition must not spin immediate infinite turns")
+	}
+	next := episode("t1", "g2")
+	if eligible := ledger.Eligible([]Episode{next}); len(eligible) != 1 {
+		t.Fatal("new evidence/currentness is a new episode and is eligible normally")
+	}
+
+	// Past the mechanism-memory bound the exact stale episode becomes
+	// eligible once more: the explicit bounded recovery policy, so a
+	// condition that outlives the ledger cannot be silenced forever.
+	*now = now.Add(MaxLedgerAge + time.Minute)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatal("aged mechanism memory loses its dedupe and may wake again")
+	}
+}
+
+func TestLedgerSurvivesRestartAndRecoversFromCorruption(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ledgerRel)
+	ledger := OpenLedger(home)
+	e := episode("t1", "g1")
+	if err := ledger.MarkOriented([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	reopened := OpenLedger(home)
+	if eligible := reopened.Eligible([]Episode{e}); len(eligible) != 0 {
+		t.Fatal("mechanism memory must survive a process restart")
+	}
+
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	corrupted := OpenLedger(home)
+	// Corruption costs at most one bounded duplicate wake; it never errors.
+	if eligible := corrupted.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatal("corrupted ledger recovers as disposable empty state")
+	}
+	if err := corrupted.MarkRequested([]Episode{e}); err != nil {
+		t.Fatalf("write after corruption: %v", err)
+	}
+}
+
+func TestLedgerPrunesAgeAndCount(t *testing.T) {
+	ledger, now := testLedger(t)
+	for i := range MaxLedgerEntries + 10 {
+		e := episode(string(rune('a'+i%26))+string(rune('a'+i/26)), "g")
+		if err := ledger.MarkRequested([]Episode{e}); err != nil {
+			t.Fatal(err)
+		}
+		*now = now.Add(time.Second)
+	}
+	file := ledger.read()
+	if len(file.Episodes) > MaxLedgerEntries {
+		t.Fatalf("entries = %d, want the count bound enforced", len(file.Episodes))
+	}
+
+	old := OpenLedger(t.TempDir())
+	oldNow := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	old.now = func() time.Time { return oldNow }
+	e := episode("t1", "g1")
+	if err := old.MarkRequested([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	old.now = func() time.Time { return oldNow.Add(MaxLedgerAge + time.Minute) }
+	if eligible := old.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatal("an aged-out entry loses its mechanism memory and may wake again")
+	}
+	if _, exists := old.read().Episodes[e.Key()]; exists {
+		t.Fatal("aged entries are pruned, not merely re-eligibled")
+	}
+}
+
+func TestBridgeErrorCooldownBoundsFailureNotices(t *testing.T) {
+	ledger, now := testLedger(t)
+	host := "claude"
+	if !ledger.BridgeErroredBefore(host, BridgeFailureCooldown) {
+		t.Fatal("no recorded failure yet")
+	}
+	if err := ledger.MarkBridgeError(host, "arm failed"); err != nil {
+		t.Fatal(err)
+	}
+	if ledger.BridgeErroredBefore(host, BridgeFailureCooldown) {
+		t.Fatal("a fresh failure notice suppresses duplicates inside the cooldown")
+	}
+	*now = now.Add(BridgeFailureCooldown + time.Minute)
+	if !ledger.BridgeErroredBefore(host, BridgeFailureCooldown) {
+		t.Fatal("the cooldown re-arms so a still-broken bridge surfaces again")
+	}
+}
+
+func TestProgressDistinguishesAcceptanceFromOrientation(t *testing.T) {
+	ledger, _ := testLedger(t)
+	e := episode("t1", "g1")
+	lastAccepted, lastOriented := ledger.Progress()
+	if lastAccepted != nil || lastOriented != nil {
+		t.Fatal("empty ledger reports no stamps")
+	}
+	if err := ledger.MarkAccepted(Keys([]Episode{e})); err != nil {
+		t.Fatal(err)
+	}
+	lastAccepted, lastOriented = ledger.Progress()
+	if lastAccepted == nil || lastOriented != nil {
+		t.Fatal("acceptance alone must not read as orientation progress")
+	}
+	if err := ledger.MarkOriented([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	if _, lastOriented = ledger.Progress(); lastOriented == nil {
+		t.Fatal("orientation stamp missing after orient")
+	}
+}
+
+func TestConcurrentLedgerWritersStayConsistent(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			e := episode(string(rune('a'+i)), "g")
+			_ = ledger.MarkRequested([]Episode{e})
+			_ = ledger.MarkOriented([]Episode{e})
+		}(i)
+	}
+	wg.Wait()
+	file := ledger.read()
+	if len(file.Episodes) != 8 {
+		t.Fatalf("entries = %d, want every concurrent writer's episode recorded once", len(file.Episodes))
+	}
+	for _, record := range file.Episodes {
+		if record.Oriented == nil || record.DeliveryRequested == nil {
+			t.Fatalf("record %#v lost a stage to a racing writer", record.Key)
+		}
+	}
+}

--- a/internal/supervision/status.go
+++ b/internal/supervision/status.go
@@ -10,16 +10,57 @@ import (
 	"github.com/atqamz/hand/internal/watcher"
 )
 
+func osExecutableOrUnknown() string {
+	exe, err := os.Executable()
+	if err != nil || exe == "" {
+		return "unknown"
+	}
+	return exe
+}
+
 func osEnv(key string) string { return os.Getenv(key) }
 
-// Capability states for unattended Supervisor turn delivery, per harness.
-// A product may support Worker execution while failing turn delivery, so the
-// two are never collapsed into one supported boolean.
+// Capability states for unattended Supervisor turn delivery. A product may
+// support Worker execution while failing turn delivery; supported means
+// live-qualified, and everything before that is available-unqualified.
 const (
 	CapabilitySupported   = "supported"
+	CapabilityUnqualified = "available-unqualified"
 	CapabilityDegraded    = "degraded"
 	CapabilityUnsupported = "unsupported"
 )
+
+// Hosts whose exact runtime path has passed live no-operator-input dogfood.
+// Deliberately empty until that evidence exists; qualification flips a host
+// from available-unqualified to supported, never source-code intent.
+var qualifiedHosts = map[string]bool{}
+
+// The Supervisor turn-delivery registry, distinct from harness's Worker
+// launch support: a name may build workers while having no wake bridge, and
+// only these five carry supervisor semantics.
+var supervisorHosts = []string{
+	harness.Claude,
+	harness.Codex,
+	harness.Grok,
+	harness.Pi,
+	harness.OpenCode,
+}
+
+// IsSupervisorHost reports whether name belongs to the Supervisor
+// turn-delivery registry.
+func IsSupervisorHost(name string) bool {
+	for _, host := range supervisorHosts {
+		if host == name {
+			return true
+		}
+	}
+	return false
+}
+
+// SupervisorHosts returns the registry in stable order.
+func SupervisorHosts() []string {
+	return append([]string(nil), supervisorHosts...)
+}
 
 // Status is the typed integration diagnostic surface. Every field answers one
 // separate operator question; there is deliberately no single supervision
@@ -38,13 +79,15 @@ type Status struct {
 	Integration       string
 	IntegrationDetail string
 
-	// WakeDeliveryCapability is whether this host can convert a Hand wake into
-	// a reasoning opportunity without an operator message at all.
+	// WakeDelivery is whether this host converts a wake into a reasoning
+	// opportunity unattended - and at which confidence: supported means
+	// live-qualified, available-unqualified means static preconditions only.
 	WakeDelivery       string
 	WakeDeliveryReason string
 
-	// Attachment is whether a wake bridge is currently armed/attached where
-	// that concept applies. Watcher liveness is reported separately.
+	// Attachment is whether THIS host's wait bridge is currently held by a
+	// live runtime of THIS Fleet, read from heartbeat evidence - never from
+	// watcher liveness, which is reported separately below.
 	Attachment string
 
 	// LastAccepted and LastOriented are ledger stamps: acceptance alone is
@@ -52,6 +95,8 @@ type Status struct {
 	LastAccepted *time.Time
 	LastOriented *time.Time
 
+	// WatcherLiveness answers exactly one question: is a fleet observer
+	// process alive? It says nothing about wake delivery.
 	WatcherLiveness string
 }
 
@@ -62,28 +107,33 @@ type StatusInput struct {
 	Exe       string
 }
 
-// Names the wake mechanism each harness relies on; the entries with no
-// installed file have bridges that are instructions- or runtime-owned.
+// The wake mechanism each registry host relies on.
 var hostMechanisms = map[string]string{
-	harness.Claude:   "Stop hook async rewake",
-	harness.Codex:    "same-thread codex queue",
+	harness.Claude:   "Stop hook asyncRewake",
+	harness.Codex:    "same-thread codex queue driven by project-scope Stop hook",
 	harness.OpenCode: "persistent TUI plugin synchronous prompt",
-	harness.Pi:       "extension follow-up with turn trigger",
+	harness.Pi:       "extension mechanism follow-up with turn trigger",
 	harness.Grok:     "host-owned background monitor completion",
 }
 
-// IntegrationStatus assembles the typed diagnostics for one fleet home. The
-// Codex capability probes the installed CLI's queue behavior, not its product
-// name; every other host's capability follows from its mechanism.
+// IntegrationStatus assembles the typed diagnostics for one fleet home: the
+// Codex capability probes installed queue behavior rather than product name,
+// file-backed hosts degrade on drift, nothing claims supported pre-proof.
 func IntegrationStatus(ctx context.Context, in StatusInput) (Status, error) {
 	status := Status{
 		Harness:       in.Detection.Name,
 		HarnessSource: in.Detection.Source,
 	}
-	if in.Detection.Name == "" {
-		status.WakeDelivery = CapabilityUnsupported
-		status.WakeDeliveryReason = "no Supervisor Harness is detected in this runtime"
+	if !IsSupervisorHost(in.Detection.Name) {
+		if in.Detection.Name == "" {
+			status.WakeDelivery = CapabilityUnsupported
+			status.WakeDeliveryReason = "no Supervisor Harness is detected in this runtime"
+		} else {
+			status.WakeDelivery = CapabilityUnsupported
+			status.WakeDeliveryReason = fmt.Sprintf("harness %q has worker support but no supervisor turn-delivery path", in.Detection.Name)
+		}
 		status.Integration = "absent"
+		status.finishIndependentFields(in)
 		return status, nil
 	}
 
@@ -93,24 +143,35 @@ func IntegrationStatus(ctx context.Context, in StatusInput) (Status, error) {
 		if threadID == "" {
 			status.RuntimeIdentity = "unidentified"
 			status.RuntimeDetail = fmt.Sprintf("%s is not set, so the live Codex thread cannot be addressed", CodexThreadEnv)
-			status.WakeDelivery = CapabilityDegraded
-			status.WakeDeliveryReason = "wake can be requested but no live thread is addressable from this runtime"
 		} else {
 			status.RuntimeIdentity = "identified"
 			status.RuntimeDetail = threadID
-			if err := ProbeCodexQueue(ctx, RunCommand); err != nil {
-				status.WakeDelivery = CapabilityUnsupported
-				status.WakeDeliveryReason = err.Error()
-				break
-			}
-			status.WakeDelivery = CapabilitySupported
 		}
-		status.Integration = "not-required"
+		status.Integration = inspectCodexHooks(codexHooksPath(in.Home), osExecutableOrUnknown()).State
+		probeErr := ProbeCodexQueue(ctx, RunCommand)
+		switch {
+		case status.Integration != "installed" && status.Integration != "unchanged":
+			status.WakeDelivery = CapabilityDegraded
+			status.WakeDeliveryReason = fmt.Sprintf("codex Stop-hook integration is %s; run hand init to repair it, then approve it under /hooks", status.Integration)
+		case probeErr != nil:
+			status.WakeDelivery = CapabilityUnsupported
+			status.WakeDeliveryReason = probeErr.Error()
+		case threadID == "":
+			status.WakeDelivery = CapabilityDegraded
+			status.WakeDeliveryReason = "wake can be requested but no live thread is addressable from this runtime"
+		default:
+			status.WakeDelivery = CapabilityUnqualified
+			status.WakeDeliveryReason = hostMechanisms[harness.Codex] + "; requires features.hooks enabled and /hooks trust approval"
+		}
 
 	case harness.Claude:
 		result, err := CheckClaudeStopHook(in.Home, in.Exe)
 		if err != nil {
-			return status, err
+			status.Integration = result.State
+			status.IntegrationDetail = result.Detail
+			status.WakeDelivery = CapabilityDegraded
+			status.WakeDeliveryReason = fmt.Sprintf("claude integration is %s: %s; run hand init to repair it", result.State, result.Detail)
+			break
 		}
 		status.Integration = result.State
 		status.IntegrationDetail = result.Detail
@@ -132,37 +193,47 @@ func IntegrationStatus(ctx context.Context, in StatusInput) (Status, error) {
 	case harness.Grok:
 		status.Integration = "not-required"
 		status.IntegrationDetail = "the Grok bridge is the host background-task lifecycle, established through generated Supervisor instructions"
-		status.WakeDelivery = CapabilitySupported
-		status.WakeDeliveryReason = hostMechanisms[harness.Grok]
+		status.WakeDelivery = CapabilityUnqualified
+		status.WakeDeliveryReason = hostMechanisms[harness.Grok] + "; instruction-established, live qualification pending"
+	}
 
+	status.finishIndependentFields(in)
+	return status, nil
+}
+
+// Fills the two mechanically independent liveness answers: bridge attachment
+// comes from this Fleet's heartbeat record, watcher liveness from fleet-home
+// ownership. Neither implies the other.
+func (s *Status) finishIndependentFields(in StatusInput) {
+	record := ReadAttachment(in.Home)
+	switch {
+	case record != nil && record.Fresh(time.Now()) && (record.Host == s.Harness || s.Harness == ""):
+		s.Attachment = "attached"
+		if record.Runtime != "" {
+			s.Attachment += ":" + record.Runtime
+		}
 	default:
-		status.WakeDelivery = CapabilityUnsupported
-		status.WakeDeliveryReason = fmt.Sprintf("harness %q has no qualified unattended turn delivery path", in.Detection.Name)
-		status.Integration = "absent"
+		s.Attachment = "detached"
 	}
 
 	attached, err := watcher.IsAttached(in.Home)
 	switch {
 	case err != nil:
-		status.Attachment = "unknown"
-		status.WatcherLiveness = "unknown"
+		s.WatcherLiveness = "unknown"
 	case attached:
-		status.Attachment = "attached"
-		status.WatcherLiveness = "alive"
+		s.WatcherLiveness = "alive"
 	default:
-		status.Attachment = "detached"
-		status.WatcherLiveness = "idle"
+		s.WatcherLiveness = "idle"
 	}
 
 	lastAccepted, lastOriented := OpenLedger(in.Home).Progress()
-	status.LastAccepted = lastAccepted
-	status.LastOriented = lastOriented
-	return status, nil
+	s.LastAccepted = lastAccepted
+	s.LastOriented = lastOriented
 }
 
 func setFileBackedDelivery(status *Status, integrationState string) {
-	status.WakeDelivery = CapabilitySupported
-	status.WakeDeliveryReason = hostMechanisms[status.Harness]
+	status.WakeDelivery = CapabilityUnqualified
+	status.WakeDeliveryReason = hostMechanisms[status.Harness] + "; live qualification pending"
 	if integrationState != "installed" && integrationState != "unchanged" {
 		status.WakeDelivery = CapabilityDegraded
 		status.WakeDeliveryReason = fmt.Sprintf("%s integration is %s; run hand init to repair it", status.Harness, integrationState)

--- a/internal/supervision/status.go
+++ b/internal/supervision/status.go
@@ -1,0 +1,183 @@
+package supervision
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/watcher"
+)
+
+func osEnv(key string) string { return os.Getenv(key) }
+
+// Capability states for unattended Supervisor turn delivery, per harness.
+// A product may support Worker execution while failing turn delivery, so the
+// two are never collapsed into one supported boolean.
+const (
+	CapabilitySupported   = "supported"
+	CapabilityDegraded    = "degraded"
+	CapabilityUnsupported = "unsupported"
+)
+
+// Status is the typed integration diagnostic surface. Every field answers one
+// separate operator question; there is deliberately no single supervision
+// healthy boolean that could erase which stage is or is not working.
+type Status struct {
+	Harness       string
+	HarnessSource string
+
+	// RuntimeIdentity says whether the exact live Supervisor runtime can be
+	// addressed where the host supports it (a Codex thread ID, for example).
+	RuntimeIdentity string
+	RuntimeDetail   string
+
+	// Integration is the bootstrap/install state of Hand-owned host glue:
+	// installed, unchanged, stale, absent, conflict, not-required.
+	Integration       string
+	IntegrationDetail string
+
+	// WakeDeliveryCapability is whether this host can convert a Hand wake into
+	// a reasoning opportunity without an operator message at all.
+	WakeDelivery       string
+	WakeDeliveryReason string
+
+	// Attachment is whether a wake bridge is currently armed/attached where
+	// that concept applies. Watcher liveness is reported separately.
+	Attachment string
+
+	// LastAccepted and LastOriented are ledger stamps: acceptance alone is
+	// never progress; only orient demonstrates reasoning re-entry.
+	LastAccepted *time.Time
+	LastOriented *time.Time
+
+	WatcherLiveness string
+}
+
+// StatusInput carries what status assembly cannot discover itself.
+type StatusInput struct {
+	Home      string
+	Detection harness.Detection
+	Exe       string
+}
+
+// Names the wake mechanism each harness relies on; the entries with no
+// installed file have bridges that are instructions- or runtime-owned.
+var hostMechanisms = map[string]string{
+	harness.Claude:   "Stop hook async rewake",
+	harness.Codex:    "same-thread codex queue",
+	harness.OpenCode: "persistent TUI plugin synchronous prompt",
+	harness.Pi:       "extension follow-up with turn trigger",
+	harness.Grok:     "host-owned background monitor completion",
+}
+
+// IntegrationStatus assembles the typed diagnostics for one fleet home. The
+// Codex capability probes the installed CLI's queue behavior, not its product
+// name; every other host's capability follows from its mechanism.
+func IntegrationStatus(ctx context.Context, in StatusInput) (Status, error) {
+	status := Status{
+		Harness:       in.Detection.Name,
+		HarnessSource: in.Detection.Source,
+	}
+	if in.Detection.Name == "" {
+		status.WakeDelivery = CapabilityUnsupported
+		status.WakeDeliveryReason = "no Supervisor Harness is detected in this runtime"
+		status.Integration = "absent"
+		return status, nil
+	}
+
+	switch in.Detection.Name {
+	case harness.Codex:
+		threadID := osEnv(CodexThreadEnv)
+		if threadID == "" {
+			status.RuntimeIdentity = "unidentified"
+			status.RuntimeDetail = fmt.Sprintf("%s is not set, so the live Codex thread cannot be addressed", CodexThreadEnv)
+			status.WakeDelivery = CapabilityDegraded
+			status.WakeDeliveryReason = "wake can be requested but no live thread is addressable from this runtime"
+		} else {
+			status.RuntimeIdentity = "identified"
+			status.RuntimeDetail = threadID
+			if err := ProbeCodexQueue(ctx, RunCommand); err != nil {
+				status.WakeDelivery = CapabilityUnsupported
+				status.WakeDeliveryReason = err.Error()
+				break
+			}
+			status.WakeDelivery = CapabilitySupported
+		}
+		status.Integration = "not-required"
+
+	case harness.Claude:
+		result, err := CheckClaudeStopHook(in.Home, in.Exe)
+		if err != nil {
+			return status, err
+		}
+		status.Integration = result.State
+		status.IntegrationDetail = result.Detail
+		setFileBackedDelivery(&status, result.State)
+
+	case harness.OpenCode, harness.Pi:
+		results, err := CheckHostAssets(in.Home, in.Detection.Name, in.Exe)
+		if err != nil {
+			return status, err
+		}
+		status.Integration = aggregateAssetState(results)
+		for _, result := range results {
+			if result.Detail != "" {
+				status.IntegrationDetail = result.Detail
+			}
+		}
+		setFileBackedDelivery(&status, status.Integration)
+
+	case harness.Grok:
+		status.Integration = "not-required"
+		status.IntegrationDetail = "the Grok bridge is the host background-task lifecycle, established through generated Supervisor instructions"
+		status.WakeDelivery = CapabilitySupported
+		status.WakeDeliveryReason = hostMechanisms[harness.Grok]
+
+	default:
+		status.WakeDelivery = CapabilityUnsupported
+		status.WakeDeliveryReason = fmt.Sprintf("harness %q has no qualified unattended turn delivery path", in.Detection.Name)
+		status.Integration = "absent"
+	}
+
+	attached, err := watcher.IsAttached(in.Home)
+	switch {
+	case err != nil:
+		status.Attachment = "unknown"
+		status.WatcherLiveness = "unknown"
+	case attached:
+		status.Attachment = "attached"
+		status.WatcherLiveness = "alive"
+	default:
+		status.Attachment = "detached"
+		status.WatcherLiveness = "idle"
+	}
+
+	lastAccepted, lastOriented := OpenLedger(in.Home).Progress()
+	status.LastAccepted = lastAccepted
+	status.LastOriented = lastOriented
+	return status, nil
+}
+
+func setFileBackedDelivery(status *Status, integrationState string) {
+	status.WakeDelivery = CapabilitySupported
+	status.WakeDeliveryReason = hostMechanisms[status.Harness]
+	if integrationState != "installed" && integrationState != "unchanged" {
+		status.WakeDelivery = CapabilityDegraded
+		status.WakeDeliveryReason = fmt.Sprintf("%s integration is %s; run hand init to repair it", status.Harness, integrationState)
+	}
+}
+
+func aggregateAssetState(results []InstallResult) string {
+	state := "installed"
+	for _, result := range results {
+		switch result.State {
+		case "conflict":
+			return "conflict"
+		case "stale", "absent":
+			state = result.State
+		}
+	}
+	return state
+}

--- a/internal/supervision/status.go
+++ b/internal/supervision/status.go
@@ -107,7 +107,7 @@ type StatusInput struct {
 	Exe       string
 }
 
-// The wake mechanism each registry host relies on.
+// Wake mechanism each registry host relies on.
 var hostMechanisms = map[string]string{
 	harness.Claude:   "Stop hook asyncRewake",
 	harness.Codex:    "same-thread codex queue driven by project-scope Stop hook",

--- a/internal/supervision/subject.go
+++ b/internal/supervision/subject.go
@@ -1,0 +1,92 @@
+// Package supervision owns Supervisor turn delivery: exact wake episode
+// identity, the disposable wake/progress ledger, the provider-neutral wait,
+// and managed host-integration installation. It deliberately does not live in
+// internal/harness, which means Worker Harness launch/routing only.
+package supervision
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+
+	"github.com/atqamz/hand/internal/orientation"
+)
+
+// Episode is one actionable subject at one exact currentness. The zero value
+// is never a valid episode: every field is required for the key.
+type Episode struct {
+	FleetID     string
+	TargetID    string
+	TargetKind  string
+	Currentness orientation.CurrentnessToken
+	Kind        string
+}
+
+// Key is the stable dedupe identity: fleet, target, currentness token, and
+// actionable kind. Rendered reason, PIDs, wall-clock, display labels, and
+// conversation IDs are deliberately excluded from deciding a wake.
+func (e Episode) Key() string {
+	parts := []string{e.FleetID, e.TargetKind, e.TargetID, e.Currentness.String(), e.Kind}
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = fmt.Fprintf(hash, "%d:", len(part))
+		hash.Write([]byte(part))
+	}
+	return "w_" + hex.EncodeToString(hash.Sum(nil))
+}
+
+// FromEvidence derives wake episodes from unbounded underlying evidence,
+// never the bounded rendered orientation: a new subject behind a full display
+// slice is exactly the starvation this seam prevents. Duplicates coalesce.
+func FromEvidence(evidence orientation.Evidence) []Episode {
+	seen := make(map[string]bool, len(evidence.Actionable))
+	var episodes []Episode
+	for _, item := range evidence.Actionable {
+		target := orientation.TargetFor(evidence.FleetID, orientation.TargetEvidence{
+			ID:         item.TargetID,
+			Kind:       item.TargetKind,
+			Generation: item.Generation,
+		})
+		if target.ID == "" || target.Currentness.IsZero() {
+			continue
+		}
+		episode := Episode{
+			FleetID:     evidence.FleetID,
+			TargetID:    item.TargetID,
+			TargetKind:  item.TargetKind,
+			Currentness: target.Currentness,
+			Kind:        item.Kind,
+		}
+		key := episode.Key()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		episodes = append(episodes, episode)
+	}
+	sort.Slice(episodes, func(i, j int) bool { return episodes[i].Key() < episodes[j].Key() })
+	return episodes
+}
+
+// Keys maps episodes to their dedupe identities in episode order.
+func Keys(episodes []Episode) []string {
+	keys := make([]string, len(episodes))
+	for i, episode := range episodes {
+		keys[i] = episode.Key()
+	}
+	return keys
+}
+
+const maxWakeReason = 240
+
+// WakeText is the bounded mechanism input handed to a host bridge. It carries
+// no worker report prose, plan brief, pane content, or environment: a Hand
+// wake is mechanism input, never operator authority or mutation authorization.
+func WakeText(fleetID string) string {
+	text := fmt.Sprintf("Hand has current actionable work for Fleet %s. Run `hand orient` before reasoning or acting.", fleetID)
+	if runes := []rune(text); len(runes) > maxWakeReason {
+		text = string(runes[:maxWakeReason])
+	}
+	return text
+}

--- a/internal/supervision/subject.go
+++ b/internal/supervision/subject.go
@@ -78,6 +78,31 @@ func Keys(episodes []Episode) []string {
 	return keys
 }
 
+// EpisodePayload is one episode's machine-protocol projection: exact
+// identifiers only, no report prose, plan briefs, or environment.
+type EpisodePayload struct {
+	Key         string `json:"key"`
+	TargetID    string `json:"target_id"`
+	TargetKind  string `json:"target_kind"`
+	Currentness string `json:"currentness"`
+	Action      string `json:"action"`
+}
+
+// EpisodePayloads projects episodes for the versioned wake protocol.
+func EpisodePayloads(episodes []Episode) []EpisodePayload {
+	payloads := make([]EpisodePayload, 0, len(episodes))
+	for _, episode := range episodes {
+		payloads = append(payloads, EpisodePayload{
+			Key:         episode.Key(),
+			TargetID:    episode.TargetID,
+			TargetKind:  episode.TargetKind,
+			Currentness: episode.Currentness.String(),
+			Action:      episode.Kind,
+		})
+	}
+	return payloads
+}
+
 const maxWakeReason = 240
 
 // WakeText is the bounded mechanism input handed to a host bridge. It carries

--- a/internal/supervision/subject_test.go
+++ b/internal/supervision/subject_test.go
@@ -1,0 +1,85 @@
+package supervision
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/orientation"
+)
+
+func actionable(id, generation, kind string) orientation.ActionableEvidence {
+	return orientation.ActionableEvidence{
+		TargetID: id, TargetKind: "task", Generation: []string{generation},
+		Kind: kind, Reason: "r", Provenance: "report",
+	}
+}
+
+func TestEpisodeKeySeparatesExactCurrentnessAndAction(t *testing.T) {
+	base := Episode{FleetID: "f_1", TargetID: "t1", TargetKind: "task", Currentness: currentnessOf("f_1", "g1"), Kind: "blocked"}
+	same := base
+	if base.Key() != same.Key() || base.Key() == "" {
+		t.Fatal("identical episodes must share one key")
+	}
+	nextCurrentness := base
+	nextCurrentness.Currentness = currentnessOf("f_1", "g2")
+	if base.Key() == nextCurrentness.Key() {
+		t.Fatal("changed currentness is a new episode")
+	}
+	otherAction := base
+	otherAction.Kind = "needs-decision"
+	if base.Key() == otherAction.Key() {
+		t.Fatal("different actionable kind is a different episode")
+	}
+	otherTarget := base
+	otherTarget.TargetID = "t2"
+	if base.Key() == otherTarget.Key() {
+		t.Fatal("a different target is a different episode")
+	}
+}
+
+func currentnessOf(fleetID, generation string) orientation.CurrentnessToken {
+	return orientation.TargetFor(fleetID, orientation.TargetEvidence{ID: "x", Kind: "task", Generation: []string{generation}}).Currentness
+}
+
+// The 65th genuinely new subject behind a full 64-item rendered slice is the
+// starvation this seam exists to prevent: eligibility derives from unbounded
+// evidence, so every subject produces an episode.
+func TestFromEvidenceExceedsOrientationDisplayBound(t *testing.T) {
+	evidence := orientation.Evidence{FleetID: "f_1"}
+	for i := range 100 {
+		evidence.Actionable = append(evidence.Actionable,
+			actionable(strings.Repeat("t", 1)+string(rune('a'+i/26))+string(rune('a'+i%26)), "gen", "kind"))
+	}
+	episodes := FromEvidence(evidence)
+	if len(episodes) != 100 {
+		t.Fatalf("episodes = %d, want every unbounded subject represented (100)", len(episodes))
+	}
+	bounded := orientation.Build(evidence)
+	if len(bounded.Actionable) > 64 {
+		t.Fatalf("rendered orientation = %d items, want the display bound intact", len(bounded.Actionable))
+	}
+}
+
+func TestFromEvidenceCoalescesDuplicateKeys(t *testing.T) {
+	evidence := orientation.Evidence{
+		FleetID:    "f_1",
+		Actionable: []orientation.ActionableEvidence{actionable("t1", "g1", "blocked"), actionable("t1", "g1", "blocked")},
+	}
+	episodes := FromEvidence(evidence)
+	if len(episodes) != 1 {
+		t.Fatalf("episodes = %d, want duplicates coalesced into one", len(episodes))
+	}
+}
+
+func TestWakeTextIsBoundedMechanismInput(t *testing.T) {
+	text := WakeText("f_abc")
+	if !strings.Contains(text, "f_abc") || !strings.Contains(text, "`hand orient`") {
+		t.Fatalf("text = %q, want fleet identity and the orient instruction", text)
+	}
+	huge := strings.Repeat("F", 500)
+	fleet := huge + "tail-dropped"
+	text = WakeText(fleet)
+	if runes := len([]rune(text)); runes > maxWakeReason {
+		t.Fatalf("text = %d runes, want bounded at %d", runes, maxWakeReason)
+	}
+}

--- a/internal/supervision/wait.go
+++ b/internal/supervision/wait.go
@@ -3,6 +3,7 @@ package supervision
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -61,9 +62,9 @@ type Waiter struct {
 // WakeSchema versions the machine protocol host adapters consume.
 const WakeSchema = "hand.supervision.wake.v1"
 
-// Wait blocks until at least one current actionable episode can be claimed
-// atomically, records the claim plus this runtime's bridge attachment, and
-// returns the coalesced wake. Typed watcher results pass through unchanged.
+// Wait blocks until at least one current actionable episode is claimed by a
+// runtime that provably still holds THE Fleet Supervisor bridge, then returns
+// the coalesced wake. Typed watcher results pass through unchanged.
 func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -76,7 +77,19 @@ func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 	if err != nil {
 		return Wake{}, err
 	}
+
+	// The bridge is claimed BEFORE any eligibility decision: from here until
+	// stop, this runtime either provably owns the Fleet bridge or has already
+	// been kicked out with ErrBridgeOwned.
+	guard, err := acquireBridge(ctx, w, cfg, wake.FleetID)
+	if err != nil {
+		return Wake{}, err
+	}
+	defer guard.stop()
+
 	if len(eligible) > 0 {
+		// Acquisition just proved ownership under the same lock; claiming
+		// immediately keeps that proof contiguous with the claim boundary.
 		wake, won, claimErr := claimAndDeliver(w, cfg, wake, allEpisodes)
 		if claimErr != nil || won {
 			return wake, claimErr
@@ -89,9 +102,9 @@ func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 		return Wake{}, err
 	}
 	if attached {
-		return pollUntilEligible(ctx, w, cfg)
+		return pollUntilEligible(ctx, guard, w, cfg)
 	}
-	return waitOwned(ctx, w, cfg)
+	return waitOwned(ctx, guard, w, cfg)
 }
 
 // Derives episodes from authoritative evidence and reports all of them plus
@@ -107,9 +120,9 @@ func currentEpisodes(ctx context.Context, w Waiter, host string) (Wake, []Episod
 	return wake, episodes, w.Ledger.Eligible(episodes), nil
 }
 
-// CAS-claims the host bridge under the attachment file lock, keeping its
-// record fresh until stopped. Faults and theft arrive on the guard channel:
-// a waiter running after losing its record would otherwise read as attached.
+// CAS-claims THE one Fleet bridge under the attachment file lock - exclusive
+// across every harness - and derives the wait's cancellation domain: theft
+// or refresh faults cancel guardCtx immediately, ending any in-flight wait.
 func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string) (*bridgeGuard, error) {
 	interval := intervalOr(cfg.PollInterval)
 	if interval < time.Second {
@@ -120,6 +133,7 @@ func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string
 		runtime = fmt.Sprintf("pid:%d", os.Getpid())
 	}
 	now := time.Now()
+	lease := 3 * interval
 	record := AttachmentRecord{
 		Host:        cfg.Host,
 		Runtime:     runtime,
@@ -127,7 +141,7 @@ func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string
 		FleetID:     fleetID,
 		StartedAt:   now,
 		HeartbeatAt: now,
-		ExpiresAt:   now.Add(3 * interval),
+		ExpiresAt:   now.Add(lease),
 	}
 	acquired, err := AcquireAttachment(w.Home, record)
 	if err != nil {
@@ -137,10 +151,17 @@ func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string
 		return nil, ErrBridgeOwned
 	}
 
-	guard := &bridgeGuard{stopc: make(chan struct{}), errc: make(chan error, 1)}
+	guardCtx, cancel := context.WithCancelCause(ctx)
+	guard := &bridgeGuard{
+		ctx: guardCtx, cancel: cancel,
+		stopc: make(chan struct{}), errc: make(chan error, 1),
+		home: w.Home, host: cfg.Host, runtime: runtime,
+		record: record, lease: lease,
+	}
 	guard.stop = sync.OnceFunc(func() {
 		close(guard.stopc)
 		ClearAttachment(w.Home, cfg.Host, runtime)
+		cancel(errors.New("supervision bridge stopped"))
 	})
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -151,17 +172,12 @@ func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string
 				return
 			case <-ctx.Done():
 				return
+			case <-guardCtx.Done():
+				return
 			case <-ticker.C:
-				now := time.Now()
-				record.HeartbeatAt = now
-				record.ExpiresAt = now.Add(3 * interval)
-				ours, refreshErr := RefreshAttachment(w.Home, record)
-				if refreshErr != nil {
-					guard.errc <- fmt.Errorf("attachment heartbeat: %w", refreshErr)
-					return
-				}
-				if !ours {
-					guard.errc <- ErrBridgeOwned
+				if proofErr := guard.prove(); proofErr != nil {
+					guard.errc <- proofErr
+					cancel(proofErr)
 					return
 				}
 			}
@@ -170,14 +186,40 @@ func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string
 	return guard, nil
 }
 
-// Advances one poll interval, aborting early on cancellation or a bridge-guard
-// fault so a stolen or unwritable attachment never reads as a healthy wait.
-func waitStep(ctx context.Context, guard *bridgeGuard, d time.Duration) error {
+// Proves current bridge ownership by refreshing this exact owner's record
+// under the attachment lock. Runs at every claim boundary after any blocking
+// wait so a successful ClaimEligible implies ownership held at that instant.
+func (g *bridgeGuard) prove() error {
+	ours, err := RefreshAttachment(g.home, g.record, g.lease)
+	if err != nil {
+		return fmt.Errorf("bridge ownership proof: %w", err)
+	}
+	if !ours {
+		return ErrBridgeOwned
+	}
+	return nil
+}
+
+// The first heartbeat/theft error, if the guard already reported one non-
+// blockingly.
+func (g *bridgeGuard) takeFault() error {
+	select {
+	case err := <-g.errc:
+		return err
+	default:
+		return nil
+	}
+}
+
+// Advances one poll interval on the guarded cancellation domain, aborting
+// early on cancellation or a bridge-guard fault so a stolen or unwritable
+// attachment never reads as a healthy wait.
+func waitStep(guard *bridgeGuard, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
-	case <-ctx.Done():
-		return context.Cause(ctx)
+	case <-guard.ctx.Done():
+		return context.Cause(guard.ctx)
 	case err := <-guard.errc:
 		return err
 	case <-timer.C:
@@ -186,62 +228,55 @@ func waitStep(ctx context.Context, guard *bridgeGuard, d time.Duration) error {
 }
 
 // Serves the case where another watcher owns the fleet home: stealing its
-// ownership would break that arm, so this wait levels on authoritative
-// evidence instead of watcher edges.
-func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
-	wake, _, _, err := currentEpisodes(ctx, w, cfg.Host)
-	if err != nil {
-		return Wake{}, err
-	}
-	guard, err := acquireBridge(ctx, w, cfg, wake.FleetID)
-	if err != nil {
-		return Wake{}, err
-	}
-	defer guard.stop()
+// ownership would break that arm, so this wait levels on evidence instead.
+// Every claim re-proves bridge ownership under the attachment lock first.
+func pollUntilEligible(ctx context.Context, guard *bridgeGuard, w Waiter, cfg WaitConfig) (Wake, error) {
 	for {
-		if err := waitStep(ctx, guard, intervalOr(cfg.PollInterval)); err != nil {
+		if err := waitStep(guard, intervalOr(cfg.PollInterval)); err != nil {
 			return Wake{}, err
 		}
 		wake, _, eligible, err := currentEpisodes(ctx, w, cfg.Host)
 		if err != nil {
 			return Wake{}, err
 		}
-		if len(eligible) > 0 {
-			wake, won, claimErr := claimAndDeliver(w, cfg, wake, eligible)
-			if claimErr != nil || won {
-				return wake, claimErr
-			}
-			// Lost the transaction race: the holder keeps delivering; keep
-			// observing for new work.
+		if len(eligible) == 0 {
+			continue
 		}
+		if proofErr := guard.prove(); proofErr != nil {
+			return Wake{}, proofErr
+		}
+		wake, won, claimErr := claimAndDeliver(w, cfg, wake, eligible)
+		if claimErr != nil || won {
+			return wake, claimErr
+		}
+		// Lost the transaction race: the holder keeps delivering; keep
+		// observing for new work.
 	}
 }
 
-// Holds watcher ownership and drives RunUntilEvent cycles until a delivered
-// cycle leaves something eligible. All-deduped cycles must not spin: an
-// unchanged key set backs off one poll interval; new episodes retry at once.
-func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
+// Drives RunUntilEvent cycles on the guarded cancellation domain; claims need
+// a fresh ownership proof at the boundary. All-deduped cycles back off one
+// poll interval instead of spinning; new episodes retry at once.
+func waitOwned(ctx context.Context, guard *bridgeGuard, w Waiter, cfg WaitConfig) (Wake, error) {
 	ownership, err := acquireWatcherOwnership(ctx, w.Home, false)
 	if err != nil {
 		return Wake{}, err
 	}
 	defer ownership.Release()
 
-	wake, _, _, err := currentEpisodes(ctx, w, cfg.Host)
-	if err != nil {
-		return Wake{}, err
-	}
-	guard, err := acquireBridge(ctx, w, cfg, wake.FleetID)
-	if err != nil {
-		return Wake{}, err
-	}
-	defer guard.stop()
-
 	var previous []string
 	for {
 		var caught bytes.Buffer
-		err := runWatcherUntilEvent(ctx, ownedWatcherConfig(w, cfg), &caught, io.Discard)
+		err := runWatcherUntilEvent(guard.ctx, ownedWatcherConfig(w, cfg), &caught, io.Discard)
 		if err != nil {
+			// Ownership loss cancels guardCtx mid-wait; surface that exact
+			// cause rather than the watcher's generic interruption wrapper.
+			if faultErr := guard.takeFault(); faultErr != nil {
+				return Wake{}, faultErr
+			}
+			if cause := context.Cause(guard.ctx); errors.Is(cause, ErrBridgeOwned) {
+				return Wake{}, cause
+			}
 			return Wake{}, err
 		}
 		wake, episodes, eligible, catchUpErr := currentEpisodes(ctx, w, cfg.Host)
@@ -249,6 +284,12 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 			return Wake{}, catchUpErr
 		}
 		if len(eligible) > 0 {
+			// Claim-boundary proof: a watcher cycle can sit through an entire
+			// ownership handover; the episode must go to whoever owns the
+			// bridge NOW, and this runtime must not consume it stale.
+			if proofErr := guard.prove(); proofErr != nil {
+				return Wake{}, proofErr
+			}
 			wake, won, claimErr := claimAndDeliver(w, cfg, wake, eligible)
 			if claimErr != nil || won {
 				return wake, claimErr
@@ -258,7 +299,7 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 		}
 		keys := Keys(episodes)
 		if slices.Equal(keys, previous) {
-			if err := waitStep(ctx, guard, intervalOr(cfg.PollInterval)); err != nil {
+			if err := waitStep(guard, intervalOr(cfg.PollInterval)); err != nil {
 				return Wake{}, err
 			}
 		}
@@ -307,10 +348,19 @@ func intervalOr(d time.Duration) time.Duration {
 	return d
 }
 
-// Owns one runtime's live attachment: stop() clears the record; errc carries
-// the first heartbeat fault or ownership theft.
+// Owns one runtime's live attachment and the wait's cancellation domain:
+// stop() clears the record; theft or faults cancel ctx with the exact cause
+// and mirror it on errc.
 type bridgeGuard struct {
-	stopc chan struct{}
-	stop  func()
-	errc  chan error
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	stopc  chan struct{}
+	stop   func()
+	errc   chan error
+
+	home    string
+	host    string
+	runtime string
+	record  AttachmentRecord
+	lease   time.Duration
 }

--- a/internal/supervision/wait.go
+++ b/internal/supervision/wait.go
@@ -77,7 +77,12 @@ func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 		return Wake{}, err
 	}
 	if len(eligible) > 0 {
-		return claimAndDeliver(w, cfg, wake, allEpisodes)
+		wake, won, claimErr := claimAndDeliver(w, cfg, wake, allEpisodes)
+		if claimErr != nil || won {
+			return wake, claimErr
+		}
+		// Another waiter claimed these episodes first: fall through and keep
+		// waiting instead of answering an empty success.
 	}
 	attached, err := watcherAttached(w.Home)
 	if err != nil {
@@ -102,10 +107,10 @@ func currentEpisodes(ctx context.Context, w Waiter, host string) (Wake, []Episod
 	return wake, episodes, w.Ledger.Eligible(episodes), nil
 }
 
-// Keeps the bridge-attachment record fresh while this wait runs and clears it
-// on exit. Attachment thus means "a live child of this runtime holds this
-// host's bridge" - mechanically independent from watcher liveness.
-func runHeartbeat(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string) (stop func()) {
+// CAS-claims the host bridge under the attachment file lock, keeping its
+// record fresh until stopped. Faults and theft arrive on the guard channel:
+// a waiter running after losing its record would otherwise read as attached.
+func acquireBridge(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string) (*bridgeGuard, error) {
 	interval := intervalOr(cfg.PollInterval)
 	if interval < time.Second {
 		interval = time.Second
@@ -124,68 +129,77 @@ func runHeartbeat(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string)
 		HeartbeatAt: now,
 		ExpiresAt:   now.Add(3 * interval),
 	}
-	_ = WriteAttachment(w.Home, record)
-	done := make(chan struct{})
+	acquired, err := AcquireAttachment(w.Home, record)
+	if err != nil {
+		return nil, fmt.Errorf("claim bridge attachment: %w", err)
+	}
+	if !acquired {
+		return nil, ErrBridgeOwned
+	}
+
+	guard := &bridgeGuard{stopc: make(chan struct{}), errc: make(chan error, 1)}
+	guard.stop = sync.OnceFunc(func() {
+		close(guard.stopc)
+		ClearAttachment(w.Home, cfg.Host, runtime)
+	})
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {
+			case <-guard.stopc:
+				return
 			case <-ctx.Done():
-				ClearAttachment(w.Home, cfg.Host, runtime)
-				close(done)
 				return
 			case <-ticker.C:
 				now := time.Now()
 				record.HeartbeatAt = now
 				record.ExpiresAt = now.Add(3 * interval)
-				_ = WriteAttachment(w.Home, record)
+				ours, refreshErr := RefreshAttachment(w.Home, record)
+				if refreshErr != nil {
+					guard.errc <- fmt.Errorf("attachment heartbeat: %w", refreshErr)
+					return
+				}
+				if !ours {
+					guard.errc <- ErrBridgeOwned
+					return
+				}
 			}
 		}
 	}()
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			ClearAttachment(w.Home, cfg.Host, runtime)
-			go func() {
-				select {
-				case <-done:
-				case <-time.After(2 * interval):
-				}
-			}()
-		})
-	}
+	return guard, nil
 }
 
-// Reports whether a fresh record for this host names a different live runtime,
-// in which case this waiter must defer rather than steal the bridge.
-func bridgeOwnedByAnotherRuntime(w Waiter, cfg WaitConfig) bool {
-	owner := BridgeOwner(w.Home, cfg.Host, time.Now())
-	if owner == "" || owner == cfg.RuntimeSession {
-		return false
+// Advances one poll interval, aborting early on cancellation or a bridge-guard
+// fault so a stolen or unwritable attachment never reads as a healthy wait.
+func waitStep(ctx context.Context, guard *bridgeGuard, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case err := <-guard.errc:
+		return err
+	case <-timer.C:
+		return nil
 	}
-	return !stringsHasPrefix(owner, fmt.Sprintf("pid:%d", os.Getpid()))
-}
-
-func stringsHasPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
 // Serves the case where another watcher owns the fleet home: stealing its
 // ownership would break that arm, so this wait levels on authoritative
 // evidence instead of watcher edges.
 func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
-	if bridgeOwnedByAnotherRuntime(w, cfg) {
-		return Wake{}, ErrBridgeOwned
-	}
 	wake, _, _, err := currentEpisodes(ctx, w, cfg.Host)
 	if err != nil {
 		return Wake{}, err
 	}
-	stop := runHeartbeat(ctx, w, cfg, wake.FleetID)
-	defer stop()
+	guard, err := acquireBridge(ctx, w, cfg, wake.FleetID)
+	if err != nil {
+		return Wake{}, err
+	}
+	defer guard.stop()
 	for {
-		if err := sleepCtx(ctx, intervalOr(cfg.PollInterval)); err != nil {
+		if err := waitStep(ctx, guard, intervalOr(cfg.PollInterval)); err != nil {
 			return Wake{}, err
 		}
 		wake, _, eligible, err := currentEpisodes(ctx, w, cfg.Host)
@@ -193,7 +207,12 @@ func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, err
 			return Wake{}, err
 		}
 		if len(eligible) > 0 {
-			return claimAndDeliver(w, cfg, wake, eligible)
+			wake, won, claimErr := claimAndDeliver(w, cfg, wake, eligible)
+			if claimErr != nil || won {
+				return wake, claimErr
+			}
+			// Lost the transaction race: the holder keeps delivering; keep
+			// observing for new work.
 		}
 	}
 }
@@ -202,9 +221,6 @@ func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, err
 // cycle leaves something eligible. All-deduped cycles must not spin: an
 // unchanged key set backs off one poll interval; new episodes retry at once.
 func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
-	if bridgeOwnedByAnotherRuntime(w, cfg) {
-		return Wake{}, ErrBridgeOwned
-	}
 	ownership, err := acquireWatcherOwnership(ctx, w.Home, false)
 	if err != nil {
 		return Wake{}, err
@@ -215,8 +231,11 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 	if err != nil {
 		return Wake{}, err
 	}
-	stop := runHeartbeat(ctx, w, cfg, wake.FleetID)
-	defer stop()
+	guard, err := acquireBridge(ctx, w, cfg, wake.FleetID)
+	if err != nil {
+		return Wake{}, err
+	}
+	defer guard.stop()
 
 	var previous []string
 	for {
@@ -230,11 +249,16 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 			return Wake{}, catchUpErr
 		}
 		if len(eligible) > 0 {
-			return claimAndDeliver(w, cfg, wake, eligible)
+			wake, won, claimErr := claimAndDeliver(w, cfg, wake, eligible)
+			if claimErr != nil || won {
+				return wake, claimErr
+			}
+			// Lost the transaction race: re-arm and observe again instead of
+			// answering an empty success.
 		}
 		keys := Keys(episodes)
 		if slices.Equal(keys, previous) {
-			if err := sleepCtx(ctx, intervalOr(cfg.PollInterval)); err != nil {
+			if err := waitStep(ctx, guard, intervalOr(cfg.PollInterval)); err != nil {
 				return Wake{}, err
 			}
 		}
@@ -242,17 +266,21 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 	}
 }
 
-// Performs the atomic eligibility-and-request transaction and fills in the
-// machine-protocol fields on the result.
-func claimAndDeliver(w Waiter, cfg WaitConfig, wake Wake, all []Episode) (Wake, error) {
-	claimed := w.Ledger.ClaimEligible(all)
+// Performs the atomic eligibility-and-request transaction. Won=false means
+// another waiter claimed inside the transaction: callers keep waiting and
+// never answer an empty success.
+func claimAndDeliver(w Waiter, cfg WaitConfig, wake Wake, all []Episode) (Wake, bool, error) {
+	claimed, claimErr := w.Ledger.ClaimEligible(all)
+	if claimErr != nil {
+		return Wake{}, false, claimErr
+	}
 	if len(claimed) == 0 {
-		return Wake{}, nil
+		return Wake{}, false, nil
 	}
 	wake.Schema = WakeSchema
 	wake.Episodes = claimed
 	wake.Message = WakeText(wake.FleetID)
-	return wake, nil
+	return wake, true, nil
 }
 
 func ownedWatcherConfig(w Waiter, cfg WaitConfig) watcher.Config {
@@ -279,13 +307,10 @@ func intervalOr(d time.Duration) time.Duration {
 	return d
 }
 
-func sleepCtx(ctx context.Context, d time.Duration) error {
-	timer := time.NewTimer(d)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return context.Cause(ctx)
-	case <-timer.C:
-		return nil
-	}
+// Owns one runtime's live attachment: stop() clears the record; errc carries
+// the first heartbeat fault or ownership theft.
+type bridgeGuard struct {
+	stopc chan struct{}
+	stop  func()
+	errc  chan error
 }

--- a/internal/supervision/wait.go
+++ b/internal/supervision/wait.go
@@ -1,0 +1,190 @@
+package supervision
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"github.com/atqamz/hand/internal/orientation"
+	"github.com/atqamz/hand/internal/watcher"
+)
+
+// Overridable seams onto the existing level-triggered watcher boundary.
+var (
+	acquireWatcherOwnership = watcher.AcquireContext
+	runWatcherUntilEvent    = watcher.RunUntilEvent
+	watcherAttached         = watcher.IsAttached
+)
+
+// WaitConfig carries the host name and everything the watcher boundary needs
+// to arm and poll. Timeout bounds the whole wait and only ever produces the
+// explicit checkpoint result (exit 4) the caller asked for.
+type WaitConfig struct {
+	Host           string
+	PollInterval   time.Duration
+	StaleThreshold time.Duration
+	ParkedBounds   watcher.ParkedBounds
+	Timeout        time.Duration
+}
+
+// Wake is one coalesced delivery: every currently eligible episode collapses
+// into one reasoning opportunity rather than one turn per subject.
+type Wake struct {
+	Host     string
+	FleetID  string
+	Text     string
+	Episodes []Episode
+}
+
+// EvidenceReader returns the unbounded underlying actionable evidence for the
+// resolved Fleet. It is the wake-eligibility source; rendered bounded
+// orientation is never consulted here.
+type EvidenceReader func(context.Context) (orientation.Evidence, error)
+
+// Waiter bundles what a single wait invocation reads against.
+type Waiter struct {
+	Home         string
+	ReadEvidence EvidenceReader
+	Ledger       *Ledger
+}
+
+// Wait blocks until at least one current actionable episode is wake-eligible,
+// records the delivery request, and returns the coalesced wake. Typed watcher
+// results pass through for the caller's exit-taxonomy mapping.
+func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
+	if cfg.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadlineCause(ctx, time.Now().Add(cfg.Timeout),
+			fmt.Errorf("no eligible wake within %s: %w", cfg.Timeout, watcher.ErrNoEvent))
+		defer cancel()
+	}
+
+	wake, _, eligible, err := currentEpisodes(ctx, w, cfg.Host)
+	if err != nil || len(eligible) > 0 {
+		if len(eligible) > 0 {
+			return requestDelivery(w, wake, eligible)
+		}
+		return Wake{}, err
+	}
+
+	attached, err := watcherAttached(w.Home)
+	if err != nil {
+		return Wake{}, err
+	}
+	if attached {
+		return pollUntilEligible(ctx, w, cfg)
+	}
+	return waitOwned(ctx, w, cfg)
+}
+
+func requestDelivery(w Waiter, wake Wake, eligible []Episode) (Wake, error) {
+	if err := w.Ledger.MarkRequested(eligible); err != nil {
+		return Wake{}, err
+	}
+	wake.Episodes = eligible
+	wake.Text = WakeText(wake.FleetID)
+	return wake, nil
+}
+
+// Derives episodes from authoritative evidence and reports all of them plus
+// the subset that may wake now. An already-actionable condition has no next
+// transition left to wait for, so arming observes it first.
+func currentEpisodes(ctx context.Context, w Waiter, host string) (Wake, []Episode, []Episode, error) {
+	evidence, err := w.ReadEvidence(ctx)
+	if err != nil {
+		return Wake{}, nil, nil, err
+	}
+	episodes := FromEvidence(evidence)
+	wake := Wake{Host: host, FleetID: evidence.FleetID}
+	return wake, episodes, w.Ledger.Eligible(episodes), nil
+}
+
+// Serves the case where another watcher owns the fleet home: stealing its
+// ownership would break that arm, so this wait levels on authoritative
+// evidence instead of watcher edges.
+func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
+	for {
+		if err := sleepCtx(ctx, intervalOr(cfg.PollInterval)); err != nil {
+			return Wake{}, err
+		}
+		wake, _, eligible, err := currentEpisodes(ctx, w, cfg.Host)
+		if err != nil {
+			return Wake{}, err
+		}
+		if len(eligible) > 0 {
+			return requestDelivery(w, wake, eligible)
+		}
+	}
+}
+
+// Holds watcher ownership and drives RunUntilEvent cycles until a delivered
+// cycle leaves something eligible. All-deduped cycles must not spin: an
+// unchanged key set backs off one poll interval; new episodes retry at once.
+func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
+	ownership, err := acquireWatcherOwnership(ctx, w.Home, false)
+	if err != nil {
+		return Wake{}, err
+	}
+	defer ownership.Release()
+
+	var previous []string
+	for {
+		var caught bytes.Buffer
+		err := runWatcherUntilEvent(ctx, ownedWatcherConfig(w, cfg), &caught, io.Discard)
+		if err != nil {
+			return Wake{}, err
+		}
+		wake, episodes, eligible, catchUpErr := currentEpisodes(ctx, w, cfg.Host)
+		if catchUpErr != nil {
+			return Wake{}, catchUpErr
+		}
+		if len(eligible) > 0 {
+			return requestDelivery(w, wake, eligible)
+		}
+		keys := Keys(episodes)
+		if slices.Equal(keys, previous) {
+			if err := sleepCtx(ctx, intervalOr(cfg.PollInterval)); err != nil {
+				return Wake{}, err
+			}
+		}
+		previous = keys
+	}
+}
+
+func ownedWatcherConfig(w Waiter, cfg WaitConfig) watcher.Config {
+	return watcher.Config{
+		Home:           w.Home,
+		PollInterval:   intervalOr(cfg.PollInterval),
+		StaleThreshold: cfg.StaleThreshold,
+		Timeout:        remainingOf(cfg.Timeout),
+		ParkedBounds:   cfg.ParkedBounds,
+	}
+}
+
+func remainingOf(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return 0
+	}
+	return timeout
+}
+
+func intervalOr(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 5 * time.Second
+	}
+	return d
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/supervision/wait.go
+++ b/internal/supervision/wait.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/atqamz/hand/internal/orientation"
@@ -23,7 +25,11 @@ var (
 // to arm and poll. Timeout bounds the whole wait and only ever produces the
 // explicit checkpoint result (exit 4) the caller asked for.
 type WaitConfig struct {
-	Host           string
+	Host string
+	// RuntimeSession names the exact host runtime arming this wait (an
+	// OpenCode session ID, a Codex thread). It scopes the bridge-attachment
+	// record so a secondary runtime defers instead of stealing.
+	RuntimeSession string
 	PollInterval   time.Duration
 	StaleThreshold time.Duration
 	ParkedBounds   watcher.ParkedBounds
@@ -33,9 +39,10 @@ type WaitConfig struct {
 // Wake is one coalesced delivery: every currently eligible episode collapses
 // into one reasoning opportunity rather than one turn per subject.
 type Wake struct {
-	Host     string
-	FleetID  string
-	Text     string
+	Schema   string `json:"schema"`
+	FleetID  string `json:"fleet_id"`
+	Host     string `json:"host"`
+	Message  string `json:"message"`
 	Episodes []Episode
 }
 
@@ -51,9 +58,12 @@ type Waiter struct {
 	Ledger       *Ledger
 }
 
-// Wait blocks until at least one current actionable episode is wake-eligible,
-// records the delivery request, and returns the coalesced wake. Typed watcher
-// results pass through for the caller's exit-taxonomy mapping.
+// WakeSchema versions the machine protocol host adapters consume.
+const WakeSchema = "hand.supervision.wake.v1"
+
+// Wait blocks until at least one current actionable episode can be claimed
+// atomically, records the claim plus this runtime's bridge attachment, and
+// returns the coalesced wake. Typed watcher results pass through unchanged.
 func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -62,14 +72,13 @@ func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 		defer cancel()
 	}
 
-	wake, _, eligible, err := currentEpisodes(ctx, w, cfg.Host)
-	if err != nil || len(eligible) > 0 {
-		if len(eligible) > 0 {
-			return requestDelivery(w, wake, eligible)
-		}
+	wake, allEpisodes, eligible, err := currentEpisodes(ctx, w, cfg.Host)
+	if err != nil {
 		return Wake{}, err
 	}
-
+	if len(eligible) > 0 {
+		return claimAndDeliver(w, cfg, wake, allEpisodes)
+	}
 	attached, err := watcherAttached(w.Home)
 	if err != nil {
 		return Wake{}, err
@@ -80,18 +89,9 @@ func Wait(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 	return waitOwned(ctx, w, cfg)
 }
 
-func requestDelivery(w Waiter, wake Wake, eligible []Episode) (Wake, error) {
-	if err := w.Ledger.MarkRequested(eligible); err != nil {
-		return Wake{}, err
-	}
-	wake.Episodes = eligible
-	wake.Text = WakeText(wake.FleetID)
-	return wake, nil
-}
-
 // Derives episodes from authoritative evidence and reports all of them plus
-// the subset that may wake now. An already-actionable condition has no next
-// transition left to wait for, so arming observes it first.
+// the subset that may be claimed now. An already-actionable condition has no
+// next transition left to wait for, so arming observes it first.
 func currentEpisodes(ctx context.Context, w Waiter, host string) (Wake, []Episode, []Episode, error) {
 	evidence, err := w.ReadEvidence(ctx)
 	if err != nil {
@@ -102,10 +102,88 @@ func currentEpisodes(ctx context.Context, w Waiter, host string) (Wake, []Episod
 	return wake, episodes, w.Ledger.Eligible(episodes), nil
 }
 
+// Keeps the bridge-attachment record fresh while this wait runs and clears it
+// on exit. Attachment thus means "a live child of this runtime holds this
+// host's bridge" - mechanically independent from watcher liveness.
+func runHeartbeat(ctx context.Context, w Waiter, cfg WaitConfig, fleetID string) (stop func()) {
+	interval := intervalOr(cfg.PollInterval)
+	if interval < time.Second {
+		interval = time.Second
+	}
+	runtime := cfg.RuntimeSession
+	if runtime == "" {
+		runtime = fmt.Sprintf("pid:%d", os.Getpid())
+	}
+	now := time.Now()
+	record := AttachmentRecord{
+		Host:        cfg.Host,
+		Runtime:     runtime,
+		PID:         os.Getpid(),
+		FleetID:     fleetID,
+		StartedAt:   now,
+		HeartbeatAt: now,
+		ExpiresAt:   now.Add(3 * interval),
+	}
+	_ = WriteAttachment(w.Home, record)
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				ClearAttachment(w.Home, cfg.Host, runtime)
+				close(done)
+				return
+			case <-ticker.C:
+				now := time.Now()
+				record.HeartbeatAt = now
+				record.ExpiresAt = now.Add(3 * interval)
+				_ = WriteAttachment(w.Home, record)
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			ClearAttachment(w.Home, cfg.Host, runtime)
+			go func() {
+				select {
+				case <-done:
+				case <-time.After(2 * interval):
+				}
+			}()
+		})
+	}
+}
+
+// Reports whether a fresh record for this host names a different live runtime,
+// in which case this waiter must defer rather than steal the bridge.
+func bridgeOwnedByAnotherRuntime(w Waiter, cfg WaitConfig) bool {
+	owner := BridgeOwner(w.Home, cfg.Host, time.Now())
+	if owner == "" || owner == cfg.RuntimeSession {
+		return false
+	}
+	return !stringsHasPrefix(owner, fmt.Sprintf("pid:%d", os.Getpid()))
+}
+
+func stringsHasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
 // Serves the case where another watcher owns the fleet home: stealing its
 // ownership would break that arm, so this wait levels on authoritative
 // evidence instead of watcher edges.
 func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
+	if bridgeOwnedByAnotherRuntime(w, cfg) {
+		return Wake{}, ErrBridgeOwned
+	}
+	wake, _, _, err := currentEpisodes(ctx, w, cfg.Host)
+	if err != nil {
+		return Wake{}, err
+	}
+	stop := runHeartbeat(ctx, w, cfg, wake.FleetID)
+	defer stop()
 	for {
 		if err := sleepCtx(ctx, intervalOr(cfg.PollInterval)); err != nil {
 			return Wake{}, err
@@ -115,7 +193,7 @@ func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, err
 			return Wake{}, err
 		}
 		if len(eligible) > 0 {
-			return requestDelivery(w, wake, eligible)
+			return claimAndDeliver(w, cfg, wake, eligible)
 		}
 	}
 }
@@ -124,11 +202,21 @@ func pollUntilEligible(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, err
 // cycle leaves something eligible. All-deduped cycles must not spin: an
 // unchanged key set backs off one poll interval; new episodes retry at once.
 func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
+	if bridgeOwnedByAnotherRuntime(w, cfg) {
+		return Wake{}, ErrBridgeOwned
+	}
 	ownership, err := acquireWatcherOwnership(ctx, w.Home, false)
 	if err != nil {
 		return Wake{}, err
 	}
 	defer ownership.Release()
+
+	wake, _, _, err := currentEpisodes(ctx, w, cfg.Host)
+	if err != nil {
+		return Wake{}, err
+	}
+	stop := runHeartbeat(ctx, w, cfg, wake.FleetID)
+	defer stop()
 
 	var previous []string
 	for {
@@ -142,7 +230,7 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 			return Wake{}, catchUpErr
 		}
 		if len(eligible) > 0 {
-			return requestDelivery(w, wake, eligible)
+			return claimAndDeliver(w, cfg, wake, eligible)
 		}
 		keys := Keys(episodes)
 		if slices.Equal(keys, previous) {
@@ -152,6 +240,19 @@ func waitOwned(ctx context.Context, w Waiter, cfg WaitConfig) (Wake, error) {
 		}
 		previous = keys
 	}
+}
+
+// Performs the atomic eligibility-and-request transaction and fills in the
+// machine-protocol fields on the result.
+func claimAndDeliver(w Waiter, cfg WaitConfig, wake Wake, all []Episode) (Wake, error) {
+	claimed := w.Ledger.ClaimEligible(all)
+	if len(claimed) == 0 {
+		return Wake{}, nil
+	}
+	wake.Schema = WakeSchema
+	wake.Episodes = claimed
+	wake.Message = WakeText(wake.FleetID)
+	return wake, nil
 }
 
 func ownedWatcherConfig(w Waiter, cfg WaitConfig) watcher.Config {

--- a/internal/supervision/wait_test.go
+++ b/internal/supervision/wait_test.go
@@ -1,0 +1,253 @@
+package supervision
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/orientation"
+	"github.com/atqamz/hand/internal/watcher"
+)
+
+func actionableEvidence(id, generation, kind string) orientation.ActionableEvidence {
+	return orientation.ActionableEvidence{
+		TargetID: id, TargetKind: "task", Generation: []string{generation},
+		Kind: kind, Reason: "worker reports blocked", Provenance: "report",
+	}
+}
+
+func fixedReader(evidence orientation.Evidence) EvidenceReader {
+	return func(context.Context) (orientation.Evidence, error) { return evidence, nil }
+}
+
+// Replaces the three watcher-boundary seams so tests drive delivery without
+// herdr.
+type watcherStub struct {
+	acquired int
+	cycles   int
+	onCycle  func(s *watcherStub) error
+}
+
+func newWatcherStub(t *testing.T, attached bool, onCycle func(*watcherStub) error) (*watcherStub, func()) {
+	t.Helper()
+	stub := &watcherStub{onCycle: onCycle}
+	if stub.onCycle == nil {
+		// Default: every cycle delivers a catch-up whose episodes are all
+		// already deduped, so the wait keeps re-arming until its deadline.
+		stub.onCycle = func(*watcherStub) error { return nil }
+	}
+	origAcquire, origRun, origAttached := acquireWatcherOwnership, runWatcherUntilEvent, watcherAttached
+	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) {
+		stub.acquired++
+		return nil, nil
+	}
+	runWatcherUntilEvent = func(ctx context.Context, cfg watcher.Config, out, errOut io.Writer) error {
+		stub.cycles++
+		return stub.onCycle(stub)
+	}
+	watcherAttached = func(string) (bool, error) { return attached, nil }
+	return stub, func() {
+		acquireWatcherOwnership, runWatcherUntilEvent, watcherAttached = origAcquire, origRun, origAttached
+	}
+}
+
+func TestWaitReturnsImmediatelyOnAlreadyActionableWork(t *testing.T) {
+	_, restore := newWatcherStub(t, false, nil)
+	defer restore()
+
+	wake, err := Wait(context.Background(), Waiter{
+		Home:         t.TempDir(),
+		ReadEvidence: fixedReader(orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "blocked")}}),
+		Ledger:       OpenLedger(t.TempDir()),
+	}, WaitConfig{Host: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake.Episodes) != 1 || wake.Text == "" || wake.Host != "codex" || wake.FleetID != "f_1" {
+		t.Fatalf("wake = %#v, want one coalesced eligible episode with bounded text", wake)
+	}
+}
+
+// Near-simultaneous subjects become one reasoning opportunity, never one turn
+// per worker event.
+func TestWaitCoalescesMultipleSubjectsIntoOneWake(t *testing.T) {
+	_, restore := newWatcherStub(t, false, nil)
+	defer restore()
+
+	wake, err := Wait(context.Background(), Waiter{
+		Home: t.TempDir(),
+		ReadEvidence: fixedReader(orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{
+			actionableEvidence("t1", "g1", "blocked"),
+			actionableEvidence("t2", "g1", "needs-decision"),
+			actionableEvidence("t3", "g1", "failed"),
+		}}),
+		Ledger: OpenLedger(t.TempDir()),
+	}, WaitConfig{Host: "pi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake.Episodes) != 3 {
+		t.Fatalf("episodes = %d, want all current subjects coalesced into one wake", len(wake.Episodes))
+	}
+}
+
+// The same unchanged episode must not storm turns; with a bounded deadline the
+// wait keeps cycling silently and ends as the caller-requested checkpoint.
+func TestSameEpisodeRepeatedlyObservedDoesNotStorm(t *testing.T) {
+	reader := fixedReader(orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "blocked")}})
+	ledger := OpenLedger(t.TempDir())
+	ctx := context.Background()
+
+	first, err := Wait(ctx, Waiter{Home: t.TempDir(), ReadEvidence: reader, Ledger: ledger}, WaitConfig{Host: "claude"})
+	if err != nil || len(first.Episodes) != 1 {
+		t.Fatalf("first wait = %v, %d episodes", err, len(first.Episodes))
+	}
+
+	stub, restore := newWatcherStub(t, false, nil)
+	defer restore()
+	checkpoint, err := Wait(ctx, Waiter{Home: t.TempDir(), ReadEvidence: reader, Ledger: ledger}, WaitConfig{
+		Host:         "claude",
+		PollInterval: time.Millisecond,
+		Timeout:      80 * time.Millisecond,
+	})
+	if !errors.Is(err, watcher.ErrNoEvent) || len(checkpoint.Episodes) != 0 {
+		t.Fatalf("second wait = %v, %d episodes, want the checkpoint result and no wake", err, len(checkpoint.Episodes))
+	}
+	if stub.cycles < 2 {
+		t.Fatalf("cycles = %d, want the wait to keep re-arming instead of waking on unchanged currentness", stub.cycles)
+	}
+}
+
+func TestNewCurrentnessBecomesEligibleAgainAfterOrient(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	ctx := context.Background()
+	evidence := orientation.Evidence{FleetID: "f_1", Actionable: []orientation.ActionableEvidence{actionableEvidence("t1", "g1", "blocked")}}
+
+	first, err := Wait(ctx, Waiter{Home: t.TempDir(), ReadEvidence: fixedReader(evidence), Ledger: ledger}, WaitConfig{Host: "grok"})
+	if err != nil || len(first.Episodes) != 1 {
+		t.Fatalf("first wake = %v, %d episodes", err, len(first.Episodes))
+	}
+	if err := ledger.MarkOriented(first.Episodes); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, eligible, err := currentEpisodes(ctx, Waiter{ReadEvidence: fixedReader(evidence), Ledger: ledger}, "grok"); err != nil || len(eligible) != 0 {
+		t.Fatalf("oriented unchanged condition = %d eligible (err %v), want none", len(eligible), err)
+	}
+
+	evidence.Actionable[0].Generation = []string{"g2"}
+	second, err := Wait(ctx, Waiter{Home: t.TempDir(), ReadEvidence: fixedReader(evidence), Ledger: ledger}, WaitConfig{Host: "grok"})
+	if err != nil || len(second.Episodes) != 1 {
+		t.Fatalf("changed currentness = %v, %d episodes, want normally eligible", err, len(second.Episodes))
+	}
+	if second.Episodes[0].Key() == first.Episodes[0].Key() {
+		t.Fatal("a delayed stale hint must not be mistaken for fresh truth")
+	}
+}
+
+// A condition becoming actionable after arming wakes through one delivered
+// cycle, recomputed from the authoritative level rather than the event text.
+func TestEventAfterArmWakesFromAuthoritativeLevel(t *testing.T) {
+	evidence := orientation.Evidence{FleetID: "f_1"}
+	stub, restore := newWatcherStub(t, false, func(s *watcherStub) error {
+		evidence.Actionable = append(evidence.Actionable, actionableEvidence("t9", "g1", "parked"))
+		return nil
+	})
+	defer restore()
+
+	wake, err := Wait(context.Background(), Waiter{
+		Home:         t.TempDir(),
+		ReadEvidence: func(context.Context) (orientation.Evidence, error) { return evidence, nil },
+		Ledger:       OpenLedger(t.TempDir()),
+	}, WaitConfig{Host: "opencode", PollInterval: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wake.Episodes) != 1 || wake.Episodes[0].TargetID != "t9" || stub.cycles < 1 {
+		t.Fatalf("wake = %#v after %d cycles, want the post-arm condition delivered once", wake, stub.cycles)
+	}
+}
+
+// With another watcher owning the fleet home, this wait levels on evidence
+// without stealing its ownership.
+func TestAttachedWatcherDefersToLevelPolling(t *testing.T) {
+	var mu sync.Mutex
+	evidence := orientation.Evidence{FleetID: "f_1"}
+	stub, restore := newWatcherStub(t, true, nil)
+	defer restore()
+
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		mu.Lock()
+		defer mu.Unlock()
+		evidence.Actionable = append(evidence.Actionable, actionableEvidence("t5", "g1", "blocked"))
+	}()
+
+	wake, err := Wait(context.Background(), Waiter{Home: t.TempDir(), ReadEvidence: func(context.Context) (orientation.Evidence, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return evidence, nil
+	}, Ledger: OpenLedger(t.TempDir())}, WaitConfig{Host: "claude", PollInterval: 5 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.acquired != 0 {
+		t.Fatal("an attached operator watcher keeps its ownership; supervision wait polls instead")
+	}
+	if len(wake.Episodes) != 1 {
+		t.Fatalf("episodes = %d, want the level-poll to observe the new condition", len(wake.Episodes))
+	}
+}
+
+func TestReplacedAndInterruptedPassThroughTyped(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want error
+	}{
+		{"replaced", watcher.ErrReplaced},
+		{"interrupted", watcher.ErrInterrupted},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, restore := newWatcherStub(t, false, func(*watcherStub) error { return test.want })
+			defer restore()
+
+			_, err := Wait(context.Background(), Waiter{
+				Home:         t.TempDir(),
+				ReadEvidence: fixedReader(orientation.Evidence{FleetID: "f_1"}),
+				Ledger:       OpenLedger(t.TempDir()),
+			}, WaitConfig{Host: "codex"})
+			if !errors.Is(err, test.want) {
+				t.Fatalf("err = %v, want %v preserved for the exit taxonomy", err, test.want)
+			}
+		})
+	}
+}
+
+// A host accepting a wake whose Supervisor crashes before orient loses only
+// mechanism memory: after the progress window the same currentness retries,
+// while canonical actionability never left durable state.
+func TestAcceptedWithoutOrientRetriesBounded(t *testing.T) {
+	ledger := OpenLedger(t.TempDir())
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	ledger.now = func() time.Time { return now }
+	e := Episode{FleetID: "f_1", TargetID: "t1", TargetKind: "task",
+		Currentness: orientation.TargetFor("f_1", orientation.TargetEvidence{ID: "t1", Kind: "task", Generation: []string{"g1"}}).Currentness,
+		Kind:        "unacknowledged"}
+
+	if err := ledger.MarkRequested([]Episode{e}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.MarkAccepted(Keys([]Episode{e})); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(DefaultPolicy().ProgressTimeout - time.Minute)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 0 {
+		t.Fatal("inside the progress window a crash-before-orient is still awaited")
+	}
+	now = now.Add(2 * DefaultPolicy().ProgressTimeout)
+	if eligible := ledger.Eligible([]Episode{e}); len(eligible) != 1 {
+		t.Fatal("past the window, bounded recovery makes the same episode eligible again")
+	}
+}

--- a/internal/supervision/wait_test.go
+++ b/internal/supervision/wait_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,10 +25,10 @@ func fixedReader(evidence orientation.Evidence) EvidenceReader {
 }
 
 // Replaces the three watcher-boundary seams so tests drive delivery without
-// herdr.
+// herdr. Counters stay atomic because concurrent waiters share one stub.
 type watcherStub struct {
-	acquired int
-	cycles   int
+	acquired atomic.Int64
+	cycles   atomic.Int64
 	onCycle  func(s *watcherStub) error
 }
 
@@ -41,11 +42,11 @@ func newWatcherStub(t *testing.T, attached bool, onCycle func(*watcherStub) erro
 	}
 	origAcquire, origRun, origAttached := acquireWatcherOwnership, runWatcherUntilEvent, watcherAttached
 	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) {
-		stub.acquired++
+		stub.acquired.Add(1)
 		return nil, nil
 	}
 	runWatcherUntilEvent = func(ctx context.Context, cfg watcher.Config, out, errOut io.Writer) error {
-		stub.cycles++
+		stub.cycles.Add(1)
 		return stub.onCycle(stub)
 	}
 	watcherAttached = func(string) (bool, error) { return attached, nil }
@@ -66,7 +67,7 @@ func TestWaitReturnsImmediatelyOnAlreadyActionableWork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(wake.Episodes) != 1 || wake.Text == "" || wake.Host != "codex" || wake.FleetID != "f_1" {
+	if len(wake.Episodes) != 1 || wake.Message == "" || wake.Host != "codex" || wake.FleetID != "f_1" {
 		t.Fatalf("wake = %#v, want one coalesced eligible episode with bounded text", wake)
 	}
 }
@@ -116,8 +117,8 @@ func TestSameEpisodeRepeatedlyObservedDoesNotStorm(t *testing.T) {
 	if !errors.Is(err, watcher.ErrNoEvent) || len(checkpoint.Episodes) != 0 {
 		t.Fatalf("second wait = %v, %d episodes, want the checkpoint result and no wake", err, len(checkpoint.Episodes))
 	}
-	if stub.cycles < 2 {
-		t.Fatalf("cycles = %d, want the wait to keep re-arming instead of waking on unchanged currentness", stub.cycles)
+	if stub.cycles.Load() < 2 {
+		t.Fatalf("cycles = %d, want the wait to keep re-arming instead of waking on unchanged currentness", stub.cycles.Load())
 	}
 }
 
@@ -165,8 +166,8 @@ func TestEventAfterArmWakesFromAuthoritativeLevel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(wake.Episodes) != 1 || wake.Episodes[0].TargetID != "t9" || stub.cycles < 1 {
-		t.Fatalf("wake = %#v after %d cycles, want the post-arm condition delivered once", wake, stub.cycles)
+	if len(wake.Episodes) != 1 || wake.Episodes[0].TargetID != "t9" || stub.cycles.Load() < 1 {
+		t.Fatalf("wake = %#v after %d cycles, want the post-arm condition delivered once", wake, stub.cycles.Load())
 	}
 }
 
@@ -193,7 +194,7 @@ func TestAttachedWatcherDefersToLevelPolling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stub.acquired != 0 {
+	if stub.acquired.Load() != 0 {
 		t.Fatal("an attached operator watcher keeps its ownership; supervision wait polls instead")
 	}
 	if len(wake.Episodes) != 1 {

--- a/skills/secondhand/SKILL.md
+++ b/skills/secondhand/SKILL.md
@@ -20,8 +20,10 @@ state, dependency state, or task state is something you get by running a `hand` 
 reading its structured output, never by reconstructing it from panes, files, or memory.
 
 Each supervising runtime begins once with `hand session start`, which qualifies the Supervisor
-Harness, its addressable runtime identity, and whether unattended wake delivery is supported,
-degraded, or unsupported on it.
+Harness, its addressable runtime identity, and the exact state of unattended wake delivery:
+`supported` means live-qualified, `available-unqualified` means every static precondition holds
+but live proof does not exist yet, `degraded` names what drifted, and `unsupported` means no
+path at all. Treat `available-unqualified` as working-but-unproven, never as supported.
 Every reasoning turn - including one an automatic wake re-enters - begins with `hand orient`,
 whose bounded orientation reports Fleet identity, exact monitor currentness, actionable
 provenance, and monitoring state.

--- a/skills/secondhand/SKILL.md
+++ b/skills/secondhand/SKILL.md
@@ -19,8 +19,12 @@ procedure layer over `hand`, not a second implementation of it: every claim here
 state, dependency state, or task state is something you get by running a `hand` command and
 reading its structured output, never by reconstructing it from panes, files, or memory.
 
-Each supervising turn begins with `hand session start`, whose bounded orientation reports Fleet identity,
-exact monitor currentness, actionable provenance, and whether `hand watch --until-event` must be re-armed.
+Each supervising runtime begins once with `hand session start`, which qualifies the Supervisor
+Harness, its addressable runtime identity, and whether unattended wake delivery is supported,
+degraded, or unsupported on it.
+Every reasoning turn - including one an automatic wake re-enters - begins with `hand orient`,
+whose bounded orientation reports Fleet identity, exact monitor currentness, actionable
+provenance, and monitoring state.
 
 ```text
 wrong: skill checks PATH itself and decides whether Herdr is installed

--- a/skills/secondhand/references/supervision-loop.md
+++ b/skills/secondhand/references/supervision-loop.md
@@ -70,7 +70,7 @@ wake semantics while the host owns converting them into your next reasoning oppo
 
 ```text
 claude    -> Hand-owned Stop hook: an eligible wake returns exit 2 feedback that starts a follow-up turn
-codex     -> hand supervision wait --host codex --deliver enqueues the wake on the live thread via codex queue
+codex     -> the Fleet-local .codex/hooks.json Stop hook owns the post-turn wait and enqueues the wake on the exact live thread via codex queue
 opencode  -> persistent plugin arms one wait child per idle session and delivers through the synchronous prompt API
 pi        -> extension arms one wait child and sends the wake as a followUp message that triggers a turn
 grok      -> a host-owned background task runs hand supervision wait --host grok; its completion notification re-enters you

--- a/skills/secondhand/references/supervision-loop.md
+++ b/skills/secondhand/references/supervision-loop.md
@@ -46,26 +46,49 @@ STOP when the goal/terminal condition is satisfied
 
 ## Deciding the next action
 
-Do not maintain a separate mental precedence table for what to do next: `hand session start`
+Do not maintain a separate mental precedence table for what to do next: `hand orient`
 already reports one, deterministically, in its `next_action_kind`, `next_action_task`,
 `next_action_command`, and `next_action_reason` fields. Read those, act on the named command,
-and re-run `hand session start` (or `hand status`) after acting rather than assuming the fleet
-still looks the way it did before you acted.
+and run `hand orient` again after acting rather than assuming the fleet still looks the way it
+did before you acted.
 
 ```text
 wrong: keeping your own running list of "what's next" across a long session
-right: re-reading hand session start's next_action_* fields after every action that could have
-       changed fleet state
+right: re-reading hand orient's next_action_* fields after every action that could have changed
+       fleet state
 
 The same output includes a bounded `orientation_*` view with Fleet identity, exact monitor targets,
 currentness, actionable provenance, and `monitor_state`.
-When that state is `rearmed`, follow its `monitor-rearm` action and run `hand watch --until-event` to keep monitoring.
+When that state is `rearmed`, follow its `monitor-rearm` action and keep monitoring through your
+harness's wake bridge rather than model memory.
 ```
+
+## Wakes and turn delivery
+
+There is no universal way to wake an agent; each host has its own bridge, and Hand owns the
+wake semantics while the host owns converting them into your next reasoning opportunity.
+
+```text
+claude    -> Hand-owned Stop hook: an eligible wake returns exit 2 feedback that starts a follow-up turn
+codex     -> hand supervision wait --host codex --deliver enqueues the wake on the live thread via codex queue
+opencode  -> persistent plugin arms one wait child per idle session and delivers through the synchronous prompt API
+pi        -> extension arms one wait child and sends the wake as a followUp message that triggers a turn
+grok      -> a host-owned background task runs hand supervision wait --host grok; its completion notification re-enters you
+```
+
+Run `hand doctor` and read its supervisor fields when unsure what your harness supports:
+watcher liveness, bridge attachment, wake acceptance, and orientation progress are separate
+answers, and only orientation progress demonstrates a reasoning turn actually happened.
+
+After any automatic wake, run `hand orient` before acting - the wake that reached you is one
+fact, not the full current truth, and can be stale relative to everything else that has
+happened since.
 
 ## Watching, phase by phase
 
-There is no one universal "actionable events" list to filter on; the right `--event` filter
-depends on what phase of the loop you are in.
+`hand watch --until-event` remains the operator-facing watcher: arming observes the fleet's
+already-actionable state first, then exits on the first new event with typed exits
+(8 interrupted, 9 replaced). The `--event` filter depends on what phase of the loop you are in.
 
 ```text
 wrong: always run hand watch --until-event with no --event filter, every time, at every phase

--- a/skills/secondhand/references/task-lifecycle.md
+++ b/skills/secondhand/references/task-lifecycle.md
@@ -5,6 +5,7 @@
 ```sh
 hand spawn <id> <project> [--scout] [--profile <name>]     # launch a worker
 hand status [id]                                            # fleet overview, or one task's detail
+hand orient                                                 # first Hand read of every reasoning turn
 hand watch --until-event [--event <kinds>] [--timeout <d>]  # wait for the fleet's next actionable event
 hand send <id> <message>                                    # steer a running worker
 hand hold set <id> --kind operator --reason <text>           # waiting on the operator

--- a/tests/e2e/init_config_test.go
+++ b/tests/e2e/init_config_test.go
@@ -171,8 +171,10 @@ func TestFirstRunInstalledCLIBootstrapsADetectedSession(t *testing.T) {
 	}
 	const wantAgents = `## Secondhand supervisor bootstrap
 
-Before responding or acting in a supervising session, run ` + "`hand session start`" + `.
-Do not run supervisor bootstrap when ` + "`HAND_ROLE=worker`" + `.
+At the beginning of a new Supervisor runtime/session, run ` + "`hand session start`" + ` once.
+Before reasoning or acting in every Supervisor turn, run ` + "`hand orient`" + `.
+After an automatic wake/re-entry, run ` + "`hand orient`" + ` before any action.
+Do not run supervisor commands when ` + "`HAND_ROLE=worker`" + `.
 
 This file is Hand-owned and immutable: ` + "`hand init`" + ` restores it byte-for-byte, and
 nobody edits it by hand, including the supervisor. The same rule covers every other
@@ -206,9 +208,8 @@ Hand-generated surface in this fleet home.
 	for _, want := range []string{
 		"session_bootstrap: complete",
 		"supervisor_harness: codex",
-		"harness,detected,codex",
-		"model,native-default,none",
-		"hand project add",
+		"wake_delivery_capability:",
+		"next_command: hand orient",
 	} {
 		if !strings.Contains(session.stdout, want) {
 			t.Fatalf("session stdout = %q, want %q", session.stdout, want)


### PR DESCRIPTION
## Summary

Correction pass over the original implementation (commits 7b7db7f..25cbe7a), closing every review blocker before live dogfood begins.

### Corrected ownership boundary

- `hand init` exclusively owns static Fleet-local integration: `.claude/settings.json` Hand-owned Stop group (upstream **exec form** + `asyncRewake: true` - no shell, no synchronous Stop hold), `.opencode/plugins/hand-supervisor-wake.js`, `.pi/extensions/hand-supervisor-wake.ts`, and `.codex/hooks.json` (async background Stop handler). Foreign content at an exact managed path is never overwritten; init **fails with exit 3** on conflicts. Nothing is ever installed under global harness directories.
- `hand session start` is read-only qualification: it reports absent/stale/conflict plus recovery (`hand init`, then restart/reload the host) and cannot mutate any static byte under an already-running host.
- `hand orient` records disposable orientation progress only.

### Provider capability table

`supported` is reserved for live qualification and is claimed by no one yet:

| Host | Mechanism | Capability today |
|---|---|---|
| claude | Stop hook exec-form `asyncRewake`; exit-2 stderr rewake; >=16 distinct episodes proven at ledger level | available-unqualified / degraded when integration drifts |
| codex | Fleet-local `.codex/hooks.json` async Stop handler owns the post-turn wait -> `codex queue --thread <session_id>` same-thread delivery | available-unqualified (requires `features.hooks` + `/hooks` trust); unsupported if queue probe fails; degraded without thread identity |
| opencode | persistent plugin; primary = top-level session rooted in the Fleet home (`parentID`/`directory` checked); synchronous `session.prompt` | available-unqualified / degraded |
| pi | extension arms on `agent_settled` continuously; mechanism wake via `sendMessage({customType},{triggerTurn:true,deliverAs:"followUp"})` - never a fabricated user message; generation-guarded across /new //resume//fork | available-unqualified / degraded |
| grok | instruction-established host background-task bridge | available-unqualified only |

### Semantics hardened

- **Atomic claims:** eligibility + requested stamp inside one locked `ClaimEligible([]Episode) ([]Episode, error)` transaction; faults are returned, never swallowed into empty claims. A wait that loses the race falls through to keep observing - an empty successful wake is structurally impossible (10-waiter test asserts exactly one non-empty wake, nine clean checkpoints, zero empties).
- **CAS bridge attachment:** acquire/refresh/clear run under the attachment's advisory file lock - cross-process by construction (eight processes racing one claim -> one winner; two runtimes racing attachment -> one holder, both proven with real subprocesses). Heartbeat write faults and ownership theft surface through the guard channel instead of being ignored.
- **Machine protocol:** host adapters parse versioned `hand.supervision.wake.v1` JSON (`--format json`) and fail closed on schema mismatch; rendered TOON is never a contract.
- **Attachment vs liveness:** attachment evidence comes from per-runtime heartbeats; watcher observer liveness is reported separately and neither implies the other.
- **Receipts:** requested / host-accepted / oriented recorded separately for every provider; acceptance alone is never progress.
- **Capability honesty:** `available-unqualified` added; nothing claims supported before live dogfood; supervisor registry (`claude,codex,grok,pi,opencode`) is distinct from worker harness support.
- **Asset rendering:** encoding/json string literals only (template owns no quotes - double substitution structurally impossible); generated artifacts are parsed/executed inside the suite (node ESM check + ownership predicate; bun transpile with offline module stub + protocol parser).

Refs atqamz/hand#355

The reference stays non-closing by design: live no-operator-input dogfood per provider remains the closure gate, so release PR atqamz/hand#337 stays blocked.

## Test plan

- [x] `go build ./... && go vet ./...`, golangci-lint, commentlint clean
- [x] Generated OpenCode plugin passes `node --check` as ESM; ownership predicate executes under node
- [x] Generated Pi extension transpiles under bun with offline stub; protocol parser executes (valid ok; rendered text / unknown schema / garbage fail closed)
- [x] Atomic claim: 10 concurrent waiters -> exactly 1 non-empty wake + 9 checkpoints + 0 empty successes; coalescing; new-currentness reclaim
- [x] Cross-process: 8 subprocesses racing one claim -> exactly 1 winner; 2 subprocesses racing attachment -> exactly 1 holder (real flock coordination)
- [x] 16 distinct episodes each wake once; post-orient suppression; crash-before-orient bounded recovery; corrupted-ledger recovery
- [x] Attachment independent from watcher liveness; secondary runtime ErrBridgeOwned instead of stealing
- [x] Session start mutates zero static bytes (snapshot tree); init repairs owned-stale, refuses foreign at exit 3; isolated-HOME proof of no global harness writes
- [x] Claude merge exactness incl. legacy shell-form upgrade; Codex hooks.json fleet-local/idempotent/foreign-safe/malformed-refused
- [x] >64-subject starvation regression; 100-subject coalescing; stale-wake separation; worker-role rejection; Antigravity-style names rejected
- [x] `make contract`, `make e2e`, `nix flake check`, `git diff --check`
- [x] Full unit suite green except environment failures proven identical on clean main (GPG secret key unavailable; worktree lease tests)
- [ ] LIVE DOGFOOD per provider (next phase): real host in a disposable Fleet, zero operator input, bridge delivery observed, new turn runs `hand orient`, ledger shows requested/accepted/oriented, restart recovery; Claude >=16 sequential episodes; Pi >=2 cycles; Codex same-thread queue turn; OpenCode real assistant activity; Grok host-completion re-entry

---

## Pre-dogfood correction pass 2 (heads d21f19c..9f1a434)

Closes the two ownership/cancellation blockers from the final review, plus the Windows CI fallout they exposed.

### Fleet-exclusive Supervisor ownership

Attachment ownership is now Fleet-global across harnesses: `AcquireAttachment` rejects any fresh record whose exact owner (host AND runtime) differs - claude-vs-opencode, codex-vs-pi, grok-vs-anything all contend for the ONE bridge. Harness name selects the delivery mechanism, never an ownership domain. Same-owner refresh is reentrant; expired owners are takeover-eligible; stale callbacks can neither refresh nor clear a successor.

### Ownership-loss cancellation + claim-boundary proof

`acquireBridge` derives the wait's cancellation domain (`guardCtx = WithCancelCause(parent)`); heartbeat theft/fault cancels it with the exact cause, so a blocked `runWatcherUntilEvent` ends immediately and `takeFault` surfaces `ErrBridgeOwned` instead of the generic interruption wrapper. Every claim boundary re-proves ownership under the attachment lock BEFORE `ClaimEligible`: proof fails -> no claim -> episode stays fully available to the true owner (never suppressed by a stale runtime).

### New deterministic evidence

- Cross-harness subprocess races (real processes, flock-only coordination): opencode-vs-claude, claude-vs-codex, pi-vs-grok, grok-vs-opencode -> exactly one holder each.
- In-process table: fresh cross-host reject, same-host different-runtime reject, same-owner reentrant refresh ok, foreign refresh refused, expired owner cross-host takeover allowed, StartedAt preserved with explicit lease.
- Ownership-loss: blocked watcher wait cancelled mid-wait on theft -> ErrBridgeOwned, zero claims, episode remains claimable by successor.
- Claim-boundary race: event delivery racing a takeover -> stale runtime rejected pre-claim, zero consumption.
- 10-waiter race: exactly one non-empty wake, zero empty successes, all losers clean ErrNoEvent checkpoints.
- 8-process single-episode claim -> one winner (unchanged, still green).

### Final native CI state for head 598c28c/9f1a434 lineage

- Lint PASS
- Contract PASS
- Nix build (x86_64-linux) PASS
- Ubuntu PASS
- macOS PASS
- Windows PASS (after three real fixes this pass surfaced: ledger/attachment reads take the writer lock only once one exists - never creating lock files on read-only paths - plus LF normalization of embedded assets, file:// ESM URLs in tests, bounded rename retry for AV/sharing sweeps, and .gitattributes pinning asset sources to LF)

Deterministic local runs: go test ./..., go test -race ./..., go vet ./..., make lint, make build, make contract, make e2e, nix flake check --print-build-logs, git diff --check - green except the two environment failures proven identical on clean main (GPG secret key unavailable; worktree lease tests).

Live dogfood remains unchecked and is the next phase after static review of this layer. Refs atqamz/hand#355 - not a closing keyword; #337 stays blocked." 
