### PR TITLE
fix(registry): reconcile stale same-home Fleet claims

### DIFF
--- a/docs/adr/fleet-identity-and-user-registry.md
+++ b/docs/adr/fleet-identity-and-user-registry.md
@@ -18,6 +18,11 @@ The identity is generated under the Fleet-local identity lock and is stable acro
 The user-local `~/.secondhand/registry.db` stores canonical observed locators and timestamps only.
 It is non-authoritative and has no Tasks, Attempts, Projects, configuration, reports, or runtime state.
 
+Registration first validates the canonical Fleet identity at the supplied home.
+After that positive validation, a registration transaction retires locator claims for other identities at that exact canonical home, while retaining their locators at other homes.
+It removes a superseded identity row only when no locator still references it.
+Unknown or unreadable canonical identity and registry evidence fail closed without changing the projection.
+
 `hand fleet` reads registry discovery without changing the current invocation context.
 There is no global active Fleet switch.
 Positive duplicate or identity-mismatch evidence fails closed before runtime or mutation side effects, while registry absence or degradation is reported as a warning because it cannot prove a duplicate.
@@ -41,6 +46,7 @@ Copied homes intentionally share an identity, so they must not share an IPC rout
 
 Operators can discover multiple homes from outside any Fleet while each command remains explicitly bound to its resolved home.
 Copied databases are visible and safe to refuse, but resolving a duplicate remains an operator decision because automatic re-keying would be irreversible and could orphan external resources.
+Same-home identity replacement is the narrow exception: only a positively validated canonical database may retire the stale claim for that exact home, and the transaction is atomic, deterministic, and idempotent.
 Herdr supports concurrent Fleet sessions without requiring Hand to stop or delete a named session during normal teardown.
 
 Supervisor monitor targets and currentness tokens include the authoritative Fleet identity, while watcher ownership remains scoped by canonical home and watcher generation.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -202,6 +202,13 @@ func (r *Registry) Register(home, fleetID string, now time.Time) error {
 	if err != nil {
 		return fmt.Errorf("canonicalize Fleet home: %w", err)
 	}
+	canonicalID, err := store.FleetIDReadOnly(home)
+	if err != nil {
+		return fmt.Errorf("read canonical Fleet identity: %w", err)
+	}
+	if canonicalID != fleetID {
+		return fmt.Errorf("canonical Fleet identity is %s, not %s", canonicalID, fleetID)
+	}
 	stamp := now.UTC().Format(time.RFC3339Nano)
 	if stamp == "0001-01-01T00:00:00Z" {
 		stamp = time.Now().UTC().Format(time.RFC3339Nano)
@@ -212,6 +219,15 @@ func (r *Registry) Register(home, fleetID string, now time.Time) error {
 			return fmt.Errorf("begin registry registration: %w", err)
 		}
 		defer func() { _ = tx.Rollback() }()
+		stale, err := staleLocators(tx, home, fleetID)
+		if err != nil {
+			return err
+		}
+		for _, locator := range stale {
+			if _, err := tx.Exec(`DELETE FROM fleet_locator WHERE fleet_id = ? AND home = ?`, locator.FleetID, locator.Home); err != nil {
+				return fmt.Errorf("retire superseded Fleet locator: %w", err)
+			}
+		}
 		if _, err := tx.Exec(`
 INSERT INTO fleet_registry (fleet_id, last_known_home, first_seen_at, last_seen_at)
 VALUES (?, ?, ?, ?)
@@ -224,11 +240,66 @@ VALUES (?, ?, ?, ?)
 ON CONFLICT(fleet_id, home) DO UPDATE SET last_seen_at = excluded.last_seen_at`, fleetID, home, stamp, stamp); err != nil {
 			return fmt.Errorf("write Fleet locator: %w", err)
 		}
+		for _, fleetID := range staleIDs(stale) {
+			if _, err := tx.Exec(`
+DELETE FROM fleet_registry
+WHERE fleet_id = ?
+  AND NOT EXISTS (SELECT 1 FROM fleet_locator WHERE fleet_id = ?)`, fleetID, fleetID); err != nil {
+				return fmt.Errorf("remove orphaned Fleet registry row: %w", err)
+			}
+		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("commit Fleet registration: %w", err)
 		}
 		return nil
 	})
