### PR TITLE
fix(watcher): stop re-firing attention for delivered tasks

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -303,7 +303,7 @@ func holdDetail(h state.Hold) string {
 // ship task with a recorded PR does. Delegates to watcher.GateApplies, the one copy of this rule hand
 // status and hand watch now share, so a silent task never pays for or fails over the check.
 func gateRunApplies(t state.Task, reportedDone bool) bool {
-	return watcher.GateApplies(t.Kind, t.PR, reportedDone)
+	return watcher.GateApplies(t.Kind, t.PR, t.DeliveredAt, reportedDone)
 }
 
 // Bounds one no-mistakes process the gate-run check spawns, the same 5 seconds prdetect.go bounds
@@ -597,7 +597,7 @@ func taskParked(home string, t state.Task, attempt state.Attempt, reportedState 
 		return false
 	}
 	// A one-shot render has no short, known interval baseline, so it defers corroboration to hand watch.
-	naive := watcher.Parked(reportedState, silentSince, time.Now(), bounds)
+	naive := watcher.Parked(reportedState, t.DeliveredAt, silentSince, time.Now(), bounds)
 	return naive
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -963,6 +963,44 @@ func TestTaskParkedUsesNaiveOneShotFallback(t *testing.T) {
 	}
 }
 
+// atqamz/hand#365: hand deliver is the supervisor's own verified last word, so the same silence it
+// already handled must stop re-flagging, on both the parked and the gate-run predicate.
+func TestTaskParkedAndGateRunAppliesStopOnceTheTaskIsDelivered(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	pr := "https://github.com/atqamz/hand/pull/120"
+	task := state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip, PR: pr,
+		CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)}
+	attempt := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}
+	if err := writeTaskAttempt(t, home, task, attempt); err != nil {
+		t.Fatal(err)
+	}
+	reportPath := state.ReportPath(home, task.ID)
+	if err := os.WriteFile(reportPath, []byte("done: shipped\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	silentSince := time.Now().Add(-30 * time.Minute)
+	if err := os.Chtimes(reportPath, silentSince, silentSince); err != nil {
+		t.Fatal(err)
+	}
+	bounds := watcher.ParkedBounds{Done: 20 * time.Minute, Other: 20 * time.Minute}
+
+	if !taskParked(home, task, attempt, state.ReportDone, bounds) {
+		t.Fatal("an undelivered task past its bound was not flagged parked, want the existing done-bounded behavior intact")
+	}
+	if !gateRunApplies(task, true) {
+		t.Fatal("the gate check was skipped for an undelivered done ship task with a recorded PR")
+	}
+
+	task.DeliveredAt = "2026-08-17T00:00:00Z"
+	if taskParked(home, task, attempt, state.ReportDone, bounds) {
+		t.Fatal("a delivered task was still flagged parked, want the silence exempt")
+	}
+	if gateRunApplies(task, true) {
+		t.Fatal("the gate check still applied to a delivered task, want it silent")
+	}
+}
+
 // atqamz/hand#268's "done when": a condition is added once, and both hand status and hand watch see
 // it without a second registration. watcher.GateKind is that one edit's home, so the fleet view's
 // flag and hand watch's known-kind vocabulary can never name a gate-run problem differently.

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -101,6 +101,7 @@ A consumer may rank, filter, or bound what the definition produces, and may not 
 Binds `hand status`, `hand watch`, `hand session`, and [`internal/notify`](../../internal/notify).
 There are three definitions today: `needsAttention` in [`cmd/statusview.go`](../../cmd/statusview.go), `classifyNextAction` in [`cmd/nextaction.go`](../../cmd/nextaction.go), and the `Kind` sets `internal/watcher`'s `NotifyFilter` and `CatchUpFilter` select over.
 They already disagree in three observable ways: the watcher has no gate-run kind while `needsAttention` counts `gate-absent` and `gate-unknown`; `KindParked` exists only in the watcher, so `hand status` still prints `state: idle` for exactly the pane atqamz/hand#32 describes; and `CatchUpFilter` drops `stale`, which `needsAttention` never had.
+Delivery is the supervisor's stronger, verified nothing-more-to-do signal: once `delivered_at` is set, the parked and gate-run predicates are both silent for that task.
 atqamz/hand#234's ranking in `classifyNextAction` is a consumer of the single definition and stays a ranking; atqamz/hand#218's supervisor skill is the other consumer.
 
 ### 6. Pane scraping is never primary truth

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -380,7 +380,12 @@ type ParkedBounds struct {
 // done and failed get their own tier rather than the blanket exemption this used to be: the status
 // file being torn down is what actually severs a task from steering, not the worker's own last word,
 // so a done or failed worker still attached to a pane is silence like any other and is bounded too.
-func parkedBound(lastState string, bounds ParkedBounds) (bound time.Duration, exempt bool) {
+func parkedBound(lastState, deliveredAt string, bounds ParkedBounds) (bound time.Duration, exempt bool) {
+	// Delivery is the supervisor's own verified last word on the task, stronger than any worker
+	// self-report, so silence after it is nobody's condition to act on - ClassifyStale's rule exactly.
+	if deliveredAt != "" {
+		return 0, true
+	}
 	switch lastState {
 	case state.ReportDone, state.ReportFailed:
 		bound = bounds.Done
@@ -399,8 +404,8 @@ func parkedBound(lastState string, bounds ParkedBounds) (bound time.Duration, ex
 // Parked is the level check behind ClassifyParked's latch, exported so cmd/statusview.go can ask the
 // same question for atqamz/hand#32's own case (atqamz/hand#268's disagreement 2). silentSince is the
 // evidence instant ReportEvidenceTime floors, the same one ClassifyParked calls mtime.
-func Parked(lastReportState string, silentSince, now time.Time, bounds ParkedBounds) bool {
-	bound, exempt := parkedBound(lastReportState, bounds)
+func Parked(lastReportState, deliveredAt string, silentSince, now time.Time, bounds ParkedBounds) bool {
+	bound, exempt := parkedBound(lastReportState, deliveredAt, bounds)
 	if exempt {
 		return false
 	}
@@ -410,15 +415,15 @@ func Parked(lastReportState string, silentSince, now time.Time, bounds ParkedBou
 // mtime is deliberately never reset to "now" on resume: --until-event restarts on
 // every delivered event, and a busy fleet would otherwise erase the clock before
 // it ever completes once.
-func ClassifyParked(ts *TaskState, id, lastState, lastLine string, mtime, now time.Time, bounds ParkedBounds, client PaneReader, paneID string) *Event {
-	if _, exempt := parkedBound(lastState, bounds); exempt {
+func ClassifyParked(ts *TaskState, id, lastState, lastLine, deliveredAt string, mtime, now time.Time, bounds ParkedBounds, client PaneReader, paneID string) *Event {
+	if _, exempt := parkedBound(lastState, deliveredAt, bounds); exempt {
 		ts.ParkedFiredFor = time.Time{}
 		return nil
 	}
 	if mtime.Equal(ts.ParkedFiredFor) {
 		return nil
 	}
-	naive := Parked(lastState, mtime, now, bounds)
+	naive := Parked(lastState, deliveredAt, mtime, now, bounds)
 	// Read once each tick so the next tick has a bounded activity baseline without blocking the poll loop.
 	confirmed, sample, observed := ConfirmParked(naive, ts.PaneSample, ts.PaneSampleObserved, client, paneID)
 	if observed {
@@ -450,7 +455,12 @@ func ClassifyPRMerged(ts *TaskState, id string, merged bool) *Event {
 // GateApplies is cmd/statusview.go's gateRunApplies, exported: the gate-run check has anything to say
 // about a task only when it is a done ship task carrying a recorded PR, and hand status and hand
 // watch must agree on that before either of them shells out to ask no-mistakes anything.
-func GateApplies(taskKind, pr string, reportedDone bool) bool {
+func GateApplies(taskKind, pr, deliveredAt string, reportedDone bool) bool {
+	// A delivered task has already had the supervisor's answer on what happens to its PR, so
+	// re-announcing an absent gate run on every tick asks a question nobody is waiting on.
+	if deliveredAt != "" {
+		return false
+	}
 	return taskKind == state.KindShip && pr != "" && reportedDone
 }
 

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -506,21 +506,21 @@ func TestClassifyParkedBoundsDoneAndFailedInsteadOfExemptingThem(t *testing.T) {
 
 	withinBound := now.Add(-time.Hour)
 	doneTs := NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(doneTs, "task-1", state.ReportDone, "done: shipped", withinBound, now, bounds, nil, ""); e != nil {
+	if e := ClassifyParked(doneTs, "task-1", state.ReportDone, "done: shipped", "", withinBound, now, bounds, nil, ""); e != nil {
 		t.Fatalf("got %+v, want no parked event while a done worker's silence is still under the done bound", e)
 	}
 	failedTs := NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(failedTs, "task-1", state.ReportFailed, "failed: build broke", withinBound, now, bounds, nil, ""); e != nil {
+	if e := ClassifyParked(failedTs, "task-1", state.ReportFailed, "failed: build broke", "", withinBound, now, bounds, nil, ""); e != nil {
 		t.Fatalf("got %+v, want no parked event while a failed worker's silence is still under the done bound", e)
 	}
 
 	beyondBound := now.Add(-2 * time.Hour)
 	doneTs = NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(doneTs, "task-1", state.ReportDone, "done: shipped", beyondBound, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(doneTs, "task-1", state.ReportDone, "done: shipped", "", beyondBound, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want a parked event once a done worker's silence exceeds the done bound: it may still be attached to a pane and steerable", e)
 	}
 	failedTs = NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(failedTs, "task-1", state.ReportFailed, "failed: build broke", beyondBound, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(failedTs, "task-1", state.ReportFailed, "failed: build broke", "", beyondBound, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want a parked event once a failed worker's silence exceeds the done bound", e)
 	}
 }
@@ -531,7 +531,7 @@ func TestClassifyParkedExemptsDoneAndFailedWhenTheDoneBoundIsUnconfigured(t *tes
 	old := now.Add(-24 * time.Hour)
 
 	ts := NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(ts, "task-1", state.ReportDone, "done: shipped", old, now, bounds, nil, ""); e != nil {
+	if e := ClassifyParked(ts, "task-1", state.ReportDone, "done: shipped", "", old, now, bounds, nil, ""); e != nil {
 		t.Fatalf("got %+v, want no parked event: a non-positive bound means unconfigured, not zero-tolerance", e)
 	}
 }
@@ -542,17 +542,17 @@ func TestClassifyParkedSelectsBoundByLastReport(t *testing.T) {
 
 	pausedTs := NewTaskState(herdr.StatusIdle, now)
 	silentFor30m := now.Add(-30 * time.Minute)
-	if e := ClassifyParked(pausedTs, "task-1", state.ReportPaused, "paused: waiting on review", silentFor30m, now, bounds, nil, ""); e != nil {
+	if e := ClassifyParked(pausedTs, "task-1", state.ReportPaused, "paused: waiting on review", "", silentFor30m, now, bounds, nil, ""); e != nil {
 		t.Fatalf("got %+v, want no parked event: 30m silence is still under the paused bound", e)
 	}
 
 	workingTs := NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(workingTs, "task-1", state.ReportWorking, "working: on it", silentFor30m, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(workingTs, "task-1", state.ReportWorking, "working: on it", "", silentFor30m, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want parked event: 30m silence exceeds the shorter default bound", e)
 	}
 
 	unreportedTs := NewTaskState(herdr.StatusIdle, now)
-	if e := ClassifyParked(unreportedTs, "task-1", "", "no report", silentFor30m, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(unreportedTs, "task-1", "", "no report", "", silentFor30m, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want parked event: a task that never reported gets the short bound too", e)
 	}
 }
@@ -563,18 +563,18 @@ func TestClassifyParkedFiresOncePerEpisodeAndResetsOnGrowth(t *testing.T) {
 	ts := NewTaskState(herdr.StatusIdle, now)
 	mtime := now.Add(-30 * time.Minute)
 
-	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", mtime, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", mtime, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want parked event on first crossing", e)
 	}
-	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", mtime, now.Add(10*time.Minute), bounds, nil, ""); e != nil {
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", mtime, now.Add(10*time.Minute), bounds, nil, ""); e != nil {
 		t.Fatalf("parked fired again for the same episode: %+v", e)
 	}
 
 	grown := now.Add(-time.Minute)
-	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", grown, now.Add(11*time.Minute), bounds, nil, ""); e != nil {
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", grown, now.Add(11*time.Minute), bounds, nil, ""); e != nil {
 		t.Fatalf("got %+v, want no parked event right after the report file grows", e)
 	}
-	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", grown, now.Add(45*time.Minute), bounds, nil, ""); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", grown, now.Add(45*time.Minute), bounds, nil, ""); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want a second parked event once the new episode crosses the bound", e)
 	}
 }
@@ -716,7 +716,7 @@ func TestClassifyParkedWithdrawsAndStaysAnnounceableWhileThePaneIsLive(t *testin
 	bounds := ParkedBounds{Paused: time.Hour, Other: 20 * time.Minute}
 	first := NewTaskState(herdr.StatusWorking, now)
 	firstReader := &fakePaneReader{reads: []string{"waiting for input"}}
-	if e := ClassifyParked(first, "task-1", state.ReportWorking, "working: on it", now.Add(-30*time.Minute), now, bounds, firstReader, "wA:pB"); e != nil || !first.PaneSampleObserved || !first.ParkedFiredFor.IsZero() {
+	if e := ClassifyParked(first, "task-1", state.ReportWorking, "working: on it", "", now.Add(-30*time.Minute), now, bounds, firstReader, "wA:pB"); e != nil || !first.PaneSampleObserved || !first.ParkedFiredFor.IsZero() {
 		t.Fatalf("first observation got event=%+v sample=%v latch=%v, want sample only", e, first.PaneSampleObserved, first.ParkedFiredFor)
 	}
 	ts := NewTaskState(herdr.StatusWorking, now)
@@ -725,7 +725,7 @@ func TestClassifyParkedWithdrawsAndStaysAnnounceableWhileThePaneIsLive(t *testin
 	ts.PaneSample = "esc to interrupt (12s)"
 	ts.PaneSampleObserved = true
 	live := &fakePaneReader{reads: []string{"esc to interrupt (15s)"}}
-	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", mtime, now, bounds, live, "wA:pB"); e != nil {
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", mtime, now, bounds, live, "wA:pB"); e != nil {
 		t.Fatalf("got %+v, want no parked event while the pane is still printing", e)
 	}
 	if !ts.ParkedFiredFor.IsZero() {
@@ -734,7 +734,35 @@ func TestClassifyParkedWithdrawsAndStaysAnnounceableWhileThePaneIsLive(t *testin
 
 	ts.PaneSample = "waiting for input"
 	still := &fakePaneReader{reads: []string{"waiting for input"}}
-	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", mtime, now.Add(time.Minute), bounds, still, "wA:pB"); e == nil || e.Kind != KindParked {
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", mtime, now.Add(time.Minute), bounds, still, "wA:pB"); e == nil || e.Kind != KindParked {
 		t.Fatalf("got %+v, want a parked event once the pane goes quiet inside the same silence episode", e)
+	}
+}
+
+func TestClassifyParkedExemptsADeliveredTask(t *testing.T) {
+	now := time.Now()
+	bounds := ParkedBounds{Paused: time.Hour, Other: 20 * time.Minute}
+	ts := NewTaskState(herdr.StatusIdle, now)
+	silentFor30m := now.Add(-30 * time.Minute)
+
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "2026-08-17T00:00:00Z", silentFor30m, now, bounds, nil, ""); e != nil {
+		t.Fatalf("got %+v, want no parked event: delivery is a stronger nothing-more-to-do signal than the worker's own silence", e)
+	}
+	if !ts.ParkedFiredFor.IsZero() {
+		t.Fatal("an exempt task consumed the episode latch")
+	}
+	if e := ClassifyParked(ts, "task-1", state.ReportWorking, "working: on it", "", silentFor30m, now, bounds, nil, ""); e == nil || e.Kind != KindParked {
+		t.Fatalf("got %+v, want the same silence still parked while the task is undelivered", e)
+	}
+}
+
+func TestGateAppliesStopsOnceTheTaskIsDelivered(t *testing.T) {
+	pr := "https://github.com/atqamz/hand/pull/120"
+
+	if !GateApplies(state.KindShip, pr, "", true) {
+		t.Fatal("a done ship task with a recorded PR was skipped, want the gate check to apply")
+	}
+	if GateApplies(state.KindShip, pr, "2026-08-17T00:00:00Z", true) {
+		t.Fatal("the gate check still applied after delivery, want it silent: it has nothing further to say once the supervisor has handed the task off")
 	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -478,7 +478,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		}
 		// Only shells out to no-mistakes when the check applies and has not already fired: mirrors
 		// !ts.PRMerged above, so an absent gate run does not re-exec no-mistakes on every tick forever.
-		gateApplies := GateApplies(t.Kind, t.PR, ts.LastReportState == state.ReportDone)
+		gateApplies := GateApplies(t.Kind, t.PR, t.DeliveredAt, ts.LastReportState == state.ReportDone)
 		switch {
 		case !gateApplies:
 			ClassifyGateProblem(ts, t.ID, false, "")
@@ -489,7 +489,7 @@ func tick(ctx context.Context, cfg Config, client *herdr.Client, states map[stri
 		}
 		if mtime, err := ReportEvidenceTime(cfg.Home, t, attempt); err != nil {
 			_, _ = fmt.Fprintf(errOut, "watch: stat report %s failed: %v\n", t.ID, err)
-		} else if e := ClassifyParked(ts, t.ID, ts.LastReportState, lastReportLine(ts), mtime, now, cfg.ParkedBounds, client, attempt.Herdr.PaneID); e != nil {
+		} else if e := ClassifyParked(ts, t.ID, ts.LastReportState, lastReportLine(ts), t.DeliveredAt, mtime, now, cfg.ParkedBounds, client, attempt.Herdr.PaneID); e != nil {
 			emit(e)
 		}
 		if !cfg.ObserveOnly {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -681,7 +681,7 @@ func TestTickClassifiesGateProblem(t *testing.T) {
 
 	var buf bytes.Buffer
 	// The first tick only seeds tracking for a task not seen before, the same as every other
-	// classifier in this suite - see TestTickFiresParkedOnFirstResumedTickWhenTheSilenceAlreadyExceedsTheBound.
+	// classifier in this suite - see TestTickFiresParkedOnTheFirstCorroboratingTickWhenTheSilenceAlreadyExceedsTheBound.
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 
 	buf.Reset()
@@ -1434,7 +1434,7 @@ func TestTickAnnouncesADoneRewrittenToTheSameLengthAcrossARestart(t *testing.T) 
 	}
 }
 
-func TestTickFiresParkedOnFirstResumedTickWhenTheSilenceAlreadyExceedsTheBound(t *testing.T) {
+func TestTickFiresParkedOnTheFirstCorroboratingTickWhenTheSilenceAlreadyExceedsTheBound(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "idle")
 	writeFakeHerdr(t, statusFile)


### PR DESCRIPTION
## Intent

Stop hand burning supervisor turns on a task the operator has already handed off.

The goal, in the operator's terms: two independent flags keep re-firing forever for a task the
supervisor has already `hand deliver`-ed. Delivery is a stronger, supervisor-verified "nothing more
to do here" signal than any raw worker self-report, yet `parked` and `gate-absent`/`gate-unknown`
both keep announcing against a delivered task on every tick, which wakes the supervisor into an
infinite loop over an episode it already handled. Filed as atqamz/hand#365.

What the change does:
- Threads the task's `DeliveredAt` into `parkedBound`/`Parked`/`ClassifyParked` so a delivered task
is exempt from the parked path.
- Adds `deliveredAt` to `GateApplies` (and therefore cmd/status.go's `gateRunApplies` wrapper), which
returns false once it is set: the gate-run check has nothing further to say about a PR the
supervisor has already delivered on.

Deliberate decisions - please do not flag these as mistakes:

1. This mirrors an EXISTING precedent rather than inventing anything. `ClassifyStale` in the same
file already takes `deliveredAt string` and exempts on
`state.TerminalReport(ts.LastReportState) || deliveredAt != ""`. The parked path is given the same
treatment on purpose, so the two silence classifiers cannot drift apart.

2. The delivered exemption reuses the `exempt` return path that `parkedBound` already has for the
"bound unconfigured" case. A second, parallel exemption mechanism was deliberately NOT introduced.

3. The done/failed-bounded-but-NOT-YET-delivered behavior is deliberately untouched. A worker that
reported done but has not been delivered is still bounded and can still park - that narrowing was
a deliberate earlier decision, documented in the comment directly above `parkedBound`. Delivery is
an ADDITIONAL, INDEPENDENT exemption layered on top, not a replacement for that tier.

4. `taskParked` and `gateRunApplies` in cmd/status.go read `t.DeliveredAt` off the `state.Task` they
already receive rather than gaining a new `deliveredAt` parameter, because the field is already in
scope at both sites. Only `GateApplies` in internal/watcher, which takes loose fields rather than
the task, gained the parameter.

5. Scope is atqamz/hand#365 only. No drive-by refactors.

Stack context: this branch is PR atqamz/hand#367 and is stacked on PR atqamz/hand#366
(branch 364-parked-cross-check-pane-activity), NOT on main. It therefore already carries #366's
parked pane-activity cross-check, including the three review-fix commits #366's own no-mistakes run
produced: the cached-pane-sample design that replaced a blocking 3-second sleep, `hand status`
becoming honestly naive-only and deferring corroboration to `hand watch`, and the
first-observation-takes-a-baseline-instead-of-announcing rule. Those commits are #366's, already
reviewed and already at checks-passed; they are not this change's diff.

This branch also carries one small commit of its own beyond the #365 fix:
`test(watch): name the parked tick test for the tick that announces`, renaming
TestTickFiresParkedOnFirstResumedTick... to ...OnTheFirstCorroboratingTick..., because #366's
corroborating-sample rule moved the announcement off the first resumed tick and the old name told the
next reader the wrong thing. The operator asked for it to ride here rather than cost #366 an extra
fix round.

Known pre-existing test state, NOT caused by this diff: `make test` does not pass on a clean checkout
of origin/main (26b243cc017e0066a3833590a400f660919bc523) either - internal/runtime times out inside
toolchain tarball re-extraction, internal/worktree's 19 tests shell out to the real `treehouse`
binary from a non-git temp dir, and internal/watcher's
TestRunUntilEventKeepsWaitingWhenOnlyStaleWouldFireAtArm is wall-clock bounded and load-sensitive.
Tracked as atqamz/hand#368. Do not chase them here.

## What Changed

- Suppress parked and gate-run attention for tasks with a recorded delivery timestamp.
- Cross-check parked conditions against cached pane samples, while keeping one-shot status checks naive and resetting pane samples when panes change.
- Document the delivered-task attention rule and update coverage for delivery, pane activity, and corroboration timing.

## Risk Assessment

✅ Low: The change consistently threads DeliveredAt through both parked and gate-run predicates, preserves undelivered done/failed bounds, and covers watcher and status call sites without a substantiated correctness issue.

## Testing

System Go was unavailable, so targeted tests ran through the project Nix devshell and passed. They exercised delivered and undelivered parked behavior, gate applicability, status wrappers, and corroborated watch ticks. No reviewer-visible artifact was produced; the behavior is CLI/event classification logic rather than a rendered UI. A separate existing gate-classification test failed during broader isolation and was not caused or modified by this diff.

- Outcome: ⚠️ 1 warning across 1 run (2m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"89c266f355a42c24317af73059f839e8e251668b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `/home/atqa/.no-mistakes/worktrees/6c8eede96b0d/01M0SR9F1TMFYDAHR9Y323C2TT/internal/watcher/watcher_test.go:690` - Unrelated existing TestTickClassifiesGateProblem fails with gate-unknown/pr-merged instead of gate-absent; isolated failure, outside this diff&#39;s scope.
- `nix develop --command go test ./internal/watcher -run 'TestClassifyParkedExemptsADeliveredTask|TestGateAppliesStopsOnceTheTaskIsDelivered|TestTickDoesNotRefireParkedForADoneTaskAcrossARestart|TestTickFiresParkedOnTheFirstCorroboratingTickWhenTheSilenceAlreadyExceedsTheBound' -count=1 -v`
- `nix develop --command go test ./cmd -run 'TestTaskParkedUsesNaiveOneShotFallback|TestTaskParkedAndGateRunAppliesStopOnceTheTaskIsDelivered' -count=1 -v`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
