### PR TITLE
fix(worktree): put the pool outside every fleet home

### DIFF
--- a/docs/adr/the-worktree-pool-lives-outside-every-fleet-home.md
+++ b/docs/adr/the-worktree-pool-lives-outside-every-fleet-home.md
@@ -1,0 +1,91 @@
+# The worktree pool lives outside every fleet home
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#427
+- PRs: none
+
+## Context
+
+atqamz/hand#404 scoped Treehouse pools to the registered clone, closing the cross-fleet worktree
+bleed in atqamz/hand#403 and atqamz/hand#412 where a shared `~/.treehouse` let one fleet's slots
+alias another's. It did that by passing `--root <clonePath>`, which put every pool at
+`<fleet-home>/projects/<project>/.treehouse/<pool>/<n>/<project>`.
+
+That made a worker's worktree a descendant of the fleet home, and a fleet home always carries a
+Hand-owned `CLAUDE.md`. The consequence was already written down as something that must not happen,
+in `internal/agentsmd/agentsmd.go`:
+
+> a worktree is never under the fleet home, so it never loads the home's AGENTS.md
+
+After #404 it did. Claude Code collects `CLAUDE.md` by walking up from its working directory, finds
+the home's, and the `@AGENTS.md` import it contains resolves outside the worker's project root, so
+it draws its external-import dialog and waits. `hand spawn` has no signature for that dialog, so
+every Claude worker in every fleet failed its 60s confirmation window and left a provisioning
+attempt for `hand reconcile` to unwind. The answer is never recorded either, because the pane dies
+before it is answered, so the block is deterministic rather than first-run.
+
+The blocked launch is the visible half. The other half is that a worker was being handed the
+supervisor's own operating contract, which `AGENTS.md`'s `HAND_ROLE=worker` guard limits without
+making intended.
+
+## Decision
+
+The pool root is a per-clone directory under the user-local infrastructure root, never the clone
+itself:
+
+```
+<secondhand home>/pools/<clone basename>-<12 hex of sha256(clone path)>
+```
+
+It is resolved in `internal/worktree` at the point `--root` is built, from the clone path alone.
+`#404`'s property is preserved exactly: the digest is taken over the absolute clone path, which
+contains both the fleet home and the project, so two clones can never share a pool and no fleet's
+slots can alias another's.
+
+**A worktree recorded under its clone keeps the clone as its root.** A lease acquired before this
+change is still observed and returned through the pool it was acquired from. Without that rule the
+first observation after upgrading would report `LeaseUnknown`, which correctly refuses destructive
+cleanup ([Unobservable ownership is not a mismatch](unobservable-ownership-is-not-a-mismatch.md))
+and would therefore strand the worktree rather than release it.
+
+The digest keys the pool rather than the fleet id, so this layer reads no fleet state and no root is
+threaded through the provisioning dependency graph. The fleet id would read better in a path a human
+browses; it is not worth `internal/worktree` depending on fleet identity resolution to get it.
+
+## Rejected alternatives
+
+- **Making the Hand-owned `CLAUDE.md` self-contained instead of an `@AGENTS.md` pointer.** It
+  removes the dialog, and makes the second failure strictly worse: the supervisor's contract would
+  then be reliably read by every worker instead of failing to load.
+- **Teaching `hand spawn` to answer the dialog.** It is a security prompt about trusting file
+  imports. A tool clicking through it on the operator's behalf is not a fix, and it would leave the
+  contract leak in place. Recognising the dialog and refusing with a reachable treatment is worth
+  doing on its own, and is not a substitute for removing the cause.
+- **Launching the harness with its project-context discovery disabled.** For Claude Code that is
+  `--safe-mode`, which also disables the project's own conventions, or `--bare`, which additionally
+  forces `ANTHROPIC_API_KEY` and never reads OAuth. Both trade away things a worker needs, and both
+  are per-harness where the cause is not.
+- **Reverting to a single shared `~/.treehouse`.** That is exactly the aliasing atqamz/hand#404
+  fixed.
+- **Keying the pool by fleet id rather than a digest of the clone path.** More readable, and it
+  makes `internal/worktree` depend on fleet identity resolution or on deriving the home from the
+  clone path by convention - the same class of assumption that produced this issue.
+
+## Consequences
+
+A worker worktree is no longer inside the fleet home, so the invariant `internal/agentsmd` states is
+true again, and no harness picks up the supervisor's contract by directory ancestry. The fix is not
+per-harness: Codex, Grok and Pi never see the home's files either.
+
+A fleet home is no longer self-contained. Copying or deleting one no longer takes its worktrees with
+it, and a home removed by hand leaves its pool behind under `<secondhand home>/pools/`. That is a
+real loss and the reason this record exists rather than a commit message. It is judged acceptable
+because `<secondhand home>` already holds the private pinned runtime and the user registry, so
+per-fleet state outside the home is established, and because a pool holds no durable intent: it is
+reconstructible working space, and the durable record of what a worktree was for lives in
+`state/hand.db`.
+
+Leases taken before this change keep working, and there is no migration step. The compatibility rule
+is not a temporary shim to remove later: a recorded path under its clone means that lease's pool is
+the clone, which stays true for as long as any such lease exists.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -166,7 +166,8 @@ Source: [Lock pathnames are permanent rendezvous points](adr/lock-pathnames-are-
 
 Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is-not-a-mismatch.md),
 [Mechanical plans verify acquired HEAD](adr/mechanical-plans-verify-acquired-head.md),
