### PR TITLE
fix(harness): state ship/scout delivery authorization at launch

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -242,6 +242,23 @@ func doctorFindings(fleetHome string, histories []state.TaskHistory) ([]doctorFi
 		}
 	}
 
+	for _, history := range histories {
+		task := history.Task
+		if task.Kind != state.KindShip || task.PR != "" {
+			continue
+		}
+		lines, err := state.ReadReportLines(fleetHome, task.ID)
+		if err != nil {
+			findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q report could not be read: %v", task.ID, err)})
+			continue
+		}
+		last, ok := state.LastReportedState(lines)
+		if !ok || last.State != state.ReportDone {
+			continue
+		}
+		findings = append(findings, doctorFinding{Severity: doctorWarning, Text: fmt.Sprintf("task %q is an open ship task that reported done with no pull request recorded; run `hand status %s` to see what unblocks it", task.ID, task.ID)})
+	}
+
 	projects, err := project.ListReadOnly(fleetHome)
 	if err != nil {
 		return nil, err

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -217,6 +217,59 @@ func TestDoctorWarnsForOpenBriefWithoutReportPath(t *testing.T) {
 	}
 }
 
+func TestDoctorWarnsForOpenShipTaskReportedDoneWithNoPR(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	mustConfigSet(t, settingHarness, harness.Claude)
+
+	for _, task := range []state.Task{
+		{ID: "stuck", Project: "demo", Kind: state.KindShip, Brief: "data/stuck/brief.md", Lifecycle: state.TaskOpen},
+		{ID: "delivered", Project: "demo", Kind: state.KindShip, Brief: "data/delivered/brief.md", Lifecycle: state.TaskOpen, PR: "https://github.com/atqamz/hand/pull/1"},
+		{ID: "working", Project: "demo", Kind: state.KindShip, Brief: "data/working/brief.md", Lifecycle: state.TaskOpen},
+		{ID: "scouting", Project: "demo", Kind: state.KindScout, Brief: "data/scouting/brief.md", Lifecycle: state.TaskOpen},
+	} {
+		if err := state.CreateTask(home, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for id, report := range map[string]string{
+		"stuck":     "done: nothing left to do\n",
+		"delivered": "done: PR opened\n",
+		"working":   "working: still going\n",
+		"scouting":  "done: report written\n",
+	} {
+		if err := os.WriteFile(state.ReportPath(home, id), []byte(report), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	histories, err := state.ListOpenHistoriesReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings, err := doctorFindings(".", histories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDoctorFinding(findings, doctorFinding{Severity: doctorWarning, Text: "task \"stuck\" is an open ship task that reported done with no pull request recorded; run `hand status stuck` to see what unblocks it"}) {
+		t.Fatalf("findings = %#v, want stuck ship task warning", findings)
+	}
+	for _, id := range []string{"delivered", "working", "scouting"} {
+		for _, finding := range findings {
+			if finding.Severity == doctorWarning && strings.Contains(finding.Text, fmt.Sprintf("task %q is an open ship task", id)) {
+				t.Fatalf("findings = %#v, task %q should not warn", findings, id)
+			}
+		}
+	}
+}
+
 func hasDoctorFindingPrefix(findings []doctorFinding, severity doctorSeverity, prefix string) bool {
 	for _, finding := range findings {
 		if finding.Severity == severity && strings.HasPrefix(finding.Text, prefix) {

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -210,13 +210,15 @@ Source: [Every diagnosis names a reachable treatment](adr/every-diagnosis-names-
 
 ## Launch-level delivery authorization
 
-Source: `internal/harness/harness.go` (`briefPrompt`), `cmd/doctor.go`.
+Source: `internal/harness/harness.go` (`briefPrompt`), `internal/runtime` (spawn, reopen, promote,
+reconcile), `cmd/doctor.go`.
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
-| INV-AUTH-1 | A ship task's launch prompt always states the worker is authorized to commit, push its branch, and open the pull request, regardless of what the brief itself says. | unit | `TestBuildShipCarriesDeliveryAuthorization` |
-| INV-AUTH-2 | A scout task's launch prompt always states its deliverable is a report and that it must not commit, push, or open a pull request, and never carries the ship grant. | unit | `TestBuildScoutCarriesNoDeliveryGrant` |
-| INV-AUTH-3 | `hand doctor` names every open ship task that reported done with no pull request recorded, and the finding names the command that shows the way out. | unit | `TestDoctorWarnsForOpenShipTaskReportedDoneWithNoPR` |
+| INV-AUTH-1 | Given a kind, a ship task's rendered launch prompt always states the worker is authorized to commit, push its branch, and open the pull request, regardless of what the brief itself says. | unit | `TestBuildShipCarriesDeliveryAuthorization` |
+| INV-AUTH-2 | Given a kind, a scout task's rendered launch prompt always states its deliverable is a report and that it must not commit, push, or open a pull request, and never carries the ship grant. | unit | `TestBuildScoutCarriesNoDeliveryGrant` |
+| INV-AUTH-4 | Every launch path supplies the task's kind to `harness.Build`: spawn, reopen, promote (always ship), and reconcile's confirm-launch arm all carry it through, so INV-AUTH-1/2 hold for a real launch and not only for a prompt built by hand. | unit | `TestSpawnBuildsHarnessCarryingTaskKind`, `TestReopenBuildsHarnessCarryingTaskKind`, `TestPromoteBuildsHarnessCarryingShipKind`, `TestReconcileConfirmLaunchCarriesTaskKind` |
+| INV-AUTH-3 | `hand doctor` names every open ship task whose *last* reported state is `done` with no pull request recorded, and the finding names the command that shows the way out. This does not catch a ship worker that is functionally finished but still reporting `working:` - that case is not mechanically detectable from the report channel alone. | unit | `TestDoctorWarnsForOpenShipTaskReportedDoneWithNoPR` |
 
 ## Pure helpers
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -208,6 +208,16 @@ Source: [Every diagnosis names a reachable treatment](adr/every-diagnosis-names-
 | INV-DIAG-2 | A persisted repair reason carries its treatment text with the task id substituted, so a refusal and the way out cannot drift apart. | property | unaudited |
 | INV-DIAG-3 | Every treatment falls in exactly one of the three classes. | property | unaudited |
 
+## Launch-level delivery authorization
+
+Source: `internal/harness/harness.go` (`briefPrompt`), `cmd/doctor.go`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-AUTH-1 | A ship task's launch prompt always states the worker is authorized to commit, push its branch, and open the pull request, regardless of what the brief itself says. | unit | `TestBuildShipCarriesDeliveryAuthorization` |
+| INV-AUTH-2 | A scout task's launch prompt always states its deliverable is a report and that it must not commit, push, or open a pull request, and never carries the ship grant. | unit | `TestBuildScoutCarriesNoDeliveryGrant` |
+| INV-AUTH-3 | `hand doctor` names every open ship task that reported done with no pull request recorded, and the finding names the command that shows the way out. | unit | `TestDoctorWarnsForOpenShipTaskReportedDoneWithNoPR` |
+
 ## Pure helpers
 
 Source: `internal/shellquote`, `internal/age`, `cmd/statusview.go`.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/launch"
+	"github.com/atqamz/hand/internal/state"
 )
 
 const antigravityPrintTimeout = "24h"
@@ -142,6 +143,10 @@ type Options struct {
 	Effort              string
 	ExecutionClass      brief.ExecutionClass
 	BriefHasFrontMatter bool
+	// Kind is the task kind (state.KindShip or state.KindScout) briefPrompt states the launch-level
+	// delivery authorization for. Empty for callers that never resolve a task, e.g. unit tests
+	// exercising unrelated flags: no authorization statement is added in that case.
+	Kind string
 }
 
 var modelCapable = map[string]bool{
@@ -313,6 +318,12 @@ func briefPrompt(o Options) (string, error) {
 	}
 	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
 	prompt += fmt.Sprintf(" The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", o.ReportPath)
+	switch o.Kind {
+	case state.KindShip:
+		prompt += " You are authorized to commit, push your branch, and open the pull request; merging and closing the issue are the supervisor's action only."
+	case state.KindScout:
+		prompt += " Your deliverable is a report; you must not commit, push, or open a pull request."
+	}
 	if o.BriefHasFrontMatter {
 		prompt += " Any model, effort, execution_class, or planned_against keys in its leading '---' block are dispatch metadata, not task instructions."
 	}

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atqamz/hand/internal/agentsmd"
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/launch"
+	"github.com/atqamz/hand/internal/state"
 )
 
 func buildSpec(t *testing.T, name string, options Options) launch.LaunchSpec {
@@ -266,6 +267,39 @@ func TestBuildOpenCodeNeverHeadless(t *testing.T) {
 	}
 	if spec.Env["OPENCODE_CONFIG_CONTENT"] == "" {
 		t.Fatalf("env = %#v, want OPENCODE_CONFIG_CONTENT", spec.Env)
+	}
+}
+
+func TestBuildShipCarriesDeliveryAuthorization(t *testing.T) {
+	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Kind: state.KindShip})
+		for _, want := range []string{"authorized to commit, push your branch, and open the pull request", "merging and closing the issue are the supervisor's action only"} {
+			if !containsText(spec.Args, want) {
+				t.Fatalf("Build(%q) args = %#v, want ship delivery authorization %q", name, spec.Args, want)
+			}
+		}
+		if containsText(spec.Args, "must not commit, push, or open a pull request") {
+			t.Fatalf("Build(%q) args = %#v, ship must not carry the scout refusal", name, spec.Args)
+		}
+	}
+}
+
+func TestBuildScoutCarriesNoDeliveryGrant(t *testing.T) {
+	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
+		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md", Kind: state.KindScout})
+		if !containsText(spec.Args, "must not commit, push, or open a pull request") {
+			t.Fatalf("Build(%q) args = %#v, want scout refusal", name, spec.Args)
+		}
+		if containsText(spec.Args, "authorized to commit, push your branch") {
+			t.Fatalf("Build(%q) args = %#v, scout must not carry the ship grant", name, spec.Args)
+		}
+	}
+}
+
+func TestBuildWithoutKindCarriesNoAuthorizationStatement(t *testing.T) {
+	spec := buildSpec(t, Claude, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
+	if containsText(spec.Args, "authorized to commit, push your branch") || containsText(spec.Args, "must not commit, push, or open a pull request") {
+		t.Fatalf("Build args = %#v, want no authorization statement without a kind", spec.Args)
 	}
 }
 

--- a/internal/runtime/promote.go
+++ b/internal/runtime/promote.go
@@ -151,7 +151,7 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 
 	worktreePath, err := r.provisionLocked(ctx, provisioningRequest{
 		home: req.Home, projectName: projectInfo.Name, clonePath: clonePath, briefPath: briefPath,
-		briefHasFrontMatter: route.BriefHasFrontMatter, paneStartedAt: createdAt, attempt: shipAttempt,
+		briefHasFrontMatter: route.BriefHasFrontMatter, paneStartedAt: createdAt, attempt: shipAttempt, taskKind: state.KindShip,
 	})
 	if err != nil {
 		return fail(err)

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -96,6 +96,7 @@ type provisioningRequest struct {
 	resumeExisting        bool
 	paneStartedAt         string
 	attempt               state.Attempt
+	taskKind              string
 }
 
 func absoluteReportPath(home, id string) (string, error) {
@@ -203,7 +204,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	}
 	workerSpec, err := r.deps.buildHarness(req.attempt.Harness, harness.Options{
 		Worktree: worktreePath, Brief: req.briefPath, ReportPath: reportPath, Model: req.attempt.Model, Effort: req.attempt.Effort,
-		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter,
+		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter, Kind: req.taskKind,
 	})
 	if err != nil {
 		return "", r.failProvision(req, lease, nil, false, err)

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -1361,7 +1361,7 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 		_, err = r.provision(ctx, provisioningRequest{
 			home: home, projectName: projectInfo.Name, clonePath: filepath.Join(home, "projects", projectInfo.Name),
 			briefPath: briefPath, briefHasFrontMatter: hasFrontMatter, recheckMechanicalBase: true, attempt: attempt,
-			resumeExisting: attempt.Worktree != "",
+			resumeExisting: attempt.Worktree != "", taskKind: task.Kind,
 		})
 		return err
 	case reconciliationActionConfirmLaunch:
@@ -1376,7 +1376,7 @@ func (r *Runtime) applyReconciliationAction(ctx context.Context, home string, ta
 		}
 		spec, err := r.deps.buildHarness(attempt.Harness, harness.Options{
 			Worktree: attempt.Worktree, Brief: briefPath, ReportPath: reportPath, Model: attempt.Model, Effort: attempt.Effort,
-			ExecutionClass: brief.ExecutionClass(attempt.ExecutionClass), BriefHasFrontMatter: hasFrontMatter,
+			ExecutionClass: brief.ExecutionClass(attempt.ExecutionClass), BriefHasFrontMatter: hasFrontMatter, Kind: task.Kind,
 		})
 		if err != nil {
 			return fmt.Errorf("build persisted launch evidence: %w", err)

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -422,6 +422,27 @@ func TestReconcileSubmittedLaunchConfirmsExistingPaneWithoutRelaunch(t *testing.
 	}
 }
 
+func TestReconcileConfirmLaunchCarriesTaskKind(t *testing.T) {
+	home := reconcileFixture(t)
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout, Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", LaunchSubmittedAt: "2026-08-15T00:00:00Z", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	var got harness.Options
+	r.deps.buildHarness = func(_ string, options harness.Options) (launchSpec, error) {
+		got = options
+		return launchSpec{Executable: "launch"}, nil
+	}
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != state.KindScout {
+		t.Fatalf("Options.Kind = %q, want %q", got.Kind, state.KindScout)
+	}
+}
+
 func TestReconcileRunningMissingPaneConvergesWithoutReplacement(t *testing.T) {
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{

--- a/internal/runtime/reopen.go
+++ b/internal/runtime/reopen.go
@@ -120,7 +120,7 @@ func (r *Runtime) Reopen(ctx context.Context, req ReopenRequest) (Result, error)
 
 	provisionRequest := provisioningRequest{
 		home: req.Home, projectName: projectInfo.Name, clonePath: clonePath, briefPath: briefPath,
-		briefHasFrontMatter: route.BriefHasFrontMatter, paneStartedAt: createdAt, attempt: attempt,
+		briefHasFrontMatter: route.BriefHasFrontMatter, paneStartedAt: createdAt, attempt: attempt, taskKind: task.Kind,
 	}
 	var worktreePath string
 	if releaseProject != nil {

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -475,6 +475,77 @@ func TestPromoteResolvesShipRouteBeforeScoutMutation(t *testing.T) {
 	}
 }
 
+func TestSpawnBuildsHarnessCarryingTaskKind(t *testing.T) {
+	for _, kind := range []string{state.KindShip, state.KindScout} {
+		t.Run(kind, func(t *testing.T) {
+			home := executionPlanHome(t, "---\nexecution_class: standard\n---\nbrief\n")
+			r := executionPlanRuntime(t, &executionPlanCalls{}, func(string) (string, error) { return strings.Repeat("a", 40), nil })
+			var got harness.Options
+			r.deps.buildHarness = func(_ string, options harness.Options) (launchSpec, error) {
+				got = options
+				return launchSpec{Executable: "launch"}, nil
+			}
+
+			if _, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Kind: kind}); err != nil {
+				t.Fatal(err)
+			}
+			if got.Kind != kind {
+				t.Fatalf("Options.Kind = %q, want %q", got.Kind, kind)
+			}
+		})
+	}
+}
+
+func TestReopenBuildsHarnessCarryingTaskKind(t *testing.T) {
+	home := executionPlanHome(t, "---\nexecution_class: deep\n---\nbrief\n")
+	createTerminalExecutionTask(t, home)
+	configureRoute(t, home, state.KindShip, routing.ExecutionClassDeep, routing.Profile{Name: "daily", Harness: "claude"})
+	r := executionPlanRuntime(t, &executionPlanCalls{}, func(string) (string, error) { return strings.Repeat("a", 40), nil })
+	var got harness.Options
+	r.deps.buildHarness = func(_ string, options harness.Options) (launchSpec, error) {
+		got = options
+		return launchSpec{Executable: "launch"}, nil
+	}
+
+	if _, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != state.KindShip {
+		t.Fatalf("Options.Kind = %q, want %q", got.Kind, state.KindShip)
+	}
+}
+
+func TestPromoteBuildsHarnessCarryingShipKind(t *testing.T) {
+	home := executionPlanHome(t, "---\nexecution_class: standard\n---\nbrief\n")
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("report\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scout, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindScout, Lifecycle: state.TaskOpen}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: "claude", Worktree: "/old/worktree",
+		Herdr: state.Herdr{WorkspaceID: "old-ws", TabID: "old-tab", PaneID: "old-pane"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	markExecutionAttemptRunning(t, home, scout.ID)
+	configureRoute(t, home, state.KindScout, routing.ExecutionClassStandard, routing.Profile{Name: "investigate", Harness: "claude"})
+	configureRoute(t, home, state.KindShip, routing.ExecutionClassStandard, routing.Profile{Name: "deliver", Harness: "codex", Model: "ship-model"})
+	addHarnessToPath(t, "codex")
+	r := executionPlanRuntime(t, &executionPlanCalls{}, func(string) (string, error) { return strings.Repeat("a", 40), nil })
+	var got harness.Options
+	r.deps.buildHarness = func(_ string, options harness.Options) (launchSpec, error) {
+		got = options
+		return launchSpec{Executable: "launch"}, nil
+	}
+
+	if _, err := r.Promote(context.Background(), PromoteRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != state.KindShip {
+		t.Fatalf("Options.Kind = %q, want %q", got.Kind, state.KindShip)
+	}
+}
+
 func TestProvisionBuildsFromPersistedAttemptSnapshot(t *testing.T) {
 	home, attempt := provisioningFixture(t)
 	attempt.Harness = "codex"

--- a/internal/runtime/spawn.go
+++ b/internal/runtime/spawn.go
@@ -97,7 +97,7 @@ func (r *Runtime) Spawn(ctx context.Context, req SpawnRequest) (Result, error) {
 
 	provisionRequest := provisioningRequest{
 		home: req.Home, projectName: projectInfo.Name, clonePath: clonePath, briefPath: briefPath,
-		briefHasFrontMatter: route.BriefHasFrontMatter, paneStartedAt: createdAt, attempt: attempt,
+		briefHasFrontMatter: route.BriefHasFrontMatter, paneStartedAt: createdAt, attempt: attempt, taskKind: kind,
 	}
 	var worktreePath string
 	if releaseProject != nil {


### PR DESCRIPTION
## Summary

- `briefPrompt` now states, unconditionally at launch, that a `kind: ship` worker is authorized to commit, push its branch, and open the pull request (merge and issue closure stay the supervisor's action), and that a `kind: scout` worker's deliverable is a report and it must not push.
- Threaded the task kind through every `harness.Options` construction site (`spawn`, `reopen`, `promote`, `reconcile`) so the grant no longer depends on brief prose.
- `hand doctor` now warns on an open ship task that reported `done:` with no pull request recorded, naming `hand status <id>` as the way to see what unblocks it.

Closes atqamz/hand#411

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
...
ok  	github.com/atqamz/hand/cmd	214.018s
...
ok  	github.com/atqamz/hand/internal/harness	3.296s
...
ok  	github.com/atqamz/hand/internal/runtime	172.851s
...
(all packages ok)

$ make e2e
ok  	github.com/atqamz/hand/tests/e2e	89.856s
```

Rendered launch prompt, real render via `harness.Build`, not source:

Ship: `...You are authorized to commit, push your branch, and open the pull request; merging and closing the issue are the supervisor's action only....`

Scout: `...Your deliverable is a report; you must not commit, push, or open a pull request....`

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->