### PR TITLE
ci(release): move linux/arm64 and darwin/amd64 to native runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            macos-latest,
+            macos-15-intel,
+            windows-latest,
+          ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -64,6 +71,18 @@ jobs:
       - name: End-to-end
         run: go test -tags=e2e,test -timeout=10m ./tests/e2e/...
 
+  e2e-linux-arm:
+    name: E2E (ubuntu-24.04-arm, bootstrap.sh)
+    runs-on: ubuntu-24.04-arm
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: End-to-end (bootstrap.sh)
+        run: go test -tags=e2e,test -timeout=10m -run "^TestBootstrap" ./tests/e2e/...
+
   e2e-windows:
     name: E2E (windows-latest, bootstrap.ps1)
     runs-on: windows-latest
@@ -79,6 +98,18 @@ jobs:
   e2e-macos:
     name: E2E (macos-latest, bootstrap.sh)
     runs-on: macos-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: End-to-end (bootstrap.sh)
+        run: go test -tags=e2e,test -timeout=10m -run "^TestBootstrap" ./tests/e2e/...
+
+  e2e-macos-intel:
+    name: E2E (macos-15-intel, bootstrap.sh)
+    runs-on: macos-15-intel
     needs: test
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,18 +71,6 @@ jobs:
       - name: End-to-end
         run: go test -tags=e2e,test -timeout=10m ./tests/e2e/...
 
-  e2e-linux-arm:
-    name: E2E (ubuntu-24.04-arm, bootstrap.sh)
-    runs-on: ubuntu-24.04-arm
-    needs: test
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - name: End-to-end (bootstrap.sh)
-        run: go test -tags=e2e,test -timeout=10m -run "^TestBootstrap" ./tests/e2e/...
-
   e2e-windows:
     name: E2E (windows-latest, bootstrap.ps1)
     runs-on: windows-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,10 +42,10 @@ jobs:
             runner: ubuntu-latest
           - goos: linux
             goarch: arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - goos: darwin
             goarch: amd64
-            runner: macos-latest
+            runner: macos-15-intel
           - goos: darwin
             goarch: arm64
             runner: macos-latest


### PR DESCRIPTION
## Summary
- Move the release workflow's `linux/arm64` and `darwin/amd64` build matrix entries off cross-compiling `ubuntu-latest`/`macos-latest` onto the real native `ubuntu-24.04-arm`/`macos-15-intel` runners, so `./hand build-info`'s host-arch self-check actually runs for them.
- Add matching `test` (unit test + build) CI lanes on `ubuntu-24.04-arm` and `macos-15-intel`, and a bootstrap e2e lane on `macos-15-intel`.
- No bootstrap e2e lane on `ubuntu-24.04-arm`: `linux/arm64` has no qualified Git artifact yet (deferred to a later release), so `runtime.lock.json` correctly marks it unsupported and `bootstrap.sh`'s `runtime ensure` fails closed by design - that's not something to route around here.

Related: atqamz/hand#354

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -tags=test ./...` all pass locally.
- [x] Release workflow's `linux/arm64`/`darwin/amd64` build jobs run natively (verified `build-info` self-check logic activates on native host arch match; full confirmation lands with the next real release run).
- [x] New `ubuntu-24.04-arm`/`macos-15-intel` `test` lanes and the `macos-15-intel` e2e lane are green.
- [x] Confirmed in the Actions run that both new runner labels (`ubuntu-24.04-arm`, `macos-15-intel`, no `-large`/`-xlarge` suffix) are scheduled as standard, not large/metered, runners.