### PR TITLE
feat(store): give projects a durable surrogate identity

### DIFF
--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -303,8 +303,11 @@ func TestProjectSetURLUpdatesRegistryAndOriginPreservingTask(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(projects) != 1 || projects[0] != (project.Project{
-		Name: "secondhand", URL: newURL, Mode: project.ModeNoMistakes, Upstream: "atqamz/hand",
+	if len(projects) != 1 || projects[0].ID == "" {
+		t.Fatalf("projects = %+v, want one project with an identity", projects)
+	}
+	if projects[0] != (project.Project{
+		ID: projects[0].ID, Name: "secondhand", URL: newURL, Mode: project.ModeNoMistakes, Upstream: "atqamz/hand",
 	}) {
 		t.Fatalf("projects = %+v, want repointed project with preserved fields", projects)
 	}
@@ -369,9 +372,14 @@ func TestProjectSetModePreservesActiveTaskAndClone(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantProject := project.Project{Name: "old-name", URL: "https://github.com/org/repo.git", Mode: project.ModeNoMistakes, Upstream: "upstream/repo"}
-	if len(projects) != 1 || projects[0] != wantProject {
+	if len(projects) != 1 || projects[0].ID == "" {
+		t.Fatalf("projects = %+v, want one project with an identity", projects)
+	}
+	wantProject.ID = projects[0].ID
+	if projects[0] != wantProject {
 		t.Fatalf("projects = %+v, want %+v", projects, wantProject)
 	}
+	wantTask.ProjectID = projects[0].ID
 	if got, err := state.Read(home, wantTask.ID); err != nil || got != wantTask {
 		t.Fatalf("task = %+v, %v, want unchanged task %+v", got, err, wantTask)
 	}
@@ -426,6 +434,14 @@ func TestProjectRenameMovesCloneAndPreservesTaskHistory(t *testing.T) {
 	if err := state.Write(home, wantTask); err != nil {
 		t.Fatal(err)
 	}
+	registered, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registered) != 1 || registered[0].ID == "" {
+		t.Fatalf("projects = %+v, want one project with an identity", registered)
+	}
+	identityBeforeRename := registered[0].ID
 
 	cmd := newProjectRenameCmd()
 	var output strings.Builder
@@ -446,7 +462,7 @@ func TestProjectRenameMovesCloneAndPreservesTaskHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantProject := project.Project{Name: "new-name", URL: "https://github.com/org/repo.git", Mode: project.ModeDirectPR, Upstream: "upstream/repo"}
+	wantProject := project.Project{ID: identityBeforeRename, Name: "new-name", URL: "https://github.com/org/repo.git", Mode: project.ModeDirectPR, Upstream: "upstream/repo"}
 	if len(projects) != 1 || projects[0] != wantProject {
 		t.Fatalf("projects = %+v, want %+v", projects, wantProject)
 	}
@@ -456,6 +472,11 @@ func TestProjectRenameMovesCloneAndPreservesTaskHistory(t *testing.T) {
 	}
 	if gotTask.Project != "new-name" || gotTask.ID != wantTask.ID || gotTask.Brief != wantTask.Brief {
 		t.Fatalf("task = %+v, want same task with new project name", gotTask)
+	}
+	// The task never had its own copy of the name rewritten: it points at the identity the
+	// rename could not change, and the live label is resolved through that (atqamz/hand#388).
+	if gotTask.ProjectID != identityBeforeRename {
+		t.Fatalf("task project identity = %q, want the pre-rename identity %q", gotTask.ProjectID, identityBeforeRename)
 	}
 	history, err := state.ReadHistory(home, wantTask.ID)
 	if err != nil {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -135,6 +135,12 @@ func importLegacyRegistry(db *store.DB, homeDir string) error {
 			return err
 		}
 	}
+	// The schema migration had no project rows to resolve task names against on a home whose
+	// registry lived only in the file, so the tasks it left without an identity are linked here,
+	// once, while the names in the file are still the names those tasks were written with.
+	if err := db.BackfillTaskProjectIdentity(); err != nil {
+		return err
+	}
 	return db.MarkMigrated(legacyRegistryKey)
 }
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -133,6 +133,7 @@ func TestSetURLPreservesProjectionAssociationAndProjectFields(t *testing.T) {
 		t.Fatalf("projects = %+v, want %d projects", projects, len(want))
 	}
 	for i := range want {
+		want[i].ID = identityOf(t, projects[i])
 		if projects[i] != want[i] {
 			t.Fatalf("project %d = %+v, want %+v", i, projects[i], want[i])
 		}
@@ -202,7 +203,11 @@ func TestSetModePreservesProjectFieldsAndProjection(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := Project{Name: "demo", URL: "https://github.com/org/demo", Mode: ModeNoMistakes, Upstream: "up/demo"}
-	if len(projects) != 1 || projects[0] != want {
+	if len(projects) != 1 {
+		t.Fatalf("projects = %+v, want one project", projects)
+	}
+	want.ID = identityOf(t, projects[0])
+	if projects[0] != want {
 		t.Fatalf("projects = %+v, want %+v", projects, want)
 	}
 	projection, err := os.ReadFile(RegistryPath(dir))
@@ -268,6 +273,7 @@ func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 		t.Fatalf("projects = %+v, want %+v", projects, want)
 	}
 	for i := range want {
+		want[i].ID = identityOf(t, projects[i])
 		if projects[i] != want[i] {
 			t.Fatalf("project %d = %+v, want %+v", i, projects[i], want[i])
 		}
@@ -588,11 +594,72 @@ func TestListParsesRegistry(t *testing.T) {
 	if len(projects) != 2 {
 		t.Fatalf("got %d projects, want 2", len(projects))
 	}
-	if projects[0] != (Project{Name: "nsr", URL: "https://github.com/yes2games/nsr", Mode: "direct-pr"}) {
+	if projects[0] != (Project{ID: identityOf(t, projects[0]), Name: "nsr", URL: "https://github.com/yes2games/nsr", Mode: "direct-pr"}) {
 		t.Errorf("got %+v", projects[0])
 	}
-	if projects[1] != (Project{Name: "secondhand", URL: "local", Mode: "local-only"}) {
+	if projects[1] != (Project{ID: identityOf(t, projects[1]), Name: "secondhand", URL: "local", Mode: "local-only"}) {
 		t.Errorf("got %+v", projects[1])
+	}
+}
+
+// The surrogate identity is minted internally, so a test that compares whole rows asserts it
+// exists and then reuses it rather than pinning a value no caller chooses.
+func identityOf(t *testing.T, p Project) string {
+	t.Helper()
+	if p.ID == "" {
+		t.Fatalf("project %q has no identity", p.Name)
+	}
+	return p.ID
+}
+
+// A home whose registry lived only in data/projects.md has no project rows for the schema
+// migration to resolve task names against, so the one-time import is what links them - and it
+// links only the names that import actually registers.
+func TestLegacyRegistryImportLinksExistingTasksToTheImportedProjects(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
+	db, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "task-1", Project: "demo", Kind: store.KindShip}); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "task-2", Project: "retired", Kind: store.KindShip}); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	projects, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 || projects[0].ID == "" {
+		t.Fatalf("projects = %+v, want the imported project with an identity", projects)
+	}
+
+	db, err = store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	linked, _, err := db.ReadTask("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked.ProjectID != projects[0].ID {
+		t.Fatalf("task-1 identity = %q, want the imported %q", linked.ProjectID, projects[0].ID)
+	}
+	unlinked, _, err := db.ReadTask("task-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unlinked.ProjectID != "" || unlinked.Project != "retired" {
+		t.Fatalf("task-2 = %+v, want it left without an identity", unlinked)
 	}
 }
 

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -75,6 +75,22 @@ func newFleetID() (string, error) {
 	return "f_" + hex.EncodeToString(raw[:]), nil
 }
 
+// A project keeps this id for as long as it is registered, across every rename. The shape
+// mirrors the fleet id so an operator reading either can tell at a glance what it names, and
+// so the migration's sqlite-side backfill can mint the same thing without Go.
+const (
+	projectIDPrefix = "p_"
+	projectIDBytes  = "16"
+)
+
+func newProjectID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate project identity: %w", err)
+	}
+	return projectIDPrefix + hex.EncodeToString(raw[:]), nil
+}
+
 func validateFleetID(id string) error {
 	if len(id) != 34 || id[:2] != "f_" {
 		return fmt.Errorf("%w: %q", ErrFleetIdentityInvalid, id)

--- a/internal/store/projectidentity_test.go
+++ b/internal/store/projectidentity_test.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The layout a fleet home carried at fleetIdentityVersion: a project keyed by its mutable name
+// and a task holding a literal copy of it, which is what the surrogate identity replaces.
+const preProjectIdentityProjectTable = `DROP TABLE project;
+CREATE TABLE project (name TEXT PRIMARY KEY, url TEXT NOT NULL, mode TEXT NOT NULL, position INTEGER NOT NULL, upstream TEXT NOT NULL DEFAULT '');`
+
+func stampPreProjectIdentity(t *testing.T, db *DB) {
+	t.Helper()
+	if _, err := db.sql.Exec(preProjectIdentityProjectTable); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`ALTER TABLE task DROP COLUMN project_id`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(fleetIdentityVersion)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func projectIdentityOf(t *testing.T, db *DB, name string) string {
+	t.Helper()
+	var id string
+	if err := db.sql.QueryRow(`SELECT id FROM project WHERE name = ?`, name).Scan(&id); err != nil {
+		t.Fatalf("read identity for project %q: %v", name, err)
+	}
+	return id
+}
+
+func taskProjectIdentity(t *testing.T, db *DB, id string) string {
+	t.Helper()
+	var projectID string
+	if err := db.sql.QueryRow(`SELECT project_id FROM task WHERE id = ?`, id).Scan(&projectID); err != nil {
+		t.Fatalf("read project identity for task %q: %v", id, err)
+	}
+	return projectID
+}
+
+func TestMigrationGivesEveryRegisteredProjectAnIdentityAndBackfillsTasks(t *testing.T) {
+	db, home := openTemp(t)
+	stampPreProjectIdentity(t, db)
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream) VALUES
+		('nsr', 'git@github.com:o/nsr.git', 'direct-pr', 0, ''),
+		('universe', 'git@github.com:o/universe.git', 'no-mistakes', 1, 'o/universe')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle) VALUES
+		('live', 'nsr', 'ship', 'open'),
+		('other', 'universe', 'scout', 'terminal'),
+		('orphan', 'retired', 'ship', 'terminal')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatalf("migrate a pre-identity home: %v", err)
+	}
+	defer func() { _ = migrated.Close() }()
+	if version, err := migrated.schemaVersion(); err != nil || version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, len(migrations))
+	}
+
+	nsr := projectIdentityOf(t, migrated, "nsr")
+	universe := projectIdentityOf(t, migrated, "universe")
+	if !strings.HasPrefix(nsr, projectIDPrefix) || len(nsr) != len(projectIDPrefix)+32 {
+		t.Fatalf("nsr identity = %q, want a %s-prefixed opaque id", nsr, projectIDPrefix)
+	}
+	if nsr == universe {
+		t.Fatalf("both projects share identity %q", nsr)
+	}
+	if got := taskProjectIdentity(t, migrated, "live"); got != nsr {
+		t.Fatalf("task live identity = %q, want %q", got, nsr)
+	}
+	if got := taskProjectIdentity(t, migrated, "other"); got != universe {
+		t.Fatalf("task other identity = %q, want %q", got, universe)
+	}
+	// "retired" names no registered project, so its lineage is not knowable from the name alone
+	// and the migration refuses to guess one for it (atqamz/hand#388).
+	if got := taskProjectIdentity(t, migrated, "orphan"); got != "" {
+		t.Fatalf("orphan task identity = %q, want no identity", got)
+	}
+
+	projects, err := migrated.ListProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 2 || projects[0].Name != "nsr" || projects[0].ID != nsr || projects[1].Upstream != "o/universe" {
+		t.Fatalf("projects = %+v, want the pre-migration rows with identities", projects)
+	}
+}
+
+func TestMigrationToProjectIdentityIsIdempotent(t *testing.T) {
+	db, home := openTemp(t)
+	stampPreProjectIdentity(t, db)
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream) VALUES ('nsr', 'u', 'direct-pr', 0, '')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle) VALUES ('live', 'nsr', 'ship', 'open')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := projectIdentityOf(t, first, "nsr")
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := Open(home)
+	if err != nil {
+		t.Fatalf("reopen an already-migrated home: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	if got := projectIdentityOf(t, second, "nsr"); got != identity {
+		t.Fatalf("identity = %q after reopening, want the minted %q", got, identity)
+	}
+	if got := taskProjectIdentity(t, second, "live"); got != identity {
+		t.Fatalf("task identity = %q, want %q", got, identity)
+	}
+	var projects int
+	if err := second.sql.QueryRow(`SELECT COUNT(*) FROM project`).Scan(&projects); err != nil {
+		t.Fatal(err)
+	}
+	if projects != 1 {
+		t.Fatalf("project rows = %d, want the one row the first migration produced", projects)
+	}
+}
+
+// The property atqamz/hand#388 and atqamz/hand#396 were both about: a rename is one row's
+// relabelling, so there is no history to search by name and none to put back.
+func TestRenameRelabelsOneRowAndLeavesTaskHistoryAlone(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.AddProject(Project{Name: "demo", URL: "u", Mode: "direct-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	identity := projectIdentityOf(t, db, "demo")
+	if err := db.CreateTask(Task{ID: "task-1", Project: "demo", Kind: KindShip}); err != nil {
+		t.Fatal(err)
+	}
+
+	renamed, err := db.RenameProject("demo", "renamed")
+	if err != nil || !renamed {
+		t.Fatalf("RenameProject = %v, %v", renamed, err)
+	}
+
+	if got := projectIdentityOf(t, db, "renamed"); got != identity {
+		t.Fatalf("identity after rename = %q, want the unchanged %q", got, identity)
+	}
+	if got := taskProjectIdentity(t, db, "task-1"); got != identity {
+		t.Fatalf("task identity after rename = %q, want the unchanged %q", got, identity)
+	}
+	var stored string
+	if err := db.sql.QueryRow(`SELECT project FROM task WHERE id = 'task-1'`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != "demo" {
+		t.Fatalf("stored task project = %q, want the rename to have left the row untouched", stored)
+	}
+	task, found, err := db.ReadTask("task-1")
+	if err != nil || !found {
+		t.Fatalf("ReadTask = %v, %v", found, err)
+	}
+	if task.Project != "renamed" {
+		t.Fatalf("resolved task project = %q, want the live label %q", task.Project, "renamed")
+	}
+}
+
+// The conflation atqamz/hand#388 reported: a name freed by a removal and claimed by a later
+// project must not carry the removed project's task history into it.
+func TestRecreatedProjectNameDoesNotInheritTheRemovedProjectsTasks(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.AddProject(Project{Name: "demo", URL: "u", Mode: "direct-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	retired := projectIdentityOf(t, db, "demo")
+	if err := db.CreateTask(Task{ID: "old-task", Project: "demo", Kind: KindShip, Lifecycle: TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	if removed, err := db.RemoveProject("demo"); err != nil || !removed {
+		t.Fatalf("RemoveProject = %v, %v", removed, err)
+	}
+	if err := db.AddProject(Project{Name: "demo", URL: "u2", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	successor := projectIdentityOf(t, db, "demo")
+	if successor == retired {
+		t.Fatalf("recreated project reused identity %q", successor)
+	}
+	if err := db.CreateTask(Task{ID: "new-task", Project: "demo", Kind: KindShip}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := taskProjectIdentity(t, db, "old-task"); got != retired {
+		t.Fatalf("old task identity = %q, want the retired %q", got, retired)
+	}
+	if got := taskProjectIdentity(t, db, "new-task"); got != successor {
+		t.Fatalf("new task identity = %q, want the successor %q", got, successor)
+	}
+
+	// Renaming the successor moves only its own tasks' live label; the retired project's task
+	// keeps the name it was written with, because nothing is rewritten by name any more.
+	if renamed, err := db.RenameProject("demo", "demo-two"); err != nil || !renamed {
+		t.Fatalf("RenameProject = %v, %v", renamed, err)
+	}
+	old, _, err := db.ReadTask("old-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if old.Project != "demo" || old.ProjectID != retired {
+		t.Fatalf("old task = %+v, want it left under the retired project", old)
+	}
+	fresh, _, err := db.ReadTask("new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Project != "demo-two" || fresh.ProjectID != successor {
+		t.Fatalf("new task = %+v, want it following the successor's new label", fresh)
+	}
+}
+
+// The read-only ladder has to keep answering for a home migrateSchema has not reached yet: at
+// fleetIdentityVersion the task table has no project_id to select or to join a live label through.
+func TestReadOnlyLadderReadsAPreIdentityHome(t *testing.T) {
+	db, home := openTemp(t)
+	stampPreProjectIdentity(t, db)
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream) VALUES ('nsr', 'u', 'direct-pr', 0, '')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle) VALUES ('live', 'nsr', 'ship', 'open')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, found, err := ReadTaskHistoryReadOnly(home, "live")
+	if err != nil || !found {
+		t.Fatalf("ReadTaskHistoryReadOnly = %v, %v", found, err)
+	}
+	if history.Task.Project != "nsr" || history.Task.ProjectID != "" {
+		t.Fatalf("task = %+v, want the stored name and no identity", history.Task)
+	}
+	histories, err := ListReconciliationHistoriesReadOnly(home)
+	if err != nil {
+		t.Fatalf("ListReconciliationHistoriesReadOnly: %v", err)
+	}
+	if len(histories) != 1 || histories[0].Task.Project != "nsr" {
+		t.Fatalf("histories = %+v, want the one open task", histories)
+	}
+}

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -153,6 +153,10 @@ var migrations = []string{
 		singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
 		fleet_id TEXT NOT NULL UNIQUE
 	);`,
+	// ensureProjectIdentity does the real work below, guarded by column existence like the
+	// placeholders above: the base schema already carries project.id and task.project_id, so a home
+	// built from it and stamped backward replays this step without a duplicate-column error.
+	`SELECT 1;`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -181,6 +185,10 @@ const preAcknowledgementVersion = attemptBranchVersion + 1
 const acknowledgedMetadataVersion = preAcknowledgementVersion + 1
 
 const fleetIdentityVersion = acknowledgedMetadataVersion + 1
+
+// The last version that identified a project by its mutable name: its task table has no
+// project_id, and its project table no surrogate id (atqamz/hand#388).
+const projectIdentityVersion = fleetIdentityVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -496,6 +504,11 @@ func (db *DB) applyMigration(version int) error {
 			return err
 		}
 	}
+	if version == projectIdentityVersion-1 {
+		if err := ensureProjectIdentity(tx); err != nil {
+			return err
+		}
+	}
 	if err := recordSchemaVersion(tx, version+1); err != nil {
 		return err
 	}
@@ -591,6 +604,48 @@ func ensureAcknowledgementColumns(tx *sql.Tx) error {
 		if _, err := tx.Exec(`ALTER TABLE task ADD COLUMN ` + column.name + ` ` + column.ddl); err != nil {
 			return fmt.Errorf("add %s: %w", column.name, err)
 		}
+	}
+	return nil
+}
+
+// Gives every registered project a durable surrogate id and every task a reference to it, inside
+// the transaction applyMigration already wraps this step in, so a home that fails partway keeps the
+// whole name-keyed layout. Rebuilt, not altered: sqlite cannot turn name into a plain unique label.
+func ensureProjectIdentity(tx *sql.Tx) error {
+	var taskColumn int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name = 'project_id'`).Scan(&taskColumn); err != nil {
+		return fmt.Errorf("inspect task project_id column: %w", err)
+	}
+	if taskColumn == 0 {
+		if _, err := tx.Exec(`ALTER TABLE task ADD COLUMN project_id TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add task project_id column: %w", err)
+		}
+	}
+	var projectColumn int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('project') WHERE name = 'id'`).Scan(&projectColumn); err != nil {
+		return fmt.Errorf("inspect project id column: %w", err)
+	}
+	if projectColumn == 0 {
+		if _, err := tx.Exec(`CREATE TABLE project_identity (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			url TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			position INTEGER NOT NULL,
+			upstream TEXT NOT NULL DEFAULT ''
+		);
+		INSERT INTO project_identity (id, name, url, mode, position, upstream)
+		SELECT '` + projectIDPrefix + `' || lower(hex(randomblob(` + projectIDBytes + `))), name, url, mode, position, upstream FROM project;
+		DROP TABLE project;
+		ALTER TABLE project_identity RENAME TO project;`); err != nil {
+			return fmt.Errorf("give projects a surrogate identity: %w", err)
+		}
+	}
+	// Only the rows that have no identity yet, so replaying this step never reattaches a task
+	// whose project was removed to whatever project now answers to that name.
+	if _, err := tx.Exec(`UPDATE task SET project_id = COALESCE((SELECT id FROM project WHERE project.name = task.project), '')
+		WHERE project_id = ''`); err != nil {
+		return fmt.Errorf("backfill task project identity: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -133,8 +133,12 @@ const (
 )
 
 type Task struct {
-	ID               string        `json:"id"`
+	ID string `json:"id"`
+	// Project is the live display name resolved through ProjectID, falling back to the name the
+	// row was written with once no registered project carries that identity any more. ProjectID
+	// is the durable identity: renaming a project never rewrites it (atqamz/hand#388).
 	Project          string        `json:"project"`
+	ProjectID        string        `json:"project_id"`
 	Kind             string        `json:"kind"`
 	Brief            string        `json:"brief"`
 	Lifecycle        TaskLifecycle `json:"lifecycle"`
@@ -234,6 +238,10 @@ func SendRetrySafe(send SendAttempt) bool {
 // its own repo. A fork has two repos, the one URL names and the one its PRs live on, and only a
 // declared upstream tells that pair from an unauthorized one (atqamz/hand#78).
 type Project struct {
+	// ID is the surrogate identity a project keeps across every rename; Name is the live,
+	// operator-facing label and the projection key, unique among registered projects but
+	// reusable once a project is removed (atqamz/hand#388).
+	ID       string
 	Name     string
 	URL      string
 	Mode     string
@@ -275,6 +283,7 @@ const schema = `
 CREATE TABLE IF NOT EXISTS task (
 	id                TEXT PRIMARY KEY,
 	project           TEXT NOT NULL DEFAULT '',
+	project_id        TEXT NOT NULL DEFAULT '',
 	kind              TEXT NOT NULL DEFAULT '',
 	brief             TEXT NOT NULL DEFAULT '',
 	lifecycle         TEXT NOT NULL DEFAULT 'open' CHECK (lifecycle IN ('open', 'terminal')),
@@ -343,7 +352,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS attempt_one_active
 ON attempt(task_id)
 WHERE lifecycle IN ('provisioning', 'running');
 CREATE TABLE IF NOT EXISTS project (
-	name     TEXT PRIMARY KEY,
+	id       TEXT PRIMARY KEY,
+	name     TEXT NOT NULL UNIQUE,
 	url      TEXT NOT NULL,
 	mode     TEXT NOT NULL,
 	position INTEGER NOT NULL,
@@ -586,8 +596,8 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
-	if current == acknowledgedMetadataVersion {
-		return db.ReadTaskHistory(id)
+	if current == fleetIdentityVersion || current == acknowledgedMetadataVersion {
+		return db.readTaskHistoryBeforeProjectIdentity(id)
 	}
 	if current == preAcknowledgementVersion || current == attemptBranchVersion {
 		return db.readTaskHistoryBeforeAcknowledgement(id)
@@ -646,18 +656,44 @@ func (db *DB) setMeta(key, value string) error {
 	return nil
 }
 
-var taskColumnNames = []string{
+// The layout every schema before projectIdentityVersion stored, and still the order the
+// read-only ladder's older scanners read: project_id is appended rather than slotted beside
+// project so the two suffix slices below keep naming the columns they always named.
+var taskColumnNamesBeforeProjectIdentity = []string{
 	"id", "project", "kind", "brief", "lifecycle", "active_attempt_id", "pr",
 	"merge_executed", "merge_executed_at", "merge_announced", "delivered_at", "delivered_reason",
 	"report_offset", "report_digest", "created_at", "repair_code", "repair_reason", "repair_attempt_id", "repair_observed_at",
 	"acknowledged_at", "acknowledged_reason", "acknowledged_offset", "acknowledged_digest",
 }
 
+var taskColumnNames = append(append([]string{}, taskColumnNamesBeforeProjectIdentity...), "project_id")
+
 var taskColumns = strings.Join(taskColumnNames, ", ")
 
-var taskColumnsBeforeRepair = strings.Join(taskColumnNames[:len(taskColumnNames)-8], ", ")
+var taskColumnsBeforeProjectIdentity = strings.Join(taskColumnNamesBeforeProjectIdentity, ", ")
 
-var taskColumnsBeforeAcknowledgement = strings.Join(taskColumnNames[:len(taskColumnNames)-4], ", ")
+var taskColumnsBeforeRepair = strings.Join(taskColumnNamesBeforeProjectIdentity[:len(taskColumnNamesBeforeProjectIdentity)-8], ", ")
+
+var taskColumnsBeforeAcknowledgement = strings.Join(taskColumnNamesBeforeProjectIdentity[:len(taskColumnNamesBeforeProjectIdentity)-4], ", ")
+
+// A task's project name is no longer stored live: rename updates the one project row and
+// nothing else, so every current-schema read resolves the label through the identity and
+// keeps the stored name only as the fallback for a project that is no longer registered.
+var taskSelectColumns = taskSelectList()
+
+const taskSelectFrom = ` FROM task LEFT JOIN project ON project.id = task.project_id`
+
+func taskSelectList() string {
+	columns := make([]string, 0, len(taskColumnNames))
+	for _, name := range taskColumnNames {
+		if name == "project" {
+			columns = append(columns, "COALESCE(project.name, task.project)")
+			continue
+		}
+		columns = append(columns, "task."+name)
+	}
+	return strings.Join(columns, ", ")
+}
 
 var attemptColumnNames = []string{
 	"id", "task_id", "ordinal", "lifecycle", "harness", "model", "effort",
@@ -687,7 +723,28 @@ func taskValues(t Task) []any {
 	return []any{t.ID, t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
 		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt,
-		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest}
+		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.ProjectID}
+}
+
+// A caller names the project it is dispatching into; the identity behind that name is looked up
+// once, at creation, and is what the row keeps from then on. An unregistered name resolves to no
+// identity rather than to whichever project later claims it.
+func resolveTaskProjectID(q interface {
+	QueryRow(string, ...any) *sql.Row
+}, t *Task) error {
+	if t.ProjectID != "" || t.Project == "" {
+		return nil
+	}
+	var id string
+	err := q.QueryRow(`SELECT id FROM project WHERE name = ?`, t.Project).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("resolve project %q for task %q: %w", t.Project, t.ID, err)
+	}
+	t.ProjectID = id
+	return nil
 }
 
 func nullableAttemptID(id int64) any {
@@ -698,6 +755,25 @@ func nullableAttemptID(id int64) any {
 }
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
+	var t Task
+	var activeID sql.NullInt64
+	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
+		&t.MergeExecuted, &t.MergeExecutedAt, &t.MergeAnnounced, &t.DeliveredAt, &t.DeliveredReason,
+		&t.ReportOffset, &t.ReportDigest, &t.CreatedAt, &t.RepairCode, &t.RepairReason, &t.RepairAttemptID, &t.RepairObservedAt,
+		&t.AcknowledgedAt, &t.AcknowledgedReason, &t.AcknowledgedOffset, &t.AcknowledgedDigest, &t.ProjectID)
+	if activeID.Valid {
+		t.ActiveAttemptID = activeID.Int64
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	return t, err
+}
+
+// Reads a task row from a database migrated no further than fleetIdentityVersion, which has no
+// project_id at all: its stored project name is still the live one, because rename rewrote every
+// task row back then.
+func scanTaskBeforeProjectIdentity(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
 	var activeID sql.NullInt64
 	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
@@ -794,7 +870,7 @@ func scanAttemptBeforeSend(row interface{ Scan(...any) error }) (Attempt, error)
 }
 
 func (db *DB) ReadTask(id string) (Task, bool, error) {
-	row := db.sql.QueryRow(`SELECT `+taskColumns+` FROM task WHERE id = ?`, id)
+	row := db.sql.QueryRow(`SELECT `+taskSelectColumns+taskSelectFrom+` WHERE task.id = ?`, id)
 	t, err := scanTask(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Task{}, false, nil
@@ -808,6 +884,9 @@ func (db *DB) ReadTask(id string) (Task, bool, error) {
 func (db *DB) CreateTask(t Task) error {
 	if t.Lifecycle == "" {
 		t.Lifecycle = TaskOpen
+	}
+	if err := resolveTaskProjectID(db.sql, &t); err != nil {
+		return err
 	}
 	_, err := db.sql.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...)
 	if err != nil {
@@ -832,7 +911,7 @@ func (db *DB) UpdateTask(t Task) error {
 }
 
 func (db *DB) ListTasks() ([]Task, error) {
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task ORDER BY id`)
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` ORDER BY task.id`)
 	if err != nil {
 		return nil, fmt.Errorf("list tasks: %w", err)
 	}
@@ -859,6 +938,35 @@ func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
 	task, found, err := db.ReadTask(id)
 	if err != nil || !found {
 		return TaskHistory{}, found, err
+	}
+	attempts, err := db.ListAttempts(id)
+	if err != nil {
+		return TaskHistory{}, false, err
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
+func (db *DB) readTaskHistoryBeforeProjectIdentity(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeProjectIdentity+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeProjectIdentity(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
 	}
 	attempts, err := db.ListAttempts(id)
 	if err != nil {
@@ -1074,7 +1182,7 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' ORDER BY id`)
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` WHERE task.lifecycle = 'open' ORDER BY task.id`)
 	if err != nil {
 		return nil, fmt.Errorf("list open tasks: %w", err)
 	}
@@ -1113,7 +1221,7 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` WHERE task.lifecycle = 'open' OR task.repair_code <> '' OR EXISTS (
 		SELECT 1 FROM attempt
 		WHERE attempt.task_id = task.id
 		AND attempt.lifecycle NOT IN ('provisioning', 'running')
@@ -1122,7 +1230,7 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
 			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
 		)
-	) ORDER BY id`)
+	) ORDER BY task.id`)
 	if err != nil {
 		return nil, fmt.Errorf("list reconciliation tasks: %w", err)
 	}
@@ -1169,13 +1277,63 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	if current == holdInferredVersion {
 		return db.listReconciliationHistoriesBeforeAcknowledgementAndBranch()
 	}
-	if current == acknowledgedMetadataVersion {
-		return db.ListReconciliationHistories()
+	if current == fleetIdentityVersion || current == acknowledgedMetadataVersion {
+		return db.listReconciliationHistoriesBeforeProjectIdentity()
 	}
 	if current == repairMetadataVersion || current == sendSchemaVersion {
 		return db.listReconciliationHistoriesBeforeSend()
 	}
 	return db.ListReconciliationHistories()
+}
+
+// The reconciliation-listing counterpart to readTaskHistoryBeforeProjectIdentity, for a home whose
+// task table has no project_id to join the live project name through.
+func (db *DB) listReconciliationHistoriesBeforeProjectIdentity() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
+	rows, err := db.sql.Query(`SELECT ` + taskColumnsBeforeProjectIdentity + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTaskBeforeProjectIdentity(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.ListAttempts(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("task %q active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
 }
 
 // The reconciliation-listing counterpart to readTaskHistoryBeforeAcknowledgementAndBranch: holdInferredVersion
@@ -1361,6 +1519,9 @@ func (db *DB) CreateTaskWithAttempt(t Task, a Attempt) (Attempt, error) {
 		return Attempt{}, fmt.Errorf("begin task creation: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := resolveTaskProjectID(tx, &t); err != nil {
+		return Attempt{}, err
+	}
 	if _, err := tx.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...); err != nil {
 		if isSQLiteBusy(err) {
 			return Attempt{}, contention("create task", t.ID, err)
@@ -2521,7 +2682,7 @@ func (db *DB) ListProjects() ([]Project, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT name, url, mode, upstream FROM project ORDER BY position, name`)
+	rows, err := db.sql.Query(`SELECT id, name, url, mode, upstream FROM project ORDER BY position, name`)
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
@@ -2530,7 +2691,7 @@ func (db *DB) ListProjects() ([]Project, error) {
 	var projects []Project
 	for rows.Next() {
 		var p Project
-		if err := rows.Scan(&p.Name, &p.URL, &p.Mode, &p.Upstream); err != nil {
+		if err := rows.Scan(&p.ID, &p.Name, &p.URL, &p.Mode, &p.Upstream); err != nil {
 			return nil, fmt.Errorf("list projects: %w", err)
 		}
 		projects = append(projects, p)
@@ -2541,9 +2702,19 @@ func (db *DB) ListProjects() ([]Project, error) {
 	return projects, nil
 }
 
+// A caller never supplies the identity: it is minted here so no command surface has to carry
+// a flag for it, and so a name reused after a removal can never inherit the removed project's
+// history (atqamz/hand#388).
 func (db *DB) AddProject(p Project) error {
-	_, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream)
-		VALUES (?, ?, ?, (SELECT COALESCE(MAX(position), -1) + 1 FROM project), ?)`, p.Name, p.URL, p.Mode, p.Upstream)
+	if p.ID == "" {
+		id, err := newProjectID()
+		if err != nil {
+			return fmt.Errorf("add project %q: %w", p.Name, err)
+		}
+		p.ID = id
+	}
+	_, err := db.sql.Exec(`INSERT INTO project (id, name, url, mode, position, upstream)
+		VALUES (?, ?, ?, ?, (SELECT COALESCE(MAX(position), -1) + 1 FROM project), ?)`, p.ID, p.Name, p.URL, p.Mode, p.Upstream)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return fmt.Errorf("project %q %w", p.Name, ErrProjectExists)
@@ -2593,7 +2764,20 @@ func (db *DB) SetProjectMode(name, mode string) (bool, error) {
 	return affected > 0, nil
 }
 
-// RenameProject updates the registry key and every task's project reference in one transaction.
+// BackfillTaskProjectIdentity links identity-less task rows to the project now answering to the
+// name they carry. It belongs to the one-time data/projects.md import, whose home had no project
+// rows for the migration to resolve against; running it later is what atqamz/hand#388 forbids.
+func (db *DB) BackfillTaskProjectIdentity() error {
+	if _, err := db.sql.Exec(`UPDATE task SET project_id = COALESCE((SELECT id FROM project WHERE project.name = task.project), '')
+		WHERE project_id = ''`); err != nil {
+		return fmt.Errorf("backfill task project identity: %w", err)
+	}
+	return nil
+}
+
+// RenameProject relabels one durable project row. Task and completion history is deliberately
+// left alone: the identity a rename cannot change is what those records reference, so there is
+// nothing to search for by name and nothing to roll back (atqamz/hand#388, atqamz/hand#396).
 func (db *DB) RenameProject(oldName, newName string) (bool, error) {
 	return db.renameProject(oldName, newName, "", false)
 }
@@ -2610,14 +2794,22 @@ func (db *DB) renameProject(oldName, newName, newURL string, updateURL bool) (bo
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	var id string
+	err = tx.QueryRow(`SELECT id FROM project WHERE name = ?`, oldName).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("rename project %q: %w", oldName, err)
+	}
 	query := `UPDATE project SET name = ?`
 	args := []any{newName}
 	if updateURL {
 		query += `, url = ?`
 		args = append(args, newURL)
 	}
-	query += ` WHERE name = ?`
-	args = append(args, oldName)
+	query += ` WHERE id = ?`
+	args = append(args, id)
 	result, err := tx.Exec(query, args...)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
@@ -2632,9 +2824,6 @@ func (db *DB) renameProject(oldName, newName, newURL string, updateURL bool) (bo
 	if affected == 0 {
 		return false, nil
 	}
-	if _, err := tx.Exec(`UPDATE task SET project = ? WHERE project = ?`, newName, oldName); err != nil {
-		return false, fmt.Errorf("rename tasks for project %q: %w", oldName, err)
-	}
 	if err := tx.Commit(); err != nil {
 		return false, fmt.Errorf("rename project %q: %w", oldName, err)
 	}
@@ -2644,7 +2833,17 @@ func (db *DB) renameProject(oldName, newName, newURL string, updateURL bool) (bo
 // RemoveProject reports whether a row was actually removed, leaving the
 // not-registered wording to the caller that already owns it.
 func (db *DB) RemoveProject(name string) (bool, error) {
-	res, err := db.sql.Exec(`DELETE FROM project WHERE name = ?`, name)
+	var id string
+	err := db.sql.QueryRow(`SELECT id FROM project WHERE name = ?`, name).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("remove project %q: %w", name, err)
+	}
+	// By identity, so a removal can never take a same-named row a concurrent writer
+	// registered in its place: the history that row owns is a different project's.
+	res, err := db.sql.Exec(`DELETE FROM project WHERE id = ?`, id)
 	if err != nil {
 		return false, fmt.Errorf("remove project %q: %w", name, err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -197,6 +197,10 @@ func TestSetProjectURLPreservesProjectIdentityAndOrder(t *testing.T) {
 		t.Fatalf("ListProjects = %+v, want %d projects", got, len(want))
 	}
 	for i := range want {
+		if got[i].ID == "" {
+			t.Fatalf("project %d = %+v, want a minted identity", i, got[i])
+		}
+		want[i].ID = got[i].ID
 		if got[i] != want[i] {
 			t.Fatalf("project %d = %+v, want %+v", i, got[i], want[i])
 		}


### PR DESCRIPTION
## Summary

- Gives every project an opaque `p_`-prefixed surrogate id that survives rename, and makes `task.project_id` the durable reference; `name` stays the unique live label and the `data/projects.md` projection key, with no identity authority of its own.
- `renameProject` now relabels exactly one row, found by id, and never rewrites task history: the live label a task reports is resolved through its identity, with the name stored on the row kept only as the fallback for a project that is no longer registered.
- The ordered migration mints an id for every registered project and backfills each task from the name it currently carries, transactionally. A task naming no registered project is left without an identity rather than attached to whatever project now answers to that name; a home whose registry lived only in `data/projects.md` gets the same link once the one-time legacy import creates the rows.

First of a stack for atqamz/hand#388; the completion-record half (`state/completions.jsonl` format version, project id on `Record`, and the legacy/unknown policy for records whose lineage is not knowable) follows in the next PR, so this one links the issue without closing it.

Refs atqamz/hand#388

## Test plan

- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean.
- New `internal/store/projectidentity_test.go`: migration from a `fleetIdentityVersion` fixture mints distinct ids, backfills two live tasks, and leaves an orphan task identity-less; the migration is idempotent across reopen; rename leaves the stored task name and the identity untouched while the resolved label follows; a removed-then-recreated name gets a fresh identity and does not inherit the retired project's tasks, including across a later rename; the read-only ladder still reads a pre-identity home.
- New `internal/project` test covers the legacy `data/projects.md` import linking pre-existing tasks by name once, and only for names that import registers.
- Existing project/store/cmd tests updated where they compared whole `Project` rows or a whole `state.Task`; `TestProjectRenameMovesCloneAndPreservesTaskHistory` now asserts the identity is the same one before and after the rename.
- CI on this PR is the evidence for `go test ./...`, not a local run: Lint, Contract, Nix build and Test on ubuntu, macos and windows all green.

