### PR TITLE
fix(attention): surface a not-submitted send to the supervisor

### DIFF
--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -20,6 +20,7 @@ const (
 	nextActionNeedsRepair      = "needs-repair"
 	nextActionSendUncertain    = "send-uncertain"
 	nextActionSendPartial      = "send-partial"
+	nextActionSendNotSubmitted = "send-not-submitted"
 	nextActionReportUnreadable = "report-unreadable"
 	nextActionUnreported       = "unreported"
 	nextActionRuntimeUnknown   = "runtime-unknown"
@@ -55,6 +56,10 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindSendPartial) }); ok {
 		return nextAction{Kind: nextActionSendPartial, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "confirm whether its send needs to be retried")}
+	}
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindSendNotSubmitted) }); ok {
+		return nextAction{Kind: nextActionSendNotSubmitted, Task: v.task.ID, Command: statusCommand(v.task.ID),
+			Reason: statusReason(v.task.ID, "resend the message that was not submitted")}
 	}
 	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindReportDecision) }); ok {
 		return nextAction{Kind: state.ReportNeedsDecision, Task: v.task.ID, Command: statusCommand(v.task.ID),

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -22,6 +22,7 @@ func TestClassifyNextActionExactPrecedence(t *testing.T) {
 	queuedBacklog := backlogSummary{Queued: 1}
 	uncertainSend := &state.SendAttempt{State: state.SendUncertain}
 	partialSend := &state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonEnterRejectedAfterTextStaged}
+	notSubmittedSend := &state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonTextRejectedBeforeAcceptance}
 	pendingSend := &state.SendAttempt{State: state.SendPending}
 
 	tests := []struct {
@@ -64,6 +65,21 @@ func TestClassifyNextActionExactPrecedence(t *testing.T) {
 			configuredWorker, 1, queuedBacklog,
 			[]taskView{{task: state.Task{ID: "send-task"}, latestSend: partialSend}}, nil,
 			nextAction{Kind: nextActionSendPartial, Task: "send-task", Command: "hand status send-task", Reason: statusReason("send-task", "confirm whether its send needs to be retried")},
+		},
+		{
+			"send-not-submitted outranks queued work",
+			configuredWorker, 1, queuedBacklog,
+			[]taskView{{task: state.Task{ID: "send-task"}, latestSend: notSubmittedSend}}, nil,
+			nextAction{Kind: nextActionSendNotSubmitted, Task: "send-task", Command: "hand status send-task", Reason: statusReason("send-task", "resend the message that was not submitted")},
+		},
+		{
+			"send-partial outranks send-not-submitted",
+			configuredWorker, 1, backlogSummary{},
+			[]taskView{
+				{task: state.Task{ID: "b-not-submitted"}, latestSend: notSubmittedSend},
+				{task: state.Task{ID: "a-partial"}, latestSend: partialSend},
+			}, nil,
+			nextAction{Kind: nextActionSendPartial, Task: "a-partial", Command: "hand status a-partial", Reason: statusReason("a-partial", "confirm whether its send needs to be retried")},
 		},
 		{
 			"send-pending is not an attention condition",

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2008,17 +2008,21 @@ func TestStatusFlagsPartialSendAfterFreshRead(t *testing.T) {
 	active := state.Attempt{ID: 2, TaskID: "task-1", Lifecycle: state.AttemptRunning}
 	base := state.TaskHistory{Task: state.Task{ID: "task-1"}, ActiveAttempt: &active}
 	tests := []struct {
-		name          string
-		send          state.SendAttempt
-		wantFlag      string
-		wantAttention bool
-		wantRetrySafe bool
+		name              string
+		send              state.SendAttempt
+		wantFlag          string
+		wantAttention     bool // needsAttention(view): the task-level attention derivation
+		wantSendAttention bool // latestSendJSON(...).NeedsAttention: the unchanged internal/store predicate
+		wantRetrySafe     bool
 	}{
-		{name: "partial composer", send: state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonEnterRejectedAfterTextStaged}, wantFlag: "send-partial", wantAttention: true},
-		{name: "retry-safe rejection", send: state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonTextRejectedBeforeAcceptance}, wantAttention: false, wantRetrySafe: true},
-		{name: "pending", send: state.SendAttempt{State: state.SendPending}, wantFlag: "send-pending", wantAttention: true},
-		{name: "uncertain", send: state.SendAttempt{State: state.SendUncertain}, wantFlag: "send-uncertain", wantAttention: true},
-		{name: "submitted", send: state.SendAttempt{State: state.SendSubmitted}, wantAttention: false},
+		{name: "partial composer", send: state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonEnterRejectedAfterTextStaged}, wantFlag: "send-partial", wantAttention: true, wantSendAttention: true},
+		// Retry-safe before-acceptance rejections now raise send-not-submitted at the task level
+		// (atqamz/hand#419) even though internal/store.SendNeedsAttention, a narrower per-send
+		// predicate this brief does not touch, still reports false for this reason code.
+		{name: "retry-safe rejection", send: state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonTextRejectedBeforeAcceptance}, wantFlag: "send-not-submitted", wantAttention: true, wantSendAttention: false, wantRetrySafe: true},
+		{name: "pending", send: state.SendAttempt{State: state.SendPending}, wantFlag: "send-pending", wantAttention: true, wantSendAttention: true},
+		{name: "uncertain", send: state.SendAttempt{State: state.SendUncertain}, wantFlag: "send-uncertain", wantAttention: true, wantSendAttention: true},
+		{name: "submitted", send: state.SendAttempt{State: state.SendSubmitted}, wantAttention: false, wantSendAttention: false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -2036,8 +2040,8 @@ func TestStatusFlagsPartialSendAfterFreshRead(t *testing.T) {
 				t.Fatalf("needsAttention = %t, want %t", got, test.wantAttention)
 			}
 			got := latestSendJSON(view.latestSend)
-			if got == nil || got.NeedsAttention != test.wantAttention || got.RetrySafe != test.wantRetrySafe {
-				t.Fatalf("latest send JSON = %+v, want attention=%t retry_safe=%t", got, test.wantAttention, test.wantRetrySafe)
+			if got == nil || got.NeedsAttention != test.wantSendAttention || got.RetrySafe != test.wantRetrySafe {
+				t.Fatalf("latest send JSON = %+v, want attention=%t retry_safe=%t", got, test.wantSendAttention, test.wantRetrySafe)
 			}
 		})
 	}

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -125,6 +125,8 @@ func taskFlags(v taskView) []string {
 			flags = append(flags, "send-"+string(v.latestSend.State))
 		case state.SendNeedsAttention(*v.latestSend):
 			flags = append(flags, "send-partial")
+		case v.latestSend.State == state.SendNotSubmitted:
+			flags = append(flags, "send-not-submitted")
 		}
 	}
 	return flags
