### PR TITLE
fix: expose exact Fleet Herdr session state

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -114,6 +114,7 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			herdrSession := observeCurrentHerdrSession(cmd.Context(), fleetHome)
 			tools := doctorManagedTools(runtimeStatus, projects)
 			integrations, err := integration.DefaultStore().List()
 			if err != nil {
@@ -138,6 +139,7 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			doc.Field("treehouse_version", valueOrNone(runtimeStatus.TreehouseVersion))
 			doc.Field("herdr_version", valueOrNone(runtimeStatus.HerdrVersion))
 			doc.Field("runtime_reason", valueOrNone(runtimeStatus.Reason))
+			appendHerdrSession(&doc, herdrSession)
 			axi.Table(&doc, "tools", tools, toolReadinessFields)
 			axi.Table(&doc, "supervisor_harnesses", harnesses, harnessReadinessFields)
 			doc.Bool("ready", len(blocking) == 0)

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/atqamz/hand/internal/attention"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/orientation"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/registry"
@@ -27,6 +28,7 @@ type fleetSnapshot struct {
 	next             nextAction
 	monitorState     orientation.MonitorState
 	monitorReason    string
+	herdrSession     herdr.SessionObservation
 }
 
 // Performs the one read-only sweep of durable Fleet state the orientation
@@ -64,6 +66,7 @@ func loadFleetSnapshot(ctx context.Context, warnOut io.Writer, fleetHome string)
 	if err != nil {
 		return nil, err
 	}
+	snapshot.herdrSession = client.ObserveSession(ctx)
 	views, holds, err := fleetViews(ctx, warnOut, fleetHome, client, true)
 	if err != nil {
 		return nil, err
@@ -112,6 +115,12 @@ func (s *fleetSnapshot) evidence() orientation.Evidence {
 	}
 	if s.monitorReason != "" && s.monitorState != orientation.MonitorStateRearmed {
 		evidence.Errors = append(evidence.Errors, orientation.BoundedError{Kind: "monitor", Reason: s.monitorReason})
+	}
+	if s.herdrSession.State != herdr.SessionRunningCompatible {
+		evidence.Errors = append(evidence.Errors, orientation.BoundedError{
+			Kind:   "herdr-session",
+			Reason: string(s.herdrSession.State) + ": " + s.herdrSession.Reason,
+		})
 	}
 	return evidence
 }

--- a/cmd/herdr.go
+++ b/cmd/herdr.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -9,20 +10,28 @@ import (
 	"github.com/atqamz/hand/internal/store"
 )
 
+func observeCurrentHerdrSession(ctx context.Context, home string) herdr.SessionObservation {
+	fleetID, err := state.FleetIDReadOnly(home)
+	if err != nil {
+		return herdr.SessionObservation{State: herdr.SessionUnknown, Reason: "read Fleet identity: " + err.Error()}
+	}
+	return herdr.ObserveFleetSession(ctx, fleetID)
+}
+
 func currentHerdrClient(home string) (*herdr.Client, error) {
 	fleetID, err := state.FleetIDReadOnly(home)
 	if err != nil {
 		if errors.Is(err, store.ErrFleetIdentityMissing) {
-			return herdr.NewClient(), nil
+			return herdr.NewManagedClient(), nil
 		}
 		return nil, fmt.Errorf("read Fleet identity: %w", err)
 	}
-	return herdr.NewSessionClient(herdr.SessionName(fleetID)), nil
+	return herdr.NewManagedSessionClient(herdr.SessionName(fleetID)), nil
 }
 
 func herdrClientForAttempt(attempt *state.Attempt, current *herdr.Client) *herdr.Client {
 	if attempt == nil || attempt.Herdr.Session == "" || attempt.Herdr.Session == "default" {
-		return herdr.NewClient()
+		return herdr.NewManagedClient()
 	}
-	return herdr.NewSessionClient(attempt.Herdr.Session)
+	return herdr.NewManagedSessionClient(attempt.Herdr.Session)
 }

--- a/cmd/orient.go
+++ b/cmd/orient.go
@@ -44,6 +44,9 @@ func newOrientCmd() *cobra.Command {
 			result := orientation.Build(evidence)
 			var doc axi.Doc
 			appendSessionOrientation(&doc, result)
+			doc.Field("herdr_session_name", orNone(snapshot.herdrSession.Name))
+			doc.Field("herdr_session_state", orNone(string(snapshot.herdrSession.State)))
+			doc.Field("herdr_session_reason", orNone(snapshot.herdrSession.Reason))
 			doc.Field("next_action_kind", snapshot.next.Kind)
 			doc.Field("next_action_task", orNone(snapshot.next.Task))
 			doc.Field("next_action_command", orNone(snapshot.next.Command))

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -203,6 +203,7 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	doc.Int("project_count", len(projects))
 	axi.Table(&doc, "projects", projects, sessionProjectFields)
 	doc.List("backlog", backlog.Items)
+	appendHerdrSession(&doc, client.ObserveSession(cmd.Context()))
 	appendFleetState(&doc, views, holds, cols)
 	appendSessionOrientation(&doc, oriented)
 	doc.Field("next_action_kind", next.Kind)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -188,10 +188,13 @@ type statusJSON struct {
 	Unannounced bool `json:"unannounced,omitempty"`
 	// The two conditions atqamz/hand#268 gave hand status a counterpart classifier for: a pane silent
 	// past its report state's bound, and one that claims a pane but never answered it.
-	Parked      bool          `json:"parked,omitempty"`
-	Unreachable bool          `json:"unreachable,omitempty"`
-	Attempts    []attemptJSON `json:"attempts,omitempty"`
-	LatestSend  *sendJSON     `json:"latest_send,omitempty"`
+	Parked             bool          `json:"parked,omitempty"`
+	Unreachable        bool          `json:"unreachable,omitempty"`
+	Attempts           []attemptJSON `json:"attempts,omitempty"`
+	LatestSend         *sendJSON     `json:"latest_send,omitempty"`
+	HerdrSessionName   string        `json:"herdr_session_name"`
+	HerdrSessionState  string        `json:"herdr_session_state"`
+	HerdrSessionReason string        `json:"herdr_session_reason"`
 }
 
 type sendJSON struct {
@@ -225,9 +228,10 @@ type attemptJSON struct {
 type fleetJSON struct {
 	// Always present, zero included, so an empty fleet is a positive statement ("no tasks") and not the
 	// same absence of output a broken command would also produce.
-	TaskCount int          `json:"task_count"`
-	Tasks     []statusJSON `json:"tasks"`
-	Holds     []holdJSON   `json:"holds"`
+	TaskCount    int                      `json:"task_count"`
+	Tasks        []statusJSON             `json:"tasks"`
+	Holds        []holdJSON               `json:"holds"`
+	HerdrSession herdr.SessionObservation `json:"herdr_session"`
 }
 
 // Mirrors state.Hold, plus Inconsistent, which is set instead of the row being dropped when a value
@@ -346,6 +350,7 @@ func gateRunObservation(home string, t state.Task, reportedDone bool, p project.
 }
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool, cols []axi.Column[taskView]) error {
+	herdrSession := client.ObserveSession(cmd.Context())
 	views, holds, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), home, client, true)
 	if err != nil {
 		return err
@@ -362,12 +367,18 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(fleetJSON{TaskCount: len(rows), Tasks: rows, Holds: holdRows})
+		return enc.Encode(fleetJSON{TaskCount: len(rows), Tasks: rows, Holds: holdRows, HerdrSession: herdrSession})
 	}
 
 	var doc axi.Doc
 	appendFleet(&doc, views, holds, cols)
 	return doc.Render(cmd.OutOrStdout())
+}
+
+func appendHerdrSession(doc *axi.Doc, observation herdr.SessionObservation) {
+	doc.Field("herdr_session_name", orNone(observation.Name))
+	doc.Field("herdr_session_state", orNone(string(observation.State)))
+	doc.Field("herdr_session_reason", orNone(observation.Reason))
 }
 
 // Writes the fleet blocks onto doc rather than a writer, so the bare command can put its identity fields
@@ -669,6 +680,7 @@ func reportedFrom(last state.ReportLine, ok bool, readErr error) *reportedJSON {
 }
 
 func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id string, asJSON, full bool, cols []axi.Column[taskView]) error {
+	herdrSession := client.ObserveSession(cmd.Context())
 	history, err := state.ReadHistoryReadOnly(home, id)
 	if err != nil {
 		return asPrecondition(err)
@@ -722,6 +734,9 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 			history[i] = reportLineText(line)
 		}
 		out := v.json()
+		out.HerdrSessionName = herdrSession.Name
+		out.HerdrSessionState = string(herdrSession.State)
+		out.HerdrSessionReason = herdrSession.Reason
 		out.ReportHistory = history
 		if held {
 			j := holdToJSON(hold)

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -68,6 +68,7 @@ func TestMain(m *testing.M) {
 		{name: "HAND_ROLE", value: ""},
 		{name: "HAND_HOME", value: ""},
 		{name: "HAND_HARNESS", value: "unknown"},
+		{name: "CODEX_THREAD_ID", value: ""},
 		{name: "SECONDHAND_HOME", value: filepath.Join(testUserHome, "Secondhand 測試")},
 	} {
 		if err := os.Setenv(tc.name, tc.value); err != nil {

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -111,6 +111,7 @@ type herdrTabRef struct {
 
 func (h Herdr) Install(t *testing.T, bin string) {
 	t.Helper()
+	t.Setenv("HAND_TEST_HERDR_PATH", filepath.Join(bin, executableName("herdr")))
 	state := stateDir(t, bin, "herdr")
 	workspaces := append(append([]HerdrWorkspace{}, h.Workspaces...), h.Creates...)
 	tabs := herdrTabs(workspaces, h.TabCreates)

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -65,6 +65,14 @@ func NewClientAt(path string, env []string) (*Client, error) {
 }
 
 func NewManagedClient() *Client {
+	if legacyHerdrFallback {
+		if path := os.Getenv("HAND_TEST_HERDR_PATH"); path != "" {
+			client, err := NewClientAt(path, os.Environ())
+			if err == nil {
+				return client
+			}
+		}
+	}
 	store, err := toolchain.DefaultStore()
 	if err != nil {
 		if legacyHerdrFallback {
@@ -171,6 +179,8 @@ type envelope struct {
 
 var ErrNotFound = errors.New("herdr resource not found")
 
+var ErrServerNotRunning = errors.New("herdr server is not running")
+
 type ExecError struct {
 	Started bool
 	Err     error
@@ -202,10 +212,31 @@ func (e *APIError) Error() string {
 
 func (e *APIError) Unwrap() error {
 	code := strings.ToLower(e.Code)
+	if code == "server_not_running" {
+		return ErrServerNotRunning
+	}
 	if code == "not_found" || strings.HasSuffix(code, "_not_found") {
 		return ErrNotFound
 	}
 	return nil
+}
+
+type ServerNotRunningError struct {
+	Session string
+	Cause   error
+}
+
+func (e *ServerNotRunningError) Error() string {
+	if e.Session == "" || e.Session == "default" {
+		return "Herdr server is not running"
+	}
+	return fmt.Sprintf("Fleet Herdr session %q is not running", e.Session)
+}
+
+func (e *ServerNotRunningError) Unwrap() error { return e.Cause }
+
+func IsServerNotRunning(err error) bool {
+	return errors.Is(err, ErrServerNotRunning)
 }
 
 func IsPreSideEffectRejection(err error) bool {
@@ -283,7 +314,7 @@ func (c *Client) callContext(ctx context.Context, args ...string) (json.RawMessa
 		return nil, err
 	}
 	if env.Error != nil {
-		return nil, newAPIError(args, env.Error)
+		return nil, c.normalizeAPIError(newAPIError(args, env.Error))
 	}
 	if runErr != nil {
 		return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
@@ -309,7 +340,7 @@ func (c *Client) callVoid(args ...string) error {
 	if len(trimmed) == 0 {
 		if runErr != nil {
 			if env, err := parseEnvelope(args, []byte(stderr)); err == nil && env.Error != nil {
-				return newAPIError(args, env.Error)
+				return c.normalizeAPIError(newAPIError(args, env.Error))
 			}
 			return fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
 		}
@@ -321,12 +352,23 @@ func (c *Client) callVoid(args ...string) error {
 		return err
 	}
 	if env.Error != nil {
-		return newAPIError(args, env.Error)
+		return c.normalizeAPIError(newAPIError(args, env.Error))
 	}
 	if runErr != nil {
 		return fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
 	}
 	return nil
+}
+
+func (c *Client) normalizeAPIError(err error) error {
+	if !IsServerNotRunning(err) {
+		return err
+	}
+	session := ""
+	if c != nil {
+		session = c.session
+	}
+	return &ServerNotRunningError{Session: session, Cause: err}
 }
 
 func newAPIError(args []string, body *errorBody) *APIError {
@@ -590,7 +632,7 @@ func (c *Client) PaneRead(paneID string, lines int) (string, error) {
 	// ahead of the exit status for callVoid's reason - that code cannot be trusted on its own.
 	var eb errorBody
 	if json.Unmarshal(stdout, &eb) == nil && eb.Code != "" && eb.Message != "" {
-		return "", fmt.Errorf("herdr %s: %s: %s", strings.Join(args, " "), eb.Code, eb.Message)
+		return "", c.normalizeAPIError(&APIError{Operation: strings.Join(args, " "), Code: eb.Code, Message: eb.Message})
 	}
 	if runErr != nil {
 		return "", fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)

--- a/internal/herdr/session.go
+++ b/internal/herdr/session.go
@@ -1,0 +1,168 @@
+package herdr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type SessionState string
+
+const (
+	SessionRunningCompatible SessionState = "running-compatible"
+	SessionStopped           SessionState = "stopped"
+	SessionUnknown           SessionState = "unknown"
+	SessionIncompatible      SessionState = "incompatible"
+)
+
+type SessionObservation struct {
+	Name   string       `json:"name"`
+	State  SessionState `json:"state"`
+	Reason string       `json:"reason"`
+}
+
+type sessionRecord struct {
+	Name    string `json:"name"`
+	Running *bool  `json:"running"`
+}
+
+type serverStatus struct {
+	Status     string `json:"status"`
+	Running    *bool  `json:"running"`
+	Compatible *bool  `json:"compatible"`
+	Session    string `json:"session"`
+}
+
+func ObserveFleetSession(ctx context.Context, fleetID string) SessionObservation {
+	if strings.TrimSpace(fleetID) == "" {
+		return SessionObservation{State: SessionUnknown, Reason: "Fleet identity is unavailable"}
+	}
+	name := SessionName(fleetID)
+	return NewManagedSessionClient(name).ObserveSession(ctx)
+}
+
+func (c *Client) ObserveSession(ctx context.Context) SessionObservation {
+	name := ""
+	if c != nil {
+		name = c.session
+	}
+	if name == "" {
+		return SessionObservation{State: SessionUnknown, Reason: "Herdr session identity is unavailable"}
+	}
+
+	sessions, err := c.sessionListContext(ctx)
+	if err != nil {
+		return unknownSessionObservation(name, err)
+	}
+	var target *sessionRecord
+	for i := range sessions {
+		if sessions[i].Name == name {
+			target = &sessions[i]
+			break
+		}
+	}
+	if target == nil {
+		return SessionObservation{Name: name, State: SessionStopped, Reason: "exact Fleet Herdr session is not present"}
+	}
+	if target.Running == nil {
+		return unknownSessionObservation(name, errors.New("session inventory omitted running state"))
+	}
+	if !*target.Running {
+		return SessionObservation{Name: name, State: SessionStopped, Reason: "exact Fleet Herdr session is stopped"}
+	}
+
+	status, err := c.serverStatusContext(ctx)
+	if err != nil {
+		if IsServerNotRunning(err) {
+			return SessionObservation{Name: name, State: SessionStopped, Reason: "exact Fleet Herdr session is stopped"}
+		}
+		return unknownSessionObservation(name, err)
+	}
+	if status.Running == nil {
+		return unknownSessionObservation(name, errors.New("server status omitted running state"))
+	}
+	if !*status.Running {
+		return SessionObservation{Name: name, State: SessionStopped, Reason: "exact Fleet Herdr session is stopped"}
+	}
+	if status.Session != "" && status.Session != name {
+		return unknownSessionObservation(name, fmt.Errorf("server status named session %q", status.Session))
+	}
+	if strings.EqualFold(status.Status, "incompatible") || (status.Compatible != nil && !*status.Compatible) {
+		return SessionObservation{Name: name, State: SessionIncompatible, Reason: "exact Fleet Herdr session is protocol-incompatible"}
+	}
+	if status.Compatible == nil {
+		return unknownSessionObservation(name, errors.New("server status omitted compatibility"))
+	}
+	return SessionObservation{Name: name, State: SessionRunningCompatible, Reason: "exact Fleet Herdr session is running with a compatible protocol"}
+}
+
+func (c *Client) sessionListContext(ctx context.Context) ([]sessionRecord, error) {
+	data, err := c.rawJSONContext(ctx, "session", "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Sessions []sessionRecord `json:"sessions"`
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, fmt.Errorf("parse Herdr session list: %w", err)
+	}
+	if body.Sessions == nil {
+		return nil, errors.New("parse Herdr session list: missing sessions")
+	}
+	return body.Sessions, nil
+}
+
+func (c *Client) serverStatusContext(ctx context.Context) (serverStatus, error) {
+	data, err := c.rawJSONContext(ctx, "status", "server", "--json")
+	if err != nil {
+		return serverStatus{}, err
+	}
+	var status serverStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return serverStatus{}, fmt.Errorf("parse Herdr server status: %w", err)
+	}
+	return status, nil
+}
+
+func (c *Client) rawJSONContext(ctx context.Context, args ...string) ([]byte, error) {
+	stdout, stderr, runErr := c.runContext(ctx, args...)
+	for _, output := range [][]byte{stdout, []byte(stderr)} {
+		if apiErr := parseAPIError(args, output); apiErr != nil {
+			return nil, c.normalizeAPIError(apiErr)
+		}
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf("herdr %s: %w: %s", strings.Join(args, " "), runErr, stderr)
+	}
+	if len(stdout) == 0 {
+		return nil, fmt.Errorf("herdr %s: empty response", strings.Join(args, " "))
+	}
+	return stdout, nil
+}
+
+func parseAPIError(args []string, data []byte) *APIError {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil
+	}
+	var env envelope
+	if err := json.Unmarshal(data, &env); err == nil && env.Error != nil {
+		return newAPIError(args, env.Error)
+	}
+	var body errorBody
+	if err := json.Unmarshal(data, &body); err == nil && body.Code != "" && body.Message != "" {
+		return &APIError{Operation: strings.Join(args, " "), Code: body.Code, Message: body.Message}
+	}
+	return nil
+}
+
+func unknownSessionObservation(name string, err error) SessionObservation {
+	reason := strings.Join(strings.Fields(err.Error()), " ")
+	reason = strings.NewReplacer("{", "", "}", "", "\"", "").Replace(reason)
+	if len(reason) > 160 {
+		reason = reason[:160]
+	}
+	return SessionObservation{Name: name, State: SessionUnknown, Reason: "could not observe exact Fleet Herdr session: " + reason}
+}

--- a/internal/herdr/session_test.go
+++ b/internal/herdr/session_test.go
@@ -1,0 +1,210 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func sessionListResponse(sessions string) faketool.HerdrResponse {
+	return faketool.HerdrResponse{
+		Command: "session list",
+		Stdout:  `{"sessions":[` + sessions + `]}`,
+	}
+}
+
+func serverStatusResponse(status string, running, compatible bool, session string) faketool.HerdrResponse {
+	return faketool.HerdrResponse{
+		Command: "status server",
+		Stdout: `{"status":"` + status + `","running":` + boolString(running) +
+			`,"version":"0.8.2","protocol":20,"compatible":` + boolString(compatible) +
+			`,"session":"` + session + `"}`,
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func observeTestSession(t *testing.T) SessionObservation {
+	t.Helper()
+	return ObserveFleetSession(context.Background(), "f_fleet")
+}
+
+func TestObserveFleetSessionClassifiesExactSessionStates(t *testing.T) {
+	tests := []struct {
+		name      string
+		session   string
+		status    *faketool.HerdrResponse
+		wantState SessionState
+	}{
+		{
+			name:      "running compatible exact session",
+			session:   `{"default":false,"name":"hand-f_fleet","running":true,"socket_path":"/stale/socket"}`,
+			status:    ptr(serverStatusResponse("running", true, true, "hand-f_fleet")),
+			wantState: SessionRunningCompatible,
+		},
+		{
+			name:      "default and another Fleet do not satisfy target",
+			session:   `{"default":true,"name":"default","running":true},{"default":false,"name":"hand-f_other","running":true},{"default":false,"name":"hand-f_fleet","running":false,"socket_path":"/stale/socket"}`,
+			wantState: SessionStopped,
+		},
+		{
+			name:      "incompatible runtime",
+			session:   `{"default":false,"name":"hand-f_fleet","running":true}`,
+			status:    ptr(serverStatusResponse("running", true, false, "hand-f_fleet")),
+			wantState: SessionIncompatible,
+		},
+		{
+			name:    "provider confirms server stopped",
+			session: `{"default":false,"name":"hand-f_fleet","running":true}`,
+			status: ptr(faketool.HerdrResponse{
+				Command: "status server",
+				Stdout:  `{"error":{"code":"server_not_running","message":"not running"}}`,
+				Exit:    1,
+			}),
+			wantState: SessionStopped,
+		},
+		{
+			name:      "missing exact session",
+			session:   `{"default":true,"name":"default","running":true}`,
+			wantState: SessionStopped,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responses := []faketool.HerdrResponse{sessionListResponse(tt.session)}
+			if tt.status != nil {
+				responses = append(responses, *tt.status)
+			}
+			bin := faketool.Bin(t)
+			faketool.Herdr{Responses: responses}.Install(t, bin)
+
+			got := observeTestSession(t)
+			if got.Name != "hand-f_fleet" || got.State != tt.wantState {
+				t.Fatalf("observation = %+v, want name hand-f_fleet and state %q", got, tt.wantState)
+			}
+			if got.Reason == "" {
+				t.Fatalf("observation = %+v, want a bounded reason", got)
+			}
+		})
+	}
+}
+
+func TestObserveFleetSessionProviderFailuresAreUnknown(t *testing.T) {
+	tests := []struct {
+		name     string
+		response faketool.HerdrResponse
+	}{
+		{
+			name:     "query failure",
+			response: faketool.HerdrResponse{Command: "session list", Stderr: "permission denied", Exit: 1},
+		},
+		{
+			name:     "malformed list",
+			response: faketool.HerdrResponse{Command: "session list", Stdout: `{"sessions":`, Exit: 0},
+		},
+		{
+			name:     "malformed status",
+			response: sessionListResponse(`{"default":false,"name":"hand-f_fleet","running":true}`),
+		},
+		{
+			name:     "status omits running state",
+			response: sessionListResponse(`{"default":false,"name":"hand-f_fleet","running":true}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responses := []faketool.HerdrResponse{tt.response}
+			if tt.name == "malformed status" {
+				responses = append(responses, faketool.HerdrResponse{Command: "status server", Stdout: `{`, Exit: 0})
+			}
+			if tt.name == "status omits running state" {
+				responses = append(responses, faketool.HerdrResponse{Command: "status server", Stdout: `{"status":"running","compatible":true}`, Exit: 0})
+			}
+			bin := faketool.Bin(t)
+			faketool.Herdr{Responses: responses}.Install(t, bin)
+
+			got := observeTestSession(t)
+			if got.State != SessionUnknown {
+				t.Fatalf("observation = %+v, want unknown", got)
+			}
+			if got.Reason == "" || strings.Contains(got.Reason, "{") {
+				t.Fatalf("observation = %+v, want bounded reason", got)
+			}
+		})
+	}
+}
+
+func TestObserveFleetSessionDoesNotTrustAStaleSocketPath(t *testing.T) {
+	bin := faketool.Bin(t)
+	faketool.Herdr{Responses: []faketool.HerdrResponse{
+		sessionListResponse(`{"default":false,"name":"hand-f_fleet","running":true,"socket_path":"/stale/socket"}`),
+		{Command: "status server", Stderr: "transport unavailable", Exit: 1},
+	}}.Install(t, bin)
+
+	got := observeTestSession(t)
+	if got.State != SessionUnknown {
+		t.Fatalf("observation = %+v, want unknown when status cannot prove the stale socket", got)
+	}
+}
+
+func TestObserveFleetSessionUsesExactNamedManagedInvocationWithoutMutation(t *testing.T) {
+	logPath := t.TempDir() + "/herdr.log"
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{
+			sessionListResponse(`{"default":true,"name":"default","running":true},{"default":false,"name":"hand-f_fleet","running":true}`),
+			serverStatusResponse("running", true, true, "hand-f_fleet"),
+		},
+		Log: logPath,
+	}.Install(t, bin)
+
+	got := observeTestSession(t)
+	if got.State != SessionRunningCompatible {
+		t.Fatalf("observation = %+v, want running-compatible", got)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "herdr --session hand-f_fleet session list --json\nherdr --session hand-f_fleet status server --json\n"
+	if string(log) != want {
+		t.Fatalf("Herdr calls = %q, want %q", log, want)
+	}
+	for _, mutation := range []string{"server", "stop", "delete", "attach"} {
+		if strings.Contains(string(log), mutation) && mutation != "server" {
+			t.Fatalf("Herdr calls = %q, observer attempted mutation %q", log, mutation)
+		}
+	}
+}
+
+func TestServerNotRunningIsTypedAndUserFacingErrorIsBounded(t *testing.T) {
+	faketool.Herdr{Responses: []faketool.HerdrResponse{{
+		Command: "workspace list",
+		Stdout:  `{"error":{"code":"server_not_running","message":"the server is not running"}}`,
+		Exit:    1,
+	}}}.Install(t, faketool.Bin(t))
+
+	_, err := NewSessionClient("hand-f_fleet").WorkspaceList()
+	if !IsServerNotRunning(err) || !errors.Is(err, ErrServerNotRunning) {
+		t.Fatalf("error = %v, want typed server-not-running condition", err)
+	}
+	if got, want := err.Error(), `Fleet Herdr session "hand-f_fleet" is not running`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	if strings.Contains(err.Error(), "server_not_running") || strings.Contains(err.Error(), `"error"`) {
+		t.Fatalf("error = %q, must not expose provider envelope", err)
+	}
+}
+
+func ptr[T any](value T) *T { return &value }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -187,7 +187,7 @@ func prepareClient(home string) (*herdr.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read Fleet identity: %w", err)
 	}
-	return herdr.NewSessionClient(herdr.SessionName(fleetID)), nil
+	return herdr.NewManagedSessionClient(herdr.SessionName(fleetID)), nil
 }
 
 // RunUntilEvent observes what is already actionable, then blocks until a tick produces events, writes


### PR DESCRIPTION
## Summary
- Add managed exact Fleet Herdr session observation with four-state classification.
- Normalize `server_not_running` into a typed Hand condition with bounded user-facing errors.
- Wire the shared read-only observation into diagnostics and managed Herdr consumers.

Closes atqamz/hand#361

## Test plan
- `nix develop -c go test -tags=test ./internal/herdr -count=1`
- `nix develop -c go test -tags=test ./cmd ./internal/watcher -count=1`
- `nix develop -c go vet ./...`
- `nix develop -c env CGO_ENABLED=0 go build -o /tmp/hand-361-observer .`
- `nix develop -c golangci-lint run` and commentlint pass.
- Live managed Herdr checks prove the current session is `running-compatible` and a separate named session is stopped.
- Full local suite reaches all touched packages but is blocked by unrelated `internal/worktree` managed-Treehouse fixture failures.