### PR TITLE
fix reconciliation for missing worker reports

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -29,10 +29,13 @@ func newReconcileCmd() *cobra.Command {
 			"A running Attempt whose Herdr pane is still present is also read for `agent_status`: `working` or\n" +
 			"`blocked` are reported as such, and `idle-unreported` names a pane that stopped being busy with\n" +
 			"nothing on the report channel explaining it since launch. The fact is recorded in the Attempt's\n" +
-			"durable status columns, so it survives whether or not `hand watch` was ever running, and it changes\n" +
-			"no lifecycle by itself: an idle, still-present harness may yet resume. Where the harness carries a\n" +
-			"catalogued usage-limit signature, an idle-unreported Attempt is also checked for it, and a detected\n" +
-			"limit's stated reset time is preserved the same way `hand watch` would preserve it.\n\n" +
+			"durable status columns, so it survives whether or not `hand watch` was ever running. A pane observed\n" +
+			"as Herdr `done` with no report or only a `working:` report also gets terminal convergence after\n" +
+			"landing evidence is checked; a `paused:`, `blocked:`, `needs-decision:`, `done:`, or `failed:`\n" +
+			"report still explains the stop and leaves the lifecycle for the operator's normal next step.\n" +
+			"Where the harness carries a catalogued usage-limit signature, an idle-unreported Attempt is also\n" +
+			"checked for it; a detected limit's stated reset time is preserved the same way `hand watch` would\n" +
+			"preserve it.\n\n" +
 			"Automatic worktree return also requires proof that no commit exists only there: a commit reachable\n" +
 			"from a remote-tracking ref, or one GitHub records as the head of the task pull request, is held\n" +
 			"elsewhere too. Unpushed commits withhold the return, and so does a comparison that could not be\n" +

--- a/internal/runtime/liveness_test.go
+++ b/internal/runtime/liveness_test.go
@@ -1,9 +1,11 @@
 package runtime
 
 import (
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -69,6 +71,53 @@ func TestReconcileRecordsIdleUnreportedOnceLaunchHasSettled(t *testing.T) {
 	}
 	if got.Worktree != attempt.Worktree || got.LeaseID != attempt.LeaseID || got.Herdr != attempt.Herdr {
 		t.Fatalf("attempt resources = %+v, want them untouched by a liveness observation", got)
+	}
+}
+
+func TestReconcileConvergesDonePaneWithoutWorkerReport(t *testing.T) {
+	client := &livenessHerdr{status: herdr.StatusDone}
+	home, r, attempt := livenessFixture(t, "2026-08-14T23:59:00Z", client)
+
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+	if report.Results[0].Landing != string(landingUnlanded) {
+		t.Fatalf("result = %+v, want unlanded landing evidence", report.Results[0])
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil {
+		t.Fatalf("history = %+v, want terminal task with no active attempt", history)
+	}
+	if got := history.Attempts[0].Lifecycle; got != state.AttemptInterrupted {
+		t.Fatalf("attempt lifecycle = %q, want interrupted", got)
+	}
+	record, found, err := completion.FindAttempt(home, attempt.ID)
+	if err != nil || !found || record.AttemptLifecycle != string(state.AttemptInterrupted) {
+		t.Fatalf("completion = %+v found=%t err=%v, want interrupted completion evidence", record, found, err)
+	}
+}
+
+func TestReconcileKeepsDonePaneWithTerminalWorkerReport(t *testing.T) {
+	client := &livenessHerdr{status: herdr.StatusDone}
+	home, r, attempt := livenessFixture(t, "2026-08-14T23:59:00Z", client)
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: checks green\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("Reconcile() = %v", err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskOpen || history.ActiveAttempt == nil || history.ActiveAttempt.ID != attempt.ID || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history = %+v, want running task preserved by terminal worker report", history)
 	}
 }
 

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -97,6 +97,7 @@ type reconciliationObservation struct {
 	Treehouse        treehouseObservation
 	Worktree         worktreeObservation
 	Herdr            herdrObservation
+	ReportState      string
 	Landing          landingState
 	ObservationError bool
 }
@@ -523,8 +524,15 @@ func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Ta
 }
 
 func terminalConvergenceCandidate(attempt state.Attempt, observation reconciliationObservation) bool {
-	return attempt.Lifecycle == state.AttemptRunning && attempt.TeardownTerminalAttempt == "" &&
-		attempt.Herdr.PaneID != "" && observation.Herdr.State == herdrOwnershipAbsent
+	if attempt.Lifecycle != state.AttemptRunning || attempt.TeardownTerminalAttempt != "" || attempt.Herdr.PaneID == "" {
+		return false
+	}
+	if observation.Herdr.State == herdrOwnershipAbsent {
+		return true
+	}
+	return observation.Herdr.State == herdrOwnershipExact &&
+		observation.Herdr.AgentStatus == herdr.StatusDone &&
+		(observation.ReportState == "" || observation.ReportState == state.ReportWorking)
 }
 
 func runningPaneMissingReason(landing landingState) string {
@@ -1243,8 +1251,15 @@ func terminalRepairEvidenceResolved(code string, attempt state.Attempt) bool {
 	}
 }
 
-func (r *Runtime) observeAttempt(_ string, task state.Task, attempt state.Attempt) (reconciliationObservation, error) {
+func (r *Runtime) observeAttempt(home string, task state.Task, attempt state.Attempt) (reconciliationObservation, error) {
 	observation := reconciliationObservation{}
+	reports, err := state.ReadReportLines(home, task.ID)
+	if err != nil {
+		return observation, fmt.Errorf("read worker report: %w", err)
+	}
+	if report, ok := state.LastReportedState(reports); ok {
+		observation.ReportState = report.State
+	}
 	skipHerdrObservation := attempt.Lifecycle == state.AttemptProvisioning && attempt.Herdr.WorkspaceID != "" && attempt.Herdr.TabID != "" && attempt.Herdr.PaneID != "" && attempt.LaunchSubmittedAt == ""
 	if attempt.Worktree != "" {
 		lease := r.observeWorktreeLease(attempt.Worktree, attempt.LeaseID)


### PR DESCRIPTION
## Summary
- Treat Herdr `done` with an absent or working-only report as terminal convergence evidence.
- Fail closed on report read errors and preserve explicit terminal report states.
- Add regression coverage for missing reports and terminal report preservation.

Related: atqamz/hand#402

This fixes one half of atqamz/hand#402: the non-convergence where an Attempt sat at
`state: done` with `attempt_lifecycle: running` because reconciliation refused to converge
without a terminal worker report. It does not fix the other half - the brief never declaring
the worker's report channel, so the worker was mute by construction - which is tracked
separately as atqamz/hand#406. atqamz/hand#402 stays open until #406 lands.

## Test plan
- `rtk nix develop -c make test`
- `rtk nix develop -c make lint`
- Regression test failed before the fix with `action = "keep"` and passed after the fix.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->