### PR TITLE
fix(holds): report a blocked hold once its blocker goes terminal

### DIFF
--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -67,7 +67,7 @@ func loadFleetSnapshot(ctx context.Context, warnOut io.Writer, fleetHome string)
 		return nil, err
 	}
 	snapshot.herdrSession = client.ObserveSession(ctx)
-	views, holds, err := fleetViews(ctx, warnOut, fleetHome, client, true)
+	views, holds, _, err := fleetViews(ctx, warnOut, fleetHome, client, true)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/holdsatisfied_test.go
+++ b/cmd/holdsatisfied_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/store"
+)
+
+// atqamz/hand#417, criterion 1: a satisfied blocked hold reaches hand orient (actionable) and hand
+// status (marked), each naming the blocker. The blocker is terminal but cleanly torn down, absent from
+// ListReconciliationHistories - this must resolve via a direct store read, not the fleet view.
+func TestOrientAndStatusReportASatisfiedBlockedHold(t *testing.T) {
+	home := setupSessionHome(t)
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AddProject(store.Project{Name: "demo", URL: "local", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "held-task", Project: "demo", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "blocker-task", Project: "demo", Kind: store.KindShip, Lifecycle: store.TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "held-task", Kind: state.HoldKindBlocked,
+		BlockedOn: "blocker-task", Reason: "waiting on blocker-task", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	orientOut, _, err := executeRootForTest(t, devBuild("test"), nil, "orient")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(orientOut, "next_action_kind: hold-satisfied\n") || !strings.Contains(orientOut, "next_action_task: held-task\n") {
+		t.Fatalf("orient = %q, want the satisfied hold to lead next_action", orientOut)
+	}
+	if !strings.Contains(orientOut, "orientation_actionable[1]{target_id,kind,reason,provenance}:") {
+		t.Fatalf("orient = %q, want exactly one actionable item", orientOut)
+	}
+	// The row's target_id is blank rather than held-task: like every other actionable subject on a task
+	// with no running attempt (e.g. needs-repair), it has no monitor target to resolve against. The task
+	// is still named unambiguously by next_action_task above and by the reason naming its blocker here.
+	if !strings.Contains(orientOut, ",hold-satisfied,blocker-task is terminal; this hold can be cleared,hold\n") {
+		t.Fatalf("orient = %q, want the actionable item naming blocker-task with hold provenance", orientOut)
+	}
+
+	statusCmd := newStatusCmd()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetArgs(nil)
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(statusOut.String(), `held-task,blocked,"satisfied: blocker-task is terminal; this hold can be cleared"`) {
+		t.Fatalf("status = %q, want the hold row naming its terminal blocker as satisfied", statusOut.String())
+	}
+
+	single := newStatusCmd()
+	var singleOut bytes.Buffer
+	single.SetOut(&singleOut)
+	single.SetArgs([]string{"held-task"})
+	if err := single.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := detailField(t, singleOut.String(), "held"); got != "satisfied: blocker-task is terminal; this hold can be cleared" {
+		t.Fatalf("held = %q, want the satisfied blocker named", got)
+	}
+
+	// Criterion 4: reporting a satisfied hold is not clearing it - only `hand hold clear` does that.
+	if _, found, err := state.ReadHold(home, "held-task"); err != nil || !found {
+		t.Fatalf("ReadHold = %v, %v, want the satisfied hold to survive being reported", found, err)
+	}
+}
+
+// Criterion 2: nothing changes from atqamz/hand#414's behaviour while the blocker is still open - the
+// hold stays deferred, not actionable, and hand status keeps showing the plain "waiting on" text.
+func TestOrientAndStatusLeaveABlockedHoldUnchangedWhileItsBlockerRuns(t *testing.T) {
+	home := setupSessionHome(t)
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AddProject(store.Project{Name: "demo", URL: "local", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "held-task", Project: "demo", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "blocker-task", Project: "demo", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "held-task", Kind: state.HoldKindBlocked,
+		BlockedOn: "blocker-task", Reason: "waiting on blocker-task", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	orientOut, _, err := executeRootForTest(t, devBuild("test"), nil, "orient")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(orientOut, "hold-satisfied") {
+		t.Fatalf("orient = %q, want no hold-satisfied subject while the blocker is still open", orientOut)
+	}
+	if !strings.Contains(orientOut, "orientation_actionable[0]") {
+		t.Fatalf("orient = %q, want nothing actionable for a still-blocked hold", orientOut)
+	}
+	if strings.Contains(orientOut, "next_action_task: held-task\n") {
+		t.Fatalf("orient = %q, want held-task excluded from next_action", orientOut)
+	}
+
+	statusCmd := newStatusCmd()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetArgs(nil)
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(statusOut.String(), `held-task,blocked,"waiting on blocker-task: waiting on blocker-task"`) {
+		t.Fatalf("status = %q, want the unchanged waiting-on text", statusOut.String())
+	}
+}
+
+// Criterion 3: a blocked_on naming an id the store has never heard of is inconsistency, not
+// satisfaction - "not found" must never read as "done". blocker-task is never created.
+func TestStatusFlagsAnUnknownBlockedOnAsInconsistentNotSatisfied(t *testing.T) {
+	home := setupSessionHome(t)
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AddProject(store.Project{Name: "demo", URL: "local", Mode: "local-only"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(store.Task{ID: "held-task", Project: "demo", Kind: store.KindShip}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "held-task", Kind: state.HoldKindBlocked,
+		BlockedOn: "blocker-task", Reason: "waiting on blocker-task", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	statusCmd := newStatusCmd()
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SetArgs(nil)
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := statusOut.String()
+	if !strings.Contains(got, `held-task,blocked,"inconsistent: blocked hold waits on unknown task \"blocker-task\""`) {
+		t.Fatalf("status = %q, want the unknown blocker flagged inconsistent", got)
+	}
+	if strings.Contains(got, "satisfied") {
+		t.Fatalf("status = %q, want an unknown blocker never reported as satisfied", got)
+	}
+
+	orientOut, _, err := executeRootForTest(t, devBuild("test"), nil, "orient")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(orientOut, "hold-satisfied") || !strings.Contains(orientOut, "orientation_actionable[0]") {
+		t.Fatalf("orient = %q, want an unknown blocker to stay non-actionable", orientOut)
+	}
+}

--- a/cmd/nextaction.go
+++ b/cmd/nextaction.go
@@ -27,6 +27,7 @@ const (
 	nextActionUnreachable      = "unreachable"
 	nextActionParked           = "parked"
 	nextActionUnacknowledged   = "unacknowledged"
+	nextActionHoldSatisfied    = "hold-satisfied"
 	nextActionHold             = "hold"
 	nextActionGate             = "gate"
 	nextActionNeedsProject     = "needs-project"
@@ -100,6 +101,10 @@ func classifyNextAction(cfg workerConfig, projectCount int, backlog backlogSumma
 	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindUnacknowledged) }); ok {
 		return nextAction{Kind: nextActionUnacknowledged, Task: v.task.ID, Command: statusCommand(v.task.ID),
 			Reason: statusReason(v.task.ID, "act on its unacknowledged worker event")}
+	}
+	if v, ok := firstView(sorted, func(v taskView) bool { return hasAttentionKind(v, attention.KindHoldSatisfied) }); ok {
+		return nextAction{Kind: nextActionHoldSatisfied, Task: v.task.ID, Command: statusCommand(v.task.ID),
+			Reason: statusReason(v.task.ID, "review its satisfied hold and clear it with `hand hold clear "+v.task.ID+"` if appropriate")}
 	}
 	if h, ok := firstOrphanHold(holds, views); ok {
 		return nextAction{Kind: nextActionHold, Task: h.ID, Command: "none",

--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -287,7 +287,7 @@ func TestClassifyNextActionFieldNamesArePinned(t *testing.T) {
 
 func observeNextAction(t *testing.T, home string) nextAction {
 	t.Helper()
-	views, holds, err := fleetViews(context.Background(), io.Discard, home, nil, true)
+	views, holds, _, err := fleetViews(context.Background(), io.Discard, home, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -170,7 +170,7 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	if err != nil {
 		return err
 	}
-	views, holds, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), fleetHome, client, true)
+	views, holds, blockers, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), fleetHome, client, true)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func renderSessionOverview(cmd *cobra.Command, version, fleetHome string) error 
 	axi.Table(&doc, "projects", projects, sessionProjectFields)
 	doc.List("backlog", backlog.Items)
 	appendHerdrSession(&doc, client.ObserveSession(cmd.Context()))
-	appendFleetState(&doc, views, holds, cols)
+	appendFleetState(&doc, views, holds, blockers, cols)
 	appendSessionOrientation(&doc, oriented)
 	doc.Field("next_action_kind", next.Kind)
 	doc.Field("next_action_task", orNone(next.Task))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -235,7 +236,8 @@ type fleetJSON struct {
 }
 
 // Mirrors state.Hold, plus Inconsistent, which is set instead of the row being dropped when a value
-// cannot be trusted at face value - see holdInconsistency.
+// cannot be trusted at face value - see holdInconsistency - and Satisfied, set once a blocked hold's
+// blocked_on task has gone terminal (atqamz/hand#417).
 type holdJSON struct {
 	ID           string `json:"id"`
 	Kind         string `json:"kind"`
@@ -244,11 +246,59 @@ type holdJSON struct {
 	SetAt        string `json:"set_at"`
 	Inferred     bool   `json:"inferred,omitempty"`
 	Inconsistent string `json:"inconsistent,omitempty"`
+	Satisfied    bool   `json:"satisfied,omitempty"`
+}
+
+// What a blocked hold's blocked_on task looks like right now, read straight from the store: a cleanly
+// torn-down blocker has already left ListReconciliationHistories, so reading it there would misreport
+// a landed blocker as unknown (atqamz/hand#417).
+type blockerState struct {
+	found    bool
+	terminal bool
+}
+
+// Reads one blocked_on task's terminal state directly, independent of the fleet view. ErrTaskNotFound
+// degrades to a plain not-found answer - the caller routes that to inconsistency, never satisfaction -
+// but every other error propagates, like every other hold read in this file.
+func resolveBlocker(home, blockedOn string, readOnly bool) (blockerState, error) {
+	read := state.ReadHistory
+	if readOnly {
+		read = state.ReadHistoryReadOnly
+	}
+	history, err := read(home, blockedOn)
+	if err != nil {
+		if errors.Is(err, state.ErrTaskNotFound) {
+			return blockerState{}, nil
+		}
+		return blockerState{}, err
+	}
+	return blockerState{found: true, terminal: history.Task.Lifecycle == state.TaskTerminal}, nil
+}
+
+// Resolves a whole hold list at once, deduplicating by blocked_on so several holds waiting on the same
+// task - the issue's own example - read that task once, not once per hold.
+func resolveBlockers(home string, holds []state.Hold, readOnly bool) (map[string]blockerState, error) {
+	resolved := make(map[string]blockerState)
+	for _, h := range holds {
+		if h.Kind != state.HoldKindBlocked || h.BlockedOn == "" {
+			continue
+		}
+		if _, ok := resolved[h.BlockedOn]; ok {
+			continue
+		}
+		b, err := resolveBlocker(home, h.BlockedOn, readOnly)
+		if err != nil {
+			return nil, err
+		}
+		resolved[h.BlockedOn] = b
+	}
+	return resolved, nil
 }
 
 // Names why a hold row cannot be trusted at face value, so that ListHolds surfacing every row (rather
-// than filtering) turns into a visible flag instead of a silently wrong render.
-func holdInconsistency(h state.Hold) string {
+// than filtering) turns into a visible flag instead of a silently wrong render. blockerFound - see
+// resolveBlocker - makes an unknown blocked_on inconsistent too, never satisfied (atqamz/hand#417).
+func holdInconsistency(h state.Hold, blockerFound bool) string {
 	// An unrecognized kind, a blocked hold with nothing to point at, or an operator or limit hold carrying
 	// a blocked_on nothing set. Nothing here writes such a row today - hand hold set validates first, and
 	// limit holds set no blocked_on - so one means something outside hand touched state/hand.db directly.
@@ -268,6 +318,9 @@ func holdInconsistency(h state.Hold) string {
 		if h.Inferred {
 			return "blocked hold carries inferred, but what it waits on is named, not scraped"
 		}
+		if !blockerFound {
+			return fmt.Sprintf("blocked hold waits on unknown task %q", h.BlockedOn)
+		}
 		return ""
 	case state.HoldKindLimit:
 		if h.BlockedOn != "" {
@@ -279,19 +332,26 @@ func holdInconsistency(h state.Hold) string {
 	}
 }
 
-func holdToJSON(h state.Hold) holdJSON {
+func holdSatisfied(h state.Hold, blocker blockerState) bool {
+	return h.Kind == state.HoldKindBlocked && blocker.found && blocker.terminal
+}
+
+func holdToJSON(h state.Hold, blocker blockerState) holdJSON {
 	return holdJSON{
 		ID: h.ID, Kind: h.Kind, Reason: h.Reason, BlockedOn: h.BlockedOn, SetAt: h.SetAt,
-		Inferred: h.Inferred, Inconsistent: holdInconsistency(h),
+		Inferred: h.Inferred, Inconsistent: holdInconsistency(h, blocker.found), Satisfied: holdSatisfied(h, blocker),
 	}
 }
 
-// Renders a hold's non-identifying fields for the plain-text held block. An inconsistency takes over the
-// whole line: a garbled blocked-on or reason next to it would read as a valid detail rather than a flag.
-// Inferred instead appends a suffix, so a pane-derived conclusion says so without hiding what it says.
-func holdDetail(h state.Hold) string {
-	if inc := holdInconsistency(h); inc != "" {
+// Renders a hold's non-identifying fields for the plain-text held block. An inconsistency, then a
+// satisfied blocker (atqamz/hand#417, only reported, never auto-cleared), each take over the whole
+// line rather than sit beside a stale reason. Inferred instead appends a suffix.
+func holdDetail(h state.Hold, blocker blockerState) string {
+	if inc := holdInconsistency(h, blocker.found); inc != "" {
 		return "inconsistent: " + inc
+	}
+	if holdSatisfied(h, blocker) {
+		return fmt.Sprintf("satisfied: %s is terminal; this hold can be cleared", h.BlockedOn)
 	}
 	detail := h.Reason
 	if h.Kind == state.HoldKindBlocked {
@@ -351,7 +411,7 @@ func gateRunObservation(home string, t state.Task, reportedDone bool, p project.
 
 func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSON bool, cols []axi.Column[taskView]) error {
 	herdrSession := client.ObserveSession(cmd.Context())
-	views, holds, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), home, client, true)
+	views, holds, blockers, err := fleetViews(cmd.Context(), cmd.ErrOrStderr(), home, client, true)
 	if err != nil {
 		return err
 	}
@@ -363,7 +423,7 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 		}
 		holdRows := make([]holdJSON, 0, len(holds))
 		for _, h := range holds {
-			holdRows = append(holdRows, holdToJSON(h))
+			holdRows = append(holdRows, holdToJSON(h, blockers[h.BlockedOn]))
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -371,7 +431,7 @@ func runStatusFleet(cmd *cobra.Command, home string, client *herdr.Client, asJSO
 	}
 
 	var doc axi.Doc
-	appendFleet(&doc, views, holds, cols)
+	appendFleet(&doc, views, holds, blockers, cols)
 	return doc.Render(cmd.OutOrStdout())
 }
 
@@ -383,14 +443,14 @@ func appendHerdrSession(doc *axi.Doc, observation herdr.SessionObservation) {
 
 // Writes the fleet blocks onto doc rather than a writer, so the bare command can put its identity fields
 // above the same overview.
-func appendFleet(doc *axi.Doc, views []taskView, holds []state.Hold, cols []axi.Column[taskView], leadHelp ...string) {
-	attention := appendFleetState(doc, views, holds, cols)
+func appendFleet(doc *axi.Doc, views []taskView, holds []state.Hold, blockers map[string]blockerState, cols []axi.Column[taskView], leadHelp ...string) {
+	attention := appendFleetState(doc, views, holds, blockers, cols)
 	// An unanswered configuration question leads: it is the one thing here the fleet cannot proceed
 	// without, and doc.Help renders a single list, so it cannot be a second block.
 	doc.Help(append(slices.Clone(leadHelp), fleetHelp(views, attention)...)...)
 }
 
-func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, cols []axi.Column[taskView]) int {
+func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, blockers map[string]blockerState, cols []axi.Column[taskView]) int {
 	attention := 0
 	for _, v := range views {
 		if needsAttention(v) {
@@ -402,11 +462,11 @@ func appendFleetState(doc *axi.Doc, views []taskView, holds []state.Hold, cols [
 	doc.Int("attention", attention)
 	doc.Int("held", len(holds))
 	axi.Table(doc, "tasks", views, cols)
-	axi.Table(doc, "holds", holds, holdFields)
+	axi.Table(doc, "holds", holds, holdFields(blockers))
 	return attention
 }
 
-func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, error) {
+func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *herdr.Client, readOnly bool) ([]taskView, []state.Hold, map[string]blockerState, error) {
 	listHistories := state.ListReconciliationHistories
 	listHolds := state.ListHolds
 	listProjects := project.List
@@ -419,13 +479,19 @@ func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *her
 	// one store handle rather than one per task.
 	histories, err := listHistories(home)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Propagated rather than degraded to an empty list: a store fault reading
 	// as no holds is exactly the false all-clear this feature exists to avoid.
 	holds, err := listHolds(home)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+	// Propagated for the same reason: a blocked hold's blocker misread as "unknown" would report
+	// inconsistency in place of the satisfaction the operator needs to see (atqamz/hand#417).
+	blockers, err := resolveBlockers(home, holds, readOnly)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	// Best-effort, like the project registry read elsewhere in this fleet view: a fault degrades every
@@ -435,7 +501,7 @@ func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *her
 		// Named on stderr all the same - silently dropping every (gate: ...) marker fleet-wide would render
 		// an ungated PR as clean, the false all-clear this feature exists to avoid.
 		if _, err := fmt.Fprintf(warnOut, "warning: project registry unreadable, gate-run checks skipped: %v\n", projectsErr); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 	projectByName := make(map[string]project.Project, len(projects))
@@ -445,7 +511,7 @@ func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *her
 	runPRs := newGateRunReader(ctx)
 	bounds, err := parkedBoundsFromConfig(home)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	views := make([]taskView, 0, len(histories))
@@ -459,12 +525,13 @@ func fleetViews(ctx context.Context, warnOut io.Writer, home string, client *her
 		if hold, ok := holdsByID[t.ID]; ok {
 			v.held = true
 			v.hold = hold
+			v.holdBlocker = blockers[hold.BlockedOn]
 		}
 		p, registered := projectByName[t.Project]
 		v.gateObserved = gateRunObservation(home, t, v.reportedState == state.ReportDone, p, registered, runPRs)
 		views = append(views, v)
 	}
-	return views, holds, nil
+	return views, holds, blockers, nil
 }
 
 func fleetHelp(views []taskView, attention int) []string {
@@ -713,6 +780,14 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		return err
 	}
 	v.hold, v.held = hold, held
+	var blocker blockerState
+	if held && hold.Kind == state.HoldKindBlocked && hold.BlockedOn != "" {
+		blocker, err = resolveBlocker(home, hold.BlockedOn, true)
+		if err != nil {
+			return err
+		}
+		v.holdBlocker = blocker
+	}
 
 	// Looked up only when the check applies, so a registry this id's detail view does not need can never
 	// fail the command.
@@ -747,7 +822,7 @@ func runStatusSingle(cmd *cobra.Command, home string, client *herdr.Client, id s
 		out.HerdrSessionReason = herdrSession.Reason
 		out.ReportHistory = history
 		if held {
-			j := holdToJSON(hold)
+			j := holdToJSON(hold, blocker)
 			out.Held = &j
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1796,6 +1796,12 @@ func TestStatusSingleTaskShowsHeldLine(t *testing.T) {
 		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
+	// Still open, not terminal: this pins the plain "waiting on" rendering while the blocker is unresolved.
+	// TestStatusSingleTaskShowsSatisfiedHeldLine and TestStatusSingleTaskShowsInconsistentHeldLine cover
+	// the terminal and unknown-blocker cases (atqamz/hand#417).
+	if err := state.CreateTask(home, state.Task{ID: "task-2", Project: "myproj", Kind: state.KindShip}); err != nil {
+		t.Fatal(err)
+	}
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindBlocked,
 		Reason: "waiting on migration", BlockedOn: "task-2", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
 		t.Fatal(err)
@@ -1810,6 +1816,67 @@ func TestStatusSingleTaskShowsHeldLine(t *testing.T) {
 	}
 	if got := detailField(t, out.String(), "held"); got != "waiting on task-2: waiting on migration" {
 		t.Fatalf("held = %q, want it naming what the task waits on", got)
+	}
+}
+
+// atqamz/hand#417: once the blocker is terminal, the single-task detail names it satisfied rather
+// than repeating the stale "waiting on" text.
+func TestStatusSingleTaskShowsSatisfiedHeldLine(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CreateTask(home, state.Task{ID: "task-2", Project: "myproj", Kind: state.KindShip, Lifecycle: state.TaskTerminal}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindBlocked,
+		Reason: "waiting on migration", BlockedOn: "task-2", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := detailField(t, out.String(), "held"); got != "satisfied: task-2 is terminal; this hold can be cleared" {
+		t.Fatalf("held = %q, want it naming the terminal blocker as satisfied", got)
+	}
+}
+
+// atqamz/hand#417: a blocked_on the store has never heard of is inconsistency, never satisfaction -
+// "not found" must never read as "done".
+func TestStatusSingleTaskShowsInconsistentHeldLine(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindBlocked,
+		Reason: "waiting on migration", BlockedOn: "task-2", SetAt: "2026-07-24T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := detailField(t, out.String(), "held"); got != `inconsistent: blocked hold waits on unknown task "task-2"` {
+		t.Fatalf("held = %q, want the unknown blocker flagged inconsistent, never satisfied", got)
 	}
 }
 
@@ -1973,7 +2040,7 @@ func TestAppendFleetStateKeepsTheStatusBlocksExact(t *testing.T) {
 	views := []taskView{{task: state.Task{ID: "task-1"}, agentState: "working", unacked: true}}
 	cols := []axi.Column[taskView]{{Name: "id", Value: func(v taskView) string { return v.task.ID }}}
 	var doc axi.Doc
-	if attention := appendFleetState(&doc, views, nil, cols); attention != 1 {
+	if attention := appendFleetState(&doc, views, nil, nil, cols); attention != 1 {
 		t.Fatalf("attention = %d, want 1", attention)
 	}
 	want := "count: 1\n" +

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -40,6 +40,9 @@ type taskView struct {
 	latestSend  *state.SendAttempt
 	held        bool
 	hold        state.Hold
+	// What hold.BlockedOn resolves to right now, meaningful only when held && hold.Kind ==
+	// state.HoldKindBlocked - see resolveBlocker in status.go (atqamz/hand#417).
+	holdBlocker blockerState
 	// Empty where no live lookup applied, which is neither a finding nor an absence.
 	prObserved ghutil.ObservationState
 	// The URL prObserved == ghutil.ObservationFound answers with. Rendered alongside task.PR rather
@@ -153,6 +156,10 @@ func taskAttentionEvidence(v taskView) attention.Evidence {
 		ReportClaim:      v.reportedState != "",
 		ReportedState:    v.reportedState,
 		Held:             v.held,
+	}
+	if v.held && holdSatisfied(v.hold, v.holdBlocker) {
+		evidence.HoldSatisfied = true
+		evidence.HoldBlockedOn = v.hold.BlockedOn
 	}
 	if v.latestSend != nil {
 		evidence.SendPending = v.latestSend.State == state.SendPending
@@ -283,7 +290,7 @@ var taskFields = []axi.Column[taskView]{
 		if !v.held {
 			return "none"
 		}
-		return holdDetail(v.hold)
+		return holdDetail(v.hold, v.holdBlocker)
 	}},
 	{Name: "gate", Value: func(v taskView) string { return orNone(string(v.gateObserved)) }},
 	{Name: "report_file", Value: func(v taskView) string { return orNone(v.reportFile) }},
@@ -317,9 +324,14 @@ var detailDefaultFields = []string{
 	"age", "last_report", "pr", "reported", "report", "delivered", "send_id", "send_attempt", "send_state", "send_origin", "send_reason", "held", "gate", "flags", "report_file",
 }
 
-var holdFields = []axi.Column[state.Hold]{
-	{Name: "id", Value: func(h state.Hold) string { return h.ID }},
-	{Name: "kind", Value: func(h state.Hold) string { return h.Kind }},
-	{Name: "detail", Value: func(h state.Hold) string { return holdDetail(h) }},
-	{Name: "age", Value: func(h state.Hold) string { return formatAge(h.SetAt) }},
+// A function rather than a package-level var: the detail column needs each hold's blocked_on
+// resolution, resolved once per render by resolveBlockers rather than re-derived per row
+// (atqamz/hand#417).
+func holdFields(blockers map[string]blockerState) []axi.Column[state.Hold] {
+	return []axi.Column[state.Hold]{
+		{Name: "id", Value: func(h state.Hold) string { return h.ID }},
+		{Name: "kind", Value: func(h state.Hold) string { return h.Kind }},
+		{Name: "detail", Value: func(h state.Hold) string { return holdDetail(h, blockers[h.BlockedOn]) }},
+		{Name: "age", Value: func(h state.Hold) string { return formatAge(h.SetAt) }},
+	}
 }

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -162,6 +162,9 @@ Source: [Lock pathnames are permanent rendezvous points](adr/lock-pathnames-are-
 | INV-SCHEMA-3 | Migration is all-or-nothing: an interrupted migration leaves the recorded version and the schema agreeing with each other. | model | unaudited |
 | INV-HOLD-1 | A hold is a standalone row with no foreign key to a task, and survives the task's teardown when human-authored. | property | unaudited |
 | INV-HOLD-2 | A machine-authored hold is cleared only after its kind is checked, never by kind-blind clearing. | property | unaudited |
+| INV-HOLD-3 | A blocked hold whose blocked_on task is terminal is actionable in both `hand orient` and `hand status`, naming the blocker; a blocked_on task that is still open leaves the hold exactly as before. | property | `TestOrientAndStatusReportASatisfiedBlockedHold`, `TestOrientAndStatusLeaveABlockedHoldUnchangedWhileItsBlockerRuns`, `TestDeriveMakesASatisfiedHoldActionableDespiteHeld` |
+| INV-HOLD-4 | A blocked_on naming an id the store has never heard of is reported as an inconsistency, never as satisfied - a not-found lookup never reads as terminal. | property | `TestStatusFlagsAnUnknownBlockedOnAsInconsistentNotSatisfied`, `TestStatusSingleTaskShowsInconsistentHeldLine` |
+| INV-HOLD-5 | Reporting a satisfied hold never clears it; only `hand hold clear` removes a hold row. | property | `TestOrientAndStatusReportASatisfiedBlockedHold` |
 
 ## Worktree lease and ownership proof
 

--- a/internal/attention/attention.go
+++ b/internal/attention/attention.go
@@ -21,6 +21,7 @@ const (
 	KindReportDone       = "report-done"
 	KindGate             = "gate"
 	KindSendPending      = "send-pending"
+	KindHoldSatisfied    = "hold-satisfied"
 )
 
 const (
@@ -32,6 +33,7 @@ const (
 	ProvenanceRepair          = "repair"
 	ProvenanceSend            = "send"
 	ProvenanceGate            = "gate"
+	ProvenanceHold            = "hold"
 )
 
 type Evidence struct {
@@ -52,6 +54,11 @@ type Evidence struct {
 	ReportedState    string
 	ReportClaim      bool
 	GateProblem      string
+	// A blocked hold whose blocked_on task has gone terminal. Set alongside Held, which is why it is
+	// derived outside add: the hold being satisfied is exactly what makes it actionable despite Held
+	// (atqamz/hand#417). Clearing stays a judgment for the operator - hand hold clear, never automatic.
+	HoldSatisfied bool
+	HoldBlockedOn string
 }
 
 type Subject struct {
@@ -121,6 +128,17 @@ func Derive(e Evidence) []Subject {
 	}
 	if e.GateProblem != "" {
 		add(KindGate, e.GateProblem, ProvenanceGate, true)
+	}
+	// Bypasses add: every other subject's actionability is masked by Held, but a satisfied hold is
+	// actionable *because* it is held - Held is definitionally still true here, since satisfaction never
+	// clears the hold itself (atqamz/hand#417).
+	if e.HoldSatisfied {
+		subjects = append(subjects, Subject{
+			Kind:       KindHoldSatisfied,
+			Reason:     fmt.Sprintf("%s is terminal; this hold can be cleared", e.HoldBlockedOn),
+			Provenance: ProvenanceHold,
+			Actionable: true,
+		})
 	}
 	return subjects
 }

--- a/internal/attention/attention_test.go
+++ b/internal/attention/attention_test.go
@@ -92,6 +92,31 @@ func TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain(t *testing.T) {
 	}
 }
 
+// atqamz/hand#417: a satisfied hold is actionable despite Held - the opposite of every other subject,
+// which Held always masks.
+func TestDeriveMakesASatisfiedHoldActionableDespiteHeld(t *testing.T) {
+	got := Derive(Evidence{ID: "task-1", Held: true, HoldSatisfied: true, HoldBlockedOn: "blocker-task"})
+	if len(got) != 1 {
+		t.Fatalf("subjects = %#v, want exactly the hold-satisfied subject", got)
+	}
+	want := Subject{Kind: KindHoldSatisfied, Reason: "blocker-task is terminal; this hold can be cleared", Provenance: ProvenanceHold, Actionable: true}
+	if got[0] != want {
+		t.Fatalf("subject = %#v, want %#v", got[0], want)
+	}
+	if !NeedsAttention(Evidence{ID: "task-1", Held: true, HoldSatisfied: true, HoldBlockedOn: "blocker-task"}) {
+		t.Fatal("satisfied hold does not need attention")
+	}
+}
+
+func TestDeriveOmitsHoldSatisfiedWhenNotSet(t *testing.T) {
+	got := Derive(Evidence{ID: "task-1", Held: true, Unreported: true})
+	for _, subject := range got {
+		if subject.Kind == KindHoldSatisfied {
+			t.Fatalf("subjects = %#v, want no hold-satisfied subject", got)
+		}
+	}
+}
+
 func TestUnreportedRuntimeMatchesWatcherCatchUpRule(t *testing.T) {
 	for _, test := range []struct {
 		runtime, reported string

--- a/tests/e2e/hold_test.go
+++ b/tests/e2e/hold_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -30,6 +31,7 @@ type holdView struct {
 	BlockedOn    string `json:"blocked_on"`
 	SetAt        string `json:"set_at"`
 	Inconsistent string `json:"inconsistent"`
+	Satisfied    bool   `json:"satisfied"`
 }
 
 func decodeJSON(t *testing.T, got invocation, into any) {
@@ -43,8 +45,8 @@ func decodeJSON(t *testing.T, got invocation, into any) {
 }
 
 // Drives holds end to end through the built binary: set on a live task and on an id with no task row at
-// all, rendered by every hand status surface, surviving the teardown of the task it was set on (the case a
-// task-scoped hold could not cover), refusing the spawn that would reuse the id, cleared without a trace.
+// all, rendered by every hand status surface (including an unknown blocked_on, atqamz/hand#417),
+// surviving teardown, refusing the spawn that would reuse the id, cleared without a trace.
 func TestHoldLifecycle(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "local-only")
@@ -75,9 +77,11 @@ func TestHoldLifecycle(t *testing.T) {
 		t.Fatalf("hold set = %q (exit %d), stderr %q", set.stdout, set.code, set.stderr)
 	}
 
+	// migrate-schema is never spawned in this test, so hand status must flag it inconsistent rather than
+	// report it satisfied or repeat the stale "waiting on" text - atqamz/hand#417's unknown-blocker case.
 	single := runHand(t, home, "status", "fix-login")
-	if single.code != 0 || !strings.Contains(single.stdout, `held: "waiting on migrate-schema: needs the new column before this can proceed"`) {
-		t.Fatalf("status fix-login = %q (exit %d), want the held field naming what it waits on", single.stdout, single.code)
+	if single.code != 0 || !strings.Contains(single.stdout, `held: "inconsistent: blocked hold waits on unknown task \"migrate-schema\""`) {
+		t.Fatalf("status fix-login = %q (exit %d), want the held field flagging its unknown blocker", single.stdout, single.code)
 	}
 
 	var one singleStatus
@@ -85,6 +89,9 @@ func TestHoldLifecycle(t *testing.T) {
 	if one.Held == nil || one.Held.Kind != state.HoldKindBlocked || one.Held.BlockedOn != "migrate-schema" ||
 		one.Held.Reason != "needs the new column before this can proceed" || one.Held.SetAt == "" {
 		t.Fatalf("single-task JSON held = %+v", one.Held)
+	}
+	if one.Held.Inconsistent == "" || one.Held.Satisfied {
+		t.Fatalf("single-task JSON held = %+v, want an unknown blocker flagged inconsistent, never satisfied", one.Held)
 	}
 
 	// An id with no task row behind it: never dispatched, so nothing but the
@@ -101,7 +108,7 @@ func TestHoldLifecycle(t *testing.T) {
 	for _, want := range []string{
 		"held: 2\n",
 		"holds[2]{id,kind,detail,age}:\n",
-		`  fix-login,blocked,"waiting on migrate-schema: needs the new column before this can proceed",`,
+		`  fix-login,blocked,"inconsistent: blocked hold waits on unknown task \"migrate-schema\"",`,
 		`  unqueued-work,operator,"two ways to do this, needs a call",`,
 	} {
 		if !strings.Contains(fleet.stdout, want) {
@@ -132,7 +139,7 @@ func TestHoldLifecycle(t *testing.T) {
 	}
 
 	survived := runHand(t, home, "status")
-	if survived.code != 0 || !strings.Contains(survived.stdout, `  fix-login,blocked,"waiting on migrate-schema`) {
+	if survived.code != 0 || !strings.Contains(survived.stdout, `  fix-login,blocked,"inconsistent: blocked hold waits on unknown task \"migrate-schema\""`) {
 		t.Fatalf("status after teardown = %q, want the torn-down task's hold still listed", survived.stdout)
 	}
 
@@ -158,5 +165,74 @@ func TestHoldLifecycle(t *testing.T) {
 	}
 	if got := runHand(t, home, "status"); got.code != 0 || !strings.Contains(got.stdout, "held: 0\n") {
 		t.Fatalf("status after clearing every hold = %q, want the held count back to zero", got.stdout)
+	}
+}
+
+// atqamz/hand#417: once a blocked hold's blocker lands, hand status and hand orient must say so - the
+// gap the issue reports as a blocked hold being write-only. migrate-schema is merged and torn down to
+// terminal (cleanly released, so it leaves ListReconciliationHistories) while needs-migration stays open.
+func TestHoldReportsSatisfiedOnceItsBlockerGoesTerminal(t *testing.T) {
+	home := newHome(t)
+	registerProject(t, home, "demo", "local-only")
+	writeBrief(t, home, "migrate-schema")
+	writeBrief(t, home, "needs-migration")
+
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	dir := binDir(t)
+	writeFakeHerdrStatic(t, dir, herdrIDs{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1", Label: "demo"})
+
+	blockerWorktree := filepath.Join(home, "wt-migrate-schema")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "migrate-schema-branch", blockerWorktree)
+	heldWorktree := filepath.Join(home, "wt-needs-migration")
+	runGitIn(t, clonePath, "worktree", "add", "-q", "-b", "needs-migration-branch", heldWorktree)
+	// Both slots declared up front: needs-migration is spawned into the workspace migrate-schema's spawn
+	// created (via the spare tab writeFakeHerdrStatic keeps ready) before migrate-schema tears down, so its
+	// tab close never has to close the whole workspace out from under the still-live task.
+	faketool.Treehouse{Slots: []string{blockerWorktree, heldWorktree}}.Install(t, dir)
+
+	if got := runHand(t, home, "spawn", "migrate-schema", "demo"); got.code != 0 {
+		t.Fatalf("spawn migrate-schema: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if got := runHand(t, home, "spawn", "needs-migration", "demo"); got.code != 0 {
+		t.Fatalf("spawn needs-migration: exit %d, stderr %q", got.code, got.stderr)
+	}
+	runGitIn(t, blockerWorktree, "commit", "--allow-empty", "-q", "-m", "wip")
+	if got := runHand(t, home, "merge", "migrate-schema", "--local"); got.code != 0 {
+		t.Fatalf("merge --local: exit %d, stderr %q", got.code, got.stderr)
+	}
+	if got := runHand(t, home, "teardown", "migrate-schema"); got.code != 0 {
+		t.Fatalf("teardown migrate-schema: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	if got := runHand(t, home, "hold", "set", "needs-migration",
+		"--kind", "blocked", "--reason", "needs the schema migration merged first",
+		"--blocked-on", "migrate-schema"); got.code != 0 {
+		t.Fatalf("hold set: exit %d, stderr %q", got.code, got.stderr)
+	}
+
+	status := runHand(t, home, "status")
+	if status.code != 0 || !strings.Contains(status.stdout, `  needs-migration,blocked,"satisfied: migrate-schema is terminal; this hold can be cleared",`) {
+		t.Fatalf("status = %q, want the hold reported satisfied, naming its terminal blocker", status.stdout)
+	}
+
+	oriented := runHand(t, home, "orient")
+	if oriented.code != 0 {
+		t.Fatalf("orient: exit %d, stderr %q", oriented.code, oriented.stderr)
+	}
+	if !strings.Contains(oriented.stdout, "next_action_kind: hold-satisfied\n") ||
+		!strings.Contains(oriented.stdout, "next_action_task: needs-migration\n") {
+		t.Fatalf("orient = %q, want the satisfied hold to lead next_action", oriented.stdout)
+	}
+	if !strings.Contains(oriented.stdout, "hold-satisfied,migrate-schema is terminal; this hold can be cleared,hold\n") {
+		t.Fatalf("orient = %q, want the actionable item naming its blocker", oriented.stdout)
+	}
+
+	// Reporting a satisfied hold did not clear it - only hand hold clear does.
+	if _, found, err := state.ReadHold(home, "needs-migration"); err != nil || !found {
+		t.Fatalf("ReadHold = %v, %v, want the satisfied hold to survive being reported", found, err)
+	}
+	if got := runHand(t, home, "hold", "clear", "needs-migration"); got.code != 0 {
+		t.Fatalf("hold clear: exit %d, stderr %q", got.code, got.stderr)
 	}
 }


### PR DESCRIPTION
## Summary

- A blocked hold's `blocked_on` was validated on write and rendered as display text, but nothing ever
  read it as a dependency - `hand orient`/`hand status` had no way to say a blocker had landed.
- The blocker is now resolved straight from the store (`state.ReadHistory`), not the
  reconciliation-scoped fleet view, since a cleanly torn-down blocker has already left it. A satisfied
  hold surfaces as an actionable `hold-satisfied` subject (provenance `hold`) in `hand orient`, ranks in
  `classifyNextAction`, and is named in `hand status`'s held field, holds table, and JSON. An unknown
  `blocked_on` is flagged `inconsistent`, never mistaken for satisfied. A still-running blocker changes
  nothing from atqamz/hand#414's behaviour. Nothing auto-clears; `hand hold clear` stays the only way.

Closes atqamz/hand#417

## Test plan

`make lint`, `make test`, and `make e2e` all pass clean. Real output:

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
# 30m covers the measured 4x Windows runner variance while keeping a real hang actionable.
SECONDHAND_HOME=$(mktemp -d) go test -tags=test -race -timeout=30m ./...
... (all packages ok)

$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	89.970s
```

New/updated coverage:
- `internal/attention`: `TestDeriveMakesASatisfiedHoldActionableDespiteHeld`,
  `TestDeriveOmitsHoldSatisfiedWhenNotSet`
- `cmd`: `TestOrientAndStatusReportASatisfiedBlockedHold`,
  `TestOrientAndStatusLeaveABlockedHoldUnchangedWhileItsBlockerRuns`,
  `TestStatusFlagsAnUnknownBlockedOnAsInconsistentNotSatisfied`,
  `TestStatusSingleTaskShowsSatisfiedHeldLine`, `TestStatusSingleTaskShowsInconsistentHeldLine`
- `tests/e2e`: `TestHoldReportsSatisfiedOnceItsBlockerGoesTerminal` (real spawn/merge/teardown through the
  built binary, reproducing the exact "blocker cleanly torn down, absent from
  ListReconciliationHistories" trap); `TestHoldLifecycle` updated since its blocked_on target was never
  spawned and is now correctly flagged inconsistent rather than silently rendered.

Also manually verified end to end in a scratch fleet home outside the suite: two bare tasks, one held
blocked on the other, the blocker transitioned to terminal, `hand status` and `hand orient` both report
it (`"satisfied": true` in JSON), and `hand hold clear` still works normally afterward.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->