### PR TITLE
fix: accept idle rendered composers

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -18,6 +18,7 @@ import (
 func newSendCmd() *cobra.Command {
 	var filePath string
 	var wait string
+	var force bool
 
 	cmd := &cobra.Command{
 		Use:   "send <id> [message]",
@@ -66,7 +67,7 @@ func newSendCmd() *cobra.Command {
 			client := herdrClientForAttempt(attempt, nil)
 			result, err := steering.Execute(steering.Request{
 				Home: fleetHome, TaskID: args[0], Message: message, Origin: steeringOperator,
-				Client: client, Wait: waitDuration, WaitComposer: client.WaitComposerEmpty, TryTaskLock: true,
+				Client: client, Wait: waitDuration, WaitComposer: client.WaitComposerEmpty, TryTaskLock: true, Force: force,
 			})
 			if err != nil {
 				return wrapSendError(err)
@@ -86,6 +87,7 @@ func newSendCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&filePath, "file", "", "read the message from this file instead of the positional argument")
 	cmd.Flags().StringVar(&wait, "wait", "", "how long to wait for a busy composer to free before giving up (default: config/send-wait, or 2m)")
+	cmd.Flags().BoolVar(&force, "force", false, "send without waiting for a busy composer; still records the send and verifies pane ownership")
 	return cmd
 }
 

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -135,6 +135,27 @@ func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 	}
 }
 
+func TestSendReachesRenderedIdlePromptDespiteWorkingAgentStatus(t *testing.T) {
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatus:  "working",
+		PaneReadOut: "────────────────────────\n❯\n────────────────────────\n  Opus 5 | 3 shells\n",
+	})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "revoke merge authority", "--wait", "1s"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want idle-looking pane to accept the send", err)
+	}
+
+	sends, err := state.ListSends(home, "task-1")
+	if err != nil || len(sends) != 1 || sends[0].State != state.SendSubmitted {
+		t.Fatalf("sends=%+v err=%v, want one submitted durable send", sends, err)
+	}
+}
+
 func TestSendDoesNotSteerAnAttemptWhileTaskOwnershipIsChanging(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "sent.log")
 	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
