### PR TITLE
docs(testing): map the invariants the suite is meant to hold hand to

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ The tracked `AGENTS.md` is already the exact canonical content `hand init` write
 ## Repository conventions
 
 - Behavioral contracts belong beside their implementation, command help, and focused tests. `docs/adr/README.md` owns the narrow bar for durable architectural rationale.
+- `docs/testing-invariants.md` is the map of the rules the suite holds hand to, each with a stable id. A new test cites the invariant id it checks, or names the specific case it pins; a test that can name neither is deleted rather than kept. `docs/adr/tests-state-invariants-first-examples-second.md` owns why.
 - Command output goes through `internal/axi` as TOON and every failure through `cmd/root.go`'s error document; `hand watch`'s event stream is the exception. Package and command tests own these shapes.
 - Harness/herdr syntax, exit enforcement, watch's stdout/errOut split, and first-run prompt handling are owned by their implementations and closest tests under `internal/harness`, `internal/herdr`, `internal/watcher`, and `cmd`.
 - `herdr`, `treehouse` and `gh` are faked once in `internal/faketool` for every suite. `internal/faketool/FIDELITY.md` records observed external behavior, `tests/contract` (`make contract`) rechecks it hermetically, and `make contract-live` separately probes reversible calls against installed tools. Extend the shared fake, never hand-write another.

