### PR TITLE
fix(init): adopt hand's own source tree, and refuse an untagged suite by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ hand.exe
 /.grok/
 /.pi/
 /.agents/
+/.opencode/
+/.codex/
 
 # Go
 coverage.out

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ An installed edge release is the preferred path for dogfooding the newest CI-ver
 1. Open an issue describing the intent, design, or proposal, and get agreement there before writing code. This applies to any contribution, no matter the size. See "Reporting issues" below for what to include.
 2. Fork and branch from main.
 3. Make changes.
-4. make lint && make test
+4. make lint && make test. A bare `go test ./...` is not the suite: the `test` build tag is what installs the external-tool fakes, and without it the cmd suite refuses with one line naming the tag rather than failing dozens of tests on absent tools.
 5. make e2e if you changed CLI behavior (end-to-end suite, excluded from make test).
 6. make contract if you changed how hand calls herdr, treehouse or gh. It checks hermetic shared-tool fixtures against the records in internal/faketool/FIDELITY.md, so CI runs it on every change. Run make contract-live separately to smoke-test reversible calls against installed tools and the live GitHub API.
 7. nix build .#default if you changed Go dependencies (CI builds the flake, and a stale vendorHash in flake.nix fails it).

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ hand init
 
 `hand init` is non-interactive. It creates the fleet structure, installs the bundled `secondhand` Agent Skill for supported harnesses, installs or refreshes the Hand-owned supervisor wake bridges (the Claude Stop hook entry in `.claude/settings.json`, the OpenCode plugin, the Pi extension, and the Codex project-scope Stop hook in `.codex/hooks.json`), and writes the canonical, Hand-owned `AGENTS.md`: a small, immutable set of invariants telling any supervising harness to run `hand session start` once per runtime and `hand orient` every turn, restored byte-for-byte on every later `hand init`. A `CLAUDE.md` reference is written alongside it when that name is otherwise absent - the `@AGENTS.md` pointer file on every platform.
 
+The target must be an empty or absent directory, or a fleet home `hand init` already created; a non-empty directory that is not a recognized fleet is refused rather than adopted. A checkout of Hand itself is the one exception, so Hand can be developed with Hand from its own tree - see [hand init adopts its own source tree](docs/adr/hand-init-adopts-its-own-source-tree.md).
+
 ### 3. Add or create a project
 
 ```sh

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,6 +28,10 @@ var skillFields = []axi.Column[skill.DestinationResult]{
 	{Name: "outcome", Value: func(r skill.DestinationResult) string { return string(r.Outcome) }},
 }
 
+// The module path of Hand's own repository, which identifies its source tree wherever a clone
+// or a fork of it sits.
+const handModulePath = "github.com/atqamz/hand"
+
 const backlogSkeleton = `# Backlog
 
 ## Queue