@@ -156,6 +158,7 @@ func taskAttentionEvidence(v taskView) attention.Evidence {
 		evidence.SendPending = v.latestSend.State == state.SendPending
 		evidence.SendUncertain = v.latestSend.State == state.SendUncertain
 		evidence.SendPartial = isSendPartial(v)
+		evidence.SendNotSubmitted = v.latestSend.State == state.SendNotSubmitted && !evidence.SendPartial
 	}
 	if kind, ok := watcher.GateKind(v.gateObserved); ok {
 		evidence.GateProblem = kind

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -115,7 +115,7 @@ Source: [The report channel is the only outcome signal](adr/the-report-channel-i
 | INV-REP-3 | Evidence and claims are stored apart and rendered apart. No field carries a value from one channel in the shape the other channel's fields use. | property | unaudited |
 | INV-REP-4 | Where the two channels disagree, the disagreement is what gets surfaced. Neither is silently resolved in favour of the other. | property | unaudited |
 | INV-REP-5 | Acknowledgement is independent of both: reading status never clears it. | property | unaudited |
-| INV-REP-6 | Every send state hand durably records reaches at least one supervisor-visible attention subject, distinguishable from every other send state's. | unit | `TestClassifyNextActionExactPrecedence/send-not-submitted_outranks_queued_work` and `TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain` cover it |
+| INV-REP-6 | A send state that records a delivery failure - pending, uncertain, partial, or not-submitted - reaches at least one supervisor-visible attention subject, and no two of them collapse to the same kind. A submitted send raises none. | unit | `TestClassifyNextActionExactPrecedence/send-not-submitted_outranks_queued_work`, `TestClassifyNextActionExactPrecedence/send-partial_outranks_send-not-submitted`, `TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain`, and `TestStatusFlagsPartialSendAfterFreshRead/submitted` cover it |
 
 ## Orientation and currentness
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -115,6 +115,7 @@ Source: [The report channel is the only outcome signal](adr/the-report-channel-i
 | INV-REP-3 | Evidence and claims are stored apart and rendered apart. No field carries a value from one channel in the shape the other channel's fields use. | property | unaudited |
 | INV-REP-4 | Where the two channels disagree, the disagreement is what gets surfaced. Neither is silently resolved in favour of the other. | property | unaudited |
 | INV-REP-5 | Acknowledgement is independent of both: reading status never clears it. | property | unaudited |
+| INV-REP-6 | Every send state hand durably records reaches at least one supervisor-visible attention subject, distinguishable from every other send state's. | unit | `TestClassifyNextActionExactPrecedence/send-not-submitted_outranks_queued_work` and `TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain` cover it |
 
 ## Orientation and currentness
 

--- a/internal/attention/attention.go
+++ b/internal/attention/attention.go
@@ -13,6 +13,7 @@ const (
 	KindNeedsRepair      = "needs-repair"
 	KindSendUncertain    = "send-uncertain"
 	KindSendPartial      = "send-partial"
+	KindSendNotSubmitted = "send-not-submitted"
 	KindReportPaused     = "paused"
 	KindReportBlocked    = "blocked"
 	KindReportDecision   = "needs-decision"
@@ -46,6 +47,7 @@ type Evidence struct {
 	SendUncertain    bool
 	SendPending      bool
 	SendPartial      bool
+	SendNotSubmitted bool
 	Held             bool
 	ReportedState    string
 	ReportClaim      bool
@@ -99,6 +101,9 @@ func Derive(e Evidence) []Subject {
 	}
 	if e.SendPartial {
 		add(KindSendPartial, "send may have been partially delivered", ProvenanceSend, true)
+	}
+	if e.SendNotSubmitted {
+		add(KindSendNotSubmitted, "send was not submitted to the worker", ProvenanceSend, true)
 	}
 	if e.ReportClaim {
 		switch e.ReportedState {

--- a/internal/attention/attention_test.go
+++ b/internal/attention/attention_test.go
@@ -72,6 +72,26 @@ func TestDeriveRetainsHeldSubjectsAsNotActionable(t *testing.T) {
 	}
 }
 
+func TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain(t *testing.T) {
+	got := Derive(Evidence{ID: "task-1", SendNotSubmitted: true})
+	if len(got) != 1 {
+		t.Fatalf("subjects = %#v, want one send-not-submitted subject", got)
+	}
+	if got[0].Kind != KindSendNotSubmitted || got[0].Provenance != ProvenanceSend {
+		t.Fatalf("subject = %#v, want send-not-submitted evidence provenance", got[0])
+	}
+	if !got[0].Actionable {
+		t.Fatal("send-not-submitted subject is not actionable")
+	}
+	if !NeedsAttention(Evidence{ID: "task-1", SendNotSubmitted: true}) {
+		t.Fatal("send-not-submitted evidence needs attention")
+	}
+	uncertain := Derive(Evidence{ID: "task-1", SendUncertain: true})
+	if uncertain[0].Kind == got[0].Kind {
+		t.Fatalf("send-uncertain and send-not-submitted collapsed to the same kind %q", got[0].Kind)
+	}
+}
+
 func TestUnreportedRuntimeMatchesWatcherCatchUpRule(t *testing.T) {
 	for _, test := range []struct {
 		runtime, reported string


### PR DESCRIPTION
## Summary

- `state.SendNotSubmitted` was already durably recorded, but `taskAttentionEvidence` mapped only pending, uncertain, and the one not-submitted reason code (`enter-rejected-after-text-staged`) that `isSendPartial` already claimed as send-partial. A send rejected before the composer ever accepted text (`text-rejected-before-acceptance`) raised no attention subject, no status flag, and no next action.
- Adds `attention.KindSendNotSubmitted`, wired through `taskAttentionEvidence`/`taskFlags` in `cmd/statusview.go`, and ranked in `classifyNextAction` (`cmd/nextaction.go`) directly below `send-partial`: both are known negatives (unlike `send-uncertain`, hand knows the message did not land), but partial leaves residual text in the composer a blind retry could duplicate, while this case is the store's own retry-safe rejection.
- `internal/store.SendNeedsAttention` (the narrower per-send predicate `cmd/status.go`'s JSON `LatestSend.NeedsAttention` field reads directly) is untouched and keeps its existing answer for this reason code; only the task-level attention derivation changes, per `docs/adr/attention-is-one-derivation-over-three-channels.md`.

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
SECONDHAND_HOME=$(mktemp -d) go test -tags=test -race -timeout=30m ./...
ok  	github.com/atqamz/hand/cmd	93.681s
ok  	github.com/atqamz/hand/internal/attention	1.065s
... (all packages ok)

$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	61.651s
```

New/changed tests:
- `cmd/nextaction_test.go`: `send-not-submitted outranks queued work` (the failing test written before the fix, confirming the issue's diagnosis) and `send-partial outranks send-not-submitted` (ranking).
- `internal/attention/attention_test.go`: `TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain`.
- `cmd/status_test.go`: updated `TestStatusFlagsPartialSendAfterFreshRead`'s "retry-safe rejection" case, now expecting the `send-not-submitted` flag and task-level attention, while splitting out the unchanged `internal/store.SendNeedsAttention`-backed JSON expectation into its own field so the two predicates can legitimately diverge for this reason code.
- `docs/testing-invariants.md`: added `INV-REP-6` citing the tests above.

Closes atqamz/hand#419

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->