### PR TITLE
clarify project gate readiness docs

### DIFF
--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -171,6 +171,51 @@ func TestDoctorIncludesProjectListGateFinding(t *testing.T) {
 	}
 }
 
+func TestDoctorKeepsProjectReadinessSeparateFromGateRunEvidence(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	if err := project.Add(home, project.Project{Name: "local", URL: "https://example.com/local.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "gated", URL: "https://example.com/gated.git", Mode: project.ModeNoMistakes}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "projects", "gated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(t.TempDir(), "no-mistakes.log")
+	faketool.NoMistakes{
+		Status: "gate: ready",
+		Runs:   "no completed runs",
+		Log:    log,
+	}.Install(t, faketool.Bin(t))
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, finding := range findings {
+		if strings.Contains(finding.Text, "no-mistakes gate") {
+			t.Fatalf("findings = %#v, want no project setup finding for ready integration", findings)
+		}
+	}
+	calls, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(calls), "no-mistakes status\n"; got != want {
+		t.Fatalf("no-mistakes calls = %q, want only the Project readiness check %q", got, want)
+	}
+}
+
 func hasDoctorFinding(findings []doctorFinding, want doctorFinding) bool {
 	for _, finding := range findings {
 		if finding.Severity == want.Severity && finding.Text == want.Text {

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
+	"github.com/atqamz/hand/internal/supervision"
 	"github.com/atqamz/hand/internal/watcher"
 )
 
@@ -34,6 +35,7 @@ func setupSessionHome(t *testing.T) string {
 	}
 	t.Chdir(home)
 	t.Setenv("HAND_HARNESS", harness.Codex)
+	t.Setenv(supervision.CodexThreadEnv, "")
 	t.Setenv(harness.RoleEnv, "")
 	writeSessionContext(t, home, "## Hard constraints\nKeep the fleet observable.\n", "# Backlog\n\n## Queue\n")
 	return home

--- a/skills/secondhand/references/setup-doctor.md
+++ b/skills/secondhand/references/setup-doctor.md
@@ -22,7 +22,9 @@ line, not just the exit code: a clean exit with warnings still means something i
   (`error`, refuse-to-overwrite) - each names its own remedy, and a collision is distinguished
   from ordinary drift because a collision needs a human to move something aside first.
 - Windows only: the `CLAUDE.md` pointer file's presence and exact content.
-- Each registered project's no-mistakes gate state (`gate-absent`, or another gate problem).
+- For each registered Project whose current v0.7 configuration selects no-mistakes, whether that
+  exact Project repository is ready for the integration, or is not initialized or unreachable.
+  This Project-readiness observation is separate from exact work/PR gate-run evidence.
 - Routing/configuration validity: missing Profiles or Routes, and whether the fleet is running
   on explicit configuration or falling back to legacy defaults.
 - The selected private Git, Treehouse, and Herdr runtime, including its target, runtime ID,
@@ -68,6 +70,16 @@ have it configured before work can proceed.
 right: reading whether a *specific registered project* declared `no-mistakes` mode, and only
 then treating its gate as required for that project.
 
+Project integration readiness is not exact work/PR gate-run evidence:
+
+- Project readiness is the existing Project-level `GateStatus` observation used by `project list`,
+  `doctor`, and dispatch/integration preflight.
+- Exact work/PR evidence is the shared `GateRunObservation` used by status/watch/orient. It keeps
+  the `found | absent | unknown` vocabulary for the exact PR recorded by completed `no-mistakes runs`.
+  `gate-absent` and `gate-unknown` belong to this work evidence, not to Project setup; `absent` is
+  distinct from `unknown`.
+- Doctor is read-only and does not inspect `no-mistakes runs` to decide Project integration readiness.
+
 Doctor never invents local installation state, account entitlement, provider billing state, or
 model availability. If a finding does not name one of those things explicitly, do not infer it.
 
@@ -76,8 +88,9 @@ model availability. If a finding does not name one of those things explicitly, d
 - A generated-surface drift finding always names its own remedy command. Run exactly that
   command; do not hand-edit the file it names, since it will be overwritten again on the next
   `hand init` regardless.
-- A project gate finding means that project's no-mistakes state, not the fleet's. Read
-  `references/task-lifecycle.md` before dispatching further into that project.
+- A Project-readiness finding means that exact registered Project's no-mistakes integration state,
+  not work/PR gate-run evidence and not the whole Fleet. Read `references/task-lifecycle.md` before
+  dispatching further into that project.
 - A routing finding means read `references/configuration.md` before dispatching a task whose
   Profile or Route is missing or invalid; do not guess a Profile to unblock a single dispatch.
 


### PR DESCRIPTION
## Summary
- distinguish Project integration readiness from exact work/PR gate-run evidence in the secondhand doctor reference
- add a doctor regression proving ready Project setup does not depend on `no-mistakes runs` evidence
- isolate session bootstrap tests from inherited Codex runtime identity

Closes atqamz/hand#362

## Test plan
- `nix develop -c go test -tags=test -race ./cmd ./internal/project -run ... -count=1`
- `nix develop -c make lint`
- `nix develop -c make build`
- Full `make test` attempted; cmd passed, but runtime/worktree had existing environment failures from concurrent toolchain extraction and Treehouse v2.3.0 drift.