### PR TITLE
feat(herdr): add Fleet-scoped session lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,8 @@ You normally let the supervising agent drive the CLI. The main lifecycle is:
 | `hand reopen <id>` | Reopen a terminal Task by creating a new Attempt. |
 | `hand status` | Read fleet or task state. |
 | `hand fleet` | List user-local Fleet homes and their observed identity state. |
+| `hand fleet herdr` | Ensure and attach the current Fleet's Herdr session. |
+| `hand fleet herdr status` | Observe the current Fleet's Herdr session without changing it. |
 | `hand ack <id> [--reason <text>]` | Record that a supervisor has acknowledged a task's report. |
 | `hand reconcile [id] [--abandon-worktree] [--abandon-pane] [--attempt-never-started]` | Reconcile one Task or the bounded fleet candidate set with observed external reality; given a Task ID, explicitly relinquish a historical worktree lease or Herdr pane identity whose ownership no observation can settle, or attest that a running Attempt's worker took no turn so the ordinary release path can end it. |
 | `hand watch` | Wait for actionable fleet events and emit Fleet-scoped structured wake hints. |

--- a/cmd/fleet.go
+++ b/cmd/fleet.go
@@ -1,17 +1,20 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"strings"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/registry"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
 )
 
 func newFleetCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "fleet",
 		Short: "List known Fleet homes for this user",
 		Args:  usageArgs(cobra.NoArgs),