-[The landed-work guard reads the work, not the record](adr/the-landed-work-guard-reads-the-work-not-the-record.md).
+[The landed-work guard reads the work, not the record](adr/the-landed-work-guard-reads-the-work-not-the-record.md),
+[The worktree pool lives outside every fleet home](adr/the-worktree-pool-lives-outside-every-fleet-home.md).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -178,6 +179,10 @@ Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is
 | INV-LEASE-6 | On mismatch or verification failure the lease is returned safely, and provisioning evidence is retained if cleanup fails. | model | unaudited |
 | INV-LEASE-7 | The project lock is held continuously across verification, worktree lock, and the provisioning boundary. | model | unaudited |
 | INV-LEASE-8 | Any unresolved read, parse, ref, or PR ambiguity in the landed-work guard refuses. Ambiguity never resolves to "landed". | property | unaudited |
+| INV-POOL-1 | A worktree pool never sits inside any fleet home, so no harness picks up the supervisor's context by directory ancestry. | property | `TestGetAcquiresFromAPoolOutsideEveryFleetHome`, `TestReturnUsesThePoolOutsideEveryFleetHome` |
+| INV-POOL-2 | Two clones never share a pool root, so one fleet's slots cannot alias another's. | property | `TestPoolRootDiffersPerClone` |
+| INV-POOL-3 | A worktree recorded under its clone keeps the clone as its pool root, so a lease taken before atqamz/hand#427 stays observable and returnable. | property | `TestPoolRootKeepsALegacyWorktreeOnItsOwnClone`, `TestReturnKeepsALegacyWorktreeOnItsOwnClone` |
+| INV-POOL-4 | Pool resolution never follows a foreign recorded worktree path to that path's own pool. | property | `TestReturnNeverFollowsAForeignRecordedPathToItsOwnPool` |
 
 ## Output rendering
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -4,6 +4,7 @@ package worktree
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	gitrepo "github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/secondhand"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/toolchain"
 )
@@ -287,7 +289,10 @@ func Get(clonePath, leaseHolder string) (Lease, error) {
 	if leaseHolder != "" {
 		args = append(args, "--lease-holder", leaseHolder)
 	}
-	args = withTreehouseRoot(clonePath, args...)
+	args, err := withTreehouseRoot(clonePath, "", args...)
+	if err != nil {
+		return Lease{}, err
+	}
 	out, stderr, err := runCore("treehouse", clonePath, args...)
 	// Banners land on stderr ahead of the JSON, so the payload has to be read from stdout alone -
 	// CombinedOutput here corrupts every parse (atqamz/hand#21).
@@ -343,7 +348,10 @@ func Return(clonePath, worktreePath string, force bool) error {
 	if force {
 		args = append(args, "--force")
 	}
-	args = withTreehouseRoot(clonePath, args...)
+	args, err := withTreehouseRoot(clonePath, worktreePath, args...)
+	if err != nil {
+		return err
+	}
 	return returnTreehouse(worktreePath, args, force)
 }
 
@@ -360,7 +368,10 @@ func ReturnLease(clonePath, worktreePath, leaseID string, force bool) error {
 		args = append(args, "--force")
 	}
 	args = append(args, "--if-lease-id", leaseID, worktreePath)
-	args = withTreehouseRoot(clonePath, args...)
+	args, err := withTreehouseRoot(clonePath, worktreePath, args...)
+	if err != nil {
+		return err
+	}
 	return returnTreehouse(worktreePath, args, force)
 }
 
