### PR TITLE
fix(test): make test pass reliably on a clean checkout under load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" .
 
 test:
-	go test -tags=test -race ./...
+	SECONDHAND_HOME=$$(mktemp -d) go test -tags=test -race ./...
 
 fmt:
 	gofmt -w .

--- a/internal/faketool/faketool.go
+++ b/internal/faketool/faketool.go
@@ -44,13 +44,14 @@ func InitRepo(t *testing.T, path string) {
 	}
 }
 
-// Returns a directory prepended to PATH for the rest of the test, so fakes
-// installed there are found ahead of any real tool. Prepending rather than
-// replacing keeps it additive: several tools' fakes can share one directory.
+// Returns a directory prepended to PATH so fakes installed there are found ahead of any real
+// tool, and points SECONDHAND_HOME at a fresh empty directory so a managed toolchain resolved
+// from the operator's real ~/.secondhand cannot answer git/treehouse/herdr calls ahead of it.
 func Bin(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SECONDHAND_HOME", t.TempDir())
 	return dir
 }
 
@@ -59,6 +60,7 @@ func Bin(t *testing.T) string {
 func NoTools(t *testing.T) {
 	t.Helper()
 	t.Setenv("PATH", t.TempDir())
+	t.Setenv("SECONDHAND_HOME", t.TempDir())
 }
 
 type commandConfig struct {

--- a/internal/runtime/execution_plan_test.go
+++ b/internal/runtime/execution_plan_test.go
@@ -337,6 +337,15 @@ func TestSpawnLegacyTierCreatesAttemptBeforeWaitingForProjectLock(t *testing.T) 
 	home := executionPlanHome(t, "---\nexecution_class: standard\n---\nbrief\n")
 	calls := &executionPlanCalls{}
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return strings.Repeat("a", 40), nil })
+	// phaseAttemptCreated fires right after the provisioning Attempt's write commits, so waiting on
+	// it proves the write already landed instead of polling for it against a wall-clock budget.
+	attemptCreated := make(chan struct{})
+	r.deps.phase = func(phase lifecyclePhase) error {
+		if phase == phaseAttemptCreated {
+			close(attemptCreated)
+		}
+		return nil
+	}
 	releaseProject, err := state.Lock(home, "project:demo")
 	if err != nil {
 		t.Fatal(err)
@@ -353,20 +362,23 @@ func TestSpawnLegacyTierCreatesAttemptBeforeWaitingForProjectLock(t *testing.T) 
 		_, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: "claude"})
 		spawnDone <- err
 	}()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		history, readErr := state.ReadHistory(home, "task-1")
-		if readErr == nil && history.ActiveAttempt != nil {
-			released = true
-			releaseProject()
-			if err := <-spawnDone; err != nil {
-				t.Fatalf("Spawn() = %v, want success after project lock release", err)
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	select {
+	case <-attemptCreated:
+	case <-time.After(15 * time.Second):
+		t.Fatal("legacy Spawn did not create its provisioning Attempt before waiting for project lock")
 	}
-	t.Fatal("legacy Spawn did not create its provisioning Attempt before waiting for project lock")
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil {
+		t.Fatalf("history after phaseAttemptCreated = %+v, want a provisioning Attempt already durable", history)
+	}
+	released = true
+	releaseProject()
+	if err := <-spawnDone; err != nil {
+		t.Fatalf("Spawn() = %v, want success after project lock release", err)
+	}
 }
 
 func TestReopenMechanicalPlanStopsBeforeTaskMutationAndProvisioning(t *testing.T) {
@@ -416,6 +428,15 @@ func TestReopenLegacyTierCreatesAttemptBeforeWaitingForProjectLock(t *testing.T)
 	createTerminalExecutionTask(t, home)
 	calls := &executionPlanCalls{}
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return strings.Repeat("a", 40), nil })
+	// phaseAttemptCreated fires right after the reopened Attempt's write commits, so waiting on it
+	// proves the write already landed instead of polling for it against a wall-clock budget.
+	attemptCreated := make(chan struct{})
+	r.deps.phase = func(phase lifecyclePhase) error {
+		if phase == phaseAttemptCreated {
+			close(attemptCreated)
+		}
+		return nil
+	}
 	releaseProject, err := state.Lock(home, "project:demo")
 	if err != nil {
 		t.Fatal(err)
@@ -432,20 +453,23 @@ func TestReopenLegacyTierCreatesAttemptBeforeWaitingForProjectLock(t *testing.T)
 		_, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1", Harness: "claude"})
 		reopenDone <- err
 	}()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		history, readErr := state.ReadHistory(home, "task-1")