+}
+
+func staleLocators(tx *sql.Tx, selectedHome, fleetID string) ([]Locator, error) {
+	selectedKey, err := pathKey(selectedHome)
+	if err != nil {
+		return nil, fmt.Errorf("resolve selected Fleet home for registry repair: %w", err)
+	}
+	rows, err := tx.Query(`SELECT fleet_id, home, first_seen_at, last_seen_at FROM fleet_locator ORDER BY fleet_id, home`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect Fleet locators for registry repair: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var stale []Locator
+	for rows.Next() {
+		var locator Locator
+		if err := rows.Scan(&locator.FleetID, &locator.Home, &locator.FirstSeenAt, &locator.LastSeenAt); err != nil {
+			return nil, fmt.Errorf("read Fleet locator for registry repair: %w", err)
+		}
+		locatorKey, err := pathKey(locator.Home)
+		if err != nil {
+			return nil, fmt.Errorf("resolve registered Fleet home %q for registry repair: %w", locator.Home, err)
+		}
+		if locatorKey != selectedKey || locator.FleetID == fleetID {
+			continue
+		}
+		var present int
+		if err := tx.QueryRow(`SELECT 1 FROM fleet_registry WHERE fleet_id = ?`, locator.FleetID).Scan(&present); err != nil {
+			return nil, fmt.Errorf("validate superseded Fleet %s registry row: %w", locator.FleetID, err)
+		}
+		stale = append(stale, locator)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("inspect Fleet locators for registry repair: %w", err)
+	}
+	return stale, nil
+}
+
+func staleIDs(locators []Locator) []string {
+	ids := make([]string, 0, len(locators))
+	seen := make(map[string]bool, len(locators))
+	for _, locator := range locators {
+		if !seen[locator.FleetID] {
+			seen[locator.FleetID] = true
+			ids = append(ids, locator.FleetID)
+		}
+	}
+	return ids
 }
 
 func (r *Registry) Locators() ([]Locator, error) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -225,7 +225,14 @@ func TestListReportsAmbiguousHomeClaims(t *testing.T) {
 	if err := registryDB.Register(home, firstID, time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
-	if err := registryDB.Register(home, secondID, time.Now().UTC()); err != nil {
+	if _, err := registryDB.sql.Exec(`
+INSERT INTO fleet_registry (fleet_id, last_known_home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, secondID, home, time.Now().UTC().Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryDB.sql.Exec(`
+INSERT INTO fleet_locator (fleet_id, home, first_seen_at, last_seen_at)
+VALUES (?, ?, ?, ?);`, secondID, home, time.Now().UTC().Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,6 +242,268 @@ func TestListReportsAmbiguousHomeClaims(t *testing.T) {
 	}
 	if len(fleets) != 2 || fleets[0].State != StateAmbiguous || fleets[1].State != StateAmbiguous {
 		t.Fatalf("fleets = %+v, want both identities ambiguous", fleets)
+	}
+}
+
+func TestRegisterReconcilesSupersededSameHomeProjection(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "fleet registry 測試")
+	home := filepath.Join(root, "home with spaces")
+	first, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	registryDB, err := OpenAt(filepath.Join(root, "runtime", "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	if err := registryDB.Register(home, firstID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(home, "state")); err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := second.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if firstID == secondID {
+		t.Fatal("recreated Fleet identity unexpectedly stayed the same")
+	}
+
+	if err := registryDB.Register(home, secondID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	locators, err := registryDB.Locators()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locators) != 1 || locators[0].FleetID != secondID {
+		t.Fatalf("locators = %+v, want only recreated Fleet %s", locators, secondID)
+	}
+	var identities int
+	if err := registryDB.sql.QueryRow(`SELECT COUNT(*) FROM fleet_registry`).Scan(&identities); err != nil {
+		t.Fatal(err)
+	}
+	if identities != 1 {
+		t.Fatalf("fleet identities = %d, want one non-orphaned identity", identities)
+	}
+	if got, err := store.FleetIDReadOnly(home); err != nil || got != secondID {
+		t.Fatalf("canonical Fleet identity = %q, %v, want %s unchanged", got, err, secondID)
+	}
+}
+
+func TestRegisterRollbackRestoresSupersededProjectionOnWriteFailure(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	first, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	if err := registryDB.Register(home, firstID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(home, "state")); err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := second.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registryDB.sql.Exec(fmt.Sprintf(`
+CREATE TRIGGER fail_register_locator
+BEFORE INSERT ON fleet_locator
+WHEN NEW.fleet_id = '%s'
+BEGIN
+	SELECT RAISE(ABORT, 'injected register failure');
+END;`, secondID)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := registryDB.Register(home, secondID, time.Now().UTC()); err == nil {
+		t.Fatal("Register succeeded across injected write failure")
+	}
+	locators, err := registryDB.Locators()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locators) != 1 || locators[0].FleetID != firstID {
+		t.Fatalf("locators after rollback = %+v, want original Fleet %s", locators, firstID)
+	}
+	var identities int
+	if err := registryDB.sql.QueryRow(`SELECT COUNT(*) FROM fleet_registry`).Scan(&identities); err != nil {
+		t.Fatal(err)
+	}
+	if identities != 1 {
+		t.Fatalf("fleet identities after rollback = %d, want one", identities)
+	}
+}
+
+func TestRegisterRetainsSupersededIdentityUsedAtAnotherHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	otherHome := filepath.Join(root, "other")
+	first, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(store.Path(otherHome)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(store.Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path(otherHome), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	for _, registeredHome := range []string{home, otherHome} {
+		if err := registryDB.Register(registeredHome, firstID, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.RemoveAll(filepath.Join(home, "state")); err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := second.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(home, secondID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(home, secondID, time.Now().Add(time.Second).UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	locators, err := registryDB.Locators()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locators) != 2 {
+		t.Fatalf("locators = %+v, want retained old-home locator and current locator", locators)
+	}
+	var oldHome, currentHome bool
+	for _, locator := range locators {
+		switch {
+		case locator.FleetID == firstID && samePath(locator.Home, otherHome):
+			oldHome = true
+		case locator.FleetID == secondID && samePath(locator.Home, home):
+			currentHome = true
+		}
+	}
+	if !oldHome || !currentHome {
+		t.Fatalf("locators = %+v, want %s at %s and %s at %s", locators, firstID, otherHome, secondID, home)
+	}
+	var identities int
+	if err := registryDB.sql.QueryRow(`SELECT COUNT(*) FROM fleet_registry`).Scan(&identities); err != nil {
+		t.Fatal(err)
+	}
+	if identities != 2 {
+		t.Fatalf("fleet identities = %d, want retained old and current identities", identities)
+	}
+}
+
+func TestRegisterRefusesUnprovableCanonicalIdentityWithoutDeletingProjection(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	first, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := first.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	secondHome := filepath.Join(root, "second")
+	second, err := store.Open(secondHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := second.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	if err := registryDB.Register(home, firstID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(home, "state")); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(home, secondID, time.Now().UTC()); err == nil {
+		t.Fatal("Register succeeded without a canonical Fleet database")
+	}
+	locators, err := registryDB.Locators()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locators) != 1 || locators[0].FleetID != firstID {
+		t.Fatalf("locators after refused repair = %+v, want original Fleet %s", locators, firstID)
 	}
 }
 


### PR DESCRIPTION
## Summary\n\n- Reconcile a positively validated canonical Fleet DB with stale same-home registry locator claims in one atomic transaction.\n- Preserve other-home projections and fail closed when canonical identity or registry evidence is not provable.\n\nCloses atqamz/hand#357\n\n## Test plan\n\n- Same-home A-to-B recreation with spaces and Unicode.\n- Transaction rollback, idempotent repeat registration, orphan-row cleanup, old-identity retention at another home, and canonical DB immutability.\n- Registry package, command tests, race suite, lint, Nix build, contract, and Linux/macOS/Windows CI.