### PR TITLE
fix(watcher): name the recorded lock holder in a contended refusal

### DIFF
--- a/docs/adr/a-contended-refusal-names-its-recorded-holder.md
+++ b/docs/adr/a-contended-refusal-names-its-recorded-holder.md
@@ -1,0 +1,98 @@
+# A contended refusal names its recorded holder
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#410
+- PRs: none
+
+## Context
+
+`contend` refused a busy `state/watch.pid.lock` with "a watcher is already attached to this fleet
+home", unconditionally, regardless of what actually held it. That was often wrong: `waitOwned`
+(`internal/supervision/wait.go`), reached from `hand supervision wait`, `claude-stop`, and
+`codex-stop`, acquires the exact same kernel lock in-process whenever no watcher currently owns the
+fleet home, to poll for actionable episodes on behalf of a Supervisor Harness's Stop hook. Its
+argv never contains "watch", so `pgrep -af 'hand watch'` finds nothing, and an operator who trusted
+the message went looking for a watcher process that did not exist.
+
+The refusal's remedy compounded the misdiagnosis. "Stop it through its owning session" named a
+session an in-process bridge cycle does not have, and "use --takeover for cooperative replacement"
+promised a protocol `waitOwned`'s holder cannot honor: `hand watch` wires `Ownership.
+TakeoverRequested()` into its own cancellation (`cmd/watch.go:110`), but `waitOwned` never reads
+that channel at all, so a takeover request against it is accepted by the endpoint and then ignored
+by the process that should act on it. A `--takeover` contender would wait out the full grace period
+and fail, having changed nothing.
+
+The information needed to fix this was already durable by the time contention is possible:
+`publishNewOwner` writes `state/watch.pid` and `state/watch.owner` while holding the authoritative
+lock, before any contender can observe it busy. `contend` simply never read them. Confirmed live on
+atqamz/hand#410 (issuecomment-5450929728): a real, alive `hand supervision claude-stop` process held
+the lock, and `state/watch.owner` named its pid and generation the entire time.
+
+Naming the pid was not previously done because an earlier decision
+([Watcher takeover is generation-attributed](watcher-takeover-is-generation-attributed.md)) removed
+pid as a *takeover target* - a stale or reused pid must never be signaled. That constraint is about
+the takeover protocol's mechanics, not about diagnostic text: reporting a pid does not signal it.
+
+## Decision
+
+`contend` reads the owner record before composing a refusal, and the message it builds depends on
+what that record shows:
+
+- A readable record naming a bridge holder (see below) says so, states that the hold is transient,
+  and does not offer `--takeover` - neither in the immediate refusal nor as a suggestion, because
+  it cannot succeed.
+- A readable record naming anything else keeps the existing remedy: stop it through its owning
+  session, or use `--takeover`.
+- An absent or unreadable record says exactly that - "the lock is held, but its ownership record
+  could not be read to identify the holder" - and offers no treatment it cannot back with evidence.
+  This satisfies [Every diagnosis names a reachable treatment](every-diagnosis-names-a-reachable-treatment.md):
+  an unnamed holder gets no unreachable promise either.
+
+A `--takeover` contender fails immediately against a recorded bridge holder rather than waiting out
+`takeoverGrace` first: since the holder is known in advance not to observe a takeover request,
+waiting out the grace period would only delay the same honest failure.
+
+`OwnerRecord` gains a `Kind` field (`internal/watcher/owner_record.go`), populated at acquisition:
+`OwnerKindWatch` for `AcquireContext` (interactive `hand watch`, wired to honor takeover) and
+`OwnerKindBridge` for the new `AcquireBridgeContext` (in-process supervision bridge cycles, which
+`internal/supervision/wait.go`'s `waitOwned` now calls instead of `AcquireContext`). Empty or any
+value other than the two known kinds is treated the same as "not provably a bridge" for the
+treatment offered - the message never claims a kind the record does not affirmatively carry.
+
+This changes nothing about who may hold the lock, how many may hold it, how release works, or how
+the generation-bound takeover endpoint itself is contacted. `Kind` is diagnostic metadata riding
+alongside the existing pid and generation; it grants no authority and answers no ownership question
+the kernel lock does not already settle.
+
+## Rejected alternatives
+
+- **Exec a real `hand watch` child from every `waitOwned` caller**, so `pgrep -af 'hand watch'`
+  would find it. Rejected: this reintroduces child-process lifecycle management (start, supervise,
+  reap, propagate cancellation) that the in-process design deliberately avoids, and it does not fix
+  the underlying assumption that "the watcher" is always literally that one command - a future fifth
+  caller would reintroduce the same misattribution.
+- **Separate lock files for an interactive watch and a bridge cycle**, so an operator's manual arm
+  never contends with a background cycle. Rejected here: it redesigns what "the fleet-home watcher"
+  means, trading one singleton role for two, which
+  [One watcher per fleet home, guarded by an flock](one-watcher-per-fleet-home-guarded-by-an-flock.md)
+  does not anticipate. It remains open as a larger, separately-weighed change; this decision only
+  fixes what the refusal says about the single lock that exists today.
+- **Infer the holder's kind from `/proc/<pid>/cmdline`** instead of recording it. Rejected: it is
+  Unix-only in a package that already carries a Windows takeover path
+  (`internal/watcher/takeover_windows.go`), and it would read a fact the acquiring process already
+  knows about itself at the moment it publishes ownership, for no benefit over recording it.
+- **Treat every unreadable record as a bridge holder, or every readable-but-unrecognized `Kind` as
+  a watch holder.** Both guess an identity from an absence. The record's own honesty standard -
+  "an unreadable or absent owner record is its own answer" - applies the same way to a partially
+  informative one: naming a fact not in evidence is not better than naming none.
+
+## Consequences
+
+A contended refusal never asserts an identity - "a watcher" - the code did not observe. Every
+treatment it offers (stop the owning session, or `--takeover`) is one the named holder can actually
+carry out; a bridge holder is told its hold is transient and given no dead-end remedy, and an
+unidentifiable holder is told plainly that it is unidentifiable rather than handed the old universal
+wording. `--takeover` against a known bridge holder fails at once instead of after a wasted grace
+period. The lock model, its single-holder invariant, release ordering, and the generation-bound
+takeover protocol are unchanged; `Kind` is additive routing metadata with no bearing on any of them.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -135,7 +135,8 @@ Source: [Stateless supervisor orientation and opaque currentness](adr/stateless-
 Source: [One watcher per fleet home, guarded by an flock](adr/one-watcher-per-fleet-home-guarded-by-an-flock.md),
 [Watcher takeover is generation-attributed](adr/watcher-takeover-is-generation-attributed.md),
 [The until-event exit is the delivery](adr/the-until-event-exit-is-the-delivery.md),
-[Arming a watch observes before it waits](adr/arming-a-watch-observes-before-it-waits.md).
+[Arming a watch observes before it waits](adr/arming-a-watch-observes-before-it-waits.md),
+[A contended refusal names its recorded holder](adr/a-contended-refusal-names-its-recorded-holder.md).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -145,6 +146,8 @@ Source: [One watcher per fleet home, guarded by an flock](adr/one-watcher-per-fl
 | INV-WATCH-4 | Arming observes already-actionable state before waiting, so a condition that arrived while nothing watched still wakes it. | property | unaudited |
 | INV-WATCH-5 | Startup state is not an event: until-event mode takes a baseline and exits on the first *new* matching event. | property | unaudited |
 | INV-WATCH-6 | Delivery, an empty window, and an unprobeable task have distinct exit codes, and each is reachable. | property | unaudited |
+| INV-WATCH-7 | A contended refusal names the durably recorded holder - pid and generation - and never asserts an identity the owner record does not carry; an unreadable or absent record is reported as such, not guessed. | property | unit - `TestAcquireRefusesASecondWatcherAndNamesTheRecordedHolder`, `TestContendNamesABridgeHolderAndOffersNoTakeover`, `TestContendWithNoRecordSaysSoRatherThanGuessingAHolder`, `TestContendWithAMalformedRecordSaysSoRatherThanGuessingAHolder`; e2e - `TestWatchNamesALiveSupervisionBridgeHolderAndOffersNoTakeover` |
+| INV-WATCH-8 | `--takeover` is offered, and attempted, only against a holder recorded as able to honor it; a recorded bridge holder refuses immediately instead of waiting out the takeover grace. | property | unit - `TestContendNamesABridgeHolderAndOffersNoTakeover`, `TestTakeoverAgainstABridgeHolderFailsFastWithoutWaitingOutTheGrace` |
 
 ## Locks and schema
 

--- a/internal/supervision/correctness_test.go
+++ b/internal/supervision/correctness_test.go
@@ -572,7 +572,7 @@ func TestOwnershipLossCancelsActiveWaitAndForbidsClaim(t *testing.T) {
 		return context.Cause(ctx)
 	}
 	origAcquire := acquireWatcherOwnership
-	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) { return nil, nil }
+	acquireWatcherOwnership = func(context.Context, string) (*watcher.Ownership, error) { return nil, nil }
 	restore := func() {
 		runWatcherUntilEvent = origRun
 		acquireWatcherOwnership = origAcquire
@@ -652,7 +652,7 @@ func TestClaimBoundaryTakeoverKeepsEpisodeAvailable(t *testing.T) {
 		return nil
 	}
 	origAcquire := acquireWatcherOwnership
-	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) { return nil, nil }
+	acquireWatcherOwnership = func(context.Context, string) (*watcher.Ownership, error) { return nil, nil }
 	watcherAttached = func(string) (bool, error) { return false, nil }
 	defer func() {
 		runWatcherUntilEvent = origRun

--- a/internal/supervision/wait.go
+++ b/internal/supervision/wait.go
@@ -16,8 +16,10 @@ import (
 )
 
 // Overridable seams onto the existing level-triggered watcher boundary.
+// acquireWatcherOwnership is the bridge acquisition path: it never listens
+// for a takeover request, and records itself as such (atqamz/hand#410).
 var (
-	acquireWatcherOwnership = watcher.AcquireContext
+	acquireWatcherOwnership = watcher.AcquireBridgeContext
 	runWatcherUntilEvent    = watcher.RunUntilEvent
 	watcherAttached         = watcher.IsAttached
 )
@@ -258,7 +260,7 @@ func pollUntilEligible(ctx context.Context, guard *bridgeGuard, w Waiter, cfg Wa
 // a fresh ownership proof at the boundary. All-deduped cycles back off one
 // poll interval instead of spinning; new episodes retry at once.
 func waitOwned(ctx context.Context, guard *bridgeGuard, w Waiter, cfg WaitConfig) (Wake, error) {
-	ownership, err := acquireWatcherOwnership(ctx, w.Home, false)
+	ownership, err := acquireWatcherOwnership(ctx, w.Home)
 	if err != nil {
 		return Wake{}, err
 	}

--- a/internal/supervision/wait_test.go
+++ b/internal/supervision/wait_test.go
@@ -41,7 +41,7 @@ func newWatcherStub(t *testing.T, attached bool, onCycle func(*watcherStub) erro
 		stub.onCycle = func(*watcherStub) error { return nil }
 	}
 	origAcquire, origRun, origAttached := acquireWatcherOwnership, runWatcherUntilEvent, watcherAttached
-	acquireWatcherOwnership = func(context.Context, string, bool) (*watcher.Ownership, error) {
+	acquireWatcherOwnership = func(context.Context, string) (*watcher.Ownership, error) {
 		stub.acquired.Add(1)
 		return nil, nil
 	}

--- a/internal/watcher/owner_record.go
+++ b/internal/watcher/owner_record.go
@@ -22,7 +22,22 @@ type OwnerRecord struct {
 	Version    int    `json:"version"`
 	Generation string `json:"generation"`
 	PID        int    `json:"pid"`
+	// Kind names what acquired ownership, so a contended refusal can describe
+	// the holder truthfully. Empty (legacy/unrecorded) is handled like an
+	// unrecognized kind, never asserted to be either known shape.
+	Kind string `json:"kind,omitempty"`
 }
+
+const (
+	// OwnerKindWatch marks ownership acquired by an interactive `hand watch`,
+	// which wires TakeoverRequested into its own cancellation and so can
+	// honor --takeover.
+	OwnerKindWatch = "watch"
+	// OwnerKindBridge marks ownership acquired in-process by a supervision
+	// bridge cycle (waitOwned, via `hand supervision wait`/claude-stop/codex-stop).
+	// It never observes TakeoverRequested, so --takeover cannot displace it.
+	OwnerKindBridge = "bridge"
+)
 
 // Fresh 128 random bits encoded as 32 lowercase hex characters, tying this
 // watcher's takeover endpoint to this incumbent alone.
@@ -71,6 +86,11 @@ func validateOwnerRecord(rec OwnerRecord) error {
 	}
 	if rec.PID <= 0 {
 		return fmt.Errorf("owner record: pid must be a positive integer, got %d", rec.PID)
+	}
+	switch rec.Kind {
+	case "", OwnerKindWatch, OwnerKindBridge:
+	default:
+		return fmt.Errorf("owner record: unsupported kind %q", rec.Kind)
 	}
 	return nil
 }

--- a/internal/watcher/owner_record_test.go
+++ b/internal/watcher/owner_record_test.go
@@ -44,6 +44,23 @@ func TestNewGenerationIsLowercaseHex(t *testing.T) {
 	}
 }
 
+// The kind names what acquired ownership so a contended refusal can describe
+// the holder truthfully - atqamz/hand#410. Empty (legacy/unrecorded) and both
+// known kinds must all round-trip; only foreign values are rejected.
+func TestOwnerRecordAcceptsEmptyOrKnownKind(t *testing.T) {
+	for _, kind := range []string{"", OwnerKindWatch, OwnerKindBridge} {
+		rec := validRecord()
+		rec.Kind = kind
+		got, err := parseOwnerRecord(mustMarshal(t, rec))
+		if err != nil {
+			t.Fatalf("kind %q rejected: %v", kind, err)
+		}
+		if got.Kind != kind {
+			t.Fatalf("kind %q round-tripped as %q", kind, got.Kind)
+		}
+	}
+}
+
 func mustMarshal(t *testing.T, rec OwnerRecord) []byte {
 	t.Helper()
 	data, err := json.Marshal(rec)
@@ -76,6 +93,7 @@ func TestParseOwnerRecordRejectsInvalidRecords(t *testing.T) {
 		{"negative pid", `{"version":1,"generation":"` + gen + `","pid":-3}`},
 		{"noninteger pid", `{"version":1,"generation":"` + gen + `","pid":"abc"}`},
 		{"unknown field", `{"version":1,"generation":"` + gen + `","pid":1,"evil":2}`},
+		{"unsupported kind", `{"version":1,"generation":"` + gen + `","pid":1,"kind":"nonsense"}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/watcher/ownership.go
+++ b/internal/watcher/ownership.go
@@ -79,6 +79,17 @@ func IsAttached(homeDir string) (bool, error) {
 
 // Context-aware acquisition stops a takeover wait without changing lock authority.
 func AcquireContext(ctx context.Context, homeDir string, takeover bool) (*Ownership, error) {
+	return acquireContext(ctx, homeDir, takeover, OwnerKindWatch)
+}
+
+// AcquireBridgeContext acquires ownership for an in-process supervision
+// bridge cycle (waitOwned). It never requests takeover, and it records
+// itself as a bridge holder so a contended refusal names it correctly.
+func AcquireBridgeContext(ctx context.Context, homeDir string) (*Ownership, error) {
+	return acquireContext(ctx, homeDir, false, OwnerKindBridge)
+}
+
+func acquireContext(ctx context.Context, homeDir string, takeover bool, kind string) (*Ownership, error) {
 	if err := acquisitionContextError(ctx); err != nil {
 		return nil, err
 	}
@@ -104,7 +115,7 @@ func AcquireContext(ctx context.Context, homeDir string, takeover bool) (*Owners
 	}
 
 	afterLockAcquired()
-	ownership, err := publishNewOwner(home, lockFile)
+	ownership, err := publishNewOwner(home, lockFile, kind)
 	if err != nil {
 		_ = lockFile.Close()
 		return nil, err
@@ -119,7 +130,7 @@ func AcquireContext(ctx context.Context, homeDir string, takeover bool) (*Owners
 // Runs the new-owner publication protocol once while holding the authoritative
 // lock: stale record out, fresh generation, endpoint ready, advisory pid, then
 // the coherent watch.owner record LAST as the readiness barrier.
-func publishNewOwner(home string, lockFile *os.File) (*Ownership, error) {
+func publishNewOwner(home string, lockFile *os.File, kind string) (*Ownership, error) {
 	if err := clearRoutingRecord(home); err != nil {
 		releaseLock(lockFile)
 		return nil, err
@@ -143,7 +154,7 @@ func publishNewOwner(home string, lockFile *os.File) (*Ownership, error) {
 		return nil, err
 	}
 
-	record := OwnerRecord{Version: ownerRecordVersion, Generation: gen, PID: os.Getpid()}
+	record := OwnerRecord{Version: ownerRecordVersion, Generation: gen, PID: os.Getpid(), Kind: kind}
 	if err := publishOwnerRecord(home, record); err != nil {
 		endpoint.Close()
 		_ = clearPID(home)
@@ -222,15 +233,19 @@ func (o *Ownership) PID() int {
 	return o.record.PID
 }
 
-// Handles lock contention. Without --takeover it refuses immediately. With
-// --takeover it requests each observed generation once after delivery succeeds
-// and waits for the kernel lock, never targeting a process by pid.
+// Handles lock contention, naming the recorded holder either way: an
+// immediate refusal without --takeover, or - with it - a fast failure
+// against a recorded bridge holder, else the usual generation-based wait.
 func contend(ctx context.Context, lockFile *os.File, home string, takeover bool) error {
 	if err := acquisitionContextError(ctx); err != nil {
 		return err
 	}
 	if !takeover {
-		return fmt.Errorf("%w - a watcher already holds the fleet-home lock; stop it through its owning session, or use --takeover for cooperative replacement", ErrAttached)
+		return refusalError(home)
+	}
+	if kind, desc := describeHolder(home); kind == holderBridge {
+		return fmt.Errorf("%w - %s; --takeover cannot succeed against it because it never observes a takeover request - wait for its current cycle to end and retry without --takeover",
+			ErrAttached, desc)
 	}
 
 	deadline := time.Now().Add(takeoverGrace)
@@ -250,8 +265,7 @@ func contend(ctx context.Context, lockFile *os.File, home string, takeover bool)
 		}
 		requestCurrent(home, requested)
 		if time.Now().After(deadline) {
-			return fmt.Errorf("%w - the fleet-home lock did not release within %s after --takeover; stop the watcher through its owning session and retry",
-				ErrAttached, takeoverGrace)
+			return timeoutError(home)
 		}
 		timer := time.NewTimer(takeoverPoll)
 		select {
@@ -262,6 +276,72 @@ func contend(ctx context.Context, lockFile *os.File, home string, takeover bool)
 			}
 		case <-timer.C:
 		}
+	}
+}
+
+// Classifies a contended lock's recorded holder: what a refusal should say,
+// and whether --takeover is a treatment that can actually work against it.
+type holderKind int
+
+const (
+	// The busy lock's owner record is absent or malformed: nothing here
+	// names a holder, so nothing is guessed.
+	holderRecordUnreadable holderKind = iota
+	// A readable record whose Kind is watch-shaped or not recorded (legacy
+	// or unrecognized) - treated alike since neither is provably a bridge.
+	holderOther
+	// A readable record naming an in-process supervision bridge cycle,
+	// which never observes a takeover request.
+	holderBridge
+)
+
+// Reads the durable owner record and turns it into the refusal's factual
+// core: what to say about who holds the lock. Never asserts an identity
+// the record does not carry.
+func describeHolder(home string) (holderKind, string) {
+	holder, err := readOwnerRecord(home)
+	if err != nil {
+		return holderRecordUnreadable, "the fleet-home watcher lock is held, but its ownership record could not be read to identify the holder"
+	}
+	if holder.Kind == OwnerKindBridge {
+		return holderBridge, fmt.Sprintf("pid %d holds the fleet-home watcher lock as a background supervision-wait cycle (generation %s), not an interactive watcher",
+			holder.PID, holder.Generation)
+	}
+	return holderOther, fmt.Sprintf("pid %d already holds the fleet-home watcher lock (generation %s)", holder.PID, holder.Generation)
+}
+
+// Composes the immediate (non-takeover) contention refusal, matching the
+// treatment to the holder read: transient for a bridge, no guess for an
+// unreadable record, the ordinary remedy otherwise.
+func refusalError(home string) error {
+	kind, desc := describeHolder(home)
+	switch kind {
+	case holderBridge:
+		return fmt.Errorf("%w - %s; it is transient and never honors --takeover - wait for its current cycle to end and retry",
+			ErrAttached, desc)
+	case holderOther:
+		return fmt.Errorf("%w - %s; stop it through its owning session, or use --takeover for cooperative replacement",
+			ErrAttached, desc)
+	default:
+		return fmt.Errorf("%w - %s; wait for it to release the lock and retry", ErrAttached, desc)
+	}
+}
+
+// Composes the refusal for a --takeover contender that never observed the
+// kernel lock release within takeoverGrace, naming whatever the owner
+// record shows for the holder at that moment.
+func timeoutError(home string) error {
+	kind, desc := describeHolder(home)
+	switch kind {
+	case holderBridge:
+		return fmt.Errorf("%w - the fleet-home lock did not release within %s after --takeover; %s and it never observes a takeover request - wait for its current cycle to end and retry without --takeover",
+			ErrAttached, takeoverGrace, desc)
+	case holderOther:
+		return fmt.Errorf("%w - the fleet-home lock did not release within %s after --takeover; %s and did not step aside - stop it through its owning session and retry",
+			ErrAttached, takeoverGrace, desc)
+	default:
+		return fmt.Errorf("%w - the fleet-home lock did not release within %s after --takeover, and %s; wait and retry",
+			ErrAttached, takeoverGrace, desc)
 	}
 }
 

--- a/internal/watcher/ownership_test.go
+++ b/internal/watcher/ownership_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +15,7 @@ import (
 	"time"
 )
 
-func TestAcquireRefusesASecondWatcherWithoutTrustingAdvisoryPID(t *testing.T) {
+func TestAcquireRefusesASecondWatcherAndNamesTheRecordedHolder(t *testing.T) {
 	home := t.TempDir()
 
 	ownership, err := Acquire(home, false)
@@ -32,11 +33,140 @@ func TestAcquireRefusesASecondWatcherWithoutTrustingAdvisoryPID(t *testing.T) {
 	if !strings.Contains(err.Error(), ErrAttached.Error()) {
 		t.Fatalf("got %v, want it to wrap ErrAttached", err)
 	}
-	if strings.Contains(err.Error(), "pid ") || !strings.Contains(err.Error(), "owning session") {
-		t.Fatalf("got %v, want no operator instruction based on advisory PID", err)
+	// The refusal names the real, durably-recorded holder rather than asserting
+	// "a watcher" - atqamz/hand#410. Naming the pid is not the same instruction
+	// the takeover ADR forbids: nothing here tells the operator to signal it.
+	wantPID := fmt.Sprintf("pid %d", os.Getpid())
+	if !strings.Contains(err.Error(), wantPID) {
+		t.Fatalf("got %v, want it to name the recorded holder %s", err, wantPID)
+	}
+	if !strings.Contains(err.Error(), ownership.Generation()) {
+		t.Fatalf("got %v, want it to name the recorded generation %s", err, ownership.Generation())
+	}
+	if !strings.Contains(err.Error(), "owning session") {
+		t.Fatalf("got %v, want the remedy to name the owning session", err)
 	}
 	if !strings.Contains(err.Error(), "--takeover") {
 		t.Fatalf("got %v, want the refusal to name the remedy", err)
+	}
+}
+
+// The core of atqamz/hand#410: a busy lock held by an in-process supervision
+// bridge cycle (never an interactive `hand watch`) must be named as such, and
+// must not be offered a takeover it can never honor.
+func TestContendNamesABridgeHolderAndOffersNoTakeover(t *testing.T) {
+	home := t.TempDir()
+	holder, err := AcquireBridgeContext(context.Background(), home)
+	if err != nil {
+		t.Fatalf("AcquireBridgeContext: %v", err)
+	}
+	defer holder.Release()
+
+	_, err = Acquire(home, false)
+	if err == nil {
+		t.Fatal("Acquire succeeded, want a refusal while a bridge cycle holds the lock")
+	}
+	if !strings.Contains(err.Error(), ErrAttached.Error()) {
+		t.Fatalf("got %v, want it to wrap ErrAttached", err)
+	}
+	wantPID := fmt.Sprintf("pid %d", os.Getpid())
+	if !strings.Contains(err.Error(), wantPID) {
+		t.Fatalf("got %v, want it to name the recorded holder %s", err, wantPID)
+	}
+	if !strings.Contains(err.Error(), holder.Generation()) {
+		t.Fatalf("got %v, want it to name the recorded generation %s", err, holder.Generation())
+	}
+	if strings.Contains(err.Error(), "owning session") {
+		t.Fatalf("got %v, want no owning-session instruction: a bridge holder is not stopped that way", err)
+	}
+	if strings.Contains(err.Error(), "for cooperative replacement") {
+		t.Fatalf("got %v, want --takeover never offered as a remedy against a holder that never honors one", err)
+	}
+}
+
+// A --takeover contender against a bridge holder must fail honestly and fast:
+// waiting out the full grace period against a holder that never observes a
+// takeover request would just be a slower version of the same wrong promise.
+func TestTakeoverAgainstABridgeHolderFailsFastWithoutWaitingOutTheGrace(t *testing.T) {
+	home := t.TempDir()
+	holder, err := AcquireBridgeContext(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Release()
+
+	restoreTakeoverClocks(t)
+	takeoverGrace, takeoverPoll = 3*time.Second, 20*time.Millisecond
+
+	start := time.Now()
+	_, err = Acquire(home, true)
+	elapsed := time.Since(start)
+	if !errors.Is(err, ErrAttached) {
+		t.Fatalf("got %v, want ErrAttached", err)
+	}
+	if elapsed >= takeoverGrace {
+		t.Fatalf("took %s to fail, want it to fail well before the %s grace since this holder can never honor takeover", elapsed, takeoverGrace)
+	}
+	if strings.Contains(err.Error(), "did not release within") {
+		t.Fatalf("got %v, want an immediate honest refusal, not a timeout message", err)
+	}
+	if strings.Contains(err.Error(), "owning session") {
+		t.Fatalf("got %v, want no owning-session instruction against a bridge holder", err)
+	}
+}
+
+// An absent owner record on a busy lock is its own answer: the refusal must
+// not guess a holder or promise a treatment it cannot back with evidence.
+func TestContendWithNoRecordSaysSoRatherThanGuessingAHolder(t *testing.T) {
+	home := t.TempDir()
+	holder, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Release()
+	if err := os.Remove(OwnerRecordPath(home)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Acquire(home, false)
+	if err == nil {
+		t.Fatal("Acquire succeeded, want a refusal while the lock is held")
+	}
+	assertNoGuessedHolder(t, err)
+}
+
+// Same expectation for a record that exists but does not parse.
+func TestContendWithAMalformedRecordSaysSoRatherThanGuessingAHolder(t *testing.T) {
+	home := t.TempDir()
+	holder, err := Acquire(home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Release()
+	if err := os.WriteFile(OwnerRecordPath(home), []byte(`{truncated`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Acquire(home, false)
+	if err == nil {
+		t.Fatal("Acquire succeeded, want a refusal while the lock is held")
+	}
+	assertNoGuessedHolder(t, err)
+}
+
+func assertNoGuessedHolder(t *testing.T, err error) {
+	t.Helper()
+	if !strings.Contains(err.Error(), ErrAttached.Error()) {
+		t.Fatalf("got %v, want it to wrap ErrAttached", err)
+	}
+	if strings.Contains(err.Error(), "pid ") {
+		t.Fatalf("got %v, want no guessed pid when the record cannot be read", err)
+	}
+	if strings.Contains(err.Error(), "owning session") || strings.Contains(err.Error(), "--takeover") {
+		t.Fatalf("got %v, want no treatment promised for an unidentified holder", err)
+	}
+	if !strings.Contains(err.Error(), "could not be read") {
+		t.Fatalf("got %v, want it to say plainly that the record could not be read", err)
 	}
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -463,6 +463,7 @@ type ownerPublication struct {
 	Version    int    `json:"version"`
 	Generation string `json:"generation"`
 	PID        int    `json:"pid"`
+	Kind       string `json:"kind,omitempty"`
 }
 
 func readOwnerPublication(t *testing.T, home string) (ownerPublication, error) {

--- a/tests/e2e/watch_ownership_test.go
+++ b/tests/e2e/watch_ownership_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -85,6 +86,34 @@ func TestWatchStartsOverACrashedWatchersStaleFiles(t *testing.T) {
 	got := runHand(t, home, "watch", "--until-event", "--poll", "30ms", "--timeout", "100ms")
 	if got.code != 4 {
 		t.Fatalf("watch after a SIGKILLed watcher: exit %d, want 4 (no event) - leftover pid/routing files must not lock this home out of watching itself (stderr %q)", got.code, got.stderr)
+	}
+}
+
+// Live corroboration on atqamz/hand#410 (issuecomment-5450929728): the reported
+// holder was a real, alive `hand supervision claude-stop` process, never `hand
+// watch`. A real `hand supervision wait` process shares that in-process path.
+func TestWatchNamesALiveSupervisionBridgeHolderAndOffersNoTakeover(t *testing.T) {
+	home := seedOneTaskHome(t)
+
+	bridge := startHandBackground(t, home, "supervision", "wait", "--host", "claude", "--timeout", "5s")
+	rec := waitForCoherentOwner(t, home, bridge.cmd.Process.Pid)
+	if rec.Kind != "bridge" {
+		t.Fatalf("owner record kind = %q, want %q for a supervision-wait holder", rec.Kind, "bridge")
+	}
+
+	refused := runHand(t, home, "watch", "--until-event", "--poll", "30ms")
+	if refused.code != 3 {
+		t.Fatalf("watch against a live supervision-wait holder: exit %d, want 3 (stderr %q)", refused.code, refused.stderr)
+	}
+	wantPID := fmt.Sprintf("pid %d", bridge.cmd.Process.Pid)
+	if !strings.Contains(refused.stderr, wantPID) {
+		t.Fatalf("watch stderr %q, want it to name the live holder %s", refused.stderr, wantPID)
+	}
+	if strings.Contains(refused.stderr, "owning session") {
+		t.Fatalf("watch stderr %q, want no owning-session instruction against a bridge holder", refused.stderr)
+	}
+	if strings.Contains(refused.stderr, "for cooperative replacement") {
+		t.Fatalf("watch stderr %q, want --takeover never offered against a holder that cannot honor it", refused.stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `contend()` refused a busy `state/watch.pid.lock` by asserting "a watcher"
  regardless of what actually held it. The real holder is often an in-process
  supervision-wait / claude-stop / codex-stop bridge cycle: no owning session
  to stop, no takeover endpoint listening, invisible to `pgrep -af 'hand watch'`.
- `OwnerRecord` now carries a `Kind` (`watch`/`bridge`), set at acquisition by
  the new `AcquireBridgeContext` that `waitOwned` calls instead of
  `AcquireContext`. `contend()` reads the recorded owner before composing its
  message and matches the treatment to the holder it found: a bridge holder is
  named and told its hold is transient with no `--takeover` offered (and a
  `--takeover` attempt against one fails immediately instead of waiting out the
  grace period); an unreadable or absent record says so rather than guessing;
  anything else keeps the existing pid/generation-named remedy.
- Lock acquisition, release, ownership transfer, and the takeover protocol are
  unchanged - only what the refusal says and reads. Rationale and rejected
  alternatives are in `docs/adr/a-contended-refusal-names-its-recorded-holder.md`.

Closes atqamz/hand#410

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .
$ make test
SECONDHAND_HOME=$(mktemp -d) go test -tags=test -race -timeout=30m ./...
ok  	github.com/atqamz/hand/cmd	290.712s
...
ok  	github.com/atqamz/hand/internal/supervision	48.606s
ok  	github.com/atqamz/hand/internal/watcher	115.861s
... (all packages ok)
$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	88.617s
```

New e2e test `TestWatchNamesALiveSupervisionBridgeHolderAndOffersNoTakeover`
reproduces atqamz/hand#410's exact live shape (issuecomment-5450929728) with a
real `hand supervision wait` subprocess holding the lock, then a contending
`hand watch --until-event` against it. Real output from that run:

```
$ hand watch --until-event --poll 30ms
exit 3
stderr: error: "a watcher is already attached to this fleet home - pid 1714540 holds the fleet-home watcher lock as a background supervision-wait cycle (generation 24776a7a3390db12118036d89c847e52), not an interactive watcher; it is transient and never honors --takeover - wait for its current cycle to end and retry"
kind: precondition
exit: 3
```

No owning-session instruction and no `--takeover` suggestion against this
holder, matching the ship brief's locked decisions.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->