### PR TITLE
wire worker report channel into launches

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/skill"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/supervision"
 	"github.com/atqamz/hand/internal/toolchain"
 	"github.com/spf13/cobra"
@@ -214,6 +216,21 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 			if !onPath(tool) {
 				findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("required tool %q is not on PATH", tool)})
 			}
+		}
+	}
+
+	tasks, err := state.ListOpen(fleetHome)
+	if err != nil {
+		return nil, err
+	}
+	for _, task := range tasks {
+		briefPath := filepath.Join(fleetHome, task.Brief)
+		data, err := os.ReadFile(briefPath)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("read task %q brief: %w", task.ID, err)
+		}
+		if !strings.Contains(string(data), state.ReportPath(fleetHome, task.ID)) {
+			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q brief does not declare report path", task.ID)})
 		}
 	}
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -225,11 +225,11 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 	}
 	for _, task := range tasks {
 		briefPath := filepath.Join(fleetHome, task.Brief)
-		data, err := os.ReadFile(briefPath)
-		if err != nil && !os.IsNotExist(err) {
+		declares, err := briefDeclaresReportPath(briefPath, state.ReportPath(fleetHome, task.ID))
+		if err != nil {
 			return nil, fmt.Errorf("read task %q brief: %w", task.ID, err)
 		}
-		if !strings.Contains(string(data), state.ReportPath(fleetHome, task.ID)) {
+		if !declares {
 			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q brief does not declare report path", task.ID)})
 		}
 	}
@@ -277,6 +277,42 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 		}
 	}
 	return findings, nil
