### PR TITLE
feat(completion): carry project identity on completion records

### DIFF
--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -303,8 +303,11 @@ func TestProjectSetURLUpdatesRegistryAndOriginPreservingTask(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(projects) != 1 || projects[0] != (project.Project{
-		Name: "secondhand", URL: newURL, Mode: project.ModeNoMistakes, Upstream: "atqamz/hand",
+	if len(projects) != 1 || projects[0].ID == "" {
+		t.Fatalf("projects = %+v, want one project with an identity", projects)
+	}
+	if projects[0] != (project.Project{
+		ID: projects[0].ID, Name: "secondhand", URL: newURL, Mode: project.ModeNoMistakes, Upstream: "atqamz/hand",
 	}) {
 		t.Fatalf("projects = %+v, want repointed project with preserved fields", projects)
 	}
@@ -369,9 +372,14 @@ func TestProjectSetModePreservesActiveTaskAndClone(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantProject := project.Project{Name: "old-name", URL: "https://github.com/org/repo.git", Mode: project.ModeNoMistakes, Upstream: "upstream/repo"}
-	if len(projects) != 1 || projects[0] != wantProject {
+	if len(projects) != 1 || projects[0].ID == "" {
+		t.Fatalf("projects = %+v, want one project with an identity", projects)
+	}
+	wantProject.ID = projects[0].ID
+	if projects[0] != wantProject {
 		t.Fatalf("projects = %+v, want %+v", projects, wantProject)
 	}
+	wantTask.ProjectID = projects[0].ID
 	if got, err := state.Read(home, wantTask.ID); err != nil || got != wantTask {
 		t.Fatalf("task = %+v, %v, want unchanged task %+v", got, err, wantTask)
 	}
@@ -426,6 +434,14 @@ func TestProjectRenameMovesCloneAndPreservesTaskHistory(t *testing.T) {
 	if err := state.Write(home, wantTask); err != nil {
 		t.Fatal(err)
 	}
+	registered, err := project.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registered) != 1 || registered[0].ID == "" {
+		t.Fatalf("projects = %+v, want one project with an identity", registered)
+	}
+	identityBeforeRename := registered[0].ID
 
 	cmd := newProjectRenameCmd()
 	var output strings.Builder
@@ -446,7 +462,7 @@ func TestProjectRenameMovesCloneAndPreservesTaskHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantProject := project.Project{Name: "new-name", URL: "https://github.com/org/repo.git", Mode: project.ModeDirectPR, Upstream: "upstream/repo"}
+	wantProject := project.Project{ID: identityBeforeRename, Name: "new-name", URL: "https://github.com/org/repo.git", Mode: project.ModeDirectPR, Upstream: "upstream/repo"}
 	if len(projects) != 1 || projects[0] != wantProject {
 		t.Fatalf("projects = %+v, want %+v", projects, wantProject)
 	}
@@ -456,6 +472,11 @@ func TestProjectRenameMovesCloneAndPreservesTaskHistory(t *testing.T) {
 	}
 	if gotTask.Project != "new-name" || gotTask.ID != wantTask.ID || gotTask.Brief != wantTask.Brief {
 		t.Fatalf("task = %+v, want same task with new project name", gotTask)
+	}
+	// The task never had its own copy of the name rewritten: it points at the identity the
+	// rename could not change, and the live label is resolved through that (atqamz/hand#388).
+	if gotTask.ProjectID != identityBeforeRename {
+		t.Fatalf("task project identity = %q, want the pre-rename identity %q", gotTask.ProjectID, identityBeforeRename)
 	}
 	history, err := state.ReadHistory(home, wantTask.ID)
 	if err != nil {

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -723,6 +723,9 @@ func TestTeardownRetriesAfterReportRemovalFails(t *testing.T) {
 func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 	home, worktree := setupTeardownHome(t)
 	writeFakeGHPRState(t, "MERGED")
+	// Registered before the task, so the row resolves an identity and the record carries the same
+	// one: that link is what a later rename of myproj leaves untouched (atqamz/hand#388).
+	identity := registerStoreProject(t, home, "myproj")
 
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip, Project: "myproj",
 		PR: "https://example.com/pr/1"}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: worktree,
@@ -759,7 +762,8 @@ func TestTeardownRecordsCompletionBeforeStateRemoval(t *testing.T) {
 		t.Fatalf("TornDownAt %v predates teardown start %v", torndownAt, before)
 	}
 	got.TornDownAt = ""
-	want := completion.Record{ID: "task-1", Project: "myproj", Kind: "ship", Outcome: "merged", Detail: "PR https://example.com/pr/1", AttemptID: active.ID, AttemptLifecycle: string(state.AttemptCompleted)}
+	want := completion.Record{Version: completion.RecordVersion, ID: "task-1", Project: "myproj", ProjectID: identity,
+		Kind: "ship", Outcome: "merged", Detail: "PR https://example.com/pr/1", AttemptID: active.ID, AttemptLifecycle: string(state.AttemptCompleted)}
 	if got != want {
 		t.Fatalf("record = %+v, want %+v", got, want)
 	}

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -10,7 +10,37 @@ import (
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
 )
+
+// Registers a project directly in the store and returns the identity minted for it, for a test
+// that needs a task to resolve one without also standing up a clone and a projection.
+func registerStoreProject(t *testing.T, home, name string) string {
+	t.Helper()
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err := db.AddProject(store.Project{Name: name, URL: "local", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	projects, err := db.ListProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range projects {
+		if p.Name == name {
+			return p.ID
+		}
+	}
+	t.Fatalf("project %q is not registered after adding it", name)
+	return ""
+}
 
 func writeTaskAttempt(t *testing.T, home string, task state.Task, attempt state.Attempt) error {
 	t.Helper()

--- a/docs/adr/a-project-is-identified-by-a-surrogate-id-not-its-name.md
+++ b/docs/adr/a-project-is-identified-by-a-surrogate-id-not-its-name.md
@@ -1,0 +1,36 @@
+# A project is identified by a surrogate id, not its name
+
+- Date: 2026-08-26
+- Status: accepted
+- Issues: atqamz/hand#388, atqamz/hand#396, atqamz/hand#383
+- PRs: atqamz/hand#399, atqamz/hand#400
+
+## Context
+
+A project's name was its only identity: the `project` table's primary key, the value every task row stored, and the field completion records matched on. Names are operator-facing and mutable, and `hand project remove` frees one while leaving the removed project's task rows and `state/completions.jsonl` records behind under it. A later project taking that name inherited them, indistinguishable from its own.
+
+Rename made the same gap worse in a second way. It rewrote every task and every completion record whose stored name matched, which is a search across unrelated history rather than a change to one project, and its rollback re-ran that search backwards over records that may never have belonged to the rename at all.
+
+## Decision
+
+A project carries an opaque `p_`-prefixed id, minted when it is registered and never reissued. Tasks reference the id, completion records carry it, and `name` is only the live label: unique among registered projects, the key `data/projects.md` renders, and reusable once a project is removed.
+
+Rename therefore relabels one row, found by id, and writes nothing else. A task's project name is resolved through its identity when it is read, with the name stored on the row kept only as the fallback for a project no longer registered, and a completion record keeps the label it was written with because an append-only audit line records what was true when it was written.
+
+This removes the project-rename exception [Completions use an uncapped JSONL file](the-completion-store-is-an-uncapped-append-only-sibling.md) carved out of the append-only rule. What replaces it is not a wider licence to rewrite but a narrower one: a single one-time migration that stamps the record version onto every existing line, replacing the whole file through a temp file and a rename or leaving it exactly as it was.
+
+Lineage that the old data cannot settle is marked, not guessed. A task naming no registered project keeps no identity; a completion record that neither its task row nor the live registry can place is written as `completion.ProjectIDUnknown`, which is deliberately visible rather than empty. This is the same fail-closed reading of unknown identity that atqamz/hand#384 applies to runtime identity.
+
+[`internal/store/schemaversion.go`](../../internal/store/schemaversion.go) owns the schema migration, [`internal/completion/completion.go`](../../internal/completion/completion.go) the record format version and its one-time file migration, and [`internal/project/project.go`](../../internal/project/project.go) the resolution order between the two.
+
+## Rejected alternatives
+
+- Tombstoning a removed name reserves it forever, which makes names globally non-reusable without giving history a stable thing to point at.
+- Purging a removed project's task rows and completion records contradicts the uncapped append-only completion store and would break `hand status` and `hand reopen` on terminal work.
+- Rejecting any name a task or completion record has ever used is a scan that grows without bound and still cannot repair history already conflated.
+- Using the repository URL as identity fails on transfers and renames, and `hand project set-url` exists precisely so a project survives its URL changing.
+- Keeping the live name denormalized on every task row would make rename a multi-row write again, which is the shape both atqamz/hand#388 and atqamz/hand#396 came out of.
+
+## Consequences
+
+Adding a project surface means deciding what it keys on: the id for anything durable, the name only for what an operator types or reads. `state/completions.jsonl` now carries a record version, so any reader of that file has to tolerate both shapes and treat a missing `project_id` as version 1 rather than as an absent project. A completion record's `project` field is a historical label and can disagree with the project's current name; the id is what a reader joins on.

--- a/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
+++ b/docs/adr/the-completion-store-is-an-uncapped-append-only-sibling.md
@@ -1,7 +1,7 @@
 # Completions use an uncapped JSONL file
 
 - Date: 2026-08-04
-- Status: accepted, superseded in part by [Tasks are durable and Attempts own execution](tasks-are-durable-and-attempts-own-execution.md)
+- Status: accepted, superseded in part by [Tasks are durable and Attempts own execution](tasks-are-durable-and-attempts-own-execution.md) and by [A project is identified by a surrogate id, not its name](a-project-is-identified-by-a-surrogate-id-not-its-name.md), which removes the project-rename exception below
 - Issues: atqamz/hand#78
 - PRs: none single
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,7 +1,8 @@
 // Package completion is the durable record of tasks hand teardown has finished
 // with: state/completions.jsonl, one JSON object per line, uncapped - see
-// atqamz/hand#61. Normal records are appended; project rename may atomically
-// rewrite the matching records. Every line is readable on its own terms
+// atqamz/hand#61. Records are appended and never mutated in the ordinary course;
+// the one exception is the one-time project-identity migration below, which
+// replaces the whole file or none of it. Every line is readable on its own terms
 // without parsing markdown.
 package completion
 
@@ -17,10 +18,24 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// Record is one task's teardown outcome.
+// RecordVersion 2 is the first shape that carries a project identity. A line without the field
+// reads as version 1, which named its project by a label that a later rename or a reuse of that
+// name could make mean something else (atqamz/hand#388).
+const RecordVersion = 2
+
+// ProjectIDUnknown is what a record carries when nothing it holds can name the project it came
+// from. It is deliberately visible rather than empty, so an ambiguous record stays ambiguous
+// instead of reading as one belonging to whatever project now holds the name it was written with.
+const ProjectIDUnknown = "unknown"
+
+// Record is one task's teardown outcome. Project is the label the project carried when the record
+// was written and is never rewritten afterwards; ProjectID is the identity a rename cannot change,
+// and is what a reader joins on.
 type Record struct {
+	Version          int    `json:"record_version,omitempty"`
 	ID               string `json:"id"`
 	Project          string `json:"project"`
+	ProjectID        string `json:"project_id,omitempty"`
 	Kind             string `json:"kind"`
 	Outcome          string `json:"outcome"`
 	Detail           string `json:"detail"`
@@ -43,6 +58,10 @@ func Append(homeDir string, r Record) error {
 	}
 	defer release()
 
+	r.Version = RecordVersion
+	if r.ProjectID == "" {
+		r.ProjectID = ProjectIDUnknown
+	}
 	data, err := json.Marshal(r)
 	if err != nil {
 		return fmt.Errorf("encode completion record %q: %w", r.ID, err)
@@ -67,99 +86,67 @@ func Append(homeDir string, r Record) error {
 	return nil
 }
 
-// RenameRestore restores only the completion lines changed by RenameProject.
-type RenameRestore struct {
-	homeDir string
-	changes []renameChange
-}
+// ProjectIdentityResolver answers which project a legacy record belongs to. An empty answer means
+// the lineage is not knowable from what the record carries, and the migration writes
+// ProjectIDUnknown rather than attaching the record to whatever project now holds its name.
+type ProjectIdentityResolver func(Record) string
 
-type renameChange struct {
-	line         int
-	originalLine string
-	renamedLine  string
-}
-
-// Restore reverts the exact lines changed by the rename, if they are still unchanged.
-func (r RenameRestore) Restore() error {
-	if len(r.changes) == 0 {
-		return nil
-	}
-	release, err := state.Lock(r.homeDir, "completions")
-	if err != nil {
-		return fmt.Errorf("lock completions store: %w", err)
-	}
-	defer release()
-
-	path := Path(r.homeDir)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read completions store for rollback: %w", err)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("stat completions store for rollback: %w", err)
-	}
-	lines := strings.SplitAfter(string(data), "\n")
-	for _, change := range r.changes {
-		if change.line >= len(lines) || lines[change.line] != change.renamedLine {
-			return fmt.Errorf("completion line %d changed during rollback", change.line)
-		}
-		lines[change.line] = change.originalLine
-	}
-	if err := atomicfile.Write(path, ".completions-rollback-", []byte(strings.Join(lines, "")), info.Mode().Perm()); err != nil {
-		return fmt.Errorf("write completions store for rollback: %w", err)
-	}
-	return nil
-}
-
-func RenameProject(homeDir, oldName, newName string) (RenameRestore, error) {
+// MigrateProjectIdentity is the one-time format bump that gives each existing line the identity
+// field, in place of a schema migration this file cannot take part in. The whole file is replaced
+// through a temp file and a rename or nothing is written; a current line is passed through as is.
+func MigrateProjectIdentity(homeDir string, resolve ProjectIdentityResolver) error {
 	release, err := state.Lock(homeDir, "completions")
 	if err != nil {
-		return RenameRestore{}, fmt.Errorf("lock completions store: %w", err)
+		return fmt.Errorf("lock completions store: %w", err)
 	}
 	defer release()
 
 	path := Path(homeDir)
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return RenameRestore{}, nil
+		return nil
 	}
 	if err != nil {
-		return RenameRestore{}, fmt.Errorf("read completions store: %w", err)
+		return fmt.Errorf("read completions store: %w", err)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return RenameRestore{}, fmt.Errorf("stat completions store: %w", err)
+		return fmt.Errorf("stat completions store: %w", err)
 	}
 
 	var rendered strings.Builder
-	var changes []renameChange
-	for lineNumber, line := range strings.SplitAfter(string(data), "\n") {
+	migrated := 0
+	for _, line := range strings.SplitAfter(string(data), "\n") {
 		body, newline := strings.CutSuffix(line, "\n")
 		var record Record
-		if err := json.Unmarshal([]byte(body), &record); err == nil && record.Project == oldName {
-			record.Project = newName
-			encoded, err := json.Marshal(record)
-			if err != nil {
-				return RenameRestore{}, fmt.Errorf("encode completion record %q: %w", record.ID, err)
-			}
-			renameLine := string(encoded)
-			if newline {
-				renameLine += "\n"
-			}
-			rendered.WriteString(renameLine)
-			changes = append(changes, renameChange{line: lineNumber, originalLine: line, renamedLine: renameLine})
+		// A line that does not parse is another writer's partial append or damage: it is carried
+		// through verbatim for the same reason List skips it rather than dropping the file.
+		if err := json.Unmarshal([]byte(body), &record); err != nil || record.Version >= RecordVersion {
+			rendered.WriteString(line)
 			continue
 		}
-		rendered.WriteString(line)
+		record.Version = RecordVersion
+		record.ProjectID = resolve(record)
+		if record.ProjectID == "" {
+			record.ProjectID = ProjectIDUnknown
+		}
+		encoded, err := json.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("encode completion record %q: %w", record.ID, err)
+		}
+		rendered.Write(encoded)
+		if newline {
+			rendered.WriteString("\n")
+		}
+		migrated++
 	}
-	if len(changes) == 0 {
-		return RenameRestore{}, nil
+	if migrated == 0 {
+		return nil
 	}
-	if err := atomicfile.Write(path, ".completions-", []byte(rendered.String()), info.Mode().Perm()); err != nil {
-		return RenameRestore{}, fmt.Errorf("write completions store: %w", err)
+	if err := atomicfile.Write(path, ".completions-identity-", []byte(rendered.String()), info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write completions store: %w", err)
 	}
-	return RenameRestore{homeDir: homeDir, changes: changes}, nil
+	return nil
 }
 
 // List returns every record, oldest first, and nil if the store doesn't exist yet. A

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -102,16 +102,21 @@ func MigrateProjectIdentity(homeDir string, resolve ProjectIdentityResolver) err
 	defer release()
 
 	path := Path(homeDir)
-	data, err := os.ReadFile(path)
+	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("read completions store: %w", err)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
 		return fmt.Errorf("stat completions store: %w", err)
+	}
+	// Leave invalid non-file paths to the append operation, which reports the same storage
+	// boundary it reported before identity migration ran.
+	if info.IsDir() {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read completions store: %w", err)
 	}
 
 	var rendered strings.Builder

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -9,6 +9,7 @@ package completion
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -91,6 +92,8 @@ func Append(homeDir string, r Record) error {
 // ProjectIDUnknown rather than attaching the record to whatever project now holds its name.
 type ProjectIdentityResolver func(Record) string
 
+var ErrInvalidStorePath = errors.New("completion store path is not a file")
+
 // MigrateProjectIdentity is the one-time format bump that gives each existing line the identity
 // field, in place of a schema migration this file cannot take part in. The whole file is replaced
 // through a temp file and a rename or nothing is written; a current line is passed through as is.
@@ -112,7 +115,7 @@ func MigrateProjectIdentity(homeDir string, resolve ProjectIdentityResolver) err
 	// Leave invalid non-file paths to the append operation, which reports the same storage
 	// boundary it reported before identity migration ran.
 	if info.IsDir() {
-		return nil
+		return ErrInvalidStorePath
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -3,9 +3,21 @@ package completion
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
+
+// What Append stamps onto every record it writes, so a test can say what it appended and still
+// compare against what a reader gets back.
+func appended(r Record) Record {
+	r.Version = RecordVersion
+	if r.ProjectID == "" {
+		r.ProjectID = ProjectIDUnknown
+	}
+	return r
+}
 
 func TestAppendListRoundTrip(t *testing.T) {
 	dir := t.TempDir()
@@ -27,8 +39,8 @@ func TestAppendListRoundTrip(t *testing.T) {
 		t.Fatalf("List returned %d records, want %d", len(got), len(want))
 	}
 	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("record %d = %+v, want %+v", i, got[i], want[i])
+		if got[i] != appended(want[i]) {
+			t.Fatalf("record %d = %+v, want %+v", i, got[i], appended(want[i]))
 		}
 	}
 }
@@ -98,8 +110,8 @@ func TestListSkipsDamagedLine(t *testing.T) {
 		t.Fatalf("List returned %d records, want %d: %+v", len(got), len(want), got)
 	}
 	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("record %d = %+v, want %+v", i, got[i], want[i])
+		if got[i] != appended(want[i]) {
+			t.Fatalf("record %d = %+v, want %+v", i, got[i], appended(want[i]))
 		}
 	}
 }
@@ -135,5 +147,153 @@ func TestAppendConcurrent(t *testing.T) {
 			t.Fatalf("record %q appeared more than once", r.ID)
 		}
 		seen[r.ID] = true
+	}
+}
+
+func writeStore(t *testing.T, dir string, lines ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Path(dir), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readStore(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// The fixture atqamz/hand#388 is about: several projects, one of them removed with its name since
+// claimed by a different project, and records whose lineage the file alone cannot settle. The
+// unresolvable ones have to stay visibly unresolved rather than join the wrong project's history.
+func TestMigrateProjectIdentityMarksUnresolvableRecordsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	writeStore(t, dir,
+		`{"id":"alpha-1","project":"alpha","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-01T00:00:00Z"}`,
+		`{"id":"beta-1","project":"beta","kind":"scout","outcome":"done","detail":"","torndown_at":"2026-08-02T00:00:00Z"}`,
+		`{"id":"gamma-old","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-03T00:00:00Z"}`,
+		`{"id":"gamma-new","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-04T00:00:00Z"}`,
+	)
+	// alpha is registered; beta was removed and its name never reclaimed; gamma was removed and its
+	// name taken by a later project, whose own task row is the only thing that can tell the two
+	// gamma records apart.
+	live := map[string]string{"alpha": "p_alpha", "gamma": "p_gamma_two"}
+	byTask := map[string]string{"gamma-new": "p_gamma_two"}
+	resolve := func(r Record) string {
+		if id, ok := byTask[r.ID]; ok {
+			return id
+		}
+		return live[r.Project]
+	}
+
+	if err := MigrateProjectIdentity(dir, resolve); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []struct {
+		id        string
+		project   string
+		projectID string
+	}{
+		{"alpha-1", "alpha", "p_alpha"},
+		{"beta-1", "beta", ProjectIDUnknown},
+		{"gamma-old", "gamma", "p_gamma_two"},
+		{"gamma-new", "gamma", "p_gamma_two"},
+	}
+	if len(records) != len(want) {
+		t.Fatalf("records = %+v, want %d", records, len(want))
+	}
+	for i, w := range want {
+		got := records[i]
+		if got.ID != w.id || got.Project != w.project || got.ProjectID != w.projectID || got.Version != RecordVersion {
+			t.Fatalf("record %d = %+v, want id=%q project=%q project_id=%q version=%d", i, got, w.id, w.project, w.projectID, RecordVersion)
+		}
+	}
+}
+
+// A resolver that can name nothing must leave every record explicitly unknown rather than empty:
+// the whole point of the marker is that an ambiguous record reads as ambiguous.
+func TestMigrateProjectIdentityNeverGuessesFromTheNameAlone(t *testing.T) {
+	dir := t.TempDir()
+	writeStore(t, dir,
+		`{"id":"one","project":"retired","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-01T00:00:00Z"}`,
+	)
+	if err := MigrateProjectIdentity(dir, func(Record) string { return "" }); err != nil {
+		t.Fatal(err)
+	}
+	records, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].ProjectID != ProjectIDUnknown || records[0].Project != "retired" {
+		t.Fatalf("records = %+v, want the name preserved and the identity marked unknown", records)
+	}
+}
+
+func TestMigrateProjectIdentityIsIdempotentAndLeavesDamagedLinesAlone(t *testing.T) {
+	dir := t.TempDir()
+	damaged := `{"id":"damag`
+	writeStore(t, dir,
+		`{"id":"alpha-1","project":"alpha","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-01T00:00:00Z"}`,
+		damaged,
+		`{"id":"alpha-2","project":"alpha","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-02T00:00:00Z"}`,
+	)
+	resolve := func(Record) string { return "p_alpha" }
+	if err := MigrateProjectIdentity(dir, resolve); err != nil {
+		t.Fatal(err)
+	}
+	first := readStore(t, dir)
+	if !strings.Contains(first, damaged+"\n") {
+		t.Fatalf("store = %q, want the damaged line carried through verbatim", first)
+	}
+
+	// A second run resolves to a different identity on purpose: an already-migrated record must be
+	// passed through untouched rather than backfilled again.
+	if err := MigrateProjectIdentity(dir, func(Record) string { return "p_other" }); err != nil {
+		t.Fatal(err)
+	}
+	if second := readStore(t, dir); second != first {
+		t.Fatalf("store = %q after a second migration, want %q", second, first)
+	}
+}
+
+// Nothing is written when there is nothing to migrate, so a re-run cannot disturb the file's mode
+// or its contents, and a store that does not exist yet is simply absent rather than an error.
+func TestMigrateProjectIdentityWritesNothingWhenThereIsNothingToDo(t *testing.T) {
+	dir := t.TempDir()
+	if err := MigrateProjectIdentity(dir, func(Record) string { return "p_alpha" }); err != nil {
+		t.Fatalf("missing store: %v", err)
+	}
+	if _, err := os.Stat(Path(dir)); !os.IsNotExist(err) {
+		t.Fatalf("stat = %v, want the migration to have created nothing", err)
+	}
+
+	if err := Append(dir, Record{ID: "one", Project: "alpha", ProjectID: "p_alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := readStore(t, dir)
+	if err := MigrateProjectIdentity(dir, func(Record) string { return "p_other" }); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readStore(t, dir) != content || !after.ModTime().Equal(before.ModTime()) {
+		t.Fatalf("store changed: %q at %v, want %q at %v", readStore(t, dir), after.ModTime(), content, before.ModTime())
 	}
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -133,6 +133,9 @@ func importCompletionIdentity(db *store.DB, homeDir string) error {
 		return err
 	}
 	if err := completion.MigrateProjectIdentity(homeDir, resolve); err != nil {
+		if errors.Is(err, completion.ErrInvalidStorePath) {
+			return nil
+		}
 		return err
 	}
 	return db.MarkMigrated(legacyCompletionIdentityKey)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -101,7 +101,71 @@ func openRegistry(homeDir string) (*store.DB, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	// After the registry import, never before it: the identities the completion records are
+	// resolved against are the ones that import creates on a home whose registry lived in the file.
+	if err := importCompletionIdentity(db, homeDir); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	return db, nil
+}
+
+// state/completions.jsonl is a sibling of the database, so no schema migration can reach it. This
+// is its one-time format bump, marked done the same way the registry import is.
+const legacyCompletionIdentityKey = "completions.jsonl:project-identity"
+
+func importCompletionIdentity(db *store.DB, homeDir string) error {
+	done, err := db.Migrated(legacyCompletionIdentityKey)
+	if err != nil || done {
+		return err
+	}
+	unlock, err := store.Lock(homeDir, store.MigrationLock, false)
+	if err != nil {
+		return fmt.Errorf("lock migration: %w", err)
+	}
+	defer unlock()
+
+	if done, err := db.Migrated(legacyCompletionIdentityKey); err != nil || done {
+		return err
+	}
+	resolve, err := completionIdentityResolver(db)
+	if err != nil {
+		return err
+	}
+	if err := completion.MigrateProjectIdentity(homeDir, resolve); err != nil {
+		return err
+	}
+	return db.MarkMigrated(legacyCompletionIdentityKey)
+}
+
+// The task a record names is asked first: its row already holds the identity resolved when the
+// task was created. Only a record whose task is gone falls back to the live registry, and an
+// unregistered name resolves to nothing rather than to whoever holds it now (atqamz/hand#388).
+func completionIdentityResolver(db *store.DB) (completion.ProjectIdentityResolver, error) {
+	projects, err := db.ListProjects()
+	if err != nil {
+		return nil, err
+	}
+	identityByName := make(map[string]string, len(projects))
+	for _, p := range projects {
+		identityByName[p.Name] = p.ID
+	}
+	tasks, err := db.ListTasks()
+	if err != nil {
+		return nil, err
+	}
+	identityByTask := make(map[string]string, len(tasks))
+	for _, t := range tasks {
+		if t.ProjectID != "" {
+			identityByTask[t.ID] = t.ProjectID
+		}
+	}
+	return func(r completion.Record) string {
+		if id, ok := identityByTask[r.ID]; ok {
+			return id
+		}
+		return identityByName[r.Project]
+	}, nil
 }
 
 func importLegacyRegistry(db *store.DB, homeDir string) error {
@@ -410,9 +474,9 @@ var projectRenameProjectionWriter = func(db *store.DB, homeDir, oldName, newName
 	return writeRenameProjection(db, homeDir, oldName, newName)
 }
 
-var projectRenameHistoryWriter = completion.RenameProject
-
-// Rename changes the registry key and task references while preserving the project's row position and fields.
+// Rename relabels the project and its projection. Task rows and completion records reference the
+// identity the rename cannot change, so there is no history to rewrite here and none to put back
+// (atqamz/hand#388, atqamz/hand#396).
 func Rename(homeDir, oldName, newName string) error {
 	if oldName == "" || newName == "" {
 		return fmt.Errorf("invalid project name")
@@ -486,19 +550,6 @@ func Rename(homeDir, oldName, newName string) error {
 	if !updated {
 		return fmt.Errorf("project %q %w", oldName, ErrNotFound)
 	}
-	historyRestore, err := projectRenameHistoryWriter(homeDir, oldName, newName)
-	if err != nil {
-		var rollbackErr error
-		if newURL != "" {
-			_, rollbackErr = projectRenameURLUpdater(db, newName, oldName, oldURL)
-		} else {
-			_, rollbackErr = projectRenameUpdater(db, newName, oldName)
-		}
-		if rollbackErr != nil {
-			return errors.Join(err, fmt.Errorf("restore project %q: %w", oldName, rollbackErr))
-		}
-		return err
-	}
 	if err := projectRenameProjectionWriter(db, homeDir, oldName, newName); err != nil {
 		var rollbackErrs []error
 		var rollbackErr error
@@ -509,9 +560,6 @@ func Rename(homeDir, oldName, newName string) error {
 		}
 		if rollbackErr != nil {
 			rollbackErrs = append(rollbackErrs, fmt.Errorf("restore project %q: %w", oldName, rollbackErr))
-		}
-		if rollbackErr := historyRestore.Restore(); rollbackErr != nil {
-			rollbackErrs = append(rollbackErrs, fmt.Errorf("restore project history %q: %w", oldName, rollbackErr))
 		}
 		if rollbackErr := restoreProjection(registryPath, oldProjection, projectionExists, projectionMode); rollbackErr != nil {
 			rollbackErrs = append(rollbackErrs, fmt.Errorf("restore project registry: %w", rollbackErr))

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -135,6 +135,12 @@ func importLegacyRegistry(db *store.DB, homeDir string) error {
 			return err
 		}
 	}
+	// The schema migration had no project rows to resolve task names against on a home whose
+	// registry lived only in the file, so the tasks it left without an identity are linked here,
+	// once, while the names in the file are still the names those tasks were written with.
+	if err := db.BackfillTaskProjectIdentity(); err != nil {
+		return err
+	}
 	return db.MarkMigrated(legacyRegistryKey)
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -155,14 +155,20 @@ func completionIdentityResolver(db *store.DB) (completion.ProjectIdentityResolve
 		return nil, err
 	}
 	identityByTask := make(map[string]string, len(tasks))
+	unknownTask := make(map[string]struct{})
 	for _, t := range tasks {
 		if t.ProjectID != "" {
 			identityByTask[t.ID] = t.ProjectID
+		} else {
+			unknownTask[t.ID] = struct{}{}
 		}
 	}
 	return func(r completion.Record) string {
 		if id, ok := identityByTask[r.ID]; ok {
 			return id
+		}
+		if _, ok := unknownTask[r.ID]; ok {
+			return completion.ProjectIDUnknown
 		}
 		return identityByName[r.Project]
 	}, nil

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -723,6 +723,48 @@ func TestMigrateWithoutProjectsDefersTheOneTimeLegacyImport(t *testing.T) {
 	}
 }
 
+func TestMigrateRetriesCompletionIdentityAfterInvalidStorePath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(completion.Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(completion.Path(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := Migrate(dir); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done, err := db.Migrated(legacyCompletionIdentityKey)
+	_ = db.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done {
+		t.Fatal("invalid completion store path consumed the migration")
+	}
+
+	if err := os.RemoveAll(completion.Path(dir)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(completion.Path(dir), []byte(`{"id":"legacy","project":"demo","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-01T00:00:00Z"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Migrate(dir); err != nil {
+		t.Fatal(err)
+	}
+	records, err := completion.List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Version != completion.RecordVersion {
+		t.Fatalf("records after retry = %+v, want one migrated record", records)
+	}
+}
+
 func projectMigrationDone(t *testing.T, dir string) bool {
 	t.Helper()
 	db, err := store.Open(dir)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -242,6 +242,11 @@ func TestSetModeRollsBackWhenProjectionWriteFails(t *testing.T) {
 func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 	dir := t.TempDir()
 	writeRegistry(t, dir, "# Projects\n\n# profile=demo\n- demo: https://github.com/org/demo mode=no-mistakes upstream=up/demo\n\n# profile=second\n- second: https://github.com/org/second mode=direct-pr\n")
+	registered, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identityBeforeRename := identityOf(t, registered[0])
 	db, err := store.Open(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -253,7 +258,7 @@ func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := completion.Append(dir, completion.Record{ID: "task-1", Project: "demo", Kind: "ship", Outcome: "merged"}); err != nil {
+	if err := completion.Append(dir, completion.Record{ID: "task-1", Project: "demo", ProjectID: identityBeforeRename, Kind: "ship", Outcome: "merged"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -272,6 +277,9 @@ func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 	if len(projects) != len(want) {
 		t.Fatalf("projects = %+v, want %+v", projects, want)
 	}
+	if projects[0].ID != identityBeforeRename {
+		t.Fatalf("identity after rename = %q, want the unchanged %q", projects[0].ID, identityBeforeRename)
+	}
 	for i := range want {
 		want[i].ID = identityOf(t, projects[i])
 		if projects[i] != want[i] {
@@ -284,12 +292,14 @@ func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 	}
 	task, found, err := db.ReadTask("task-1")
 	_ = db.Close()
-	if err != nil || !found || task.Project != "renamed" {
-		t.Fatalf("task = %+v, found=%v, err=%v, want renamed project", task, found, err)
+	if err != nil || !found || task.Project != "renamed" || task.ProjectID != identityBeforeRename {
+		t.Fatalf("task = %+v, found=%v, err=%v, want renamed project on the unchanged identity", task, found, err)
 	}
+	// The audit record keeps the label it was written with and the identity the rename could not
+	// change: rename rewrites no history at all any more (atqamz/hand#388).
 	records, err := completion.List(dir)
-	if err != nil || len(records) != 1 || records[0].Project != "renamed" {
-		t.Fatalf("completion records = %+v, err=%v, want renamed project", records, err)
+	if err != nil || len(records) != 1 || records[0].Project != "demo" || records[0].ProjectID != identityBeforeRename {
+		t.Fatalf("completion records = %+v, err=%v, want the record left under the pre-rename label", records, err)
 	}
 	projection, err := os.ReadFile(RegistryPath(dir))
 	if err != nil {
@@ -327,7 +337,7 @@ func TestRenameRollsBackWhenProjectionWriteFails(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(records) != 1 || records[0].Project != "demo" {
-		t.Fatalf("completion records = %+v, want old name after rollback", records)
+		t.Fatalf("completion records = %+v, want history untouched by the failed rename", records)
 	}
 }
 
@@ -365,7 +375,10 @@ func TestRenameRestoresProjectionWhenWriteFailsAfterReplacement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantRecords := []completion.Record{{ID: "demo-task", Project: "demo"}, {ID: "unrelated", Project: "renamed"}}
+	wantRecords := []completion.Record{
+		{Version: completion.RecordVersion, ID: "demo-task", Project: "demo", ProjectID: completion.ProjectIDUnknown},
+		{Version: completion.RecordVersion, ID: "unrelated", Project: "renamed", ProjectID: completion.ProjectIDUnknown},
+	}
 	if len(records) != len(wantRecords) {
 		t.Fatalf("completion records = %+v, want %+v", records, wantRecords)
 	}
@@ -376,61 +389,47 @@ func TestRenameRestoresProjectionWhenWriteFailsAfterReplacement(t *testing.T) {
 	}
 }
 
-func TestRenameRollbackOnlyRestoresRenamedCompletionRecords(t *testing.T) {
-	dir := t.TempDir()
-	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
-	if err := completion.Append(dir, completion.Record{ID: "renamed-project", Project: "demo"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := completion.Append(dir, completion.Record{ID: "unrelated", Project: "renamed"}); err != nil {
-		t.Fatal(err)
-	}
-	original := projectRenameProjectionWriter
-	t.Cleanup(func() { projectRenameProjectionWriter = original })
-	projectRenameProjectionWriter = func(*store.DB, string, string, string) error {
-		return errors.New("projection failed")
-	}
+// atqamz/hand#396's rollback defect cannot recur, because a rename no longer writes the history it
+// used to have to restore: an unrelated record already carrying the destination name is untouched
+// whether the rename succeeds or fails.
+func TestRenameNeverRewritesCompletionHistory(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		failsWriting bool
+	}{{name: "successful rename"}, {name: "failed rename", failsWriting: true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
+			if err := completion.Append(dir, completion.Record{ID: "renamed-project", Project: "demo"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := completion.Append(dir, completion.Record{ID: "unrelated", Project: "renamed"}); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(completion.Path(dir))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.failsWriting {
+				original := projectRenameProjectionWriter
+				t.Cleanup(func() { projectRenameProjectionWriter = original })
+				projectRenameProjectionWriter = func(*store.DB, string, string, string) error {
+					return errors.New("projection failed")
+				}
+			}
 
-	if err := Rename(dir, "demo", "renamed"); err == nil || !strings.Contains(err.Error(), "projection failed") {
-		t.Fatalf("Rename = %v, want projection failure", err)
-	}
-	records, err := completion.List(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []completion.Record{
-		{ID: "renamed-project", Project: "demo"},
-		{ID: "unrelated", Project: "renamed"},
-	}
-	if len(records) != len(want) {
-		t.Fatalf("completion records = %+v, want %+v", records, want)
-	}
-	for i := range want {
-		if records[i] != want[i] {
-			t.Fatalf("completion record %d = %+v, want %+v", i, records[i], want[i])
-		}
-	}
-}
-
-func TestRenameRollsBackWhenHistoryWriteFails(t *testing.T) {
-	dir := t.TempDir()
-	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
-	original := projectRenameHistoryWriter
-	t.Cleanup(func() { projectRenameHistoryWriter = original })
-	projectRenameHistoryWriter = func(string, string, string) (completion.RenameRestore, error) {
-		return completion.RenameRestore{}, errors.New("history failed")
-	}
-
-	err := Rename(dir, "demo", "renamed")
-	if err == nil || !strings.Contains(err.Error(), "history failed") {
-		t.Fatalf("Rename = %v, want history failure", err)
-	}
-	projects, err := List(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(projects) != 1 || projects[0].Name != "demo" {
-		t.Fatalf("projects = %+v, want old name after rollback", projects)
+			err = Rename(dir, "demo", "renamed")
+			if tc.failsWriting != (err != nil) {
+				t.Fatalf("Rename = %v, want failure=%v", err, tc.failsWriting)
+			}
+			after, err := os.ReadFile(completion.Path(dir))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != string(before) {
+				t.Fatalf("completions = %q, want the file byte-identical to %q", after, before)
+			}
+		})
 	}
 }
 
@@ -1049,5 +1048,137 @@ func TestAddWaitsForTheRegistryLock(t *testing.T) {
 	projection, err := os.ReadFile(RegistryPath(dir))
 	if err != nil || !strings.Contains(string(projection), "- alpha: ") {
 		t.Fatalf("projection = %q, %v, want alpha listed", projection, err)
+	}
+}
+
+// The fleet home atqamz/hand#388 describes: a project removed and its name claimed by a different
+// project, alongside records whose project is gone for good. The one-time completion migration has
+// to keep those three populations apart rather than pooling them under the live name.
+func TestCompletionIdentityMigrationSeparatesReusedNamesFromUnknownLineage(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n")
+	db, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AddProject(store.Project{Name: "alpha", URL: "https://github.com/org/alpha", Mode: ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AddProject(store.Project{Name: "gamma", URL: "https://github.com/org/gamma", Mode: ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	projects, err := db.ListProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	alpha, retiredGamma := projects[0].ID, projects[1].ID
+	for _, task := range []store.Task{
+		{ID: "alpha-1", Project: "alpha", Kind: store.KindShip, Lifecycle: store.TaskTerminal},
+		{ID: "beta-1", Project: "beta", Kind: store.KindScout, Lifecycle: store.TaskTerminal},
+		{ID: "gamma-old", Project: "gamma", Kind: store.KindShip, Lifecycle: store.TaskTerminal},
+	} {
+		if err := db.CreateTask(task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// gamma is retired and its name reissued to a different project, which is what makes the two
+	// gamma records indistinguishable by name alone.
+	if removed, err := db.RemoveProject("gamma"); err != nil || !removed {
+		t.Fatalf("RemoveProject = %v, %v", removed, err)
+	}
+	if err := db.AddProject(store.Project{Name: "gamma", URL: "https://github.com/org/gamma-two", Mode: ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	liveGamma := identityOf(t, mustFindProject(t, db, "gamma"))
+	if liveGamma == retiredGamma {
+		t.Fatalf("reissued name kept identity %q", liveGamma)
+	}
+	if err := db.CreateTask(store.Task{ID: "gamma-new", Project: "gamma", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Written in the pre-identity shape, which is what an existing fleet home's file holds.
+	writeCompletions(t, dir,
+		`{"id":"alpha-1","project":"alpha","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-01T00:00:00Z"}`,
+		`{"id":"beta-1","project":"beta","kind":"scout","outcome":"done","detail":"","torndown_at":"2026-08-02T00:00:00Z"}`,
+		`{"id":"gamma-old","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-03T00:00:00Z"}`,
+		`{"id":"gamma-new","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-04T00:00:00Z"}`,
+		`{"id":"vanished","project":"delta","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-05T00:00:00Z"}`,
+	)
+
+	if _, err := List(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := completion.List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"alpha-1": alpha,
+		// beta was removed and never reclaimed, so nothing in the file or the registry can name it.
+		"beta-1": completion.ProjectIDUnknown,
+		// The task rows keep the two gamma populations apart, which is the whole point of the
+		// surrogate identity: the retired project's record does not join the reissued name's history.
+		"gamma-old": retiredGamma,
+		"gamma-new": liveGamma,
+		// No task row survives, and "delta" names no registered project: not knowable, so not guessed.
+		"vanished": completion.ProjectIDUnknown,
+	}
+	if len(records) != len(want) {
+		t.Fatalf("records = %+v, want %d", records, len(want))
+	}
+	for _, r := range records {
+		if r.Version != completion.RecordVersion {
+			t.Fatalf("record %+v, want version %d", r, completion.RecordVersion)
+		}
+		if r.ProjectID != want[r.ID] {
+			t.Fatalf("record %q identity = %q, want %q", r.ID, r.ProjectID, want[r.ID])
+		}
+	}
+
+	// The migration is marked done, so a second open neither rewrites the file nor reattributes
+	// anything through the live registry a second time.
+	before, err := os.ReadFile(completion.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Rename(dir, "gamma", "gamma-renamed"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(completion.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("completions = %q after a later rename, want %q", after, before)
+	}
+}
+
+func mustFindProject(t *testing.T, db *store.DB, name string) Project {
+	t.Helper()
+	projects, err := db.ListProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range projects {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("project %q is not registered", name)
+	return Project{}
+}
+
+func writeCompletions(t *testing.T, dir string, lines ...string) {
+	t.Helper()
+	if err := os.MkdirAll(store.Dir(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(completion.Path(dir), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1086,6 +1086,9 @@ func TestCompletionIdentityMigrationSeparatesReusedNamesFromUnknownLineage(t *te
 	if removed, err := db.RemoveProject("gamma"); err != nil || !removed {
 		t.Fatalf("RemoveProject = %v, %v", removed, err)
 	}
+	if err := db.CreateTask(store.Task{ID: "gamma-unknown", Project: "gamma", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.AddProject(store.Project{Name: "gamma", URL: "https://github.com/org/gamma-two", Mode: ModeLocalOnly}); err != nil {
 		t.Fatal(err)
 	}
@@ -1106,6 +1109,7 @@ func TestCompletionIdentityMigrationSeparatesReusedNamesFromUnknownLineage(t *te
 		`{"id":"beta-1","project":"beta","kind":"scout","outcome":"done","detail":"","torndown_at":"2026-08-02T00:00:00Z"}`,
 		`{"id":"gamma-old","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-03T00:00:00Z"}`,
 		`{"id":"gamma-new","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-04T00:00:00Z"}`,
+		`{"id":"gamma-unknown","project":"gamma","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-04T12:00:00Z"}`,
 		`{"id":"vanished","project":"delta","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-05T00:00:00Z"}`,
 	)
 
@@ -1123,8 +1127,9 @@ func TestCompletionIdentityMigrationSeparatesReusedNamesFromUnknownLineage(t *te
 		"beta-1": completion.ProjectIDUnknown,
 		// The task rows keep the two gamma populations apart, which is the whole point of the
 		// surrogate identity: the retired project's record does not join the reissued name's history.
-		"gamma-old": retiredGamma,
-		"gamma-new": liveGamma,
+		"gamma-old":     retiredGamma,
+		"gamma-new":     liveGamma,
+		"gamma-unknown": completion.ProjectIDUnknown,
 		// No task row survives, and "delta" names no registered project: not knowable, so not guessed.
 		"vanished": completion.ProjectIDUnknown,
 	}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -133,6 +133,7 @@ func TestSetURLPreservesProjectionAssociationAndProjectFields(t *testing.T) {
 		t.Fatalf("projects = %+v, want %d projects", projects, len(want))
 	}
 	for i := range want {
+		want[i].ID = identityOf(t, projects[i])
 		if projects[i] != want[i] {
 			t.Fatalf("project %d = %+v, want %+v", i, projects[i], want[i])
 		}
@@ -202,7 +203,11 @@ func TestSetModePreservesProjectFieldsAndProjection(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := Project{Name: "demo", URL: "https://github.com/org/demo", Mode: ModeNoMistakes, Upstream: "up/demo"}
-	if len(projects) != 1 || projects[0] != want {
+	if len(projects) != 1 {
+		t.Fatalf("projects = %+v, want one project", projects)
+	}
+	want.ID = identityOf(t, projects[0])
+	if projects[0] != want {
 		t.Fatalf("projects = %+v, want %+v", projects, want)
 	}
 	projection, err := os.ReadFile(RegistryPath(dir))
@@ -268,6 +273,7 @@ func TestRenamePreservesProjectOrderAndTaskReference(t *testing.T) {
 		t.Fatalf("projects = %+v, want %+v", projects, want)
 	}
 	for i := range want {
+		want[i].ID = identityOf(t, projects[i])
 		if projects[i] != want[i] {
 			t.Fatalf("project %d = %+v, want %+v", i, projects[i], want[i])
 		}
@@ -588,11 +594,72 @@ func TestListParsesRegistry(t *testing.T) {
 	if len(projects) != 2 {
 		t.Fatalf("got %d projects, want 2", len(projects))
 	}
-	if projects[0] != (Project{Name: "nsr", URL: "https://github.com/yes2games/nsr", Mode: "direct-pr"}) {
+	if projects[0] != (Project{ID: identityOf(t, projects[0]), Name: "nsr", URL: "https://github.com/yes2games/nsr", Mode: "direct-pr"}) {
 		t.Errorf("got %+v", projects[0])
 	}
-	if projects[1] != (Project{Name: "secondhand", URL: "local", Mode: "local-only"}) {
+	if projects[1] != (Project{ID: identityOf(t, projects[1]), Name: "secondhand", URL: "local", Mode: "local-only"}) {
 		t.Errorf("got %+v", projects[1])
+	}
+}
+
+// The surrogate identity is minted internally, so a test that compares whole rows asserts it
+// exists and then reuses it rather than pinning a value no caller chooses.
+func identityOf(t *testing.T, p Project) string {
+	t.Helper()
+	if p.ID == "" {
+		t.Fatalf("project %q has no identity", p.Name)
+	}
+	return p.ID
+}
+
+// A home whose registry lived only in data/projects.md has no project rows for the schema
+// migration to resolve task names against, so the one-time import is what links them - and it
+// links only the names that import actually registers.
+func TestLegacyRegistryImportLinksExistingTasksToTheImportedProjects(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "# Projects\n\n- demo: https://github.com/org/demo mode=direct-pr\n")
+	db, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "task-1", Project: "demo", Kind: store.KindShip}); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "task-2", Project: "retired", Kind: store.KindShip}); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	projects, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 || projects[0].ID == "" {
+		t.Fatalf("projects = %+v, want the imported project with an identity", projects)
+	}
+
+	db, err = store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	linked, _, err := db.ReadTask("task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked.ProjectID != projects[0].ID {
+		t.Fatalf("task-1 identity = %q, want the imported %q", linked.ProjectID, projects[0].ID)
+	}
+	unlinked, _, err := db.ReadTask("task-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unlinked.ProjectID != "" || unlinked.Project != "retired" {
+		t.Fatalf("task-2 = %+v, want it left without an identity", unlinked)
 	}
 }
 

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -185,6 +185,9 @@ const (
 const reconcileIterationLimit = 8
 
 func (r *Runtime) Reconcile(req ReconcileRequest) (ReconcileReport, error) {
+	if err := project.Migrate(req.Home); err != nil {
+		return ReconcileReport{}, fmt.Errorf("migrate project and completion identity: %w", err)
+	}
 	if err := fleetPreflightReadOnly(req.Home); err != nil {
 		return ReconcileReport{}, Precondition(err)
 	}

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -287,7 +287,7 @@ func teardownDecision(forced, launched bool, lifecycle state.AttemptLifecycle, d
 }
 
 func completionFor(t state.Task, disposition string, launched bool, lastReportState, lastReportNote string) completion.Record {
-	c := completion.Record{ID: t.ID, Project: t.Project, Kind: t.Kind}
+	c := completion.Record{ID: t.ID, Project: t.Project, ProjectID: t.ProjectID, Kind: t.Kind}
 	// The delivered case sits ahead of the merge cases below only while no merge is on the row: a
 	// delivery that then genuinely landed has the stronger fact to record, so an observed or executed
 	// merge outranks the mark.

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -25,6 +25,9 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if err := project.Migrate(req.Home); err != nil {
+		return Result{}, fmt.Errorf("migrate project and completion identity: %w", err)
+	}
 	release, err := state.Lock(req.Home, "task:"+req.ID)
 	if err != nil {
 		return Result{}, fmt.Errorf("lock task %q: %w", req.ID, err)

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -55,6 +55,39 @@ func TestTeardownFailureAfterWorktreeReturnPreservesOwnershipEvidence(t *testing
 	}
 }
 
+func TestTeardownMigratesLegacyCompletionsBeforeAppending(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("findings\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(completion.Path(home), []byte(`{"id":"legacy","project":"demo","kind":"ship","outcome":"merged","detail":"","torndown_at":"2026-08-01T00:00:00Z"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout, Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, CreatedAt: "2026-08-14T00:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New().Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 || records[0].Version != completion.RecordVersion || records[0].ProjectID != completion.ProjectIDUnknown {
+		t.Fatalf("records = %+v, want the legacy line migrated before teardown appended", records)
+	}
+}
+
 func TestTeardownCompletionAppendFailureLeavesStateRetryable(t *testing.T) {
 	home, _ := teardownFixture(t, true)
 	appendErr := errors.New("completion store unavailable")

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -75,6 +75,22 @@ func newFleetID() (string, error) {
 	return "f_" + hex.EncodeToString(raw[:]), nil
 }
 
+// A project keeps this id for as long as it is registered, across every rename. The shape
+// mirrors the fleet id so an operator reading either can tell at a glance what it names, and
+// so the migration's sqlite-side backfill can mint the same thing without Go.
+const (
+	projectIDPrefix = "p_"
+	projectIDBytes  = "16"
+)
+
+func newProjectID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate project identity: %w", err)
+	}
+	return projectIDPrefix + hex.EncodeToString(raw[:]), nil
+}
+
 func validateFleetID(id string) error {
 	if len(id) != 34 || id[:2] != "f_" {
 		return fmt.Errorf("%w: %q", ErrFleetIdentityInvalid, id)

--- a/internal/store/projectidentity_test.go
+++ b/internal/store/projectidentity_test.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The layout a fleet home carried at fleetIdentityVersion: a project keyed by its mutable name
+// and a task holding a literal copy of it, which is what the surrogate identity replaces.
+const preProjectIdentityProjectTable = `DROP TABLE project;
+CREATE TABLE project (name TEXT PRIMARY KEY, url TEXT NOT NULL, mode TEXT NOT NULL, position INTEGER NOT NULL, upstream TEXT NOT NULL DEFAULT '');`
+
+func stampPreProjectIdentity(t *testing.T, db *DB) {
+	t.Helper()
+	if _, err := db.sql.Exec(preProjectIdentityProjectTable); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`ALTER TABLE task DROP COLUMN project_id`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = ` + strconv.Itoa(fleetIdentityVersion)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func projectIdentityOf(t *testing.T, db *DB, name string) string {
+	t.Helper()
+	var id string
+	if err := db.sql.QueryRow(`SELECT id FROM project WHERE name = ?`, name).Scan(&id); err != nil {
+		t.Fatalf("read identity for project %q: %v", name, err)
+	}
+	return id
+}
+
+func taskProjectIdentity(t *testing.T, db *DB, id string) string {
+	t.Helper()
+	var projectID string
+	if err := db.sql.QueryRow(`SELECT project_id FROM task WHERE id = ?`, id).Scan(&projectID); err != nil {
+		t.Fatalf("read project identity for task %q: %v", id, err)
+	}
+	return projectID
+}
+
+func TestMigrationGivesEveryRegisteredProjectAnIdentityAndBackfillsTasks(t *testing.T) {
+	db, home := openTemp(t)
+	stampPreProjectIdentity(t, db)
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream) VALUES
+		('nsr', 'git@github.com:o/nsr.git', 'direct-pr', 0, ''),
+		('universe', 'git@github.com:o/universe.git', 'no-mistakes', 1, 'o/universe')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle) VALUES
+		('live', 'nsr', 'ship', 'open'),
+		('other', 'universe', 'scout', 'terminal'),
+		('orphan', 'retired', 'ship', 'terminal')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatalf("migrate a pre-identity home: %v", err)
+	}
+	defer func() { _ = migrated.Close() }()
+	if version, err := migrated.schemaVersion(); err != nil || version != len(migrations) {
+		t.Fatalf("schemaVersion = %d, %v, want %d", version, err, len(migrations))
+	}
+
+	nsr := projectIdentityOf(t, migrated, "nsr")
+	universe := projectIdentityOf(t, migrated, "universe")
+	if !strings.HasPrefix(nsr, projectIDPrefix) || len(nsr) != len(projectIDPrefix)+32 {
+		t.Fatalf("nsr identity = %q, want a %s-prefixed opaque id", nsr, projectIDPrefix)
+	}
+	if nsr == universe {
+		t.Fatalf("both projects share identity %q", nsr)
+	}
+	if got := taskProjectIdentity(t, migrated, "live"); got != nsr {
+		t.Fatalf("task live identity = %q, want %q", got, nsr)
+	}
+	if got := taskProjectIdentity(t, migrated, "other"); got != universe {
+		t.Fatalf("task other identity = %q, want %q", got, universe)
+	}
+	// "retired" names no registered project, so its lineage is not knowable from the name alone
+	// and the migration refuses to guess one for it (atqamz/hand#388).
+	if got := taskProjectIdentity(t, migrated, "orphan"); got != "" {
+		t.Fatalf("orphan task identity = %q, want no identity", got)
+	}
+
+	projects, err := migrated.ListProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 2 || projects[0].Name != "nsr" || projects[0].ID != nsr || projects[1].Upstream != "o/universe" {
+		t.Fatalf("projects = %+v, want the pre-migration rows with identities", projects)
+	}
+}
+
+func TestMigrationToProjectIdentityIsIdempotent(t *testing.T) {
+	db, home := openTemp(t)
+	stampPreProjectIdentity(t, db)
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream) VALUES ('nsr', 'u', 'direct-pr', 0, '')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle) VALUES ('live', 'nsr', 'ship', 'open')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := projectIdentityOf(t, first, "nsr")
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := Open(home)
+	if err != nil {
+		t.Fatalf("reopen an already-migrated home: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	if got := projectIdentityOf(t, second, "nsr"); got != identity {
+		t.Fatalf("identity = %q after reopening, want the minted %q", got, identity)
+	}
+	if got := taskProjectIdentity(t, second, "live"); got != identity {
+		t.Fatalf("task identity = %q, want %q", got, identity)
+	}
+	var projects int
+	if err := second.sql.QueryRow(`SELECT COUNT(*) FROM project`).Scan(&projects); err != nil {
+		t.Fatal(err)
+	}
+	if projects != 1 {
+		t.Fatalf("project rows = %d, want the one row the first migration produced", projects)
+	}
+}
+
+// The property atqamz/hand#388 and atqamz/hand#396 were both about: a rename is one row's
+// relabelling, so there is no history to search by name and none to put back.
+func TestRenameRelabelsOneRowAndLeavesTaskHistoryAlone(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.AddProject(Project{Name: "demo", URL: "u", Mode: "direct-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	identity := projectIdentityOf(t, db, "demo")
+	if err := db.CreateTask(Task{ID: "task-1", Project: "demo", Kind: KindShip}); err != nil {
+		t.Fatal(err)
+	}
+
+	renamed, err := db.RenameProject("demo", "renamed")
+	if err != nil || !renamed {
+		t.Fatalf("RenameProject = %v, %v", renamed, err)
+	}
+
+	if got := projectIdentityOf(t, db, "renamed"); got != identity {
+		t.Fatalf("identity after rename = %q, want the unchanged %q", got, identity)
+	}
+	if got := taskProjectIdentity(t, db, "task-1"); got != identity {
+		t.Fatalf("task identity after rename = %q, want the unchanged %q", got, identity)
+	}
+	var stored string
+	if err := db.sql.QueryRow(`SELECT project FROM task WHERE id = 'task-1'`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != "demo" {
+		t.Fatalf("stored task project = %q, want the rename to have left the row untouched", stored)
+	}
+	task, found, err := db.ReadTask("task-1")
+	if err != nil || !found {
+		t.Fatalf("ReadTask = %v, %v", found, err)
+	}
+	if task.Project != "renamed" {
+		t.Fatalf("resolved task project = %q, want the live label %q", task.Project, "renamed")
+	}
+}
+
+// The conflation atqamz/hand#388 reported: a name freed by a removal and claimed by a later
+// project must not carry the removed project's task history into it.
+func TestRecreatedProjectNameDoesNotInheritTheRemovedProjectsTasks(t *testing.T) {
+	db, _ := openTemp(t)
+	if err := db.AddProject(Project{Name: "demo", URL: "u", Mode: "direct-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	retired := projectIdentityOf(t, db, "demo")
+	if err := db.CreateTask(Task{ID: "old-task", Project: "demo", Kind: KindShip, Lifecycle: TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	if removed, err := db.RemoveProject("demo"); err != nil || !removed {
+		t.Fatalf("RemoveProject = %v, %v", removed, err)
+	}
+	if err := db.AddProject(Project{Name: "demo", URL: "u2", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	successor := projectIdentityOf(t, db, "demo")
+	if successor == retired {
+		t.Fatalf("recreated project reused identity %q", successor)
+	}
+	if err := db.CreateTask(Task{ID: "new-task", Project: "demo", Kind: KindShip}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := taskProjectIdentity(t, db, "old-task"); got != retired {
+		t.Fatalf("old task identity = %q, want the retired %q", got, retired)
+	}
+	if got := taskProjectIdentity(t, db, "new-task"); got != successor {
+		t.Fatalf("new task identity = %q, want the successor %q", got, successor)
+	}
+
+	// Renaming the successor moves only its own tasks' live label; the retired project's task
+	// keeps the name it was written with, because nothing is rewritten by name any more.
+	if renamed, err := db.RenameProject("demo", "demo-two"); err != nil || !renamed {
+		t.Fatalf("RenameProject = %v, %v", renamed, err)
+	}
+	old, _, err := db.ReadTask("old-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if old.Project != "demo" || old.ProjectID != retired {
+		t.Fatalf("old task = %+v, want it left under the retired project", old)
+	}
+	fresh, _, err := db.ReadTask("new-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Project != "demo-two" || fresh.ProjectID != successor {
+		t.Fatalf("new task = %+v, want it following the successor's new label", fresh)
+	}
+}
+
+// The read-only ladder has to keep answering for a home migrateSchema has not reached yet: at
+// fleetIdentityVersion the task table has no project_id to select or to join a live label through.
+func TestReadOnlyLadderReadsAPreIdentityHome(t *testing.T) {
+	db, home := openTemp(t)
+	stampPreProjectIdentity(t, db)
+	if _, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream) VALUES ('nsr', 'u', 'direct-pr', 0, '')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO task (id, project, kind, lifecycle) VALUES ('live', 'nsr', 'ship', 'open')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, found, err := ReadTaskHistoryReadOnly(home, "live")
+	if err != nil || !found {
+		t.Fatalf("ReadTaskHistoryReadOnly = %v, %v", found, err)
+	}
+	if history.Task.Project != "nsr" || history.Task.ProjectID != "" {
+		t.Fatalf("task = %+v, want the stored name and no identity", history.Task)
+	}
+	histories, err := ListReconciliationHistoriesReadOnly(home)
+	if err != nil {
+		t.Fatalf("ListReconciliationHistoriesReadOnly: %v", err)
+	}
+	if len(histories) != 1 || histories[0].Task.Project != "nsr" {
+		t.Fatalf("histories = %+v, want the one open task", histories)
+	}
+}

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -153,6 +153,10 @@ var migrations = []string{
 		singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
 		fleet_id TEXT NOT NULL UNIQUE
 	);`,
+	// ensureProjectIdentity does the real work below, guarded by column existence like the
+	// placeholders above: the base schema already carries project.id and task.project_id, so a home
+	// built from it and stamped backward replays this step without a duplicate-column error.
+	`SELECT 1;`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -181,6 +185,10 @@ const preAcknowledgementVersion = attemptBranchVersion + 1
 const acknowledgedMetadataVersion = preAcknowledgementVersion + 1
 
 const fleetIdentityVersion = acknowledgedMetadataVersion + 1
+
+// The last version that identified a project by its mutable name: its task table has no
+// project_id, and its project table no surrogate id (atqamz/hand#388).
+const projectIdentityVersion = fleetIdentityVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -496,6 +504,11 @@ func (db *DB) applyMigration(version int) error {
 			return err
 		}
 	}
+	if version == projectIdentityVersion-1 {
+		if err := ensureProjectIdentity(tx); err != nil {
+			return err
+		}
+	}
 	if err := recordSchemaVersion(tx, version+1); err != nil {
 		return err
 	}
@@ -591,6 +604,48 @@ func ensureAcknowledgementColumns(tx *sql.Tx) error {
 		if _, err := tx.Exec(`ALTER TABLE task ADD COLUMN ` + column.name + ` ` + column.ddl); err != nil {
 			return fmt.Errorf("add %s: %w", column.name, err)
 		}
+	}
+	return nil
+}
+
+// Gives every registered project a durable surrogate id and every task a reference to it, inside
+// the transaction applyMigration already wraps this step in, so a home that fails partway keeps the
+// whole name-keyed layout. Rebuilt, not altered: sqlite cannot turn name into a plain unique label.
+func ensureProjectIdentity(tx *sql.Tx) error {
+	var taskColumn int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name = 'project_id'`).Scan(&taskColumn); err != nil {
+		return fmt.Errorf("inspect task project_id column: %w", err)
+	}
+	if taskColumn == 0 {
+		if _, err := tx.Exec(`ALTER TABLE task ADD COLUMN project_id TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add task project_id column: %w", err)
+		}
+	}
+	var projectColumn int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('project') WHERE name = 'id'`).Scan(&projectColumn); err != nil {
+		return fmt.Errorf("inspect project id column: %w", err)
+	}
+	if projectColumn == 0 {
+		if _, err := tx.Exec(`CREATE TABLE project_identity (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			url TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			position INTEGER NOT NULL,
+			upstream TEXT NOT NULL DEFAULT ''
+		);
+		INSERT INTO project_identity (id, name, url, mode, position, upstream)
+		SELECT '` + projectIDPrefix + `' || lower(hex(randomblob(` + projectIDBytes + `))), name, url, mode, position, upstream FROM project;
+		DROP TABLE project;
+		ALTER TABLE project_identity RENAME TO project;`); err != nil {
+			return fmt.Errorf("give projects a surrogate identity: %w", err)
+		}
+	}
+	// Only the rows that have no identity yet, so replaying this step never reattaches a task
+	// whose project was removed to whatever project now answers to that name.
+	if _, err := tx.Exec(`UPDATE task SET project_id = COALESCE((SELECT id FROM project WHERE project.name = task.project), '')
+		WHERE project_id = ''`); err != nil {
+		return fmt.Errorf("backfill task project identity: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -133,8 +133,12 @@ const (
 )
 
 type Task struct {
-	ID               string        `json:"id"`
+	ID string `json:"id"`
+	// Project is the live display name resolved through ProjectID, falling back to the name the
+	// row was written with once no registered project carries that identity any more. ProjectID
+	// is the durable identity: renaming a project never rewrites it (atqamz/hand#388).
 	Project          string        `json:"project"`
+	ProjectID        string        `json:"project_id"`
 	Kind             string        `json:"kind"`
 	Brief            string        `json:"brief"`
 	Lifecycle        TaskLifecycle `json:"lifecycle"`
@@ -234,6 +238,10 @@ func SendRetrySafe(send SendAttempt) bool {
 // its own repo. A fork has two repos, the one URL names and the one its PRs live on, and only a
 // declared upstream tells that pair from an unauthorized one (atqamz/hand#78).
 type Project struct {
+	// ID is the surrogate identity a project keeps across every rename; Name is the live,
+	// operator-facing label and the projection key, unique among registered projects but
+	// reusable once a project is removed (atqamz/hand#388).
+	ID       string
 	Name     string
 	URL      string
 	Mode     string
@@ -275,6 +283,7 @@ const schema = `
 CREATE TABLE IF NOT EXISTS task (
 	id                TEXT PRIMARY KEY,
 	project           TEXT NOT NULL DEFAULT '',
+	project_id        TEXT NOT NULL DEFAULT '',
 	kind              TEXT NOT NULL DEFAULT '',
 	brief             TEXT NOT NULL DEFAULT '',
 	lifecycle         TEXT NOT NULL DEFAULT 'open' CHECK (lifecycle IN ('open', 'terminal')),
@@ -343,7 +352,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS attempt_one_active
 ON attempt(task_id)
 WHERE lifecycle IN ('provisioning', 'running');
 CREATE TABLE IF NOT EXISTS project (
-	name     TEXT PRIMARY KEY,
+	id       TEXT PRIMARY KEY,
+	name     TEXT NOT NULL UNIQUE,
 	url      TEXT NOT NULL,
 	mode     TEXT NOT NULL,
 	position INTEGER NOT NULL,
@@ -586,8 +596,8 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
-	if current == acknowledgedMetadataVersion {
-		return db.ReadTaskHistory(id)
+	if current == fleetIdentityVersion || current == acknowledgedMetadataVersion {
+		return db.readTaskHistoryBeforeProjectIdentity(id)
 	}
 	if current == preAcknowledgementVersion || current == attemptBranchVersion {
 		return db.readTaskHistoryBeforeAcknowledgement(id)
@@ -646,18 +656,44 @@ func (db *DB) setMeta(key, value string) error {
 	return nil
 }
 
-var taskColumnNames = []string{
+// The layout every schema before projectIdentityVersion stored, and still the order the
+// read-only ladder's older scanners read: project_id is appended rather than slotted beside
+// project so the two suffix slices below keep naming the columns they always named.
+var taskColumnNamesBeforeProjectIdentity = []string{
 	"id", "project", "kind", "brief", "lifecycle", "active_attempt_id", "pr",
 	"merge_executed", "merge_executed_at", "merge_announced", "delivered_at", "delivered_reason",
 	"report_offset", "report_digest", "created_at", "repair_code", "repair_reason", "repair_attempt_id", "repair_observed_at",
 	"acknowledged_at", "acknowledged_reason", "acknowledged_offset", "acknowledged_digest",
 }
 
+var taskColumnNames = append(append([]string{}, taskColumnNamesBeforeProjectIdentity...), "project_id")
+
 var taskColumns = strings.Join(taskColumnNames, ", ")
 
-var taskColumnsBeforeRepair = strings.Join(taskColumnNames[:len(taskColumnNames)-8], ", ")
+var taskColumnsBeforeProjectIdentity = strings.Join(taskColumnNamesBeforeProjectIdentity, ", ")
 
-var taskColumnsBeforeAcknowledgement = strings.Join(taskColumnNames[:len(taskColumnNames)-4], ", ")
+var taskColumnsBeforeRepair = strings.Join(taskColumnNamesBeforeProjectIdentity[:len(taskColumnNamesBeforeProjectIdentity)-8], ", ")
+
+var taskColumnsBeforeAcknowledgement = strings.Join(taskColumnNamesBeforeProjectIdentity[:len(taskColumnNamesBeforeProjectIdentity)-4], ", ")
+
+// A task's project name is no longer stored live: rename updates the one project row and
+// nothing else, so every current-schema read resolves the label through the identity and
+// keeps the stored name only as the fallback for a project that is no longer registered.
+var taskSelectColumns = taskSelectList()
+
+const taskSelectFrom = ` FROM task LEFT JOIN project ON project.id = task.project_id`
+
+func taskSelectList() string {
+	columns := make([]string, 0, len(taskColumnNames))
+	for _, name := range taskColumnNames {
+		if name == "project" {
+			columns = append(columns, "COALESCE(project.name, task.project)")
+			continue
+		}
+		columns = append(columns, "task."+name)
+	}
+	return strings.Join(columns, ", ")
+}
 
 var attemptColumnNames = []string{
 	"id", "task_id", "ordinal", "lifecycle", "harness", "model", "effort",
@@ -687,7 +723,28 @@ func taskValues(t Task) []any {
 	return []any{t.ID, t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
 		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt,
-		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest}
+		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.ProjectID}
+}
+
+// A caller names the project it is dispatching into; the identity behind that name is looked up
+// once, at creation, and is what the row keeps from then on. An unregistered name resolves to no
+// identity rather than to whichever project later claims it.
+func resolveTaskProjectID(q interface {
+	QueryRow(string, ...any) *sql.Row
+}, t *Task) error {
+	if t.ProjectID != "" || t.Project == "" {
+		return nil
+	}
+	var id string
+	err := q.QueryRow(`SELECT id FROM project WHERE name = ?`, t.Project).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("resolve project %q for task %q: %w", t.Project, t.ID, err)
+	}
+	t.ProjectID = id
+	return nil
 }
 
 func nullableAttemptID(id int64) any {
@@ -698,6 +755,25 @@ func nullableAttemptID(id int64) any {
 }
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
+	var t Task
+	var activeID sql.NullInt64
+	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
+		&t.MergeExecuted, &t.MergeExecutedAt, &t.MergeAnnounced, &t.DeliveredAt, &t.DeliveredReason,
+		&t.ReportOffset, &t.ReportDigest, &t.CreatedAt, &t.RepairCode, &t.RepairReason, &t.RepairAttemptID, &t.RepairObservedAt,
+		&t.AcknowledgedAt, &t.AcknowledgedReason, &t.AcknowledgedOffset, &t.AcknowledgedDigest, &t.ProjectID)
+	if activeID.Valid {
+		t.ActiveAttemptID = activeID.Int64
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	return t, err
+}
+
+// Reads a task row from a database migrated no further than fleetIdentityVersion, which has no
+// project_id at all: its stored project name is still the live one, because rename rewrote every
+// task row back then.
+func scanTaskBeforeProjectIdentity(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
 	var activeID sql.NullInt64
 	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
@@ -794,7 +870,7 @@ func scanAttemptBeforeSend(row interface{ Scan(...any) error }) (Attempt, error)
 }
 
 func (db *DB) ReadTask(id string) (Task, bool, error) {
-	row := db.sql.QueryRow(`SELECT `+taskColumns+` FROM task WHERE id = ?`, id)
+	row := db.sql.QueryRow(`SELECT `+taskSelectColumns+taskSelectFrom+` WHERE task.id = ?`, id)
 	t, err := scanTask(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Task{}, false, nil
@@ -808,6 +884,9 @@ func (db *DB) ReadTask(id string) (Task, bool, error) {
 func (db *DB) CreateTask(t Task) error {
 	if t.Lifecycle == "" {
 		t.Lifecycle = TaskOpen
+	}
+	if err := resolveTaskProjectID(db.sql, &t); err != nil {
+		return err
 	}
 	_, err := db.sql.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...)
 	if err != nil {
@@ -832,7 +911,7 @@ func (db *DB) UpdateTask(t Task) error {
 }
 
 func (db *DB) ListTasks() ([]Task, error) {
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task ORDER BY id`)
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` ORDER BY task.id`)
 	if err != nil {
 		return nil, fmt.Errorf("list tasks: %w", err)
 	}
@@ -859,6 +938,35 @@ func (db *DB) ReadTaskHistory(id string) (TaskHistory, bool, error) {
 	task, found, err := db.ReadTask(id)
 	if err != nil || !found {
 		return TaskHistory{}, found, err
+	}
+	attempts, err := db.ListAttempts(id)
+	if err != nil {
+		return TaskHistory{}, false, err
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
+func (db *DB) readTaskHistoryBeforeProjectIdentity(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
+	row := db.sql.QueryRow(`SELECT `+taskColumnsBeforeProjectIdentity+` FROM task WHERE id = ?`, id)
+	task, err := scanTaskBeforeProjectIdentity(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
 	}
 	attempts, err := db.ListAttempts(id)
 	if err != nil {
@@ -1074,7 +1182,7 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' ORDER BY id`)
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` WHERE task.lifecycle = 'open' ORDER BY task.id`)
 	if err != nil {
 		return nil, fmt.Errorf("list open tasks: %w", err)
 	}
@@ -1113,7 +1221,7 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT ` + taskColumns + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` WHERE task.lifecycle = 'open' OR task.repair_code <> '' OR EXISTS (
 		SELECT 1 FROM attempt
 		WHERE attempt.task_id = task.id
 		AND attempt.lifecycle NOT IN ('provisioning', 'running')
@@ -1122,7 +1230,7 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
 			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
 		)
-	) ORDER BY id`)
+	) ORDER BY task.id`)
 	if err != nil {
 		return nil, fmt.Errorf("list reconciliation tasks: %w", err)
 	}
@@ -1169,13 +1277,63 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	if current == holdInferredVersion {
 		return db.listReconciliationHistoriesBeforeAcknowledgementAndBranch()
 	}
-	if current == acknowledgedMetadataVersion {
-		return db.ListReconciliationHistories()
+	if current == fleetIdentityVersion || current == acknowledgedMetadataVersion {
+		return db.listReconciliationHistoriesBeforeProjectIdentity()
 	}
 	if current == repairMetadataVersion || current == sendSchemaVersion {
 		return db.listReconciliationHistoriesBeforeSend()
 	}
 	return db.ListReconciliationHistories()
+}
+
+// The reconciliation-listing counterpart to readTaskHistoryBeforeProjectIdentity, for a home whose
+// task table has no project_id to join the live project name through.
+func (db *DB) listReconciliationHistoriesBeforeProjectIdentity() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
+	rows, err := db.sql.Query(`SELECT ` + taskColumnsBeforeProjectIdentity + ` FROM task WHERE lifecycle = 'open' OR repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTaskBeforeProjectIdentity(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.ListAttempts(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("task %q active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
 }
 
 // The reconciliation-listing counterpart to readTaskHistoryBeforeAcknowledgementAndBranch: holdInferredVersion
@@ -1361,6 +1519,9 @@ func (db *DB) CreateTaskWithAttempt(t Task, a Attempt) (Attempt, error) {
 		return Attempt{}, fmt.Errorf("begin task creation: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := resolveTaskProjectID(tx, &t); err != nil {
+		return Attempt{}, err
+	}
 	if _, err := tx.Exec(`INSERT INTO task (`+taskColumns+`) VALUES (`+placeholders(len(taskColumnNames))+`)`, taskValues(t)...); err != nil {
 		if isSQLiteBusy(err) {
 			return Attempt{}, contention("create task", t.ID, err)
@@ -2521,7 +2682,7 @@ func (db *DB) ListProjects() ([]Project, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT name, url, mode, upstream FROM project ORDER BY position, name`)
+	rows, err := db.sql.Query(`SELECT id, name, url, mode, upstream FROM project ORDER BY position, name`)
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
@@ -2530,7 +2691,7 @@ func (db *DB) ListProjects() ([]Project, error) {
 	var projects []Project
 	for rows.Next() {
 		var p Project
-		if err := rows.Scan(&p.Name, &p.URL, &p.Mode, &p.Upstream); err != nil {
+		if err := rows.Scan(&p.ID, &p.Name, &p.URL, &p.Mode, &p.Upstream); err != nil {
 			return nil, fmt.Errorf("list projects: %w", err)
 		}
 		projects = append(projects, p)
@@ -2541,9 +2702,19 @@ func (db *DB) ListProjects() ([]Project, error) {
 	return projects, nil
 }
 
+// A caller never supplies the identity: it is minted here so no command surface has to carry
+// a flag for it, and so a name reused after a removal can never inherit the removed project's
+// history (atqamz/hand#388).
 func (db *DB) AddProject(p Project) error {
-	_, err := db.sql.Exec(`INSERT INTO project (name, url, mode, position, upstream)
-		VALUES (?, ?, ?, (SELECT COALESCE(MAX(position), -1) + 1 FROM project), ?)`, p.Name, p.URL, p.Mode, p.Upstream)
+	if p.ID == "" {
+		id, err := newProjectID()
+		if err != nil {
+			return fmt.Errorf("add project %q: %w", p.Name, err)
+		}
+		p.ID = id
+	}
+	_, err := db.sql.Exec(`INSERT INTO project (id, name, url, mode, position, upstream)
+		VALUES (?, ?, ?, ?, (SELECT COALESCE(MAX(position), -1) + 1 FROM project), ?)`, p.ID, p.Name, p.URL, p.Mode, p.Upstream)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			return fmt.Errorf("project %q %w", p.Name, ErrProjectExists)
@@ -2593,7 +2764,20 @@ func (db *DB) SetProjectMode(name, mode string) (bool, error) {
 	return affected > 0, nil
 }
 
-// RenameProject updates the registry key and every task's project reference in one transaction.
+// BackfillTaskProjectIdentity links identity-less task rows to the project now answering to the
+// name they carry. It belongs to the one-time data/projects.md import, whose home had no project
+// rows for the migration to resolve against; running it later is what atqamz/hand#388 forbids.
+func (db *DB) BackfillTaskProjectIdentity() error {
+	if _, err := db.sql.Exec(`UPDATE task SET project_id = COALESCE((SELECT id FROM project WHERE project.name = task.project), '')
+		WHERE project_id = ''`); err != nil {
+		return fmt.Errorf("backfill task project identity: %w", err)
+	}
+	return nil
+}
+
+// RenameProject relabels one durable project row. Task and completion history is deliberately
+// left alone: the identity a rename cannot change is what those records reference, so there is
+// nothing to search for by name and nothing to roll back (atqamz/hand#388, atqamz/hand#396).
 func (db *DB) RenameProject(oldName, newName string) (bool, error) {
 	return db.renameProject(oldName, newName, "", false)
 }
@@ -2610,14 +2794,22 @@ func (db *DB) renameProject(oldName, newName, newURL string, updateURL bool) (bo
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	var id string
+	err = tx.QueryRow(`SELECT id FROM project WHERE name = ?`, oldName).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("rename project %q: %w", oldName, err)
+	}
 	query := `UPDATE project SET name = ?`
 	args := []any{newName}
 	if updateURL {
 		query += `, url = ?`
 		args = append(args, newURL)
 	}
-	query += ` WHERE name = ?`
-	args = append(args, oldName)
+	query += ` WHERE id = ?`
+	args = append(args, id)
 	result, err := tx.Exec(query, args...)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
@@ -2632,9 +2824,6 @@ func (db *DB) renameProject(oldName, newName, newURL string, updateURL bool) (bo
 	if affected == 0 {
 		return false, nil
 	}
-	if _, err := tx.Exec(`UPDATE task SET project = ? WHERE project = ?`, newName, oldName); err != nil {
-		return false, fmt.Errorf("rename tasks for project %q: %w", oldName, err)
-	}
 	if err := tx.Commit(); err != nil {
 		return false, fmt.Errorf("rename project %q: %w", oldName, err)
 	}
@@ -2644,7 +2833,17 @@ func (db *DB) renameProject(oldName, newName, newURL string, updateURL bool) (bo
 // RemoveProject reports whether a row was actually removed, leaving the
 // not-registered wording to the caller that already owns it.
 func (db *DB) RemoveProject(name string) (bool, error) {
-	res, err := db.sql.Exec(`DELETE FROM project WHERE name = ?`, name)
+	var id string
+	err := db.sql.QueryRow(`SELECT id FROM project WHERE name = ?`, name).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("remove project %q: %w", name, err)
+	}
+	// By identity, so a removal can never take a same-named row a concurrent writer
+	// registered in its place: the history that row owns is a different project's.
+	res, err := db.sql.Exec(`DELETE FROM project WHERE id = ?`, id)
 	if err != nil {
 		return false, fmt.Errorf("remove project %q: %w", name, err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -197,6 +197,10 @@ func TestSetProjectURLPreservesProjectIdentityAndOrder(t *testing.T) {
 		t.Fatalf("ListProjects = %+v, want %d projects", got, len(want))
 	}
 	for i := range want {
+		if got[i].ID == "" {
+			t.Fatalf("project %d = %+v, want a minted identity", i, got[i])
+		}
+		want[i].ID = got[i].ID
 		if got[i] != want[i] {
 			t.Fatalf("project %d = %+v, want %+v", i, got[i], want[i])
 		}


### PR DESCRIPTION
## Summary

- `completion.Record` gains a format version and `project_id`, keeping `project` as the display label the record was written with; `Append` stamps both, so nothing downstream has to know the old shape.
- A one-time migration brings every pre-identity line up to the current version under the existing completion lock, replacing the whole file through a temp file and a rename or leaving it byte-identical. It is idempotent: a line already at the current version is passed through untouched, an unparseable line is carried through verbatim, and a run that changes nothing writes nothing.
- A record is placed by the task row it names first (that row already holds the identity resolved when the task was created), then by the live registry. A record neither can place is written as `unknown` rather than attached to whatever project now answers to its name, which is what keeps a removed-and-reissued name's two populations apart.
- Rename now touches no history at all. The identity task rows and completion records reference is exactly the thing a rename cannot change, so `completion.RenameProject`/`RenameRestore` and the rename's history-rollback branch are gone: atqamz/hand#396's defect class is removed rather than guarded.
- ADR for the identity model, naming the project-rename exception it removes from the append-only completion ADR and updating that record's status to point here.

Second and last of the stack for atqamz/hand#388; stacked on #399, so review that one first. This PR links the issue without closing it - I have left the close for you after both land, since the invariants are only true with both merged.

Refs atqamz/hand#388

## Test plan

- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean.
- New `internal/project` fixture is the one atqamz/hand#388 describes: `alpha` live, `beta` removed and never reclaimed, `gamma` removed with its name reissued to a different project, plus a record whose task row is gone. Asserts `alpha` and both `gamma` populations land on their own identities (the retired one on the retired id, via its task row) and that `beta` and the vanished record land as `unknown`; then asserts a later rename leaves the file byte-identical.
- New `internal/completion` tests: unresolvable records marked unknown, no guessing from the name alone, idempotence across a re-run with a deliberately different resolver, damaged lines carried through verbatim, and nothing written (mtime included) when there is nothing to do.
- `TestRenameRollbackOnlyRestoresRenamedCompletionRecords` is replaced by `TestRenameNeverRewritesCompletionHistory`, which asserts the file is byte-identical after both a successful and a failed rename - the same property atqamz/hand#396 was protecting, now by construction.
- `TestTeardownRecordsCompletionBeforeStateRemoval` now registers the project before the task, so it asserts the identity actually travels from the task row onto the record rather than comparing an unregistered project against `unknown`.
- GitHub Actions does not run on this PR: `.github/workflows/ci.yaml` triggers only on pull requests into `main`, and this one targets `388-project-surrogate-id`. Standing in for it, `nix build .#default` - the same hermetic derivation CI's Nix build job builds, whose `checkPhase` is the full `go test ./...` - passes locally on this commit, and `gofmt`, `go vet`, `golangci-lint` and `tools/commentlint` are clean. Real CI runs the moment #399 merges and this PR retargets `main`; treat that run, not this note, as the gate.

