### PR TITLE
respect task holds during orientation

### DIFF
--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -128,7 +128,7 @@ func appendTaskAttention(evidence *orientation.Evidence, view taskView, targetEv
 		} else if view.held {
 			evidence.Deferred = append(evidence.Deferred, orientation.DeferredSubject{
 				TargetID: view.task.ID,
-				Kind:     subject.Kind, Reason: fmt.Sprintf("%s; deferred by %s hold: %s", item.Reason, view.hold.Kind, holdDetail(view.hold)),
+				Kind:     subject.Kind, HoldKind: view.hold.Kind, BlockedOn: view.hold.BlockedOn,
 				Provenance: subject.Provenance,
 			})
 		}

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -94,15 +94,7 @@ func (s *fleetSnapshot) evidence() orientation.Evidence {
 			evidence.Targets = append(evidence.Targets, targetEvidence)
 		}
 		evidence.Work = append(evidence.Work, orientation.WorkEvidence{ID: view.task.ID, Kind: "task", State: view.agentState, Reported: view.reportedState})
-		for _, subject := range attention.Derive(taskAttentionEvidence(view)) {
-			if !subject.Actionable {
-				continue
-			}
-			evidence.Actionable = append(evidence.Actionable, orientation.ActionableEvidence{
-				TargetID: view.task.ID, TargetKind: "task", Generation: targetEvidence.Generation,
-				Kind: subject.Kind, Reason: subject.Reason, Provenance: subject.Provenance,
-			})
-		}
+		appendTaskAttention(&evidence, view, targetEvidence)
 	}
 	if s.next.Kind != "" {
 		evidence.NextActions = append(evidence.NextActions, orientation.NextAction{Kind: s.next.Kind, Target: s.next.Task, Command: s.next.Command, Reason: s.next.Reason})
@@ -123,4 +115,22 @@ func (s *fleetSnapshot) evidence() orientation.Evidence {
 		})
 	}
 	return evidence
+}
+
+func appendTaskAttention(evidence *orientation.Evidence, view taskView, targetEvidence orientation.TargetEvidence) {
+	for _, subject := range attention.Derive(taskAttentionEvidence(view)) {
+		item := orientation.ActionableEvidence{
+			TargetID: view.task.ID, TargetKind: "task", Generation: targetEvidence.Generation,
+			Kind: subject.Kind, Reason: subject.Reason, Provenance: subject.Provenance,
+		}
+		if subject.Actionable {
+			evidence.Actionable = append(evidence.Actionable, item)
+		} else if view.held {
+			evidence.Deferred = append(evidence.Deferred, orientation.DeferredSubject{
+				TargetID: view.task.ID,
+				Kind:     subject.Kind, Reason: fmt.Sprintf("%s; deferred by %s hold: %s", item.Reason, view.hold.Kind, holdDetail(view.hold)),
+				Provenance: subject.Provenance,
+			})
+		}
+	}
 }

--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -96,13 +96,7 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 		return nextAction{Kind: nextActionUnacknowledged, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "act on its unacknowledged worker event")}
 	}