@@ -77,7 +81,8 @@ func newInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := preflightInitTarget(homePath); err != nil {
+			handSourceTree, err := preflightInitTarget(homePath)
+			if err != nil {
 				return err
 			}
 
@@ -125,6 +130,7 @@ func newInitCmd() *cobra.Command {
 			var doc axi.Doc
 			doc.Field("result", "initialized")
 			doc.Field("home", homePath)
+			doc.Bool("hand_source_tree", handSourceTree)
 			doc.Field("fleet_id", fleetID)
 			doc.Field("registry", registryOutcome)
 			doc.Field("agents_md", writtenOrUnchanged(refresh.Changed))
@@ -159,6 +165,9 @@ func newInitCmd() *cobra.Command {
 				"Run `hand project add <source>` or `hand project create <name>` to register the first project",
 				"AGENTS.md and its CLAUDE.md reference carry the startup integration across harnesses",
 			}
+			if handSourceTree {
+				help = append(help, "This home is Hand's own source tree; register Hand as a project so workers change it in their own worktrees rather than in this checkout")
+			}
 			if refresh.ArchivedPath != "" {
 				help = append(help, fmt.Sprintf("This home's previous AGENTS.md content was archived verbatim at %s; review it and relocate anything still useful yourself", refresh.ArchivedPath))
 			}
@@ -183,45 +192,74 @@ func newInitCmd() *cobra.Command {
 	}
 }
 
-func preflightInitTarget(target string) error {
+// Also reports whether target is Hand's own source tree, which init adopts and every later
+// command reports as such whether or not this call was the one that adopted it.
+func preflightInitTarget(target string) (bool, error) {
 	info, err := os.Stat(target)
 	if os.IsNotExist(err) {
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return fmt.Errorf("inspect init target %s: %w", target, err)
+		return false, fmt.Errorf("inspect init target %s: %w", target, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("init target %s exists and is not a directory", target)
+		return false, fmt.Errorf("init target %s exists and is not a directory", target)
+	}
+	sourceTree, err := isHandSourceTree(target)
+	if err != nil {
+		return false, err
 	}
 	known, err := home.IsHome(target)
 	if err != nil {
-		return fmt.Errorf("inspect init target %s: %w", target, err)
+		return false, fmt.Errorf("inspect init target %s: %w", target, err)
 	}
 	if known {
 		if err := state.ValidateInitTarget(target); err != nil {
-			return fmt.Errorf("init target %s is recognized but unsafe to reconcile: %w; refusing before mutation", target, err)
+			return false, fmt.Errorf("init target %s is recognized but unsafe to reconcile: %w; refusing before mutation", target, err)
 		}
-		return nil
+		return sourceTree, nil
 	}
 	entries, err := os.ReadDir(target)
 	if err != nil {
-		return fmt.Errorf("inspect init target %s: %w", target, err)
+		return false, fmt.Errorf("inspect init target %s: %w", target, err)
 	}
 	if len(entries) == 0 {
-		return nil
+		return sourceTree, nil
+	}
+	if sourceTree {
+		return true, nil
 	}
 	runtimeRoot, err := handOwnedRuntimeRoot()
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, entry := range entries {
 		if entry.Name() == ".secondhand" && runtimeRoot == filepath.Join(target, entry.Name()) {
 			continue
 		}
-		return fmt.Errorf("init target %s exists, is not empty, and is not a recognized Secondhand fleet; refusing to adopt it", target)
+		return false, fmt.Errorf("init target %s exists, is not empty, and is not a recognized Secondhand fleet; refusing to adopt it", target)
 	}
-	return nil
+	return false, nil
+}
+
+// Hand's own source tree is the one non-empty directory init adopts, because developing Hand
+// with Hand needs a fleet home in the repository it works on. Module path rather than pathname,
+// so any clone qualifies while a subdirectory, carrying no go.mod of its own, does not.
+func isHandSourceTree(target string) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(target, "go.mod"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect init target %s module path: %w", target, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "module" {
+			return fields[1] == handModulePath, nil
+		}
+	}
+	return false, nil
 }
 
 func handOwnedRuntimeRoot() (string, error) {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -587,3 +587,112 @@ func TestInitReportsASkillDestinationConflictWithoutOverwritingTheForeignFile(t 
 		t.Fatalf("unaffected destination not installed: %v", err)
 	}
 }
+
+func seedModuleTree(t *testing.T, dir, modulePath string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "home"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "internal", "home", "home.go"), []byte("package home\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInitAdoptsHandOwnSourceTree(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	setTestUserHome(t, t.TempDir())
+	target := t.TempDir()
+	seedModuleTree(t, target, "github.com/atqamz/hand")
+
+	cmd := newInitCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{target})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init on Hand's own source tree: %v", err)
+	}
+
+	ok, err := home.IsHome(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("got IsHome false after adopting Hand's own source tree, want true")
+	}
+	if !strings.Contains(out.String(), "hand_source_tree: true\n") {
+		t.Fatalf("init output = %q, want hand_source_tree: true", out.String())
+	}
+	source, err := os.ReadFile(filepath.Join(target, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(source) != "package main\n" {
+		t.Fatalf("adopted source tree's main.go = %q, want it untouched", string(source))
+	}
+}
+
+func TestInitReportsHandSourceTreeOnEveryLaterRun(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	setTestUserHome(t, t.TempDir())
+	target := t.TempDir()
+	seedModuleTree(t, target, "github.com/atqamz/hand")
+
+	first := newInitCmd()
+	first.SetOut(&bytes.Buffer{})
+	first.SetArgs([]string{target})
+	if err := first.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	second := newInitCmd()
+	var out bytes.Buffer
+	second.SetOut(&out)
+	second.SetArgs([]string{target})
+	if err := second.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "hand_source_tree: true\n") {
+		t.Fatalf("reconcile output = %q, want hand_source_tree: true", out.String())
+	}
+}
+
+func TestInitRefusesANonEmptyTreeWithAForeignModulePath(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	target := t.TempDir()
+	seedModuleTree(t, target, "github.com/someone/else")
+	before := snapshotInitTarget(t, target)
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{target})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("init error = %v, want foreign non-empty refusal", err)
+	}
+	if after := snapshotInitTarget(t, target); !reflect.DeepEqual(after, before) {
+		t.Fatalf("foreign module tree changed: before=%v after=%v", before, after)
+	}
+}
+
+func TestInitRefusesASubdirectoryOfHandSourceTree(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	tree := t.TempDir()
+	seedModuleTree(t, tree, "github.com/atqamz/hand")
+	target := filepath.Join(tree, "internal")
+	before := snapshotInitTarget(t, target)
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{target})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("init error = %v, want subdirectory refusal", err)
+	}
+	if after := snapshotInitTarget(t, target); !reflect.DeepEqual(after, before) {
+		t.Fatalf("source subdirectory changed: before=%v after=%v", before, after)
+	}
+}