-		if readErr == nil && len(history.Attempts) == 2 && history.ActiveAttempt != nil {
-			released = true
-			releaseProject()
-			if err := <-reopenDone; err != nil {
-				t.Fatalf("Reopen() = %v, want success after project lock release", err)
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	select {
+	case <-attemptCreated:
+	case <-time.After(15 * time.Second):
+		t.Fatal("legacy Reopen did not create its provisioning Attempt before waiting for project lock")
 	}
-	t.Fatal("legacy Reopen did not create its provisioning Attempt before waiting for project lock")
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 2 || history.ActiveAttempt == nil {
+		t.Fatalf("history after phaseAttemptCreated = %+v, want the reopened Attempt already durable", history)
+	}
+	released = true
+	releaseProject()
+	if err := <-reopenDone; err != nil {
+		t.Fatalf("Reopen() = %v, want success after project lock release", err)
+	}
 }
 
 func TestPromoteMechanicalPlanStopsBeforeTaskMutationAndProvisioning(t *testing.T) {
@@ -608,6 +632,15 @@ func TestPromoteLegacyTierCreatesAttemptBeforeWaitingForProjectLock(t *testing.T
 	markExecutionAttemptRunning(t, home, attempt.ID)
 	calls := &executionPlanCalls{}
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return strings.Repeat("a", 40), nil })
+	// phaseAttemptCreated fires right after state.PromoteTask's write commits, so waiting on it
+	// proves the ship Attempt already landed instead of polling for it against a wall-clock budget.
+	attemptCreated := make(chan struct{})
+	r.deps.phase = func(phase lifecyclePhase) error {
+		if phase == phaseAttemptCreated {
+			close(attemptCreated)
+		}
+		return nil
+	}
 	releaseProject, err := state.Lock(home, "project:demo")
 	if err != nil {
 		t.Fatal(err)
@@ -624,20 +657,23 @@ func TestPromoteLegacyTierCreatesAttemptBeforeWaitingForProjectLock(t *testing.T
 		_, err := r.Promote(context.Background(), PromoteRequest{Home: home, ID: "task-1", Harness: "claude"})
 		promoteDone <- err
 	}()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		history, readErr := state.ReadHistory(home, "task-1")
-		if readErr == nil && len(history.Attempts) == 2 && history.Task.Kind == state.KindShip {
-			released = true
-			releaseProject()
-			if err := <-promoteDone; err != nil {
-				t.Fatalf("Promote() = %v, want success after project lock release", err)
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	select {
+	case <-attemptCreated:
+	case <-time.After(15 * time.Second):
+		t.Fatal("legacy Promote did not create its ship Attempt before waiting for project lock")
 	}
-	t.Fatal("legacy Promote did not create its ship Attempt before waiting for project lock")
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 2 || history.Task.Kind != state.KindShip {
+		t.Fatalf("history after phaseAttemptCreated = %+v, want the ship Attempt already durable", history)
+	}
+	released = true
+	releaseProject()
+	if err := <-promoteDone; err != nil {
+		t.Fatalf("Promote() = %v, want success after project lock release", err)
+	}
 }
 
 func TestSpawnHoldsProjectLockFromMechanicalCheckThroughWorktree(t *testing.T) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1018,7 +1018,10 @@ func TestTickSurfacesAContendedAutoRecordInsteadOfWaiting(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(10 * time.Second):
+	// This tick still forks a fake gh subprocess for ValidatePR before it ever reaches the
+	// non-blocking task lock, so the watchdog has to outlast fork/exec latency under a loaded box,
+	// not just the (already non-blocking) lock check the test is actually about.
+	case <-time.After(30 * time.Second):
 		unlock()
 		t.Fatal("tick blocked on a task lock held by another command")
 	}
@@ -2686,30 +2689,50 @@ func TestRunUntilEventKeepsWaitingWhenOnlyStaleWouldFireAtArm(t *testing.T) {
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
 
-	home := t.TempDir()
 	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
-	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, CreatedAt: dwelling},
-		state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
-			StatusChangedAt: dwelling, StatusChangedFor: "working"}); err != nil {
+	staleTask := state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip, CreatedAt: dwelling}
+	staleAttempt := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		StatusChangedAt: dwelling, StatusChangedFor: "working"}
+
+	// Drive the arm's own two ticks directly with an unbounded context: asserting on RunUntilEvent's
+	// return instead would race that recording against its --timeout clock, which a loaded box can
+	// win before the second tick's herdr round trip returns.
+	recordHome := t.TempDir()
+	if err := writeTaskAttempt(t, recordHome, staleTask, staleAttempt); err != nil {
 		t.Fatal(err)
 	}
