### PR TITLE
fix(worktree): enforce pool-slot integrity and lease recovery

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -378,7 +378,7 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 				soundness := worktree.CheckSoundness(clone, entry.Path)
 				key := filepath.Clean(worktree.CanonicalPath(entry.Path))
 				reported[key] = struct{}{}
-				appendUnsoundPoolFinding(&findings, p.Name, worktree.CanonicalPath(entry.Path), soundness, entry.Status == "leased")
+				appendUnsoundPoolFinding(&findings, p.Name, entry.Path, soundness, entry.Status == "leased")
 			}
 		}
 		poolSlots, discoverErr := worktree.DiscoverPoolSlots(clone, worktree.PoolSearchRoots(fleetHome, clone)...)
@@ -394,9 +394,9 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 			for _, collision := range worktree.PoolSlotCollisions(poolSlots) {
 				claims := make([]string, 0, len(collision))
 				for _, slot := range collision {
-					claims = append(claims, fmt.Sprintf("pool %q slot %q", slot.PoolRoot, slot.Path))
+					claims = append(claims, fmt.Sprintf("pool \"%s\" slot \"%s\"", slot.PoolRoot, slot.Path))
 				}
-				findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q metadata target %q is claimed by %s", p.Name, collision[0].MetadataDir, strings.Join(claims, ", "))})
+				findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q metadata target \"%s\" is claimed by %s", p.Name, collision[0].MetadataDir, strings.Join(claims, ", "))})
 			}
 		}
 	}
@@ -407,7 +407,7 @@ func appendUnsoundPoolFinding(findings *[]doctorFinding, projectName, path strin
 	if soundness.Sound {
 		return
 	}
-	text := fmt.Sprintf("project %q pool slot %q is unsound: %s", projectName, path, strings.Join(soundness.Failures, "; "))
+	text := fmt.Sprintf("project %q pool slot \"%s\" is unsound: %s", projectName, path, strings.Join(soundness.Failures, "; "))
 	if leased {
 		text += "; leased, not retired"
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -354,21 +354,31 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 	if err != nil {
 		return append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("registered project pools cannot be inspected: %v", err)})
 	}
+	seenProjects := make(map[string]struct{}, len(projects))
 	for _, p := range projects {
+		if _, seen := seenProjects[p.Name]; seen {
+			continue
+		}
+		seenProjects[p.Name] = struct{}{}
 		clone := filepath.Join(fleetHome, "projects", p.Name)
 		if _, err := os.Stat(filepath.Join(clone, ".git")); os.IsNotExist(err) {
 			continue
 		}
 		entries, err := worktree.PoolStatus(clone)
 		reported := make(map[string]struct{}, len(entries))
-		if err != nil {
+		switch {
+		case err != nil && worktree.IsTreehouseUnavailable(err):
+			// Already surfaced once as a top-level tool warning; a missing treehouse binary is not
+			// a per-project pool integrity finding, and reporting it as one for every registered
+			// project only duplicates that warning without giving the operator anything new to fix.
+		case err != nil:
 			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q worktree pool cannot be inspected: %v", p.Name, err)})
-		} else {
+		default:
 			for _, entry := range entries {
 				soundness := worktree.CheckSoundness(clone, entry.Path)
-				key, _ := filepath.Abs(entry.Path)
-				reported[filepath.Clean(key)] = struct{}{}
-				appendUnsoundPoolFinding(&findings, p.Name, entry.Path, soundness, entry.Status == "leased")
+				key := filepath.Clean(worktree.CanonicalPath(entry.Path))
+				reported[key] = struct{}{}
+				appendUnsoundPoolFinding(&findings, p.Name, worktree.CanonicalPath(entry.Path), soundness, entry.Status == "leased")
 			}
 		}
 		poolSlots, discoverErr := worktree.DiscoverPoolSlots(clone, worktree.PoolSearchRoots(fleetHome, clone)...)
@@ -376,8 +386,7 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q worktree pool directories cannot be inspected: %v", p.Name, discoverErr)})
 		} else {
 			for _, slot := range poolSlots {
-				key, _ := filepath.Abs(slot.Path)
-				if _, ok := reported[filepath.Clean(key)]; ok {
+				if _, ok := reported[filepath.Clean(worktree.CanonicalPath(slot.Path))]; ok {
 					continue
 				}
 				appendUnsoundPoolFinding(&findings, p.Name, slot.Path, slot.Soundness, false)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -360,23 +360,49 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 			continue
 		}
 		entries, err := worktree.PoolStatus(clone)
+		reported := make(map[string]struct{}, len(entries))
 		if err != nil {
 			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q worktree pool cannot be inspected: %v", p.Name, err)})
-			continue
+		} else {
+			for _, entry := range entries {
+				soundness := worktree.CheckSoundness(clone, entry.Path)
+				key, _ := filepath.Abs(entry.Path)
+				reported[filepath.Clean(key)] = struct{}{}
+				appendUnsoundPoolFinding(&findings, p.Name, entry.Path, soundness, entry.Status == "leased")
+			}
 		}
-		for _, entry := range entries {
-			soundness := worktree.CheckSoundness(clone, entry.Path)
-			if soundness.Sound {
-				continue
+		poolSlots, discoverErr := worktree.DiscoverPoolSlots(clone, worktree.PoolSearchRoots(fleetHome, clone)...)
+		if discoverErr != nil {
+			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q worktree pool directories cannot be inspected: %v", p.Name, discoverErr)})
+		} else {
+			for _, slot := range poolSlots {
+				key, _ := filepath.Abs(slot.Path)
+				if _, ok := reported[filepath.Clean(key)]; ok {
+					continue
+				}
+				appendUnsoundPoolFinding(&findings, p.Name, slot.Path, slot.Soundness, false)
 			}
-			text := fmt.Sprintf("project %q pool slot %q is unsound: %s", p.Name, entry.Path, strings.Join(soundness.Failures, "; "))
-			if entry.Status == "leased" {
-				text += "; leased, not retired"
+			for _, collision := range worktree.PoolSlotCollisions(poolSlots) {
+				claims := make([]string, 0, len(collision))
+				for _, slot := range collision {
+					claims = append(claims, fmt.Sprintf("pool %q slot %q", slot.PoolRoot, slot.Path))
+				}
+				findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q metadata target %q is claimed by %s", p.Name, collision[0].MetadataDir, strings.Join(claims, ", "))})
 			}
-			findings = append(findings, doctorFinding{Severity: doctorError, Text: text})
 		}
 	}
 	return findings
+}
+
+func appendUnsoundPoolFinding(findings *[]doctorFinding, projectName, path string, soundness worktree.SlotSoundness, leased bool) {
+	if soundness.Sound {
+		return
+	}
+	text := fmt.Sprintf("project %q pool slot %q is unsound: %s", projectName, path, strings.Join(soundness.Failures, "; "))
+	if leased {
+		text += "; leased, not retired"
+	}
+	*findings = append(*findings, doctorFinding{Severity: doctorError, Text: text})
 }
 
 // A local-only fleet never needs gh, while a registered project delivering through direct-pr or

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/supervision"
 	"github.com/atqamz/hand/internal/toolchain"
+	"github.com/atqamz/hand/internal/worktree"
 	"github.com/spf13/cobra"
 )
 
@@ -348,6 +349,32 @@ func doctorWorktreeFindings(fleetHome string, histories []state.TaskHistory) []d
 			continue
 		}
 		findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("task %q worktree is rooted in another Git repository: got %s, want %s", history.Task.ID, actual, expected)})
+	}
+	projects, err := project.ListReadOnly(fleetHome)
+	if err != nil {
+		return append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("registered project pools cannot be inspected: %v", err)})
+	}
+	for _, p := range projects {
+		clone := filepath.Join(fleetHome, "projects", p.Name)
+		if _, err := os.Stat(filepath.Join(clone, ".git")); os.IsNotExist(err) {
+			continue
+		}
+		entries, err := worktree.PoolStatus(clone)
+		if err != nil {
+			findings = append(findings, doctorFinding{Severity: doctorError, Text: fmt.Sprintf("project %q worktree pool cannot be inspected: %v", p.Name, err)})
+			continue
+		}
+		for _, entry := range entries {
+			soundness := worktree.CheckSoundness(clone, entry.Path)
+			if soundness.Sound {
+				continue
+			}
+			text := fmt.Sprintf("project %q pool slot %q is unsound: %s", p.Name, entry.Path, strings.Join(soundness.Failures, "; "))
+			if entry.Status == "leased" {
+				text += "; leased, not retired"
+			}
+			findings = append(findings, doctorFinding{Severity: doctorError, Text: text})
+		}
 	}
 	return findings
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/atqamz/hand/internal/skill"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/supervision"
+	"github.com/atqamz/hand/internal/worktree"
 )
 
 func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
@@ -308,6 +309,51 @@ func TestDoctorFindsWorktreeUsingTheFleetHomeCheckout(t *testing.T) {
 		}
 	}
 	t.Fatalf("findings = %#v, want an operator-checkout worktree finding", findings)