--- a/cmd/test_support_test.go
+++ b/cmd/test_support_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/store"
+	"github.com/atqamz/hand/internal/testtag"
 )
 
 // Registers a project directly in the store and returns the identity minted for it, for a test
@@ -86,6 +87,9 @@ func scopeHerdrForFleet(t *testing.T, home string, h faketool.Herdr) faketool.He
 }
 
 func TestMain(m *testing.M) {
+	if !testtag.Present {
+		testtag.Refuse()
+	}
 	testUserHome, err := os.MkdirTemp("", "hand-cmd-home-")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -204,6 +204,7 @@ Repeated bootstrap runs are safe:
 | empty directory | initialized |
 | existing valid Hand fleet | reconciled by `hand init`, no destructive rewrite |
 | existing, non-empty, not a recognized fleet | refused |
+| Hand's own source tree, non-empty | adopted; the one non-empty exception |
 | already healthy | reports ready, mutates nothing |
 
 The registry is discovery metadata, not a second source of Fleet state.

--- a/docs/adr/hand-init-adopts-its-own-source-tree.md
+++ b/docs/adr/hand-init-adopts-its-own-source-tree.md
@@ -1,0 +1,39 @@
+# hand init adopts its own source tree
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#436
+- PRs: none
+
+## Context
+
+`hand init` refuses a non-empty directory that is not already a recognized fleet home, so that adopting an operator's unrelated working directory is impossible by construction (see [hand init is the canonical fleet reconciler](hand-init-is-the-canonical-fleet-reconciler.md)). That guard also refuses the one directory where Hand's own development wants a fleet home: a checkout of Hand itself.
+
+That configuration was never speculative: CONTRIBUTING.md already instructs a contributor to run `./hand init` in the checkout, and states that every directory it creates there is gitignored so the fleet home lives alongside the source without being committed. Every surface `hand init` writes into a fleet home - `state/`, `data/`, `projects/`, `config/`, and the per-harness bridge directories - is in fact ignored, and the canonical `AGENTS.md` and its `CLAUDE.md` reference are committed byte-for-byte identical to what `agentsmd.Refresh` generates, so a reconcile writes nothing and leaves no drift. The guard was refusing a documented, harmless configuration rather than preventing a hazard, and the documentation was the older of the two.
+
+## Decision
+
+Hand's own source tree is the single exception to the non-empty refusal. `hand init` adopts a non-empty directory when, and only when, that directory's `go.mod` declares the module path `github.com/atqamz/hand`. Every other non-empty directory that is not a recognized fleet home is still refused, unchanged.
+
+Identity is the module path rather than a pathname or a Git remote:
+
+- A clone or a fork under any directory name qualifies, so the exception is not tied to one operator's layout.
+- A subdirectory of the tree carries no `go.mod` of its own, so `hand init internal` is still refused without a second guard.
+- A fork that renames its module has opted out, which is the correct reading: it is no longer Hand's source tree.
+- The check reads one file and executes nothing, so preflight stays free of a Git dependency.
+
+`hand init` reports `hand_source_tree: true` in its output for such a home, on the adopting run and on every later reconcile, and its help names registering Hand as a project so the supervisor does not edit the checkout it supervises.
+
+## Rejected alternatives
+
+- An explicit `--adopt` or `--force` flag makes the exception general: it re-opens adoption of any non-empty directory, which is exactly what the refusal exists to prevent, and it contradicts `hand init` asking no questions.
+- Matching on the Git remote URL requires executing Git during preflight, breaks for a tarball or a mirror, and still says nothing a renamed module path would not say better.
+- Matching on a directory name such as `hand` or `hand-dev` adopts any unrelated directory that happens to carry the name, and refuses a clone that does not.
+- Dropping the non-empty refusal entirely, and letting the gitignored layout make adoption harmless everywhere, removes the guard for repositories that ignore none of those paths.
+- Keeping Hand's fleet home outside the checkout and registering Hand as a project from there works, and remains available, but it never exercises a fleet home that is also a working repository - the case Hand's own development is best placed to keep honest. It also contradicts CONTRIBUTING.md, which would then need rewriting to describe a workflow nobody uses.
+
+## Consequences
+
+Hand can be developed with Hand from its own checkout: `hand init` in the tree, then `hand project add https://github.com/atqamz/hand`, which registers a separate Fleet-managed clone under `projects/` for workers to worktree from. The checkout remains the supervisor's workspace and is never a registered project, so the invariant that nobody edits a registered project directly is untouched.
+
+The exception is narrow enough to stay honest: `cmd/init_test.go` asserts adoption of a tree whose module path matches, continued refusal of a non-empty tree whose module path does not, and continued refusal of a subdirectory of the tree. A change that widened the exception to any non-empty directory fails those tests rather than surfacing as an adopted working directory.

--- a/internal/ghutil/testtag_test.go
+++ b/internal/ghutil/testtag_test.go
@@ -1,0 +1,11 @@
+package ghutil
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/git/testtag_test.go
+++ b/internal/git/testtag_test.go
@@ -1,0 +1,11 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/herdr/testtag_test.go
+++ b/internal/herdr/testtag_test.go
@@ -1,0 +1,11 @@
+package herdr
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/project/testtag_test.go
+++ b/internal/project/testtag_test.go
@@ -1,0 +1,11 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/runtime/testtag_test.go
+++ b/internal/runtime/testtag_test.go
@@ -1,0 +1,11 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/selfupdate/testtag_test.go
+++ b/internal/selfupdate/testtag_test.go
@@ -1,0 +1,11 @@
+package selfupdate
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/testtag/present_prod.go
+++ b/internal/testtag/present_prod.go
@@ -1,0 +1,6 @@
+//go:build !test
+
+package testtag
+
+// Present is false: the fakes are compiled out, so every call reaches a real external tool.
+const Present = false

--- a/internal/testtag/present_testmode.go
+++ b/internal/testtag/present_testmode.go
@@ -1,0 +1,6 @@
+//go:build test
+
+package testtag
+
+// Present is true: the fakes are compiled in and stand in for every external tool.
+const Present = true

--- a/internal/testtag/testtag.go
+++ b/internal/testtag/testtag.go
@@ -1,0 +1,24 @@
+// Package testtag reports whether the test build tag installed the external-tool fakes, and
+// refuses a suite that needs them without it. Untagged, hand resolves the real private runtime
+// and the real gh, so the suite fails on the machine instead of on the code.
+package testtag
+
+import (
+	"fmt"
+	"os"
+)
+
+// Refuse names the tag and exits non-zero, because a pile of failures against absent tools says
+// nothing about the one thing that was wrong with how the suite was invoked.
+func Refuse() {
+	fmt.Fprintln(os.Stderr, "this suite needs the test build tag, which installs the external-tool fakes: run `make test`, or `go test -tags=test ./...`")
+	os.Exit(1)
+}
+
+// Main is the entire TestMain a package needs when it has no other setup of its own.
+func Main(run func() int) {
+	if !Present {
+		Refuse()
+	}
+	os.Exit(run())
+}

--- a/internal/watcher/testtag_test.go
+++ b/internal/watcher/testtag_test.go
@@ -1,0 +1,11 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}

