### PR TITLE
fix: refresh mechanical plan base before dispatch

### DIFF
--- a/internal/runtime/execution_plan_test.go
+++ b/internal/runtime/execution_plan_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/routing"
 	"github.com/atqamz/hand/internal/state"
@@ -145,35 +146,35 @@ func TestProjectBaseCommitResolvesLocalDefaultBranchCommit(t *testing.T) {
 	}
 }
 
-func TestProjectBaseCommitDoesNotQueryRemoteToResolveBranch(t *testing.T) {
+func TestProjectBaseCommitRefreshesOriginDefaultBranchForConsecutiveChecks(t *testing.T) {
 	clonePath := filepath.Join(t.TempDir(), "clone")
 	initRuntimeGitRepo(t, clonePath)
-	runRuntimeGit(t, clonePath, "remote", "add", "origin", "ssh://example.invalid/review/repo.git")
-	realGit, err := exec.LookPath("git")
-	if err != nil {
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	if err := os.MkdirAll(remote, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	marker := filepath.Join(t.TempDir(), "remote-show-called")
-	fakeDir := t.TempDir()
-	fakeGit := filepath.Join(fakeDir, "git")
-	script := "#!/bin/sh\nif [ \"$1\" = remote ] && [ \"$2\" = show ] && [ \"$3\" = origin ]; then\n  echo queried > \"$HAND_GIT_QUERY_MARKER\"\n  exit 1\nfi\nexec \"$HAND_REAL_GIT\" \"$@\"\n"
-	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+	runRuntimeGit(t, remote, "init", "--bare", "-q")
+	runRuntimeGit(t, clonePath, "remote", "add", "origin", remote)
+	initial := gitOutput(t, clonePath, "rev-parse", "refs/heads/main")
+	runRuntimeGit(t, clonePath, "push", "-q", "-u", "origin", "main")
+	runRuntimeGit(t, clonePath, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	if err := os.WriteFile(filepath.Join(clonePath, "remote.txt"), []byte("remote\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HAND_GIT_QUERY_MARKER", marker)
-	t.Setenv("HAND_REAL_GIT", realGit)
-	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runRuntimeGit(t, clonePath, "add", "remote.txt")
+	runRuntimeGit(t, clonePath, "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "-m", "remote advance")
+	remoteHead := gitOutput(t, clonePath, "rev-parse", "HEAD")
+	runRuntimeGit(t, clonePath, "push", "-q", "origin", "main")
+	runRuntimeGit(t, clonePath, "reset", "--hard", "-q", initial)
 
-	want := gitOutput(t, clonePath, "rev-parse", "refs/heads/main")
-	got, err := projectBaseCommit(clonePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != want {
-		t.Fatalf("projectBaseCommit() = %q, want %q", got, want)
-	}
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("remote show marker exists with err %v, want no remote query", err)
+	for i := 0; i < 2; i++ {
+		got, err := projectBaseCommit(clonePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != remoteHead {
+			t.Fatalf("projectBaseCommit() check %d = %q, want freshly fetched origin/main %q", i+1, got, remoteHead)
+		}
 	}
 }
 
@@ -252,6 +253,40 @@ func TestSpawnMechanicalPlanRejectsWorktreeHeadDriftBeforeHerdr(t *testing.T) {
 	}
 	if history.ActiveAttempt == nil || history.ActiveAttempt.Worktree != "" {
 		t.Fatalf("attempt after rejected worktree = %+v, want no worktree evidence", history.ActiveAttempt)
+	}
+}
+
+func TestReconcileRetriesMechanicalPlanWithFreshAcquiredHead(t *testing.T) {
+	planned := strings.Repeat("a", 40)
+	acquired := strings.Repeat("b", 40)
+	home := executionPlanHome(t, "---\nexecution_class: mechanical\nplanned_against: "+planned+"\n---\nbrief\n")
+	calls := &executionPlanCalls{}
+	r := executionPlanRuntime(t, calls, func(string) (string, error) { return planned, nil })
+	reads := 0
+	calls.herdr.paneStatus = herdr.StatusWorking
+	r.deps.worktree.headCommit = func(string) (string, error) {
+		reads++
+		if reads == 1 {
+			return acquired, nil
+		}
+		return planned, nil
+	}
+	r.deps.worktree.observeClean = func(string) (worktree.Cleanliness, error) { return worktree.Clean, nil }
+	r.deps.worktree.observeCommits = func(string) worktree.CommitSafetyObservation {
+		return worktree.CommitSafetyObservation{State: worktree.CommitSafetyRemoteObserved}
+	}
+
+	_, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: "claude"})
+	assertPreconditionError(t, err)
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("Reconcile() = %v, want a fresh acquired-head check to advance the same attempt", err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reads != 2 || calls.baseLookups != 2 || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("base reads=%d head reads=%d history=%+v, want fresh base and acquired-head checks on retry", calls.baseLookups, reads, history)
 	}
 }
 
@@ -751,6 +786,7 @@ type executionPlanCalls struct {
 	herdrGets        int
 	harnessBuilds    int
 	projectLockProbe error
+	herdr            *provisionHerdr
 }
 
 func executionPlanHome(t *testing.T, briefText string) string {
@@ -782,6 +818,7 @@ func executionPlanHome(t *testing.T, briefText string) string {
 func executionPlanRuntime(t *testing.T, calls *executionPlanCalls, base func(string) (string, error)) *Runtime {
 	t.Helper()
 	fakeHerdr := &provisionHerdr{}
+	calls.herdr = fakeHerdr
 	r := testProvisionRuntime(fakeHerdr, func(lifecyclePhase) error { return nil })
 	r.deps.projectBaseCommit = func(path string) (string, error) {
 		calls.baseLookups++

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -87,14 +87,15 @@ func defaultDependencies() dependencies {
 }
 
 type provisioningRequest struct {
-	home                string
-	projectName         string
-	clonePath           string
-	briefPath           string
-	briefHasFrontMatter bool
-	resumeExisting      bool
-	paneStartedAt       string
-	attempt             state.Attempt
+	home                  string
+	projectName           string
+	clonePath             string
+	briefPath             string
+	briefHasFrontMatter   bool
+	recheckMechanicalBase bool
+	resumeExisting        bool
+	paneStartedAt         string
+	attempt               state.Attempt
 }
 
 func absoluteReportPath(home, id string) (string, error) {
@@ -111,6 +112,14 @@ func (r *Runtime) provision(ctx context.Context, req provisioningRequest) (strin
 }
 
 func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) (string, error) {
+	if req.recheckMechanicalBase && brief.ExecutionClass(req.attempt.ExecutionClass) == brief.ExecutionClassMechanical {
+		if err := r.preflightBrief(brief.Declaration{
+			ExecutionClass: brief.ExecutionClassMechanical,
+			PlannedAgainst: req.attempt.PlannedAgainst,
+		}, req.clonePath); err != nil {
+			return "", err
+		}
+	}
 	session := req.attempt.Herdr.Session
 	fleetID := ""
 	var err error

--- a/internal/runtime/provision_test.go
+++ b/internal/runtime/provision_test.go
@@ -431,8 +431,8 @@ type provisionHerdr struct {
 	submitted        launchSpec
 }
 
-func (f *provisionHerdr) FindWorkspaceByLabel(string) (herdr.Workspace, bool, error) {
-	return herdr.Workspace{WorkspaceID: "ws-1"}, true, nil
+func (f *provisionHerdr) FindWorkspaceByLabel(label string) (herdr.Workspace, bool, error) {
+	return herdr.Workspace{WorkspaceID: "ws-1", Label: label}, true, nil
 }
 
 func (f *provisionHerdr) WorkspaceList() ([]herdr.Workspace, error) { return nil, nil }
@@ -449,12 +449,12 @@ func (f *provisionHerdr) TabList(string) ([]herdr.Tab, error) {
 	if f.tabs != nil {
 		return f.tabs, nil
 	}
-	return []herdr.Tab{{TabID: "tab-1"}}, nil
+	return []herdr.Tab{{TabID: "tab-1", WorkspaceID: "ws-1", Label: "task-1"}}, nil
 }
 
-func (f *provisionHerdr) TabCreate(_ string, cwd string, env map[string]string, _ string) (herdr.Tab, herdr.Pane, error) {
+func (f *provisionHerdr) TabCreate(workspaceID string, cwd string, env map[string]string, label string) (herdr.Tab, herdr.Pane, error) {
 	f.tabCwd, f.tabEnv = cwd, env
-	return herdr.Tab{TabID: "tab-1"}, herdr.Pane{PaneID: "pane-1"}, nil
+	return herdr.Tab{TabID: "tab-1", WorkspaceID: workspaceID, Label: label}, herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: workspaceID}, nil
 }
 
 func (f *provisionHerdr) TabRename(string, string) error { return nil }
@@ -469,7 +469,7 @@ func (f *provisionHerdr) PaneGet(string) (herdr.Pane, error) {
 	if status == "" {
 		status = herdr.StatusDone
 	}
-	return herdr.Pane{PaneID: "pane-1", Agent: "claude", AgentStatus: status}, nil
+	return herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1", Agent: "claude", AgentStatus: status}, nil
 }
 
 func (f *provisionHerdr) PaneProcessInfo(string) (herdr.ProcessInfo, error) {

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1360,7 +1360,7 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 		}
 		_, err = r.provision(ctx, provisioningRequest{
 			home: home, projectName: projectInfo.Name, clonePath: filepath.Join(home, "projects", projectInfo.Name),
-			briefPath: briefPath, briefHasFrontMatter: hasFrontMatter, attempt: attempt,
+			briefPath: briefPath, briefHasFrontMatter: hasFrontMatter, recheckMechanicalBase: true, attempt: attempt,
 			resumeExisting: attempt.Worktree != "",
 		})
 		return err

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -662,9 +662,20 @@ func projectBaseCommit(clonePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	commit, err := git.BranchCommit(clonePath, branch)
+	ref := "refs/heads/" + branch
+	if _, err := git.Run(clonePath, "remote", "get-url", "origin"); err == nil {
+		if _, err := git.Run(clonePath, "fetch", "--quiet", "origin", branch); err != nil {
+			return "", fmt.Errorf("refresh origin/%s for project base: %w", branch, err)
+		}
+		ref = "refs/remotes/origin/" + branch
+	}
+	commit, err := git.Run(clonePath, "rev-parse", "--verify", ref+"^{commit}")
 	if err != nil {
-		return "", fmt.Errorf("resolve local default branch commit refs/heads/%s: %w", branch, err)
+		return "", fmt.Errorf("resolve project base commit %s: %w", ref, err)
+	}
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return "", fmt.Errorf("resolve project base commit %s: empty Git object ID", ref)
 	}
 	return commit, nil
 }


### PR DESCRIPTION
## Summary
- Refresh the registered project base from origin before mechanical staleness comparison, while preserving the local fallback for origin-less clones.
- Re-run the mechanical base check when reconciliation retries provisioning, so wedged attempts do not replay stale cached refusal state.
- Add regressions for consecutive fresh base reads and reconcile retry behavior.

Fixes atqamz/hand#401

## Test plan
- `SECONDHAND_HOME=$(mktemp -d) nix develop -c go test -tags=test -race ./internal/runtime -run 'Test(ProjectBaseCommit|PreflightBrief|SpawnMechanicalPlan|ReconcileRetriesMechanicalPlanWithFreshAcquiredHead)' -count=1` - passes.\n- `nix develop -c make test` - attempted twice; the command runner terminated it after about two minutes before completion, without a test assertion failure. The untagged runtime package check separately exposed the known missing selected managed-runtime setup; the tagged focused run passes with isolated `SECONDHAND_HOME`.

<!-- hand:pipeline-region:start -->
## Summary

- `projectBaseCommit` now refreshes `origin/<default-branch>` and resolves the base from
  `refs/remotes/origin/<branch>`, falling back to the local `refs/heads/<branch>` only when the clone
  has no `origin`. That is the root cause: the pre-check read the local ref while worktree
  acquisition saw fresh remote state, so two checks inside one invocation could legitimately
  disagree and chasing the last-reported sha never converged.
- `hand reconcile` re-runs the mechanical base check when it retries provisioning
  (`recheckMechanicalBase`), so a wedged attempt no longer replays a cached refusal with
  byte-identical text and an unchanged attempt counter.
- Regressions for both: consecutive `projectBaseCommit` calls against an advanced origin, and a
  reconcile that advances the same attempt once the acquired head stops drifting.

Fixes atqamz/hand#401

## Behaviour change worth knowing

A mechanical dispatch now requires network reachability to `origin`. If the fetch fails the dispatch
fails with `refresh origin/<branch> for project base` rather than silently comparing against a stale
local ref. That is deliberate - a mechanical plan's premise is that the base has not moved, which
cannot be established offline - but it is a real change for an offline supervisor, and it is scoped
to mechanical dispatch only: `preflightBrief` returns early for every other execution class, and
`projectBaseCommit` has no other caller.

## Test plan

- Changed regressions, isolated home:
  `SECONDHAND_HOME=$(mktemp -d) nix develop -c go test -tags=test -race ./internal/runtime -run 'Test(ProjectBaseCommit|PreflightBrief|SpawnMechanicalPlan|ReconcileRetriesMechanicalPlanWithFreshAcquiredHead)' -count=1`
  passes in 6.484s.
- Full `make test` could not be completed locally. It was launched detached and the harness
  terminated it before completion, so it is reported as no result rather than as a pass.
- Falling back to per-package runs with `-tags=test -race`, every package passed except
  `internal/runtime`, which hit Go's own 10-minute package timeout in the pre-existing
  `TestReconcileWithholdsPrunedWorktreeCarryingALocalOnlyCommit`. Notable durations on this worker:
  `internal/worktree` 192.5s, `cmd` 156.1s, `tests/release` 69.4s, `internal/watcher` 60.2s.
- **CI is the authoritative result here and it is green on all five platforms**, including
  `Test (ubuntu-latest)` in 3m44s and `Test (windows-latest)` in 7m41s, so the local
  `internal/runtime` timeout is environmental. It is the margin problem in atqamz/hand#416 showing
  up on a loaded Linux box - that host was running concurrent Nix builds and QEMU VMs at load
  average 4.8/7.8/9.5 - not a regression from this change. atqamz/hand#430 covers making that
  failure mode legible.
- No controlled before/after timing comparison was performed, and no evidence was found that this
  change makes any package slower. The added `git fetch` runs once per mechanical dispatch, not per
  test.

## Registry caveat

atqamz/hand#413 records that hand's own tests register Fleets in the operator's real registry. The
focused run above used an isolated `SECONDHAND_HOME`; the per-package fallback runs did not all
inherit the Makefile's temporary-home wrapper, so that caveat applies to those runs.
<!-- hand:pipeline-region:end -->