--- a/docs/adr/tests-state-invariants-first-examples-second.md
+++ b/docs/adr/tests-state-invariants-first-examples-second.md
@@ -1,0 +1,112 @@
+# Tests state invariants first, examples second
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#442
+- PRs: none
+
+## Context
+
+Every architectural boundary in this repository is already written down as a rule: at most one
+provisioning or running attempt per task, reconciliation converges, an observation failure is not
+contradiction evidence, unknown lease ownership is not a mismatch, init resets nothing it did not
+create. The ADRs state them precisely and each names the code that owns it.
+
+The suite does not test those rules. It tests instances of them. `cmd/init_reconciler_test.go`
+asserts that three consecutive `hand init` runs converge; the invariant is that init converges from
+any starting state. Both are worth having, and only one of them fails when a change breaks
+convergence on a state nobody wrote a case for.
+
+That asymmetry has a second half. A test written by reading the implementation asserts what the code
+currently does. It passes before and after a defect is introduced into behavior the example does not
+reach, and it keeps passing when the behavior it does reach is wrong, because the implementation was
+the oracle. Nothing in the suite currently measures whether a given test is capable of failing at
+all, so "the tests pass" carries less information than it appears to.
+
+## Decision
+
+Tests are derived from stated invariants, in this order, and the order is the point.
+
+**1. The invariant map is a reviewed artifact, authored from the ADRs.** It lives at
+[`docs/testing-invariants.md`](../testing-invariants.md), each entry carrying a stable id, a
+falsifiable statement, the source that owns it, and the layer meant to check it. An entry is derived
+from an ADR or from the code that ADR names - never from a test, and never from the implementation's
+current behavior, because a map derived from the implementation cannot disagree with it.
+
+A statement earns a line only if an input could break it. If none could, it is a description.
+
+**2. Property tests state the invariant; unit tests sit underneath them.** The property is the
+assertion, over generated inputs. Unit tests remain for the specific cases worth naming - a
+regression with a name, a boundary a reader should see spelled out - and they are added beside a
+property rather than instead of one.
+
+Lifecycle rules are stated as *models*: generated sequences of operations checked against a
+reference model after every step. INV-TASK-1 is not expressible as a property over one input,
+because the thing that violates it is an ordering.
+
+**3. Mutation testing judges the tests, not the code.** A surviving mutant is a statement that the
+suite does not constrain the behavior that mutant changed. It runs per package and on demand,
+documented in CONTRIBUTING.md; whether it becomes a gate is decided after its cost here is measured,
+not before.
+
+**4. `pgregory.net/rapid` is an accepted test-only dependency.** It brings shrinking that reports a
+minimal failing case instead of a random one, and `rapid.StateMachine`, which is what makes layer 2's
+models declarative rather than a hand-rolled decoder over `[]byte`. Native `go test -fuzz` stays the
+tool wherever a property needs no state machine, since it costs nothing.
+
+**5. The map's `coverage` column is answered by audit, not by assertion.** Every invariant starts
+`unaudited`. A phase that adds tests updates only the lines it touched. Writing `covered` on a line
+whose test was not read is the same error as deriving the invariant from the implementation.
+
+**6. A test names what it is for, and one that cannot is deleted.** Every test either cites the
+invariant id it checks or pins a specific case worth naming - a regression, a boundary a reader
+should see spelled out. A test that can name neither is not kept as harmless ballast: it costs
+runtime on every run, and it reads as coverage of something.
+
+This cuts in a direction a suite-growing rule does not. A mutant that survives means the tests do not
+constrain the behavior it changed; the fix is sometimes a stronger test, and sometimes deleting the
+test that appeared to cover it and did not. Removing such a test is progress, and it makes the suite
+say something truer than it did before, so it is not treated as a regression in test count.
+
+## Rejected alternatives
+
+- **Raising coverage instead.** Line coverage measures which lines ran, not which behaviors are
+  constrained. A test that executes a function and asserts nothing about it counts fully. It is the
+  metric that made the current gap invisible.
+- **Property tests without a written map.** The properties would then be derived by whoever writes
+  them, from the code in front of them, which reintroduces the implementation as the oracle at the
+  layer meant to remove it. The map is reviewable precisely because it is separate.
+- **Mutation testing first, as the entry point.** It reports on tests that exist. Run against a suite
+  of implementation-derived examples it produces a long list of survivors and no guidance about which
+  ones matter, because there is no stated invariant to say what should have failed.
+- **Native fuzzing only, no new dependency.** Workable, and it stays in use for stateless properties.
+  For the lifecycle models it means decoding operation sequences out of the fuzzer's byte slice by
+  hand, so the model's logic would sit inside a decoder, and a failure would report a byte slice
+  rather than a minimal sequence of operations.
+- **A generated map, derived from the ADRs mechanically.** The ADRs state rules in prose whose
+  testable form requires judgment - which quantifier, over which inputs, falsifiable how. A
+  generated map would be a restatement, and its errors would be invisible for the same reason.
+- **Rewriting the existing suite around properties.** The existing tests pass for good reasons and
+  encode real cases. Properties are added beside them.
+- **Keeping every existing test on the grounds that deleting one loses coverage.** A test that
+  constrains nothing is not coverage; it is runtime plus a false signal. The rule above makes its
+  removal a normal outcome of the audit rather than something needing separate justification.
+
+## Consequences
+
+An invariant now has one place to be written, one id to be referenced by, and one answer about
+whether anything checks it. A change that breaks a documented boundary fails a test that names the
+boundary, rather than an example that happened to cover it.
+
+The map also makes absence legible: an invariant with no coverage is a visible line rather than an
+unasked question, which is what atqamz/hand#442's phases work through.
+
+Mutation testing introduces a cost that has to stay bounded deliberately. It re-runs the tests once
+per mutant, against a suite that already needs the `test` build tag and minutes of `-race` time, so
+it is scoped per package from the start and any CI gate waits on measurement.
+
+The map can be wrong, and that is a real risk this record accepts: an incorrect invariant becomes a
+test that pins the code to a mistake, which is worse than no test because it looks like a
+specification. That is why the map is reviewed as claims about intent, separately from the tests
+derived from it, and why its `What is deliberately not an invariant` section is part of the artifact
+rather than a footnote.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -1,0 +1,236 @@
+# Invariant map
+
+The rules hand's tests are meant to hold it to, written as claims about intended behavior rather
+than descriptions of current behavior. Every entry comes from an ADR or from the code that ADR
+names, never from reading a test: a test derived from the implementation asserts what the code
+does, which is exactly the assertion that cannot catch the code being wrong.
+
+This is a living document. It is not an ADR, records no decision, and carries no date. The decision
+that produced it is [Tests state invariants first, examples second](adr/tests-state-invariants-first-examples-second.md);
+the staged work that fills it in is atqamz/hand#442.
+
+## How to read an entry
+
+Each invariant has a stable id, a statement, and the source that owns it. The statement is what a
+test must be able to falsify. If you cannot imagine an input that would break it, it is a
+description, not an invariant, and it does not belong here.
+
+`layer` names where the invariant is meant to be checked:
+
+- **property** - stated over generated inputs; the rule is the assertion.
+- **model** - stated over generated *sequences* of operations against a reference model.
+- **unit** - a specific case worth naming, underneath a property rather than instead of one.
+- **manual** - checkable only against real external state; recorded here so it is not mistaken for
+  something the suite covers.
+
+`coverage` is deliberately `unaudited` throughout on first writing. Phase 0 of atqamz/hand#442
+fills it in per invariant, and a phase that adds tests updates only the lines it actually touched.
+An unaudited line is a question, not a claim that coverage is missing.
+
+## Task and Attempt lifecycle
+
+Source: [Tasks are durable and Attempts own execution](adr/tasks-are-durable-and-attempts-own-execution.md),
+`internal/store`, `internal/runtime`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-TASK-1 | At most one attempt of a task is provisioning or running, at any point in any sequence of operations. | model | unaudited |
+| INV-TASK-2 | Attempt ordinals within a task are contiguous and start at 1, and an ordinal is never reused. | model | unaudited |
+| INV-TASK-3 | A terminal attempt is immutable with respect to activation: no operation reactivates it. | model | unaudited |
+| INV-TASK-4 | The report cursor is continuous across attempts: promotion and reopen do not reset or rewind it. | model | unaudited |
+| INV-TASK-5 | Teardown terminalizes the task and attempt rows and deletes neither. | property | unaudited |
+| INV-TASK-6 | `hand reopen` on a terminal task creates a new attempt and mutates no existing one. | model | unaudited |
+| INV-TASK-7 | Promotion preserves the scout attempt and creates the next one. | model | unaudited |
+| INV-TASK-8 | An existing attempt's execution identity - harness, model, effort, execution class, planned-against commit, requested profile, routing source - is write-once. Nothing reroutes it after creation. | model | unaudited |
+
+## Reconciliation
+
+Source: [Deterministic reconciliation observes before mutating](adr/deterministic-reconciliation-observes-before-mutating.md),
+[Liveness is observed, not assumed from launch](adr/liveness-is-observed-not-assumed-from-launch.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-REC-1 | Reconciliation converges: applied twice to unchanged observed reality, the second run changes no durable state. | model | unaudited |
+| INV-REC-2 | The decision table is a function of (durable intent, observed evidence). Same pair, same decision, for any pair. | property | unaudited |
+| INV-REC-3 | An observation *failure* never becomes contradiction evidence, and never clears an existing repair marker. | property | unaudited |
+| INV-REC-4 | A repair marker survives until the same contradiction is proven gone or a safe lifecycle transition resolves it. | model | unaudited |
+| INV-REC-5 | Reconciliation applies at most one action per loop iteration, then re-observes. | model | unaudited |
+| INV-REC-6 | Automatic resource cleanup requires exact ownership proof, a clean worktree, and positive proof that returning the worktree discards no commit held nowhere else. All three, never two. | property | unaudited |
+| INV-REC-7 | Classifying an attempt idle-unreported changes no lifecycle, releases no lease, returns no worktree, and touches no Herdr resource. | property | unaudited |
+| INV-REC-8 | The usage-limit probe fires at most once per stop. | model | unaudited |
+
+## Init and generated surfaces
+
+Source: [hand init is the canonical fleet reconciler](adr/hand-init-is-the-canonical-fleet-reconciler.md),
+[AGENTS.md is fully Hand-owned and immutable](adr/agents-md-is-fully-hand-owned-and-immutable.md),
+[hand init adopts its own source tree](adr/hand-init-adopts-its-own-source-tree.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-INIT-1 | Init is idempotent: from any home state, running it twice leaves the same state as running it once. | property | unaudited |
+| INV-INIT-2 | Init resets nothing it did not create: arbitrary `data/**` content, `config/**` values, project rows, and task history all survive it. | property | unaudited |
+| INV-INIT-3 | `AGENTS.md` and its `CLAUDE.md` reference are restored to canonical bytes from any drifted content, and pre-immutable content is archived rather than discarded. | property | unaudited |
+| INV-INIT-4 | A skeleton file is written only when absent. Its content, once written by anyone, is never rewritten by init. | property | unaudited |
+| INV-INIT-5 | A non-empty directory is adopted if and only if its `go.mod` declares hand's own module path. | property | phase 0 of atqamz/hand#436 landed unit tests; property form unaudited |
+| INV-INIT-6 | Preflight refusal is total: a refused target has no byte changed, including the private runtime root. | property | unaudited |
+
+## Registry and fleet identity
+
+Source: [Fleet identity and user registry](adr/fleet-identity-and-user-registry.md), `internal/registry`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-REG-1 | `Register` is idempotent per (home, fleet id): repeating it yields one row, not many. | property | unaudited |
+| INV-REG-2 | A home's fleet identity is never reissued or rewritten by any registry operation. | property | unaudited |
+| INV-REG-3 | Entry classification is a function of (stored rows, observed filesystem), and reading it mutates nothing. | property | unaudited |
+| INV-REG-4 | Losing or deleting the registry changes no fleet identity; re-registering a home restores the identity its own `state/hand.db` carries. | property | unaudited |
+| INV-REG-5 | Pruning removes only entries already classified `missing`, and never the current home. | property | not yet implemented - atqamz/hand#413 |
+| INV-REG-6 | A full test run adds zero entries to the operator's real user registry. Reaching it from a test is impossible, not merely discouraged. | property | violated today - atqamz/hand#413 |
+| INV-REG-7 | A fleet home inside a Treehouse worktree, or inside another fleet's managed tree, is refused rather than registered. | property | violated today - atqamz/hand#413 |
+
+## Project identity and the completion store
+
+Source: [A project is identified by a surrogate id, not its name](adr/a-project-is-identified-by-a-surrogate-id-not-its-name.md),
+[Completions use an uncapped append-only sibling](adr/the-completion-store-is-an-uncapped-append-only-sibling.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-PROJ-1 | A project's `p_`-prefixed id is minted once and never reissued, for any sequence of add, rename, and remove. | model | unaudited |
+| INV-PROJ-2 | Rename writes exactly one row, found by id, and nothing else. | property | unaudited |
+| INV-PROJ-3 | A name is unique among registered projects and reusable after removal. | model | unaudited |
+| INV-PROJ-4 | A completion record keeps the label it was written with; it is an audit line, not a view. | property | unaudited |
+| INV-PROJ-5 | The completion file is append-only. The single exception - project rename rewriting only that project's records under the same lock - never touches an unrelated record, including on rollback. | property | unaudited |
+| INV-PROJ-6 | Unplaceable lineage is marked, never guessed: an unresolvable project id is written as the explicit unknown value rather than empty. | property | unaudited |
+| INV-PROJ-7 | A completion is appended before its task row is removed, never after. | model | unaudited |
+
+## The report channel and attention
+
+Source: [The report channel is the only outcome signal](adr/the-report-channel-is-the-only-outcome-signal.md),
+[Attention is one derivation over three channels](adr/attention-is-one-derivation-over-three-channels.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-REP-1 | `state/<id>.status` is authoritative for what a worker said. Where a stored projection disagrees with the file, the file wins. | property | unaudited |
+| INV-REP-2 | Parsing the report file is total: arbitrary bytes yield a determinate result, never a panic and never a silently dropped report. | property | unaudited |
+| INV-REP-3 | Evidence and claims are stored apart and rendered apart. No field carries a value from one channel in the shape the other channel's fields use. | property | unaudited |
+| INV-REP-4 | Where the two channels disagree, the disagreement is what gets surfaced. Neither is silently resolved in favour of the other. | property | unaudited |
+| INV-REP-5 | Acknowledgement is independent of both: reading status never clears it. | property | unaudited |
+
+## Orientation and currentness
+
+Source: [Stateless supervisor orientation and opaque currentness](adr/stateless-supervisor-orientation-and-opaque-currentness.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-ORI-1 | Orientation is a function of persisted state: same state, same orientation. | property | unaudited |
+| INV-ORI-2 | Orientation surfaces no actionable item not backed by one of the three channels. | property | unaudited |
+| INV-ORI-3 | A currentness token is opaque to every consumer: it is carried, compared, returned, or rejected, never parsed or constructed. | property | unaudited |
+| INV-ORI-4 | A token is scoped to exactly one (fleet, monitor kind, target identity, generation). A token from any other tuple is rejected. | property | unaudited |
+| INV-ORI-5 | `hand session start` creates no supervisor-session row and acknowledges or mutates no work. | property | unaudited |
+| INV-ORI-6 | A wake is a hint only. It is accepted only when fleet, target, kind, and currentness all match exactly. | property | unaudited |
+| INV-ORI-7 | Truncated orientation says it was truncated and how much it omitted; a bounded summary never silently drops an item. | property | unaudited |
+
+## Watcher ownership and delivery
+
+Source: [One watcher per fleet home, guarded by an flock](adr/one-watcher-per-fleet-home-guarded-by-an-flock.md),
+[Watcher takeover is generation-attributed](adr/watcher-takeover-is-generation-attributed.md),
+[The until-event exit is the delivery](adr/the-until-event-exit-is-the-delivery.md),
+[Arming a watch observes before it waits](adr/arming-a-watch-observes-before-it-waits.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-WATCH-1 | At most one watcher per fleet home holds the kernel lock, under any interleaving of starts and takeovers. | model | unaudited |
+| INV-WATCH-2 | The stored pid is advisory. No decision treats it as ownership. | property | unaudited |
+| INV-WATCH-3 | Takeover proceeds only after the incumbent releases the kernel lock. | model | unaudited |
+| INV-WATCH-4 | Arming observes already-actionable state before waiting, so a condition that arrived while nothing watched still wakes it. | property | unaudited |
+| INV-WATCH-5 | Startup state is not an event: until-event mode takes a baseline and exits on the first *new* matching event. | property | unaudited |
+| INV-WATCH-6 | Delivery, an empty window, and an unprobeable task have distinct exit codes, and each is reachable. | property | unaudited |
+
+## Locks and schema
+
+Source: [Lock pathnames are permanent rendezvous points](adr/lock-pathnames-are-permanent-rendezvous-points.md),
+[The schema version lives in PRAGMA user_version](adr/the-schema-version-lives-in-pragma-user-version.md),
+[Holds are their own table](adr/holds-are-their-own-table.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-LOCK-1 | A logical lock key maps to one permanent pathname for the life of the fleet home, created on first acquisition and never unlinked by any caller. | property | unaudited |
+| INV-LOCK-2 | Neither zero size nor an old mtime is read as evidence about whether a lock is held. | property | unaudited |
+| INV-SCHEMA-1 | A fresh database is created directly at the latest version; an existing one applies pending steps transactionally. | property | unaudited |
+| INV-SCHEMA-2 | A database newer than the binary is refused before any other statement runs. | property | unaudited |
+| INV-SCHEMA-3 | Migration is all-or-nothing: an interrupted migration leaves the recorded version and the schema agreeing with each other. | model | unaudited |
+| INV-HOLD-1 | A hold is a standalone row with no foreign key to a task, and survives the task's teardown when human-authored. | property | unaudited |
+| INV-HOLD-2 | A machine-authored hold is cleared only after its kind is checked, never by kind-blind clearing. | property | unaudited |
+
+## Worktree lease and ownership proof
+
+Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is-not-a-mismatch.md),
+[Mechanical plans verify acquired HEAD](adr/mechanical-plans-verify-acquired-head.md),
+[The landed-work guard reads the work, not the record](adr/the-landed-work-guard-reads-the-work-not-the-record.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-LEASE-1 | `ObserveLease` returns no error: every outcome, including the absence of an answer, is a determinate state. | property | unaudited |
+| INV-LEASE-2 | Absent executable, non-zero exit, unparsable output, empty pool, and a pool describing other worktrees all classify as unknown, never as mismatch. | property | unaudited |
+| INV-LEASE-3 | Unknown carries the probe that failed: the command, the working directory that selected the pool, and the reason. | property | unaudited |
+| INV-LEASE-4 | Unproven ownership never authorizes a destructive command, and `--force` does not change that. | property | unaudited |
+| INV-LEASE-5 | Mechanical provisioning verifies the leased worktree's full HEAD against `planned_against` before Herdr or worker launch, never after. | model | unaudited |
+| INV-LEASE-6 | On mismatch or verification failure the lease is returned safely, and provisioning evidence is retained if cleanup fails. | model | unaudited |
+| INV-LEASE-7 | The project lock is held continuously across verification, worktree lock, and the provisioning boundary. | model | unaudited |
+| INV-LEASE-8 | Any unresolved read, parse, ref, or PR ambiguity in the landed-work guard refuses. Ambiguity never resolves to "landed". | property | unaudited |
+
+## Output rendering
+
+Source: [Output is TOON by default and JSON is retained](adr/output-is-toon-by-default-and-json-is-retained.md),
+`internal/axi`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-OUT-1 | A rendered block's `[N]` always equals the number of rows that follow it. | property | unaudited |
+| INV-OUT-2 | Rendering is total: arbitrary field values, including quotes, newlines, commas, and non-ASCII, render to a document that parses back to the same values. | property | unaudited |
+| INV-OUT-3 | An empty result renders its header with a count of `0` rather than nothing. | property | unaudited |
+| INV-OUT-4 | Every failure writes exactly one document carrying `error`, `kind`, and `exit`, and a command that already produced stdout keeps it. | property | unaudited |
+| INV-OUT-5 | Field selection is a projection: it changes which fields appear and never their values or their order relative to each other. | property | unaudited |
+| INV-OUT-6 | A request combining TOON-only field selection with JSON is rejected, never silently honoured in part. | property | unaudited |
+
+## Diagnosis and treatment
+
+Source: [Every diagnosis names a reachable treatment](adr/every-diagnosis-names-a-reachable-treatment.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-DIAG-1 | Every reachable stuck state has an entry naming the supported commands that leave it, or is explicitly marked undiagnosed. | property | unaudited |
+| INV-DIAG-2 | A persisted repair reason carries its treatment text with the task id substituted, so a refusal and the way out cannot drift apart. | property | unaudited |
+| INV-DIAG-3 | Every treatment falls in exactly one of the three classes. | property | unaudited |
+
+## Pure helpers
+
+Source: `internal/shellquote`, `internal/age`, `cmd/statusview.go`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-PURE-1 | For any string, a real shell parses `shellquote.Quote(s)` back to exactly `s`, including spaces, quotes, newlines, and non-ASCII. | property | unaudited |
+| INV-PURE-2 | Truncation never splits a UTF-8 rune, never exceeds the requested width, and is idempotent. | property | unaudited |
+| INV-PURE-3 | Age rendering is monotonic in its input: a larger duration never renders as a smaller age. | property | unaudited |
+
+## What is deliberately not an invariant
+
+These read like invariants and are not. Each is a misreading an ADR explicitly warns about, recorded
+here so nobody encodes one as a test.
+
+- **An idle pane means the worker is dead.** It does not. An idle, still-present harness is exactly
+  the shape a resume recovers. Only an explicit operator attestation may end an attempt on that
+  judgment. See [Liveness is observed, not assumed from launch](adr/liveness-is-observed-not-assumed-from-launch.md).
+- **An unobservable lease means ownership is wrong.** Unknown is the absence of an answer, not a
+  mismatch, and nothing about it disproves the recorded ownership. See
+  [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is-not-a-mismatch.md).
+- **The stored pid identifies the watcher.** It is advisory metadata. The kernel lock is the only
+  ownership authority. See [Watcher takeover is generation-attributed](adr/watcher-takeover-is-generation-attributed.md).
+- **A lock file's absence, size, or mtime says whether a lock is held.** None of them carry that
+  information. See [Lock pathnames are permanent rendezvous points](adr/lock-pathnames-are-permanent-rendezvous-points.md).
+- **A watcher process exiting is delivery.** Delivery is host-specific and only an owning host
+  guarantees the conversion. An exit code, a notification, and an accepted request are each not
+  proof that anyone reasoned.
+- **A green CI run means the change is safe.** It means the suite did not object. Whether the suite
+  can object is what mutation testing measures, and atqamz/hand#442 exists because that is currently
+  unmeasured.


### PR DESCRIPTION
## Summary

Phase 0 of atqamz/hand#442. Documents only; no code, no test, no dependency.

- `docs/testing-invariants.md` - 60 invariants across 13 domains, each with a stable id, a falsifiable statement, the ADR or code that owns it, and the layer meant to check it (`property`, `model`, `unit`, `manual`). Every entry is derived from an ADR or the code that ADR names, never from a test and never from the implementation's current behavior.
- `docs/adr/tests-state-invariants-first-examples-second.md` - why that order, why `pgregory.net/rapid` is accepted as a test-only dependency, why mutation testing is scoped per package rather than wired to CI, and the rule that a test cites the invariant id it checks or names the case it pins - or is deleted.
- `CONTRIBUTING.md` - one line pointing contributors at both.

Two parts are worth reading rather than skimming:

**`coverage` starts `unaudited` on every line.** Writing `covered` on a line whose test was not read is the same error as deriving the invariant from the implementation. Phase 0's audit fills it in; a later phase updates only the lines it touched.

**The `What is deliberately not an invariant` section.** Six misreadings the ADRs explicitly warn about - an idle pane meaning the worker is dead, unknown lease ownership meaning a mismatch, the stored pid identifying the watcher, a lock file's mtime saying whether it is held, a watcher exit being delivery, a green CI run meaning the change is safe. These are recorded so nobody encodes one as a test, which is a failure mode the rest of the map makes more likely rather than less.

Three lines already record a violation rather than a gap, from atqamz/hand#413: INV-REG-5 (no way to prune), INV-REG-6 (a test run adds entries to the operator's real registry), INV-REG-7 (a home inside a Treehouse worktree is registrable).

## Test plan

Documents only, so the gates are the tree's own:

- `make lint` - gofmt, `go vet`, golangci-lint, commentlint
- `make test` - unchanged, nothing in this PR is compiled

Every ADR link in both new files resolves to a file in `docs/adr/`, and every invariant traces to a Decision section quoted from the ADR that owns it.

## Notes

Refs atqamz/hand#442. No closing keyword: the umbrella issue stays open for phases 1-8.

Phases 1-8 are one task each and are meant to run through the hand-dev fleet, which currently cannot launch a worker - atqamz/hand#441. That is the practical blocker on everything after this PR.