@@ -328,7 +349,7 @@ func TestSendClassifiesStructuredPreTextRejectionAsNotSubmitted(t *testing.T) {
 func TestSendDoesNotCreateRecordWhenComposerStaysBusy(t *testing.T) {
 	// The composer never frees, so WaitComposerEmpty always exhausts --wait;
 	// a short --wait keeps the test itself fast.
-	home := setupSendHome(t, faketool.Herdr{PaneStatus: "working"})
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "working", PaneReadOut: "working...\nesc to interrupt (15s)\n  3 shells\n"})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -340,10 +361,31 @@ func TestSendDoesNotCreateRecordWhenComposerStaysBusy(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 6 {
 		t.Fatalf("got %v, want ExitError code 6", err)
 	}
+	if !strings.Contains(err.Error(), `agent_status="working"`) || !strings.Contains(err.Error(), "background_shells=3") {
+		t.Fatalf("got err %v, want status and shell diagnostics", err)
+	}
 
 	sends, err := state.ListSends(home, "task-1")
 	if err != nil || len(sends) != 0 {
 		t.Fatalf("sends=%+v err=%v, want no send before composer mutation", sends, err)
+	}
+}
+
+func TestSendForceBypassesBusyComposerAndKeepsDurableRecord(t *testing.T) {
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "working", PaneReadOut: "working...\nesc to interrupt (15s)\n  3 shells\n"})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "revoke merge authority", "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want --force to submit", err)
+	}
+
+	sends, err := state.ListSends(home, "task-1")
+	if err != nil || len(sends) != 1 || sends[0].State != state.SendSubmitted {
+		t.Fatalf("sends=%+v err=%v, want one submitted durable send", sends, err)
 	}
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -23,6 +23,28 @@ import (
 // transient and worth retrying, a pane that stopped answering will never answer a retry.
 var ErrComposerBusyTimeout = errors.New("composer still busy")
 
+// ComposerBusyError preserves the observed pane state when a composer never becomes ready.
+type ComposerBusyError struct {
+	Timeout          time.Duration
+	AgentStatus      Status
+	BackgroundShells int
+	ShellsKnown      bool
+}
+
+func (e *ComposerBusyError) Error() string {
+	return fmt.Sprintf("%s after %s (%s)", ErrComposerBusyTimeout, e.Timeout, e.Detail())
+}
+
+func (e *ComposerBusyError) Unwrap() error { return ErrComposerBusyTimeout }
+
+func (e *ComposerBusyError) Detail() string {
+	detail := fmt.Sprintf("agent_status=%q", e.AgentStatus)
+	if e.ShellsKnown {
+		detail += fmt.Sprintf(", background_shells=%d", e.BackgroundShells)
+	}
+	return detail
+}
+
 type Client struct {
 	session    string
 	executable string
@@ -576,22 +598,66 @@ func (c *Client) PaneRead(paneID string, lines int) (string, error) {
 	return string(stdout), nil
 }
 
-// WaitComposerEmpty polls the pane until the agent is no longer "working" or timeout elapses.
-// There is no herdr primitive for "not working", so this polls pane state directly
-// rather than depending on a single-target wait command.
+// WaitComposerEmpty polls pane state and its recent rendering until the agent is no longer "working",
+// the rendered composer is visibly empty, or timeout elapses. There is no herdr primitive for "not
+// working", so this combines the pane signals rather than depending on a single-target wait command.
 func (c *Client) WaitComposerEmpty(paneID string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
+	var shellsKnown bool
+	var backgroundShells int
+	var lastStatus Status
 	for {
 		pane, err := c.PaneGet(paneID)
 		if err != nil {
 			return err
 		}
+		lastStatus = pane.AgentStatus
 		if pane.AgentStatus != StatusWorking {
 			return nil
 		}
+		if text, err := c.PaneRead(paneID, 20); err == nil {
+			if count, ok := renderedBackgroundShells(text); ok {
+				backgroundShells, shellsKnown = count, true
+			}
+			if renderedEmptyComposer(text) {
+				return nil
+			}
+		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("%w after %s", ErrComposerBusyTimeout, timeout)
+			return &ComposerBusyError{Timeout: timeout, AgentStatus: lastStatus, BackgroundShells: backgroundShells, ShellsKnown: shellsKnown}
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
+}
+
+func renderedEmptyComposer(text string) bool {
+	lines := strings.Split(strings.ReplaceAll(text, "\r", ""), "\n")
+	start := len(lines) - 6
+	if start < 0 {
+		start = 0
+	}
+	for _, line := range lines[start:] {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(strings.ToLower(trimmed), "esc to interrupt") {
+			return false
+		}
+		if trimmed == "❯" || trimmed == ">" || trimmed == "›" || trimmed == "»" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderedBackgroundShells(text string) (int, bool) {
+	fields := strings.Fields(text)
+	for i := 1; i < len(fields); i++ {
+		if fields[i] != "shells" && fields[i] != "shell" {
+			continue
+		}
+		count, err := strconv.Atoi(fields[i-1])
+		if err == nil && count >= 0 {
+			return count, true
+		}
+	}
+	return 0, false
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -570,12 +570,23 @@ func TestWaitComposerEmptyReturnsWhenIdle(t *testing.T) {
 	}
 }
 
+func TestWaitComposerEmptyAcceptsRenderedIdlePromptWhileAgentStatusIsWorking(t *testing.T) {
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"}, faketool.HerdrResponse{Command: "pane read", Stdout: "────────────────────────\n❯\n────────────────────────\n  Opus 5 | 3 shells\n"})
+	c := NewClient()
+	if err := c.WaitComposerEmpty("wA:pB", time.Second); err != nil {
+		t.Fatalf("got %v, want rendered idle prompt to override stale working status", err)
+	}
+}
+
 func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
-	writeFakeHerdr(t, herdrResponse("pane get", "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"))
+	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"}, faketool.HerdrResponse{Command: "pane read", Stdout: "working...\nesc to interrupt (15s)\n  3 shells\n"})
 	c := NewClient()
 	err := c.WaitComposerEmpty("wA:pB", 10*time.Millisecond)
 	if !errors.Is(err, ErrComposerBusyTimeout) {
 		t.Fatalf("got err %v, want ErrComposerBusyTimeout", err)
+	}
+	if !strings.Contains(err.Error(), `agent_status="working"`) || !strings.Contains(err.Error(), "background_shells=3") {
+		t.Fatalf("got err %v, want status and shell diagnostics", err)
 	}
 }
 

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -31,6 +31,7 @@ type Request struct {
 	WaitComposer      func(paneID string, timeout time.Duration) error
 	TryLock           bool
 	TryTaskLock       bool
+	Force             bool
 	Expected          *state.Attempt
 	UsageLimitEpisode int64
 	Now               func() time.Time
@@ -139,10 +140,15 @@ func Execute(req Request) (Result, error) {
 	if err != nil {
 		return Result{}, paneError(active, "observe pane", err)
 	}
-	if pane.AgentStatus == herdr.StatusWorking {
+	if pane.AgentStatus == herdr.StatusWorking && !req.Force {
 		if err := req.WaitComposer(active.Herdr.PaneID, req.Wait); err != nil {
 			if errors.Is(err, herdr.ErrComposerBusyTimeout) {
-				return Result{}, &Error{Cause: fmt.Errorf("composer stayed busy for %s; no external message mutation occurred", req.Wait), AttemptID: active.ID, State: state.SendNotSubmitted, Reason: "composer-timeout", RetrySafe: true}
+				cause := fmt.Errorf("composer stayed busy for %s; no external message mutation occurred", req.Wait)
+				var busyErr *herdr.ComposerBusyError
+				if errors.As(err, &busyErr) {
+					cause = fmt.Errorf("%s (%s)", cause, busyErr.Detail())
+				}
+				return Result{}, &Error{Cause: cause, AttemptID: active.ID, State: state.SendNotSubmitted, Reason: "composer-timeout", RetrySafe: true}
 			}
 			return Result{}, paneError(active, "wait for composer", err)
 		}


### PR DESCRIPTION
## Summary

- Cross-check `herdr pane read` for a rendered empty composer before timing out a `working` pane.
- Preserve `agent_status` and background-shell diagnostics in composer timeout errors.
- Add `hand send --force` while retaining pane ownership checks, locks, and durable send records.

Fixes atqamz/hand#369

## Test plan

- `nix develop --offline -c go test -race -count=1 ./internal/herdr ./internal/steering`
- `nix develop --offline -c go test -race -count=1 ./cmd -run '^TestSend'`
- `nix develop --offline -c make lint`
- `nix develop --offline -c make e2e`
- `nix develop --offline -c make contract`
- `nix develop --offline -c make build`
- Full `make test` reaches the changed packages successfully but remains red in unrelated environment-dependent cmd integration tests requiring unavailable gh/no-mistakes/managed-runtime capabilities.