### PR TITLE
fix(registry): scope ambiguity classification to affected Fleets

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"database/sql"
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,6 +19,7 @@ import (
 	"github.com/atqamz/hand/internal/steering"
 	"github.com/atqamz/hand/internal/store"
 	"github.com/spf13/cobra"
+	_ "modernc.org/sqlite"
 )
 
 func devBuild(version string) selfupdate.BuildInfo {
@@ -218,18 +221,9 @@ func unrelatedAmbiguousHelpRegistry(t *testing.T, _, path string) {
 	secondHome := filepath.Join(t.TempDir(), "second")
 	firstID := createHelpFleet(t, firstHome)
 	secondID := createHelpFleet(t, secondHome)
-	registryDB, err := registry.OpenAt(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = registryDB.Close() }()
 	claimedHome := filepath.Join(t.TempDir(), "unrelated")
-	if err := registryDB.Register(claimedHome, firstID, time.Now().UTC()); err != nil {
-		t.Fatal(err)
-	}
-	if err := registryDB.Register(claimedHome, secondID, time.Now().UTC()); err != nil {
-		t.Fatal(err)
-	}
+	insertHelpRegistryClaim(t, path, claimedHome, firstID)
+	insertHelpRegistryClaim(t, path, claimedHome, secondID)
 }
 
 func selectedAmbiguousHelpRegistry(t *testing.T, home, path string) {
@@ -243,11 +237,39 @@ func selectedAmbiguousHelpRegistry(t *testing.T, home, path string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = registryDB.Close() }()
 	if err := registryDB.Register(home, currentID, time.Now().UTC()); err != nil {
+		_ = registryDB.Close()
 		t.Fatal(err)
 	}
-	if err := registryDB.Register(home, otherID, time.Now().UTC()); err != nil {
+	if err := registryDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	insertHelpRegistryClaim(t, path, home, otherID)
+}
+
+func insertHelpRegistryClaim(t *testing.T, path, home, fleetID string) {
+	t.Helper()
+	registryDB, err := registry.OpenAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+(&url.URL{Path: filepath.ToSlash(path)}).EscapedPath()+"?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_pragma=txlock=immediate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(`
+INSERT INTO fleet_registry (fleet_id, last_known_home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, fleetID, home, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO fleet_locator (fleet_id, home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, fleetID, home, stamp, stamp); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/docs/adr/fleet-identity-and-user-registry.md
+++ b/docs/adr/fleet-identity-and-user-registry.md
@@ -17,6 +17,7 @@ Each Fleet home stores one immutable opaque Fleet identity in `state/hand.db`.
 The identity is generated under the Fleet-local identity lock and is stable across restarts, moves, and registry loss.
 The user-local `~/.secondhand/registry.db` stores canonical observed locators and timestamps only.
 It is non-authoritative and has no Tasks, Attempts, Projects, configuration, reports, or runtime state.
+Registration validates the Fleet database identity before changing the registry and transactionally retires only provably superseded locators at the same canonical home; it never changes the Fleet database.
 
 Registration first validates the canonical Fleet identity at the supplied home.
 After that positive validation, a registration transaction retires locator claims for other identities at that exact canonical home, while retaining their locators at other homes.
@@ -26,6 +27,7 @@ Unknown or unreadable canonical identity and registry evidence fail closed witho
 `hand fleet` reads registry discovery without changing the current invocation context.
 There is no global active Fleet switch.
 Positive duplicate or identity-mismatch evidence fails closed before runtime or mutation side effects, while registry absence or degradation is reported as a warning because it cannot prove a duplicate.
+List classification is deterministic and marks only Fleets participating in an exact-home collision as ambiguous; unrelated unreadable or healthy locators retain their own states.
 
 New Herdr resources use the Fleet identity in a named session and workspace label.
 Legacy Attempts with empty or `default` sessions use the legacy session and require exact persisted workspace, tab, and pane identities for observation and cleanup.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -332,7 +332,10 @@ func (r *Registry) List(currentHome string) ([]Fleet, error) {
 	claims := make(map[string]map[string]bool)
 	for _, locator := range locators {
 		byID[locator.FleetID] = append(byID[locator.FleetID], locator)
-		key, _ := pathKey(locator.Home)
+		key, err := pathKey(locator.Home)
+		if err != nil {
+			continue
+		}
 		if claims[key] == nil {
 			claims[key] = make(map[string]bool)
 		}
@@ -371,38 +374,41 @@ type observation struct {
 	valid   bool
 	state   State
 	reason  string
+	homeKey string
+	homeErr error
 }
 
 func observe(locator Locator) observation {
+	homeKey, homeErr := pathKey(locator.Home)
 	info, err := os.Stat(locator.Home)
 	if os.IsNotExist(err) {
-		return observation{locator: locator, state: StateMissing}
+		return observation{locator: locator, state: StateMissing, homeKey: homeKey, homeErr: homeErr}
 	}
 	if err != nil {
-		return observation{locator: locator, state: StateUnreadable, reason: err.Error()}
+		return observation{locator: locator, state: StateUnreadable, reason: err.Error(), homeKey: homeKey, homeErr: homeErr}
 	}
 	if !info.IsDir() {
-		return observation{locator: locator, state: StateUnreadable, reason: "Fleet home is not a directory"}
+		return observation{locator: locator, state: StateUnreadable, reason: "Fleet home is not a directory", homeKey: homeKey, homeErr: homeErr}
 	}
 	if _, err := os.Stat(store.Path(locator.Home)); err != nil {
 		if os.IsNotExist(err) {
-			return observation{locator: locator, state: StateUnreadable, reason: "state/hand.db is missing"}
+			return observation{locator: locator, state: StateUnreadable, reason: "state/hand.db is missing", homeKey: homeKey, homeErr: homeErr}
 		}
-		return observation{locator: locator, state: StateUnreadable, reason: err.Error()}
+		return observation{locator: locator, state: StateUnreadable, reason: err.Error(), homeKey: homeKey, homeErr: homeErr}
 	}
 	db, err := store.OpenReadOnly(locator.Home)
 	if err != nil {
-		return observation{locator: locator, state: StateUnreadable, reason: err.Error()}
+		return observation{locator: locator, state: StateUnreadable, reason: err.Error(), homeKey: homeKey, homeErr: homeErr}
 	}
 	defer func() { _ = db.Close() }()
 	observedID, err := db.FleetID()
 	if err != nil {
-		return observation{locator: locator, state: StateIdentityMismatch, reason: err.Error()}
+		return observation{locator: locator, state: StateIdentityMismatch, reason: err.Error(), homeKey: homeKey, homeErr: homeErr}
 	}
 	if observedID != locator.FleetID {
-		return observation{locator: locator, state: StateIdentityMismatch, reason: fmt.Sprintf("authoritative identity is %s", observedID)}
+		return observation{locator: locator, state: StateIdentityMismatch, reason: fmt.Sprintf("authoritative identity is %s", observedID), homeKey: homeKey, homeErr: homeErr}
 	}
-	return observation{locator: locator, valid: true, state: StateReady}
+	return observation{locator: locator, valid: true, state: StateReady, homeKey: homeKey, homeErr: homeErr}
 }
 
 func classify(observations []observation, claims map[string]map[string]bool) (State, string) {
@@ -420,23 +426,33 @@ func classify(observations []observation, claims map[string]map[string]bool) (St
 		case observed.state == StateUnreadable:
 			unreadable = append(unreadable, observed.locator.Home+": "+observed.reason)
 		}
+		if observed.homeErr != nil {
+			unreadable = append(unreadable, observed.locator.Home+": cannot establish canonical home: "+observed.homeErr.Error())
+		}
 	}
 	if valid > 1 {
 		return StateDuplicate, "the same Fleet identity is valid at multiple homes"
 	}
-	for _, ids := range claims {
-		if len(ids) > 1 {
-			return StateAmbiguous, "one home is registered for multiple Fleet identities"
+	if len(unreadable) > 0 {
+		sort.Strings(unreadable)
+		return StateUnreadable, strings.Join(unreadable, "; ")
+	}
+	ambiguous := false
+	for _, observed := range observations {
+		if ids := claims[observed.homeKey]; len(ids) > 1 {
+			ambiguous = true
+			break
 		}
 	}
+	if ambiguous {
+		return StateAmbiguous, "one home is registered for multiple Fleet identities"
+	}
+	sort.Strings(mismatch)
 	if len(mismatch) > 0 {
 		return StateIdentityMismatch, strings.Join(mismatch, "; ")
 	}
 	if valid == 1 {
 		return StateReady, ""
-	}
-	if len(unreadable) > 0 {
-		return StateUnreadable, strings.Join(unreadable, "; ")
 	}
 	if missing == len(observations) {
 		return StateMissing, "all known Fleet homes are missing"

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -433,10 +433,6 @@ func classify(observations []observation, claims map[string]map[string]bool) (St
 	if valid > 1 {
 		return StateDuplicate, "the same Fleet identity is valid at multiple homes"
 	}
-	if len(unreadable) > 0 {
-		sort.Strings(unreadable)
-		return StateUnreadable, strings.Join(unreadable, "; ")
-	}
 	ambiguous := false
 	for _, observed := range observations {
 		if ids := claims[observed.homeKey]; len(ids) > 1 {
@@ -446,6 +442,10 @@ func classify(observations []observation, claims map[string]map[string]bool) (St
 	}
 	if ambiguous {
 		return StateAmbiguous, "one home is registered for multiple Fleet identities"
+	}
+	if len(unreadable) > 0 {
+		sort.Strings(unreadable)
+		return StateUnreadable, strings.Join(unreadable, "; ")
 	}
 	sort.Strings(mismatch)
 	if len(mismatch) > 0 {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -507,6 +507,65 @@ func TestRegisterRefusesUnprovableCanonicalIdentityWithoutDeletingProjection(t *
 	}
 }
 
+func TestListScopesAmbiguousClaimsToParticipatingFleets(t *testing.T) {
+	root := t.TempDir()
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	ids := make(map[string]string)
+	for _, name := range []string{"healthy A", "healthy B", "ambiguous C", "other"} {
+		home := filepath.Join(root, name)
+		db, err := store.Open(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[name], err = db.FleetID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"healthy A", "healthy B"} {
+		if err := registryDB.Register(filepath.Join(root, name), ids[name], time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ambiguousHome := filepath.Join(root, "ambiguous C")
+	if err := registryDB.Register(ambiguousHome, ids["ambiguous C"], time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := registryDB.sql.Exec(`
+INSERT INTO fleet_registry (fleet_id, last_known_home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, ids["other"], ambiguousHome, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryDB.sql.Exec(`
+INSERT INTO fleet_locator (fleet_id, home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, ids["other"], ambiguousHome, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+
+	fleets, err := registryDB.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	states := make(map[string]State, len(fleets))
+	for _, fleet := range fleets {
+		states[fleet.ID] = fleet.State
+	}
+	if states[ids["healthy A"]] != StateReady || states[ids["healthy B"]] != StateReady {
+		t.Fatalf("healthy Fleet states = %#v, want both ready", states)
+	}
+	if states[ids["ambiguous C"]] != StateAmbiguous || states[ids["other"]] != StateAmbiguous {
+		t.Fatalf("participating Fleet states = %#v, want both ambiguous", states)
+	}
+}
+
 func TestPreflightRefusesARegisteredDuplicateBeforeRuntime(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HOME", root)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -566,6 +566,85 @@ VALUES (?, ?, ?, ?);`, ids["other"], ambiguousHome, stamp, stamp); err != nil {
 	}
 }
 
+func TestListAmbiguityPrecedesUnrelatedUnreadableObservation(t *testing.T) {
+	root := t.TempDir()
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+
+	collidedHome := filepath.Join(root, "collided")
+	first, err := store.Open(collidedHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(collidedHome, firstID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	unreadableHome := filepath.Join(root, "unreadable")
+	if err := os.MkdirAll(filepath.Dir(store.Path(unreadableHome)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(store.Path(collidedHome))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path(unreadableHome), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(unreadableHome, firstID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(store.Path(unreadableHome)); err != nil {
+		t.Fatal(err)
+	}
+
+	secondHome := filepath.Join(root, "second")
+	second, err := store.Open(secondHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := second.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := registryDB.sql.Exec(`
+INSERT INTO fleet_registry (fleet_id, last_known_home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, secondID, collidedHome, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryDB.sql.Exec(`
+INSERT INTO fleet_locator (fleet_id, home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, secondID, collidedHome, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+
+	fleets, err := registryDB.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	states := make(map[string]State, len(fleets))
+	for _, fleet := range fleets {
+		states[fleet.ID] = fleet.State
+	}
+	if states[firstID] != StateAmbiguous || states[secondID] != StateAmbiguous {
+		t.Fatalf("states = %#v, want both participating Fleets ambiguous", states)
+	}
+}
+
 func TestPreflightRefusesARegisteredDuplicateBeforeRuntime(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HOME", root)


### PR DESCRIPTION
## Summary

- Scoped exact-home ambiguity classification in `classify()` to only the Fleets participating in that
  collision, so an unrelated home's ambiguity no longer poisons a healthy Fleet's own state.
- Fixed the two stale `unrelatedAmbiguousHelpRegistry`/`selectedAmbiguousHelpRegistry` test fixtures,
  which called `Register()` directly to construct ambiguous registry state - that now correctly fails
  under `#357`'s new canonical-identity validation, since the fixture's fake claim has no matching
  canonical Fleet DB. The fixtures now insert the ambiguous claim rows directly via a new
  `insertHelpRegistryClaim` test helper, bypassing `Register()`'s validation exactly as intended, since
  the fixture's purpose is to simulate pre-existing ambiguous state, not to exercise registration.

Closes atqamz/hand#358

## Test plan

- Full named suites (`TestHelpFormsIgnoreBrokenFleetRegistries`, `TestFleetCommandKeepsRegistryPreflight`,
  registry package tests) pass under `-race -count=5`.
- Manual corrupt-registry check: `hand --help` still renders normal usage output.
- Build, contract suite, lint, and CI all green.
- Two pre-existing, unrelated E2E watcher/concurrency flakes (terminal-report event timeout; `send`
  observing a changed steering target) reproduce independently of this change - not introduced by it.

## Risk Assessment

✅ Low: The changes are bounded to registry classification coverage, durable registry documentation, and
regression fixtures; no source-verifiable correctness or intent-conformance issue was found.

<details>
<summary>Evidence: Help with corrupt registry</summary>

```text
Corrupt-registry manual check rendered normal `hand --help` usage output.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a0b7d35b1ca71aebc30de8cd7e90437ce188b8d0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ E2E watcher/concurrency tests fail reproducibly outside this change: terminal-report event timeout and `send` seeing a changed steering target.
- `Focused cmd and registry regression tests`
- `Build`
- `Contract suite`
- `Full E2E suite and focused rerun`
- <code>Manual corrupt-registry `hand --help` check</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