@@ -379,7 +390,11 @@ func returnTreehouse(worktreePath string, args []string, force bool) error {
 // Reports the pool entries, or the reason the pool could not be observed. A missing executable, a
 // non-zero exit and unparsable output are all unobservability, never absence and never a mismatch.
 func treehouseStatus(clonePath, worktreePath string) ([]statusEntry, string) {
-	out, stderr, err := runCore("treehouse", worktreePath, withTreehouseRoot(clonePath, "status", "--json")...)
+	args, err := withTreehouseRoot(clonePath, worktreePath, "status", "--json")
+	if err != nil {
+		return nil, err.Error()
+	}
+	out, stderr, err := runCore("treehouse", worktreePath, args...)
 	if err != nil {
 		if strings.Contains(err.Error(), "executable file not found") {
 			return nil, fmt.Sprintf("treehouse is not executable: %v", err)
@@ -397,8 +412,38 @@ func treehouseStatus(clonePath, worktreePath string) ([]statusEntry, string) {
 	return entries, ""
 }
 
-func withTreehouseRoot(clonePath string, args ...string) []string {
-	return append([]string{"--root", clonePath}, args...)
+func withTreehouseRoot(clonePath, recordedWorktreePath string, args ...string) ([]string, error) {
+	root, err := poolRoot(clonePath, recordedWorktreePath)
+	if err != nil {
+		return nil, err
+	}
+	return append([]string{"--root", root}, args...), nil
+}
+
+// Where this clone's pool lives. Before atqamz/hand#427 it was the clone itself, which put every
+// worker worktree under the fleet home and fed the worker the supervisor's own CLAUDE.md. A digest
+// of the clone path keys it instead: one pool per fleet home and project, outside every home.
+func poolRoot(clonePath, recordedWorktreePath string) (string, error) {
+	if recordedWorktreePath != "" && withinPath(clonePath, recordedWorktreePath) {
+		return clonePath, nil
+	}
+	infra, err := secondhand.Home()
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree pool root: %w", err)
+	}
+	digest := sha256.Sum256([]byte(filepath.Clean(clonePath)))
+	return filepath.Join(infra, "pools", fmt.Sprintf("%s-%x", filepath.Base(clonePath), digest[:6])), nil
+}
+
+// Reports whether path is root or sits inside it, comparing the recorded strings without resolving
+// symlinks: a worktree recorded under the clone was leased before atqamz/hand#427 and its pool is
+// still the clone, so it stays observable and returnable.
+func withinPath(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }
 
 func runCore(tool, dir string, args ...string) ([]byte, []byte, error) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -31,7 +31,14 @@ func testReturnLease(worktreePath, leaseID string, force bool) error {
 
 func writeFakeTreehouse(t *testing.T, response faketool.TreehouseResponse) {
 	t.Helper()
-	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, faketool.Bin(t))
+	writeFakeTreehouseAt(t, faketool.Bin(t), response)
+}
+
+// faketool.Bin repoints SECONDHAND_HOME, and poolRoot reads it, so a test asserting the resolved
+// --root has to take the bin directory first and compute the expected root after it.
+func writeFakeTreehouseAt(t *testing.T, bin string, response faketool.TreehouseResponse) {
+	t.Helper()
+	faketool.Treehouse{Responses: []faketool.TreehouseResponse{response}}.Install(t, bin)
 }
 
 func mustJSON(t *testing.T, value any) string {
@@ -109,18 +116,52 @@ func TestGetPassesLeaseHolder(t *testing.T) {
 	}
 }
 
-func TestGetScopesPoolToTheFleetHome(t *testing.T) {
+func TestGetAcquiresFromAPoolOutsideEveryFleetHome(t *testing.T) {
+	bin := faketool.Bin(t)
 	home := t.TempDir()
 	clone := filepath.Join(home, "projects", "demo")
 	if err := os.MkdirAll(clone, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeFakeTreehouse(t, faketool.TreehouseResponse{
-		Command: "--root", Args: []string{clone, "get", "--lease", "--json", "--lease-holder", "hand:task-1"},
+	root, err := poolRoot(clone, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withinPath(home, root) {
+		t.Fatalf("pool root %s is inside fleet home %s, which is what atqamz/hand#427 fixes", root, home)
+	}
+	writeFakeTreehouseAt(t, bin, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{root, "get", "--lease", "--json", "--lease-holder", "hand:task-1"},
 		Stdout: `{"path":"/tmp/wt-1"}`,
 	})
 	if _, err := Get(clone, "hand:task-1"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPoolRootDiffersPerClone(t *testing.T) {
+	first, err := poolRoot(filepath.Join(t.TempDir(), "projects", "demo"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := poolRoot(filepath.Join(t.TempDir(), "projects", "demo"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("two clones share pool root %s, so one fleet's worktrees can alias another's", first)
+	}
+}
+
+func TestPoolRootKeepsALegacyWorktreeOnItsOwnClone(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "projects", "demo")
+	legacy := filepath.Join(clone, ".treehouse", "demo-123", "1", "demo")
+	got, err := poolRoot(clone, legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != clone {
+		t.Fatalf("poolRoot() = %s, want the clone %s so a lease taken before atqamz/hand#427 stays returnable", got, clone)
 	}
 }
 
@@ -369,27 +410,53 @@ func TestReturnPassesForceFlag(t *testing.T) {
 	}
 }
 
-func TestReturnScopesPoolToTheFleetHome(t *testing.T) {
+func TestReturnUsesThePoolOutsideEveryFleetHome(t *testing.T) {
+	bin := faketool.Bin(t)
 	home := t.TempDir()
 	clone := filepath.Join(home, "projects", "demo")
 	wt := filepath.Join(home, ".treehouse", "demo-123", "1", "demo")
-	writeFakeTreehouse(t, faketool.TreehouseResponse{
-		Command: "--root", Args: []string{clone, "return", wt, "--force"},
+	root, err := poolRoot(clone, wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withinPath(home, root) {
+		t.Fatalf("pool root %s is inside fleet home %s", root, home)
+	}
+	writeFakeTreehouseAt(t, bin, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{root, "return", wt, "--force"},
 	})
 	if err := Return(clone, wt, true); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestReturnUsesTheCurrentFleetHomeForAForeignRecordedPath(t *testing.T) {
-	currentHome := t.TempDir()
-	currentClone := filepath.Join(currentHome, "projects", "demo")
+func TestReturnNeverFollowsAForeignRecordedPathToItsOwnPool(t *testing.T) {
+	bin := faketool.Bin(t)
+	currentClone := filepath.Join(t.TempDir(), "projects", "demo")
 	foreignHome := t.TempDir()
 	wt := filepath.Join(foreignHome, ".treehouse", "demo-123", "1", "demo")
-	writeFakeTreehouse(t, faketool.TreehouseResponse{
-		Command: "--root", Args: []string{currentClone, "return", wt, "--force"},
+	root, err := poolRoot(currentClone, wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withinPath(foreignHome, root) {
+		t.Fatalf("pool root %s follows the foreign recorded path into %s", root, foreignHome)
+	}
+	writeFakeTreehouseAt(t, bin, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{root, "return", wt, "--force"},
 	})
 	if err := Return(currentClone, wt, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReturnKeepsALegacyWorktreeOnItsOwnClone(t *testing.T) {
+	clone := filepath.Join(t.TempDir(), "projects", "demo")
+	wt := filepath.Join(clone, ".treehouse", "demo-123", "1", "demo")
+	writeFakeTreehouse(t, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{clone, "return", wt, "--force"},
+	})
+	if err := Return(clone, wt, true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -404,13 +471,18 @@ func TestReturnLeasePassesConditionalLeaseIdentity(t *testing.T) {
 	}
 }
 
-func TestObserveLeaseScopesStatusToTheFleetHome(t *testing.T) {
+func TestObserveLeaseStatusUsesThisClonesPool(t *testing.T) {
+	bin := faketool.Bin(t)
 	home := t.TempDir()
 	clone := filepath.Join(home, "projects", "demo")
 	path := filepath.Join(home, ".treehouse", "demo-123", "1", "demo")
 	faketool.InitRepo(t, path)
-	writeFakeTreehouse(t, faketool.TreehouseResponse{
-		Command: "--root", Args: []string{clone, "status", "--json"},
+	root, err := poolRoot(clone, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFakeTreehouseAt(t, bin, faketool.TreehouseResponse{
+		Command: "--root", Args: []string{root, "status", "--json"},
 		Stdout: mustJSON(t, []map[string]string{{"path": path, "status": "leased", "lease_id": "lease-1"}}),
 	})
 	if got := ObserveLease(clone, path, "lease-1"); got.State != LeaseExact {


### PR DESCRIPTION
## Summary

atqamz/hand#404 passed `--root <clonePath>` to treehouse, which put every pool inside the clone and so made a worker worktree a descendant of the fleet home. The home always carries a Hand-owned `CLAUDE.md`, so Claude Code found it by walking up from the worktree, its `@AGENTS.md` import resolved outside the worker's project root, and every launch stalled on the external-import dialog until `hand spawn`'s 60s window expired.

`internal/agentsmd/agentsmd.go:34` already stated the invariant this broke:

> a worktree is never under the fleet home, so it never loads the home's AGENTS.md

So the blocked launch was the visible half. The other half is that a worker was being handed the supervisor's own operating contract.

The pool root is now `<secondhand home>/pools/<clone basename>-<12 hex of sha256(clone path)>`. The digest covers the absolute clone path, which contains both the fleet home and the project, so #404's property is preserved exactly: no two clones can share a pool, and no fleet's slots can alias another's.

**A worktree recorded under its clone keeps the clone as its root.** Without that rule the first observation after upgrading would report `LeaseUnknown`, which correctly refuses destructive cleanup and would therefore strand a live lease rather than release it. There is at least one lease of that shape on this machine, in a fleet this change must not disturb.

`docs/adr/the-worktree-pool-lives-outside-every-fleet-home.md` records the decision, including the real cost: a fleet home is no longer self-contained, so copying or deleting one no longer takes its worktrees with it.

## Why not the alternatives

- Making the Hand-owned `CLAUDE.md` self-contained removes the dialog and makes the contract leak strictly worse - the supervisor's contract would then be reliably read by every worker instead of failing to load.
- Teaching `hand spawn` to answer the dialog means a tool clicking through a security prompt about trusting file imports, and leaves the leak in place.
- `--safe-mode` also disables the project's own conventions; `--bare` additionally forces `ANTHROPIC_API_KEY` and never reads OAuth. Both are per-harness where the cause is not.

Full reasoning and the rejected alternatives are in the ADR.

## Test plan

- `make lint` - gofmt, `go vet`, golangci-lint 0 issues, commentlint clean
- `make test` - full tagged `-race` suite, exit 0
- Verified against real treehouse that `--root` outside the repo works and the repo is still selected by cwd, before writing the change:

```
$ treehouse --root <scratch>/pools get --lease --json --no-fetch
🌳 Leased worktree at <scratch>/pools/.treehouse/repo-d23eb9/1/repo
{"path":"<scratch>/pools/.treehouse/repo-d23eb9/1/repo","lease_id":"a3c497..."}
```

Four tests from #404 asserted the old location by name and are rewritten to the new contract rather than deleted, and each now cites the invariant it checks. New coverage: `INV-POOL-1` through `INV-POOL-4` in `docs/testing-invariants.md`, including that pool resolution never follows a foreign recorded path to that path's own pool, and that a legacy worktree stays on its clone.

One trap worth recording for the next test in this package: `faketool.Bin(t)` repoints `SECONDHAND_HOME`, and pool resolution reads it, so a test asserting the resolved `--root` has to take the bin directory first and compute the expected root after it. `writeFakeTreehouseAt` exists for that.

## Notes

Closes atqamz/hand#427

`hand spawn` still has no signature for either first-run dialog, and the workspace trust prompt is a sibling blocker for a newly registered project. That is worth its own change and is not a substitute for removing the cause; noted on the issue.

Does not close atqamz/hand#412 or atqamz/hand#421. Both are pre-#404 debris - worktrees bound to an operator-owned checkout, stale slots aliasing live directories - whose cause is already fixed and whose remaining work is that nothing can clean them up.