--- a/internal/worktree/testtag_test.go
+++ b/internal/worktree/testtag_test.go
@@ -1,0 +1,11 @@
+package worktree
+
+import (
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}


### PR DESCRIPTION
## Summary

- `hand init` adopts a non-empty directory when its `go.mod` declares `github.com/atqamz/hand`, and refuses every other non-empty directory exactly as before. Module path rather than pathname keeps a clone or fork under any name eligible, while a subdirectory of the tree carries no `go.mod` and stays refused. `.gitignore` picks up `.opencode/` and `.codex/`, which `hand init` writes and it did not list.
- Nine packages whose tests need the `test` build tag now refuse with one line naming it, instead of reaching the real private runtime and the real `gh` and answering with dozens of failures about absent tools.
- New ADR records the adoption boundary; README, `docs/adoption.md` and CONTRIBUTING.md state both behaviors.

Closes atqamz/hand#436
Closes atqamz/hand#437

## Test plan

- `make lint` - gofmt, `go vet`, golangci-lint 0 issues, commentlint clean
- `make test` - 38 packages ok, `-tags=test -race`
- `make e2e` - ok
- `make contract` - ok, confirming the guard leaves the suite that runs without the `test` tag alone
- `go test ./...` untagged - nine packages, one refusal line each, in place of 88s of misdirected failures
- `hand init` against a copy of this repository's `go.mod`, `AGENTS.md` and `CLAUDE.md`: `hand_source_tree: true`, `agents_md: unchanged`, no `AGENTS.md` drift, and `git check-ignore` confirms every directory it creates is ignored