+}
+
+func briefDeclaresReportPath(briefPath, reportPath string) (bool, error) {
+	data, err := os.ReadFile(briefPath)
+	if err != nil {
+		info, statErr := os.Stat(briefPath)
+		if os.IsNotExist(err) || (statErr == nil && info.IsDir()) {
+			return false, nil
+		}
+		return false, err
+	}
+	text := string(data)
+	for start := 0; start < len(text); {
+		at := strings.Index(text[start:], reportPath)
+		if at < 0 {
+			return false, nil
+		}
+		end := start + at + len(reportPath)
+		if end == len(text) || !reportPathSuffix(text, end) {
+			return true, nil
+		}
+		start += at + 1
+	}
+	return false, nil
+}
+
+func reportPathSuffix(text string, end int) bool {
+	next := text[end]
+	if next == '.' && end+1 < len(text) && isReportPathSuffixChar(text[end+1]) {
+		return true
+	}
+	return isReportPathSuffixChar(next)
+}
+
+func isReportPathSuffixChar(char byte) bool {
+	return (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-' || char == '/' || char == '\\'
 }
 
 // A local-only fleet never needs gh, while a registered project delivering through direct-pr or

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -90,7 +90,11 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
-			findings, err := doctorFindings(fleetHome)
+			histories, err := state.ListOpenHistoriesReadOnly(fleetHome)
+			if err != nil {
+				return err
+			}
+			findings, err := doctorFindings(fleetHome, histories)
 			if err != nil {
 				return err
 			}
@@ -185,7 +189,7 @@ func legacyDoctorCompatibility() bool {
 	return legacyDoctorCompat
 }
 
-func doctorFindings(fleetHome string) ([]doctorFinding, error) {
+func doctorFindings(fleetHome string, histories []state.TaskHistory) ([]doctorFinding, error) {
 	findings := make([]doctorFinding, 0)
 
 	agentsViolations, err := agentsmd.Check(fleetHome)
@@ -219,15 +223,18 @@ func doctorFindings(fleetHome string) ([]doctorFinding, error) {
 		}
 	}
 
-	tasks, err := state.ListOpen(fleetHome)
-	if err != nil {
-		return nil, err
-	}
-	for _, task := range tasks {
+	for _, history := range histories {
+		task := history.Task
 		briefPath := filepath.Join(fleetHome, task.Brief)
-		declares, err := briefDeclaresReportPath(briefPath, state.ReportPath(fleetHome, task.ID))
+		reportPath, err := filepath.Abs(state.ReportPath(fleetHome, task.ID))
 		if err != nil {
-			return nil, fmt.Errorf("read task %q brief: %w", task.ID, err)
+			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q report path could not be resolved: %v", task.ID, err)})
+			continue
+		}
+		declares, err := briefDeclaresReportPath(briefPath, reportPath)
+		if err != nil {
+			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q brief could not be read: %v", task.ID, err)})
+			continue
 		}
 		if !declares {
 			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q brief does not declare report path", task.ID)})
@@ -304,6 +311,8 @@ func briefDeclaresReportPath(briefPath, reportPath string) (bool, error) {
 }
 
 func reportPathSuffix(text string, end int) bool {
+	// A report path is declared only when it is not followed by a path/suffix character, or by a
+	// dot followed by one; punctuation, a bare dot, and a newline are valid boundaries.
 	next := text[end]
 	if next == '.' && end+1 < len(text) && isReportPathSuffixChar(text[end+1]) {
 		return true

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -160,10 +160,15 @@ func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
 	mustConfigSet(t, settingHarness, harness.Claude)
 	missingPath := filepath.Join(home, "data", "missing", "brief.md")
 	declaredPath := filepath.Join(home, "data", "declared", "brief.md")
-	for _, path := range []string{missingPath, declaredPath} {
+	suffixPath := filepath.Join(home, "data", "suffix", "brief.md")
+	directoryPath := filepath.Join(home, "data", "directory", "brief.md")
+	for _, path := range []string{missingPath, declaredPath, suffixPath} {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := os.MkdirAll(directoryPath, 0o755); err != nil {
+		t.Fatal(err)
 	}
 	if err := os.WriteFile(missingPath, []byte("do the work\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -172,9 +177,15 @@ func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
 	if err := os.WriteFile(declaredPath, []byte("append reports to "+declaredReportPath+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	suffixReportPath := state.ReportPath(home, "suffix")
+	if err := os.WriteFile(suffixPath, []byte("append reports to "+suffixReportPath+".bak\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	for _, task := range []state.Task{
 		{ID: "missing", Brief: "data/missing/brief.md", Lifecycle: state.TaskOpen},
 		{ID: "declared", Brief: "data/declared/brief.md", Lifecycle: state.TaskOpen},
+		{ID: "suffix", Brief: "data/suffix/brief.md", Lifecycle: state.TaskOpen},
+		{ID: "directory", Brief: "data/directory/brief.md", Lifecycle: state.TaskOpen},
 	} {
 		if err := state.CreateTask(home, task); err != nil {
 			t.Fatal(err)
@@ -190,6 +201,11 @@ func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
 	}
 	if hasDoctorFinding(findings, doctorFinding{Severity: doctorWarning, Text: `task "declared" brief does not declare report path`}) {
 		t.Fatalf("findings = %#v, declared report path should not warn", findings)
+	}
+	for _, id := range []string{"suffix", "directory"} {
+		if !hasDoctorFinding(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf(`task %q brief does not declare report path`, id)}) {
+			t.Fatalf("findings = %#v, want %s report path warning", findings, id)
+		}
 	}
 }
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -134,7 +134,7 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 			t.Setenv("HAND_HARNESS", harness.Claude)
 			tt.setup(t, home)
 
-			findings, err := doctorFindings(home)
+			findings, err := doctorFindings(home, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -186,13 +186,18 @@ func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
 		{ID: "declared", Brief: "data/declared/brief.md", Lifecycle: state.TaskOpen},
 		{ID: "suffix", Brief: "data/suffix/brief.md", Lifecycle: state.TaskOpen},
 		{ID: "directory", Brief: "data/directory/brief.md", Lifecycle: state.TaskOpen},
+		{ID: "unreadable", Brief: "data/unreadable\x00/brief.md", Lifecycle: state.TaskOpen},
 	} {
 		if err := state.CreateTask(home, task); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	findings, err := doctorFindings(home)
+	histories, err := state.ListOpenHistoriesReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings, err := doctorFindings(".", histories)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,6 +212,18 @@ func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
 			t.Fatalf("findings = %#v, want %s report path warning", findings, id)
 		}
 	}
+	if !hasDoctorFindingPrefix(findings, doctorWarning, `task "unreadable" brief could not be read: `) {
+		t.Fatalf("findings = %#v, want unreadable brief finding", findings)
+	}
+}
+
+func hasDoctorFindingPrefix(findings []doctorFinding, severity doctorSeverity, prefix string) bool {
+	for _, finding := range findings {
+		if finding.Severity == severity && strings.HasPrefix(finding.Text, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDoctorIncludesProjectListGateFinding(t *testing.T) {
@@ -225,7 +242,7 @@ func TestDoctorIncludesProjectListGateFinding(t *testing.T) {
 	}
 	t.Setenv("PATH", t.TempDir())
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +278,7 @@ func TestDoctorKeepsProjectReadinessSeparateFromGateRunEvidence(t *testing.T) {
 		Log:    log,
 	}.Install(t, faketool.Bin(t))
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +370,7 @@ func TestDoctorReportsConfiguredRoutingDecision(t *testing.T) {
 	}
 	t.Setenv("HAND_HARNESS", harness.Claude)
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +398,7 @@ func TestDoctorReportsUnresolvedConfiguredRoutingDecision(t *testing.T) {
 	}
 	t.Setenv("HAND_HARNESS", harness.Claude)
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +427,7 @@ func TestDoctorReportsMalformedRoutingBeforeEffectiveFallback(t *testing.T) {
 	}
 	mustConfigSet(t, settingHarness, harness.Claude)
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -650,7 +667,7 @@ func TestDoctorFlagsEveryMissingBundledSkillDestination(t *testing.T) {
 	mustConfigSet(t, settingHarness, harness.Claude)
 	// No skill.Refresh: every destination is missing.
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -689,7 +706,7 @@ func TestDoctorFlagsADriftedBundledSkillFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -714,7 +731,7 @@ func TestDoctorFlagsAForeignFileAtASkillDestinationAsAConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -745,7 +762,7 @@ func TestDoctorWarnsOnEachMissingRequiredTool(t *testing.T) {
 	mustConfigSet(t, settingHarness, harness.Claude)
 	faketool.NoTools(t)
 
-	findings, err := doctorFindings(home)
+	findings, err := doctorFindings(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/skill"
+	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/supervision"
 )
 
@@ -143,6 +144,52 @@ func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+	missingPath := filepath.Join(home, "data", "missing", "brief.md")
+	declaredPath := filepath.Join(home, "data", "declared", "brief.md")
+	for _, path := range []string{missingPath, declaredPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(missingPath, []byte("do the work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	declaredReportPath := state.ReportPath(home, "declared")
+	if err := os.WriteFile(declaredPath, []byte("append reports to "+declaredReportPath+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, task := range []state.Task{
+		{ID: "missing", Brief: "data/missing/brief.md", Lifecycle: state.TaskOpen},
+		{ID: "declared", Brief: "data/declared/brief.md", Lifecycle: state.TaskOpen},
+	} {
+		if err := state.CreateTask(home, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	findings, err := doctorFindings(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDoctorFinding(findings, doctorFinding{Severity: doctorWarning, Text: `task "missing" brief does not declare report path`}) {
+		t.Fatalf("findings = %#v, want missing report path warning", findings)
+	}
+	if hasDoctorFinding(findings, doctorFinding{Severity: doctorWarning, Text: `task "declared" brief does not declare report path`}) {
+		t.Fatalf("findings = %#v, declared report path should not warn", findings)
 	}
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -188,28 +188,32 @@ func Build(name string, opts Options) (launch.LaunchSpec, error) {
 		return launch.LaunchSpec{}, err
 	}
 	var spec launch.LaunchSpec
+	var buildErr error
 	// Each builder below uses only flags verified against its documented CLI contract.
 	switch name {
 	case Claude:
-		spec = buildClaude(opts)
+		spec, buildErr = buildClaude(opts)
 	case Codex:
-		spec = buildCodex(opts)
+		spec, buildErr = buildCodex(opts)
 	case Grok:
 		spec = buildGrok(opts)
 	case Pi:
 		spec = buildPi(opts)
 	case OpenCode:
-		spec = buildOpenCode(opts)
+		spec, buildErr = buildOpenCode(opts)
 	case Antigravity:
-		spec = buildAntigravity(opts)
+		spec, buildErr = buildAntigravity(opts)
 	default:
 		return launch.LaunchSpec{}, fmt.Errorf("harness %q not recognized", name)
+	}
+	if buildErr != nil {
+		return launch.LaunchSpec{}, buildErr
 	}
 	spec.Cwd = opts.Worktree
 	return launch.NewSpec(spec)
 }
 
-func buildAntigravity(o Options) launch.LaunchSpec {
+func buildAntigravity(o Options) (launch.LaunchSpec, error) {
 	// stream-json gives launch confirmation typed init evidence without treating the provider's
 	// terminal result as Hand task outcome. One-shot workers must execute unattended: otherwise a
 	// permission request can soft-deny a required tool action while the headless process still exits.
@@ -224,14 +228,18 @@ func buildAntigravity(o Options) launch.LaunchSpec {
 	if o.Effort != "" {
 		args = append(args, "--effort", o.Effort)
 	}
-	args = append(args, "-p", briefPrompt(o))
-	return launch.LaunchSpec{Executable: Executable(Antigravity), Args: args}
+	prompt, err := briefPrompt(o)
+	if err != nil {
+		return launch.LaunchSpec{}, err
+	}
+	args = append(args, "-p", prompt)
+	return launch.LaunchSpec{Executable: Executable(Antigravity), Args: args}, nil
 }
 
 // Launches claude interactively - no --print - so the pane stays resident for hand send and hand
 // watch across a multi-turn no-mistakes pipeline. Verified via `claude --help`: --model, --effort
 // and --dangerously-skip-permissions all apply outside --print.
-func buildClaude(o Options) launch.LaunchSpec {
+func buildClaude(o Options) (launch.LaunchSpec, error) {
 	// --dangerously-skip-permissions, or an unattended worker stalls on a permission prompt.
 	// CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false suppresses the dim predicted-next-prompt ghost text,
 	// which a pane-watching supervisor would otherwise read as typed input under an idle worker.
@@ -242,14 +250,18 @@ func buildClaude(o Options) launch.LaunchSpec {
 	if o.Effort != "" {
 		args = append(args, "--effort", o.Effort)
 	}
-	args = append(args, briefPrompt(o))
-	return launch.LaunchSpec{Executable: Claude, Args: args, Env: map[string]string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "false"}}
+	prompt, err := briefPrompt(o)
+	if err != nil {
+		return launch.LaunchSpec{}, err
+	}
+	args = append(args, prompt)
+	return launch.LaunchSpec{Executable: Claude, Args: args, Env: map[string]string{"CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "false"}}, nil
 }
 
 // Launches Codex CLI 0.146.0 interactively with its positional prompt. Its help and config schema
 // expose the flags below; paste-burst buffering otherwise absorbs hand send's immediate Enter, and
 // auto effort means inherit Codex's default rather than pass a literal value.
-func buildCodex(o Options) launch.LaunchSpec {
+func buildCodex(o Options) (launch.LaunchSpec, error) {
 	args := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true"}
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)
@@ -257,8 +269,12 @@ func buildCodex(o Options) launch.LaunchSpec {
 	if o.Effort != "" && o.Effort != "auto" {
 		args = append(args, "-c", fmt.Sprintf(`model_reasoning_effort="%s"`, o.Effort))
 	}
-	args = append(args, briefPrompt(o))
-	return launch.LaunchSpec{Executable: Codex, Args: args}
+	prompt, err := briefPrompt(o)
+	if err != nil {
+		return launch.LaunchSpec{}, err
+	}
+	args = append(args, prompt)
+	return launch.LaunchSpec{Executable: Codex, Args: args}, nil
 }
 
 func buildGrok(o Options) launch.LaunchSpec {
@@ -271,7 +287,7 @@ func buildPi(o Options) launch.LaunchSpec {
 
 // Uses the bare `opencode` command (verified via `opencode --help`), which opens an interactive TUI,
 // rather than `opencode run` - that one is explicitly headless and exits after a single reply.
-func buildOpenCode(o Options) launch.LaunchSpec {
+func buildOpenCode(o Options) (launch.LaunchSpec, error) {
 	// OPENCODE_CONFIG_CONTENT grants blanket tool permission so an unattended worker does not stall
 	// on a permission prompt.
 	args := []string{}
@@ -280,14 +296,22 @@ func buildOpenCode(o Options) launch.LaunchSpec {
 	}
 	// The bare command has no --file flag and no effort or variant flag, so the brief path rides in
 	// the --prompt text and Options.Effort is dropped here rather than passed.
-	args = append(args, "--prompt", briefPrompt(o))
-	return launch.LaunchSpec{Executable: OpenCode, Args: args, Env: map[string]string{"OPENCODE_CONFIG_CONTENT": `{"permission":{"*":"allow"}}`}}
+	prompt, err := briefPrompt(o)
+	if err != nil {
+		return launch.LaunchSpec{}, err
+	}
+	args = append(args, "--prompt", prompt)
+	return launch.LaunchSpec{Executable: OpenCode, Args: args, Env: map[string]string{"OPENCODE_CONFIG_CONTENT": `{"permission":{"*":"allow"}}`}}, nil
 }
 
 // Shared so the wording cannot drift between harnesses. It ends with agentsmd.OperatorDecisionRule
 // because a worker runs in a worktree that is never under the fleet home, so the home's AGENTS.md
 // never reaches it and the launch prompt is the only channel that rule has.
-func briefPrompt(o Options) string {
+
+func briefPrompt(o Options) (string, error) {
+	if o.ReportPath == "" {
+		return "", fmt.Errorf("report path is required for a prompt-capable harness")
+	}
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
 	prompt += fmt.Sprintf(" The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", o.ReportPath)
 	if o.BriefHasFrontMatter {
@@ -296,5 +320,5 @@ func briefPrompt(o Options) string {
 	if o.ExecutionClass == brief.ExecutionClassMechanical {
 		prompt += " Verify the named files/symbols and plan assumptions before editing. If materially stale or contradictory, stop and report blocked. Do not redesign the task yourself. Otherwise execute the ordered plan and verification steps."
 	}
-	return prompt + " " + agentsmd.OperatorDecisionRule
+	return prompt + " " + agentsmd.OperatorDecisionRule, nil
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -137,6 +137,7 @@ func AgentDetectionVerified(name string) bool {
 type Options struct {
 	Worktree            string
 	Brief               string
+	ReportPath          string
 	Model               string
 	Effort              string
 	ExecutionClass      brief.ExecutionClass
@@ -288,6 +289,7 @@ func buildOpenCode(o Options) launch.LaunchSpec {
 // never reaches it and the launch prompt is the only channel that rule has.
 func briefPrompt(o Options) string {
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
+	prompt += fmt.Sprintf(" The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", o.ReportPath)
 	if o.BriefHasFrontMatter {
 		prompt += " Any model, effort, execution_class, or planned_against keys in its leading '---' block are dispatch metadata, not task instructions."
 	}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -176,7 +176,7 @@ func SupportsEffort(name string) bool {
 
 // False means the builder hands the brief over as a file and has no prompt to append to, so
 // briefPrompt's operator-decision rule and front-matter disclaimer never reach the worker.
-// Carrying them properly needs flags verified against a real --help (atqamz/hand#36).
+// Carrying them properly needs flags verified against a real --help (atqamz/hand#418).
 func CarriesPrompt(name string) bool {
 	return promptCapable[name]
 }
@@ -307,7 +307,6 @@ func buildOpenCode(o Options) (launch.LaunchSpec, error) {
 // Shared so the wording cannot drift between harnesses. It ends with agentsmd.OperatorDecisionRule
 // because a worker runs in a worktree that is never under the fleet home, so the home's AGENTS.md
 // never reaches it and the launch prompt is the only channel that rule has.
-
 func briefPrompt(o Options) (string, error) {
 	if o.ReportPath == "" {
 		return "", fmt.Errorf("report path is required for a prompt-capable harness")

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -13,6 +13,7 @@ import (
 
 func buildSpec(t *testing.T, name string, options Options) launch.LaunchSpec {
 	t.Helper()
+	options = withTestReportPath(options)
 	spec, err := Build(name, options)
 	if err != nil {
 		t.Fatal(err)
@@ -20,9 +21,32 @@ func buildSpec(t *testing.T, name string, options Options) launch.LaunchSpec {
 	return spec
 }
 
+func withTestReportPath(options Options) Options {
+	if options.ReportPath == "" {
+		options.ReportPath = "/tmp/state/task-1.status"
+	}
+	return options
+}
+
+func testBriefPrompt(t *testing.T, options Options) string {
+	t.Helper()
+	prompt, err := briefPrompt(withTestReportPath(options))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return prompt
+}
+
 func TestBuildUnrecognizedHarness(t *testing.T) {
 	if _, err := Build("nonexistent", Options{}); err == nil {
 		t.Fatal("expected error for unrecognized harness")
+	}
+}
+
+func TestBuildRejectsMissingReportPath(t *testing.T) {
+	_, err := Build(Claude, Options{Brief: "/tmp/brief.md"})
+	if err == nil || !strings.Contains(err.Error(), "report path") {
+		t.Fatalf("Build() error = %v, want missing report path error", err)
 	}
 }
 
@@ -42,7 +66,7 @@ func TestBuildAntigravity(t *testing.T) {
 	spec := buildSpec(t, Antigravity, options)
 	want := launch.LaunchSpec{
 		Executable: "agy",
-		Args:       []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--print-timeout", antigravityPrintTimeout, "-p", briefPrompt(options)},
+		Args:       []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--print-timeout", antigravityPrintTimeout, "-p", testBriefPrompt(t, options)},
 		Cwd:        options.Worktree,
 	}
 	if !reflect.DeepEqual(spec, want) {
@@ -64,7 +88,7 @@ func TestBuildAntigravity(t *testing.T) {
 func TestBuildAntigravityWithModelAndEffort(t *testing.T) {
 	options := Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "gemini-3.5-flash-medium", Effort: "high"}
 	spec := buildSpec(t, Antigravity, options)
-	want := []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--print-timeout", antigravityPrintTimeout, "--model", options.Model, "--effort", options.Effort, "-p", briefPrompt(options)}
+	want := []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--print-timeout", antigravityPrintTimeout, "--model", options.Model, "--effort", options.Effort, "-p", testBriefPrompt(t, options)}
 	if !reflect.DeepEqual(spec.Args, want) {
 		t.Fatalf("args = %#v, want %#v", spec.Args, want)
 	}
@@ -96,7 +120,7 @@ func TestBuildCarriesStructuredCwdAndNoShellPrefixes(t *testing.T) {
 
 func TestBuildClaude(t *testing.T) {
 	spec := buildSpec(t, Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/data/fix-login/brief.md"})
-	wantPrompt := briefPrompt(Options{Brief: "/tmp/data/fix-login/brief.md"})
+	wantPrompt := testBriefPrompt(t, Options{Brief: "/tmp/data/fix-login/brief.md"})
 	want := launch.LaunchSpec{
 		Executable: Claude,
 		Args:       []string{"--dangerously-skip-permissions", wantPrompt},
@@ -127,7 +151,7 @@ func TestBuildClaudeNeverHeadless(t *testing.T) {
 
 func TestBuildCodex(t *testing.T) {
 	spec := buildSpec(t, Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-	want := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true", briefPrompt(Options{Brief: "/tmp/brief.md"})}
+	want := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true", testBriefPrompt(t, Options{Brief: "/tmp/brief.md"})}
 	if !reflect.DeepEqual(spec.Args, want) {
 		t.Fatalf("args = %#v, want %#v", spec.Args, want)
 	}
@@ -135,7 +159,7 @@ func TestBuildCodex(t *testing.T) {
 
 func TestBuildCodexWithModelAndEffort(t *testing.T) {
 	spec := buildSpec(t, Codex, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Model: "gpt-5.6-codex", Effort: "high"})
-	want := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true", "--model", "gpt-5.6-codex", "-c", `model_reasoning_effort="high"`, briefPrompt(Options{Brief: "/tmp/brief.md"})}
+	want := []string{"--dangerously-bypass-approvals-and-sandbox", "-c", "disable_paste_burst=true", "--model", "gpt-5.6-codex", "-c", `model_reasoning_effort="high"`, testBriefPrompt(t, Options{Brief: "/tmp/brief.md"})}
 	if !reflect.DeepEqual(spec.Args, want) {
 		t.Fatalf("args = %#v, want %#v", spec.Args, want)
 	}
@@ -168,7 +192,7 @@ func TestBuildOpenCode(t *testing.T) {
 	spec := buildSpec(t, OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
 	want := launch.LaunchSpec{
 		Executable: OpenCode,
-		Args:       []string{"--prompt", briefPrompt(Options{Brief: "/tmp/brief.md"})},
+		Args:       []string{"--prompt", testBriefPrompt(t, Options{Brief: "/tmp/brief.md"})},
 		Env:        map[string]string{"OPENCODE_CONFIG_CONTENT": `{"permission":{"*":"allow"}}`},
 		Cwd:        "/tmp/wt",
 	}

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -186,6 +186,28 @@ func TestBuildFrontMatterDisclaimer(t *testing.T) {
 	}
 }
 
+func TestBuildPromptDeclaresReportChannel(t *testing.T) {
+	options := Options{
+		Brief:      "/tmp/data/task-1/brief.md",
+		ReportPath: "/tmp/state/task-1.status",
+	}
+	spec := buildSpec(t, Claude, options)
+	for _, want := range []string{
+		options.ReportPath,
+		"working:",
+		"done:",
+		"failed:",
+		"blocked:",
+		"needs-decision:",
+		"paused:",
+		"plain shell redirection",
+	} {
+		if !containsText(spec.Args, want) {
+			t.Fatalf("Build prompt = %#v, want report-channel guidance %q", spec.Args, want)
+		}
+	}
+}
+
 func TestBuildMechanicalExecutionGuidance(t *testing.T) {
 	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
 		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", ExecutionClass: brief.ExecutionClassMechanical})

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -184,7 +184,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	}
 
 	workerSpec, err := r.deps.buildHarness(req.attempt.Harness, harness.Options{
-		Worktree: worktreePath, Brief: req.briefPath, Model: req.attempt.Model, Effort: req.attempt.Effort,
+		Worktree: worktreePath, Brief: req.briefPath, ReportPath: state.ReportPath(req.home, req.attempt.TaskID), Model: req.attempt.Model, Effort: req.attempt.Effort,
 		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter,
 	})
 	if err != nil {

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/atqamz/hand/internal/brief"
@@ -96,6 +97,10 @@ type provisioningRequest struct {
 	attempt             state.Attempt
 }
 
+func absoluteReportPath(home, id string) (string, error) {
+	return filepath.Abs(state.ReportPath(home, id))
+}
+
 func (r *Runtime) provision(ctx context.Context, req provisioningRequest) (string, error) {
 	releaseProject, err := state.Lock(req.home, "project:"+req.projectName)
 	if err != nil {
@@ -183,8 +188,12 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 		}
 	}
 
+	reportPath, err := absoluteReportPath(req.home, req.attempt.TaskID)
+	if err != nil {
+		return "", r.failProvision(req, lease, nil, false, fmt.Errorf("resolve report path: %w", err))
+	}
 	workerSpec, err := r.deps.buildHarness(req.attempt.Harness, harness.Options{
-		Worktree: worktreePath, Brief: req.briefPath, ReportPath: state.ReportPath(req.home, req.attempt.TaskID), Model: req.attempt.Model, Effort: req.attempt.Effort,
+		Worktree: worktreePath, Brief: req.briefPath, ReportPath: reportPath, Model: req.attempt.Model, Effort: req.attempt.Effort,
 		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter,
 	})
 	if err != nil {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1333,7 +1333,7 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 			return fmt.Errorf("parse persisted brief for launch confirmation: %w", err)
 		}
 		spec, err := r.deps.buildHarness(attempt.Harness, harness.Options{
-			Worktree: attempt.Worktree, Brief: briefPath, Model: attempt.Model, Effort: attempt.Effort,
+			Worktree: attempt.Worktree, Brief: briefPath, ReportPath: state.ReportPath(home, task.ID), Model: attempt.Model, Effort: attempt.Effort,
 			ExecutionClass: brief.ExecutionClass(attempt.ExecutionClass), BriefHasFrontMatter: hasFrontMatter,
 		})
 		if err != nil {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1332,8 +1332,12 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 		if err != nil {
 			return fmt.Errorf("parse persisted brief for launch confirmation: %w", err)
 		}
+		reportPath, err := absoluteReportPath(home, task.ID)
+		if err != nil {
+			return fmt.Errorf("resolve persisted report path: %w", err)
+		}
 		spec, err := r.deps.buildHarness(attempt.Harness, harness.Options{
-			Worktree: attempt.Worktree, Brief: briefPath, ReportPath: state.ReportPath(home, task.ID), Model: attempt.Model, Effort: attempt.Effort,
+			Worktree: attempt.Worktree, Brief: briefPath, ReportPath: reportPath, Model: attempt.Model, Effort: attempt.Effort,
 			ExecutionClass: brief.ExecutionClass(attempt.ExecutionClass), BriefHasFrontMatter: hasFrontMatter,
 		})
 		if err != nil {

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -495,7 +495,7 @@ func TestProvisionBuildsFromPersistedAttemptSnapshot(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if gotHarness != "codex" || gotOptions.Model != "snapshot-model" || gotOptions.Effort != "high" || gotOptions.ExecutionClass != "deep" {
+	if gotHarness != "codex" || gotOptions.Model != "snapshot-model" || gotOptions.Effort != "high" || gotOptions.ExecutionClass != "deep" || gotOptions.ReportPath != state.ReportPath(home, attempt.TaskID) {
 		t.Fatalf("harness build = %q %+v, want persisted attempt snapshot", gotHarness, gotOptions)
 	}
 }

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -495,7 +495,11 @@ func TestProvisionBuildsFromPersistedAttemptSnapshot(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if gotHarness != "codex" || gotOptions.Model != "snapshot-model" || gotOptions.Effort != "high" || gotOptions.ExecutionClass != "deep" || gotOptions.ReportPath != state.ReportPath(home, attempt.TaskID) {
+	reportPath, err := filepath.Abs(state.ReportPath(home, attempt.TaskID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotHarness != "codex" || gotOptions.Model != "snapshot-model" || gotOptions.Effort != "high" || gotOptions.ExecutionClass != "deep" || gotOptions.ReportPath != reportPath {
 		t.Fatalf("harness build = %q %+v, want persisted attempt snapshot", gotHarness, gotOptions)
 	}
 }


### PR DESCRIPTION
## Summary
- Inject each task absolute `state/<id>.status` path and the six report prefixes into every prompt-capable worker launch.
- The shared provisioning path covers `hand spawn`, `hand reopen`, and `hand promote`; `reconcile.go` also rebuilds the same absolute path for persisted launch confirmation, so reopen preserves the injected path.
- `hand doctor` opens open task histories once through `ListOpenHistoriesReadOnly` and passes the histories into its checks, leaving the seam for atqamz/hand#404's worktree check to reuse without another database open or migration.
- Doctor reports unreadable briefs as task-specific findings and continues scanning, and compares normalized absolute report paths.
- Empty report paths fail prompt-capable harness builds instead of emitting a false instruction.
- Preserve existing briefs and do not add a `report_file` front-matter key.
- Scope: prompt injection covers four of six harnesses. `grok` and `pi` pass the brief as a file with no prompt, so their workers remain without the report channel; follow-up atqamz/hand#418 tracks that limitation.

Before, a constructed Claude prompt for a brief with no report path was:
`Read the brief at /tmp/data/task-1/brief.md and carry out the task it describes.`

After, the same constructed prompt is:
`Read the brief at /tmp/data/task-1/brief.md and carry out the task it describes. The worker report channel is /tmp/state/task-1.status. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.`

Closes atqamz/hand#406

Related: atqamz/hand#418 - the `grok` and `pi` gap is tracked there and only there, so #406 is not held open duplicating it.

## Test plan
- `make test` - pass, including the full race suite.
- `make lint` - pass with `0 issues` and commentlint complete.
- Focused harness, doctor, and runtime path tests - pass.
- CI matrix covers Ubuntu x86/ARM, macOS ARM/Intel, and Windows; build and bootstrap E2E jobs remain enabled.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->


