### PR TITLE
fix: centralize secondhand infrastructure root

### DIFF
--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -37,6 +37,7 @@ func setTestUserHome(t *testing.T, home string) {
 	t.Helper()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("SECONDHAND_HOME", filepath.Join(home, "Secondhand 測試"))
 }
 
 func scopeHerdrForFleet(t *testing.T, home string, h faketool.Herdr) faketool.Herdr {
@@ -67,6 +68,7 @@ func TestMain(m *testing.M) {
 		{name: "HAND_ROLE", value: ""},
 		{name: "HAND_HOME", value: ""},
 		{name: "HAND_HARNESS", value: "unknown"},
+		{name: "SECONDHAND_HOME", value: filepath.Join(testUserHome, "Secondhand 測試")},
 	} {
 		if err := os.Setenv(tc.name, tc.value); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -110,5 +112,8 @@ func TestCommandPackageStartsWithNeutralEnvironment(t *testing.T) {
 				t.Fatalf("%s = %q, want %q", tc.name, got, tc.want)
 			}
 		})
+	}
+	if got := os.Getenv("SECONDHAND_HOME"); !strings.HasSuffix(got, filepath.Join("Secondhand 測試")) {
+		t.Fatalf("SECONDHAND_HOME = %q, want an isolated Unicode test root", got)
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/filelock"
+	"github.com/atqamz/hand/internal/secondhand"
 	"github.com/atqamz/hand/internal/store"
 	_ "modernc.org/sqlite"
 )
