### PR TITLE
fix: scope treehouse pools to fleet homes

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/integration"
@@ -250,6 +252,7 @@ func doctorFindings(fleetHome string, histories []state.TaskHistory) ([]doctorFi
 			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q no-mistakes gate is %s", p.Name, issue)})
 		}
 	}
+	findings = append(findings, doctorWorktreeFindings(fleetHome, histories)...)
 
 	detection, err := harness.DetectCurrent()
 	if err != nil {
@@ -322,6 +325,50 @@ func reportPathSuffix(text string, end int) bool {
 
 func isReportPathSuffixChar(char byte) bool {
 	return (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-' || char == '/' || char == '\\'
+}
+
+func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []doctorFinding {
+	findings := make([]doctorFinding, 0)
+	for _, history := range histories {
+		attempt := history.ActiveAttempt
+		if attempt == nil || attempt.Worktree == "" {
+			continue
+		}
+		clone := filepath.Join(fleetHome, "projects", history.Task.Project)
+		expected := filepath.Join(clone, ".git")
+		if _, err := os.Stat(expected); err != nil {
+			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("task %q registered clone cannot be inspected: %v", history.Task.ID, err)})
+			continue
+		}
+		actual, err := git.CommonDir(attempt.Worktree)
+		if err != nil {
+			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("task %q worktree common directory cannot be inspected: %v", history.Task.ID, err)})
+			continue
+		}
+		if sameDoctorPath(expected, actual) {
+			continue
+		}
+		findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("task %q worktree is rooted in another Git repository: got %s, want %s", history.Task.ID, actual, expected)})
+	}
+	return findings
+}
+
+func sameDoctorPath(left, right string) bool {
+	canonical := func(path string) string {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return filepath.Clean(path)
+		}
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = resolved
+		}
+		return filepath.Clean(abs)
+	}
+	left, right = canonical(left), canonical(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
 }
 
 // A local-only fleet never needs gh, while a registered project delivering through direct-pr or

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -345,30 +344,12 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("task %q worktree common directory cannot be inspected: %v", history.Task.ID, err)})
 			continue
 		}
-		if sameDoctorPath(expected, actual) {
+		if git.SamePath(expected, actual) {
 			continue
 		}
 		findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("task %q worktree is rooted in another Git repository: got %s, want %s", history.Task.ID, actual, expected)})
 	}
 	return findings
-}
-
-func sameDoctorPath(left, right string) bool {
-	canonical := func(path string) string {
-		abs, err := filepath.Abs(path)
-		if err != nil {
-			return filepath.Clean(path)
-		}
-		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-			abs = resolved
-		}
-		return filepath.Clean(abs)
-	}
-	left, right = canonical(left), canonical(right)
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(left, right)
-	}
-	return left == right
 }
 
 // A local-only fleet never needs gh, while a registered project delivering through direct-pr or

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -226,6 +226,90 @@ func hasDoctorFindingPrefix(findings []doctorFinding, severity doctorSeverity, p
 	return false
 }
 
