### PR TITLE
fix(project): preserve unrelated completion records during rename rollback

### DIFF
--- a/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
+++ b/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
@@ -1,4 +1,4 @@
-# Completions use an uncapped append-only file
+# Completions use an uncapped JSONL file
 
 - Date: 2026-08-04
 - Status: accepted, superseded in part by [Tasks are durable and Attempts own execution](tasks-are-durable-and-attempts-own-execution.md)
@@ -11,7 +11,7 @@ Teardown removes live task state, but a completion must remain readable afterwar
 
 ## Decision
 
-Completions are appended to a dedicated JSONL file under their own lock before the task row is removed. The file is uncapped because it is the durable record of tasks no longer present.
+Completions are appended to a dedicated JSONL file under their own lock before the task row is removed. Project rename is the one controlled exception: it may atomically rewrite only records belonging to the renamed project, under the same lock, so rollback cannot overwrite unrelated records. The file is uncapped because it is the durable record of tasks no longer present.
 
 [`internal/completion`](../../internal/completion) owns the format and append operation. Its tests and teardown tests own failure ordering and duplicate tolerance.
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -66,53 +66,99 @@ func Append(homeDir string, r Record) error {
 	return nil
 }
 
-func RenameProject(homeDir, oldName, newName string) error {
-	release, err := state.Lock(homeDir, "completions")
+// RenameRestore restores only the completion lines changed by RenameProject.
+type RenameRestore struct {
+	homeDir string
+	changes []renameChange
+}
+
+type renameChange struct {
+	line         int
+	originalLine string
+	renamedLine  string
+}
+
+// Restore reverts the exact lines changed by the rename, if they are still unchanged.
+func (r RenameRestore) Restore() error {
+	if len(r.changes) == 0 {
+		return nil
+	}
+	release, err := state.Lock(r.homeDir, "completions")
 	if err != nil {
 		return fmt.Errorf("lock completions store: %w", err)
+	}
+	defer release()
+
+	path := Path(r.homeDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read completions store for rollback: %w", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat completions store for rollback: %w", err)
+	}
+	lines := strings.SplitAfter(string(data), "\n")
+	for _, change := range r.changes {
+		if change.line >= len(lines) || lines[change.line] != change.renamedLine {
+			return fmt.Errorf("completion line %d changed during rollback", change.line)
+		}
+		lines[change.line] = change.originalLine
+	}
+	if err := atomicfile.Write(path, ".completions-rollback-", []byte(strings.Join(lines, "")), info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write completions store for rollback: %w", err)
+	}
+	return nil
+}
+
+func RenameProject(homeDir, oldName, newName string) (RenameRestore, error) {
+	release, err := state.Lock(homeDir, "completions")
+	if err != nil {
+		return RenameRestore{}, fmt.Errorf("lock completions store: %w", err)
 	}
 	defer release()
 
 	path := Path(homeDir)
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return nil
+		return RenameRestore{}, nil
 	}
 	if err != nil {
-		return fmt.Errorf("read completions store: %w", err)
+		return RenameRestore{}, fmt.Errorf("read completions store: %w", err)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("stat completions store: %w", err)
+		return RenameRestore{}, fmt.Errorf("stat completions store: %w", err)
 	}
 
 	var rendered strings.Builder
