### PR TITLE
fix(runtime): use recorded PR after detached HEAD

### DIFF
--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -12,7 +12,7 @@ import (
 )
 
 func DetectPR(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation, error) {
-	observation := observePR(ctx, homeDir, active, projectInfo)
+	observation := observePR(ctx, homeDir, task.PR, active, projectInfo)
 	if !observation.Found() {
 		return task, observation, nil
 	}
@@ -30,13 +30,19 @@ func DetectPR(ctx context.Context, homeDir string, task state.Task, active state
 // DetectPR: a rendering caller must never receive a task shaped as though the durable record already
 // carried a value only this observation found (ADR attention-is-one-derivation..., invariant 1).
 func DetectPRReadOnly(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
-	return observePR(ctx, homeDir, active, projectInfo)
+	return observePR(ctx, homeDir, "", active, projectInfo)
 }
 
-// Live worktree state wins when it is determinable, since it is more current than what attempt
-// creation recorded; the durably stored branch is the fallback, since a detached or torn-down
-// worktree cannot answer at all - not evidence that no branch, and so no PR, ever existed.
-func observePR(ctx context.Context, homeDir string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
+// A recorded PR is stronger than branch-based re-detection: it was already validated and survives
+// a detached or torn-down worktree. Read-only callers without the task record pass an empty PR.
+func observePR(ctx context.Context, homeDir, recordedPR string, active state.Attempt, projectInfo project.Project) ghutil.PRObservation {
+	if recordedPR != "" {
+		return ghutil.PRObservation{State: ghutil.ObservationFound, URL: recordedPR}
+	}
+
+	// Live worktree state wins when it is determinable, since it is more current than what attempt
+	// creation recorded; the durably stored branch is the fallback, since a detached or torn-down
+	// worktree cannot answer at all - not evidence that no branch, and so no PR, ever existed.
 	branch, liveErr := currentBranch(active.Worktree)
 	if liveErr != nil {
 		branch = active.Branch

--- a/internal/runtime/pr_test.go
+++ b/internal/runtime/pr_test.go
@@ -55,6 +55,23 @@ func TestObservePRFindsAMergedPRByTheDurablyStoredBranchAfterDetachedHead(t *tes
 	}
 }
 
+func TestDetectPRUsesTheRecordedPRAfterDetachedHead(t *testing.T) {
+	worktreePath := detachedHeadWorktreeFixture(t, "topic")
+	pr := "https://github.com/atqamz/detach-fixture/pull/9"
+	active := state.Attempt{Worktree: worktreePath}
+
+	detected, observation, err := DetectPR(context.Background(), t.TempDir(), state.Task{ID: "task-1", PR: pr}, active, project.Project{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !observation.Found() || observation.URL != pr {
+		t.Fatalf("observation = %+v, want recorded PR %s", observation, pr)
+	}
+	if detected.PR != pr {
+		t.Fatalf("detected task PR = %q, want %q", detected.PR, pr)
+	}
+}
+
 func TestObservePRReportsUnknownNotAbsentOnDetachedHeadWithNoBranchHistory(t *testing.T) {
 	home := t.TempDir()
 	worktreePath := detachedHeadWorktreeFixture(t, "topic")


### PR DESCRIPTION
## Summary

- Use the task's recorded PR before branch lookup when detecting PRs after a detached HEAD.
- Preserve the live-HEAD and durable-branch fallback chain when no PR is recorded.

Fixes atqamz/hand#377

## Test plan

- `make build` passed via `nix develop -c make build`.
- `make test` passed via `nix develop -c make test`.
- `make lint` passed via `nix develop -c make lint`.
