### PR TITLE
docs(orientation): correct session vocabulary

### DIFF
--- a/docs/adr/stateless-supervisor-orientation-and-opaque-currentness.md
+++ b/docs/adr/stateless-supervisor-orientation-and-opaque-currentness.md
@@ -21,6 +21,10 @@ Callers may carry, compare, return, or reject them, but never parse or construct
 The bounded arm reports `rearmed` or `degraded`; only a lock-proven live watcher reports `already-armed`.
 The command never creates a supervisor-session row and never acknowledges or mutates work.
 
+### Amendment - 2026-08-25
+
+The implementation now separates runtime bootstrap from orientation. `hand session start` performs the one-time bootstrap, emits `next_command: hand orient`, and does not derive orientation or arm a watcher. `hand orient` exclusively reads and records the bounded orientation; live monitoring is established with `hand watch --until-event`.
+
 Watcher wakes carry Fleet identity, monitor kind, opaque target identity, opaque currentness, event kind, and a bounded reason.
 A wake is only a hint: a consumer must read fresh orientation and accept the wake only when Fleet, target, kind, and currentness match exactly.
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -47,7 +47,7 @@ Registry absence or degradation does not replace the authoritative identity in a
 
 ### Supervisor orientation
 
-A bounded, stateless read model returned by `hand session start`.
+A bounded, stateless read model returned by `hand orient`.
 It contains Fleet identity, work and actionable summaries, exact monitor targets, monitor state, next actions, truncation, and uncertainty.
 It is not a durable supervisor session, Task-to-Plan record, FleetSnapshot, or Attention table.
 


### PR DESCRIPTION
## Summary
- Attribute supervisor orientation to `hand orient` in the vocabulary.
- Amend the ADR with the current `session start` bootstrap/orientation split.

Fixes atqamz/hand#353

## Test plan
- `nix develop --command make build`
- `nix develop --command make test`
- `nix develop --command make lint`

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->