@@ -57,6 +60,76 @@ func newFleetCmd() *cobra.Command {
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}
+	cmd.AddCommand(newFleetHerdrCmd())
+	return cmd
+}
+
+type fleetHerdrCommand interface {
+	Session() string
+	Observe(context.Context) herdr.SessionObservation
+	Ensure(context.Context) error
+	Open(context.Context) error
+}
+
+var newFleetHerdrCommand = func(fleetID string) fleetHerdrCommand {
+	return herdr.NewFleetHerdr(fleetID)
+}
+
+func newFleetHerdrCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "herdr",
+		Short: "Ensure and attach the current Fleet Herdr session",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetID, fleetHerdr, err := currentFleetHerdrCommand()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			if err := fleetHerdr.Open(cmd.Context()); err != nil {
+				return asPrecondition(err)
+			}
+			doc := axi.Doc{}
+			doc.Field("fleet_id", fleetID)
+			doc.Field("herdr_session", fleetHerdr.Session())
+			doc.Bool("opened", true)
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+	cmd.AddCommand(newFleetHerdrStatusCmd())
+	return cmd
+}
+
+func newFleetHerdrStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Observe the current Fleet Herdr session",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetID, fleetHerdr, err := currentFleetHerdrCommand()
+			if err != nil {
+				return asPrecondition(err)
+			}
+			observation := fleetHerdr.Observe(cmd.Context())
+			doc := axi.Doc{}
+			doc.Field("fleet_id", fleetID)
+			doc.Field("herdr_session", fleetHerdr.Session())
+			doc.Field("state", string(observation.State))
+			doc.Field("reason", orNone(observation.Reason))
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+}
+
+func currentFleetHerdrCommand() (string, fleetHerdrCommand, error) {
+	fleetHome, err := home.Resolve()
+	if err != nil {
+		return "", nil, err
+	}
+	fleetID, err := state.FleetIDReadOnly(fleetHome)
+	if err != nil {
+		return "", nil, err
+	}
+	return fleetID, newFleetHerdrCommand(fleetID), nil
 }
 
 func boolString(value bool) string {

--- a/cmd/fleet_herdr_test.go
+++ b/cmd/fleet_herdr_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/state"
+)
+
+type fakeFleetHerdrCommand struct {
+	session      string
+	observation  herdr.SessionObservation
+	observeCalls int
+	ensureCalls  int
+	openCalls    int
+}
+
+func (f *fakeFleetHerdrCommand) Session() string {
+	return f.session
+}
+
+func (f *fakeFleetHerdrCommand) Observe(context.Context) herdr.SessionObservation {
+	f.observeCalls++
+	return f.observation
+}
+
+func (f *fakeFleetHerdrCommand) Ensure(context.Context) error {
+	f.ensureCalls++
+	return nil
+}
+
+func (f *fakeFleetHerdrCommand) Open(context.Context) error {
+	f.openCalls++
+	return nil
+}
+
+func TestFleetHerdrStatusObservesOnlyCurrentFleetNamespace(t *testing.T) {
+	home := setupSessionHome(t)
+	fleetID, err := state.FleetIDReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeFleetHerdrCommand{
+		session: herdr.SessionName(fleetID),
+		observation: herdr.SessionObservation{
+			Name:   herdr.SessionName(fleetID),
+			State:  herdr.SessionRunningCompatible,
+			Reason: "server is compatible",
+		},
+	}
+	original := newFleetHerdrCommand
+	newFleetHerdrCommand = func(gotFleetID string) fleetHerdrCommand {
+		if gotFleetID != fleetID {
+			t.Fatalf("fleet ID = %q, want %q", gotFleetID, fleetID)
+		}
+		return fake
+	}
+	t.Cleanup(func() { newFleetHerdrCommand = original })
+
+	var out bytes.Buffer
+	root := newRootCmd(devBuild("test"))
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"fleet", "herdr", "status"})
+	before := snapshotFleetTree(t, home)
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshotFleetTree(t, home); !slices.Equal(after, before) {
+		t.Fatalf("status mutated Fleet home:\nbefore: %v\nafter: %v", before, after)
+	}
+
+	for _, want := range []string{
+		"fleet_id: " + fleetID + "\n",
+		"herdr_session: " + herdr.SessionName(fleetID) + "\n",
+		"state: running-compatible\n",
+		"reason: server is compatible\n",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("status output = %q, want %q", out.String(), want)
+		}
+	}
+	if fake.observeCalls != 1 || fake.ensureCalls != 0 || fake.openCalls != 0 {
+		t.Fatalf("calls = observe %d, ensure %d, open %d; want observe only", fake.observeCalls, fake.ensureCalls, fake.openCalls)
+	}
+}
+
+func TestFleetHerdrCommandOpensCurrentFleetNamespace(t *testing.T) {
+	home := setupSessionHome(t)
+	fleetID, err := state.FleetIDReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeFleetHerdrCommand{session: herdr.SessionName(fleetID)}
+	original := newFleetHerdrCommand
+	newFleetHerdrCommand = func(gotFleetID string) fleetHerdrCommand {
+		if gotFleetID != fleetID {
+			t.Fatalf("fleet ID = %q, want %q", gotFleetID, fleetID)
+		}
+		return fake
+	}
+	t.Cleanup(func() { newFleetHerdrCommand = original })
+
+	var out bytes.Buffer
+	root := newRootCmd(devBuild("test"))
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"fleet", "herdr"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+
+	if fake.openCalls != 1 || fake.ensureCalls != 0 || fake.observeCalls != 0 {
+		t.Fatalf("calls = observe %d, ensure %d, open %d; want Open only", fake.observeCalls, fake.ensureCalls, fake.openCalls)
+	}
+	for _, want := range []string{
+		"fleet_id: " + fleetID + "\n",
+		"herdr_session: " + herdr.SessionName(fleetID) + "\n",
+		"opened: true\n",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("open output = %q, want %q", out.String(), want)
+		}
+	}
+}

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/runtime"
@@ -12,6 +13,8 @@ import (
 // These package errors are precondition failures rather than general errors. The imported packages
 // cannot construct cmd.ExitError themselves, so they signal through sentinels.
 var preconditionSentinels = []error{
+	herdr.ErrSessionUnknown,
+	herdr.ErrSessionIncompatible,
 	state.ErrTaskNotFound,
 	state.ErrTaskActive,
 	state.ErrLifecycleConflict,

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -15,6 +15,7 @@ import (
 var preconditionSentinels = []error{
 	herdr.ErrSessionUnknown,
 	herdr.ErrSessionIncompatible,
+	herdr.ErrEnsureTimeout,
 	state.ErrTaskNotFound,
 	state.ErrTaskActive,
 	state.ErrLifecycleConflict,

--- a/cmd/precondition_test.go
+++ b/cmd/precondition_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+func TestAsPreconditionClassifiesEnsureTimeout(t *testing.T) {
+	err := asPrecondition(&herdr.SessionEnsureError{Cause: herdr.ErrEnsureTimeout})
+	if code := exitCodeFor(t, err); code != 3 {
+		t.Fatalf("exit code = %d, want 3 for Ensure timeout (err = %v)", code, err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,7 +111,7 @@ func newRootCmd(info selfupdate.BuildInfo) *cobra.Command {
 
 func isReadOnlyCommand(cmd *cobra.Command) bool {
 	switch cmd.CommandPath() {
-	case "hand", "hand doctor", "hand runtime status":
+	case "hand", "hand doctor", "hand runtime status", "hand fleet herdr status":
 		return true
 	default:
 		return false

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -102,6 +102,7 @@ type herdrSpec struct {
 	ReadLogEnv         bool
 	AllowUnknownPane   bool
 	MutateBeforeHang   bool
+	activeSession      string
 }
 
 type herdrTabRef struct {
@@ -147,11 +148,12 @@ func runHerdrFromPayload(payload json.RawMessage, args []string) int {
 		return fail("prepare Herdr session state: %v", err)
 	}
 	spec.StateDir = stateDir
+	spec.activeSession = herdrSession(args)
 	logicalArgs := herdrLogicalArgs(args)
-	if len(logicalArgs) < 2 {
+	command, commandArgs := herdrCommand(logicalArgs)
+	if command == "" {
 		return fail("unexpected herdr invocation: %s", strings.Join(args, " "))
 	}
-	command := logicalArgs[0] + " " + logicalArgs[1]
 	for _, blocked := range spec.Hang {
 		if blocked == command {
 			if spec.MutateBeforeHang {
@@ -174,7 +176,7 @@ func runHerdrFromPayload(payload json.RawMessage, args []string) int {
 		return 1
 	}
 	for _, response := range spec.Responses {
-		if response.Command == command && (response.Args == nil || sameArgs(response.Args, logicalArgs[2:])) {
+		if response.Command == command && (response.Args == nil || sameArgs(response.Args, commandArgs)) {
 			if response.MutateBeforeResponse {
 				if exit := runHerdrState(spec, command, logicalArgs); exit != 0 {
 					return exit
@@ -247,6 +249,19 @@ func herdrLogicalArgs(args []string) []string {
 	return args
 }
 
+func herdrCommand(args []string) (string, []string) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	if args[0] == "server" {
+		return "server", args[1:]
+	}
+	if len(args) < 2 {
+		return "", nil
+	}
+	return args[0] + " " + args[1], args[2:]
+}
+
 func logHerdrInvocation(spec herdrSpec, args []string) error {
 	if spec.Log == "" || (len(spec.LogCommands) > 0 && !containsString(spec.LogCommands, commandName(args))) {
 		return nil
@@ -255,11 +270,8 @@ func logHerdrInvocation(spec herdrSpec, args []string) error {
 }
 
 func commandName(args []string) string {
-	args = herdrLogicalArgs(args)
-	if len(args) < 2 {
-		return strings.Join(args, " ")
-	}
-	return args[0] + " " + args[1]
+	command, _ := herdrCommand(herdrLogicalArgs(args))
+	return command
 }
 
 func containsString(values []string, want string) bool {
@@ -275,6 +287,14 @@ func runHerdrState(spec herdrSpec, command string, args []string) int {
 	workspaces := append(append([]HerdrWorkspace{}, spec.Workspaces...), spec.Creates...)
 	tabs := herdrTabs(workspaces, spec.TabCreates)
 	switch command {
+	case "server":
+		return 0
+	case "session list":
+		return herdrSessionList(spec, args)
+	case "session attach":
+		return 0
+	case "status server":
+		return herdrServerStatus(spec, args)
 	case "workspace list":
 		return herdrWorkspaceList(spec, workspaces)
 	case "workspace create":
@@ -300,6 +320,22 @@ func runHerdrState(spec herdrSpec, command string, args []string) int {
 	default:
 		return fail("unexpected herdr invocation: %s", strings.Join(args, " "))
 	}
+}
+
+func herdrSessionList(spec herdrSpec, args []string) int {
+	session := spec.activeSession
+	if session == "" {
+		_, _ = io.WriteString(os.Stdout, "{\"sessions\":[]}\n")
+		return 0
+	}
+	fmt.Fprintf(os.Stdout, "{\"sessions\":[{\"name\":%s,\"running\":true}]}\n", jsonQuote(session))
+	return 0
+}
+
+func herdrServerStatus(spec herdrSpec, args []string) int {
+	session := spec.activeSession
+	fmt.Fprintf(os.Stdout, "{\"status\":\"running\",\"running\":true,\"compatible\":true,\"session\":%s}\n", jsonQuote(session))
+	return 0
 }
 
 func herdrWorkspaceList(spec herdrSpec, workspaces []HerdrWorkspace) int {

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -328,13 +328,13 @@ func herdrSessionList(spec herdrSpec, args []string) int {
 		_, _ = io.WriteString(os.Stdout, "{\"sessions\":[]}\n")
 		return 0
 	}
-	fmt.Fprintf(os.Stdout, "{\"sessions\":[{\"name\":%s,\"running\":true}]}\n", jsonQuote(session))
+	_, _ = fmt.Fprintf(os.Stdout, "{\"sessions\":[{\"name\":%s,\"running\":true}]}\n", jsonQuote(session))
 	return 0
 }
 
 func herdrServerStatus(spec herdrSpec, args []string) int {
 	session := spec.activeSession
-	fmt.Fprintf(os.Stdout, "{\"status\":\"running\",\"running\":true,\"compatible\":true,\"session\":%s}\n", jsonQuote(session))
+	_, _ = fmt.Fprintf(os.Stdout, "{\"status\":\"running\",\"running\":true,\"compatible\":true,\"session\":%s}\n", jsonQuote(session))
 	return 0
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -276,6 +276,80 @@ func (c *Client) runContext(ctx context.Context, args ...string) ([]byte, string
 	return bytes.TrimSpace(stdout.Bytes()), strings.TrimSpace(stderr.String()), runErr
 }
 
+func (c *Client) startServer(ctx context.Context) error {
+	if c == nil {
+		return errors.New("managed Herdr client is unavailable")
+	}
+	if c.initErr != nil {
+		return c.initErr
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	executable := c.executable
+	if executable == "" {
+		executable = "herdr"
+	}
+	if !filepath.IsAbs(executable) {
+		return fmt.Errorf("managed Herdr executable %q must be an absolute path", executable)
+	}
+	cmd := exec.Command(executable, c.wireArgs("server")...)
+	parentEnv := c.env
+	if parentEnv == nil {
+		parentEnv = os.Environ()
+	}
+	cmd.Env = daemonEnvironment(parentEnv)
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open detached Herdr stdio: %w", err)
+	}
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = devNull, devNull, devNull
+	detachCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		_ = devNull.Close()
+		return &ExecError{Started: false, Err: err}
+	}
+	closeErr := devNull.Close()
+	releaseErr := cmd.Process.Release()
+	if closeErr != nil || releaseErr != nil {
+		return errors.Join(closeErr, releaseErr)
+	}
+	return nil
+}
+
+func (c *Client) attach(ctx context.Context) error {
+	if c == nil {
+		return errors.New("managed Herdr client is unavailable")
+	}
+	if c.initErr != nil {
+		return c.initErr
+	}
+	if c.session == "" {
+		return errors.New("Herdr session identity is unavailable")
+	}
+	executable := c.executable
+	if executable == "" {
+		executable = "herdr"
+	}
+	if !filepath.IsAbs(executable) {
+		return fmt.Errorf("managed Herdr executable %q must be an absolute path", executable)
+	}
+	cmd := exec.CommandContext(ctx, executable, "session", "attach", c.session)
+	if c.env != nil {
+		cmd.Env = daemonEnvironment(c.env)
+	} else {
+		cmd.Env = daemonEnvironment(os.Environ())
+	}
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("attach Herdr session %q: %w", c.session, err)
+	}
+	return nil
+}
+
 func (c *Client) wireArgs(args ...string) []string {
 	if c.session == "" {
 		return args

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -328,7 +328,7 @@ func (c *Client) attach(ctx context.Context) error {
 		return c.initErr
 	}
 	if c.session == "" {
-		return errors.New("Herdr session identity is unavailable")
+		return errors.New("herdr session identity is unavailable")
 	}
 	executable := c.executable
 	if executable == "" {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -315,11 +315,8 @@ func (c *Client) startServer(ctx context.Context) error {
 		_ = devNull.Close()
 		return &ExecError{Started: false, Err: err}
 	}
-	closeErr := devNull.Close()
-	releaseErr := cmd.Process.Release()
-	if closeErr != nil || releaseErr != nil {
-		return errors.Join(closeErr, releaseErr)
-	}
+	_ = devNull.Close()
+	_ = cmd.Process.Release()
 	return nil
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -253,6 +253,7 @@ func (c *Client) run(args ...string) ([]byte, string, error) {
 func (c *Client) runContext(ctx context.Context, args ...string) ([]byte, string, error) {
 	executable := "herdr"
 	var env []string
+	wireArgs := args
 	if c != nil {
 		if c.initErr != nil {
 			return nil, "", c.initErr
@@ -261,11 +262,13 @@ func (c *Client) runContext(ctx context.Context, args ...string) ([]byte, string
 			executable = c.executable
 		}
 		env = c.env
+		wireArgs = c.wireArgs(args...)
 	}
-	cmd := exec.CommandContext(ctx, executable, c.wireArgs(args...)...)
-	if env != nil {
-		cmd.Env = append([]string(nil), env...)
+	cmd := exec.CommandContext(ctx, executable, wireArgs...)
+	if env == nil {
+		env = os.Environ()
 	}
+	cmd.Env = daemonEnvironment(env)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/herdr/detach_unix.go
+++ b/internal/herdr/detach_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package herdr
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func detachCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/herdr/detach_windows.go
+++ b/internal/herdr/detach_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package herdr
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func detachCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x00000008 | 0x00000200}
+}

--- a/internal/herdr/lifecycle.go
+++ b/internal/herdr/lifecycle.go
@@ -271,11 +271,11 @@ func daemonEnvironment(parent []string) []string {
 
 func daemonEnvironmentKey(key string) bool {
 	key = strings.ToUpper(key)
-	if strings.HasPrefix(key, "HAND_TASK_") || strings.HasPrefix(key, "HAND_ATTEMPT_") || strings.HasPrefix(key, "HAND_REPORT_") || strings.HasPrefix(key, "HAND_WORKSPACE_") || strings.HasPrefix(key, "HAND_TAB_") || strings.HasPrefix(key, "HAND_PANE_") || strings.HasPrefix(key, "HAND_BRIDGE_") || strings.HasPrefix(key, "HAND_ROUTING_") || strings.HasPrefix(key, "HAND_ROUTE_") || strings.HasPrefix(key, "HAND_RUNTIME_") || strings.HasPrefix(key, "HAND_SUPERVISOR_") || strings.HasPrefix(key, "HAND_WORKER_") || strings.HasPrefix(key, "NO_MISTAKES_") {
+	if strings.HasPrefix(key, "HAND_TASK_") || strings.HasPrefix(key, "HAND_ATTEMPT_") || strings.HasPrefix(key, "HAND_REPORT_") || strings.HasPrefix(key, "HAND_WORKSPACE_") || strings.HasPrefix(key, "HAND_TAB_") || strings.HasPrefix(key, "HAND_PANE_") || strings.HasPrefix(key, "HAND_BRIDGE_") || strings.HasPrefix(key, "HAND_ROUTING_") || strings.HasPrefix(key, "HAND_ROUTE_") || strings.HasPrefix(key, "HAND_SUPERVISOR_") || strings.HasPrefix(key, "HAND_WORKER_") || strings.HasPrefix(key, "NO_MISTAKES_") {
 		return true
 	}
 	switch key {
-	case "HAND_HOME", "HAND_ROLE", "HAND_HARNESS", "HAND_PROJECT_ID", "HAND_ROUTING_SOURCE", "HAND_PROFILE", "HAND_MODEL", "HAND_EFFORT",
+	case "HAND_HOME", "HAND_ROLE", "HAND_HARNESS", "HAND_PROJECT_ID", "HAND_RUNTIME_ID", "HAND_ROUTING_SOURCE",
 		"HERDR_ENV", "HERDR_SESSION", "HERDR_SOCKET", "HERDR_SOCKET_PATH", "HERDR_CLIENT_SOCKET", "HERDR_SOCKET_OVERRIDE", "HERDR_WORKSPACE", "HERDR_TAB", "HERDR_PANE", "HERDR_WORKSPACE_ID", "HERDR_TAB_ID", "HERDR_PANE_ID",
 		"CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDECODE", "CODEX_THREAD_ID", "PI_CODING_AGENT", "PI_SESSION_ID", "GROK_AGENT", "GROK_SESSION_ID", "OPENCODE_SESSION_ID", "OPENAI_SESSION_ID":
 		return true

--- a/internal/herdr/lifecycle.go
+++ b/internal/herdr/lifecycle.go
@@ -21,8 +21,8 @@ const (
 )
 
 var (
-	ErrSessionUnknown      = errors.New("Fleet Herdr session observation is unknown")
-	ErrSessionIncompatible = errors.New("Fleet Herdr session is incompatible")
+	ErrSessionUnknown      = errors.New("fleet Herdr session observation is unknown")
+	ErrSessionIncompatible = errors.New("fleet Herdr session is incompatible")
 	ErrEnsureTimeout       = errors.New("timed out waiting for Fleet Herdr session")
 )
 

--- a/internal/herdr/lifecycle.go
+++ b/internal/herdr/lifecycle.go
@@ -1,0 +1,285 @@
+package herdr
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/atqamz/hand/internal/filelock"
+	"github.com/atqamz/hand/internal/secondhand"
+)
+
+const (
+	defaultHerdrStartTimeout = 15 * time.Second
+	defaultHerdrPollInterval = 100 * time.Millisecond
+)
+
+var (
+	ErrSessionUnknown      = errors.New("Fleet Herdr session observation is unknown")
+	ErrSessionIncompatible = errors.New("Fleet Herdr session is incompatible")
+	ErrEnsureTimeout       = errors.New("timed out waiting for Fleet Herdr session")
+)
+
+type SessionEnsureError struct {
+	Observation SessionObservation
+	Cause       error
+}
+
+func (e *SessionEnsureError) Error() string {
+	if e.Observation.Name == "" {
+		return fmt.Sprintf("ensure Fleet Herdr session: %v", e.Cause)
+	}
+	if e.Observation.Reason == "" {
+		return fmt.Sprintf("ensure Fleet Herdr session %q: %v", e.Observation.Name, e.Cause)
+	}
+	return fmt.Sprintf("ensure Fleet Herdr session %q: %v (%s)", e.Observation.Name, e.Cause, e.Observation.Reason)
+}
+
+func (e *SessionEnsureError) Unwrap() error { return e.Cause }
+
+// FleetHerdr owns the exact Herdr namespace for one canonical Fleet identity.
+type FleetHerdr struct {
+	fleetID string
+	session string
+	client  *Client
+
+	observeFn func(context.Context) SessionObservation
+	startFn   func(context.Context) error
+	attachFn  func(context.Context) error
+	lockFn    func(context.Context) (func(), error)
+
+	startTimeout time.Duration
+	pollInterval time.Duration
+}
+
+func NewFleetHerdr(fleetID string) *FleetHerdr {
+	return &FleetHerdr{
+		fleetID:      fleetID,
+		session:      SessionName(fleetID),
+		client:       NewManagedSessionClient(SessionName(fleetID)),
+		startTimeout: defaultHerdrStartTimeout,
+		pollInterval: defaultHerdrPollInterval,
+	}
+}
+
+func (f *FleetHerdr) Session() string {
+	if f == nil {
+		return ""
+	}
+	return f.session
+}
+
+func (f *FleetHerdr) Observe(ctx context.Context) SessionObservation {
+	if f == nil {
+		return SessionObservation{State: SessionUnknown, Reason: "Fleet Herdr runtime is unavailable"}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if strings.TrimSpace(f.fleetID) == "" {
+		return SessionObservation{Name: f.session, State: SessionUnknown, Reason: "Fleet identity is unavailable"}
+	}
+	if f.observeFn != nil {
+		return f.observeFn(ctx)
+	}
+	if f.client == nil {
+		return SessionObservation{Name: f.session, State: SessionUnknown, Reason: "managed Herdr client is unavailable"}
+	}
+	return f.client.ObserveSession(ctx)
+}
+
+func (f *FleetHerdr) Ensure(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	observation := f.Observe(ctx)
+	switch observation.State {
+	case SessionRunningCompatible:
+		return nil
+	case SessionUnknown:
+		return sessionEnsureError(observation, ErrSessionUnknown)
+	case SessionIncompatible:
+		return sessionEnsureError(observation, ErrSessionIncompatible)
+	case SessionStopped:
+		return f.ensureStopped(ctx)
+	default:
+		return sessionEnsureError(observation, ErrSessionUnknown)
+	}
+}
+
+func (f *FleetHerdr) ensureStopped(ctx context.Context) error {
+	release, err := f.acquireStartLock(ctx)
+	if err != nil {
+		return fmt.Errorf("coordinate Fleet Herdr start: %w", err)
+	}
+	defer release()
+
+	observation := f.Observe(ctx)
+	switch observation.State {
+	case SessionRunningCompatible:
+		return nil
+	case SessionUnknown:
+		return sessionEnsureError(observation, ErrSessionUnknown)
+	case SessionIncompatible:
+		return sessionEnsureError(observation, ErrSessionIncompatible)
+	case SessionStopped:
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := f.start(ctx); err != nil {
+			return fmt.Errorf("start Fleet Herdr session %q: %w", f.session, err)
+		}
+		return f.waitReady(ctx)
+	default:
+		return sessionEnsureError(observation, ErrSessionUnknown)
+	}
+}
+
+func (f *FleetHerdr) waitReady(ctx context.Context) error {
+	timeout := f.startTimeout
+	if timeout <= 0 {
+		timeout = defaultHerdrStartTimeout
+	}
+	interval := f.pollInterval
+	if interval <= 0 {
+		interval = defaultHerdrPollInterval
+	}
+	deadline := time.Now().Add(timeout)
+	var last SessionObservation
+	for {
+		last = f.Observe(ctx)
+		switch last.State {
+		case SessionRunningCompatible:
+			return nil
+		case SessionUnknown:
+			return sessionEnsureError(last, ErrSessionUnknown)
+		case SessionIncompatible:
+			return sessionEnsureError(last, ErrSessionIncompatible)
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return sessionEnsureError(last, ErrEnsureTimeout)
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (f *FleetHerdr) start(ctx context.Context) error {
+	if f.startFn != nil {
+		return f.startFn(ctx)
+	}
+	if f.client == nil {
+		return errors.New("managed Herdr client is unavailable")
+	}
+	return f.client.startServer(ctx)
+}
+
+func (f *FleetHerdr) Open(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := f.Ensure(ctx); err != nil {
+		return err
+	}
+	if f.attachFn != nil {
+		return f.attachFn(ctx)
+	}
+	if f.client == nil {
+		return errors.New("managed Herdr client is unavailable")
+	}
+	return f.client.attach(ctx)
+}
+
+func sessionEnsureError(observation SessionObservation, cause error) error {
+	return &SessionEnsureError{Observation: observation, Cause: cause}
+}
+
+func (f *FleetHerdr) acquireStartLock(ctx context.Context) (func(), error) {
+	if f.lockFn != nil {
+		return f.lockFn(ctx)
+	}
+	root, err := secondhand.Home()
+	if err != nil {
+		return nil, err
+	}
+	lockRoot := filepath.Join(root, "herdr")
+	if err := os.MkdirAll(lockRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("create Herdr start lock directory: %w", err)
+	}
+	key := sha256.Sum256([]byte(f.session))
+	lockPath := filepath.Join(lockRoot, hex.EncodeToString(key[:])+".start.lock")
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open Herdr start lock: %w", err)
+	}
+	for {
+		err = filelock.Lock(file, false)
+		if err == nil {
+			return func() {
+				_ = filelock.Unlock(file)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, filelock.ErrBusy) {
+			_ = file.Close()
+			return nil, err
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func daemonEnvironment(parent []string) []string {
+	result := make([]string, 0, len(parent))
+	for _, item := range parent {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && daemonEnvironmentKey(key) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func daemonEnvironmentKey(key string) bool {
+	key = strings.ToUpper(key)
+	if strings.HasPrefix(key, "HAND_TASK_") || strings.HasPrefix(key, "HAND_ATTEMPT_") || strings.HasPrefix(key, "HAND_REPORT_") || strings.HasPrefix(key, "HAND_WORKSPACE_") || strings.HasPrefix(key, "HAND_TAB_") || strings.HasPrefix(key, "HAND_PANE_") || strings.HasPrefix(key, "HAND_BRIDGE_") || strings.HasPrefix(key, "HAND_ROUTING_") || strings.HasPrefix(key, "HAND_ROUTE_") || strings.HasPrefix(key, "HAND_RUNTIME_") || strings.HasPrefix(key, "HAND_SUPERVISOR_") || strings.HasPrefix(key, "HAND_WORKER_") || strings.HasPrefix(key, "NO_MISTAKES_") {
+		return true
+	}
+	switch key {
+	case "HAND_HOME", "HAND_ROLE", "HAND_HARNESS", "HAND_PROJECT_ID", "HAND_ROUTING_SOURCE", "HAND_PROFILE", "HAND_MODEL", "HAND_EFFORT",
+		"HERDR_ENV", "HERDR_SESSION", "HERDR_SOCKET", "HERDR_SOCKET_PATH", "HERDR_CLIENT_SOCKET", "HERDR_SOCKET_OVERRIDE", "HERDR_WORKSPACE", "HERDR_TAB", "HERDR_PANE", "HERDR_WORKSPACE_ID", "HERDR_TAB_ID", "HERDR_PANE_ID",
+		"CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDECODE", "CODEX_THREAD_ID", "PI_CODING_AGENT", "PI_SESSION_ID", "GROK_AGENT", "GROK_SESSION_ID", "OPENCODE_SESSION_ID", "OPENAI_SESSION_ID":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/herdr/lifecycle.go
+++ b/internal/herdr/lifecycle.go
@@ -161,8 +161,7 @@ func (f *FleetHerdr) waitReady(ctx context.Context) error {
 		switch last.State {
 		case SessionRunningCompatible:
 			return nil
-		case SessionUnknown:
-			return sessionEnsureError(last, ErrSessionUnknown)
+		case SessionUnknown, SessionStopped:
 		case SessionIncompatible:
 			return sessionEnsureError(last, ErrSessionIncompatible)
 		}

--- a/internal/herdr/lifecycle_test.go
+++ b/internal/herdr/lifecycle_test.go
@@ -407,6 +407,59 @@ func TestFleetHerdrAttachUsesStructuredArgvAndScrubbedEnvironment(t *testing.T) 
 	}
 }
 
+func TestFleetHerdrObservationUsesScrubbedEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the shell fixture is POSIX-only")
+	}
+	root := t.TempDir()
+	observer := filepath.Join(root, "managed herdr observer")
+	envPath := filepath.Join(root, "env")
+	script := fmt.Sprintf("#!/bin/sh\nenv > %q\ncase \"$3\" in\nsession) printf '%%s\\n' '{\"sessions\":[{\"name\":\"hand-f_test\",\"running\":true}]}' ;;\nstatus) printf '%%s\\n' '{\"status\":\"running\",\"running\":true,\"compatible\":true,\"session\":\"hand-f_test\"}' ;;\nesac\n", envPath)
+	if err := os.WriteFile(observer, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClientAt(observer, []string{
+		"HAND_HOME=/stale/home",
+		"HAND_ROLE=worker",
+		"HAND_RUNTIME_ID=stale-runtime",
+		"HAND_RUNTIME_MODE=managed",
+		"HERDR_ENV=stale",
+		"HERDR_SESSION=wrong",
+		"HERDR_SOCKET_PATH=/stale/socket",
+		"HERDR_TEST_CREDENTIAL=keep",
+		"PATH=" + os.Getenv("PATH"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.session = "hand-f_test"
+
+	observation := client.ObserveSession(context.Background())
+	if observation.State != SessionRunningCompatible {
+		t.Fatalf("observation = %+v, want running-compatible", observation)
+	}
+
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := environmentMap(strings.Split(strings.TrimSpace(string(env)), "\n"))
+	for _, key := range []string{"HAND_HOME", "HAND_ROLE", "HAND_RUNTIME_ID", "HERDR_ENV", "HERDR_SESSION", "HERDR_SOCKET_PATH"} {
+		if _, found := values[key]; found {
+			t.Fatalf("observation environment retained %s: %q", key, env)
+		}
+	}
+	if got := values["HAND_RUNTIME_MODE"]; got != "managed" {
+		t.Fatalf("generic runtime variable = %q, want managed", got)
+	}
+	if got := values["HERDR_TEST_CREDENTIAL"]; got != "keep" {
+		t.Fatalf("observation credential = %q, want keep", got)
+	}
+	if got := values["PATH"]; got != os.Getenv("PATH") {
+		t.Fatalf("PATH = %q, want %q", got, os.Getenv("PATH"))
+	}
+}
+
 func waitForTestFile(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/internal/herdr/lifecycle_test.go
+++ b/internal/herdr/lifecycle_test.go
@@ -238,6 +238,7 @@ func TestDaemonEnvironmentStripsSemanticIdentityAndPreservesCredentials(t *testi
 		"HAND_BRIDGE_ID=bridge-1",
 		"HAND_ROUTING_MARKER=route-1",
 		"HAND_RUNTIME_ID=runtime-1",
+		"HAND_RUNTIME_MODE=managed",
 		"HAND_SUPERVISOR_ID=supervisor-1",
 		"CLAUDECODE=1",
 		"CLAUDE_CODE_CHILD_SESSION=child",
@@ -265,6 +266,9 @@ func TestDaemonEnvironmentStripsSemanticIdentityAndPreservesCredentials(t *testi
 	}
 	if got := values["HERDR_TEST_CREDENTIAL"]; got != "keep" {
 		t.Fatalf("credential = %q, want keep", got)
+	}
+	if got := values["HAND_RUNTIME_MODE"]; got != "managed" {
+		t.Fatalf("generic runtime variable = %q, want managed", got)
 	}
 	if got := values["PATH"]; got != "/usr/bin" {
 		t.Fatalf("PATH = %q, want /usr/bin", got)

--- a/internal/herdr/lifecycle_test.go
+++ b/internal/herdr/lifecycle_test.go
@@ -27,6 +27,11 @@ func testFleetHerdr(observe func(context.Context) SessionObservation, start func
 	}
 }
 
+func setFleetHerdrHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("SECONDHAND_HOME", t.TempDir())
+}
+
 func TestFleetHerdrEnsureReadyDoesNotStart(t *testing.T) {
 	var starts atomic.Int32
 	h := testFleetHerdr(func(context.Context) SessionObservation {
@@ -45,6 +50,7 @@ func TestFleetHerdrEnsureReadyDoesNotStart(t *testing.T) {
 }
 
 func TestFleetHerdrEnsureStartsOnlyAfterStoppedReobserve(t *testing.T) {
+	setFleetHerdrHome(t)
 	var observations atomic.Int32
 	var starts atomic.Int32
 	h := testFleetHerdr(func(context.Context) SessionObservation {
@@ -138,6 +144,7 @@ func TestFleetHerdrEnsureConvergesConcurrentCallers(t *testing.T) {
 }
 
 func TestFleetHerdrEnsureRetriesAfterDetachedStartReceiptLoss(t *testing.T) {
+	setFleetHerdrHome(t)
 	var running atomic.Bool
 	var starts atomic.Int32
 	receiptErr := errors.New("detached start receipt lost")
@@ -164,6 +171,7 @@ func TestFleetHerdrEnsureRetriesAfterDetachedStartReceiptLoss(t *testing.T) {
 }
 
 func TestFleetHerdrEnsureTimeoutDoesNotKillOrRestart(t *testing.T) {
+	setFleetHerdrHome(t)
 	var starts atomic.Int32
 	h := testFleetHerdr(func(context.Context) SessionObservation {
 		return SessionObservation{Name: "hand-f_test", State: SessionStopped}
@@ -183,6 +191,7 @@ func TestFleetHerdrEnsureTimeoutDoesNotKillOrRestart(t *testing.T) {
 }
 
 func TestFleetHerdrOpenEnsuresBeforeAttach(t *testing.T) {
+	setFleetHerdrHome(t)
 	var order []string
 	var mu sync.Mutex
 	appendOrder := func(value string) {

--- a/internal/herdr/lifecycle_test.go
+++ b/internal/herdr/lifecycle_test.go
@@ -74,6 +74,28 @@ func TestFleetHerdrEnsureStartsOnlyAfterStoppedReobserve(t *testing.T) {
 	}
 }
 
+func TestFleetHerdrEnsureRetriesTransientUnknownAfterStart(t *testing.T) {
+	setFleetHerdrHome(t)
+	var observations atomic.Int32
+	h := testFleetHerdr(func(context.Context) SessionObservation {
+		switch observations.Add(1) {
+		case 1, 2:
+			return SessionObservation{Name: "hand-f_test", State: SessionStopped}
+		case 3:
+			return SessionObservation{Name: "hand-f_test", State: SessionUnknown, Reason: "daemon socket not ready"}
+		default:
+			return SessionObservation{Name: "hand-f_test", State: SessionRunningCompatible}
+		}
+	}, func(context.Context) error { return nil }, nil)
+
+	if err := h.Ensure(context.Background()); err != nil {
+		t.Fatalf("Ensure() = %v, want readiness after transient unknown observation", err)
+	}
+	if got := observations.Load(); got != 4 {
+		t.Fatalf("observations = %d, want initial, post-lock, transient unknown, and ready", got)
+	}
+}
+
 func TestFleetHerdrEnsureFailsClosedForUnknownAndIncompatible(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/herdr/lifecycle_test.go
+++ b/internal/herdr/lifecycle_test.go
@@ -1,0 +1,418 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testFleetHerdr(observe func(context.Context) SessionObservation, start func(context.Context) error, attach func(context.Context) error) *FleetHerdr {
+	return &FleetHerdr{
+		fleetID:      "f_test",
+		session:      SessionName("f_test"),
+		observeFn:    observe,
+		startFn:      start,
+		attachFn:     attach,
+		startTimeout: 50 * time.Millisecond,
+		pollInterval: time.Millisecond,
+	}
+}
+
+func TestFleetHerdrEnsureReadyDoesNotStart(t *testing.T) {
+	var starts atomic.Int32
+	h := testFleetHerdr(func(context.Context) SessionObservation {
+		return SessionObservation{Name: "hand-f_test", State: SessionRunningCompatible}
+	}, func(context.Context) error {
+		starts.Add(1)
+		return nil
+	}, nil)
+
+	if err := h.Ensure(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("start calls = %d, want zero", got)
+	}
+}
+
+func TestFleetHerdrEnsureStartsOnlyAfterStoppedReobserve(t *testing.T) {
+	var observations atomic.Int32
+	var starts atomic.Int32
+	h := testFleetHerdr(func(context.Context) SessionObservation {
+		if observations.Add(1) <= 2 {
+			return SessionObservation{Name: "hand-f_test", State: SessionStopped}
+		}
+		return SessionObservation{Name: "hand-f_test", State: SessionRunningCompatible}
+	}, func(context.Context) error {
+		starts.Add(1)
+		return nil
+	}, nil)
+
+	if err := h.Ensure(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want one", got)
+	}
+	if got := observations.Load(); got != 3 {
+		t.Fatalf("observations = %d, want initial, post-lock, and post-start readiness", got)
+	}
+}
+
+func TestFleetHerdrEnsureFailsClosedForUnknownAndIncompatible(t *testing.T) {
+	tests := []struct {
+		name  string
+		state SessionState
+		want  error
+	}{
+		{name: "unknown", state: SessionUnknown, want: ErrSessionUnknown},
+		{name: "incompatible", state: SessionIncompatible, want: ErrSessionIncompatible},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var starts atomic.Int32
+			h := testFleetHerdr(func(context.Context) SessionObservation {
+				return SessionObservation{Name: "hand-f_test", State: tt.state, Reason: tt.name}
+			}, func(context.Context) error {
+				starts.Add(1)
+				return nil
+			}, nil)
+
+			err := h.Ensure(context.Background())
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Ensure() = %v, want %v", err, tt.want)
+			}
+			if got := starts.Load(); got != 0 {
+				t.Fatalf("start calls = %d, want zero", got)
+			}
+		})
+	}
+}
+
+func TestFleetHerdrEnsureConvergesConcurrentCallers(t *testing.T) {
+	t.Setenv("SECONDHAND_HOME", filepath.Join(t.TempDir(), "Secondhand 測試"))
+	var running atomic.Bool
+	var starts atomic.Int32
+	observe := func(context.Context) SessionObservation {
+		if running.Load() {
+			return SessionObservation{Name: "hand-f_test", State: SessionRunningCompatible}
+		}
+		return SessionObservation{Name: "hand-f_test", State: SessionStopped}
+	}
+	start := func(context.Context) error {
+		starts.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		running.Store(true)
+		return nil
+	}
+
+	const callers = 12
+	results := make(chan error, callers)
+	var group sync.WaitGroup
+	for range callers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			results <- testFleetHerdr(observe, start, nil).Ensure(context.Background())
+		}()
+	}
+	group.Wait()
+	close(results)
+	for err := range results {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want one", got)
+	}
+}
+
+func TestFleetHerdrEnsureRetriesAfterDetachedStartReceiptLoss(t *testing.T) {
+	var running atomic.Bool
+	var starts atomic.Int32
+	receiptErr := errors.New("detached start receipt lost")
+	h := testFleetHerdr(func(context.Context) SessionObservation {
+		if running.Load() {
+			return SessionObservation{Name: "hand-f_test", State: SessionRunningCompatible}
+		}
+		return SessionObservation{Name: "hand-f_test", State: SessionStopped}
+	}, func(context.Context) error {
+		starts.Add(1)
+		running.Store(true)
+		return receiptErr
+	}, nil)
+
+	if err := h.Ensure(context.Background()); !errors.Is(err, receiptErr) {
+		t.Fatalf("first Ensure() = %v, want receipt error", err)
+	}
+	if err := h.Ensure(context.Background()); err != nil {
+		t.Fatalf("retry Ensure() = %v, want exact ready observation", err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want one", got)
+	}
+}
+
+func TestFleetHerdrEnsureTimeoutDoesNotKillOrRestart(t *testing.T) {
+	var starts atomic.Int32
+	h := testFleetHerdr(func(context.Context) SessionObservation {
+		return SessionObservation{Name: "hand-f_test", State: SessionStopped}
+	}, func(context.Context) error {
+		starts.Add(1)
+		return nil
+	}, nil)
+	h.startTimeout = 10 * time.Millisecond
+
+	err := h.Ensure(context.Background())
+	if !errors.Is(err, ErrEnsureTimeout) {
+		t.Fatalf("Ensure() = %v, want timeout", err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want one without blind restart", got)
+	}
+}
+
+func TestFleetHerdrOpenEnsuresBeforeAttach(t *testing.T) {
+	var order []string
+	var mu sync.Mutex
+	appendOrder := func(value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, value)
+	}
+	var observations atomic.Int32
+	h := testFleetHerdr(func(context.Context) SessionObservation {
+		appendOrder("observe")
+		if observations.Add(1) <= 2 {
+			return SessionObservation{Name: "hand-f_test", State: SessionStopped}
+		}
+		return SessionObservation{Name: "hand-f_test", State: SessionRunningCompatible}
+	}, func(context.Context) error {
+		appendOrder("start")
+		return nil
+	}, func(context.Context) error {
+		appendOrder("attach")
+		return nil
+	})
+
+	if err := h.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(order, ","), "observe,observe,start,observe,attach"; got != want {
+		t.Fatalf("operation order = %q, want %q", got, want)
+	}
+}
+
+func TestDaemonEnvironmentStripsSemanticIdentityAndPreservesCredentials(t *testing.T) {
+	parent := []string{
+		"HAND_HOME=/stale/home",
+		"HAND_ROLE=worker",
+		"HAND_TASK_ID=task-1",
+		"HAND_ATTEMPT_ID=7",
+		"HAND_REPORT_PATH=/stale/report",
+		"HERDR_ENV=worker",
+		"HERDR_SESSION=default",
+		"HERDR_SOCKET_PATH=/stale/socket",
+		"HERDR_WORKSPACE_ID=w1",
+		"HERDR_TAB_ID=t1",
+		"HERDR_PANE_ID=p1",
+		"HAND_BRIDGE_ID=bridge-1",
+		"HAND_ROUTING_MARKER=route-1",
+		"HAND_RUNTIME_ID=runtime-1",
+		"HAND_SUPERVISOR_ID=supervisor-1",
+		"CLAUDECODE=1",
+		"CLAUDE_CODE_CHILD_SESSION=child",
+		"CLAUDE_CODE_SESSION_ID=session",
+		"CODEX_THREAD_ID=thread",
+		"PI_CODING_AGENT=true",
+		"GROK_AGENT=true",
+		"OPENCODE_SESSION_ID=session",
+		"NO_MISTAKES_RUN_ID=run-1",
+		"HERDR_TEST_CREDENTIAL=keep",
+		"PATH=/usr/bin",
+	}
+
+	values := environmentMap(daemonEnvironment(parent))
+	for _, key := range []string{
+		"HAND_HOME", "HAND_ROLE", "HAND_TASK_ID", "HAND_ATTEMPT_ID", "HAND_REPORT_PATH",
+		"HERDR_ENV", "HERDR_SESSION", "HERDR_SOCKET_PATH", "HERDR_WORKSPACE_ID", "HERDR_TAB_ID", "HERDR_PANE_ID",
+		"HAND_BRIDGE_ID", "HAND_ROUTING_MARKER", "HAND_RUNTIME_ID", "HAND_SUPERVISOR_ID",
+		"CLAUDECODE", "CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CODEX_THREAD_ID", "PI_CODING_AGENT", "GROK_AGENT",
+		"OPENCODE_SESSION_ID", "NO_MISTAKES_RUN_ID",
+	} {
+		if _, found := values[key]; found {
+			t.Fatalf("daemon environment retained %s", key)
+		}
+	}
+	if got := values["HERDR_TEST_CREDENTIAL"]; got != "keep" {
+		t.Fatalf("credential = %q, want keep", got)
+	}
+	if got := values["PATH"]; got != "/usr/bin" {
+		t.Fatalf("PATH = %q, want /usr/bin", got)
+	}
+}
+
+func TestFleetHerdrServerParentHelper(t *testing.T) {
+	if os.Getenv("HERDR_TEST_PARENT_HELPER") != "1" {
+		return
+	}
+	client, err := NewClientAt(os.Getenv("HERDR_TEST_SERVER_EXECUTABLE"), []string{
+		"HAND_HOME=/stale/home",
+		"HAND_ROLE=worker",
+		"HERDR_ENV=stale",
+		"HERDR_SESSION=wrong",
+		"HERDR_SOCKET_PATH=/stale/socket",
+		"CODEX_THREAD_ID=stale-thread",
+		"HERDR_TEST_CREDENTIAL=keep",
+		"PATH=" + os.Getenv("PATH"),
+		"HERDR_TEST_ARGS=" + os.Getenv("HERDR_TEST_ARGS"),
+		"HERDR_TEST_ENV=" + os.Getenv("HERDR_TEST_ENV"),
+		"HERDR_TEST_READY=" + os.Getenv("HERDR_TEST_READY"),
+		"HERDR_TEST_SURVIVED=" + os.Getenv("HERDR_TEST_SURVIVED"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.session = "hand-f_test"
+	if err := client.startServer(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFleetHerdrServerStartUsesStructuredArgvAndSurvivesParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the detached shell fixture is POSIX-only; Windows uses the native helper")
+	}
+	root := t.TempDir()
+	server := filepath.Join(root, "managed herdr server")
+	argsPath := filepath.Join(root, "args")
+	envPath := filepath.Join(root, "env")
+	readyPath := filepath.Join(root, "ready")
+	survivedPath := filepath.Join(root, "survived")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nenv > %q\n: > %q\nsleep 0.25\n: > %q\n", argsPath, envPath, readyPath, survivedPath)
+	if err := os.WriteFile(server, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=^TestFleetHerdrServerParentHelper$")
+	command.Env = append(os.Environ(),
+		"HERDR_TEST_PARENT_HELPER=1",
+		"HERDR_TEST_SERVER_EXECUTABLE="+server,
+		"HERDR_TEST_ARGS="+argsPath,
+		"HERDR_TEST_ENV="+envPath,
+		"HERDR_TEST_READY="+readyPath,
+		"HERDR_TEST_SURVIVED="+survivedPath,
+	)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitForTestFile(t, readyPath)
+	if err := command.Wait(); err != nil {
+		t.Fatalf("parent helper: %v", err)
+	}
+	waitForTestFile(t, survivedPath)
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Fields(string(args)), []string{"--session", "hand-f_test", "server"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("server argv = %q, want %q", got, want)
+	}
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := environmentMap(strings.Split(strings.TrimSpace(string(env)), "\n"))
+	for _, key := range []string{"HAND_HOME", "HAND_ROLE", "HERDR_ENV", "HERDR_SESSION", "HERDR_SOCKET_PATH", "CODEX_THREAD_ID"} {
+		if _, found := values[key]; found {
+			t.Fatalf("server environment retained %s: %q", key, env)
+		}
+	}
+	if got := values["HERDR_TEST_CREDENTIAL"]; got != "keep" {
+		t.Fatalf("server credential = %q, want keep", got)
+	}
+}
+
+func TestFleetHerdrAttachUsesStructuredArgvAndScrubbedEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the shell fixture is POSIX-only")
+	}
+	root := t.TempDir()
+	attach := filepath.Join(root, "managed herdr attach")
+	argsPath := filepath.Join(root, "args")
+	envPath := filepath.Join(root, "env")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nenv > %q\n", argsPath, envPath)
+	if err := os.WriteFile(attach, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClientAt(attach, []string{
+		"HAND_HOME=/stale/home",
+		"HAND_ROLE=worker",
+		"HERDR_SESSION=wrong",
+		"CODEX_THREAD_ID=stale-thread",
+		"HERDR_TEST_CREDENTIAL=keep",
+		"PATH=" + os.Getenv("PATH"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.session = "hand-f_test"
+	if err := client.attach(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Fields(string(args)), []string{"session", "attach", "hand-f_test"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("attach argv = %q, want %q", got, want)
+	}
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := environmentMap(strings.Split(strings.TrimSpace(string(env)), "\n"))
+	for _, key := range []string{"HAND_HOME", "HAND_ROLE", "HERDR_SESSION", "CODEX_THREAD_ID"} {
+		if _, found := values[key]; found {
+			t.Fatalf("attach environment retained %s: %q", key, env)
+		}
+	}
+	if got := values["HERDR_TEST_CREDENTIAL"]; got != "keep" {
+		t.Fatalf("attach credential = %q, want keep", got)
+	}
+}
+
+func waitForTestFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func environmentMap(entries []string) map[string]string {
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	return values
+}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -47,6 +47,7 @@ type dependencies struct {
 	now               func() time.Time
 	herdr             func() herdrClient
 	herdrFor          func(string) herdrClient
+	ensureHerdr       func(context.Context, string) error
 	worktree          worktreeDependencies
 	projectBaseCommit func(string) (string, error)
 	buildHarness      func(string, harness.Options) (launch.LaunchSpec, error)
@@ -70,6 +71,7 @@ func defaultDependencies() dependencies {
 	return dependencies{
 		now:               func() time.Time { return time.Now().UTC() },
 		herdr:             newHerdrClient,
+		ensureHerdr:       func(ctx context.Context, fleetID string) error { return herdr.NewFleetHerdr(fleetID).Ensure(ctx) },
 		worktree:          worktreeDependencies{get: worktree.Get, observeLease: worktree.ObserveLease, observeClean: worktree.ObserveCleanliness, observeCommits: worktree.ObserveCommitSafety, headCommit: worktree.HeadCommit, returnWorktree: worktree.Return, returnWithID: worktree.ReturnLease, checkCollision: worktree.CheckCollision},
 		projectBaseCommit: projectBaseCommit,
 		buildHarness:      harness.Build,
@@ -103,14 +105,21 @@ func (r *Runtime) provision(ctx context.Context, req provisioningRequest) (strin
 }
 
 func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) (string, error) {
-	_ = ctx
-	lease := worktree.Lease{Path: req.attempt.Worktree, ID: req.attempt.LeaseID}
-	var err error
-	if lease.Path == "" {
-		fleetID, err := state.FleetID(req.home)
-		if err != nil {
-			return "", fmt.Errorf("read Fleet identity for Treehouse lease holder: %w", err)
+	fleetID, err := state.FleetIDReadOnly(req.home)
+	if err != nil {
+		return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
+	}
+	session := req.attempt.Herdr.Session
+	if session == "" {
+		session = herdr.SessionName(fleetID)
+	}
+	if session == herdr.SessionName(fleetID) && r.deps.ensureHerdr != nil {
+		if err := r.deps.ensureHerdr(ctx, fleetID); err != nil {
+			return "", fmt.Errorf("ensure Fleet Herdr session: %w", err)
 		}
+	}
+	lease := worktree.Lease{Path: req.attempt.Worktree, ID: req.attempt.LeaseID}
+	if lease.Path == "" {
 		lease, err = r.deps.worktree.get(req.clonePath, "hand:"+fleetID+":"+req.attempt.TaskID)
 		if err != nil {
 			return "", fmt.Errorf("acquire treehouse worktree: %w", err)
@@ -176,14 +185,6 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		return "", r.failProvision(req, lease, nil, false, err)
 	}
 
-	session := req.attempt.Herdr.Session
-	if session == "" {
-		fleetID, err := state.FleetID(req.home)
-		if err != nil {
-			return "", r.failProvision(req, lease, nil, false, fmt.Errorf("read Fleet identity for Herdr session: %w", err))
-		}
-		session = herdr.SessionName(fleetID)
-	}
 	client := r.herdrClient(session)
 	workerSpec, err = composeWorkerSpec(workerSpec, req.home, herdrWorkerEnvironment(client))
 	if err != nil {

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -105,15 +105,20 @@ func (r *Runtime) provision(ctx context.Context, req provisioningRequest) (strin
 }
 
 func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) (string, error) {
-	fleetID, err := state.FleetIDReadOnly(req.home)
-	if err != nil {
-		return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
-	}
 	session := req.attempt.Herdr.Session
+	fleetID := ""
+	var err error
+	needsFleetIdentity := session == "" || req.attempt.Worktree == ""
+	if needsFleetIdentity {
+		fleetID, err = state.FleetIDReadOnly(req.home)
+		if err != nil {
+			return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
+		}
+	}
 	if session == "" {
 		session = herdr.SessionName(fleetID)
 	}
-	if session == herdr.SessionName(fleetID) && r.deps.ensureHerdr != nil {
+	if fleetID != "" && session == herdr.SessionName(fleetID) && r.deps.ensureHerdr != nil {
 		if err := r.deps.ensureHerdr(ctx, fleetID); err != nil {
 			return "", fmt.Errorf("ensure Fleet Herdr session: %w", err)
 		}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -114,6 +114,9 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		if err != nil {
 			return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
 		}
+		if req.attempt.Worktree == "" && session != "" && session != herdr.SessionName(fleetID) {
+			return "", fmt.Errorf("Herdr session %q does not match Fleet identity %q", session, fleetID)
+		}
 	}
 	if session == "" {
 		session = herdr.SessionName(fleetID)

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -110,7 +110,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	fleetID := ""
 	var err error
 	fleetID, err = state.FleetIDReadOnly(req.home)
-	if err != nil && !(req.attempt.Worktree != "" && session != "" && errors.Is(err, state.ErrFleetIdentityMissing)) {
+	if err != nil && (req.attempt.Worktree == "" || session == "" || !errors.Is(err, state.ErrFleetIdentityMissing)) {
 		return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
 	}
 	if fleetID != "" && session != "" && session != herdr.SessionName(fleetID) {

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -115,7 +115,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 			return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
 		}
 		if req.attempt.Worktree == "" && session != "" && session != herdr.SessionName(fleetID) {
-			return "", fmt.Errorf("Herdr session %q does not match Fleet identity %q", session, fleetID)
+			return "", fmt.Errorf("herdr session %q does not match Fleet identity %q", session, fleetID)
 		}
 	}
 	if session == "" {

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -108,15 +109,12 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	session := req.attempt.Herdr.Session
 	fleetID := ""
 	var err error
-	needsFleetIdentity := session == "" || req.attempt.Worktree == ""
-	if needsFleetIdentity {
-		fleetID, err = state.FleetIDReadOnly(req.home)
-		if err != nil {
-			return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
-		}
-		if req.attempt.Worktree == "" && session != "" && session != herdr.SessionName(fleetID) {
-			return "", fmt.Errorf("herdr session %q does not match Fleet identity %q", session, fleetID)
-		}
+	fleetID, err = state.FleetIDReadOnly(req.home)
+	if err != nil && !(req.attempt.Worktree != "" && session != "" && errors.Is(err, state.ErrFleetIdentityMissing)) {
+		return "", fmt.Errorf("read Fleet identity for Herdr session: %w", err)
+	}
+	if fleetID != "" && session != "" && session != herdr.SessionName(fleetID) {
+		return "", fmt.Errorf("herdr session %q does not match Fleet identity %q", session, fleetID)
 	}
 	if session == "" {
 		session = herdr.SessionName(fleetID)

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -150,11 +150,33 @@ func TestProvisionRejectsMismatchedSessionForFreshWorktree(t *testing.T) {
 	}
 }
 
-func TestProvisionPreservesLegacySessionWithoutFleetIdentity(t *testing.T) {
+func TestProvisionRejectsMismatchedSessionForResumedWorktree(t *testing.T) {
 	home, attempt := provisioningFixture(t)
-	attempt.Herdr.Session = "default"
+	attempt.Herdr.Session = "hand-old"
 	attempt.Worktree = filepath.Join(home, "projects", "demo")
 	attempt.LeaseID = "lease-1"
+	fake := &provisionHerdr{}
+	r := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
+
+	_, err := r.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt, resumeExisting: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match Fleet identity") {
+		t.Fatalf("provision() = %v, want mismatched Fleet session error", err)
+	}
+	if fake.createdWorkspace {
+		t.Fatal("provision() created a Herdr workspace after session mismatch")
+	}
+}
+
+func TestProvisionPreservesLegacySessionWithoutFleetIdentity(t *testing.T) {
+	home := t.TempDir()
+	attempt := state.Attempt{
+		ID: 1, TaskID: "task-1", Lifecycle: state.AttemptProvisioning,
+		Worktree: filepath.Join(home, "projects", "demo"), LeaseID: "lease-1",
+		Herdr: state.Herdr{Session: "default"},
+	}
 	phaseErr := errors.New("stop after legacy worktree observation")
 	r := testProvisionRuntime(&provisionHerdr{}, func(phase lifecyclePhase) error {
 		if phase == phaseWorktreeRecorded {
@@ -163,7 +185,7 @@ func TestProvisionPreservesLegacySessionWithoutFleetIdentity(t *testing.T) {
 		return nil
 	})
 
-	_, err := r.provision(context.Background(), provisioningRequest{
+	_, err := r.provisionLocked(context.Background(), provisioningRequest{
 		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
 		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt, resumeExisting: true,
 	})

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -97,6 +97,36 @@ func TestProvisionUsesFleetScopedTreehouseLeaseHolder(t *testing.T) {
 	}
 }
 
+func TestProvisionEnsuresFleetHerdrBeforeTreehouseAcquisition(t *testing.T) {
+	home, attempt := provisioningFixture(t)
+	fake := &provisionHerdr{}
+	r := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
+	var events []string
+	r.deps.ensureHerdr = func(_ context.Context, fleetID string) error {
+		events = append(events, "ensure:"+fleetID)
+		return nil
+	}
+	r.deps.worktree.get = func(path, _ string) (worktree.Lease, error) {
+		events = append(events, "treehouse")
+		return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
+	}
+
+	if _, err := r.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := state.FleetID(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"ensure:" + fleetID, "treehouse"}
+	if strings.Join(events, ",") != strings.Join(want, ",") {
+		t.Fatalf("provisioning events = %q, want %q", events, want)
+	}
+}
+
 func TestProvisionResumeRefusesChangedLeaseBeforeHerdrCreation(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	attempt.Worktree = "/tmp/hand-wt"

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -127,6 +127,29 @@ func TestProvisionEnsuresFleetHerdrBeforeTreehouseAcquisition(t *testing.T) {
 	}
 }
 
+func TestProvisionRejectsMismatchedSessionForFreshWorktree(t *testing.T) {
+	home, attempt := provisioningFixture(t)
+	attempt.Herdr.Session = "hand-old"
+	fake := &provisionHerdr{}
+	r := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
+	acquired := false
+	r.deps.worktree.get = func(string, string) (worktree.Lease, error) {
+		acquired = true
+		return worktree.Lease{Path: filepath.Join(home, "projects", "demo", "leased"), ID: "lease-1"}, nil
+	}
+
+	_, err := r.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt,
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match Fleet identity") {
+		t.Fatalf("provision() = %v, want mismatched Fleet session error", err)
+	}
+	if acquired || fake.createdWorkspace {
+		t.Fatal("provision() acquired a worktree or created a Herdr workspace after session mismatch")
+	}
+}
+
 func TestProvisionPreservesLegacySessionWithoutFleetIdentity(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	attempt.Herdr.Session = "default"

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -129,9 +129,6 @@ func TestProvisionEnsuresFleetHerdrBeforeTreehouseAcquisition(t *testing.T) {
 
 func TestProvisionPreservesLegacySessionWithoutFleetIdentity(t *testing.T) {
 	home, attempt := provisioningFixture(t)
-	if err := os.Remove(filepath.Join(home, "state", "hand.db")); err != nil {
-		t.Fatal(err)
-	}
 	attempt.Herdr.Session = "default"
 	attempt.Worktree = filepath.Join(home, "projects", "demo")
 	attempt.LeaseID = "lease-1"

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -127,6 +127,31 @@ func TestProvisionEnsuresFleetHerdrBeforeTreehouseAcquisition(t *testing.T) {
 	}
 }
 
+func TestProvisionPreservesLegacySessionWithoutFleetIdentity(t *testing.T) {
+	home, attempt := provisioningFixture(t)
+	if err := os.Remove(filepath.Join(home, "state", "hand.db")); err != nil {
+		t.Fatal(err)
+	}
+	attempt.Herdr.Session = "default"
+	attempt.Worktree = filepath.Join(home, "projects", "demo")
+	attempt.LeaseID = "lease-1"
+	phaseErr := errors.New("stop after legacy worktree observation")
+	r := testProvisionRuntime(&provisionHerdr{}, func(phase lifecyclePhase) error {
+		if phase == phaseWorktreeRecorded {
+			return phaseErr
+		}
+		return nil
+	})
+
+	_, err := r.provision(context.Background(), provisioningRequest{
+		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
+		briefPath: filepath.Join(home, "data", "task-1", "brief.md"), attempt: attempt, resumeExisting: true,
+	})
+	if !errors.Is(err, phaseErr) {
+		t.Fatalf("provision() = %v, want %v", err, phaseErr)
+	}
+}
+
 func TestProvisionResumeRefusesChangedLeaseBeforeHerdrCreation(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	attempt.Worktree = "/tmp/hand-wt"

--- a/internal/selfupdate/adopt_test.go
+++ b/internal/selfupdate/adopt_test.go
@@ -38,10 +38,11 @@ func TestAdoptInstallsAnExactDirectBuildIntoAnEmptyTarget(t *testing.T) {
 }
 
 func TestAdoptReusesAnExactDirectBuild(t *testing.T) {
+	goPath := isolateHandPath(t)
 	want := BuildInfo{Version: "1.2.3", Channel: ChannelStable, Commit: stableTestCommit, Distribution: DistributionGitHub}
-	source := writeIdentityExecutable(t, want, "new-source")
+	source := writeIdentityExecutable(t, want, "new-source", goPath)
 	target := testHandPath(t.TempDir())
-	writeIdentityExecutableAt(t, target, want, "existing-target")
+	writeIdentityExecutableAt(t, target, want, "existing-target", goPath)
 	before, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatal(err)
@@ -64,10 +65,11 @@ func TestAdoptReusesAnExactDirectBuild(t *testing.T) {
 }
 
 func TestAdoptRefusesPackageOwnedBuildBeforeMutation(t *testing.T) {
+	goPath := isolateHandPath(t)
 	want := BuildInfo{Version: "1.2.3", Channel: ChannelStable, Commit: stableTestCommit, Distribution: DistributionGitHub}
-	source := writeIdentityExecutable(t, want, "source")
+	source := writeIdentityExecutable(t, want, "source", goPath)
 	target := testHandPath(t.TempDir())
-	writeIdentityExecutableAt(t, target, BuildInfo{Version: "1.0.0", Channel: ChannelStable, Commit: "package", Distribution: DistributionBrew}, "package")
+	writeIdentityExecutableAt(t, target, BuildInfo{Version: "1.0.0", Channel: ChannelStable, Commit: "package", Distribution: DistributionBrew}, "package", goPath)
 
 	_, err := Adopt(context.Background(), source, target, want)
 	if err == nil || !strings.Contains(err.Error(), "brew") {
@@ -106,10 +108,11 @@ func TestAdoptRefusesAStagedIdentityMismatchBeforeMutation(t *testing.T) {
 }
 
 func TestAdoptRefusesANewerDirectBuild(t *testing.T) {
+	goPath := isolateHandPath(t)
 	want := BuildInfo{Version: "1.2.3", Channel: ChannelStable, Commit: stableTestCommit, Distribution: DistributionGitHub}
-	source := writeIdentityExecutable(t, want, "source")
+	source := writeIdentityExecutable(t, want, "source", goPath)
 	target := testHandPath(t.TempDir())
-	writeIdentityExecutableAt(t, target, BuildInfo{Version: "1.3.0", Channel: ChannelStable, Commit: stableTestCommit, Distribution: DistributionGitHub}, "newer")
+	writeIdentityExecutableAt(t, target, BuildInfo{Version: "1.3.0", Channel: ChannelStable, Commit: stableTestCommit, Distribution: DistributionGitHub}, "newer", goPath)
 
 	_, err := Adopt(context.Background(), source, target, want)
 	if err == nil || !strings.Contains(err.Error(), "downgrade") {
@@ -176,6 +179,20 @@ func writeIdentityExecutable(t *testing.T, info BuildInfo, marker string, goPath
 	}
 	writeIdentityExecutableAt(t, path, info, marker, goPath...)
 	return path
+}
+
+func isolateHandPath(t *testing.T) string {
+	t.Helper()
+	goPath := ""
+	if runtime.GOOS == "windows" {
+		var err error
+		goPath, err = exec.LookPath("go")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", t.TempDir())
+	return goPath
 }
 
 func writeIdentityExecutableAt(t *testing.T, path string, info BuildInfo, marker string, goPath ...string) {

--- a/internal/selfupdate/adopt_unix_test.go
+++ b/internal/selfupdate/adopt_unix_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdoptPreservesDirectInstallWhenHardLinksAreUnavailable(t *testing.T) {
+	isolateHandPath(t)
 	want := BuildInfo{Version: "1.2.3", Channel: ChannelStable, Commit: stableTestCommit, Distribution: DistributionGitHub}
 	source := writeIdentityExecutable(t, want, "new-source")
 	target := testHandPath(t.TempDir())

--- a/tests/e2e/execution_class_test.go
+++ b/tests/e2e/execution_class_test.go
@@ -92,7 +92,7 @@ func TestMechanicalPlanRefusesWhenTreehouseAcquiresADifferentHead(t *testing.T) 
 	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") || !strings.Contains(log, "treehouse return") {
 		t.Fatalf("treehouse log = %q, want acquisition followed by safe return", log)
 	}
-	if log := readOptionalLog(t, herdrLog); log != "" {
+	if log := readOptionalLog(t, herdrLog); strings.Contains(log, " pane ") {
 		t.Fatalf("herdr log = %q, want no pane or launch activity", log)
 	}
 	if exists, err := state.Exists(home, "task-1"); err != nil || !exists {

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -74,7 +74,7 @@ func writeFakeDispatch(t *testing.T, dir, name, logPath, selector, caseBody stri
 	if logPath != "" {
 		script = fmt.Sprintf("echo \"%s $@\" >> %s\n", name, shellSingleQuote(logPath))
 	}
-	script += "if [ \"$1\" = \"--session\" ]; then shift 2; fi\n"
+	script += "session_name=\"$2\"\nif [ \"$1\" = \"--session\" ]; then shift 2; fi\n"
 	script += fmt.Sprintf("case \"%s\" in\n%s\n  *) echo \"unexpected %s invocation: $@\" >&2; exit 1 ;;\nesac\n",
 		selector, caseBody, name)
 	writeFakeBin(t, dir, name, script)

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -51,7 +51,9 @@ func TestPromoteScoutToShip(t *testing.T) {
   return) echo ok ;;`)
 	// The scout's old workspace holds a second tab, so releasing the scout is a
 	// tab close rather than closeTaskTab's sole-tab workspace-close shortcut.
-	writeFakeDispatch(t, dir, "herdr", invocationLog, "$1 $2", `  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
+	writeFakeDispatch(t, dir, "herdr", invocationLog, "$1 $2", `  "session list") printf '{"sessions":[{"name":"%s","running":true}]}\n' "$session_name" ;;
+  "status server") printf '{"status":"running","running":true,"compatible":true,"session":"%s"}\n' "$session_name" ;;
+  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
   "workspace create") echo '{"result":{"workspace":{"workspace_id":"ws-new","label":"demo","tab_count":1},"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"1"},"root_pane":{"pane_id":"pane-new","tab_id":"tab-new","workspace_id":"ws-new","agent_status":"working"}}}' ;;
   "tab rename") echo '{"result":{"tab":{"tab_id":"tab-new","workspace_id":"ws-new","label":"task-1"}}}' ;;
   "pane process-info") echo '{"result":{"process_info":{"pane_id":"pane-new","shell_pid":1,"foreground_processes":[{"pid":1,"name":"bash"},{"pid":2,"name":"claude","argv":["claude"]}]}}}' ;;


### PR DESCRIPTION
## Intent

Fix PR #386's four blocking review findings before merge: validate Fleet identity for resumed attempts with existing worktrees and reject stale or cross-Fleet Herdr sessions while preserving legacy resumed sessions only when no Fleet identity exists; retry transient SessionUnknown observations during waitReady until the existing start timeout; ignore post-start /dev/null close and process-release cleanup errors after the Herdr server has started; and classify ErrEnsureTimeout as a precondition failure with exit code 3. Keep the optional cleanup findings out of scope, push the validated branch, and stop at checks-passed without merging.

## What Changed

- Added Fleet-scoped Herdr lifecycle management with `hand fleet herdr` and read-only status commands.
- Validated Fleet and Herdr session identity during provisioning, preserved legacy sessions without Fleet identity, and handled transient startup observations and detached server cleanup.
- Classified Herdr session incompatibility and ensure timeouts as precondition failures.

## Risk Assessment

✅ Low: The changed lifecycle, Fleet identity validation, session handling, cleanup, exit classification, and supporting fakes are bounded and satisfy the stated source-level requirements.

## Testing

All targeted tests passed. No UI surface exists, so visual evidence was not applicable.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"30a3de90083d8a8268f7a302fe8c5127ad37f70b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Focused `go test` via `nix develop` for Herdr, runtime, and command packages.</code>
- `Verified Fleet session rejection, legacy resume compatibility, transient readiness retry, timeout classification, detached startup, and CLI operations.`
- `Verified clean worktree.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