+	armCfg := Config{Home: recordHome, StaleThreshold: 20 * time.Minute, catchUp: CatchUpFilter()}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	var caught, armErrOut bytes.Buffer
+	tick(context.Background(), armCfg, client, states, &caught, &armErrOut)
+	tick(context.Background(), armCfg, client, states, &caught, &armErrOut)
+	if caught.Len() != 0 {
+		t.Fatalf("arm out = %q, want nothing delivered: a stale-only condition must not wake the arm", caught.String())
+	}
+	logData, err := os.ReadFile(filepath.Join(recordHome, "state", "events.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "stale task-1") {
+		t.Fatalf("events.log = %q, want stale recorded: the arm withholds the wake, not the record", string(logData))
+	}
 
+	// RunUntilEvent's own ErrNoEvent contract, on a fresh home so the direct ticks above cannot leave
+	// it any durable state: whatever wall-clock margin the arm needed to record, the same condition
+	// must still not wake it.
+	waitHome := t.TempDir()
+	if err := writeTaskAttempt(t, waitHome, staleTask, staleAttempt); err != nil {
+		t.Fatal(err)
+	}
 	var out bytes.Buffer
-	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: 20 * time.Minute, Timeout: 500 * time.Millisecond}
-	err := RunUntilEvent(context.Background(), cfg, &out, io.Discard)
-
+	waitCfg := Config{Home: waitHome, PollInterval: 10 * time.Millisecond, StaleThreshold: 20 * time.Minute, Timeout: 500 * time.Millisecond}
+	err = RunUntilEvent(context.Background(), waitCfg, &out, io.Discard)
 	if !errors.Is(err, ErrNoEvent) {
 		t.Fatalf("RunUntilEvent = %v, want ErrNoEvent: a working worker whose status has not changed is not actionable", err)
 	}
 	if out.Len() != 0 {
 		t.Fatalf("out = %q, want the watcher still waiting", out.String())
-	}
-	logData, err := os.ReadFile(filepath.Join(home, "state", "events.log"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(logData), "stale task-1") {
-		t.Fatalf("events.log = %q, want stale still recorded: the arm withholds the wake, not the record", string(logData))
 	}
 }
 
@@ -3311,9 +3334,18 @@ func TestRunUntilEventFailsToArmWhenATaskCannotBeProbed(t *testing.T) {
 	writeFakeHerdr(t, statusFile)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
-	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour, Timeout: time.Second}
+	// No cfg.Timeout: ErrArmFailed is a logical result of the probe, not a wall-clock one, and
+	// racing it against a --timeout clock is what let a loaded box report ErrNoEvent instead.
+	cfg := Config{Home: home, PollInterval: 10 * time.Millisecond, StaleThreshold: time.Hour}
 
-	err := RunUntilEvent(context.Background(), cfg, &bytes.Buffer{}, io.Discard)
+	done := make(chan error, 1)
+	go func() { done <- RunUntilEvent(context.Background(), cfg, &bytes.Buffer{}, io.Discard) }()
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunUntilEvent did not exit after an unprobeable worker")
+	}
 	if !errors.Is(err, ErrArmFailed) {
 		t.Fatalf("RunUntilEvent = %v, want ErrArmFailed: an unprobeable worker must not look armed", err)
 	}


### PR DESCRIPTION
## Summary

- `internal/worktree.runCore` resolved a managed treehouse/git through `toolchain.Resolve()` before ever falling back to the PATH-based legacy exec `faketool` relies on, so any machine with a real `~/.secondhand` runtime already installed silently bypassed the fake and, under `-race`, could hang for minutes re-extracting a retained artifact to verify it; `faketool.Bin`/`NoTools` now isolate `SECONDHAND_HOME` per test, and `make test` isolates it for the whole run.
- Two `internal/watcher` tests and three `internal/runtime` tests raced a real background operation against a fixed wall-clock budget (a `--timeout` clock, a 2-second polling deadline); all five now wait on the actual condition instead - a direct arm tick, a phase hook, a done channel - with a generous safety-net ceiling only where no better condition exists.

## Test plan

- `make build` clean, `make lint` clean.
- `make test` green twice in a row under a sustained `stress-ng --cpu 10` load, and again under a heavier ~18-worker burst combined with the machine's own ambient multi-session load.
- Each of the fixed tests individually re-run with `-race -count=10..20` under CPU stress to confirm they no longer flake.
- The originally-named failure 1 (`internal/worktree.TestUnknownAndMismatchAreDistinguishableWithoutReadingAMessage`) also surfaced four more silently-wrong subtests of `TestObserveLeaseReportsUnknownForEveryUnobservablePool` that were quietly exercising the real treehouse instead of the fake on this machine; all five now pass for the right reason.

Fixes atqamz/hand#368