-	if h, ok := firstHold(holds); ok {
-		for _, v := range views {
-			if v.task.ID == h.ID {
-				return nextAction{Kind: nextActionHold, Task: h.ID, Command: statusCommand(h.ID),
-					Reason: statusReason(h.ID, "resolve its active hold")}
-			}
-		}
+	if h, ok := firstOrphanHold(holds, views); ok {
 		return nextAction{Kind: nextActionHold, Task: h.ID, Command: "none",
 			Reason: "Operator or supervisor judgment is needed to resolve its active hold"}
 	}
@@ -159,12 +153,21 @@ func firstView(views []taskView, match func(taskView) bool) (taskView, bool) {
 	return taskView{}, false
 }
 
-func firstHold(holds []state.Hold) (state.Hold, bool) {
+func firstOrphanHold(holds []state.Hold, views []taskView) (state.Hold, bool) {
 	if len(holds) == 0 {
 		return state.Hold{}, false
+	}
+	known := make(map[string]bool, len(views))
+	for _, view := range views {
+		known[view.task.ID] = true
 	}
 	sorted := make([]state.Hold, len(holds))
 	copy(sorted, holds)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
-	return sorted[0], true
+	for _, hold := range sorted {
+		if !known[hold.ID] {
+			return hold, true
+		}
+	}
+	return state.Hold{}, false
 }

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -115,13 +115,25 @@ func TestClassifyNextActionExactPrecedence(t *testing.T) {
 		},
 		{
 			"hold outranks needs-project",
-			configuredWorker, 0, backlogSummary{}, []taskView{{task: state.Task{ID: "held-task"}}}, []state.Hold{{ID: "held-task"}},
-			nextAction{Kind: nextActionHold, Task: "held-task", Command: "hand status held-task", Reason: statusReason("held-task", "resolve its active hold")},
+			configuredWorker, 0, backlogSummary{}, nil, []state.Hold{{ID: "orphan-hold"}},
+			nextAction{Kind: nextActionHold, Task: "orphan-hold", Command: "none", Reason: "Operator or supervisor judgment is needed to resolve its active hold"},
 		},
 		{
 			"hold without a task has no safe command",
 			configuredWorker, 0, backlogSummary{}, nil, []state.Hold{{ID: "orphan-hold"}},
 			nextAction{Kind: nextActionHold, Task: "orphan-hold", Command: "none", Reason: "Operator or supervisor judgment is needed to resolve its active hold"},
+		},
+		{
+			"operator hold suppresses underlying attention",
+			configuredWorker, 1, backlogSummary{}, []taskView{{task: state.Task{ID: "operator-held"}, held: true, agentState: "idle"}},
+			[]state.Hold{{ID: "operator-held", Kind: state.HoldKindOperator, Reason: "needs a call"}},
+			nextAction{Kind: nextActionMonitor, Command: "hand watch --until-event", Reason: "Run `hand watch --until-event` as a background task; re-arm it after an event or when intentionally resuming after interruption or takeover"},
+		},
+		{
+			"blocked hold suppresses underlying attention",
+			configuredWorker, 1, backlogSummary{}, []taskView{{task: state.Task{ID: "blocked-held"}, held: true, agentState: "idle"}},
+			[]state.Hold{{ID: "blocked-held", Kind: state.HoldKindBlocked, BlockedOn: "other-task", Reason: "waiting for other-task"}},
+			nextAction{Kind: nextActionMonitor, Command: "hand watch --until-event", Reason: "Run `hand watch --until-event` as a background task; re-arm it after an event or when intentionally resuming after interruption or takeover"},
 		},
 		{
 			"gate outranks queued work",
@@ -184,6 +196,20 @@ func TestClassifyNextActionIsOrderIndependent(t *testing.T) {
 	}
 	if forward.Task != "a-repair" {
 		t.Fatalf("task = %q, want the needs-repair candidate regardless of input order", forward.Task)
+	}
+}
+
+func TestClassifyNextActionClearingHoldRestoresUnderlyingAttention(t *testing.T) {
+	view := taskView{task: state.Task{ID: "task-1"}, held: true, agentState: "idle"}
+	deferred := classifyNextAction(configuredWorker, 1, backlogSummary{}, []taskView{view}, []state.Hold{{ID: "task-1", Kind: state.HoldKindOperator}})
+	if deferred.Kind != nextActionMonitor || deferred.Task != "" {
+		t.Fatalf("held action = %#v, want monitoring while deferred", deferred)
+	}
+
+	view.held = false
+	released := classifyNextAction(configuredWorker, 1, backlogSummary{}, []taskView{view}, nil)
+	if released.Kind != nextActionUnreported || released.Task != "task-1" {
+		t.Fatalf("cleared action = %#v, want the underlying task attention", released)
 	}
 }
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/agentsmd"
-	"github.com/atqamz/hand/internal/attention"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/home"
@@ -239,15 +238,7 @@ func buildSessionOrientation(ctx context.Context, fleetHome string, views []task
 				evidence.Targets = append(evidence.Targets, targetEvidence)
 			}
 			evidence.Work = append(evidence.Work, orientation.WorkEvidence{ID: view.task.ID, Kind: "task", State: view.agentState, Reported: view.reportedState})
-			for _, subject := range attention.Derive(taskAttentionEvidence(view)) {
-				if !subject.Actionable {
-					continue
-				}
-				evidence.Actionable = append(evidence.Actionable, orientation.ActionableEvidence{
-					TargetID: view.task.ID, TargetKind: "task", Generation: targetEvidence.Generation,
-					Kind: subject.Kind, Reason: subject.Reason, Provenance: subject.Provenance,
-				})
-			}
+			appendTaskAttention(&evidence, view, targetEvidence)
 		}
 		if next.Kind != "" {
 			evidence.NextActions = []orientation.NextAction{{Kind: next.Kind, Target: next.Task, Command: next.Command, Reason: next.Reason}}
@@ -339,6 +330,11 @@ func appendSessionOrientation(doc *axi.Doc, result orientation.SupervisorOrienta
 		actionRows = append(actionRows, []string{subject.Target.ID, subject.Kind, subject.Reason, subject.Provenance})
 	}
 	doc.Rows("orientation_actionable", []string{"target_id", "kind", "reason", "provenance"}, actionRows)
+	deferredRows := make([][]string, 0, len(result.Deferred))
+	for _, subject := range result.Deferred {
+		deferredRows = append(deferredRows, []string{subject.TargetID, subject.Kind, subject.Reason, subject.Provenance})
+	}
+	doc.Rows("orientation_deferred", []string{"target_id", "kind", "reason", "provenance"}, deferredRows)
 	nextRows := make([][]string, 0, len(result.NextActions))
 	for _, action := range result.NextActions {
 		nextRows = append(nextRows, []string{action.Kind, action.Target, action.Command, action.Reason})

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -332,9 +332,9 @@ func appendSessionOrientation(doc *axi.Doc, result orientation.SupervisorOrienta
 	doc.Rows("orientation_actionable", []string{"target_id", "kind", "reason", "provenance"}, actionRows)
 	deferredRows := make([][]string, 0, len(result.Deferred))
 	for _, subject := range result.Deferred {
-		deferredRows = append(deferredRows, []string{subject.TargetID, subject.Kind, subject.Reason, subject.Provenance})
+		deferredRows = append(deferredRows, []string{subject.TargetID, subject.Kind, subject.HoldKind, subject.BlockedOn, subject.Provenance})
 	}
-	doc.Rows("orientation_deferred", []string{"target_id", "kind", "reason", "provenance"}, deferredRows)
+	doc.Rows("orientation_deferred", []string{"target_id", "kind", "hold_kind", "blocked_on", "provenance"}, deferredRows)
 	nextRows := make([][]string, 0, len(result.NextActions))
 	for _, action := range result.NextActions {
 		nextRows = append(nextRows, []string{action.Kind, action.Target, action.Command, action.Reason})

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/attention"
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/orientation"
@@ -658,6 +660,66 @@ func TestOrientRendersNextActionFromFleetState(t *testing.T) {
 	}
 	if after.Task.RepairCode != "E_ORPHAN" {
 		t.Fatalf("task mutated by orient: %#v", after.Task)
+	}
+}
+
+func TestOrientRendersHeldConditionAsDeferred(t *testing.T) {
+	home := setupSessionHome(t)
+	view := taskView{
+		task:       state.Task{ID: "held-task", Lifecycle: state.TaskOpen},
+		held:       true,
+		hold:       state.Hold{ID: "held-task", Kind: state.HoldKindOperator, Reason: "needs a call"},
+		agentState: "idle",
+	}
+	got, err := buildSessionOrientation(context.Background(), home, []taskView{view}, nextAction{Kind: nextActionMonitor}, orientation.MonitorStateRearmed, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Deferred) != 1 || got.Deferred[0].TargetID != "held-task" || got.Deferred[0].Kind != attention.KindUnreported {
+		t.Fatalf("deferred = %#v, want held unreported condition", got.Deferred)
+	}
+	if len(got.Actionable) != 0 {
+		t.Fatalf("actionable = %#v, want no held condition", got.Actionable)
+	}
+}
+
+func TestOrientLoadsTaskHoldAndKeepsItsConditionVisible(t *testing.T) {
+	home := setupSessionHome(t)
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AddProject(store.Project{Name: "demo", URL: "local", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "held-task", Project: "demo", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(state.ReportPath(home, "held-task"), []byte("blocked: waiting for another task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "held-task", Kind: state.HoldKindBlocked, BlockedOn: "other-task", Reason: "waiting for other-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"orient"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(new(bytes.Buffer))
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "orientation_deferred[1]{target_id,kind,reason,provenance}:") ||
+		!strings.Contains(got, "held-task,blocked,") || !strings.Contains(got, "deferred by blocked hold") {
+		t.Fatalf("out = %q, want the held blocked condition in orientation_deferred", got)
+	}
+	if strings.Contains(got, "next_action_task: held-task\n") || strings.Contains(got, "orientation_actionable[1]") {
+		t.Fatalf("out = %q, want held task excluded from actionable next work", got)
 	}
 }
 

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -714,8 +714,8 @@ func TestOrientLoadsTaskHoldAndKeepsItsConditionVisible(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "orientation_deferred[1]{target_id,kind,reason,provenance}:") ||
-		!strings.Contains(got, "held-task,blocked,") || !strings.Contains(got, "deferred by blocked hold") {
+	if !strings.Contains(got, "orientation_deferred[1]{target_id,kind,hold_kind,blocked_on,provenance}:") ||
+		!strings.Contains(got, "held-task,blocked,blocked,other-task,") {
 		t.Fatalf("out = %q, want the held blocked condition in orientation_deferred", got)
 	}
 	if strings.Contains(got, "next_action_task: held-task\n") || strings.Contains(got, "orientation_actionable[1]") {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -449,9 +449,17 @@ func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *her
 	}
 
 	views := make([]taskView, 0, len(histories))
+	holdsByID := make(map[string]state.Hold, len(holds))
+	for _, hold := range holds {
+		holdsByID[hold.ID] = hold
+	}
 	for _, history := range histories {
 		t := history.Task
 		v, _ := buildTaskView(home, client, history, false, readOnly, bounds)
+		if hold, ok := holdsByID[t.ID]; ok {
+			v.held = true
+			v.hold = hold
+		}
 		p, registered := projectByName[t.Project]
 		v.gateObserved = gateRunObservation(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -150,6 +150,7 @@ func taskAttentionEvidence(v taskView) attention.Evidence {
 		Repair:           v.task.RepairCode != "",
 		ReportClaim:      v.reportedState != "",
 		ReportedState:    v.reportedState,
+		Held:             v.held,
 	}
 	if v.latestSend != nil {
 		evidence.SendPending = v.latestSend.State == state.SendPending
@@ -172,7 +173,7 @@ func runtimeUnknown(v taskView) bool {
 
 func hasAttentionKind(v taskView, kind string) bool {
 	for _, subject := range attention.Derive(taskAttentionEvidence(v)) {
-		if subject.Kind == kind {
+		if subject.Kind == kind && subject.Actionable {
 			return true
 		}
 	}

--- a/internal/attention/attention.go
+++ b/internal/attention/attention.go
@@ -46,6 +46,7 @@ type Evidence struct {
 	SendUncertain    bool
 	SendPending      bool
 	SendPartial      bool
+	Held             bool
 	ReportedState    string
 	ReportClaim      bool
 	GateProblem      string
@@ -61,6 +62,9 @@ type Subject struct {
 func Derive(e Evidence) []Subject {
 	var subjects []Subject
 	add := func(kind, reason, provenance string, actionable bool) {
+		if e.Held {
+			actionable = false
+		}
 		subjects = append(subjects, Subject{Kind: kind, Reason: reason, Provenance: provenance, Actionable: actionable})
 	}
 	if e.ReportUnreadable {

--- a/internal/attention/attention_test.go
+++ b/internal/attention/attention_test.go
@@ -56,6 +56,22 @@ func TestDeriveIsDeterministicAndSeparatesUnknownRuntimeFromReportClaim(t *testi
 	}
 }
 
+func TestDeriveRetainsHeldSubjectsAsNotActionable(t *testing.T) {
+	got := Derive(Evidence{ID: "task-1", Held: true, Unreported: true})
+	if len(got) != 1 {
+		t.Fatalf("subjects = %#v, want one held subject", got)
+	}
+	if got[0].Kind != KindUnreported || got[0].Reason != "worker stopped without a terminal report" {
+		t.Fatalf("subject = %#v, want the underlying unreported condition", got[0])
+	}
+	if got[0].Actionable {
+		t.Fatal("held subject is actionable")
+	}
+	if NeedsAttention(Evidence{ID: "task-1", Held: true, Unreported: true}) {
+		t.Fatal("held subject needs attention")
+	}
+}
+
 func TestUnreportedRuntimeMatchesWatcherCatchUpRule(t *testing.T) {
 	for _, test := range []struct {
 		runtime, reported string

--- a/internal/orientation/orientation.go
+++ b/internal/orientation/orientation.go
@@ -66,7 +66,8 @@ type ActionableSubject struct {
 type DeferredSubject struct {
 	TargetID   string `json:"target_id"`
 	Kind       string `json:"kind"`
-	Reason     string `json:"reason"`
+	HoldKind   string `json:"hold_kind"`
+	BlockedOn  string `json:"blocked_on,omitempty"`
 	Provenance string `json:"provenance"`
 }
 
@@ -337,14 +338,20 @@ func sortedActionable(items []ActionableEvidence) []ActionableEvidence {
 
 func sortedDeferred(items []DeferredSubject) []DeferredSubject {
 	items = append([]DeferredSubject(nil), items...)
-	sort.Slice(items, func(i, j int) bool {
+	sort.SliceStable(items, func(i, j int) bool {
 		if items[i].TargetID != items[j].TargetID {
 			return items[i].TargetID < items[j].TargetID
 		}
 		if items[i].Kind != items[j].Kind {
 			return items[i].Kind < items[j].Kind
 		}
-		return items[i].Reason < items[j].Reason
+		if items[i].HoldKind != items[j].HoldKind {
+			return items[i].HoldKind < items[j].HoldKind
+		}
+		if items[i].BlockedOn != items[j].BlockedOn {
+			return items[i].BlockedOn < items[j].BlockedOn
+		}
+		return items[i].Provenance < items[j].Provenance
 	})
 	return items
 }
@@ -405,6 +412,13 @@ func bound(result *SupervisorOrientation) {
 		result.Actionable[i].Kind, result.Truncated = boundedText(result.Actionable[i].Kind, result.Truncated)
 		result.Actionable[i].Reason, result.Truncated = boundedText(result.Actionable[i].Reason, result.Truncated)
 		result.Actionable[i].Provenance, result.Truncated = boundedText(result.Actionable[i].Provenance, result.Truncated)
+	}
+	for i := range result.Deferred {
+		result.Deferred[i].TargetID, result.Truncated = boundedText(result.Deferred[i].TargetID, result.Truncated)
+		result.Deferred[i].Kind, result.Truncated = boundedText(result.Deferred[i].Kind, result.Truncated)
+		result.Deferred[i].HoldKind, result.Truncated = boundedText(result.Deferred[i].HoldKind, result.Truncated)
+		result.Deferred[i].BlockedOn, result.Truncated = boundedText(result.Deferred[i].BlockedOn, result.Truncated)
+		result.Deferred[i].Provenance, result.Truncated = boundedText(result.Deferred[i].Provenance, result.Truncated)
 	}
 	for i := range result.NextActions {
 		result.NextActions[i].Kind, result.Truncated = boundedText(result.NextActions[i].Kind, result.Truncated)

--- a/internal/orientation/orientation.go
+++ b/internal/orientation/orientation.go
@@ -63,6 +63,13 @@ type ActionableSubject struct {
 	Provenance string        `json:"provenance"`
 }
 
+type DeferredSubject struct {
+	TargetID   string `json:"target_id"`
+	Kind       string `json:"kind"`
+	Reason     string `json:"reason"`
+	Provenance string `json:"provenance"`
+}
+
 type NextAction struct {
 	Kind    string `json:"kind"`
 	Target  string `json:"target,omitempty"`
@@ -80,6 +87,7 @@ type SupervisorOrientation struct {
 	FleetID      string              `json:"fleet_id"`
 	Work         []WorkSummary       `json:"work"`
 	Actionable   []ActionableSubject `json:"actionable"`
+	Deferred     []DeferredSubject   `json:"deferred"`
 	Monitors     []MonitorTarget     `json:"monitors"`
 	MonitorState MonitorState        `json:"monitor_state"`
 	NextActions  []NextAction        `json:"next_actions"`
@@ -134,6 +142,7 @@ type Evidence struct {
 	FleetID      string               `json:"fleet_id"`
 	Work         []WorkEvidence       `json:"work"`
 	Actionable   []ActionableEvidence `json:"actionable"`
+	Deferred     []DeferredSubject    `json:"deferred"`
 	Targets      []TargetEvidence     `json:"targets"`
 	NextActions  []NextAction         `json:"next_actions"`
 	MonitorState MonitorState         `json:"monitor_state"`
@@ -204,6 +213,7 @@ func Build(evidence Evidence) SupervisorOrientation {
 		}
 		result.Actionable = append(result.Actionable, ActionableSubject{Target: monitor, Kind: item.Kind, Reason: item.Reason, Provenance: item.Provenance})
 	}
+	result.Deferred = append(result.Deferred, sortedDeferred(evidence.Deferred)...)
 	result.NextActions = sortedNextActions(evidence.NextActions)
 	result.Errors = append(result.Errors, evidence.Errors...)
 	sort.SliceStable(result.Errors, func(i, j int) bool {
@@ -325,6 +335,20 @@ func sortedActionable(items []ActionableEvidence) []ActionableEvidence {
 	return items
 }
 
+func sortedDeferred(items []DeferredSubject) []DeferredSubject {
+	items = append([]DeferredSubject(nil), items...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].TargetID != items[j].TargetID {
+			return items[i].TargetID < items[j].TargetID
+		}
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].Reason < items[j].Reason
+	})
+	return items
+}
+
 func sortedNextActions(items []NextAction) []NextAction {
 	items = append([]NextAction(nil), items...)
 	sort.SliceStable(items, func(i, j int) bool {
@@ -350,6 +374,10 @@ func bound(result *SupervisorOrientation) {
 	if len(result.Actionable) > maxOrientationItems {
 		result.Omitted += len(result.Actionable) - maxOrientationItems
 		result.Actionable = result.Actionable[:maxOrientationItems]
+	}
+	if len(result.Deferred) > maxOrientationItems {
+		result.Omitted += len(result.Deferred) - maxOrientationItems
+		result.Deferred = result.Deferred[:maxOrientationItems]
 	}
 	if len(result.Monitors) > maxOrientationItems {
 		result.Omitted += len(result.Monitors) - maxOrientationItems

--- a/internal/orientation/orientation_test.go
+++ b/internal/orientation/orientation_test.go
@@ -148,6 +148,22 @@ func TestBuildNormalizesUnknownMonitorStateAndBoundsText(t *testing.T) {
 	}
 }
 
+func TestBuildPreservesDeferredSubjectsSeparatelyFromActionableSubjects(t *testing.T) {
+	got := Build(Evidence{
+		FleetID: "f_one",
+		Targets: []TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"one"}}},
+		Deferred: []DeferredSubject{{
+			TargetID: "task-1", Kind: "unreported", Reason: "worker stopped; held by operator", Provenance: "runtime",
+		}},
+	})
+	if len(got.Deferred) != 1 || got.Deferred[0].Kind != "unreported" {
+		t.Fatalf("deferred = %#v, want the underlying held condition", got.Deferred)
+	}
+	if len(got.Actionable) != 0 {
+		t.Fatalf("actionable = %#v, want held condition excluded", got.Actionable)
+	}
+}
+
 func TestBuildDeduplicatesTargetsAndSortsAllBoundedCollections(t *testing.T) {
 	got := Build(Evidence{
 		FleetID: "f_one",

--- a/internal/orientation/orientation_test.go
+++ b/internal/orientation/orientation_test.go
@@ -153,7 +153,7 @@ func TestBuildPreservesDeferredSubjectsSeparatelyFromActionableSubjects(t *testi
 		FleetID: "f_one",
 		Targets: []TargetEvidence{{ID: "task-1", Kind: "task", Generation: []string{"one"}}},
 		Deferred: []DeferredSubject{{
-			TargetID: "task-1", Kind: "unreported", Reason: "worker stopped; held by operator", Provenance: "runtime",
+			TargetID: "task-1", Kind: "unreported", HoldKind: "operator", Provenance: "runtime",
 		}},
 	})
 	if len(got.Deferred) != 1 || got.Deferred[0].Kind != "unreported" {
@@ -161,6 +161,34 @@ func TestBuildPreservesDeferredSubjectsSeparatelyFromActionableSubjects(t *testi
 	}
 	if len(got.Actionable) != 0 {
 		t.Fatalf("actionable = %#v, want held condition excluded", got.Actionable)
+	}
+}
+
+func TestBuildBoundsDeferredSubjectFieldsAndUsesStableTies(t *testing.T) {
+	long := strings.Repeat("x", maxOrientationText+1)
+	got := Build(Evidence{
+		FleetID: "f_one",
+		Deferred: []DeferredSubject{
+			{TargetID: "task-1", Kind: "unreported", HoldKind: "operator", BlockedOn: "", Provenance: "first"},
+			{TargetID: long, Kind: long, HoldKind: long, BlockedOn: long, Provenance: long},
+			{TargetID: "task-1", Kind: "unreported", HoldKind: "operator", BlockedOn: "", Provenance: "second"},
+		},
+	})
+	if !got.Truncated || len(got.Deferred) != 3 {
+		t.Fatalf("deferred = %#v, want bounded deferred rows", got.Deferred)
+	}
+	for _, subject := range got.Deferred {
+		for name, value := range map[string]string{
+			"target_id": subject.TargetID, "kind": subject.Kind, "hold_kind": subject.HoldKind,
+			"blocked_on": subject.BlockedOn, "provenance": subject.Provenance,
+		} {
+			if len([]rune(value)) > maxOrientationText {
+				t.Fatalf("deferred %s has %d runes, want at most %d", name, len([]rune(value)), maxOrientationText)
+			}
+		}
+	}
+	if got.Deferred[0].TargetID != "task-1" || got.Deferred[1].TargetID != "task-1" || got.Deferred[0].Provenance != "first" || got.Deferred[1].Provenance != "second" {
+		t.Fatalf("deferred order = %#v, want stable order for tied rows", got.Deferred)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Propagate task holds into shared attention evidence and exclude held subjects from next-action ranking.
- Preserve held conditions in a dedicated orientation_deferred surface, including operator and blocked hold context.

Fixes atqamz/hand#408

## Test plan
- `make test`
- `make lint`
- Cross-build with CGO disabled for linux amd64/arm64, darwin amd64/arm64, and windows amd64.

<!-- hand:pipeline-region:start -->
## Summary
- Propagate task holds into shared attention evidence and exclude held subjects from every next-action branch.
- Preserve held conditions in bounded `orientation_deferred` rows with the subject kind, hold kind, and `blocked_on` facts; full free-text reasons remain in `hand status`.
- Held subjects are silent by design once deferred. Resolution of a satisfied `blocked_on` is tracked in atqamz/hand#417; this PR deliberately does not close that loop.

Fixes atqamz/hand#408

## Test plan
- `make test`
- `make lint`
- Cross-build with CGO disabled for linux amd64/arm64, darwin amd64/arm64, and windows amd64.
<!-- hand:pipeline-region:end -->