### PR TITLE
test(store): reduce fsync cost for test databases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Test
-        run: go test -tags=test -race ./...
+        # 30m covers the measured 4x Windows runner variance while keeping a real hang actionable.
+        run: go test -tags=test -race -timeout=30m ./...
       - name: Build
         run: go build -o hand .
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" .
 
 test:
-	SECONDHAND_HOME=$$(mktemp -d) go test -tags=test -race ./...
+	# 30m covers the measured 4x Windows runner variance while keeping a real hang actionable.
+	SECONDHAND_HOME=$$(mktemp -d) go test -tags=test -race -timeout=30m ./...
 
 fmt:
 	gofmt -w .

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -177,7 +177,7 @@ func OpenReadOnlyAt(path string) (*Registry, error) {
 }
 
 func open(path string, readOnly bool) (*sql.DB, error) {
-	query := "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate"
+	query := "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate" + sqliteTestPragmas
 	if readOnly {
 		query = "?mode=ro&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_pragma=query_only(1)"
 	}

--- a/internal/registry/sqlite_pragmas_prod.go
+++ b/internal/registry/sqlite_pragmas_prod.go
@@ -1,0 +1,5 @@
+//go:build !test
+
+package registry
+
+const sqliteTestPragmas = ""

--- a/internal/registry/sqlite_pragmas_testmode.go
+++ b/internal/registry/sqlite_pragmas_testmode.go
@@ -1,0 +1,5 @@
+//go:build test
+
+package registry
+
+const sqliteTestPragmas = "&_pragma=journal_mode(MEMORY)&_pragma=synchronous(OFF)"

--- a/internal/registry/sqlite_testmode_test.go
+++ b/internal/registry/sqlite_testmode_test.go
@@ -1,0 +1,32 @@
+//go:build test
+
+package registry
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenUsesCheapDurabilityInTestBuild(t *testing.T) {
+	db, err := open(filepath.Join(t.TempDir(), "registry.db"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "memory" {
+		t.Fatalf("journal mode = %q, want memory", journalMode)
+	}
+
+	var synchronous int
+	if err := db.QueryRow("PRAGMA synchronous").Scan(&synchronous); err != nil {
+		t.Fatal(err)
+	}
+	if synchronous != 0 {
+		t.Fatalf("synchronous = %d, want 0", synchronous)
+	}
+}

--- a/internal/store/sqlite_pragmas_prod.go
+++ b/internal/store/sqlite_pragmas_prod.go
@@ -1,0 +1,5 @@
+//go:build !test
+
+package store
+
+const sqliteTestPragmas = ""

--- a/internal/store/sqlite_pragmas_testmode.go
+++ b/internal/store/sqlite_pragmas_testmode.go
@@ -1,0 +1,5 @@
+//go:build test
+
+package store
+
+const sqliteTestPragmas = "&_pragma=journal_mode(MEMORY)&_pragma=synchronous(OFF)"

--- a/internal/store/sqlite_testmode_test.go
+++ b/internal/store/sqlite_testmode_test.go
@@ -1,0 +1,25 @@
+//go:build test
+
+package store
+
+import "testing"
+
+func TestOpenUsesCheapDurabilityInTestBuild(t *testing.T) {
+	db, _ := openTemp(t)
+
+	var journalMode string
+	if err := db.sql.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "memory" {
+		t.Fatalf("journal mode = %q, want memory", journalMode)
+	}
+
+	var synchronous int
+	if err := db.sql.QueryRow("PRAGMA synchronous").Scan(&synchronous); err != nil {
+		t.Fatal(err)
+	}
+	if synchronous != 0 {
+		t.Fatalf("synchronous = %d, want 0", synchronous)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -410,7 +410,7 @@ func open(path string) (*sql.DB, error) {
 	}
 	// The pragmas need a file: URI, and a URI means sqlite reads `%`, `#` and
 	// `?` in the fleet home's path as syntax rather than as filename.
-	uri := "file:" + (&url.URL{Path: path}).EscapedPath() + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate"
+	uri := "file:" + (&url.URL{Path: path}).EscapedPath() + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate" + sqliteTestPragmas
 	db, err := sql.Open("sqlite", uri)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)


### PR DESCRIPTION
## Summary

- Use `journal_mode=MEMORY` and `synchronous=OFF` only for writable SQLite connections in `-tags=test` builds, covering `internal/store` and `internal/registry`.
- Keep production helpers empty and read-only paths unchanged, preserving production rollback-journal/FULL durability.
- Set the unit-test timeout to 30m in `Makefile` and `.github/workflows/ci.yaml`; e2e and contract targets are unchanged.

Fixes atqamz/hand#416
Fixes atqamz/hand#430

## Test plan

- Red-green targeted tests verified test builds select `journal_mode=MEMORY` and `synchronous=OFF`.
- `nix develop -c make test` passed all packages with race detection and `-timeout=30m`; isolated `SECONDHAND_HOME` was used.
- Production build and default-tag `internal/store`/`internal/registry` tests passed.
- `nix develop -c make lint` passed with 0 issues.
- Linux before/after package durations (`go test -tags=test -race -count=1`, isolated `SECONDHAND_HOME`):

  | package | before | after |
  | --- | ---: | ---: |
  | `cmd` | 124.171s | 77.896s |
  | `internal/runtime` | 105.436s | 51.655s |
  | `internal/watcher` | 46.655s | 33.101s |
  | `internal/store` | 24.295s | 10.694s |

- Windows could not be measured locally; PR CI passed `Test (windows-latest)` in 7m13s, and all five platform unit checks plus e2e, contract, lint, and build checks passed.
- Production WAL is deferred to atqamz/hand#433 for separate crash/recovery, locking, Windows, and concurrent benchmark evidence.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->