@@ -111,14 +112,11 @@ CREATE INDEX IF NOT EXISTS fleet_locator_by_id ON fleet_locator(fleet_id, home);
 `
 
 func Path() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := secondhand.Home()
 	if err != nil {
-		return "", fmt.Errorf("resolve user home: %w", err)
+		return "", err
 	}
-	if home == "" {
-		return "", errors.New("resolve user home: empty path")
-	}
-	return filepath.Join(home, ".secondhand", "registry.db"), nil
+	return filepath.Join(home, "registry.db"), nil
 }
 
 func Open() (*Registry, error) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -2,13 +2,83 @@ package registry
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/secondhand"
 	"github.com/atqamz/hand/internal/store"
 )
+
+func TestMain(m *testing.M) {
+	root, err := os.MkdirTemp("", "hand-registry-test-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("SECONDHAND_HOME", filepath.Join(root, "Secondhand 測試")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_ = os.RemoveAll(root)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(root)
+	os.Exit(code)
+}
+
+func TestPathUsesConfiguredSecondhandHome(t *testing.T) {
+	configured := filepath.Join(t.TempDir(), "Secondhand 測試")
+	t.Setenv("SECONDHAND_HOME", configured)
+	operatorHome := filepath.Join(t.TempDir(), "operator")
+	t.Setenv("HOME", operatorHome)
+	t.Setenv("USERPROFILE", operatorHome)
+	t.Setenv("HAND_HOME", filepath.Join(t.TempDir(), "fleet"))
+
+	got, err := Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := secondhand.Home()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = filepath.Join(want, "registry.db")
+	if got != want {
+		t.Fatalf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestOpenDoesNotTouchProductionRegistryWhenOverrideIsSet(t *testing.T) {
+	operatorHome := filepath.Join(t.TempDir(), "operator")
+	sentinelPath := filepath.Join(operatorHome, ".secondhand", "registry.db")
+	if err := os.MkdirAll(filepath.Dir(sentinelPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := []byte("operator registry sentinel")
+	if err := os.WriteFile(sentinelPath, sentinel, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", operatorHome)
+	t.Setenv("USERPROFILE", operatorHome)
+	t.Setenv("SECONDHAND_HOME", filepath.Join(t.TempDir(), "Secondhand 測試"))
+
+	db, err := Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(sentinel) {
+		t.Fatalf("production registry changed from %q to %q", sentinel, got)
+	}
+}
 
 func TestRegisterAndListReadyFleet(t *testing.T) {
 	root := t.TempDir()

--- a/internal/secondhand/home.go
+++ b/internal/secondhand/home.go
@@ -1,0 +1,23 @@
+// Package secondhand resolves the user-local infrastructure root shared by Hand components.
+package secondhand
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func Home() (string, error) {
+	if configured := os.Getenv("SECONDHAND_HOME"); configured != "" {
+		path, err := filepath.Abs(configured)
+		if err != nil {
+			return "", fmt.Errorf("resolve SECONDHAND_HOME: %w", err)
+		}
+		return filepath.Clean(path), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home for Secondhand infrastructure: %w", err)
+	}
+	return filepath.Join(home, ".secondhand"), nil
+}

--- a/internal/secondhand/home_test.go
+++ b/internal/secondhand/home_test.go
@@ -1,0 +1,45 @@
+package secondhand
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestHomeUsesExplicitInfrastructureRoot(t *testing.T) {
+	configured := filepath.Join(t.TempDir(), "Secondhand 測試")
+	t.Setenv("SECONDHAND_HOME", configured)
+	operatorHome := filepath.Join(t.TempDir(), "operator")
+	t.Setenv("HOME", operatorHome)
+	t.Setenv("USERPROFILE", operatorHome)
+
+	got, err := Home()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Clean(want) {
+		t.Fatalf("Home() = %q, want %q", got, filepath.Clean(want))
+	}
+}
+
+func TestHomeUsesCanonicalUserRootWithoutOverride(t *testing.T) {
+	configured := filepath.Join(t.TempDir(), "operator")
+	t.Setenv("SECONDHAND_HOME", "")
+	t.Setenv("HOME", configured)
+	t.Setenv("USERPROFILE", configured)
+
+	got, err := Home()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs(filepath.Join(configured, ".secondhand"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Clean(want) {
+		t.Fatalf("Home() = %q, want %q", got, filepath.Clean(want))
+	}
+}

--- a/internal/toolchain/manifest.go
+++ b/internal/toolchain/manifest.go
@@ -7,9 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	pathpkg "path"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -215,19 +213,4 @@ func executableName(name string) string {
 		return name + ".exe"
 	}
 	return name
-}
-
-func secondhandHome() (string, error) {
-	if configured := os.Getenv("SECONDHAND_HOME"); configured != "" {
-		path, err := filepath.Abs(configured)
-		if err != nil {
-			return "", fmt.Errorf("resolve SECONDHAND_HOME: %w", err)
-		}
-		return filepath.Clean(path), nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve user home for Secondhand runtime: %w", err)
-	}
-	return filepath.Join(home, ".secondhand"), nil
 }

--- a/internal/toolchain/store.go
+++ b/internal/toolchain/store.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/atqamz/hand/internal/atomicfile"
 	"github.com/atqamz/hand/internal/filelock"
+	"github.com/atqamz/hand/internal/secondhand"
 )
 
 const (
@@ -61,7 +62,7 @@ type Status struct {
 func NewStore(root string, lock Lock) (*Store, error) {
 	if root == "" {
 		var err error
-		root, err = secondhandHome()
+		root, err = secondhand.Home()
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +82,7 @@ func DefaultStore() (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	root, err := secondhandHome()
+	root, err := secondhand.Home()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -29,6 +29,7 @@ import (
 
 var handBin string
 var goBin string
+var suiteSecondhandHome string
 
 // The tools hand shells out to that this suite never runs for real. None of them may resolve on the
 // hermetic PATH: a real one would silently answer in place of a test's fake, so the affected test would
@@ -90,6 +91,11 @@ func TestMain(m *testing.M) {
 	// working directory, so a developer who exported one would otherwise have the suite spawn, merge and tear
 	// down against their real fleet.
 	if err := os.Unsetenv("HAND_HOME"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	suiteSecondhandHome = filepath.Join(dir, "Secondhand 測試")
+	if err := os.Setenv("SECONDHAND_HOME", suiteSecondhandHome); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -177,6 +183,16 @@ func TestHandProcessEnvFiltersAmbientSemanticEnvironment(t *testing.T) {
 		if len(got) != 1 || got[0] != want {
 			t.Fatalf("handProcessEnv() %s entries = %q, want exactly %q", name, got, want)
 		}
+	}
+}
+
+func TestHandProcessUsesItsIsolatedSecondhandHome(t *testing.T) {
+	home := newHome(t)
+	if _, err := os.Stat(filepath.Join(home, ".secondhand", "registry.db")); err != nil {
+		t.Fatalf("child registry = %v, want a registry under the fleet-specific test root", err)
+	}
+	if _, err := os.Stat(filepath.Join(suiteSecondhandHome, "registry.db")); !os.IsNotExist(err) {
+		t.Fatalf("suite registry = %v, want no registry outside the child fixture root", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- promote the SECONDHAND_HOME resolver into internal/secondhand and use it for registry and private runtime paths
- isolate command, registry, and E2E test processes with disposable roots and prove child registry placement
- add regression coverage for Unicode/space roots, HAND_HOME independence, and production-registry sentinel preservation

Fixes atqamz/hand#359

## Test plan
- `nix develop -c go test -tags=test ./internal/secondhand ./internal/registry ./internal/toolchain ./cmd -race -count=1` (touched packages pass; cmd has existing environment-dependent failures when gh/no-mistakes are unavailable)
- `nix develop -c go test -tags=e2e,test ./tests/e2e -run 'TestHandProcessUsesItsIsolatedSecondhandHome|TestHandProcessEnvFiltersAmbientSemanticEnvironment' -count=1 -timeout=10m`
- `nix develop -c go vet ./internal/secondhand ./internal/registry ./internal/toolchain ./cmd`
- operator registry checksum was unchanged across isolated validation runs