### PR TITLE
feat(harness): catalogue codex's usage-limit signature

### DIFF
--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -81,11 +81,11 @@ Source: [Usage-limit detection is a harness capability](adr/usage-limit-detectio
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
-| INV-LIMIT-1 | A catalogued harness's stop refusal is detected as a usage limit; an uncatalogued harness never is, for any text. | property | `TestSupportsUsageLimitOnlyWhereASignatureIsCatalogued`, `TestDetectUsageLimitDeclinesForAnUncataloguedHarness` |
+| INV-LIMIT-1 | A catalogued harness's stop refusal is detected as a usage limit; an uncatalogued harness never is, for any text. | property | `TestSupportsUsageLimitOnlyWhereASignatureIsCatalogued`, `TestDetectUsageLimitDeclinesForAnUncataloguedHarness` land unit cases; property form unaudited |
 | INV-LIMIT-2 | No catalogued signature matches an approaching-limit warning, only the stop itself. | unit | `TestDetectUsageLimitIgnoresTextThatIsNotAStop`, `TestDetectUsageLimitIgnoresCodexTextThatIsNotAStop` |
 | INV-LIMIT-3 | One harness's signature never matches another harness's wording. | unit | `TestDetectUsageLimitDoesNotCrossMatchClaudeAndCodex` |
-| INV-LIMIT-4 | A reset instant that does not parse degrades to no prediction, never to a guessed one. | unit | `TestDetectCodexUsageLimitResetInstant` |
-| INV-LIMIT-5 | A dateless clock-time reset resolves against `now` in the local zone, rolling forward when the named time is not after `now`. | unit | `TestDetectUsageLimitReadsTheResetInstant`, `TestDetectCodexUsageLimitResetInstant` |
+| INV-LIMIT-4 | A reset instant that does not parse degrades to no prediction, never to a guessed one, for any unrecognized wording. | property | `TestDetectCodexUsageLimitResetInstant` lands a unit case; property form unaudited |
+| INV-LIMIT-5 | A dateless clock-time reset resolves against `now` in the local zone, rolling forward when the named time is not after `now`, for any (now, clock time) pair. | property | `TestDetectUsageLimitReadsTheResetInstant`, `TestDetectCodexUsageLimitResetInstant` land unit cases; property form unaudited |
 
 ## Registry and fleet identity
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -74,6 +74,19 @@ Source: [hand init is the canonical fleet reconciler](adr/hand-init-is-the-canon
 | INV-INIT-5 | A non-empty directory is adopted if and only if its `go.mod` declares hand's own module path. | property | phase 0 of atqamz/hand#436 landed unit tests; property form unaudited |
 | INV-INIT-6 | Preflight refusal is total: a refused target has no byte changed, including the private runtime root. | property | unaudited |
 
+## Usage-limit signatures
+
+Source: [Usage-limit detection is a harness capability](adr/usage-limit-detection-is-a-harness-capability.md),
+`internal/harness/usagelimit.go`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-LIMIT-1 | A catalogued harness's stop refusal is detected as a usage limit; an uncatalogued harness never is, for any text. | property | `TestSupportsUsageLimitOnlyWhereASignatureIsCatalogued`, `TestDetectUsageLimitDeclinesForAnUncataloguedHarness` |
+| INV-LIMIT-2 | No catalogued signature matches an approaching-limit warning, only the stop itself. | unit | `TestDetectUsageLimitIgnoresTextThatIsNotAStop`, `TestDetectUsageLimitIgnoresCodexTextThatIsNotAStop` |
+| INV-LIMIT-3 | One harness's signature never matches another harness's wording. | unit | `TestDetectUsageLimitDoesNotCrossMatchClaudeAndCodex` |
+| INV-LIMIT-4 | A reset instant that does not parse degrades to no prediction, never to a guessed one. | unit | `TestDetectCodexUsageLimitResetInstant` |
+| INV-LIMIT-5 | A dateless clock-time reset resolves against `now` in the local zone, rolling forward when the named time is not after `now`. | unit | `TestDetectUsageLimitReadsTheResetInstant`, `TestDetectCodexUsageLimitResetInstant` |
+
 ## Registry and fleet identity
 
 Source: [Fleet identity and user registry](adr/fleet-identity-and-user-registry.md), `internal/registry`.

--- a/internal/harness/usagelimit.go
+++ b/internal/harness/usagelimit.go
@@ -18,8 +18,8 @@ type usageLimit struct {
 }
 
 // The per-harness catalogue, and the reason adding a harness here is an implementation rather than one
-// more branch in the poll loop. Only claude has a signature; every other harness declines the
-// capability until someone catalogues its refusal against a real limited run, the bar firstRunPrompts holds.
+// more branch in the poll loop. An uncatalogued harness declines the capability until someone
+// catalogues its refusal against a real limited run, the bar firstRunPrompts holds.
 var usageLimits = map[string]usageLimit{
 	Claude: {
 		// Three wordings claude has shipped: the REPL's "limit will reset at 3pm (UTC)", the
@@ -27,6 +27,13 @@ var usageLimits = map[string]usageLimit{
 		// Anchored on *reached*, never "limit" alone, so an approaching-your-limit warning cannot read as a stop.
 		Match: regexp.MustCompile(`(?i)usage limit reached|\d+-hour limit reached|reached your (?:\w+ )*limit`),
 		Reset: parseClaudeReset,
+	},
+	// atqamz/hand#435: codex says *hit*, never *reached*, so claude's pattern cannot match it and is
+	// not loosened to match it either. Anchored on "hit" for the same reason claude is anchored on
+	// "reached": a bare "limit" would read an approaching-limit warning as a stop.
+	Codex: {
+		Match: regexp.MustCompile(`(?i)hit your (?:\w+ )*usage limit`),
+		Reset: parseCodexReset,
 	},
 }
 
@@ -119,6 +126,48 @@ func parseClaudeReset(text string, now time.Time) (time.Time, bool) {
 	reset := time.Date(local.Year(), local.Month(), local.Day(), hour, minute, 0, 0, loc)
 	// A limit's reset is always ahead of the message announcing it, so an hour already past today
 	// resolves to the next occurrence of that clock time.
+	if !reset.After(now) {
+		reset = reset.AddDate(0, 0, 1)
+	}
+	return reset, true
+}
+
+// codex's only observed reset wording, from a real limited run: "try again at 7:27 PM". A minute is
+// always present in the wording actually seen, so - unlike claude's clock form - it is required here
+// rather than defaulted; any other shape returns false rather than guessing at one.
+var codexResetClock = regexp.MustCompile(`(?i)try again at (\d{1,2}):(\d{2})\s*(am|pm)\b`)
+
+// codex's reset names a bare local clock time: no date, and no zone at all, unlike claude's optional
+// "(UTC)". The message cannot mean any zone but the one it was read in, so it is resolved directly
+// against now's own location rather than falling back to it after a failed parse.
+func parseCodexReset(text string, now time.Time) (time.Time, bool) {
+	m := codexResetClock.FindStringSubmatch(text)
+	if m == nil {
+		return time.Time{}, false
+	}
+	hour, err := strconv.Atoi(m[1])
+	if err != nil || hour < 1 || hour > 12 {
+		return time.Time{}, false
+	}
+	minute, err := strconv.Atoi(m[2])
+	if err != nil || minute > 59 {
+		return time.Time{}, false
+	}
+	switch strings.ToLower(m[3]) {
+	case "pm":
+		if hour < 12 {
+			hour += 12
+		}
+	case "am":
+		if hour == 12 {
+			hour = 0
+		}
+	}
+
+	loc := now.Location()
+	local := now.In(loc)
+	reset := time.Date(local.Year(), local.Month(), local.Day(), hour, minute, 0, 0, loc)
+	// Dateless, so a clock time already past today - or equal to now - names tomorrow's occurrence.
 	if !reset.After(now) {
 		reset = reset.AddDate(0, 0, 1)
 	}

--- a/internal/harness/usagelimit_test.go
+++ b/internal/harness/usagelimit_test.go
@@ -6,10 +6,12 @@ import (
 )
 
 func TestSupportsUsageLimitOnlyWhereASignatureIsCatalogued(t *testing.T) {
-	if !SupportsUsageLimit(Claude) {
-		t.Fatal("SupportsUsageLimit(claude) = false, want true")
+	for _, name := range []string{Claude, Codex} {
+		if !SupportsUsageLimit(name) {
+			t.Errorf("SupportsUsageLimit(%q) = false, want true", name)
+		}
 	}
-	for _, name := range []string{Codex, Grok, Pi, OpenCode, Antigravity, "", "nonesuch"} {
+	for _, name := range []string{Grok, Pi, OpenCode, Antigravity, "", "nonesuch"} {
 		if SupportsUsageLimit(name) {
 			t.Errorf("SupportsUsageLimit(%q) = true, want false: no signature is catalogued for it", name)
 		}
@@ -49,8 +51,109 @@ func TestDetectUsageLimitIgnoresTextThatIsNotAStop(t *testing.T) {
 func TestDetectUsageLimitDeclinesForAnUncataloguedHarness(t *testing.T) {
 	now := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
 	text := "Claude usage limit reached. Your limit will reset at 3pm (UTC)."
-	if _, limited := DetectUsageLimit(Codex, text, now); limited {
-		t.Fatal("DetectUsageLimit(codex) = true: claude's wording must not be matched against another harness")
+	if _, limited := DetectUsageLimit(Grok, text, now); limited {
+		t.Fatal("DetectUsageLimit(grok) = true: claude's wording must not be matched against another harness")
+	}
+}
+
+func TestDetectUsageLimitDoesNotCrossMatchClaudeAndCodex(t *testing.T) {
+	now := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
+	claudeText := "Claude usage limit reached. Your limit will reset at 3pm (UTC)."
+	if _, limited := DetectUsageLimit(Codex, claudeText, now); limited {
+		t.Fatal("DetectUsageLimit(codex, claude's wording) = true, want false")
+	}
+	codexText := "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), " +
+		"visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 7:27 PM."
+	if _, limited := DetectUsageLimit(Claude, codexText, now); limited {
+		t.Fatal("DetectUsageLimit(claude, codex's wording) = true, want false")
+	}
+}
+
+// The verbatim refusal from atqamz/hand#435: two codex workers hit the limit simultaneously and
+// the claude-anchored pattern could not match "hit", only "reached".
+func TestDetectUsageLimitRecognizesTheObservedCodexRefusal(t *testing.T) {
+	now := time.Date(2026, 8, 27, 18, 21, 0, 0, time.FixedZone("WIB", 7*3600))
+	text := "■ You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), " +
+		"visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 7:27 PM."
+	reset, limited := DetectUsageLimit(Codex, text, now)
+	if !limited {
+		t.Fatal("DetectUsageLimit(codex, observed refusal) = false, want true")
+	}
+	want := time.Date(2026, 8, 27, 19, 27, 0, 0, now.Location())
+	if !reset.Equal(want) {
+		t.Fatalf("reset = %s, want %s", reset, want)
+	}
+}
+
+// The warning codex prints as quota runs low - if it ever does - must not read as a stop: the
+// signature is anchored on "hit", the word the real refusal uses, not on bare "limit".
+func TestDetectUsageLimitIgnoresCodexTextThatIsNotAStop(t *testing.T) {
+	now := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
+	for _, text := range []string{
+		"You're approaching your usage limit.",
+		"10% of your usage limit remains.",
+		"Set a spend limit for this account",
+		"",
+	} {
+		if _, limited := DetectUsageLimit(Codex, text, now); limited {
+			t.Errorf("DetectUsageLimit(codex, %q) = true, want false", text)
+		}
+	}
+}
+
+func TestDetectCodexUsageLimitResetInstant(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		now  time.Time
+		want time.Time
+		ok   bool
+	}{
+		{
+			// The exact observed shape.
+			name: "observed shape",
+			text: "You've hit your usage limit. ... or try again at 7:27 PM.",
+			now:  time.Date(2026, 8, 27, 18, 21, 0, 0, time.UTC),
+			want: time.Date(2026, 8, 27, 19, 27, 0, 0, time.UTC),
+			ok:   true,
+		},
+		{
+			// A shape the parser must not guess at: no reset is better than a wrong one.
+			name: "unparseable shape does not parse",
+			text: "You've hit your usage limit. Try again later.",
+			now:  time.Date(2026, 8, 27, 18, 21, 0, 0, time.UTC),
+			ok:   false,
+		},
+		{
+			// Dateless and zoneless: a clock time earlier than now rolls to tomorrow.
+			name: "rollover across midnight",
+			text: "You've hit your usage limit. ... or try again at 12:15 AM.",
+			now:  time.Date(2026, 8, 27, 23, 50, 0, 0, time.UTC),
+			want: time.Date(2026, 8, 28, 0, 15, 0, 0, time.UTC),
+			ok:   true,
+		},
+		{
+			// A clock time still ahead of now resolves to today, no rollover.
+			name: "clock time later today",
+			text: "You've hit your usage limit. ... or try again at 11:05 AM.",
+			now:  time.Date(2026, 8, 27, 9, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 8, 27, 11, 5, 0, 0, time.UTC),
+			ok:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reset, limited := DetectUsageLimit(Codex, tt.text, tt.now)
+			if !limited {
+				t.Fatalf("DetectUsageLimit(codex, %q) limited = false, want true: text still names a stop even when the reset does not parse", tt.text)
+			}
+			if reset.IsZero() != !tt.ok {
+				t.Fatalf("reset zero = %v, want ok=%v", reset.IsZero(), tt.ok)
+			}
+			if tt.ok && !reset.Equal(tt.want) {
+				t.Fatalf("reset = %s, want %s", reset, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/liveness_test.go
+++ b/internal/runtime/liveness_test.go
@@ -348,12 +348,12 @@ func TestReconcileDoesNotReprobeAnAlreadyScheduledUsageLimit(t *testing.T) {
 	}
 }
 
-// A harness with no catalogued usage-limit signature - every harness but claude today - gets no pane
-// read and no attempted detection; only status_changed_for durably changes.
+// A harness with no catalogued usage-limit signature - every harness but claude and codex today -
+// gets no pane read and no attempted detection; only status_changed_for durably changes.
 func TestReconcileSkipsUsageLimitDetectionForAnUncataloguedHarness(t *testing.T) {
-	client := &livenessHerdr{agent: "codex", status: herdr.StatusIdle, paneText: claudeUsageLimitText(true)}
+	client := &livenessHerdr{agent: "grok", status: herdr.StatusIdle, paneText: claudeUsageLimitText(true)}
 	home, attempt := repairFixture(t, state.Task{}, state.Attempt{
-		Lifecycle: state.AttemptProvisioning, Harness: "codex", Worktree: "/pool/1", LeaseID: "lease-1",
+		Lifecycle: state.AttemptProvisioning, Harness: "grok", Worktree: "/pool/1", LeaseID: "lease-1",
 		Herdr:             state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
 		LaunchSubmittedAt: "2026-08-14T23:00:00Z", LaunchConfirmedAt: "2026-08-14T23:59:00Z",
 	})

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -192,7 +192,7 @@ func TestTickReadsNoPaneForAHarnessWithoutTheCapability(t *testing.T) {
 	statusFile := filepath.Join(t.TempDir(), "status")
 	setStatus(t, statusFile, "working")
 	writeFakeHerdr(t, statusFile)
-	paneLog := paneScript(t, "codex", claudeLimitText)
+	paneLog := paneScript(t, "grok", claudeLimitText)
 
 	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
 	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
@@ -206,7 +206,7 @@ func TestTickReadsNoPaneForAHarnessWithoutTheCapability(t *testing.T) {
 	tick(ctx, cfg, client, states, &buf, &buf)
 
 	if calls := paneCalls(t, paneLog); calls != "" {
-		t.Fatalf("pane calls = %q, want none: codex declines the usage-limit capability", calls)
+		t.Fatalf("pane calls = %q, want none: grok declines the usage-limit capability", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- codex stops on a usage limit with "You've hit your usage limit ... try again at 7:27 PM" (atqamz/hand#435), which claude's `reached`-anchored pattern cannot match, so `hand watch` classified it `stale`, then `parked`, then `idle-unreported` instead of held on `limit`.
- Adds a codex entry anchored on "hit" - the word codex actually uses, for the same reason claude's is anchored on "reached", so an approaching-limit warning still cannot read as a stop.
- Adds a reset parser for codex's dateless, zoneless 12-hour clock wording (`try again at 7:27 PM`), resolved against `now` in the local zone with rollover across midnight. Any wording but the exact observed shape degrades to no prediction, never a guessed one.
- Extends `docs/testing-invariants.md` with the invariants this catalogue holds.

Closes atqamz/hand#435

## Note for the watcher, not fixed here

The issue observes that a codex usage limit is account-wide: it stops every codex-routed worker in the fleet at once. `internal/watcher/usagelimit.go` and `internal/runtime/liveness.go` both detect and schedule per attempt/pane, with no fleet-wide awareness. Nothing here makes that assumption more visible than it already was - the issue explicitly calls this a design question, not something this change should fix - but flagging it per the brief's ask.

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
...
ok  	github.com/atqamz/hand/internal/harness	0.005s
...
ok  	github.com/atqamz/hand/internal/runtime	106.766s
...
ok  	github.com/atqamz/hand/internal/watcher	47.758s
...
(full suite green)

$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	170.971s
```

New/updated tests: `TestSupportsUsageLimitOnlyWhereASignatureIsCatalogued`, `TestDetectUsageLimitDoesNotCrossMatchClaudeAndCodex`, `TestDetectUsageLimitRecognizesTheObservedCodexRefusal` (verbatim string from the issue), `TestDetectUsageLimitIgnoresCodexTextThatIsNotAStop`, `TestDetectCodexUsageLimitResetInstant` (observed shape, unparseable shape, midnight rollover, later-today clock time). `TestDetectUsageLimitRecognizesEveryCatalogedWording` and the rest of claude's existing suite pass unchanged, confirming claude's pattern still matches everything it matched before.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->