-	changed := false
-	for _, line := range strings.SplitAfter(string(data), "\n") {
+	var changes []renameChange
+	for lineNumber, line := range strings.SplitAfter(string(data), "\n") {
 		body, newline := strings.CutSuffix(line, "\n")
 		var record Record
 		if err := json.Unmarshal([]byte(body), &record); err == nil && record.Project == oldName {
 			record.Project = newName
 			encoded, err := json.Marshal(record)
 			if err != nil {
-				return fmt.Errorf("encode completion record %q: %w", record.ID, err)
+				return RenameRestore{}, fmt.Errorf("encode completion record %q: %w", record.ID, err)
 			}
-			rendered.Write(encoded)
+			renameLine := string(encoded)
 			if newline {
-				rendered.WriteByte('\n')
+				renameLine += "\n"
 			}
-			changed = true
+			rendered.WriteString(renameLine)
+			changes = append(changes, renameChange{line: lineNumber, originalLine: line, renamedLine: renameLine})
 			continue
 		}
 		rendered.WriteString(line)
 	}
-	if !changed {
-		return nil
+	if len(changes) == 0 {
+		return RenameRestore{}, nil
 	}
 	if err := atomicfile.Write(path, ".completions-", []byte(rendered.String()), info.Mode().Perm()); err != nil {
-		return fmt.Errorf("write completions store: %w", err)
+		return RenameRestore{}, fmt.Errorf("write completions store: %w", err)
 	}
-	return nil
+	return RenameRestore{homeDir: homeDir, changes: changes}, nil
 }
 
 // List returns every record, oldest first, and nil if the store doesn't exist yet. A

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,7 +1,8 @@
 // Package completion is the durable record of tasks hand teardown has finished
 // with: state/completions.jsonl, one JSON object per line, uncapped - see
-// atqamz/hand#61. Every line is readable on its own terms without
-// parsing markdown.
+// atqamz/hand#61. Normal records are appended; project rename may atomically
+// rewrite the matching records. Every line is readable on its own terms
+// without parsing markdown.
 package completion
 
 import (

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -480,7 +480,8 @@ func Rename(homeDir, oldName, newName string) error {
 	if !updated {
 		return fmt.Errorf("project %q %w", oldName, ErrNotFound)
 	}
-	if err := projectRenameHistoryWriter(homeDir, oldName, newName); err != nil {
+	historyRestore, err := projectRenameHistoryWriter(homeDir, oldName, newName)
+	if err != nil {
 		var rollbackErr error
 		if newURL != "" {
 			_, rollbackErr = projectRenameURLUpdater(db, newName, oldName, oldURL)
@@ -503,7 +504,7 @@ func Rename(homeDir, oldName, newName string) error {
 		if rollbackErr != nil {
 			rollbackErrs = append(rollbackErrs, fmt.Errorf("restore project %q: %w", oldName, rollbackErr))
 		}
-		if rollbackErr := projectRenameHistoryWriter(homeDir, newName, oldName); rollbackErr != nil {
+		if rollbackErr := historyRestore.Restore(); rollbackErr != nil {
 			rollbackErrs = append(rollbackErrs, fmt.Errorf("restore project history %q: %w", oldName, rollbackErr))
 		}
 		if rollbackErr := restoreProjection(registryPath, oldProjection, projectionExists, projectionMode); rollbackErr != nil {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -298,6 +298,9 @@ func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 func TestRenameRollsBackWhenProjectionWriteFails(t *testing.T) {
 	dir := t.TempDir()
 	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
+	if err := completion.Append(dir, completion.Record{ID: "demo-task", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
 	original := projectRenameProjectionWriter
 	t.Cleanup(func() { projectRenameProjectionWriter = original })
 	projectRenameProjectionWriter = func(*store.DB, string, string, string) error { return errors.New("projection failed") }
@@ -313,12 +316,25 @@ func TestRenameRollsBackWhenProjectionWriteFails(t *testing.T) {
 	if len(projects) != 1 || projects[0].Name != "demo" {
 		t.Fatalf("projects = %+v, want old name after rollback", projects)
 	}
+	records, err := completion.List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Project != "demo" {
+		t.Fatalf("completion records = %+v, want old name after rollback", records)
+	}
 }
 
 func TestRenameRestoresProjectionWhenWriteFailsAfterReplacement(t *testing.T) {
 	dir := t.TempDir()
 	original := "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n"
 	writeRegistry(t, dir, original)
+	if err := completion.Append(dir, completion.Record{ID: "demo-task", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := completion.Append(dir, completion.Record{ID: "unrelated", Project: "renamed"}); err != nil {
+		t.Fatal(err)
+	}
 	oldWriter := projectRenameProjectionWriter
 	t.Cleanup(func() { projectRenameProjectionWriter = oldWriter })
 	projectRenameProjectionWriter = func(db *store.DB, homeDir, oldName, newName string) error {
@@ -339,6 +355,55 @@ func TestRenameRestoresProjectionWhenWriteFailsAfterReplacement(t *testing.T) {
 	if string(got) != original {
 		t.Fatalf("projection = %q, want original projection %q", got, original)
 	}
+	records, err := completion.List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRecords := []completion.Record{{ID: "demo-task", Project: "demo"}, {ID: "unrelated", Project: "renamed"}}
+	if len(records) != len(wantRecords) {
+		t.Fatalf("completion records = %+v, want %+v", records, wantRecords)
+	}
+	for i := range wantRecords {
+		if records[i] != wantRecords[i] {
+			t.Fatalf("completion record %d = %+v, want %+v", i, records[i], wantRecords[i])
+		}
+	}
+}
+
+func TestRenameRollbackOnlyRestoresRenamedCompletionRecords(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
+	if err := completion.Append(dir, completion.Record{ID: "renamed-project", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := completion.Append(dir, completion.Record{ID: "unrelated", Project: "renamed"}); err != nil {
+		t.Fatal(err)
+	}
+	original := projectRenameProjectionWriter
+	t.Cleanup(func() { projectRenameProjectionWriter = original })
+	projectRenameProjectionWriter = func(*store.DB, string, string, string) error {
+		return errors.New("projection failed")
+	}
+
+	if err := Rename(dir, "demo", "renamed"); err == nil || !strings.Contains(err.Error(), "projection failed") {
+		t.Fatalf("Rename = %v, want projection failure", err)
+	}
+	records, err := completion.List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []completion.Record{
+		{ID: "renamed-project", Project: "demo"},
+		{ID: "unrelated", Project: "renamed"},
+	}
+	if len(records) != len(want) {
+		t.Fatalf("completion records = %+v, want %+v", records, want)
+	}
+	for i := range want {
+		if records[i] != want[i] {
+			t.Fatalf("completion record %d = %+v, want %+v", i, records[i], want[i])
+		}
+	}
 }
 
 func TestRenameRollsBackWhenHistoryWriteFails(t *testing.T) {
@@ -346,7 +411,9 @@ func TestRenameRollsBackWhenHistoryWriteFails(t *testing.T) {
 	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
 	original := projectRenameHistoryWriter
 	t.Cleanup(func() { projectRenameHistoryWriter = original })
-	projectRenameHistoryWriter = func(string, string, string) error { return errors.New("history failed") }
+	projectRenameHistoryWriter = func(string, string, string) (completion.RenameRestore, error) {
+		return completion.RenameRestore{}, errors.New("history failed")
+	}
 
 	err := Rename(dir, "demo", "renamed")
 	if err == nil || !strings.Contains(err.Error(), "history failed") {


### PR DESCRIPTION
## Intent

Fix project rename rollback so a projection failure restores only completion records changed by that rename, while preserving unrelated pre-existing records with the new name. Add regression coverage for the failing rollback path and close the existing tests setup gap. Keep normal rename behavior unchanged and do not change the project-identity model, schema, or CLI surface. Commit, push the branch, and open the PR, but do not merge it.

## What Changed

- Changed project rename rollback to restore only completion records modified by that rename, preserving unrelated records with the new project name.
- Updated completion-store rename handling to track exact changed lines and restore them safely.
- Added regression coverage for projection-failure rollback and filled completion setup in existing rename tests; updated the completion-store ADR.

## Risk Assessment

✅ Low: The fix is narrowly scoped, preserves normal rename behavior, and correctly restores only the completion lines changed by that rename under the existing store lock.

## Testing

Verified normal rename, projection-failure rollback, selective completion restoration preserving unrelated new-name records, and CLI rename behavior. All targeted tests passed in the repository’s ephemeral Nix dev shell; no source or worktree artifacts were created.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"70ee9feb808973048eca7e66f8368021aff382df","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Targeted internal/project rename rollback tests`
- `Targeted internal/completion tests`
- `Targeted cmd project rename tests`
- `Worktree status check`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->