+}
+
+func TestDoctorFindsEveryUnsoundPoolSlotIncludingLeasedSlots(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://example.com/demo.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	clone := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clone)
+	sound := filepath.Join(t.TempDir(), "sound")
+	runGitOutput(t, clone, "worktree", "add", "-q", "-b", "sound", sound)
+	missing := filepath.Join(t.TempDir(), "missing")
+	if err := os.MkdirAll(missing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(missing, ".git"), []byte("gitdir: "+filepath.Join(t.TempDir(), "gone")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	leased := filepath.Join(t.TempDir(), "leased")
+	if err := os.MkdirAll(leased, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(leased, ".git"), []byte("broken\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Treehouse{Slots: []string{sound, missing, leased}, Held: []string{leased}}.Install(t, faketool.Bin(t))
+
+	findings := doctorWorktreeFindings(home, nil)
+	if !hasDoctorFindingPrefix(findings, doctorError, `project "demo" pool slot "`+missing+`" is unsound: `) ||
+		!hasDoctorFindingPrefix(findings, doctorError, `project "demo" pool slot "`+leased+`" is unsound: `) {
+		t.Fatalf("findings = %#v, want both unsound slots", findings)
+	}
+	for _, finding := range findings {
+		if strings.Contains(finding.Text, sound) {
+			t.Fatalf("findings = %#v, sound slot was reported", findings)
+		}
+	}
+	if _, err := os.Stat(leased); err != nil {
+		t.Fatalf("doctor retired leased unsound slot: %v", err)
+	}
+	if got := worktree.CheckSoundness(clone, sound); !got.Sound {
+		t.Fatalf("sound slot became unsound: %+v", got)
+	}
 }
 
 func TestDoctorIncludesProjectListGateFinding(t *testing.T) {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -227,6 +227,15 @@ func hasDoctorFindingPrefix(findings []doctorFinding, severity doctorSeverity, p
 	return false
 }
 
+func hasDoctorFindingContaining(findings []doctorFinding, severity doctorSeverity, text string) bool {
+	for _, finding := range findings {
+		if finding.Severity == severity && strings.Contains(finding.Text, text) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestDoctorFindsWorktreeUsingAnotherFleetClone(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
@@ -353,6 +362,40 @@ func TestDoctorFindsEveryUnsoundPoolSlotIncludingLeasedSlots(t *testing.T) {
 	}
 	if got := worktree.CheckSoundness(clone, sound); !got.Sound {
 		t.Fatalf("sound slot became unsound: %+v", got)
+	}
+}
+
+func TestDoctorReportsMetadataAliasAcrossPoolRoots(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://example.com/demo.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	clone := filepath.Join(home, "projects", "demo")
+	faketool.InitRepo(t, clone)
+	first := filepath.Join(clone, ".treehouse", "pool-a", "1", "demo")
+	second := filepath.Join(home, ".treehouse", "pool-b", "1", "demo")
+	runGitOutput(t, clone, "worktree", "add", "-q", "-b", "first", first)
+	runGitOutput(t, clone, "worktree", "add", "-q", "-b", "second", second)
+	metadata, err := worktree.ReadMetadataDir(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(second, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, ".git"), []byte("gitdir: "+metadata+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Treehouse{Slots: []string{first}}.Install(t, faketool.Bin(t))
+
+	findings := doctorWorktreeFindings(home, nil)
+	for _, want := range []string{metadata, first, second} {
+		if !hasDoctorFindingContaining(findings, doctorError, want) {
+			t.Fatalf("findings = %#v, want collision to name %q", findings, want)
+		}
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -47,9 +47,12 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 	if err := project.Add(home, project.Project{Name: "myproj", URL: "https://example.com/myproj.git", Mode: project.ModeDirectPR}); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(home, "projects", "myproj"), 0o755); err != nil {
+	clone := filepath.Join(home, "projects", "myproj")
+	initGitRepo(t, clone)
+	if err := os.MkdirAll(filepath.Dir(newWorktree), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	runGitOutput(t, clone, "worktree", "add", "-q", "-b", "slot", newWorktree)
 
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}}); err != nil {
 		t.Fatal(err)

--- a/cmd/reopen_test.go
+++ b/cmd/reopen_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"os/exec"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,12 +20,6 @@ func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 	}
 	worktree := t.TempDir() + "/wt"
 	home := setupSpawnHome(t, worktree, herdr)
-	clone := filepath.Join(home, "projects", "myproj")
-	initGitRepo(t, clone)
-	command := exec.Command("git", "-C", clone, "worktree", "add", "--detach", worktree)
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Fatalf("git worktree add: %v: %s", err, output)
-	}
 
 	spawn := newSpawnCmd()
 	spawn.SetArgs([]string{"task-1", "myproj", "--harness", harness.Claude})
@@ -48,6 +42,12 @@ func TestReopenCreatesANewAttemptWithoutResurrectingTheOldOne(t *testing.T) {
 	if err := teardown.Execute(); err != nil {
 		t.Fatal(err)
 	}
+	nextWorktree := filepath.Join(home, "projects", "myproj", ".treehouse", "pool", "2", "myproj")
+	if err := os.MkdirAll(filepath.Dir(nextWorktree), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitOutput(t, filepath.Join(home, "projects", "myproj"), "worktree", "add", "-q", "-b", "slot-2", nextWorktree)
+	faketool.Treehouse{Slots: []string{worktree, nextWorktree}, Log: os.Getenv("TREEHOUSE_CALL_LOG")}.Install(t, faketool.Bin(t))
 
 	reopen := newReopenCmd()
 	var out strings.Builder

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -41,9 +41,12 @@ func setupSpawnHome(t *testing.T, worktreePath string, herdr faketool.Herdr) str
 	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "brief.md"), []byte("do the thing"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(home, "projects", "myproj"), 0o755); err != nil {
+	clone := filepath.Join(home, "projects", "myproj")
+	initGitRepo(t, clone)
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	runGitOutput(t, clone, "worktree", "add", "-q", "-b", "slot", worktreePath)
 
 	bin := faketool.Bin(t)
 	callLog := filepath.Join(t.TempDir(), "calls.log")

--- a/internal/faketool/treehouse.go
+++ b/internal/faketool/treehouse.go
@@ -113,6 +113,9 @@ func runTreehouseFromPayload(payload json.RawMessage, args []string) int {
 
 func treehouseGet(spec treehouseSpec) int {
 	for _, slot := range spec.Slots {
+		if _, err := os.Stat(slot); os.IsNotExist(err) && retiredTreehouseSlot(spec.StateDir, slot) {
+			continue
+		}
 		marker := treehouseMarker(spec.StateDir, slot)
 		leased, err := treehouseLeased(marker)
 		if err != nil {
@@ -256,6 +259,11 @@ func treehouseReturn(spec treehouseSpec, args []string) int {
 	if err := atomicWrite(marker, ""); err != nil {
 		return fail("return treehouse slot: %v", err)
 	}
+	if info, err := os.Stat(filepath.Join(slot, ".git")); err == nil && !info.IsDir() {
+		if err := atomicWrite(retiredTreehouseSlotPath(spec.StateDir, slot), "retired\n"); err != nil {
+			return fail("record retired treehouse slot: %v", err)
+		}
+	}
 	_, _ = io.WriteString(os.Stderr, "Worktree returned to pool.\n")
 	return 0
 }
@@ -279,7 +287,8 @@ func treehouseInit() int {
 }
 
 func treehouseDirty(path string) (bool, error) {
-	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	if err != nil || !info.IsDir() {
 		return false, nil
 	}
 	out, err := exec.Command("git", "-C", path, "status", "--porcelain").Output()
@@ -301,6 +310,15 @@ func treehouseClean(path string) error {
 
 func treehouseMarker(state, slot string) string {
 	return filepath.Join(state, "slot-"+key(slot))
+}
+
+func retiredTreehouseSlotPath(state, slot string) string {
+	return filepath.Join(state, "retired-"+key(slot))
+}
+
+func retiredTreehouseSlot(state, slot string) bool {
+	_, err := os.Stat(retiredTreehouseSlotPath(state, slot))
+	return err == nil
 }
 
 func treehouseCounterPath(state string) string {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -73,6 +73,51 @@ func SamePath(left, right string) bool {
 	return left == right
 }
 
+// ReadGitDirFile reads Git's gitdir pointer file and resolves relative targets from its directory.
+func ReadGitDirFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read Git directory pointer %q: %w", path, err)
+	}
+	const prefix = "gitdir:"
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("git directory pointer %q has no gitdir target", path)
+	}
+	target := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if target == "" {
+		return "", fmt.Errorf("git directory pointer %q has an empty gitdir target", path)
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return "", fmt.Errorf("make Git directory pointer absolute: %w", err)
+	}
+	return filepath.Clean(abs), nil
+}
+
+// ReadWorktreeGitDir reads the raw gitdir pointer stored in linked-worktree metadata.
+func ReadWorktreeGitDir(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read linked worktree pointer %q: %w", path, err)
+	}
+	target := strings.TrimSpace(string(data))
+	if target == "" {
+		return "", fmt.Errorf("linked worktree pointer %q is empty", path)
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return "", fmt.Errorf("make linked worktree pointer absolute: %w", err)
+	}
+	return filepath.Clean(abs), nil
+}
+
 func Run(dir string, args ...string) (string, error) {
 	return run(dir, args...)
 }

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -42,6 +42,36 @@ func TestCommonDirReturnsTheMainRepositoryForAWorktree(t *testing.T) {
 	}
 }
 
+func TestReadGitDirFileResolvesRelativeGitdirTargets(t *testing.T) {
+	root := t.TempDir()
+	metadata := filepath.Join(root, ".git", "worktrees", "slot")
+	if err := os.MkdirAll(metadata, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(metadata, "gitdir")
+	if err := os.WriteFile(path, []byte("gitdir: ../../../slot\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadGitDirFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !SamePath(got, filepath.Join(root, "slot")) {
+		t.Fatalf("ReadGitDirFile() = %q, want %q", got, filepath.Join(root, "slot"))
+	}
+}
+
+func TestReadGitDirFileRejectsMissingGitdirPrefix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitdir")
+	if err := os.WriteFile(path, []byte("not a gitdir\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadGitDirFile(path); err == nil {
+		t.Fatal("ReadGitDirFile() accepted a file without a gitdir prefix")
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	if len(args) > 1 && args[0] == "init" {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -317,6 +317,12 @@ func (r *Runtime) releaseWorktree(clonePath, home, taskID string, attempt state.
 		}
 		return err
 	}
+	if err := worktree.RemoveMetadata(clonePath, attempt.Worktree); err != nil {
+		if stateErr := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAmbiguous); stateErr != nil {
+			return fmt.Errorf("record failed worktree metadata removal: %w", stateErr)
+		}
+		return err
+	}
 	if err := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
 		return fmt.Errorf("record worktree release evidence: %w", err)
 	}

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -317,12 +317,6 @@ func (r *Runtime) releaseWorktree(clonePath, home, taskID string, attempt state.
 		}
 		return err
 	}
-	if err := worktree.RemoveMetadata(clonePath, attempt.Worktree); err != nil {
-		if stateErr := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceAmbiguous); stateErr != nil {
-			return fmt.Errorf("record failed worktree metadata removal: %w", stateErr)
-		}
-		return err
-	}
 	if err := state.SetAttemptTeardownResourceState(home, taskID, attempt.ID, attempt.Lifecycle, "worktree", state.TeardownResourceReleased); err != nil {
 		return fmt.Errorf("record worktree release evidence: %w", err)
 	}

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -55,6 +55,44 @@ func TestTeardownFailureAfterWorktreeReturnPreservesOwnershipEvidence(t *testing
 	}
 }
 
+func TestReleaseWorktreeRemovesLinkedWorktreeMetadata(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	clone := filepath.Join(home, "projects", "demo")
+	if err := os.MkdirAll(filepath.Dir(clone), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeGit(t, home, "init", "-q", "-b", "main", clone)
+	runRuntimeGit(t, clone, "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-q", "--allow-empty", "-m", "initial")
+	worktreePath := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runRuntimeGit(t, clone, "worktree", "add", "-q", "-b", "slot", worktreePath)
+	metadata, err := worktree.ReadMetadataDir(worktreePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://example.com/demo.git", Mode: project.ModeLocalOnly}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-1", Project: "demo", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	created, err := state.CreateAttempt(home, state.Attempt{TaskID: "task-1", Lifecycle: state.AttemptRunning, Worktree: worktreePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempt := created
+	deps := defaultDependencies()
+	deps.worktree.returnWorktree = func(string, string, bool) error { return nil }
+	if err := (&Runtime{deps: deps}).releaseWorktree(clone, home, "task-1", attempt, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(metadata); !os.IsNotExist(err) {
+		t.Fatalf("linked worktree metadata still exists: %v", err)
+	}
+}
+
 func TestTeardownMigratesLegacyCompletionsBeforeAppending(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -55,7 +55,7 @@ func TestTeardownFailureAfterWorktreeReturnPreservesOwnershipEvidence(t *testing
 	}
 }
 
-func TestReleaseWorktreeRemovesLinkedWorktreeMetadata(t *testing.T) {
+func TestReleaseWorktreeKeepsPooledWorktreeMetadata(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
 		t.Fatal(err)
@@ -88,8 +88,8 @@ func TestReleaseWorktreeRemovesLinkedWorktreeMetadata(t *testing.T) {
 	if err := (&Runtime{deps: deps}).releaseWorktree(clone, home, "task-1", attempt, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(metadata); !os.IsNotExist(err) {
-		t.Fatalf("linked worktree metadata still exists: %v", err)
+	if _, err := os.Stat(metadata); err != nil {
+		t.Fatalf("pooled worktree metadata was removed: %v", err)
 	}
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -35,6 +35,19 @@ type Lease struct {
 	ID   string
 }
 
+type SlotSoundness struct {
+	Sound       bool
+	MetadataDir string
+	CommonDir   string
+	Failures    []string
+}
+
+type PoolEntry struct {
+	Path    string
+	Status  string
+	LeaseID string
+}
+
 type statusEntry struct {
 	Path    string `json:"path"`
 	Status  string `json:"status"`
@@ -288,13 +301,80 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 		args = append(args, "--lease-holder", leaseHolder)
 	}
 	args = withTreehouseRoot(clonePath, args...)
+	const maxUnsoundLeases = 128
+	seen := make(map[string]struct{})
+	var retired []string
+	for range maxUnsoundLeases {
+		lease, err := getLease(clonePath, args)
+		if err != nil {
+			if len(retired) > 0 {
+				return Lease{}, fmt.Errorf("%w; treehouse exhausted: %v", unsoundPoolError(clonePath, retired), err)
+			}
+			return Lease{}, err
+		}
+		pool, err := PoolStatus(clonePath)
+		if err != nil {
+			if !cloneOwnsWorktree(clonePath, lease.Path) {
+				return Lease{}, fmt.Errorf("inspect treehouse pool after acquisition: %w; refusing to return an unverified lease path %s", err, lease.Path)
+			}
+			if returnErr := ReturnLease(clonePath, lease.Path, lease.ID, true); returnErr != nil {
+				return Lease{}, fmt.Errorf("inspect treehouse pool after acquisition: %w; return lease: %v", err, returnErr)
+			}
+			return Lease{}, fmt.Errorf("inspect treehouse pool after acquisition: %w", err)
+		}
+		if !poolContains(pool, lease.Path) {
+			return Lease{}, fmt.Errorf("treehouse returned worktree outside its reported pool: %s", lease.Path)
+		}
+		soundness := CheckSoundness(clonePath, lease.Path)
+		if soundness.Sound {
+			return lease, nil
+		}
+		key, _ := filepath.Abs(lease.Path)
+		if _, ok := seen[key]; ok {
+			_ = ReturnLease(clonePath, lease.Path, lease.ID, true)
+			return Lease{}, unsoundPoolError(clonePath, append(retired, soundness.Failures...))
+		}
+		seen[key] = struct{}{}
+		if err := ReturnLease(clonePath, lease.Path, lease.ID, true); err != nil {
+			return Lease{}, fmt.Errorf("return unsound treehouse lease %s: %w", lease.Path, err)
+		}
+		foreign, err := retireSlot(clonePath, lease.Path, soundness)
+		if err != nil {
+			return Lease{}, err
+		}
+		retired = append(retired, fmt.Sprintf("%s: %s", lease.Path, strings.Join(soundness.Failures, ", ")))
+		if foreign != "" {
+			retired = append(retired, foreign)
+		}
+	}
+	return Lease{}, unsoundPoolError(clonePath, retired)
+}
+
+func poolContains(pool []PoolEntry, path string) bool {
+	for _, entry := range pool {
+		if gitrepo.SamePath(entry.Path, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneOwnsWorktree(clonePath, worktreePath string) bool {
+	info, err := os.Stat(filepath.Join(worktreePath, ".git"))
+	if err != nil || info.IsDir() {
+		return false
+	}
+	common, err := gitrepo.CommonDir(worktreePath)
+	return err == nil && gitrepo.SamePath(common, filepath.Join(clonePath, ".git"))
+}
+
+func getLease(clonePath string, args []string) (Lease, error) {
 	out, stderr, err := runCore("treehouse", clonePath, args...)
 	// Banners land on stderr ahead of the JSON, so the payload has to be read from stdout alone -
 	// CombinedOutput here corrupts every parse (atqamz/hand#21).
 	if err != nil {
 		return Lease{}, fmt.Errorf("treehouse get failed: %w: %s", err, strings.TrimSpace(string(stderr)))
 	}
-
 	var payload struct {
 		Path    string `json:"path"`
 		LeaseID string `json:"lease_id"`
@@ -305,20 +385,96 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 	if payload.Path == "" {
 		return Lease{}, fmt.Errorf("treehouse get returned no worktree path")
 	}
-	lease := Lease{Path: payload.Path, ID: payload.LeaseID}
-	if _, err := os.Stat(lease.Path); err == nil {
-		actual, err := gitrepo.CommonDir(lease.Path)
-		if err != nil {
-			_ = ReturnLease(clonePath, lease.Path, lease.ID, true)
-			return Lease{}, fmt.Errorf("treehouse get returned an unreadable worktree: %w", err)
-		}
-		expected := filepath.Join(clonePath, ".git")
-		if !gitrepo.SamePath(expected, actual) {
-			_ = ReturnLease(clonePath, lease.Path, lease.ID, true)
-			return Lease{}, fmt.Errorf("treehouse get returned worktree rooted in another Git repository: got %s, want %s", actual, expected)
+	return Lease{Path: payload.Path, ID: payload.LeaseID}, nil
+}
+
+func unsoundPoolError(clonePath string, findings []string) error {
+	return fmt.Errorf("treehouse pool for %s has no sound free slot: %s", clonePath, strings.Join(findings, "; "))
+}
+
+func ReadMetadataDir(worktreePath string) (string, error) {
+	return gitrepo.ReadGitDirFile(filepath.Join(worktreePath, ".git"))
+}
+
+func CheckSoundness(clonePath, worktreePath string) SlotSoundness {
+	result := SlotSoundness{}
+	metadata, err := ReadMetadataDir(worktreePath)
+	if err != nil {
+		result.Failures = append(result.Failures, fmt.Sprintf(".git does not resolve: %v", err))
+	} else {
+		result.MetadataDir = metadata
+		info, statErr := os.Stat(metadata)
+		if os.IsNotExist(statErr) {
+			result.Failures = append(result.Failures, "metadata directory does not exist")
+		} else if statErr != nil {
+			result.Failures = append(result.Failures, fmt.Sprintf("metadata directory cannot be inspected: %v", statErr))
+		} else if !info.IsDir() {
+			result.Failures = append(result.Failures, "metadata path is not a directory")
+		} else {
+			back, backErr := gitrepo.ReadWorktreeGitDir(filepath.Join(metadata, "gitdir"))
+			if backErr != nil {
+				result.Failures = append(result.Failures, fmt.Sprintf("metadata gitdir does not point back to this slot: %v", backErr))
+			} else if !gitrepo.SamePath(back, filepath.Join(worktreePath, ".git")) {
+				result.Failures = append(result.Failures, fmt.Sprintf("metadata gitdir does not point back to this slot: got %s", back))
+			}
 		}
 	}
-	return lease, nil
+	common, commonErr := gitrepo.CommonDir(worktreePath)
+	if commonErr != nil {
+		result.Failures = append(result.Failures, fmt.Sprintf("common directory cannot be resolved: %v", commonErr))
+	} else {
+		result.CommonDir = common
+		expected := filepath.Join(clonePath, ".git")
+		if !gitrepo.SamePath(common, expected) {
+			result.Failures = append(result.Failures, fmt.Sprintf("common directory is %s, want %s", common, expected))
+		}
+	}
+	result.Sound = len(result.Failures) == 0
+	return result
+}
+
+func RemoveMetadata(clonePath, worktreePath string) error {
+	gitFile := filepath.Join(worktreePath, ".git")
+	info, err := os.Stat(gitFile)
+	if errors.Is(err, os.ErrNotExist) || (err == nil && info.IsDir()) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect worktree Git file: %w", err)
+	}
+	metadata, err := ReadMetadataDir(worktreePath)
+	if err != nil {
+		return fmt.Errorf("read worktree Git file: %w", err)
+	}
+	expected := filepath.Join(clonePath, ".git", "worktrees")
+	rel, err := filepath.Rel(expected, metadata)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("refuse to remove worktree metadata outside the registered clone: %s", metadata)
+	}
+	if err := os.RemoveAll(metadata); err != nil {
+		return fmt.Errorf("remove worktree metadata %s: %w", metadata, err)
+	}
+	return nil
+}
+
+func retireSlot(clonePath, worktreePath string, soundness SlotSoundness) (string, error) {
+	if info, err := os.Stat(filepath.Join(worktreePath, ".git")); err == nil && info.IsDir() {
+		return "", fmt.Errorf("refuse to retire Git repository root %s", worktreePath)
+	}
+	if err := os.RemoveAll(worktreePath); err != nil {
+		return "", fmt.Errorf("retire unsound worktree %s: %w", worktreePath, err)
+	}
+	expected := filepath.Join(clonePath, ".git")
+	if soundness.CommonDir != "" && !gitrepo.SamePath(soundness.CommonDir, expected) {
+		return fmt.Sprintf("foreign Git registration for %s remains at %s; prune it by hand", worktreePath, soundness.CommonDir), nil
+	}
+	if soundness.CommonDir == "" {
+		return "", nil
+	}
+	if _, err := gitrepo.Run(clonePath, "worktree", "prune"); err != nil {
+		return "", fmt.Errorf("prune retired worktree metadata: %w", err)
+	}
+	return "", nil
 }
 
 // Reads the full commit object ID currently checked out by a leased worktree.
@@ -395,6 +551,18 @@ func treehouseStatus(clonePath, worktreePath string) ([]statusEntry, string) {
 		return nil, fmt.Sprintf("treehouse status output is not a JSON array: %v", err)
 	}
 	return entries, ""
+}
+
+func PoolStatus(clonePath string) ([]PoolEntry, error) {
+	entries, reason := treehouseStatus(clonePath, clonePath)
+	if reason != "" {
+		return nil, errors.New(reason)
+	}
+	pool := make([]PoolEntry, 0, len(entries))
+	for _, entry := range entries {
+		pool = append(pool, PoolEntry(entry))
+	}
+	return pool, nil
 }
 
 func withTreehouseRoot(clonePath string, args ...string) []string {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -370,12 +370,6 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 			retired = append(retired, foreign)
 		}
 	}
-	return Lease{}, unsoundPoolError(clonePath, retired)
-}
-
-func poolContains(pool []PoolEntry, path string) bool {
-	_, ok := poolEntry(pool, path)
-	return ok
 }
 
 func poolEntry(pool []PoolEntry, path string) (PoolEntry, bool) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -603,6 +603,11 @@ func canonicalPath(path string) string {
 	return filepath.Clean(abs)
 }
 
+// CanonicalPath exposes the path form used when comparing pool observations from different roots.
+func CanonicalPath(path string) string {
+	return canonicalPath(path)
+}
+
 func RemoveMetadata(clonePath, worktreePath string) error {
 	if pathWithin(canonicalPath(filepath.Join(clonePath, ".treehouse")), canonicalPath(worktreePath)) {
 		return nil
@@ -723,6 +728,12 @@ func treehouseStatus(clonePath, worktreePath string) ([]statusEntry, string) {
 		return nil, fmt.Sprintf("treehouse status output is not a JSON array: %v", err)
 	}
 	return entries, ""
+}
+
+// IsTreehouseUnavailable reports whether err reflects the treehouse binary itself being missing,
+// as opposed to an installed treehouse failing to report on a resolvable pool.
+func IsTreehouseUnavailable(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "treehouse is not executable")
 }
 
 func PoolStatus(clonePath string) ([]PoolEntry, error) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -46,6 +47,13 @@ type PoolEntry struct {
 	Path    string
 	Status  string
 	LeaseID string
+}
+
+type PoolSlot struct {
+	PoolRoot    string
+	Path        string
+	MetadataDir string
+	Soundness   SlotSoundness
 }
 
 type statusEntry struct {
@@ -431,6 +439,143 @@ func CheckSoundness(clonePath, worktreePath string) SlotSoundness {
 	}
 	result.Sound = len(result.Failures) == 0
 	return result
+}
+
+func PoolSearchRoots(fleetHome, clonePath string) []string {
+	roots := make([]string, 0, 3)
+	add := func(path string) {
+		for _, existing := range roots {
+			if gitrepo.SamePath(existing, path) {
+				return
+			}
+		}
+		roots = append(roots, filepath.Clean(path))
+	}
+	add(filepath.Join(clonePath, ".treehouse"))
+	add(filepath.Join(fleetHome, ".treehouse"))
+	if home, err := os.UserHomeDir(); err == nil {
+		add(filepath.Join(home, ".treehouse"))
+	}
+	return roots
+}
+
+func DiscoverPoolSlots(clonePath string, searchRoots ...string) ([]PoolSlot, error) {
+	expected := filepath.Join(clonePath, ".git")
+	slots := make([]PoolSlot, 0)
+	seenRoots := make(map[string]struct{}, len(searchRoots))
+	for _, searchRoot := range searchRoots {
+		root, err := filepath.Abs(searchRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve pool search root %q: %w", searchRoot, err)
+		}
+		root = filepath.Clean(root)
+		key := canonicalPath(root)
+		if _, seen := seenRoots[key]; seen {
+			continue
+		}
+		seenRoots[key] = struct{}{}
+		poolDirs, err := os.ReadDir(root)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspect pool search root %s: %w", root, err)
+		}
+		for _, poolDir := range poolDirs {
+			if !poolDir.IsDir() {
+				continue
+			}
+			poolPath := filepath.Join(root, poolDir.Name())
+			slotDirs, err := os.ReadDir(poolPath)
+			if err != nil {
+				return nil, fmt.Errorf("inspect pool %s: %w", poolPath, err)
+			}
+			for _, slotDir := range slotDirs {
+				if !slotDir.IsDir() {
+					continue
+				}
+				slotPath := filepath.Join(poolPath, slotDir.Name())
+				worktrees, err := os.ReadDir(slotPath)
+				if err != nil {
+					return nil, fmt.Errorf("inspect pool slot directory %s: %w", slotPath, err)
+				}
+				for _, worktree := range worktrees {
+					if !worktree.IsDir() {
+						continue
+					}
+					worktreePath := filepath.Join(slotPath, worktree.Name())
+					if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
+						if os.IsNotExist(err) {
+							continue
+						}
+						return nil, fmt.Errorf("inspect pool worktree %s: %w", worktreePath, err)
+					}
+					soundness := CheckSoundness(clonePath, worktreePath)
+					if !resolvesIntoClone(expected, soundness) {
+						continue
+					}
+					slots = append(slots, PoolSlot{
+						PoolRoot: poolPath, Path: worktreePath, MetadataDir: soundness.MetadataDir, Soundness: soundness,
+					})
+				}
+			}
+		}
+	}
+	return slots, nil
+}
+
+func resolvesIntoClone(expected string, soundness SlotSoundness) bool {
+	if soundness.CommonDir != "" && gitrepo.SamePath(soundness.CommonDir, expected) {
+		return true
+	}
+	return pathWithin(filepath.Join(expected, "worktrees"), soundness.MetadataDir)
+}
+
+func pathWithin(root, path string) bool {
+	if path == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func PoolSlotCollisions(slots []PoolSlot) [][]PoolSlot {
+	groups := make(map[string][]PoolSlot)
+	for _, slot := range slots {
+		if slot.MetadataDir == "" {
+			continue
+		}
+		key := canonicalPath(slot.MetadataDir)
+		groups[key] = append(groups[key], slot)
+	}
+	collisions := make([][]PoolSlot, 0)
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].PoolRoot == group[j].PoolRoot {
+				return group[i].Path < group[j].Path
+			}
+			return group[i].PoolRoot < group[j].PoolRoot
+		})
+		collisions = append(collisions, group)
+	}
+	sort.Slice(collisions, func(i, j int) bool {
+		return collisions[i][0].MetadataDir < collisions[j][0].MetadataDir
+	})
+	return collisions
+}
+
+func canonicalPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(abs)
 }
 
 func RemoveMetadata(clonePath, worktreePath string) error {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -625,7 +625,7 @@ func RemoveMetadata(clonePath, worktreePath string) error {
 	expected := filepath.Join(clonePath, ".git", "worktrees")
 	rel, err := filepath.Rel(expected, metadata)
 	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		return fmt.Errorf("refuse to remove worktree metadata outside the registered clone: %s", metadata)
+		return nil
 	}
 	if err := os.RemoveAll(metadata); err != nil {
 		return fmt.Errorf("remove worktree metadata %s: %w", metadata, err)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -331,6 +331,12 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 			return Lease{}, fmt.Errorf("inspect treehouse pool after acquisition: %w", err)
 		}
 		if !poolContains(pool, lease.Path) {
+			if cloneOwnsWorktree(clonePath, lease.Path) {
+				if returnErr := ReturnLease(clonePath, lease.Path, lease.ID, true); returnErr != nil {
+					return Lease{}, fmt.Errorf("treehouse acquired worktree %s but status omitted it; lease release failed: %w", lease.Path, returnErr)
+				}
+				return Lease{}, fmt.Errorf("treehouse acquired worktree %s but status omitted it; lease released", lease.Path)
+			}
 			return Lease{}, fmt.Errorf("treehouse returned worktree outside its reported pool: %s", lease.Path)
 		}
 		soundness := CheckSoundness(clonePath, lease.Path)
@@ -509,10 +515,6 @@ func DiscoverPoolSlots(clonePath string, searchRoots ...string) ([]PoolSlot, err
 							continue
 						}
 						return nil, fmt.Errorf("inspect pool worktree %s: %w", worktreePath, err)
-					}
-					metadata, metadataErr := ReadMetadataDir(worktreePath)
-					if metadataErr == nil && !pathWithin(filepath.Join(expected, "worktrees"), metadata) {
-						continue
 					}
 					soundness := CheckSoundness(clonePath, worktreePath)
 					if !resolvesIntoClone(expected, soundness) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -510,6 +510,10 @@ func DiscoverPoolSlots(clonePath string, searchRoots ...string) ([]PoolSlot, err
 						}
 						return nil, fmt.Errorf("inspect pool worktree %s: %w", worktreePath, err)
 					}
+					metadata, metadataErr := ReadMetadataDir(worktreePath)
+					if metadataErr == nil && !pathWithin(filepath.Join(expected, "worktrees"), metadata) {
+						continue
+					}
 					soundness := CheckSoundness(clonePath, worktreePath)
 					if !resolvesIntoClone(expected, soundness) {
 						continue

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -620,8 +620,7 @@ func RemoveMetadata(clonePath, worktreePath string) error {
 		return fmt.Errorf("read worktree Git file: %w", err)
 	}
 	expected := filepath.Join(clonePath, ".git", "worktrees")
-	rel, err := filepath.Rel(expected, metadata)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+	if !pathWithin(canonicalPath(expected), canonicalPath(metadata)) {
 		return nil
 	}
 	if err := os.RemoveAll(metadata); err != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -309,10 +309,9 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 		args = append(args, "--lease-holder", leaseHolder)
 	}
 	args = withTreehouseRoot(clonePath, args...)
-	const maxUnsoundLeases = 128
 	seen := make(map[string]struct{})
 	var retired []string
-	for range maxUnsoundLeases {
+	for {
 		lease, err := getLease(clonePath, args)
 		if err != nil {
 			if len(retired) > 0 {
@@ -356,6 +355,9 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 			return Lease{}, unsoundPoolError(clonePath, append(retired, soundness.Failures...))
 		}
 		seen[key] = struct{}{}
+		if !safeToRetireSlot(clonePath, lease.Path, soundness) {
+			return Lease{}, fmt.Errorf("refuse to mutate foreign unsound worktree %s", lease.Path)
+		}
 		if err := ReturnLease(clonePath, lease.Path, lease.ID, true); err != nil {
 			return Lease{}, fmt.Errorf("return unsound treehouse lease %s: %w", lease.Path, err)
 		}
@@ -392,6 +394,13 @@ func cloneOwnsWorktree(clonePath, worktreePath string) bool {
 	}
 	common, err := gitrepo.CommonDir(worktreePath)
 	return err == nil && gitrepo.SamePath(common, filepath.Join(clonePath, ".git"))
+}
+
+func safeToRetireSlot(clonePath, worktreePath string, soundness SlotSoundness) bool {
+	if soundness.CommonDir != "" {
+		return gitrepo.SamePath(soundness.CommonDir, filepath.Join(clonePath, ".git"))
+	}
+	return pathWithin(canonicalPath(filepath.Join(clonePath, ".treehouse")), canonicalPath(worktreePath))
 }
 
 func rejectAcquiredLease(clonePath string, lease Lease, reason error) error {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -397,10 +397,7 @@ func cloneOwnsWorktree(clonePath, worktreePath string) bool {
 }
 
 func safeToRetireSlot(clonePath, worktreePath string, soundness SlotSoundness) bool {
-	if soundness.CommonDir != "" {
-		return gitrepo.SamePath(soundness.CommonDir, filepath.Join(clonePath, ".git"))
-	}
-	return pathWithin(canonicalPath(filepath.Join(clonePath, ".treehouse")), canonicalPath(worktreePath))
+	return soundness.CommonDir != "" && gitrepo.SamePath(soundness.CommonDir, filepath.Join(clonePath, ".git"))
 }
 
 func rejectAcquiredLease(clonePath string, lease Lease, reason error) error {
@@ -562,10 +559,7 @@ func DiscoverPoolSlots(clonePath string, searchRoots ...string) ([]PoolSlot, err
 }
 
 func resolvesIntoClone(expected string, soundness SlotSoundness) bool {
-	if soundness.CommonDir != "" && gitrepo.SamePath(soundness.CommonDir, expected) {
-		return true
-	}
-	return pathWithin(filepath.Join(expected, "worktrees"), soundness.MetadataDir)
+	return soundness.CommonDir != "" && gitrepo.SamePath(soundness.CommonDir, expected)
 }
 
 func pathWithin(root, path string) bool {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -330,7 +330,8 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 			}
 			return Lease{}, fmt.Errorf("inspect treehouse pool after acquisition: %w", err)
 		}
-		if !poolContains(pool, lease.Path) {
+		entry, found := poolEntry(pool, lease.Path)
+		if !found {
 			if cloneOwnsWorktree(clonePath, lease.Path) {
 				if returnErr := ReturnLease(clonePath, lease.Path, lease.ID, true); returnErr != nil {
 					return Lease{}, fmt.Errorf("treehouse acquired worktree %s but status omitted it; lease release failed: %w", lease.Path, returnErr)
@@ -338,6 +339,12 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 				return Lease{}, fmt.Errorf("treehouse acquired worktree %s but status omitted it; lease released", lease.Path)
 			}
 			return Lease{}, fmt.Errorf("treehouse returned worktree outside its reported pool: %s", lease.Path)
+		}
+		if entry.Status != "leased" {
+			return Lease{}, rejectAcquiredLease(clonePath, lease, fmt.Errorf("treehouse reported acquired worktree %s as %s, not leased", lease.Path, entry.Status))
+		}
+		if lease.ID != "" && entry.LeaseID != lease.ID {
+			return Lease{}, rejectAcquiredLease(clonePath, lease, fmt.Errorf("treehouse reported acquired worktree %s with lease %s, want %s", lease.Path, entry.LeaseID, lease.ID))
 		}
 		soundness := CheckSoundness(clonePath, lease.Path)
 		if soundness.Sound {
@@ -365,12 +372,17 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 }
 
 func poolContains(pool []PoolEntry, path string) bool {
+	_, ok := poolEntry(pool, path)
+	return ok
+}
+
+func poolEntry(pool []PoolEntry, path string) (PoolEntry, bool) {
 	for _, entry := range pool {
 		if gitrepo.SamePath(entry.Path, path) {
-			return true
+			return entry, true
 		}
 	}
-	return false
+	return PoolEntry{}, false
 }
 
 func cloneOwnsWorktree(clonePath, worktreePath string) bool {
@@ -380,6 +392,16 @@ func cloneOwnsWorktree(clonePath, worktreePath string) bool {
 	}
 	common, err := gitrepo.CommonDir(worktreePath)
 	return err == nil && gitrepo.SamePath(common, filepath.Join(clonePath, ".git"))
+}
+
+func rejectAcquiredLease(clonePath string, lease Lease, reason error) error {
+	if !cloneOwnsWorktree(clonePath, lease.Path) {
+		return reason
+	}
+	if err := ReturnLease(clonePath, lease.Path, lease.ID, true); err != nil {
+		return fmt.Errorf("%v; lease release failed: %w", reason, err)
+	}
+	return fmt.Errorf("%v; lease released", reason)
 }
 
 func getLease(clonePath string, args []string) (Lease, error) {
@@ -585,6 +607,9 @@ func canonicalPath(path string) string {
 }
 
 func RemoveMetadata(clonePath, worktreePath string) error {
+	if pathWithin(canonicalPath(filepath.Join(clonePath, ".treehouse")), canonicalPath(worktreePath)) {
+		return nil
+	}
 	gitFile := filepath.Join(worktreePath, ".git")
 	info, err := os.Stat(gitFile)
 	if errors.Is(err, os.ErrNotExist) || (err == nil && info.IsDir()) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -249,6 +249,37 @@ func TestRemoveMetadataRemovesTheLinkedWorktreeMetadataDirectory(t *testing.T) {
 	}
 }
 
+func TestRemoveMetadataKeepsExternalLinkedWorktreeMetadata(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(t.TempDir(), "slot")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	metadata, err := ReadMetadataDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(t.TempDir(), "metadata")
+	if err := os.Rename(metadata, external); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ".git"), []byte("gitdir: "+external+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "gitdir"), []byte(filepath.Join(path, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "commondir"), []byte(filepath.Join(clone, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveMetadata(clone, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(external); err != nil {
+		t.Fatalf("external metadata was removed: %v", err)
+	}
+}
+
 func TestGetRetiresAnUnsoundLeaseAndAcquiresTheNextSoundSlot(t *testing.T) {
 	clone := filepath.Join(t.TempDir(), "clone")
 	faketool.InitRepo(t, clone)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -174,6 +174,39 @@ func TestDiscoverPoolSlotsFindsAliasesAcrossPoolRoots(t *testing.T) {
 	}
 }
 
+func TestDiscoverPoolSlotsFindsCloneOwnedSlotWithExternalMetadata(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	root := filepath.Join(t.TempDir(), ".treehouse")
+	path := filepath.Join(root, "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	metadata, err := ReadMetadataDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(t.TempDir(), "metadata")
+	if err := os.Rename(metadata, external); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ".git"), []byte("gitdir: "+external+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "gitdir"), []byte(filepath.Join(path, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "commondir"), []byte(filepath.Join(clone, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DiscoverPoolSlots(clone, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || !gitrepo.SamePath(got[0].Path, path) || !gitrepo.SamePath(got[0].MetadataDir, external) {
+		t.Fatalf("DiscoverPoolSlots() = %+v, want the clone-owned external-metadata slot", got)
+	}
+}
+
 func TestCheckSoundnessReportsMissingMetadataAndForeignCommonDirectory(t *testing.T) {
 	clone := filepath.Join(t.TempDir(), "clone")
 	foreign := filepath.Join(t.TempDir(), "foreign")
@@ -361,6 +394,29 @@ func TestGetRejectsAWorktreeOutsideTheReportedPool(t *testing.T) {
 	}
 	if _, err := os.Stat(outside); err != nil {
 		t.Fatalf("outside path was mutated: %v", err)
+	}
+}
+
+func TestGetReleasesACloneOwnedLeaseWhenStatusOmitsIt(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	log := filepath.Join(t.TempDir(), "treehouse.log")
+	faketool.Treehouse{Log: log, Slots: []string{path}, Responses: []faketool.TreehouseResponse{
+		{Command: "status", Stdout: "[]\n"},
+		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", path}},
+	}}.Install(t, faketool.Bin(t))
+
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "status omitted it; lease released") {
+		t.Fatalf("Get() error = %v, want acquisition and release report", err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), " get --lease --json --lease-holder hand:task-1") || !strings.Contains(string(data), " status --json") || !strings.Contains(string(data), " return --force --if-lease-id lease-1 "+path) {
+		t.Fatalf("treehouse invocations = %q, want acquisition, omitted status, and conditional release", data)
 	}
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -14,7 +14,11 @@ import (
 )
 
 func testGet(clonePath, leaseHolder string) (Lease, error) {
-	return Get(clonePath, leaseHolder)
+	args := []string{"get", "--lease", "--json"}
+	if leaseHolder != "" {
+		args = append(args, "--lease-holder", leaseHolder)
+	}
+	return getLease(clonePath, withTreehouseRoot(clonePath, args...))
 }
 
 func testObserveLease(worktreePath, expectedLeaseID string) LeaseObservation {
@@ -31,7 +35,15 @@ func testReturnLease(worktreePath, leaseID string, force bool) error {
 
 func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	t.Helper()
-	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
+	var payload struct {
+		Path string `json:"path"`
+	}
+	_ = json.Unmarshal([]byte(response.Stdout), &payload)
+	var slots []string
+	if payload.Path != "" {
+		slots = []string{payload.Path}
+	}
+	faketool.Treehouse{Slots: slots, Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
 }
 
 func mustJSON(t *testing.T, value any) string {
@@ -54,13 +66,17 @@ func writeCollisionTask(t *testing.T, home, id, path, leaseID string) {
 }
 
 func TestGetParsesLeasePathAndIdentity(t *testing.T) {
-	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1","lease_id":"5fe5412a4aabdeb85a148d6d73eb42d8"}`})
-	got, err := testGet(t.TempDir(), "hand:task-1")
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: mustJSON(t, map[string]string{"path": path, "lease_id": "5fe5412a4aabdeb85a148d6d73eb42d8"})})
+	got, err := Get(clone, "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := Lease{Path: "/tmp/wt-1", ID: "5fe5412a4aabdeb85a148d6d73eb42d8"}
-	if got != want {
+	want := Lease{Path: path, ID: "5fe5412a4aabdeb85a148d6d73eb42d8"}
+	if got != (Lease{Path: path, ID: "5fe5412a4aabdeb85a148d6d73eb42d8"}) {
 		t.Fatalf("got %+v, want %+v", got, want)
 	}
 }
@@ -69,14 +85,155 @@ func TestGetParsesLeasePathAndIdentity(t *testing.T) {
 // stay a usable lease rather than an error - CheckCollision falls back to the
 // path for it.
 func TestGetAcceptsAPayloadWithoutALeaseIdentity(t *testing.T) {
-	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: `{"path":"/tmp/wt-1"}`})
-	got, err := testGet(t.TempDir(), "hand:task-1")
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	writeFakeTreehouse(t, faketool.TreehouseResponse{Command: "get", Stdout: mustJSON(t, map[string]string{"path": path})})
+	got, err := Get(clone, "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != (Lease{Path: "/tmp/wt-1"}) {
+	if got != (Lease{Path: path}) {
 		t.Fatalf("got %+v, want path-only lease", got)
 	}
+}
+
+func TestCheckSoundnessAcceptsALinkedWorktreeOwnedByTheRegisteredClone(t *testing.T) {
+	home := t.TempDir()
+	clone := filepath.Join(home, "projects", "demo")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+
+	got := CheckSoundness(clone, path)
+	if !got.Sound {
+		t.Fatalf("CheckSoundness() = %+v, want sound", got)
+	}
+}
+
+func TestCheckSoundnessReportsAnAliasedMetadataDirectory(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "first", first)
+	runGit(t, clone, "worktree", "add", "-q", "-b", "second", second)
+	metadata, err := ReadMetadataDir(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(second, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, ".git"), []byte("gitdir: "+metadata+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := CheckSoundness(clone, second)
+	if got.Sound || !containsFailure(got, "metadata gitdir does not point back to this slot") {
+		t.Fatalf("CheckSoundness() = %+v, want aliased metadata failure", got)
+	}
+}
+
+func TestCheckSoundnessReportsMissingMetadataAndForeignCommonDirectory(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	foreign := filepath.Join(t.TempDir(), "foreign")
+	faketool.InitRepo(t, clone)
+	faketool.InitRepo(t, foreign)
+	missing := filepath.Join(t.TempDir(), "missing")
+	if err := os.MkdirAll(missing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(missing, ".git"), []byte("gitdir: "+filepath.Join(t.TempDir(), "gone")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	foreignSlot := filepath.Join(t.TempDir(), "foreign-slot")
+	runGit(t, foreign, "worktree", "add", "-q", "-b", "foreign-slot", foreignSlot)
+
+	missingGot := CheckSoundness(clone, missing)
+	if missingGot.Sound || !containsFailure(missingGot, "metadata directory does not exist") {
+		t.Fatalf("missing metadata CheckSoundness() = %+v", missingGot)
+	}
+	foreignGot := CheckSoundness(clone, foreignSlot)
+	if foreignGot.Sound || !containsFailure(foreignGot, "common directory is") {
+		t.Fatalf("foreign common directory CheckSoundness() = %+v", foreignGot)
+	}
+}
+
+func TestRemoveMetadataRemovesTheLinkedWorktreeMetadataDirectory(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(t.TempDir(), "slot")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	metadata, err := ReadMetadataDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveMetadata(clone, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(metadata); !os.IsNotExist(err) {
+		t.Fatalf("metadata directory still exists: %v", err)
+	}
+}
+
+func TestGetRetiresAnUnsoundLeaseAndAcquiresTheNextSoundSlot(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	bad := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	if err := os.MkdirAll(filepath.Dir(bad), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, ".git"), []byte("broken\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sound := filepath.Join(clone, ".treehouse", "pool", "2", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "sound", sound)
+	faketool.Treehouse{Slots: []string{bad, sound}}.Install(t, faketool.Bin(t))
+
+	got, err := Get(clone, "hand:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != sound {
+		t.Fatalf("Get() path = %q, want sound slot %q", got.Path, sound)
+	}
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Fatalf("unsound slot still exists: %v", err)
+	}
+}
+
+func TestGetFailsWithThePoolNamedWhenEverySlotIsUnsound(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	bad := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	if err := os.MkdirAll(filepath.Dir(bad), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, ".git"), []byte("broken\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Treehouse{Slots: []string{bad}}.Install(t, faketool.Bin(t))
+
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "treehouse pool for "+clone+" has no sound free slot") {
+		t.Fatalf("Get() error = %v, want a named exhausted pool", err)
+	}
+}
+
+func containsFailure(result SlotSoundness, want string) bool {
+	for _, failure := range result.Failures {
+		if strings.Contains(failure, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestHeadCommitReturnsTheWorktreeCommit(t *testing.T) {
@@ -100,11 +257,15 @@ func TestHeadCommitReturnsTheWorktreeCommit(t *testing.T) {
 }
 
 func TestGetPassesLeaseHolder(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
 	writeFakeTreehouse(t, faketool.TreehouseResponse{
 		Command: "get", Args: []string{"--lease", "--json", "--lease-holder", "hand:task-1"},
-		Stdout: `{"path":"/tmp/wt-1"}`,
+		Stdout: mustJSON(t, map[string]string{"path": path}),
 	})
-	if _, err := testGet(t.TempDir(), "hand:task-1"); err != nil {
+	if _, err := Get(clone, "hand:task-1"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -112,12 +273,12 @@ func TestGetPassesLeaseHolder(t *testing.T) {
 func TestGetScopesPoolToTheFleetHome(t *testing.T) {
 	home := t.TempDir()
 	clone := filepath.Join(home, "projects", "demo")
-	if err := os.MkdirAll(clone, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
 	writeFakeTreehouse(t, faketool.TreehouseResponse{
 		Command: "--root", Args: []string{clone, "get", "--lease", "--json", "--lease-holder", "hand:task-1"},
-		Stdout: `{"path":"/tmp/wt-1"}`,
+		Stdout: mustJSON(t, map[string]string{"path": path}),
 	})
 	if _, err := Get(clone, "hand:task-1"); err != nil {
 		t.Fatal(err)
@@ -130,12 +291,86 @@ func TestGetRejectsAWorktreeFromAnotherRegisteredClone(t *testing.T) {
 	foreign := filepath.Join(t.TempDir(), "demo")
 	faketool.InitRepo(t, clone)
 	faketool.InitRepo(t, foreign)
+	foreignSlot := filepath.Join(foreign, ".treehouse", "pool", "1", "demo")
+	runGit(t, foreign, "worktree", "add", "-q", "-b", "foreign-slot", foreignSlot)
 	faketool.Treehouse{Responses: []faketool.TreehouseResponse{
-		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": foreign, "lease_id": "lease-1"})},
-		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", foreign}},
+		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": foreignSlot, "lease_id": "lease-1"})},
+		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", foreignSlot}},
+	}, Slots: []string{foreignSlot}}.Install(t, faketool.Bin(t))
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "foreign Git registration") {
+		t.Fatalf("Get() error = %v, want a foreign registration report", err)
+	}
+	if _, err := os.Stat(foreignSlot); !os.IsNotExist(err) {
+		t.Fatalf("foreign slot was not retired: %v", err)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("foreign repository was removed: %v", err)
+	}
+}
+
+func TestGetRejectsAWorktreeOutsideTheReportedPool(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	allowed := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "allowed", allowed)
+	outside := filepath.Join(t.TempDir(), "outside")
+	faketool.InitRepo(t, outside)
+	faketool.Treehouse{Slots: []string{allowed}, Responses: []faketool.TreehouseResponse{
+		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": outside, "lease_id": "lease-1"})},
 	}}.Install(t, faketool.Bin(t))
-	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "another Git repository") {
-		t.Fatalf("Get() error = %v, want a registered-clone mismatch", err)
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "outside its reported pool") {
+		t.Fatalf("Get() error = %v, want an outside-pool refusal", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside path was mutated: %v", err)
+	}
+}
+
+func TestGetReturnsLeaseWhenPoolStatusFails(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+	log := filepath.Join(t.TempDir(), "treehouse.log")
+	faketool.Treehouse{Log: log, Slots: []string{path}, Responses: []faketool.TreehouseResponse{
+		{Command: "status", Stderr: "status unavailable\n", Exit: 1},
+		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": path, "lease_id": "lease-1"})},
+		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", path}},
+	}}.Install(t, faketool.Bin(t))
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "status unavailable") {
+		t.Fatalf("Get() error = %v, want pool status failure", err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), " return --force --if-lease-id lease-1 "+path) {
+		t.Fatalf("treehouse invocations = %q, want the held lease returned", data)
+	}
+}
+
+func TestGetDoesNotReturnAnUnverifiedForeignLeaseWhenPoolStatusFails(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	foreign := filepath.Join(t.TempDir(), "foreign")
+	faketool.InitRepo(t, clone)
+	faketool.InitRepo(t, foreign)
+	path := filepath.Join(foreign, ".treehouse", "pool", "1", "demo")
+	runGit(t, foreign, "worktree", "add", "-q", "-b", "slot", path)
+	log := filepath.Join(t.TempDir(), "treehouse.log")
+	faketool.Treehouse{Log: log, Slots: []string{path}, Responses: []faketool.TreehouseResponse{
+		{Command: "status", Stderr: "status unavailable\n", Exit: 1},
+		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": path, "lease_id": "lease-1"})},
+		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", path}},
+	}}.Install(t, faketool.Bin(t))
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "refusing to return an unverified lease path") {
+		t.Fatalf("Get() error = %v, want an unverified foreign lease refusal", err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), " return ") {
+		t.Fatalf("treehouse invocations = %q, want no return against the foreign repository", data)
 	}
 }
 
@@ -327,11 +562,13 @@ func TestObserveCleanlinessIncludesUntrackedFiles(t *testing.T) {
 }
 
 func TestObserveLeaseRunsStatusFromTheWorktreeRepository(t *testing.T) {
-	worktreePath := filepath.Join(t.TempDir(), "worktree")
-	faketool.InitRepo(t, worktreePath)
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	worktreePath := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "slot", worktreePath)
 	faketool.Treehouse{Slots: []string{worktreePath}}.Install(t, faketool.Bin(t))
 
-	lease, err := testGet(worktreePath, "hand:task-1")
+	lease, err := Get(clone, "hand:task-1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -3,6 +3,7 @@ package worktree
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -395,18 +396,55 @@ func TestGetRejectsAWorktreeFromAnotherRegisteredClone(t *testing.T) {
 	faketool.InitRepo(t, foreign)
 	foreignSlot := filepath.Join(foreign, ".treehouse", "pool", "1", "demo")
 	runGit(t, foreign, "worktree", "add", "-q", "-b", "foreign-slot", foreignSlot)
-	faketool.Treehouse{Responses: []faketool.TreehouseResponse{
+	log := filepath.Join(t.TempDir(), "treehouse.log")
+	faketool.Treehouse{Log: log, Responses: []faketool.TreehouseResponse{
 		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": foreignSlot, "lease_id": "lease-1"})},
+		{Command: "status", Stdout: mustJSON(t, []map[string]string{{"path": foreignSlot, "status": "leased", "lease_id": "lease-1"}})},
 		{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", foreignSlot}},
 	}, Slots: []string{foreignSlot}}.Install(t, faketool.Bin(t))
-	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "foreign Git registration") {
-		t.Fatalf("Get() error = %v, want a foreign registration report", err)
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "refuse to mutate foreign unsound worktree") {
+		t.Fatalf("Get() error = %v, want a foreign mutation refusal", err)
 	}
-	if _, err := os.Stat(foreignSlot); !os.IsNotExist(err) {
-		t.Fatalf("foreign slot was not retired: %v", err)
+	if _, err := os.Stat(foreignSlot); err != nil {
+		t.Fatalf("foreign slot was mutated: %v", err)
 	}
 	if _, err := os.Stat(foreign); err != nil {
 		t.Fatalf("foreign repository was removed: %v", err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), " return ") {
+		t.Fatalf("treehouse invocations = %q, want no foreign mutation", data)
+	}
+}
+
+func TestGetExaminesMoreThan128UnsoundSlots(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	slots := make([]string, 0, 130)
+	for i := 0; i < 129; i++ {
+		path := filepath.Join(clone, ".treehouse", "pool", fmt.Sprintf("%03d", i), "demo")
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, ".git"), []byte("broken\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		slots = append(slots, path)
+	}
+	sound := filepath.Join(clone, ".treehouse", "pool", "129", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "sound", sound)
+	slots = append(slots, sound)
+	faketool.Treehouse{Slots: slots}.Install(t, faketool.Bin(t))
+
+	got, err := Get(clone, "hand:task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != sound {
+		t.Fatalf("Get() path = %q, want sound slot %q", got.Path, sound)
 	}
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -37,14 +37,24 @@ func testReturnLease(worktreePath, leaseID string, force bool) error {
 func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	t.Helper()
 	var payload struct {
-		Path string `json:"path"`
+		Path    string `json:"path"`
+		LeaseID string `json:"lease_id"`
 	}
 	_ = json.Unmarshal([]byte(response.Stdout), &payload)
 	var slots []string
+	var held []string
+	leaseIDs := map[string]string{}
+	noLeaseIdentity := false
 	if payload.Path != "" {
 		slots = []string{payload.Path}
+		held = []string{payload.Path}
+		if payload.LeaseID != "" {
+			leaseIDs[payload.Path] = payload.LeaseID
+		} else {
+			noLeaseIdentity = true
+		}
 	}
-	faketool.Treehouse{Slots: slots, Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
+	faketool.Treehouse{Slots: slots, Held: held, LeaseIDs: leaseIDs, NoLeaseIdentity: noLeaseIdentity, Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
 }
 
 func mustJSON(t *testing.T, value any) string {
@@ -355,8 +365,8 @@ func TestGetFailsWithThePoolNamedWhenEverySlotIsUnsound(t *testing.T) {
 	}
 	faketool.Treehouse{Slots: []string{bad}}.Install(t, faketool.Bin(t))
 
-	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "treehouse pool for "+clone+" has no sound free slot") {
-		t.Fatalf("Get() error = %v, want a named exhausted pool", err)
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "refuse to mutate foreign unsound worktree") {
+		t.Fatalf("Get() error = %v, want an ownership refusal", err)
 	}
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -420,6 +420,41 @@ func TestGetReleasesACloneOwnedLeaseWhenStatusOmitsIt(t *testing.T) {
 	}
 }
 
+func TestGetRejectsStatusThatDoesNotProveTheAcquiredLease(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{name: "available", status: "available", want: "not leased"},
+		{name: "different lease", status: "leased", want: "with lease lease-other"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clone := filepath.Join(t.TempDir(), "clone")
+			faketool.InitRepo(t, clone)
+			path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+			runGit(t, clone, "worktree", "add", "-q", "-b", "slot", path)
+			log := filepath.Join(t.TempDir(), "treehouse.log")
+			status := mustJSON(t, []map[string]string{{"path": path, "status": test.status, "lease_id": "lease-other"}})
+			faketool.Treehouse{Log: log, Slots: []string{path}, Responses: []faketool.TreehouseResponse{
+				{Command: "status", Stdout: status},
+				{Command: "return", Args: []string{"--force", "--if-lease-id", "lease-1", path}},
+			}}.Install(t, faketool.Bin(t))
+
+			if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Get() error = %v, want status ownership failure", err)
+			}
+			data, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(data), " return --force --if-lease-id lease-1 "+path) {
+				t.Fatalf("treehouse invocations = %q, want conditional release", data)
+			}
+		})
+	}
+}
+
 func TestGetReturnsLeaseWhenPoolStatusFails(t *testing.T) {
 	clone := filepath.Join(t.TempDir(), "clone")
 	faketool.InitRepo(t, clone)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	gitrepo "github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/faketool"
+	gitrepo "github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/state"
 )
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -3,7 +3,6 @@ package worktree
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -208,6 +207,38 @@ func TestDiscoverPoolSlotsFindsCloneOwnedSlotWithExternalMetadata(t *testing.T) 
 	}
 }
 
+func TestDiscoverPoolSlotsExcludesForeignCommonDirectoryUnderCloneMetadata(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	foreign := filepath.Join(t.TempDir(), "foreign")
+	faketool.InitRepo(t, clone)
+	faketool.InitRepo(t, foreign)
+	metadata := filepath.Join(clone, ".git", "worktrees", "foreign")
+	if err := os.MkdirAll(metadata, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ".git"), []byte("gitdir: "+metadata+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metadata, "gitdir"), []byte(filepath.Join(path, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(metadata, "commondir"), []byte(filepath.Join(foreign, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DiscoverPoolSlots(clone, filepath.Join(clone, ".treehouse"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("DiscoverPoolSlots() = %+v, want no foreign slot", got)
+	}
+}
+
 func TestCheckSoundnessReportsMissingMetadataAndForeignCommonDirectory(t *testing.T) {
 	clone := filepath.Join(t.TempDir(), "clone")
 	foreign := filepath.Join(t.TempDir(), "foreign")
@@ -285,13 +316,12 @@ func TestGetRetiresAnUnsoundLeaseAndAcquiresTheNextSoundSlot(t *testing.T) {
 	clone := filepath.Join(t.TempDir(), "clone")
 	faketool.InitRepo(t, clone)
 	bad := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
-	if err := os.MkdirAll(filepath.Dir(bad), 0o755); err != nil {
+	runGit(t, clone, "worktree", "add", "-q", "-b", "bad", bad)
+	badMetadata, err := ReadMetadataDir(bad)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(bad, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(bad, ".git"), []byte("broken\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(badMetadata, "gitdir"), []byte(filepath.Join(t.TempDir(), ".git")+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	sound := filepath.Join(clone, ".treehouse", "pool", "2", "demo")
@@ -420,31 +450,38 @@ func TestGetRejectsAWorktreeFromAnotherRegisteredClone(t *testing.T) {
 	}
 }
 
-func TestGetExaminesMoreThan128UnsoundSlots(t *testing.T) {
+func TestGetDoesNotMutateMalformedUnownedSlot(t *testing.T) {
 	clone := filepath.Join(t.TempDir(), "clone")
 	faketool.InitRepo(t, clone)
-	slots := make([]string, 0, 130)
-	for i := 0; i < 129; i++ {
-		path := filepath.Join(clone, ".treehouse", "pool", fmt.Sprintf("%03d", i), "demo")
-		if err := os.MkdirAll(path, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(path, ".git"), []byte("broken\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		slots = append(slots, path)
+	path := filepath.Join(clone, ".treehouse", "pool", "1", "demo")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	sound := filepath.Join(clone, ".treehouse", "pool", "129", "demo")
-	runGit(t, clone, "worktree", "add", "-q", "-b", "sound", sound)
-	slots = append(slots, sound)
-	faketool.Treehouse{Slots: slots}.Install(t, faketool.Bin(t))
+	if err := os.WriteFile(filepath.Join(path, ".git"), []byte("not a git pointer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(path, "important")
+	if err := os.WriteFile(marker, []byte("preserve\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(t.TempDir(), "treehouse.log")
+	faketool.Treehouse{Log: log, Slots: []string{path}, Responses: []faketool.TreehouseResponse{
+		{Command: "get", Stdout: mustJSON(t, map[string]string{"path": path, "lease_id": "lease-1"})},
+		{Command: "status", Stdout: mustJSON(t, []map[string]string{{"path": path, "status": "leased", "lease_id": "lease-1"}})},
+	}}.Install(t, faketool.Bin(t))
 
-	got, err := Get(clone, "hand:task-1")
+	if _, err := Get(clone, "hand:task-1"); err == nil || !strings.Contains(err.Error(), "refuse to mutate foreign unsound worktree") {
+		t.Fatalf("Get() error = %v, want ownership refusal", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("malformed unowned slot was mutated: %v", err)
+	}
+	data, err := os.ReadFile(log)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Path != sound {
-		t.Fatalf("Get() path = %q, want sound slot %q", got.Path, sound)
+	if strings.Contains(string(data), " return ") {
+		t.Fatalf("treehouse invocations = %q, want no return", data)
 	}
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	gitrepo "github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -133,6 +134,43 @@ func TestCheckSoundnessReportsAnAliasedMetadataDirectory(t *testing.T) {
 	got := CheckSoundness(clone, second)
 	if got.Sound || !containsFailure(got, "metadata gitdir does not point back to this slot") {
 		t.Fatalf("CheckSoundness() = %+v, want aliased metadata failure", got)
+	}
+}
+
+func TestDiscoverPoolSlotsFindsAliasesAcrossPoolRoots(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "clone")
+	faketool.InitRepo(t, clone)
+	first := filepath.Join(clone, ".treehouse", "pool-a", "1", "demo")
+	secondRoot := filepath.Join(t.TempDir(), ".treehouse")
+	second := filepath.Join(secondRoot, "pool-b", "1", "demo")
+	runGit(t, clone, "worktree", "add", "-q", "-b", "first", first)
+	runGit(t, clone, "worktree", "add", "-q", "-b", "second", second)
+	metadata, err := ReadMetadataDir(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(second, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, ".git"), []byte("gitdir: "+metadata+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DiscoverPoolSlots(clone, filepath.Join(clone, ".treehouse"), secondRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("DiscoverPoolSlots() = %+v, want both pool slots", got)
+	}
+	collisions := PoolSlotCollisions(got)
+	if len(collisions) != 1 || len(collisions[0]) != 2 {
+		t.Fatalf("PoolSlotCollisions() = %+v, want one two-slot collision", collisions)
+	}
+	for _, slot := range got {
+		if !gitrepo.SamePath(slot.MetadataDir, metadata) {
+			t.Fatalf("slot %+v has metadata target %q, want %q", slot, slot.MetadataDir, metadata)
+		}
 	}
 }
 

--- a/tests/e2e/brief_tier_test.go
+++ b/tests/e2e/brief_tier_test.go
@@ -159,9 +159,10 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("# report\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(home, "projects", "demo"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	newWorktree := filepath.Join(home, "wt-ship-new")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "ship", newWorktree)
 	writeTaskAttempt(t, home, state.Task{
 		ID: "task-1", Project: "demo", Kind: state.KindScout,
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
@@ -173,7 +174,7 @@ func TestPromoteHonorsBriefDeclaredTier(t *testing.T) {
 	// one, and hands the scout's worktree back to the pool that leased it.
 	launchLog := filepath.Join(t.TempDir(), "launch.log")
 	dir := binDir(t)
-	writeFakeTreehouse(t, dir, filepath.Join(home, "wt-ship-new"), filepath.Join(home, "wt-scout-old"))
+	writeFakeTreehouse(t, dir, newWorktree, filepath.Join(home, "wt-scout-old"))
 	fleetID, err := state.FleetID(home)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,9 +20,9 @@ func setupCollisionHome(t *testing.T) (string, string) {
 	writeBrief(t, home, "task-2")
 
 	clonePath := filepath.Join(home, "projects", "demo")
-	if err := os.MkdirAll(clonePath, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	initGitRepo(t, clonePath)
+	sharedWorktree := filepath.Join(home, "wt-shared")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "shared", sharedWorktree)
 
 	dir := binDir(t)
 	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})

--- a/tests/e2e/gate_visibility_test.go
+++ b/tests/e2e/gate_visibility_test.go
@@ -91,6 +91,9 @@ func TestStatusFlagsAShippedPRThatNeverRanThroughTheGate(t *testing.T) {
 	if added.code != 0 {
 		t.Fatalf("project add: exit %d, stderr %q", added.code, added.stderr)
 	}
+	clonePath := filepath.Join(home, "projects", "demo")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "ship-login-fix", worktree)
+	writeFakeTreehouse(t, dir, worktree)
 	writeBrief(t, home, "ship-login-fix")
 
 	spawned := runHand(t, home, "spawn", "ship-login-fix", "demo")

--- a/tests/e2e/promote_test.go
+++ b/tests/e2e/promote_test.go
@@ -3,12 +3,14 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 )
@@ -21,9 +23,7 @@ func TestPromoteScoutToShip(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 
 	clonePath := filepath.Join(home, "projects", "demo")
-	if err := os.MkdirAll(clonePath, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	initGitRepo(t, clonePath)
 
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
 		t.Fatal(err)
@@ -43,12 +43,10 @@ func TestPromoteScoutToShip(t *testing.T) {
 
 	dir := binDir(t)
 	newWorktree := filepath.Join(home, "wt-ship-new")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "ship", newWorktree)
 	invocationLog := filepath.Join(t.TempDir(), "invocations.log")
-	// Return (worktree.go) only checks CombinedOutput's error on success, never its content, so the "ok" line
-	// stands in harmlessly for real treehouse return's actual (silent) output; likewise "pane run" below is a
-	// void command whose real success is empty stdout (callVoid doc, client.go), and it checks only env.Error.
-	writeFakeDispatch(t, dir, "treehouse", invocationLog, "$1", `  get) printf '{"path":"%s","lease_id":"lease-new"}\n' `+shellSingleQuote(newWorktree)+` ;;
-  return) echo ok ;;`)
+	faketool.Treehouse{Slots: []string{newWorktree}, Held: []string{oldWorktree}, Log: invocationLog,
+		Responses: []faketool.TreehouseResponse{{Command: "get", Stdout: fmt.Sprintf("{\"path\":%q,\"lease_id\":\"lease-new\"}", newWorktree)}}}.Install(t, dir)
 	// The scout's old workspace holds a second tab, so releasing the scout is a
 	// tab close rather than closeTaskTab's sole-tab workspace-close shortcut.
 	writeFakeDispatch(t, dir, "herdr", invocationLog, "$1 $2", `  "session list") printf '{"sessions":[{"name":"%s","running":true}]}\n' "$session_name" ;;

--- a/tests/e2e/reopen_test.go
+++ b/tests/e2e/reopen_test.go
@@ -48,9 +48,11 @@ func TestReopenIsTheOnlyWayBackFromATerminalTask(t *testing.T) {
 	initGitRepo(t, clonePath)
 	worktree := filepath.Join(home, "wt-task-1")
 	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
+	nextWorktree := filepath.Join(home, "wt-task-2")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-2-branch", nextWorktree)
 
 	dir := binDir(t)
-	writeFakeTreehouse(t, dir, worktree)
+	faketool.Treehouse{Slots: []string{worktree, nextWorktree}}.Install(t, dir)
 	// Two workspaces, because teardown closes the first attempt's: the reopened attempt is dispatched into
 	// herdr as freshly as the spawn was, not reattached to the pane the torn-down attempt left behind.
 	faketool.Herdr{

--- a/tests/e2e/runtime_hardening_test.go
+++ b/tests/e2e/runtime_hardening_test.go
@@ -99,10 +99,12 @@ func TestReopenUsesCurrentRouteWithoutMutatingHistoricalAttempt(t *testing.T) {
 	plannedAgainst := strings.TrimSpace(runGitIn(t, clonePath, "rev-parse", "HEAD"))
 	worktree := filepath.Join(home, "wt-task-1")
 	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-1-branch", worktree)
+	nextWorktree := filepath.Join(home, "wt-task-2")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "task-2-branch", nextWorktree)
 
 	dir := binDir(t)
 	writeFakeBin(t, dir, "claude", "exit 0\n")
-	faketool.Treehouse{Slots: []string{worktree}}.Install(t, dir)
+	faketool.Treehouse{Slots: []string{worktree, nextWorktree}}.Install(t, dir)
 	faketool.Herdr{
 		Creates: []faketool.HerdrWorkspace{
 			{ID: "workspace-1", Label: "demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: "1", Pane: "pane-1"}}},


### PR DESCRIPTION
## Intent

Complete atqamz/hand#412 pool-slot integrity for criteria A-D: guard clone-scoped Treehouse pool slot soundness and lease recovery, make hand doctor inspect every pool root that resolves into each registered clone and report many-to-one metadata-target aliases by pool path and slot, and keep legacy pools read-only and out of acquisition. Leave criterion E, unregistered Fleet-id lease handling, out of scope for issue #432. Preserve the merged origin/main changes from atqamz/hand#429, validate fixtures without network access, run lint, race-enabled tests, and e2e, and deliver through the no-mistakes gate to the existing PR without merging it.

## What Changed

- Hardened clone-scoped Treehouse lease acquisition by validating pool status, lease ownership, and linked-worktree soundness, with recovery and safe retirement for invalid slots.
- Extended `hand doctor` to inspect pool roots resolving into registered clones and report unsound slots, including leased slots, plus metadata-target aliases across pool paths and slots.
- Kept legacy pools out of acquisition and preserved pooled worktree metadata during teardown, with expanded offline fixture, unit, and end-to-end coverage.

## Risk Assessment

✅ Low: The reviewed changes satisfy the stated pool ownership, discovery, alias reporting, lease recovery, and metadata-preservation requirements without a substantiated remaining source defect.

## Testing

Race-enabled worktree/runtime tests, doctor regressions, offline Treehouse contracts, and selected teardown e2e flows passed. No UI artifact was applicable.

- Outcome: ⚠️ 1 warning across 1 run (8m59s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"06e4f5eadeff4dfc3543352a39de2808c05399c6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5) ✅</summary>

- 🚨 `internal/worktree/worktree.go:514` - Criterion requires doctor to inspect every pool root resolving into a registered clone and report aliases. At line 514, any slot whose metadata target is outside `&lt;clone&gt;/.git/worktrees` is skipped before `CheckSoundness`, even when its common Git directory resolves to the registered clone. Such slots, and aliases among them, are therefore silently omitted.
- 🚨 `internal/worktree/worktree.go:333` - If acquisition succeeds but `treehouse status` omits the returned path, `Get` returns at line 334 without releasing the lease. A clone-owned path can be safely returned conditionally by the lease ID, while foreign paths must retain the current no-mutation protection; otherwise a status race leaves a permanently held slot.

🔧 Fix: Fixed pool discovery and omitted-lease recovery
2 errors still open:

- 🚨 `internal/runtime/teardown.go:320` - After a successful return, this deletes the linked-worktree metadata that the Treehouse pool needs to reuse the slot. A later acquisition receives the same path, CheckSoundness reports missing metadata, and the slot is retired, permanently shrinking pool capacity. Keep metadata for pooled slots or remove the slot from Treehouse before deleting it.
- 🚨 `internal/worktree/worktree.go:333` - The status verification checks only whether the acquired path appears, ignoring Status and LeaseID. If status races and reports the slot as available or leased under another identity, this returns the lease anyway, allowing use of an unowned or recycled worktree. Validate the matching leased state and lease ID at this shared boundary.

🔧 Fix: Preserved pooled metadata and validated acquired lease ownership
1 error still open:

- 🚨 `internal/runtime/teardown.go:320` - After successfully returning a clone-owned worktree, this calls `RemoveMetadata`. For a valid slot whose metadata lives outside `&lt;clone&gt;/.git/worktrees` (a case the new discovery logic explicitly accepts), `RemoveMetadata` returns an error, teardown records the resource as ambiguous, and future retries refuse because the lease is already absent. This permanently strands the attempt after releasing its slot; cleanup must handle external metadata without converting a successful return into unretryable ambiguity.

🔧 Fix: Handled external metadata cleanup without stranding teardown
2 issues (1 error, 1 warning) still open:

- 🚨 `internal/worktree/worktree.go:640` - After `CheckSoundness` identifies a returned path as rooted in another repository, `Get` still calls `retireSlot`, whose `os.RemoveAll(worktreePath)` deletes that foreign worktree. A corrupted or misreported pool can therefore destroy another clone&#39;s checked-out worktree; refuse mutation for non-clone-owned paths before returning or retiring them.
- ⚠️ `internal/worktree/worktree.go:312` - The fixed upper bound makes acquisition fail after 128 unsound slots even when a later sound slot exists. Treehouse pool size is configurable, so a valid pool with more than 128 retired/unsound entries can incorrectly report exhaustion and leave usable capacity undiscovered.

🔧 Fix: Protected foreign worktrees and removed acquisition cap
2 errors still open:

- 🚨 `internal/worktree/worktree.go:568` - Criterion requires doctor to distinguish slots resolving elsewhere from clone-owned slots. At line 568, a slot whose CommonDir resolves to another repository is nevertheless included when its metadata path lies under the inspected clone&#39;s .git/worktrees, causing false unsoundness and alias reports.
- 🚨 `internal/worktree/worktree.go:403` - A foreign worktree placed under the clone&#39;s .treehouse pool with an unreadable or malformed .git has CommonDir empty, so the fallback at line 403 permits ReturnLease followed by retireSlot and os.RemoveAll. This still allows deletion of a foreign worktree; an unproven repository owner must remain non-mutated.

🔧 Fix: Restricted ownership to CommonDir and protected malformed slots
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `cmd` - Broad cmd tests include unrelated cases requiring unavailable gh/no-mistakes integrations; issue-specific cmd tests passed.
- `go test -tags=test -race ./internal/worktree ./internal/runtime`
- <code>Issue-specific doctor tests in `./cmd`</code>
- `Offline Treehouse contract tests`
- `Selected teardown e2e tests`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
