### PR TITLE
docs: clarify scout report path

### DIFF
--- a/skills/secondhand/references/planning-and-briefs.md
+++ b/skills/secondhand/references/planning-and-briefs.md
@@ -7,10 +7,11 @@ investigation or report; use `ship` when the deliverable is a change that must b
 explicitly delivered. A worker is simply the agent process Hand launches to execute delegated
 work, whichever kind the Task is.
 
-A scout brief must instruct the worker to write its landed investigation to `data/<id>/report.md`.
-That file is a machine-enforced deliverable: teardown, promote, and the watcher use it as the
-scout's landed-work evidence. The `state/<id>.status` file is only the status report stream and
-does not replace `report.md`.
+A scout brief must instruct the worker to write its landed investigation to
+`$HAND_HOME/data/<id>/report.md`, under the fleet home root in `HAND_HOME`, not the worker's own
+worktree. That file is a machine-enforced deliverable: teardown, promote, and the watcher use it as
+the scout's landed-work evidence. The `state/<id>.status` file is only the status report stream and
+does not replace `$HAND_HOME/data/<id>/report.md`.
 
 ## Execution class: mechanical, standard, or deep
 
@@ -73,11 +74,13 @@ right: the project advanced past planned_against, so re-check every assumption t
 ## Recording and dispatching the task
 
 - Edit `data/backlog.md` to record the task with a unique ID.
-- Write the brief at `data/<id>/brief.md`, including the absolute path to `state/<id>.status`
-  and the report vocabulary the worker should append to it (see
+- Write the brief at `data/<id>/brief.md`, relative to the fleet home root and not a worker
+  worktree, including the absolute path to `state/<id>.status` and the report vocabulary the worker
+  should append to it (see
   `references/task-lifecycle.md`).
-- When dispatching a scout, make the brief require `data/<id>/report.md`; without it, teardown
-  refuses to release the scout worktree even when the status report says `done:`.
+- When dispatching a scout, make the brief require `$HAND_HOME/data/<id>/report.md` under the fleet
+  home root, not the worker's own worktree; without it, teardown refuses to release the scout
+  worktree even when the status report says `done:`.
 - Dispatch with `hand spawn <id> <project> [--scout] [--profile <name>] [--harness ...]
   [--model ...] [--effort ...]`. Normally omit `--model`/`--effort`: use them only for a genuine
   task-specific need, never as routine routing - routine routing belongs in a configured Route.


### PR DESCRIPTION
## Summary
- Clarify that scout reports live under the dispatched fleet home via $HAND_HOME, not the worker worktree.
- Clarify the nearby fleet-home-relative brief path wording.

Fixes atqamz/hand#395

## Test plan
- nix develop -c go build ./...
- nix develop -c make test
- grep -n "report.md" skills/secondhand/references/*.md skills/secondhand/SKILL.md

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->