+func TestDoctorFindsWorktreeUsingAnotherFleetClone(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://example.com/demo.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	clone := filepath.Join(home, "projects", "demo")
+	foreign := filepath.Join(t.TempDir(), "demo")
+	initGitRepo(t, clone)
+	initGitRepo(t, foreign)
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Worktree: foreign}); err != nil {
+		t.Fatal(err)
+	}
+	histories, err := state.ListOpenHistoriesReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings, err := doctorFindings(home, histories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, finding := range findings {
+		if finding.Severity == doctorError && strings.Contains(finding.Text, `task "task-1" worktree is rooted in another Git repository`) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("findings = %#v, want a cross-fleet worktree finding", findings)
+	}
+}
+
+func TestDoctorFindsWorktreeUsingTheFleetHomeCheckout(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://example.com/demo.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	clone := filepath.Join(home, "projects", "demo")
+	operatorCheckout := filepath.Join(home, "operator-checkout")
+	initGitRepo(t, clone)
+	initGitRepo(t, operatorCheckout)
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Worktree: operatorCheckout}); err != nil {
+		t.Fatal(err)
+	}
+	histories, err := state.ListOpenHistoriesReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings, err := doctorFindings(home, histories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, finding := range findings {
+		if finding.Severity == doctorError && strings.Contains(finding.Text, `task "task-1" worktree is rooted in another Git repository`) {
+			return
+		}
+	}
+	t.Fatalf("findings = %#v, want an operator-checkout worktree finding", findings)
+}
+
 func TestDoctorIncludesProjectListGateFinding(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -628,7 +628,7 @@ func treehouseInitIfNeeded(clonePath string) error {
 	if _, err := os.Stat(filepath.Join(clonePath, "treehouse.toml")); err == nil {
 		return excludeLocally(clonePath, "treehouse.toml")
 	}
-	out, err := runManagedCore(context.Background(), "treehouse", clonePath, "init")
+	out, err := runManagedCore(context.Background(), "treehouse", clonePath, "--root", clonePath, "init")
 	if err != nil {
 		return fmt.Errorf("treehouse init failed: %s", string(out))
 	}

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -482,7 +482,7 @@ func TestPromoteReturnsScoutResourcesWhenTheShipLaunchFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(calls), "treehouse return "+oldWt) {
+	if !strings.Contains(string(calls), " return "+oldWt) {
 		t.Fatalf("calls = %q, want the scout worktree returned", calls)
 	}
 	if !strings.Contains(string(calls), "tab close wA:tOld") {

--- a/cmd/reopen_test.go
+++ b/cmd/reopen_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,7 +20,12 @@ func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 	}
 	worktree := t.TempDir() + "/wt"
 	home := setupSpawnHome(t, worktree, herdr)
-	initGitRepo(t, worktree)
+	clone := filepath.Join(home, "projects", "myproj")
+	initGitRepo(t, clone)
+	command := exec.Command("git", "-C", clone, "worktree", "add", "--detach", worktree)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v: %s", err, output)
+	}
 
 	spawn := newSpawnCmd()
 	spawn.SetArgs([]string{"task-1", "myproj", "--harness", harness.Claude})

--- a/cmd/teardown_test.go
+++ b/cmd/teardown_test.go
@@ -1555,8 +1555,11 @@ func readTreehouseReturnArgs(t *testing.T, worktree string) []string {
 	t.Helper()
 	var args []string
 	for _, line := range readInvocations(t, worktree) {
-		if fields := strings.Fields(line); len(fields) > 1 && fields[1] == "return" {
-			args = fields[1:]
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "return" {
+				args = fields[i:]
+			}
 		}
 	}
 	if args == nil {

--- a/internal/faketool/treehouse.go
+++ b/internal/faketool/treehouse.go
@@ -83,12 +83,19 @@ func runTreehouseFromPayload(payload json.RawMessage, args []string) int {
 		return fail("unexpected treehouse invocation")
 	}
 	for _, response := range spec.Responses {
-		if response.Command != args[0] || (response.Args != nil && !sameArgs(response.Args, args[1:])) {
+		matchArgs := args
+		if response.Command != "--root" && len(args) >= 3 && args[0] == "--root" {
+			matchArgs = args[2:]
+		}
+		if response.Command != matchArgs[0] || (response.Args != nil && !sameArgs(response.Args, matchArgs[1:])) {
 			continue
 		}
 		_, _ = io.WriteString(os.Stdout, response.Stdout)
 		_, _ = io.WriteString(os.Stderr, response.Stderr)
 		return response.Exit
+	}
+	if len(args) >= 2 && args[0] == "--root" {
+		args = args[2:]
 	}
 	switch args[0] {
 	case "get":

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -22,6 +22,26 @@ func ResolveRoot(path string) (string, error) {
 	return filepath.Clean(root), nil
 }
 
+// CommonDir returns the repository's shared Git directory.
+func CommonDir(path string) (string, error) {
+	out, err := run(path, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", fmt.Errorf("resolve Git common directory: %w", err)
+	}
+	common := filepath.FromSlash(strings.TrimSpace(out))
+	if common == "" {
+		return "", fmt.Errorf("resolve Git common directory: empty path")
+	}
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(path, common)
+	}
+	common, err = filepath.Abs(common)
+	if err != nil {
+		return "", fmt.Errorf("make Git common directory absolute: %w", err)
+	}
+	return filepath.Clean(common), nil
+}
+
 func Run(dir string, args ...string) (string, error) {
 	return run(dir, args...)
 }

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -45,15 +45,26 @@ func CommonDir(path string) (string, error) {
 
 // SamePath reports whether two paths identify the same filesystem location.
 func SamePath(left, right string) bool {
-	canonical := func(path string) string {
+	absolute := func(path string) string {
 		abs, err := filepath.Abs(path)
 		if err != nil {
 			return filepath.Clean(path)
 		}
-		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-			abs = resolved
-		}
 		return filepath.Clean(abs)
+	}
+	left, right = absolute(left), absolute(right)
+	if runtime.GOOS == "windows" {
+		if strings.EqualFold(left, right) {
+			return true
+		}
+	} else if left == right {
+		return true
+	}
+	canonical := func(path string) string {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return filepath.Clean(resolved)
+		}
+		return path
 	}
 	left, right = canonical(left), canonical(right)
 	if runtime.GOOS == "windows" {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/atqamz/hand/internal/toolchain"
@@ -40,6 +41,25 @@ func CommonDir(path string) (string, error) {
 		return "", fmt.Errorf("make Git common directory absolute: %w", err)
 	}
 	return filepath.Clean(common), nil
+}
+
+// SamePath reports whether two paths identify the same filesystem location.
+func SamePath(left, right string) bool {
+	canonical := func(path string) string {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return filepath.Clean(path)
+		}
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = resolved
+		}
+		return filepath.Clean(abs)
+	}
+	left, right = canonical(left), canonical(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
 }
 
 func Run(dir string, args ...string) (string, error) {

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -37,7 +37,7 @@ func TestCommonDirReturnsTheMainRepositoryForAWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := filepath.Join(repo, ".git")
-	if got != want {
+	if !SamePath(got, want) {
 		t.Fatalf("CommonDir() = %q, want %q", got, want)
 	}
 }

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -25,6 +25,23 @@ func TestDefaultBranchUsesLocalMarkerWithoutOrigin(t *testing.T) {
 	}
 }
 
+func TestCommonDirReturnsTheMainRepositoryForAWorktree(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	runGit(t, repo, "init", "-q", "-b", "main")
+	runGit(t, repo, "-c", "user.name=git-test", "-c", "user.email=git-test@example.invalid", "commit", "-q", "--allow-empty", "-m", "baseline")
+	worktree := filepath.Join(t.TempDir(), "worktree")
+	runGit(t, repo, "worktree", "add", "-q", "-b", "feature", worktree)
+
+	got, err := CommonDir(worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(repo, ".git")
+	if got != want {
+		t.Fatalf("CommonDir() = %q, want %q", got, want)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	if len(args) > 1 && args[0] == "init" {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -696,11 +696,15 @@ func (c *Client) PaneSendKeys(paneID string, keys ...string) error {
 // text, since a failure read as pane text would confirm a worker nobody observed. Re-answering a dialog
 // that lingers in scrollback is prevented in internal/runtime/launch.go, by answering each one once per launch.
 func (c *Client) PaneRead(paneID string, lines int) (string, error) {
+	return c.paneRead(context.Background(), paneID, lines)
+}
+
+func (c *Client) paneRead(ctx context.Context, paneID string, lines int) (string, error) {
 	// The one caller matches first-run dialogs on their lower half, so a viewport too short for the whole
 	// dialog clips exactly the text that has to match, and an unmatched dialog under a live agent reads as
 	// started. Hence recent, not visible's 23-row unattached viewport (internal/faketool/FIDELITY.md).
 	args := []string{"pane", "read", paneID, "--source", "recent", "--lines", strconv.Itoa(lines)}
-	stdout, stderr, runErr := c.run(args...)
+	stdout, stderr, runErr := c.runContext(ctx, args...)
 	// Unlike every command above, herdr's contract for pane read is a third shape: raw text on
 	// success, on failure a bare {"code","message"} object, not the {"error":{...}} envelope. Read
 	// ahead of the exit status for callVoid's reason - that code cannot be trusted on its own.
@@ -719,19 +723,24 @@ func (c *Client) PaneRead(paneID string, lines int) (string, error) {
 // working", so this combines the pane signals rather than depending on a single-target wait command.
 func (c *Client) WaitComposerEmpty(paneID string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
 	var shellsKnown bool
 	var backgroundShells int
 	var lastStatus Status
 	for {
-		pane, err := c.PaneGet(paneID)
+		pane, err := c.paneGet(ctx, paneID)
 		if err != nil {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return &ComposerBusyError{Timeout: timeout, AgentStatus: lastStatus, BackgroundShells: backgroundShells, ShellsKnown: shellsKnown}
+			}
 			return err
 		}
 		lastStatus = pane.AgentStatus
 		if pane.AgentStatus != StatusWorking {
 			return nil
 		}
-		if text, err := c.PaneRead(paneID, 20); err == nil {
+		if text, err := c.paneRead(ctx, paneID, 20); err == nil {
 			if count, ok := renderedBackgroundShells(text); ok {
 				backgroundShells, shellsKnown = count, true
 			}
@@ -739,10 +748,18 @@ func (c *Client) WaitComposerEmpty(paneID string, timeout time.Duration) error {
 				return nil
 			}
 		}
-		if time.Now().After(deadline) {
+		if time.Now().After(deadline) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return &ComposerBusyError{Timeout: timeout, AgentStatus: lastStatus, BackgroundShells: backgroundShells, ShellsKnown: shellsKnown}
 		}
-		time.Sleep(250 * time.Millisecond)
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return &ComposerBusyError{Timeout: timeout, AgentStatus: lastStatus, BackgroundShells: backgroundShells, ShellsKnown: shellsKnown}
+		case <-timer.C:
+		}
 	}
 }
 

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -581,7 +581,7 @@ func TestWaitComposerEmptyAcceptsRenderedIdlePromptWhileAgentStatusIsWorking(t *
 func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
 	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"}, faketool.HerdrResponse{Command: "pane read", Stdout: "working...\nesc to interrupt (15s)\n  3 shells\n"})
 	c := NewClient()
-	err := c.WaitComposerEmpty("wA:pB", 10*time.Millisecond)
+	err := c.WaitComposerEmpty("wA:pB", 100*time.Millisecond)
 	if !errors.Is(err, ErrComposerBusyTimeout) {
 		t.Fatalf("got err %v, want ErrComposerBusyTimeout", err)
 	}
@@ -598,6 +598,20 @@ func TestWaitComposerEmptyPaneFailureIsNotABusyTimeout(t *testing.T) {
 	err := c.WaitComposerEmpty("wA:pB", time.Second)
 	if err == nil || errors.Is(err, ErrComposerBusyTimeout) {
 		t.Fatalf("got err %v, want a non-timeout pane failure", err)
+	}
+}
+
+func TestWaitComposerEmptyHonorsTimeoutWhenPaneGetHangs(t *testing.T) {
+	bin := faketool.Bin(t)
+	faketool.Herdr{Hang: []string{"pane get"}}.Install(t, bin)
+	c := NewClient()
+	started := time.Now()
+	err := c.WaitComposerEmpty("wA:pB", 25*time.Millisecond)
+	if !errors.Is(err, ErrComposerBusyTimeout) {
+		t.Fatalf("got err %v, want ErrComposerBusyTimeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("WaitComposerEmpty took %s after pane get hung", elapsed)
 	}
 }
 

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -581,7 +581,7 @@ func TestWaitComposerEmptyAcceptsRenderedIdlePromptWhileAgentStatusIsWorking(t *
 func TestWaitComposerEmptyTimesOutWhileWorking(t *testing.T) {
 	writeFakeHerdr(t, faketool.HerdrResponse{Command: "pane get", Stdout: "{\"id\":\"cli:1\",\"result\":{\"pane\":{\"pane_id\":\"wA:pB\",\"agent_status\":\"working\"}}}"}, faketool.HerdrResponse{Command: "pane read", Stdout: "working...\nesc to interrupt (15s)\n  3 shells\n"})
 	c := NewClient()
-	err := c.WaitComposerEmpty("wA:pB", 100*time.Millisecond)
+	err := c.WaitComposerEmpty("wA:pB", time.Second)
 	if !errors.Is(err, ErrComposerBusyTimeout) {
 		t.Fatalf("got err %v, want ErrComposerBusyTimeout", err)
 	}

--- a/internal/runtime/execution_plan_test.go
+++ b/internal/runtime/execution_plan_test.go
@@ -262,7 +262,7 @@ func TestSpawnMechanicalPlanRetainsWorktreeEvidenceWhenLeaseChangesDuringCleanup
 	calls := &executionPlanCalls{}
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return planned, nil })
 	r.deps.worktree.headCommit = func(string) (string, error) { return acquired, nil }
-	r.deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+	r.deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
 		if path == "" || leaseID != "lease-1" || !force {
 			t.Fatalf("returnWithID(%q, %q, %t), want acquired lease-1 with force", path, leaseID, force)
 		}
@@ -796,7 +796,7 @@ func executionPlanRuntime(t *testing.T, calls *executionPlanCalls, base func(str
 		return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
 	}
 	r.deps.worktree.headCommit = func(string) (string, error) { return strings.Repeat("a", 40), nil }
-	r.deps.worktree.returnWorktree = func(string, bool) error {
+	r.deps.worktree.returnWorktree = func(string, string, bool) error {
 		calls.worktreeReturns++
 		return nil
 	}

--- a/internal/runtime/promote.go
+++ b/internal/runtime/promote.go
@@ -143,7 +143,7 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 		defer releaseProject()
 	}
 
-	cleanupWarnings, err := r.cleanupScout(req.Home, req.ID, scout)
+	cleanupWarnings, err := r.cleanupScout(req.Home, clonePath, req.ID, scout)
 	if err != nil {
 		return Result{}, WithWarnings(err, append(warnings, cleanupWarnings...))
 	}
@@ -167,7 +167,7 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 	}, nil
 }
 
-func (r *Runtime) cleanupScout(homeDir, taskID string, scout state.Attempt) ([]string, error) {
+func (r *Runtime) cleanupScout(homeDir, clonePath, taskID string, scout state.Attempt) ([]string, error) {
 	client := r.herdrClient(scout.Herdr.Session)
 	var warnings []string
 	setState := func(resource, next string) error {
@@ -208,7 +208,7 @@ func (r *Runtime) cleanupScout(homeDir, taskID string, scout state.Attempt) ([]s
 		default:
 			if err := setState("worktree", state.TeardownResourceReleasing); err != nil {
 				warnings = append(warnings, fmt.Sprintf("warning: record scout worktree release phase failed: %v", err))
-			} else if err := r.deps.worktree.returnLease(worktree.Lease{Path: scout.Worktree, ID: scout.LeaseID}, true); err != nil {
+			} else if err := r.deps.worktree.returnLease(clonePath, worktree.Lease{Path: scout.Worktree, ID: scout.LeaseID}, true); err != nil {
 				_ = setState("worktree", state.TeardownResourceAmbiguous)
 				warnings = append(warnings, fmt.Sprintf("warning: return scout worktree failed: %v", err))
 			} else if err := setState("worktree", state.TeardownResourceReleased); err != nil {

--- a/internal/runtime/promote_test.go
+++ b/internal/runtime/promote_test.go
@@ -21,7 +21,7 @@ func TestCleanupScoutStopsAfterPaneReleasePhase(t *testing.T) {
 	returned := false
 	runtime := &Runtime{deps: dependencies{
 		herdr: func() herdrClient { return fake },
-		worktree: worktreeDependencies{returnWorktree: func(string, bool) error {
+		worktree: worktreeDependencies{returnWorktree: func(string, string, bool) error {
 			returned = true
 			return nil
 		}},
@@ -33,7 +33,7 @@ func TestCleanupScoutStopsAfterPaneReleasePhase(t *testing.T) {
 		},
 	}}
 
-	warnings, err := runtime.cleanupScout("/tmp/home", "task-1", scoutAttempt("/tmp/old", "old-workspace", "old-tab"))
+	warnings, err := runtime.cleanupScout("/tmp/home", "/tmp/home/projects/demo", "task-1", scoutAttempt("/tmp/old", "old-workspace", "old-tab"))
 	if !errors.Is(err, phaseErr) {
 		t.Fatalf("cleanupScout() = %v, want %v", err, phaseErr)
 	}
@@ -53,7 +53,7 @@ func TestCleanupScoutReportsPartialReleaseOutcomes(t *testing.T) {
 	returned := false
 	runtime := &Runtime{deps: dependencies{
 		herdr: func() herdrClient { return fake },
-		worktree: worktreeDependencies{returnWorktree: func(string, bool) error {
+		worktree: worktreeDependencies{returnWorktree: func(string, string, bool) error {
 			returned = true
 			return returnErr
 		}},
@@ -65,7 +65,7 @@ func TestCleanupScoutReportsPartialReleaseOutcomes(t *testing.T) {
 		},
 	}}
 
-	warnings, err := runtime.cleanupScout("/tmp/home", "task-1", scoutAttempt("/tmp/old", "old-workspace", "old-tab"))
+	warnings, err := runtime.cleanupScout("/tmp/home", "/tmp/home/projects/demo", "task-1", scoutAttempt("/tmp/old", "old-workspace", "old-tab"))
 	if !errors.Is(err, phaseErr) {
 		t.Fatalf("cleanupScout() = %v, want %v", err, phaseErr)
 	}
@@ -81,11 +81,11 @@ func TestCleanupScoutReportsPartialReleaseOutcomes(t *testing.T) {
 func TestCleanupScoutReportsIncompleteHerdrOwnership(t *testing.T) {
 	runtime := &Runtime{deps: dependencies{
 		herdr:    func() herdrClient { return &provisionHerdr{} },
-		worktree: worktreeDependencies{returnWorktree: func(string, bool) error { return nil }},
+		worktree: worktreeDependencies{returnWorktree: func(string, string, bool) error { return nil }},
 		phase:    func(lifecyclePhase) error { return nil },
 	}}
 
-	warnings, err := runtime.cleanupScout("/tmp/home", "task-1", state.Attempt{
+	warnings, err := runtime.cleanupScout("/tmp/home", "/tmp/home/projects/demo", "task-1", state.Attempt{
 		TaskID: "task-1", Lifecycle: state.AttemptCompleted,
 		Herdr: state.Herdr{PaneID: "pane-only"},
 	})
@@ -129,7 +129,7 @@ func TestPromotePersistsPartialOldScoutCleanupWithoutMovingOwnership(t *testing.
 	deps.worktree.get = func(string, string) (worktree.Lease, error) {
 		return worktree.Lease{Path: "/new/worktree", ID: "L2"}, nil
 	}
-	deps.worktree.returnWorktree = func(path string, force bool) error {
+	deps.worktree.returnWorktree = func(_, path string, force bool) error {
 		if path == oldPath && !force {
 			t.Fatalf("old scout return force = %t, want true", force)
 		}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -36,12 +36,12 @@ const (
 
 type worktreeDependencies struct {
 	get            func(string, string) (worktree.Lease, error)
-	observeLease   func(string, string) worktree.LeaseObservation
+	observeLease   func(string, string, string) worktree.LeaseObservation
 	observeClean   func(string) (worktree.Cleanliness, error)
 	observeCommits func(string) worktree.CommitSafetyObservation
 	headCommit     func(string) (string, error)
-	returnWorktree func(string, bool) error
-	returnWithID   func(string, string, bool) error
+	returnWorktree func(string, string, bool) error
+	returnWithID   func(string, string, string, bool) error
 	checkCollision func(string, worktree.Lease, string) (string, error)
 }
 
@@ -142,7 +142,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		// durably recorded, and PR detection falls back to a live re-derivation as before.
 		branch, _ := currentBranch(worktreePath)
 		if err := state.RecordAttemptWorktree(req.home, req.attempt.TaskID, req.attempt.ID, worktreePath, branch, lease.ID); err != nil {
-			return "", reportCleanup(fmt.Errorf("record worktree ownership: %w", err), r.deps.worktree.returnLease(lease, true))
+			return "", reportCleanup(fmt.Errorf("record worktree ownership: %w", err), r.deps.worktree.returnLease(req.clonePath, lease, true))
 		}
 	}
 	var releaseWorktree func()
@@ -181,7 +181,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		return "", r.failProvision(req, lease, nil, false, err)
 	}
 	if req.resumeExisting {
-		observation := r.observeWorktreeLease(worktreePath, lease.ID)
+		observation := r.observeWorktreeLease(req.clonePath, worktreePath, lease.ID)
 		if observation.State != worktree.LeaseExact {
 			unproven := &worktree.UnprovenLeaseError{WorktreePath: worktreePath, ExpectedLeaseID: lease.ID, Observation: observation}
 			return "", r.failProvision(req, lease, nil, false, Precondition(fmt.Errorf("resumed worktree lease is %s: %w; refusing to launch", observation.State, unproven)))
@@ -280,15 +280,15 @@ func (r *Runtime) failProvision(req provisioningRequest, lease worktree.Lease, r
 		}
 	}
 	if lease.Path != "" && !req.resumeExisting {
-		if err := r.returnProvisioningWorktree(req.home, req.attempt.TaskID, req.attempt.ID, lease); err != nil {
+		if err := r.returnProvisioningWorktree(req.home, req.clonePath, req.attempt.TaskID, req.attempt.ID, lease); err != nil {
 			cleanup = append(cleanup, err)
 		}
 	}
 	return reportCleanup(cause, cleanup...)
 }
 
-func (r *Runtime) returnProvisioningWorktree(home, taskID string, attemptID int64, lease worktree.Lease) error {
-	if err := r.deps.worktree.returnLease(lease, true); err != nil {
+func (r *Runtime) returnProvisioningWorktree(home, clonePath, taskID string, attemptID int64, lease worktree.Lease) error {
+	if err := r.deps.worktree.returnLease(clonePath, lease, true); err != nil {
 		return err
 	}
 	if err := state.ClearAttemptWorktree(home, taskID, attemptID); err != nil {
@@ -297,12 +297,12 @@ func (r *Runtime) returnProvisioningWorktree(home, taskID string, attemptID int6
 	return nil
 }
 
-func (d worktreeDependencies) returnLease(lease worktree.Lease, force bool) error {
+func (d worktreeDependencies) returnLease(clonePath string, lease worktree.Lease, force bool) error {
 	if lease.ID != "" && d.returnWithID != nil {
-		return d.returnWithID(lease.Path, lease.ID, force)
+		return d.returnWithID(clonePath, lease.Path, lease.ID, force)
 	}
 	if d.returnWorktree != nil {
-		return d.returnWorktree(lease.Path, force)
+		return d.returnWorktree(clonePath, lease.Path, force)
 	}
-	return worktree.ReturnLease(lease.Path, lease.ID, force)
+	return worktree.ReturnLease(clonePath, lease.Path, lease.ID, force)
 }

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -26,7 +26,7 @@ func TestProvisionFailureAfterWorktreeRecordClearsOnlyReturnedEvidence(t *testin
 			get: func(string, string) (worktree.Lease, error) {
 				return worktree.Lease{Path: "/tmp/hand-wt", ID: "lease-1"}, nil
 			},
-			returnWorktree: func(string, bool) error {
+			returnWorktree: func(string, string, bool) error {
 				returned = true
 				return nil
 			},
@@ -200,7 +200,7 @@ func TestProvisionResumeRefusesChangedLeaseBeforeHerdrCreation(t *testing.T) {
 	attempt.LeaseID = "lease-old"
 	fake := &provisionHerdr{}
 	runtime := testProvisionRuntime(fake, func(lifecyclePhase) error { return nil })
-	runtime.deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	runtime.deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		if path != attempt.Worktree || leaseID != attempt.LeaseID {
 			t.Fatalf("observeLease(%q, %q), want persisted lease", path, leaseID)
 		}
@@ -228,7 +228,7 @@ func TestProvisionFailurePreservesWorktreeEvidenceWhenReturnFails(t *testing.T) 
 			get: func(string, string) (worktree.Lease, error) {
 				return worktree.Lease{Path: "/tmp/hand-wt", ID: "lease-1"}, nil
 			},
-			returnWorktree: func(string, bool) error { return returnErr },
+			returnWorktree: func(string, string, bool) error { return returnErr },
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },
 		},
 		phase: func(phase lifecyclePhase) error {
@@ -271,7 +271,7 @@ func TestProvisionFailureAfterHerdrRecordPreservesAttemptAttribution(t *testing.
 		}
 		return nil
 	})
-	runtime.deps.worktree.returnWorktree = func(string, bool) error { returned = true; return nil }
+	runtime.deps.worktree.returnWorktree = func(string, string, bool) error { returned = true; return nil }
 
 	_, err := runtime.provision(context.Background(), provisioningRequest{
 		home: home, projectName: "demo", clonePath: filepath.Join(home, "projects", "demo"),
@@ -495,10 +495,10 @@ func testProvisionRuntime(client herdrClient, phase func(lifecyclePhase) error) 
 			get: func(path, holder string) (worktree.Lease, error) {
 				return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
 			},
-			observeLease: func(string, string) worktree.LeaseObservation {
+			observeLease: func(string, string, string) worktree.LeaseObservation {
 				return worktree.LeaseObservation{State: worktree.LeaseExact}
 			},
-			returnWorktree: func(string, bool) error { return nil },
+			returnWorktree: func(string, string, bool) error { return nil },
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },
 		},
 		buildHarness: func(_ string, opts harness.Options) (launchSpec, error) {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -482,7 +482,7 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 		return false, false, "local-git", fmt.Errorf("lock worktree %q for local merge observation: %w", attempt.Worktree, err)
 	}
 	defer releaseWorktree()
-	lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
+	lease := r.observeWorktreeLease(filepath.Join(home, "projects", task.Project), attempt.Worktree, attempt.LeaseID)
 	if lease.State != worktree.LeaseExact {
 		unproven := &worktree.UnprovenLeaseError{WorktreePath: attempt.Worktree, ExpectedLeaseID: attempt.LeaseID, Observation: lease}
 		return false, false, "local-git", fmt.Errorf("observe local merge for task %q Attempt %d: %w", task.ID, attempt.ID, unproven)
@@ -970,7 +970,7 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 	}
 
 	if attempt.Worktree != "" && !worktreeCleanupSettled(attempt.TeardownWorktreeState) {
-		lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
+		lease := r.observeWorktreeLease(filepath.Join(home, "projects", task.Project), attempt.Worktree, attempt.LeaseID)
 		switch lease.State {
 		case worktree.LeaseUnknown, worktree.LeaseUnprovable:
 			if attest.Worktree {
@@ -1028,10 +1028,11 @@ func (r *Runtime) reconcileHistoricalAttempt(ctx context.Context, home string, t
 				if r.deps.worktree.returnWorktree == nil {
 					return false, reconciliationDecision{}, fmt.Errorf("no worktree return operation configured")
 				}
-				if err := r.deps.worktree.returnWorktree(attempt.Worktree, false); err != nil {
+				clonePath := filepath.Join(home, "projects", task.Project)
+				if err := r.deps.worktree.returnWorktree(clonePath, attempt.Worktree, false); err != nil {
 					return false, reconciliationDecision{}, fmt.Errorf("return historical worktree: %w", err)
 				}
-			} else if err := returnLease(attempt.Worktree, attempt.LeaseID, false); err != nil {
+			} else if err := returnLease(filepath.Join(home, "projects", task.Project), attempt.Worktree, attempt.LeaseID, false); err != nil {
 				return false, reconciliationDecision{}, fmt.Errorf("return historical worktree lease: %w", err)
 			}
 			if err := state.SetAttemptTeardownResourceState(home, task.ID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
@@ -1299,7 +1300,7 @@ func (r *Runtime) observeAttempt(home string, task state.Task, attempt state.Att
 	}
 	skipHerdrObservation := attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.WorkspaceID != "" && attempt.Herdr.TabID != "" && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == ""
 	if attempt.Worktree != "" {
-		lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
+		lease := r.observeWorktreeLease(filepath.Join(home, "projects", task.Project), attempt.Worktree, attempt.LeaseID)
 		observation.Treehouse.State = treehouseLeaseState(lease.State)
 		observation.Treehouse.Probe = lease.Probe
 		if lease.State == worktree.LeaseExact {

--- a/internal/runtime/reconcile_commit_safety_test.go
+++ b/internal/runtime/reconcile_commit_safety_test.go
@@ -91,7 +91,7 @@ func observingCommitSafetyRuntime(t *testing.T, worktreePath string, observe fun
 		}
 		return observe(path)
 	}
-	r.deps.worktree.returnWithID = func(string, string, bool) error {
+	r.deps.worktree.returnWithID = func(string, string, string, bool) error {
 		counts.returns++
 		return nil
 	}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -257,7 +257,7 @@ func TestReconcileAttemptCreatedContinuesTheSameAttempt(t *testing.T) {
 	}
 	client := &healthyReconcileHerdr{}
 	gets := 0
-	r := reconcileRuntime(client, func(path, holder string) (worktree.Lease, error) {
+	r := reconcileRuntime(client, func(path, _ string) (worktree.Lease, error) {
 		gets++
 		return worktree.Lease{Path: filepath.Join(home, "leased"), ID: "lease-1"}, nil
 	})
@@ -465,7 +465,7 @@ func TestReconcileRunningWorktreeLeaseMismatchWinsOverHealthyPane(t *testing.T) 
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}
 	}
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
@@ -920,7 +920,7 @@ func TestReconcileConvergesLifecycleWhileWorktreeStillNeedsRepair(t *testing.T) 
 	}
 	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
 	r.deps.prMerged = observedMergedPR(true)
-	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
 	}
 	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
@@ -966,7 +966,7 @@ func TestReconcileConvergesLifecycleDespiteRecordedRepairMarker(t *testing.T) {
 	}
 	r := reconcileRuntime(&missingReconcileHerdr{}, nil)
 	r.deps.prMerged = observedMergedPR(true)
-	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
 	}
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
@@ -1175,7 +1175,7 @@ func TestReconcileTerminalOwnedResourcesCleansEachResourceOnce(t *testing.T) {
 	client := &healthyReconcileHerdr{}
 	r := reconcileRuntime(client, nil)
 	returns := 0
-	r.deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+	r.deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
 		returns++
 		if path != "/pool/1" || leaseID != "lease-1" || force {
 			t.Fatalf("returnWithID(%q, %q, %t), want exact clean lease", path, leaseID, force)
@@ -1218,7 +1218,7 @@ func TestReconcileTerminalDirtyWorktreeRefusesCleanup(t *testing.T) {
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
 	returns := 0
 	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Dirty, nil }
-	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	r.deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
@@ -1267,11 +1267,11 @@ func TestReconcileReusedTerminalLeaseDoesNotReturnNewOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "new-lease"}
 	}
 	returns := 0
-	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	r.deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
@@ -1316,13 +1316,13 @@ func unobservableTeardownFixture(t *testing.T, latch string) (string, state.Atte
 func unobservableReconcileRuntime(t *testing.T, returns *int) *Runtime {
 	t.Helper()
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
-	r.deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseUnknown, Probe: worktree.LeaseProbe{
 			Command: "treehouse status --json", WorkingDir: path, Reason: "treehouse reported no pool entries",
 		}}
 	}
-	r.deps.worktree.returnWithID = func(string, string, bool) error { *returns++; return nil }
-	r.deps.worktree.returnWorktree = func(string, bool) error { *returns++; return nil }
+	r.deps.worktree.returnWithID = func(string, string, string, bool) error { *returns++; return nil }
+	r.deps.worktree.returnWorktree = func(string, string, bool) error { *returns++; return nil }
 	return r
 }
 
@@ -1440,7 +1440,7 @@ func TestReconcileAbandonWorktreeRefusesProvableOwnership(t *testing.T) {
 			home, _ := unobservableTeardownFixture(t, state.TeardownResourceAmbiguous)
 			returns := 0
 			r := unobservableReconcileRuntime(t, &returns)
-			r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return test.observation }
+			r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation { return test.observation }
 			if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1", AbandonWorktree: true}); err != nil {
 				t.Fatal(err)
 			}
@@ -1632,7 +1632,7 @@ func TestReconcileConvergesALatchedWorktreeOnceOwnershipIsProven(t *testing.T) {
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
-	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
@@ -1673,7 +1673,7 @@ func TestReconcilePromotionCrashCleansScoutBeforeShipLaunch(t *testing.T) {
 	client := &healthyReconcileHerdr{}
 	r := reconcileRuntime(client, nil)
 	returns := 0
-	r.deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+	r.deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
 		returns++
 		if path != "/scout" || leaseID != "scout-lease" || force {
 			t.Fatalf("scout return = %q %q %t", path, leaseID, force)
@@ -1933,7 +1933,7 @@ func TestReconcileLocalMergeDoesNotInspectReusedTreehousePath(t *testing.T) {
 	}
 	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
 	observed := 0
-	r.deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	r.deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		observed++
 		if path != "/pool/shared" || leaseID != "lease-a" {
 			t.Fatalf("observeLease(%q, %q), want Task 1 lease", path, leaseID)
@@ -2006,7 +2006,7 @@ func TestReconcileResumesPartialTeardownWithoutChangingDisposition(t *testing.T)
 	client := &healthyReconcileHerdr{}
 	r := reconcileRuntime(client, nil)
 	returns := 0
-	r.deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	r.deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatal(err)
 	}
@@ -2163,7 +2163,7 @@ func TestReconcileNormalizesPendingSendWithoutSteering(t *testing.T) {
 
 func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lease, error)) *Runtime {
 	if get == nil {
-		get = func(path, holder string) (worktree.Lease, error) {
+		get = func(path, _ string) (worktree.Lease, error) {
 			return worktree.Lease{Path: filepath.Join(path, "leased"), ID: "lease-1"}, nil
 		}
 	}
@@ -2172,7 +2172,7 @@ func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lea
 		herdr: func() herdrClient { return client },
 		worktree: worktreeDependencies{
 			get: get,
-			observeLease: func(string, string) worktree.LeaseObservation {
+			observeLease: func(string, string, string) worktree.LeaseObservation {
 				return worktree.LeaseObservation{State: worktree.LeaseExact}
 			},
 			observeClean: func(path string) (worktree.Cleanliness, error) {
@@ -2185,8 +2185,8 @@ func reconcileRuntime(client herdrClient, get func(string, string) (worktree.Lea
 				}
 			},
 			checkCollision: func(string, worktree.Lease, string) (string, error) { return "", nil },
-			returnWorktree: func(string, bool) error { return nil },
-			returnWithID:   func(string, string, bool) error { return nil },
+			returnWorktree: func(string, string, bool) error { return nil },
+			returnWithID:   func(string, string, string, bool) error { return nil },
 		},
 		buildHarness:     func(string, harness.Options) (launchSpec, error) { return launchSpec{Executable: "launch"}, nil },
 		confirmLaunch:    func(herdrClient, string, string, launchSpec) error { return nil },

--- a/internal/runtime/repair_test.go
+++ b/internal/runtime/repair_test.go
@@ -117,7 +117,7 @@ func repairRuntime(client herdrClient) *Runtime {
 }
 
 func repairLeaseObservation(r *Runtime, lease worktree.LeaseObservation) {
-	r.deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return lease }
+	r.deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation { return lease }
 }
 
 func repairCommitSafety(r *Runtime, state worktree.CommitSafetyState, probe worktree.CommitSafetyProbe) {

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -133,12 +133,12 @@ func closeTaskTab(client herdrClient, workspaceID, tabID string) error {
 	return client.TabClose(tabID)
 }
 
-func (r *Runtime) observeWorktreeLease(worktreePath, leaseID string) worktree.LeaseObservation {
+func (r *Runtime) observeWorktreeLease(clonePath, worktreePath, leaseID string) worktree.LeaseObservation {
 	observe := r.deps.worktree.observeLease
 	if observe == nil {
 		observe = worktree.ObserveLease
 	}
-	return observe(worktreePath, leaseID)
+	return observe(clonePath, worktreePath, leaseID)
 }
 
 func worktreeCleanupSettled(teardownWorktreeState string) bool {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -132,7 +132,8 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 		return fail(err)
 	}
 	returnForce := teardownReturnForce(req.Force, dirtWasSafe, disposition)
-	if err := r.releaseWorktree(req.Home, req.ID, active, returnForce); err != nil {
+	clonePath := filepath.Join(req.Home, "projects", task.Project)
+	if err := r.releaseWorktree(clonePath, req.Home, req.ID, active, returnForce); err != nil {
 		return fail(err)
 	}
 	if recoveredCompletion != nil {
@@ -259,12 +260,12 @@ func (r *Runtime) releaseHerdr(home, taskID string, attempt state.Attempt, warni
 	return nil
 }
 
-func (r *Runtime) releaseWorktree(home, taskID string, attempt state.Attempt, force bool) error {
+func (r *Runtime) releaseWorktree(clonePath, home, taskID string, attempt state.Attempt, force bool) error {
 	if attempt.Worktree == "" {
 		return nil
 	}
 	proveOwnership := func(action string) error {
-		observation := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)
+		observation := r.observeWorktreeLease(clonePath, attempt.Worktree, attempt.LeaseID)
 		if observation.State == worktree.LeaseExact {
 			return nil
 		}
@@ -304,7 +305,7 @@ func (r *Runtime) releaseWorktree(home, taskID string, attempt state.Attempt, fo
 	if err := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleasing); err != nil {
 		return fmt.Errorf("record worktree release phase: %w", err)
 	}
-	if err := r.deps.worktree.returnLease(worktree.Lease{Path: attempt.Worktree, ID: attempt.LeaseID}, force); err != nil {
+	if err := r.deps.worktree.returnLease(clonePath, worktree.Lease{Path: attempt.Worktree, ID: attempt.LeaseID}, force); err != nil {
 		if errors.Is(err, worktree.ErrReturnAborted) {
 			if stateErr := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceRetryable); stateErr != nil {
 				return fmt.Errorf("record retryable worktree return: %w", stateErr)

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -20,7 +20,7 @@ func TestTeardownFailureAfterWorktreeReturnPreservesOwnershipEvidence(t *testing
 	phaseErr := errors.New("stop after worktree return")
 	returned := false
 	deps := defaultDependencies()
-	deps.worktree.returnWorktree = func(path string, force bool) error {
+	deps.worktree.returnWorktree = func(_, path string, force bool) error {
 		if path != worktree || force {
 			t.Fatalf("returnWorktree(%q, %t), want (%q, false)", path, force, worktree)
 		}
@@ -92,7 +92,7 @@ func TestTeardownCompletionAppendFailureLeavesStateRetryable(t *testing.T) {
 	home, _ := teardownFixture(t, true)
 	appendErr := errors.New("completion store unavailable")
 	deps := defaultDependencies()
-	deps.worktree.returnWorktree = func(string, bool) error { return nil }
+	deps.worktree.returnWorktree = func(string, string, bool) error { return nil }
 	deps.appendCompletion = func(string, completion.Record) error { return appendErr }
 
 	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
@@ -117,7 +117,7 @@ func TestTeardownFailureAfterCompletionAppendLeavesBoundaryObservable(t *testing
 	home, _ := teardownFixture(t, true)
 	phaseErr := errors.New("stop after completion append")
 	deps := defaultDependencies()
-	deps.worktree.returnWorktree = func(string, bool) error { return nil }
+	deps.worktree.returnWorktree = func(string, string, bool) error { return nil }
 	deps.phase = func(phase lifecyclePhase) error {
 		if phase == phaseCompletionAppended {
 			return phaseErr
@@ -151,7 +151,7 @@ func TestTeardownRetryAfterCompletionAppendDoesNotRepeatCleanup(t *testing.T) {
 	phaseFailure := true
 	phaseErr := errors.New("stop after completion append")
 	deps := defaultDependencies()
-	deps.worktree.returnWorktree = func(path string, force bool) error {
+	deps.worktree.returnWorktree = func(_, path string, force bool) error {
 		if path != worktree || force {
 			t.Fatalf("returnWorktree(%q, %t), want (%q, false)", path, force, worktree)
 		}
@@ -470,7 +470,7 @@ func TestTeardownForcedRetryKeepsForcedWorktreeReturn(t *testing.T) {
 	phaseFailure := true
 	returned := 0
 	deps := defaultDependencies()
-	deps.worktree.returnWorktree = func(path string, force bool) error {
+	deps.worktree.returnWorktree = func(_, path string, force bool) error {
 		if path != worktree || !force {
 			t.Fatalf("returnWorktree(%q, %t), want (%q, true)", path, force, worktree)
 		}
@@ -537,7 +537,7 @@ func TestTeardownRetrySkipsReleasedWorktreeAfterLeaseReused(t *testing.T) {
 	reacquired := false
 	phaseFailure := true
 	deps := defaultDependencies()
-	deps.worktree.returnWorktree = func(path string, force bool) error {
+	deps.worktree.returnWorktree = func(_, path string, force bool) error {
 		if path != worktree || force {
 			t.Fatalf("returnWorktree(%q, %t), want (%q, false)", path, force, worktree)
 		}
@@ -581,14 +581,14 @@ func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
 	returns := 0
 	observed := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "lease-1" {
 			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
 		observed++
 		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
-	deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+	deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
 		if path != worktreePath {
 			t.Fatalf("returnWithID path = %q, want %q", path, worktreePath)
 		}
@@ -632,17 +632,17 @@ func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 	home, worktreePath, attempt := leasedTeardownFixture(t)
 	called := false
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "lease-1" {
 			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
 		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
-	deps.worktree.returnWorktree = func(string, bool) error {
+	deps.worktree.returnWorktree = func(string, string, bool) error {
 		t.Fatal("teardown used path-only return for a known lease")
 		return nil
 	}
-	deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+	deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
 		if path != worktreePath || leaseID != "lease-1" || force {
 			t.Fatalf("returnWithID(%q, %q, %t), want (%q, %q, false)", path, leaseID, force, worktreePath, "lease-1")
 		}
@@ -650,7 +650,7 @@ func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 		return nil
 	}
 
-	if err := (&Runtime{deps: deps}).releaseWorktree(home, "task-1", attempt, false); err != nil {
+	if err := (&Runtime{deps: deps}).releaseWorktree(filepath.Join(home, "projects", "myproj"), home, "task-1", attempt, false); err != nil {
 		t.Fatal(err)
 	}
 	if !called {
@@ -663,14 +663,14 @@ func TestTeardownRefusesARecycledWorktreeLeaseOnFirstReturn(t *testing.T) {
 	observed := 0
 	returns := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "lease-1" {
 			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
 		observed++
 		return worktree.LeaseObservation{State: worktree.LeaseMismatch, LeaseID: "lease-2"}
 	}
-	deps.worktree.returnWorktree = func(string, bool) error {
+	deps.worktree.returnWorktree = func(string, string, bool) error {
 		returns++
 		return nil
 	}
@@ -779,8 +779,8 @@ func TestTeardownDoesNotLatchOnAnUnobservablePool(t *testing.T) {
 	returns := 0
 	observation := unobservablePool(worktreePath)
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return observation }
-	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation { return observation }
+	deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 	runtime := &Runtime{deps: deps}
 
 	_, err := runtime.Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
@@ -829,8 +829,8 @@ func TestTeardownForceCannotDestroyAnUnobservableWorktree(t *testing.T) {
 	returns := 0
 	observation := worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return observation }
-	deps.worktree.returnWithID = func(_, _ string, force bool) error {
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation { return observation }
+	deps.worktree.returnWithID = func(_, _, _ string, force bool) error {
 		returns++
 		if !force {
 			return worktree.ErrReturnAborted
@@ -868,10 +868,10 @@ func TestTeardownConvergesALatchedWorktreeOnceOwnershipIsProven(t *testing.T) {
 	}
 	returns := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
-	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 
 	if _, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); err != nil {
 		t.Fatalf("Teardown() on a latched attempt = %v, want release once ownership is proven", err)
@@ -897,8 +897,8 @@ func TestTeardownKeepsALatchedWorktreeWhenOwnershipStaysUnobservable(t *testing.
 	}
 	returns := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation { return unobservablePool(worktreePath) }
-	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation { return unobservablePool(worktreePath) }
+	deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 
 	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1", Force: true})
 	if err == nil || !strings.Contains(err.Error(), "could not be observed") {
@@ -921,14 +921,14 @@ func TestTeardownRetryRefusesWorktreeWithoutLeaseIdentity(t *testing.T) {
 	returns := 0
 	observed := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
 		if path != worktreePath || leaseID != "" {
 			t.Fatalf("observeLease(%q, %q), want (%q, empty)", path, leaseID, worktreePath)
 		}
 		observed++
 		return worktree.LeaseObservation{State: worktree.LeaseUnprovable}
 	}
-	deps.worktree.returnWorktree = func(string, bool) error {
+	deps.worktree.returnWorktree = func(string, string, bool) error {
 		returns++
 		return worktree.ErrReturnAborted
 	}

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -231,11 +231,15 @@ func TestTeardownSecondInvocationRefusesWithoutRepeatingCompletion(t *testing.T)
 
 func TestTeardownReleasesResourcesRecordedOnTerminalTask(t *testing.T) {
 	home, worktreePath, _ := terminalResourceFixture(t)
+	clonePath := filepath.Join(home, "projects", "demo")
 	client := &teardownHerdr{}
 	returns := 0
 	deps := defaultDependencies()
 	deps.herdr = func() herdrClient { return client }
-	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(gotClonePath, path, leaseID string) worktree.LeaseObservation {
+		if gotClonePath != clonePath {
+			t.Fatalf("observeLease clone path = %q, want %q", gotClonePath, clonePath)
+		}
 		if path != worktreePath || leaseID != "lease-1" {
 			t.Fatalf("observeLease(%q, %q), want (%q, lease-1)", path, leaseID, worktreePath)
 		}
@@ -244,7 +248,10 @@ func TestTeardownReleasesResourcesRecordedOnTerminalTask(t *testing.T) {
 	deps.worktree.observeCommits = func(string) worktree.CommitSafetyObservation {
 		return worktree.CommitSafetyObservation{State: worktree.CommitSafetyRemoteObserved}
 	}
-	deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+	deps.worktree.returnWithID = func(gotClonePath, path, leaseID string, force bool) error {
+		if gotClonePath != clonePath {
+			t.Fatalf("returnWithID clone path = %q, want %q", gotClonePath, clonePath)
+		}
 		if path != worktreePath || leaseID != "lease-1" || force {
 			t.Fatalf("returnWithID(%q, %q, %t), want the proven terminal lease returned", path, leaseID, force)
 		}
@@ -268,13 +275,13 @@ func TestTeardownRefusesTerminalTaskWhenCommitSafetyIsUnprovable(t *testing.T) {
 	home, worktreePath, _ := terminalResourceFixture(t)
 	returns := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
 		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
 	deps.worktree.observeCommits = func(string) worktree.CommitSafetyObservation {
 		return worktree.CommitSafetyObservation{State: worktree.CommitSafetyUnknown, Probe: worktree.CommitSafetyProbe{WorkingDir: worktreePath}}
 	}
-	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+	deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
 
 	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
 	if err == nil || !strings.Contains(err.Error(), "commit safety") {

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -578,17 +578,24 @@ func TestTeardownRetrySkipsReleasedWorktreeAfterLeaseReused(t *testing.T) {
 
 func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
 	home, worktreePath, _ := leasedTeardownFixture(t)
+	clonePath := filepath.Join(home, "projects", "demo")
 	returns := 0
 	observed := 0
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(gotClonePath, path, leaseID string) worktree.LeaseObservation {
+		if gotClonePath != clonePath {
+			t.Fatalf("observeLease clone path = %q, want %q", gotClonePath, clonePath)
+		}
 		if path != worktreePath || leaseID != "lease-1" {
 			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
 		observed++
 		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
 	}
-	deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
+	deps.worktree.returnWithID = func(gotClonePath, path, leaseID string, force bool) error {
+		if gotClonePath != clonePath {
+			t.Fatalf("returnWithID clone path = %q, want %q", gotClonePath, clonePath)
+		}
 		if path != worktreePath {
 			t.Fatalf("returnWithID path = %q, want %q", path, worktreePath)
 		}
@@ -630,9 +637,13 @@ func TestTeardownRetriesKnownAbortedReturnWithForce(t *testing.T) {
 
 func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 	home, worktreePath, attempt := leasedTeardownFixture(t)
+	clonePath := filepath.Join(home, "projects", "demo")
 	called := false
 	deps := defaultDependencies()
-	deps.worktree.observeLease = func(_, path, leaseID string) worktree.LeaseObservation {
+	deps.worktree.observeLease = func(gotClonePath, path, leaseID string) worktree.LeaseObservation {
+		if gotClonePath != clonePath {
+			t.Fatalf("observeLease clone path = %q, want %q", gotClonePath, clonePath)
+		}
 		if path != worktreePath || leaseID != "lease-1" {
 			t.Fatalf("observeLease(%q, %q), want (%q, %q)", path, leaseID, worktreePath, "lease-1")
 		}
@@ -642,7 +653,10 @@ func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 		t.Fatal("teardown used path-only return for a known lease")
 		return nil
 	}
-	deps.worktree.returnWithID = func(_, path, leaseID string, force bool) error {
+	deps.worktree.returnWithID = func(gotClonePath, path, leaseID string, force bool) error {
+		if gotClonePath != clonePath {
+			t.Fatalf("returnWithID clone path = %q, want %q", gotClonePath, clonePath)
+		}
 		if path != worktreePath || leaseID != "lease-1" || force {
 			t.Fatalf("returnWithID(%q, %q, %t), want (%q, %q, false)", path, leaseID, force, worktreePath, "lease-1")
 		}
@@ -650,7 +664,7 @@ func TestTeardownUsesConditionalReturnForKnownLease(t *testing.T) {
 		return nil
 	}
 
-	if err := (&Runtime{deps: deps}).releaseWorktree(filepath.Join(home, "projects", "myproj"), home, "task-1", attempt, false); err != nil {
+	if err := (&Runtime{deps: deps}).releaseWorktree(clonePath, home, "task-1", attempt, false); err != nil {
 		t.Fatal(err)
 	}
 	if !called {

--- a/internal/runtime/unwind_test.go
+++ b/internal/runtime/unwind_test.go
@@ -51,8 +51,8 @@ func unwindRuntime(t *testing.T, returns *int) *Runtime {
 	r.deps.herdr = func() herdrClient { return herdr.NewClient() }
 	r.deps.buildHarness = harness.Build
 	r.deps.confirmLaunch = confirmLaunch
-	r.deps.worktree.returnWorktree = func(string, bool) error { *returns++; return nil }
-	r.deps.worktree.returnWithID = func(string, string, bool) error { *returns++; return nil }
+	r.deps.worktree.returnWorktree = func(string, string, bool) error { *returns++; return nil }
+	r.deps.worktree.returnWithID = func(string, string, string, bool) error { *returns++; return nil }
 	return r
 }
 

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -470,7 +470,9 @@ func runTaskLockHoldForeverHelper(t *testing.T) {
 		t.Fatalf("holder Lock: %v", err)
 	}
 	fmt.Println("acquired")
-	select {}
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func waitForHolderReady(t *testing.T, r io.Reader) bool {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1198,6 +1198,9 @@ func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("list open tasks: %w", err)
 	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("list open tasks: %w", err)
+	}
 	for i := range histories {
 		attempts, err := db.ListAttempts(histories[i].Task.ID)
 		if err != nil {
@@ -1244,6 +1247,9 @@ func (db *DB) ListReconciliationHistories() ([]TaskHistory, error) {
 		histories = append(histories, TaskHistory{Task: task})
 	}
 	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list reconciliation tasks: %w", err)
+	}
+	if err := rows.Close(); err != nil {
 		return nil, fmt.Errorf("list reconciliation tasks: %w", err)
 	}
 	for i := range histories {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -121,7 +121,7 @@ func ObserveLease(clonePath, worktreePath, expectedLeaseID string) LeaseObservat
 		return unknownLease(worktreePath, reason)
 	}
 	for _, entry := range entries {
-		if entry.Path != worktreePath {
+		if !gitrepo.SamePath(entry.Path, worktreePath) {
 			continue
 		}
 		if entry.Status != "leased" {
@@ -454,7 +454,7 @@ func CheckCollision(homeDir string, lease Lease, excludeID string) (string, erro
 		}
 		// Fallback whenever either side has no identity, which is any row written before the
 		// lease_id column existed.
-		if attempt.Worktree == lease.Path {
+		if gitrepo.SamePath(attempt.Worktree, lease.Path) {
 			return history.Task.ID, nil
 		}
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -313,26 +313,12 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 			return Lease{}, fmt.Errorf("treehouse get returned an unreadable worktree: %w", err)
 		}
 		expected := filepath.Join(clonePath, ".git")
-		if !sameWorktreeRepository(expected, actual) {
+		if !gitrepo.SamePath(expected, actual) {
 			_ = ReturnLease(clonePath, lease.Path, lease.ID, true)
 			return Lease{}, fmt.Errorf("treehouse get returned worktree rooted in another Git repository: got %s, want %s", actual, expected)
 		}
 	}
 	return lease, nil
-}
-
-func sameWorktreeRepository(left, right string) bool {
-	canonical := func(path string) string {
-		abs, err := filepath.Abs(path)
-		if err != nil {
-			return filepath.Clean(path)
-		}
-		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-			abs = resolved
-		}
-		return filepath.Clean(abs)
-	}
-	return canonical(left) == canonical(right)
 }
 
 // Reads the full commit object ID currently checked out by a leased worktree.

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	gitrepo "github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/toolchain"
 )
@@ -104,7 +106,7 @@ const (
 // ObserveLease classifies recorded worktree ownership and never fails: every cause that stops the
 // pool from being observed is reported as LeaseUnknown carrying its probe, because an observation
 // that could not be made is not evidence that ownership changed.
-func ObserveLease(worktreePath, expectedLeaseID string) LeaseObservation {
+func ObserveLease(clonePath, worktreePath, expectedLeaseID string) LeaseObservation {
 	if worktreePath == "" {
 		return LeaseObservation{State: LeaseAbsent}
 	}
@@ -114,7 +116,7 @@ func ObserveLease(worktreePath, expectedLeaseID string) LeaseObservation {
 		}
 		return unknownLease(worktreePath, fmt.Sprintf("inspect worktree path: %v", err))
 	}
-	entries, reason := treehouseStatus(worktreePath)
+	entries, reason := treehouseStatus(clonePath, worktreePath)
 	if reason != "" {
 		return unknownLease(worktreePath, reason)
 	}
@@ -285,6 +287,7 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 	if leaseHolder != "" {
 		args = append(args, "--lease-holder", leaseHolder)
 	}
+	args = withTreehouseRoot(clonePath, args...)
 	out, stderr, err := runCore("treehouse", clonePath, args...)
 	// Banners land on stderr ahead of the JSON, so the payload has to be read from stdout alone -
 	// CombinedOutput here corrupts every parse (atqamz/hand#21).
@@ -302,7 +305,34 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 	if payload.Path == "" {
 		return Lease{}, fmt.Errorf("treehouse get returned no worktree path")
 	}
-	return Lease{Path: payload.Path, ID: payload.LeaseID}, nil
+	lease := Lease{Path: payload.Path, ID: payload.LeaseID}
+	if _, err := os.Stat(lease.Path); err == nil {
+		actual, err := gitrepo.CommonDir(lease.Path)
+		if err != nil {
+			_ = ReturnLease(clonePath, lease.Path, lease.ID, true)
+			return Lease{}, fmt.Errorf("treehouse get returned an unreadable worktree: %w", err)
+		}
+		expected := filepath.Join(clonePath, ".git")
+		if !sameWorktreeRepository(expected, actual) {
+			_ = ReturnLease(clonePath, lease.Path, lease.ID, true)
+			return Lease{}, fmt.Errorf("treehouse get returned worktree rooted in another Git repository: got %s, want %s", actual, expected)
+		}
+	}
+	return lease, nil
+}
+
+func sameWorktreeRepository(left, right string) bool {
+	canonical := func(path string) string {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return filepath.Clean(path)
+		}
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = resolved
+		}
+		return filepath.Clean(abs)
+	}
+	return canonical(left) == canonical(right)
 }
 
 // Reads the full commit object ID currently checked out by a leased worktree.
@@ -319,7 +349,7 @@ func HeadCommit(worktreePath string) (string, error) {
 }
 
 // Return releases a worktree back to its treehouse pool without lease identity.
-func Return(worktreePath string, force bool) error {
+func Return(clonePath, worktreePath string, force bool) error {
 	if worktreePath == "" {
 		return nil
 	}
@@ -327,22 +357,24 @@ func Return(worktreePath string, force bool) error {
 	if force {
 		args = append(args, "--force")
 	}
+	args = withTreehouseRoot(clonePath, args...)
 	return returnTreehouse(worktreePath, args, force)
 }
 
 // ReturnLease releases a worktree only when treehouse still owns the expected lease.
-func ReturnLease(worktreePath, leaseID string, force bool) error {
+func ReturnLease(clonePath, worktreePath, leaseID string, force bool) error {
 	if worktreePath == "" {
 		return nil
 	}
 	if leaseID == "" {
-		return Return(worktreePath, force)
+		return Return(clonePath, worktreePath, force)
 	}
 	args := []string{"return"}
 	if force {
 		args = append(args, "--force")
 	}
 	args = append(args, "--if-lease-id", leaseID, worktreePath)
+	args = withTreehouseRoot(clonePath, args...)
 	return returnTreehouse(worktreePath, args, force)
 }
 
@@ -360,8 +392,8 @@ func returnTreehouse(worktreePath string, args []string, force bool) error {
 
 // Reports the pool entries, or the reason the pool could not be observed. A missing executable, a
 // non-zero exit and unparsable output are all unobservability, never absence and never a mismatch.
-func treehouseStatus(worktreePath string) ([]statusEntry, string) {
-	out, stderr, err := runCore("treehouse", worktreePath, "status", "--json")
+func treehouseStatus(clonePath, worktreePath string) ([]statusEntry, string) {
+	out, stderr, err := runCore("treehouse", worktreePath, withTreehouseRoot(clonePath, "status", "--json")...)
 	if err != nil {
 		if strings.Contains(err.Error(), "executable file not found") {
 			return nil, fmt.Sprintf("treehouse is not executable: %v", err)
@@ -377,6 +409,10 @@ func treehouseStatus(worktreePath string) ([]statusEntry, string) {
 		return nil, fmt.Sprintf("treehouse status output is not a JSON array: %v", err)
 	}
 	return entries, ""
+}
+
+func withTreehouseRoot(clonePath string, args ...string) []string {
+	return append([]string{"--root", clonePath}, args...)
 }
 
 func runCore(tool, dir string, args ...string) ([]byte, []byte, error) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -12,6 +12,22 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
+func testGet(clonePath, leaseHolder string) (Lease, error) {
+	return Get(clonePath, leaseHolder)
+}
+
+func testObserveLease(worktreePath, expectedLeaseID string) LeaseObservation {
+	return ObserveLease(filepath.Dir(worktreePath), worktreePath, expectedLeaseID)
+}
+
+func testReturn(worktreePath string, force bool) error {
+	return Return(filepath.Dir(worktreePath), worktreePath, force)
+}
+
+func testReturnLease(worktreePath, leaseID string, force bool) error {
+	return ReturnLease(filepath.Dir(worktreePath), worktreePath, leaseID, force)
+}
+
 func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	t.Helper()
 	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
@@ -29,7 +45,7 @@ func writeCollisionTask(t *testing.T, home, id, path, leaseID string) {
 
 func TestGetParsesLeasePathAndIdentity(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1","lease_id":"5fe5412a4aabdeb85a148d6d73eb42d8"}`})
-	got, err := Get(t.TempDir(), "hand:task-1")
+	got, err := testGet(t.TempDir(), "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +60,7 @@ func TestGetParsesLeasePathAndIdentity(t *testing.T) {
 // path for it.
 func TestGetAcceptsAPayloadWithoutALeaseIdentity(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1"}`})
-	got, err := Get(t.TempDir(), "hand:task-1")
+	got, err := testGet(t.TempDir(), "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,21 +94,51 @@ func TestGetPassesLeaseHolder(t *testing.T) {
 		Command: "get", Args: []string{"--lease", "--json", "--lease-holder", "hand:task-1"},
 		Stdout: `{"path":"/tmp/wt-1"}`,
 	})
-	if _, err := Get(t.TempDir(), "hand:task-1"); err != nil {
+	if _, err := testGet(t.TempDir(), "hand:task-1"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetScopesPoolToTheFleetHome(t *testing.T) {
+	home := t.TempDir()
+	clone := filepath.Join(home, "projects", "demo")
+	if err := os.MkdirAll(clone, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeTreehouse(t, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{clone, "get", "--lease", "--json", "--lease-holder", "hand:task-1"},
+		Stdout: `{"path":"/tmp/wt-1"}`,
+	})
+	if _, err := Get(clone, "hand:task-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetRejectsAWorktreeFromAnotherRegisteredClone(t *testing.T) {
+	home := t.TempDir()
+	clone := filepath.Join(home, "projects", "demo")
+	foreign := filepath.Join(t.TempDir(), "demo")
+	faketool.InitRepo(t, clone)
+	faketool.InitRepo(t, foreign)
+	faketool.Treehouse{Responses: []faketool.TreehouseResponse{
+		{Command: "get", Stdout: `{"path":"` + foreign + `","lease_id":"lease-1"}`},
+		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", foreign}},
+	}}.Install(t, faketool.Bin(t))
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "another Git repository") {
+		t.Fatalf("Get() error = %v, want a registered-clone mismatch", err)
 	}
 }
 
 func TestGetFailsOnNonZeroExit(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stderr: "pool exhausted\n", Exit: 1})
-	if _, err := Get(t.TempDir(), ""); err == nil || !strings.Contains(err.Error(), "pool exhausted") {
+	if _, err := testGet(t.TempDir(), ""); err == nil || !strings.Contains(err.Error(), "pool exhausted") {
 		t.Fatalf("got err %v, want pool exhausted failure", err)
 	}
 }
 
 func TestGetFailsOnMissingPath(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{}`})
-	if _, err := Get(t.TempDir(), ""); err == nil {
+	if _, err := testGet(t.TempDir(), ""); err == nil {
 		t.Fatal("expected error for missing path in lease response")
 	}
 }
@@ -111,12 +157,12 @@ func TestObserveLeaseDistinguishesExactMissingReusedAndLegacyOwnership(t *testin
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
-			got := ObserveLease(path, test.leaseID)
+			got := testObserveLease(path, test.leaseID)
 			if got.State != test.want {
-				t.Fatalf("ObserveLease() = %+v, want %s", got, test.want)
+				t.Fatalf("testObserveLease() = %+v, want %s", got, test.want)
 			}
 			if got.Probe != (LeaseProbe{}) {
-				t.Fatalf("ObserveLease() probe = %+v, want no probe on an observed pool", got.Probe)
+				t.Fatalf("testObserveLease() probe = %+v, want no probe on an observed pool", got.Probe)
 			}
 		})
 	}
@@ -126,17 +172,17 @@ func TestObserveLeaseReportsAbsentAfterReturn(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
-	if err := ReturnLease(path, "lease-1", true); err != nil {
+	if err := testReturnLease(path, "lease-1", true); err != nil {
 		t.Fatal(err)
 	}
-	if got := ObserveLease(path, "lease-1"); got.State != LeaseAbsent {
-		t.Fatalf("ObserveLease() = %+v, want absent", got)
+	if got := testObserveLease(path, "lease-1"); got.State != LeaseAbsent {
+		t.Fatalf("testObserveLease() = %+v, want absent", got)
 	}
 }
 
 func TestObserveLeaseReportsAbsentWhenTheRecordedPathIsGone(t *testing.T) {
-	if got := ObserveLease(filepath.Join(t.TempDir(), "gone"), "lease-1"); got.State != LeaseAbsent {
-		t.Fatalf("ObserveLease() = %+v, want absent", got)
+	if got := testObserveLease(filepath.Join(t.TempDir(), "gone"), "lease-1"); got.State != LeaseAbsent {
+		t.Fatalf("testObserveLease() = %+v, want absent", got)
 	}
 }
 
@@ -189,15 +235,15 @@ func TestObserveLeaseReportsUnknownForEveryUnobservablePool(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "wt-1")
 			faketool.InitRepo(t, path)
 			test.install(t, path)
-			got := ObserveLease(path, "lease-1")
+			got := testObserveLease(path, "lease-1")
 			if got.State != LeaseUnknown {
-				t.Fatalf("ObserveLease() = %+v, want %s", got, LeaseUnknown)
+				t.Fatalf("testObserveLease() = %+v, want %s", got, LeaseUnknown)
 			}
 			if got.Probe.Command != "treehouse status --json" || got.Probe.WorkingDir != path {
-				t.Fatalf("ObserveLease() probe = %+v, want the command and working directory that selected the pool", got.Probe)
+				t.Fatalf("testObserveLease() probe = %+v, want the command and working directory that selected the pool", got.Probe)
 			}
 			if !strings.Contains(got.Probe.Reason, test.wantReason) {
-				t.Fatalf("ObserveLease() probe reason = %q, want it to contain %q", got.Probe.Reason, test.wantReason)
+				t.Fatalf("testObserveLease() probe reason = %q, want it to contain %q", got.Probe.Reason, test.wantReason)
 			}
 		})
 	}
@@ -209,21 +255,21 @@ func TestUnknownAndMismatchAreDistinguishableWithoutReadingAMessage(t *testing.T
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-2"}}.Install(t, faketool.Bin(t))
-	mismatch := ObserveLease(path, "lease-1")
+	mismatch := testObserveLease(path, "lease-1")
 	if mismatch.State != LeaseMismatch || mismatch.LeaseID != "lease-2" {
-		t.Fatalf("ObserveLease() = %+v, want a mismatch naming the observed lease", mismatch)
+		t.Fatalf("testObserveLease() = %+v, want a mismatch naming the observed lease", mismatch)
 	}
 
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "status", Stdout: "[]"})
-	unknown := ObserveLease(path, "lease-1")
+	unknown := testObserveLease(path, "lease-1")
 	if unknown.State != LeaseUnknown {
-		t.Fatalf("ObserveLease() = %+v, want %s", unknown, LeaseUnknown)
+		t.Fatalf("testObserveLease() = %+v, want %s", unknown, LeaseUnknown)
 	}
 	if unknown.State == mismatch.State {
 		t.Fatal("an unobservable pool is reported with the same state as a lease held by another owner")
 	}
 	if unknown.LeaseID != "" {
-		t.Fatalf("ObserveLease() = %+v, want no observed lease identity when nothing was observed", unknown)
+		t.Fatalf("testObserveLease() = %+v, want no observed lease identity when nothing was observed", unknown)
 	}
 
 	message := (&UnprovenLeaseError{WorktreePath: path, ExpectedLeaseID: "lease-1", Observation: unknown}).Error()
@@ -245,12 +291,12 @@ func TestObserveLeaseProvesOwnershipAfterATransientUnobservablePool(t *testing.T
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "status", Stderr: "connection reset\n", Exit: 1})
-	if got := ObserveLease(path, "lease-1"); got.State != LeaseUnknown {
-		t.Fatalf("ObserveLease() = %+v, want %s", got, LeaseUnknown)
+	if got := testObserveLease(path, "lease-1"); got.State != LeaseUnknown {
+		t.Fatalf("testObserveLease() = %+v, want %s", got, LeaseUnknown)
 	}
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-1"}}.Install(t, faketool.Bin(t))
-	if got := ObserveLease(path, "lease-1"); got.State != LeaseExact {
-		t.Fatalf("ObserveLease() = %+v, want %s once the pool answers again", got, LeaseExact)
+	if got := testObserveLease(path, "lease-1"); got.State != LeaseExact {
+		t.Fatalf("testObserveLease() = %+v, want %s once the pool answers again", got, LeaseExact)
 	}
 }
 
@@ -275,12 +321,12 @@ func TestObserveLeaseRunsStatusFromTheWorktreeRepository(t *testing.T) {
 	faketool.InitRepo(t, worktreePath)
 	faketool.Treehouse{Slots: []string{worktreePath}}.Install(t, faketool.Bin(t))
 
-	lease, err := Get(worktreePath, "hand:task-1")
+	lease, err := testGet(worktreePath, "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := ObserveLease(worktreePath, lease.ID); got.State != LeaseExact {
-		t.Fatalf("ObserveLease() = %+v, want the lease visible from the worktree repository", got)
+	if got := testObserveLease(worktreePath, lease.ID); got.State != LeaseExact {
+		t.Fatalf("testObserveLease() = %+v, want the lease visible from the worktree repository", got)
 	}
 }
 
@@ -288,11 +334,11 @@ func TestObserveLeaseRejectsARecycledOrMissingIdentity(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-2"}}.Install(t, faketool.Bin(t))
-	if got := ObserveLease(path, "lease-1"); got.State != LeaseMismatch {
-		t.Fatalf("ObserveLease() = %+v, want a recycled lease identity reported as %s", got, LeaseMismatch)
+	if got := testObserveLease(path, "lease-1"); got.State != LeaseMismatch {
+		t.Fatalf("testObserveLease() = %+v, want a recycled lease identity reported as %s", got, LeaseMismatch)
 	}
-	if got := ObserveLease(path, ""); got.State != LeaseUnprovable {
-		t.Fatalf("ObserveLease() = %+v, want an empty expected identity reported as %s", got, LeaseUnprovable)
+	if got := testObserveLease(path, ""); got.State != LeaseUnprovable {
+		t.Fatalf("testObserveLease() = %+v, want an empty expected identity reported as %s", got, LeaseUnprovable)
 	}
 }
 
@@ -300,15 +346,40 @@ func TestObserveLeaseRejectsAnAvailableStatus(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "wt-1")
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}}.Install(t, faketool.Bin(t))
-	if got := ObserveLease(path, "lease-1"); got.State != LeaseAbsent {
-		t.Fatalf("ObserveLease() = %+v, want an available entry reported as %s", got, LeaseAbsent)
+	if got := testObserveLease(path, "lease-1"); got.State != LeaseAbsent {
+		t.Fatalf("testObserveLease() = %+v, want an available entry reported as %s", got, LeaseAbsent)
 	}
 }
 
 func TestReturnPassesForceFlag(t *testing.T) {
 	wt := t.TempDir()
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "return", Args: []string{wt, "--force"}})
-	if err := Return(wt, true); err != nil {
+	if err := testReturn(wt, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReturnScopesPoolToTheFleetHome(t *testing.T) {
+	home := t.TempDir()
+	clone := filepath.Join(home, "projects", "demo")
+	wt := filepath.Join(home, ".treehouse", "demo-123", "1", "demo")
+	writeFakeTreehouse(t, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{clone, "return", wt, "--force"},
+	})
+	if err := Return(clone, wt, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReturnUsesTheCurrentFleetHomeForAForeignRecordedPath(t *testing.T) {
+	currentHome := t.TempDir()
+	currentClone := filepath.Join(currentHome, "projects", "demo")
+	foreignHome := t.TempDir()
+	wt := filepath.Join(foreignHome, ".treehouse", "demo-123", "1", "demo")
+	writeFakeTreehouse(t, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{currentClone, "return", wt, "--force"},
+	})
+	if err := Return(currentClone, wt, true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -318,8 +389,22 @@ func TestReturnLeasePassesConditionalLeaseIdentity(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{
 		Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", wt},
 	})
-	if err := ReturnLease(wt, "lease-1", true); err != nil {
+	if err := testReturnLease(wt, "lease-1", true); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestObserveLeaseScopesStatusToTheFleetHome(t *testing.T) {
+	home := t.TempDir()
+	clone := filepath.Join(home, "projects", "demo")
+	path := filepath.Join(home, ".treehouse", "demo-123", "1", "demo")
+	faketool.InitRepo(t, path)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{clone, "status", "--json"},
+		Stdout: `[{"path":"` + path + `","status":"leased","lease_id":"lease-1"}]`,
+	})
+	if got := ObserveLease(clone, path, "lease-1"); got.State != LeaseExact {
+		t.Fatalf("testObserveLease() = %+v, want the scoped pool lease", got)
 	}
 }
 
@@ -328,11 +413,11 @@ func TestReturnLeaseRejectsMismatchedIdentityAndKeepsLease(t *testing.T) {
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-2"}}.Install(t, faketool.Bin(t))
 
-	if err := ReturnLease(path, "lease-1", true); err == nil {
-		t.Fatal("ReturnLease() succeeded for a mismatched lease identity")
+	if err := testReturnLease(path, "lease-1", true); err == nil {
+		t.Fatal("testReturnLease() succeeded for a mismatched lease identity")
 	}
-	if _, err := Get(path, "hand:still-held"); err == nil {
-		t.Fatal("mismatched ReturnLease() released the current lease")
+	if _, err := testGet(path, "hand:still-held"); err == nil {
+		t.Fatal("mismatched testReturnLease() released the current lease")
 	}
 }
 
@@ -341,32 +426,32 @@ func TestReturnLeaseProtectsAReusedPathFromAStaleLease(t *testing.T) {
 	faketool.InitRepo(t, path)
 	faketool.Treehouse{Slots: []string{path}, Held: []string{path}, LeaseIDs: map[string]string{path: "lease-original"}}.Install(t, faketool.Bin(t))
 
-	if err := ReturnLease(path, "lease-original", true); err != nil {
+	if err := testReturnLease(path, "lease-original", true); err != nil {
 		t.Fatal(err)
 	}
-	l2, err := Get(path, "hand:l2")
+	l2, err := testGet(path, "hand:l2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ReturnLease(path, "lease-original", true); err == nil {
-		t.Fatal("stale ReturnLease() released the reused path")
+	if err := testReturnLease(path, "lease-original", true); err == nil {
+		t.Fatal("stale testReturnLease() released the reused path")
 	}
-	if _, err := Get(path, "hand:still-held"); err == nil {
-		t.Fatalf("stale ReturnLease() released current lease %q", l2.ID)
+	if _, err := testGet(path, "hand:still-held"); err == nil {
+		t.Fatalf("stale testReturnLease() released current lease %q", l2.ID)
 	}
 }
 
 func TestReturnLeaseFallsBackForAnEmptyLeaseIdentity(t *testing.T) {
 	wt := t.TempDir()
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "return", Args: []string{wt, "--force"}})
-	if err := ReturnLease(wt, "", true); err != nil {
+	if err := testReturnLease(wt, "", true); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestReturnFailsOnNonZeroExit(t *testing.T) {
 	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "return", Stderr: "worktree busy\n", Exit: 1})
-	if err := Return(t.TempDir(), false); err == nil || !strings.Contains(err.Error(), "worktree busy") {
+	if err := testReturn(t.TempDir(), false); err == nil || !strings.Contains(err.Error(), "worktree busy") {
 		t.Fatalf("got err %v, want worktree busy failure", err)
 	}
 }
@@ -379,20 +464,20 @@ func TestReturnIsIdempotentOnAnAlreadyReturnedWorktree(t *testing.T) {
 	faketool.InitRepo(t, wt)
 	faketool.Treehouse{Held: []string{wt}}.Install(t, faketool.Bin(t))
 
-	if err := Return(wt, false); err != nil {
+	if err := testReturn(wt, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(wt); err != nil {
 		t.Fatalf("worktree path gone after return: %v", err)
 	}
-	if err := Return(wt, false); err != nil {
+	if err := testReturn(wt, false); err != nil {
 		t.Fatalf("got err %v, want a repeated return to succeed", err)
 	}
 }
 
 func TestReturnFailsOnAWorktreeNoPoolManages(t *testing.T) {
 	faketool.Treehouse{Slots: []string{t.TempDir()}}.Install(t, faketool.Bin(t))
-	err := Return(filepath.Join(t.TempDir(), "gone"), false)
+	err := testReturn(filepath.Join(t.TempDir(), "gone"), false)
 	if err == nil || !strings.Contains(err.Error(), "not managed by treehouse") {
 		t.Fatalf("got err %v, want an unmanaged worktree reported", err)
 	}
@@ -409,7 +494,7 @@ func TestReturnFailsWhenAnUnforcedDirtyReturnAborts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := Return(wt, false)
+	err := testReturn(wt, false)
 	if err == nil || !strings.Contains(err.Error(), "still leased") {
 		t.Fatalf("got err %v, want the aborted return reported as a failure", err)
 	}
@@ -419,7 +504,7 @@ func TestReturnFailsWhenAnUnforcedDirtyReturnAborts(t *testing.T) {
 	if out, gitErr := exec.Command("git", "-C", wt, "status", "--porcelain").Output(); gitErr != nil || len(out) == 0 {
 		t.Fatalf("worktree cleaned by an aborted return: %q %v", out, gitErr)
 	}
-	if err := Return(wt, true); err != nil {
+	if err := testReturn(wt, true); err != nil {
 		t.Fatalf("got err %v, want the forced retry to succeed", err)
 	}
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -31,6 +32,15 @@ func testReturnLease(worktreePath, leaseID string, force bool) error {
 func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	t.Helper()
 	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func writeCollisionTask(t *testing.T, home, id, path, leaseID string) {
@@ -121,7 +131,7 @@ func TestGetRejectsAWorktreeFromAnotherRegisteredClone(t *testing.T) {
 	faketool.InitRepo(t, clone)
 	faketool.InitRepo(t, foreign)
 	faketool.Treehouse{Responses: []faketool.TreehouseResponse{
-		{Command: "get", Stdout: `{"path":"` + foreign + `","lease_id":"lease-1"}`},
+		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": foreign, "lease_id": "lease-1"})},
 		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", foreign}},
 	}}.Install(t, faketool.Bin(t))
 	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "another Git repository") {
@@ -401,7 +411,7 @@ func TestObserveLeaseScopesStatusToTheFleetHome(t *testing.T) {
 	faketool.InitRepo(t, path)
 	writeFakeTreehouse(t, faketool.TreehouseResponse{
 		Command: "--root", Args: []string{clone, "status", "--json"},
-		Stdout: `[{"path":"` + path + `","status":"leased","lease_id":"lease-1"}]`,
+		Stdout: mustJSON(t, []map[string]string{{"path": path, "status": "leased", "lease_id": "lease-1"}}),
 	})
 	if got := ObserveLease(clone, path, "lease-1"); got.State != LeaseExact {
 		t.Fatalf("testObserveLease() = %+v, want the scoped pool lease", got)

--- a/tests/e2e/execution_class_test.go
+++ b/tests/e2e/execution_class_test.go
@@ -25,7 +25,7 @@ func TestMechanicalPlanDispatchesAgainstTheRegisteredBase(t *testing.T) {
 	if task.Project != "demo" || attempt.Worktree != worktree {
 		t.Fatalf("spawned task = %+v, attempt = %+v, want project demo and worktree %s", task, attempt, worktree)
 	}
-	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") {
+	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, " get ") {
 		t.Fatalf("treehouse log = %q, want acquisition", log)
 	}
 	if log := readOptionalLog(t, herdrLog); !strings.Contains(log, " pane run") {
@@ -89,7 +89,7 @@ func TestMechanicalPlanRefusesWhenTreehouseAcquiresADifferentHead(t *testing.T) 
 			t.Fatalf("error = %q, want %q", message, want)
 		}
 	}
-	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") || !strings.Contains(log, "treehouse return") {
+	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, " get ") || !strings.Contains(log, " return ") {
 		t.Fatalf("treehouse log = %q, want acquisition followed by safe return", log)
 	}
 	if log := readOptionalLog(t, herdrLog); strings.Contains(log, " pane ") {
@@ -119,7 +119,7 @@ func TestStandardAndDeepPlansDoNotUseMechanicalStaleRefusal(t *testing.T) {
 			if attempt.Worktree != worktree {
 				t.Fatalf("attempt.Worktree = %q, want %q", attempt.Worktree, worktree)
 			}
-			if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") {
+			if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, " get ") {
 				t.Fatalf("treehouse log = %q, want acquisition", log)
 			}
 			if log := readOptionalLog(t, herdrLog); !strings.Contains(log, " pane run") {
@@ -141,7 +141,7 @@ func TestLegacyBriefStillDispatchesWithoutExecutionPlanPreflight(t *testing.T) {
 	if attempt.Worktree != worktree {
 		t.Fatalf("attempt.Worktree = %q, want %q", attempt.Worktree, worktree)
 	}
-	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, "treehouse get") {
+	if log := readOptionalLog(t, treehouseLog); !strings.Contains(log, " get ") {
 		t.Fatalf("treehouse log = %q, want acquisition", log)
 	}
 	if log := readOptionalLog(t, herdrLog); !strings.Contains(log, " pane run") {

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -74,6 +74,9 @@ func writeFakeDispatch(t *testing.T, dir, name, logPath, selector, caseBody stri
 	if logPath != "" {
 		script = fmt.Sprintf("echo \"%s $@\" >> %s\n", name, shellSingleQuote(logPath))
 	}
+	if name == "treehouse" {
+		script += "if [ \"$1\" = \"--root\" ]; then shift 2; fi\n"
+	}
 	script += "session_name=\"$2\"\nif [ \"$1\" = \"--session\" ]; then shift 2; fi\n"
 	script += fmt.Sprintf("case \"%s\" in\n%s\n  *) echo \"unexpected %s invocation: $@\" >&2; exit 1 ;;\nesac\n",
 		selector, caseBody, name)

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -133,7 +133,7 @@ func TestPromoteScoutToShip(t *testing.T) {
 	if strings.Contains(log, " tab create --workspace ws-new") {
 		t.Fatalf("invocation log = %q, want promote to reuse the new workspace's root tab instead of creating a second one", log)
 	}
-	if !strings.Contains(log, "treehouse return --force --if-lease-id lease-old "+oldWorktree) {
+	if !strings.Contains(log, " return --force --if-lease-id lease-old "+oldWorktree) {
 		t.Fatalf("invocation log = %q, want promote to have returned the OLD worktree %s", log, oldWorktree)
 	}
 }


### PR DESCRIPTION
## Summary
- Scope Treehouse acquisition, status, return, and initialization to the registered project clone.
- Reject an acquired worktree whose Git common directory differs from the registered clone, and make `hand doctor` report active mismatches.
- Keep mechanical base and acquired-worktree reads on the same repository, addressing the root cause reported in atqamz/hand#401.

Fixes atqamz/hand#403

## Test plan
- `make test`
- `make e2e`
- `make lint`
- `make build`
- Focused foreign-path and same-fleet operator-checkout regressions
- Read-only inspection of the live mismatches; no changes to `/home/atqa/hand-fleet`.

<!-- hand:pipeline-region:start -->
## Summary
- Scope Treehouse acquisition, status, return, and initialization to the registered project clone.
- Reject an acquired worktree whose Git common directory differs from the registered clone, and make `hand doctor` report active mismatches.
- Centralize filesystem path identity in `internal/git`, encode Windows-path fixtures with `encoding/json`, and close task query rows before nested attempt reads to avoid the one-connection SQLite deadlock.
- Load doctor histories at the command boundary, close observation gaps for canonical lease paths, and enforce Herdr composer deadlines.

Fixes atqamz/hand#403

Closes atqamz/hand#425

## Decisions
- Acquisition binds to the registered clone path, not merely the fleet home. `get`, `status`, `return`, and `init` select the pool with the clone path, and acquired worktrees are checked against the registered clone `.git` common directory.
- Slots 3, 4, 5, and 11 are all deferred, not repaired. Slots 3 and 11 alias the `hand4` metadata directory owned by live slot 16; pruning either could touch a live index. Slots 4 and 5 point at missing `hand5` and `hand6` metadata directories, so they are dangling and unusable rather than empty.
- The wider live alias set is tracked in [atqamz/hand#412](https://github.com/atqamz/hand/issues/412): slot 7 aliases `hand` (slot 12), slot 8 aliases `hand1` (slot 13), slot 9 aliases `hand2` (slot 14), slot 10 aliases `hand3` (slot 15), and slots 3 and 11 alias `hand4` (slot 16). Repair waits until 403, 406, 407, and 408 have landed because several aliased metadata directories belong to live workers.
- Registered-clone binding is necessary but not sufficient for those aliases: both sides resolve to the correct clone common directory, so this PR deliberately does not try to detect them. Slots 1, 2, and 6 instead point at the fleet home repository and remain distinct wrong-repository findings.

## Test plan
- `make test` (race-enabled full suite)
- `make e2e`
- `make lint`
- `make build`
- Focused foreign-path, same-fleet operator-checkout, canonical path, and Windows-safe JSON regressions
- Read-only inspection of live mismatches; no changes to `/home/atqa/hand-fleet`
- Windows test run: `cmd` 453.6s and `internal/runtime` 330.8s, both below the 600s per-package cap; main baseline is 353.6s and 217.0s, with additional headroom tracked in [atqamz/hand#416](https://github.com/atqamz/hand/issues/416). The timeout cap was not raised.
<!-- hand:pipeline-region:end -->