### PR TITLE
Reconcile landing evidence and terminal cleanup

### DIFF
--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -43,9 +43,13 @@ func observePR(ctx context.Context, homeDir, recordedPR string, active state.Att
 	// Live worktree state wins when it is determinable, since it is more current than what attempt
 	// creation recorded; the durably stored branch is the fallback, since a detached or torn-down
 	// worktree cannot answer at all - not evidence that no branch, and so no PR, ever existed.
-	branch, liveErr := currentBranch(active.Worktree)
-	if liveErr != nil {
-		branch = active.Branch
+	branch := active.Branch
+	var liveErr error
+	if active.Worktree != "" {
+		branch, liveErr = currentBranch(active.Worktree)
+		if liveErr != nil {
+			branch = active.Branch
+		}
 	}
 	if branch == "" {
 		return ghutil.UnknownPRObservation("git symbolic-ref --short -q HEAD", fmt.Sprintf("resolve the branch to search for in %s: %v", active.Worktree, liveErr))

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -513,11 +513,26 @@ func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Ta
 	}
 	if task.PR == "" {
 		projectInfo, found, err := project.FindReadOnly(home, task.Project)
-		if err != nil || !found {
-			return task, landingUnknown, nil
+		if err != nil {
+			return task, landingUnknown, fmt.Errorf("observe landing project %q: %w", task.Project, err)
+		}
+		if !found {
+			if task.Kind == "" {
+				return task, landingUnlanded, nil
+			}
+			return task, landingUnknown, fmt.Errorf("observe landing project %q: project is not registered", task.Project)
+		}
+		if projectInfo.Mode == project.ModeLocalOnly && (task.Kind == "" || (attempt.Worktree != "" && attempt.Branch == "")) {
+			return task, landingUnlanded, nil
 		}
 		detected, observation, err := DetectPR(ctx, home, task, attempt, projectInfo)
-		if err != nil || !observation.Found() {
+		if err != nil {
+			return task, landingUnknown, fmt.Errorf("record observed PR for task %q: %w", task.ID, err)
+		}
+		if observation.Absent() {
+			return task, landingUnlanded, nil
+		}
+		if observation.Unknown() {
 			return task, landingUnknown, nil
 		}
 		if observation.Merged && !task.MergeAnnounced {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -350,7 +350,12 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, attest rec
 			return result, err
 		}
 		if terminalConvergenceCandidate(attempt, observation) {
-			observation.Landing = r.observeLanding(ctx, home, history.Task, mergeObserved)
+			history.Task, observation.Landing, err = r.observeLanding(ctx, home, history.Task, attempt, mergeObserved)
+			if err != nil {
+				result.Outcome = reconcileOutcomeBlocked
+				result.Landing = string(observation.Landing)
+				return result, err
+			}
 			result.Landing = string(observation.Landing)
 		}
 		decision := decideReconciliation(history.Task, attempt, observation)
@@ -493,21 +498,38 @@ func (r *Runtime) observeMerge(ctx context.Context, home string, history state.T
 	return merged, !merged, "local-git", nil
 }
 
-func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Task, mergeObserved bool) landingState {
+func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Task, attempt state.Attempt, mergeObserved bool) (state.Task, landingState, error) {
 	if mergeObserved || task.DeliveredAt != "" {
-		return landingLanded
+		return task, landingLanded, nil
 	}
 	if task.Kind == state.KindScout {
 		if _, err := os.Stat(filepath.Join(home, "data", task.ID, "report.md")); err != nil {
 			if os.IsNotExist(err) {
-				return landingUnlanded
+				return task, landingUnlanded, nil
 			}
-			return landingUnknown
+			return task, landingUnknown, nil
 		}
-		return landingLanded
+		return task, landingLanded, nil
 	}
 	if task.PR == "" {
-		return landingUnlanded
+		projectInfo, found, err := project.FindReadOnly(home, task.Project)
+		if err != nil || !found {
+			return task, landingUnknown, nil
+		}
+		detected, observation, err := DetectPR(ctx, home, task, attempt, projectInfo)
+		if err != nil || !observation.Found() {
+			return task, landingUnknown, nil
+		}
+		if observation.Merged && !task.MergeAnnounced {
+			if err := state.SetTaskMergeAnnounced(home, task.ID); err != nil {
+				return task, landingUnknown, fmt.Errorf("record observed merged PR for task %q: %w", task.ID, err)
+			}
+			detected.MergeAnnounced = true
+		}
+		if observation.Merged {
+			return detected, landingLanded, nil
+		}
+		return detected, landingUnlanded, nil
 	}
 	prMerged := r.deps.prMerged
 	if prMerged == nil {
@@ -515,12 +537,12 @@ func (r *Runtime) observeLanding(ctx context.Context, home string, task state.Ta
 	}
 	observation := prMerged(ctx, task.PR)
 	if !observation.Found() {
-		return landingUnknown
+		return task, landingUnknown, nil
 	}
 	if observation.Merged {
-		return landingLanded
+		return task, landingLanded, nil
 	}
-	return landingUnlanded
+	return task, landingUnlanded, nil
 }
 
 func terminalConvergenceCandidate(attempt state.Attempt, observation reconciliationObservation) bool {

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
@@ -730,29 +731,59 @@ func TestReconcileConvergesExitedWorkerWhoseMergedPRLanded(t *testing.T) {
 	}
 }
 
-func TestReconcileConvergesKilledWorkerToInterrupted(t *testing.T) {
+func TestReconcileDiscoversMergedPRForShipWithoutRecordedPR(t *testing.T) {
 	home := reconcileFixture(t)
-	attempt := convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
-	report, err := reconcileRuntime(&missingReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	clonePath := filepath.Join(home, "projects", "demo")
+	runRuntimeGit(t, clonePath, "init", "-q")
+	runRuntimeGit(t, clonePath, "remote", "add", "origin", "https://github.com/example/demo.git")
+	prURL := "https://github.com/example/demo/pull/7"
+	faketool.GH{PRs: []faketool.GHPR{{Number: 7, URL: prURL, Branch: "topic", State: "MERGED", Repo: "example/demo"}}}.Install(t, faketool.Bin(t))
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Branch: "topic",
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+		Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.Results[0].Landing != string(landingUnlanded) {
-		t.Fatalf("landing = %q, want unlanded", report.Results[0].Landing)
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	report, err := reconcileRuntime(&missingReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
 	}
 	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if history.Task.Lifecycle != state.TaskTerminal || history.Attempts[0].Lifecycle != state.AttemptInterrupted {
-		t.Fatalf("history = %+v, want an interrupted Attempt on a terminal task", history)
+	if report.Results[0].Landing != string(landingLanded) || history.Task.PR != prURL || !history.Task.MergeAnnounced || history.Task.Lifecycle != state.TaskTerminal {
+		t.Fatalf("report=%+v task=%+v, want discovered merged PR and terminal task", report, history.Task)
 	}
-	if history.Attempts[0].TeardownDisposition != state.TeardownDispositionWorkerExitedUnlanded {
-		t.Fatalf("disposition = %q, want %q", history.Attempts[0].TeardownDisposition, state.TeardownDispositionWorkerExitedUnlanded)
+	if record, found, err := completion.FindAttempt(home, history.Attempts[0].ID); err != nil || !found || record.Outcome != "merged" {
+		t.Fatalf("completion=%+v found=%v err=%v, want merged completion", record, found, err)
 	}
-	record, found, err := completion.FindAttempt(home, attempt.ID)
-	if err != nil || !found || record.Outcome != "unlanded" {
-		t.Fatalf("record=%+v found=%v err=%v, want an unlanded completion record", record, found, err)
+}
+
+func TestReconcileKeepsKilledWorkerUnknownWithoutDiscoverablePR(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	report, err := reconcileRuntime(&missingReconcileHerdr{}, nil).Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingUnknown) {
+		t.Fatalf("landing = %q, want unknown", report.Results[0].Landing)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskOpen || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history = %+v, want an open task and running Attempt", history)
+	}
+	if history.Task.RepairCode != repairCodeRunningPaneMissing {
+		t.Fatalf("repair code = %q, want running pane repair", history.Task.RepairCode)
 	}
 }
 

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -41,15 +41,27 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 		}
 		return Result{}, err
 	}
+	terminalCleanup := false
+	var active state.Attempt
 	if history.ActiveAttempt == nil {
-		return Result{}, Precondition(fmt.Errorf("task %q has no active attempt", req.ID))
+		if history.Task.Lifecycle != state.TaskTerminal {
+			return Result{}, Precondition(fmt.Errorf("task %q has no active attempt", req.ID))
+		}
+		var found bool
+		active, found = terminalAttemptWithResources(history)
+		if !found {
+			return Result{}, Precondition(fmt.Errorf("task %q has no active attempt", req.ID))
+		}
+		terminalCleanup = true
+	} else {
+		active = *history.ActiveAttempt
 	}
 	task := history.Task
 	originalTask := task
-	active := *history.ActiveAttempt
 	warnings := []string{}
 	fail := func(err error) (Result, error) { return Result{}, WithWarnings(err, warnings) }
 	launched := active.Lifecycle != state.AttemptProvisioning || active.LaunchSubmittedAt != "" || active.LaunchConfirmedAt != ""
+	var recoveredCompletion *completion.Record
 	if active.TeardownCompletionState != "" {
 		record, found, err := completion.FindAttempt(req.Home, active.ID)
 		if err != nil {
@@ -61,9 +73,12 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 					return fail(fmt.Errorf("record recovered completion state: %w", err))
 				}
 			}
-			return r.finishTeardown(req, record, active, warnings)
+			if !terminalCleanup {
+				return r.finishTeardown(req, record, active, warnings)
+			}
+			recoveredCompletion = &record
 		}
-		if active.TeardownCompletionState == state.TeardownCompletionAppended {
+		if active.TeardownCompletionState == state.TeardownCompletionAppended && recoveredCompletion == nil {
 			return fail(fmt.Errorf("completion state for attempt %d has no exact completion record", active.ID))
 		}
 	}
@@ -92,6 +107,12 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 	} else if disposition == "" {
 		return fail(fmt.Errorf("attempt %d has teardown lifecycle without disposition", active.ID))
 	}
+	if terminalCleanup && active.Worktree != "" && !worktreeCleanupSettled(active.TeardownWorktreeState) {
+		safety := r.resolveWorktreeCommitSafety(ctx, task, active)
+		if safety.State != commitSafetyProvenDurable {
+			return fail(Precondition(fmt.Errorf("refusing to return terminal task %q worktree %s: commit safety is not proven: %s", req.ID, active.Worktree, safety.Reason)))
+		}
+	}
 	releaseProject, err := state.Lock(req.Home, "project:"+task.Project)
 	if err != nil {
 		return fail(fmt.Errorf("lock project %q: %w", task.Project, err))
@@ -110,6 +131,9 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 	returnForce := teardownReturnForce(req.Force, dirtWasSafe, disposition)
 	if err := r.releaseWorktree(req.Home, req.ID, active, returnForce); err != nil {
 		return fail(err)
+	}
+	if recoveredCompletion != nil {
+		return r.finishTeardown(req, *recoveredCompletion, active, warnings)
 	}
 
 	record := completionFor(task, disposition, launched, active.LastReportState, active.LastReportNote)
@@ -146,6 +170,22 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 	return r.finishTeardown(req, record, active, warnings)
 }
 
+func terminalAttemptWithResources(history state.TaskHistory) (state.Attempt, bool) {
+	for i := len(history.Attempts) - 1; i >= 0; i-- {
+		attempt := history.Attempts[i]
+		if attempt.Lifecycle == state.AttemptProvisioning || attempt.Lifecycle == state.AttemptRunning {
+			continue
+		}
+		if hasHerdrIdentity(attempt.Herdr) && !herdrCleanupSettled(attempt.TeardownHerdrState) {
+			return attempt, true
+		}
+		if attempt.Worktree != "" && !worktreeCleanupSettled(attempt.TeardownWorktreeState) {
+			return attempt, true
+		}
+	}
+	return state.Attempt{}, false
+}
+
 func teardownReturnForce(requestForce, dirtWasSafe bool, disposition string) bool {
 	return requestForce || dirtWasSafe || disposition == state.TeardownDispositionForced || disposition == state.TeardownDispositionCompletedSafeDirt
 }
@@ -158,8 +198,16 @@ func (r *Runtime) finishTeardown(req TeardownRequest, record completion.Record, 
 	if terminalAttempt == "" {
 		return Result{}, WithWarnings(fmt.Errorf("attempt %d has no durable teardown terminal lifecycle", active.ID), warnings)
 	}
-	if err := state.TerminalizeTaskAndAttempt(req.Home, req.ID, active.ID, active.Lifecycle, terminalAttempt); err != nil {
-		return Result{}, WithWarnings(fmt.Errorf("record task completion: %w", err), warnings)
+	currentHistory, err := state.ReadHistory(req.Home, req.ID)
+	if err != nil {
+		return Result{}, WithWarnings(fmt.Errorf("read task completion state: %w", err), warnings)
+	}
+	if currentHistory.Task.Lifecycle != state.TaskTerminal {
+		if err := state.TerminalizeTaskAndAttempt(req.Home, req.ID, active.ID, active.Lifecycle, terminalAttempt); err != nil {
+			return Result{}, WithWarnings(fmt.Errorf("record task completion: %w", err), warnings)
+		}
+	} else if active.Lifecycle != terminalAttempt {
+		return Result{}, WithWarnings(fmt.Errorf("terminal task %q attempt %d has lifecycle %q, want recorded teardown lifecycle %q", req.ID, active.ID, active.Lifecycle, terminalAttempt), warnings)
 	}
 	if err := state.ClearHoldIfKind(req.Home, req.ID, state.HoldKindLimit); err != nil {
 		warnings = append(warnings, fmt.Sprintf("warning: clear usage-limit hold failed: %v", err))

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -56,6 +56,9 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 	} else {
 		active = *history.ActiveAttempt
 	}
+	if terminalCleanup && active.TeardownTerminalAttempt != "" && active.Lifecycle != active.TeardownTerminalAttempt {
+		return Result{}, Precondition(fmt.Errorf("terminal task %q attempt %d has lifecycle %q, want recorded teardown lifecycle %q", req.ID, active.ID, active.Lifecycle, active.TeardownTerminalAttempt))
+	}
 	task := history.Task
 	originalTask := task
 	warnings := []string{}
@@ -173,7 +176,7 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 func terminalAttemptWithResources(history state.TaskHistory) (state.Attempt, bool) {
 	for i := len(history.Attempts) - 1; i >= 0; i-- {
 		attempt := history.Attempts[i]
-		if attempt.Lifecycle == state.AttemptProvisioning || attempt.Lifecycle == state.AttemptRunning {
+		if attempt.Lifecycle == state.AttemptRunning {
 			continue
 		}
 		if hasHerdrIdentity(attempt.Herdr) && !herdrCleanupSettled(attempt.TeardownHerdrState) {
@@ -207,7 +210,7 @@ func (r *Runtime) finishTeardown(req TeardownRequest, record completion.Record, 
 			return Result{}, WithWarnings(fmt.Errorf("record task completion: %w", err), warnings)
 		}
 	} else if active.Lifecycle != terminalAttempt {
-		return Result{}, WithWarnings(fmt.Errorf("terminal task %q attempt %d has lifecycle %q, want recorded teardown lifecycle %q", req.ID, active.ID, active.Lifecycle, terminalAttempt), warnings)
+		warnings = append(warnings, fmt.Sprintf("warning: terminal task %q attempt %d has lifecycle %q, want recorded teardown lifecycle %q", req.ID, active.ID, active.Lifecycle, terminalAttempt))
 	}
 	if err := state.ClearHoldIfKind(req.Home, req.ID, state.HoldKindLimit); err != nil {
 		warnings = append(warnings, fmt.Sprintf("warning: clear usage-limit hold failed: %v", err))

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -229,6 +229,62 @@ func TestTeardownSecondInvocationRefusesWithoutRepeatingCompletion(t *testing.T)
 	}
 }
 
+func TestTeardownReleasesResourcesRecordedOnTerminalTask(t *testing.T) {
+	home, worktreePath, _ := terminalResourceFixture(t)
+	client := &teardownHerdr{}
+	returns := 0
+	deps := defaultDependencies()
+	deps.herdr = func() herdrClient { return client }
+	deps.worktree.observeLease = func(path, leaseID string) worktree.LeaseObservation {
+		if path != worktreePath || leaseID != "lease-1" {
+			t.Fatalf("observeLease(%q, %q), want (%q, lease-1)", path, leaseID, worktreePath)
+		}
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: leaseID}
+	}
+	deps.worktree.observeCommits = func(string) worktree.CommitSafetyObservation {
+		return worktree.CommitSafetyObservation{State: worktree.CommitSafetyRemoteObserved}
+	}
+	deps.worktree.returnWithID = func(path, leaseID string, force bool) error {
+		if path != worktreePath || leaseID != "lease-1" || force {
+			t.Fatalf("returnWithID(%q, %q, %t), want the proven terminal lease returned", path, leaseID, force)
+		}
+		returns++
+		return nil
+	}
+
+	if _, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if returns != 1 || client.closes != 1 || history.Task.Lifecycle != state.TaskTerminal || history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased || history.Attempts[0].TeardownHerdrState != state.TeardownResourceReleased {
+		t.Fatalf("returns=%d closes=%d history=%+v, want terminal resources released", returns, client.closes, history)
+	}
+}
+
+func TestTeardownRefusesTerminalTaskWhenCommitSafetyIsUnprovable(t *testing.T) {
+	home, worktreePath, _ := terminalResourceFixture(t)
+	returns := 0
+	deps := defaultDependencies()
+	deps.worktree.observeLease = func(string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	}
+	deps.worktree.observeCommits = func(string) worktree.CommitSafetyObservation {
+		return worktree.CommitSafetyObservation{State: worktree.CommitSafetyUnknown, Probe: worktree.CommitSafetyProbe{WorkingDir: worktreePath}}
+	}
+	deps.worktree.returnWithID = func(string, string, bool) error { returns++; return nil }
+
+	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
+	if err == nil || !strings.Contains(err.Error(), "commit safety") {
+		t.Fatalf("Teardown() = %v, want commit-safety refusal", err)
+	}
+	if returns != 0 {
+		t.Fatalf("worktree returns = %d, want no return", returns)
+	}
+}
+
 func TestTeardownDoesNotUseAnOlderSameSecondCompletion(t *testing.T) {
 	home, _ := teardownFixture(t, false)
 	first, err := state.ActiveAttempt(home, "task-1")
@@ -661,6 +717,53 @@ func leasedTeardownFixture(t *testing.T) (string, string, state.Attempt) {
 		t.Fatal(err)
 	}
 	return home, worktreePath, *history.ActiveAttempt
+}
+
+func terminalResourceFixture(t *testing.T) (string, string, state.Attempt) {
+	t.Helper()
+	home, worktreePath := teardownFixture(t, true)
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempt := *history.ActiveAttempt
+	attempt.LeaseID = "lease-1"
+	attempt.Herdr = state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}
+	if err := state.UpdateAttempt(home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptCompleted, state.TeardownDispositionCompleted); err != nil {
+		t.Fatal(err)
+	}
+	record := completion.Record{ID: "task-1", Project: "demo", Kind: state.KindScout, Outcome: "done", Detail: "already recorded", AttemptID: attempt.ID, AttemptLifecycle: string(state.AttemptCompleted)}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptRunning, state.TeardownCompletionPending); err != nil {
+		t.Fatal(err)
+	}
+	if err := completion.Append(home, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetAttemptTeardownCompletionState(home, "task-1", attempt.ID, state.AttemptRunning, state.TeardownCompletionAppended); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, state.AttemptRunning, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	return home, worktreePath, attempt
+}
+
+type teardownHerdr struct {
+	healthyReconcileHerdr
+	closes int
+}
+
+func (f *teardownHerdr) TabClose(string) error {
+	f.closes++
+	return nil
+}
+
+func (f *teardownHerdr) WorkspaceClose(string) error {
+	f.closes++
+	return nil
 }
 
 func unobservablePool(worktreePath string) worktree.LeaseObservation {


### PR DESCRIPTION
## Summary
- discover and persist a ship PR by attempt branch when no PR is recorded
- return unknown when landing cannot be observed, avoiding false unlanded conclusions
- let teardown release resources held by terminal tasks only after commit safety is proven

## Verification
- `make lint`
- `make build`
- focused runtime tests and race tests
- serial runtime suite
- cross-platform compile/build checks for linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, and windows/amd64
- `make test` was attempted with a 180-second limit and hit the existing toolchain extraction timeout in `TestSpawnLegacyTierCreatesAttemptBeforeWaitingForProjectLock` before completion

Closes #407

<!-- hand:pipeline-region:start -->
## Summary
- distinguish proven PR absence from unknown observation during reconciliation
- persist discovered PRs and propagate project or persistence failures
- safely clean resources held by terminal tasks, including provisioning attempts, with pre-release lifecycle and commit-safety validation

## Verification
- `make test` passes with race detection across all packages
- `make lint`
- `make build`
- focused reviewer regression tests pass under race detection
- cross-platform compile/build checks pass for linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, and windows/amd64

Closes #407
<!-- hand:pipeline-region:end -->