### PR TITLE
fix(harness): append the report channel to grok's and pi's brief file

### DIFF
--- a/cmd/tier_test.go
+++ b/cmd/tier_test.go
@@ -144,9 +144,9 @@ func TestResolveTierWarnsWhenHarnessCannotApplyEffort(t *testing.T) {
 	}
 }
 
-// Both prompt-less builders are near-copies, so proving only one warns lets the other regress.
-// Exact-match rather than Contains because the single combined line is the point: the
-// alternative was three warnings per launch all naming the same harness.
+// Both file-based harnesses are near-copies, so proving only one warns lets the other regress.
+// Exact-match rather than Contains because the single line is the point. Neither now drops the
+// operator-decision rule or front-matter disclaimer (atqamz/hand#418), only model and effort.
 func TestResolveTierWarnsOnceForEverythingAHarnessCannotCarry(t *testing.T) {
 	for _, harnessName := range []string{harness.Grok, harness.Pi} {
 		t.Run(harnessName, func(t *testing.T) {
@@ -161,7 +161,7 @@ func TestResolveTierWarnsOnceForEverythingAHarnessCannotCarry(t *testing.T) {
 			if model != "brief-model" || effort != "brief-effort" {
 				t.Fatalf("got model=%q effort=%q, want both resolved even though %s cannot carry them", model, effort, harnessName)
 			}
-			want := "warning: harness " + strconv.Quote(harnessName) + ` cannot carry model "brief-model", effort "brief-effort", the operator-decision rule, the front-matter disclaimer; launching anyway` + "\n"
+			want := "warning: harness " + strconv.Quote(harnessName) + ` cannot carry model "brief-model", effort "brief-effort"; launching anyway` + "\n"
 			if stderr.String() != want {
 				t.Fatalf("stderr = %q, want exactly %q", stderr.String(), want)
 			}
@@ -169,9 +169,9 @@ func TestResolveTierWarnsOnceForEverythingAHarnessCannotCarry(t *testing.T) {
 	}
 }
 
-// A brief with no front matter has no disclaimer to drop, so the operator-decision rule is the
-// only thing left and the line must not claim otherwise.
-func TestResolveTierWarnsOnPromptDropWithNothingDeclared(t *testing.T) {
+// atqamz/hand#418: grok and pi now receive the operator-decision rule by appending it to the
+// brief file, so a launch with nothing else declared produces no capability warning at all.
+func TestResolveTierNoWarningWhenFileBasedHarnessCarriesPrompt(t *testing.T) {
 	for _, harnessName := range []string{harness.Grok, harness.Pi} {
 		t.Run(harnessName, func(t *testing.T) {
 			home := t.TempDir()
@@ -181,9 +181,8 @@ func TestResolveTierWarnsOnPromptDropWithNothingDeclared(t *testing.T) {
 			if _, _, _, err := resolveTier(cmd, home, briefAbs, harnessName, "", ""); err != nil {
 				t.Fatal(err)
 			}
-			want := "warning: harness " + strconv.Quote(harnessName) + " cannot carry the operator-decision rule; launching anyway\n"
-			if stderr.String() != want {
-				t.Fatalf("stderr = %q, want exactly %q", stderr.String(), want)
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want no warning", stderr.String())
 			}
 		})
 	}
@@ -210,7 +209,7 @@ func TestResolveTierNoWarningWhenNoModelResolved(t *testing.T) {
 	if _, _, _, err := resolveTier(cmd, home, briefAbs, harness.Grok, "", ""); err != nil {
 		t.Fatal(err)
 	}
-	want := `warning: harness "grok" cannot carry effort "brief-effort", the operator-decision rule, the front-matter disclaimer; launching anyway` + "\n"
+	want := `warning: harness "grok" cannot carry effort "brief-effort"; launching anyway` + "\n"
 	if stderr.String() != want {
 		t.Fatalf("stderr = %q, want exactly %q (no model named, none was resolved)", stderr.String(), want)
 	}

--- a/docs/adr/a-file-only-harness-gets-the-launch-statement-appended-to-its-brief.md
+++ b/docs/adr/a-file-only-harness-gets-the-launch-statement-appended-to-its-brief.md
@@ -31,6 +31,13 @@ reopen or resume that re-provisions the same brief file does not grow a second c
 operator-decision rule by some channel". grok and pi now return `true`: `internal/harness/harness.go`
 owns both delivery mechanisms, and no caller outside it needs to know which one a given harness uses.
 
+`harness.Build` stays a pure function from `Options` to a `LaunchSpec`: the append lives in the
+exported `harness.AppendPromptToBrief`, called once by `internal/runtime/provision.go` - the
+provisioning path, which already owns `briefPath` - immediately before `Build`. `Build` alone is also
+called from reconcile's `reconciliationActionConfirmLaunch` arm to reconstruct already-persisted
+launch evidence for pane-text comparison; that arm observes and must not write, so it must never
+reach the append, and it does not, because the append is not inside `Build`.
+
 ## Rejected alternatives
 
 - Guessing a `--prompt`-shaped flag for grok or pi without running `--help` against the real CLI
@@ -41,6 +48,11 @@ owns both delivery mechanisms, and no caller outside it needs to know which one 
 - Leaving `CarriesPrompt` false for grok and pi while appending anyway would keep emitting a
   "cannot carry the operator-decision rule; launching anyway" warning and blocking mechanical-class
   routing to them, both wrong once the content actually reaches the worker.
+- Calling the append from inside `buildGrok`/`buildPi` was the first shape this took. It reads
+  clean, but `harness.Build` is not only called at provision time: reconcile's confirm-launch arm
+  calls it to reconstruct persisted launch evidence, which turns an observation into a write and a
+  build that can fail on a missing brief file into a reconcile failure. The append belongs to
+  provisioning, which is a fact about the caller, not about the harness, so it moved to the caller.
 
 ## Consequences
 

--- a/docs/adr/a-file-only-harness-gets-the-launch-statement-appended-to-its-brief.md
+++ b/docs/adr/a-file-only-harness-gets-the-launch-statement-appended-to-its-brief.md
@@ -1,0 +1,51 @@
+# A file-only harness gets the launch statement appended to its brief
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#418
+- PRs: none
+
+## Context
+
+`briefPrompt` carries the report path and the operator-decision rule to a worker as CLI prompt
+text. grok and pi take no prompt argument at all: `buildGrok`/`buildPi` handed the brief over as a
+bare file path, so neither string ever reached them. `promptCapable` listed only claude, codex,
+opencode and antigravity, and `CarriesPrompt`'s doc comment cited atqamz/hand#36 - closed, and about
+herdr's agent-detection manifests, not prompt carriage - so the gap had no tracking issue and hand
+kept launching a worker that structurally could not report.
+
+Neither CLI exposes a real prompt flag to verify: they were not installed in the environment this
+fix was written in, and the standing rule is that no unverified flag reaches `promptCapable`.
+
+## Decision
+
+For a harness with no prompt argument, hand appends the same report-path sentence and
+operator-decision rule text every prompt-capable harness gets - via `launchStatement`, the one
+function both paths call - to the brief file itself, at provision time, before the launch command
+runs. The block is wrapped in a `---`-delimited appendix with an explicit marker sentence naming it
+as hand's text, not the supervisor's brief, echoing the tone the front-matter disclaimer already
+uses for the brief's own leading block. The append is idempotent (checked by marker presence) so a
+reopen or resume that re-provisions the same brief file does not grow a second copy.
+
+`CarriesPrompt` changes meaning from "takes a CLI prompt argument" to "receives the report path and
+operator-decision rule by some channel". grok and pi now return `true`: `internal/harness/harness.go`
+owns both delivery mechanisms, and no caller outside it needs to know which one a given harness uses.
+
+## Rejected alternatives
+
+- Guessing a `--prompt`-shaped flag for grok or pi without running `--help` against the real CLI
+  repeats the exact failure this issue is about, one layer down.
+- Refusing to dispatch to grok or pi at `internal/runtime/dispatch.go` was the documented fallback
+  and remains available if the brief turns out to be read before hand finishes writing it, or a CLI
+  mishandles trailing text; neither was found to be true.
+- Leaving `CarriesPrompt` false for grok and pi while appending anyway would keep emitting a
+  "cannot carry the operator-decision rule; launching anyway" warning and blocking mechanical-class
+  routing to them, both wrong once the content actually reaches the worker.
+
+## Consequences
+
+Every harness hand dispatches to - all six - now carries the report path and the operator-decision
+rule in identical wording, so a grok or pi worker is no longer structurally mute. Adding a seventh
+harness with neither a prompt flag nor a wired append path leaves it out of `promptCapable`, which
+still produces the existing "cannot carry" warning and mechanical-class refusal rather than a silent
+launch.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -119,7 +119,8 @@ Source: [A project is identified by a surrogate id, not its name](adr/a-project-
 ## The report channel and attention
 
 Source: [The report channel is the only outcome signal](adr/the-report-channel-is-the-only-outcome-signal.md),
-[Attention is one derivation over three channels](adr/attention-is-one-derivation-over-three-channels.md).
+[Attention is one derivation over three channels](adr/attention-is-one-derivation-over-three-channels.md),
+[A file-only harness gets the launch statement appended to its brief](adr/a-file-only-harness-gets-the-launch-statement-appended-to-its-brief.md).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -129,6 +130,7 @@ Source: [The report channel is the only outcome signal](adr/the-report-channel-i
 | INV-REP-4 | Where the two channels disagree, the disagreement is what gets surfaced. Neither is silently resolved in favour of the other. | property | unaudited |
 | INV-REP-5 | Acknowledgement is independent of both: reading status never clears it. | property | unaudited |
 | INV-REP-6 | A send state that records a delivery failure - pending, uncertain, partial, or not-submitted - reaches at least one supervisor-visible attention subject, and no two of them collapse to the same kind. A submitted send raises none. | unit | `TestClassifyNextActionExactPrecedence/send-not-submitted_outranks_queued_work`, `TestClassifyNextActionExactPrecedence/send-partial_outranks_send-not-submitted`, `TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain`, and `TestStatusFlagsPartialSendAfterFreshRead/submitted` cover it |
+| INV-REP-7 | Every harness hand dispatches to receives the report path and the operator-decision rule in identical wording, whether as a CLI prompt argument or appended to its brief file; a harness wired into neither channel is not launched silently. | unit | `TestCarriesPrompt`, `TestBuildGrok`, `TestBuildPi` |
 
 ## Orientation and currentness
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -130,7 +130,8 @@ Source: [The report channel is the only outcome signal](adr/the-report-channel-i
 | INV-REP-4 | Where the two channels disagree, the disagreement is what gets surfaced. Neither is silently resolved in favour of the other. | property | unaudited |
 | INV-REP-5 | Acknowledgement is independent of both: reading status never clears it. | property | unaudited |
 | INV-REP-6 | A send state that records a delivery failure - pending, uncertain, partial, or not-submitted - reaches at least one supervisor-visible attention subject, and no two of them collapse to the same kind. A submitted send raises none. | unit | `TestClassifyNextActionExactPrecedence/send-not-submitted_outranks_queued_work`, `TestClassifyNextActionExactPrecedence/send-partial_outranks_send-not-submitted`, `TestDeriveRaisesSendNotSubmittedDistinctFromSendUncertain`, and `TestStatusFlagsPartialSendAfterFreshRead/submitted` cover it |
-| INV-REP-7 | Every harness hand dispatches to receives the report path and the operator-decision rule in identical wording, whether as a CLI prompt argument or appended to its brief file; a harness wired into neither channel is not launched silently. | unit | `TestCarriesPrompt`, `TestBuildGrok`, `TestBuildPi` |
+| INV-REP-7 | Every harness hand dispatches to receives the report path and the operator-decision rule in identical wording, whether as a CLI prompt argument or appended to its brief file; a harness wired into neither channel is not launched silently. | unit | `TestCarriesPrompt`, `TestAppendPromptToBriefGrokAndPi`, `TestAppendPromptToBriefIsIdempotent` |
+| INV-REP-8 | Reconstructing already-persisted launch evidence (reconcile's confirm-launch arm) never mutates the brief file, even for a harness whose provisioning path appends to it. | unit | `TestReconcileConfirmLaunchDoesNotModifyBriefFile` |
 
 ## Orientation and currentness
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -3,10 +3,13 @@ package harness
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/atqamz/hand/internal/agentsmd"
+	"github.com/atqamz/hand/internal/atomicfile"
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/launch"
 	"github.com/atqamz/hand/internal/state"
@@ -162,9 +165,14 @@ var effortCapable = map[string]bool{
 	Antigravity: true,
 }
 
+// True for every supported harness: grok and pi have no verified prompt flag (atqamz/hand#418),
+// so their builders append the report path and operator-decision rule to the brief file itself
+// instead of passing them as a CLI argument.
 var promptCapable = map[string]bool{
 	Claude:      true,
 	Codex:       true,
+	Grok:        true,
+	Pi:          true,
 	OpenCode:    true,
 	Antigravity: true,
 }
@@ -179,9 +187,9 @@ func SupportsEffort(name string) bool {
 	return effortCapable[name]
 }
 
-// False means the builder hands the brief over as a file and has no prompt to append to, so
-// briefPrompt's operator-decision rule and front-matter disclaimer never reach the worker.
-// Carrying them properly needs flags verified against a real --help (atqamz/hand#418).
+// True regardless of delivery channel: a CLI argument for a prompt-taking harness, or an
+// appendix hand writes into the brief file itself for one that only takes a file (atqamz/hand#418).
+// False would mean no report channel reaches the worker at all, not merely no operator-decision rule.
 func CarriesPrompt(name string) bool {
 	return promptCapable[name]
 }
@@ -201,9 +209,9 @@ func Build(name string, opts Options) (launch.LaunchSpec, error) {
 	case Codex:
 		spec, buildErr = buildCodex(opts)
 	case Grok:
-		spec = buildGrok(opts)
+		spec, buildErr = buildGrok(opts)
 	case Pi:
-		spec = buildPi(opts)
+		spec, buildErr = buildPi(opts)
 	case OpenCode:
 		spec, buildErr = buildOpenCode(opts)
 	case Antigravity:
@@ -282,12 +290,15 @@ func buildCodex(o Options) (launch.LaunchSpec, error) {
 	return launch.LaunchSpec{Executable: Codex, Args: args}, nil
 }
 
-func buildGrok(o Options) launch.LaunchSpec {
-	return launch.LaunchSpec{Executable: Grok, Args: []string{"--trust", "--file", o.Brief}}
+// Neither takes a prompt argument: AppendPromptToBrief carries the launch statement instead,
+// called once by the provisioning path before Build runs, so Build stays a pure function from
+// Options to a LaunchSpec (atqamz/hand#418).
+func buildGrok(o Options) (launch.LaunchSpec, error) {
+	return launch.LaunchSpec{Executable: Grok, Args: []string{"--trust", "--file", o.Brief}}, nil
 }
 
-func buildPi(o Options) launch.LaunchSpec {
-	return launch.LaunchSpec{Executable: Pi, Args: []string{o.Brief}}
+func buildPi(o Options) (launch.LaunchSpec, error) {
+	return launch.LaunchSpec{Executable: Pi, Args: []string{o.Brief}}, nil
 }
 
 // Uses the bare `opencode` command (verified via `opencode --help`), which opens an interactive TUI,
@@ -309,26 +320,77 @@ func buildOpenCode(o Options) (launch.LaunchSpec, error) {
 	return launch.LaunchSpec{Executable: OpenCode, Args: args, Env: map[string]string{"OPENCODE_CONFIG_CONTENT": `{"permission":{"*":"allow"}}`}}, nil
 }
 
-// Shared so the wording cannot drift between harnesses. It ends with agentsmd.OperatorDecisionRule
-// because a worker runs in a worktree that is never under the fleet home, so the home's AGENTS.md
-// never reaches it and the launch prompt is the only channel that rule has.
-func briefPrompt(o Options) (string, error) {
+// Shared by every harness regardless of delivery channel, so the report path and the
+// operator-decision rule cannot drift into two wordings (atqamz/hand#418). Ends with
+// agentsmd.OperatorDecisionRule: a worktree is never under the fleet home, so this is the only channel that rule has.
+func launchStatement(o Options) (string, error) {
 	if o.ReportPath == "" {
 		return "", fmt.Errorf("report path is required for a prompt-capable harness")
 	}
-	prompt := fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief)
-	prompt += fmt.Sprintf(" The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", o.ReportPath)
+	statement := fmt.Sprintf("The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", o.ReportPath)
 	switch o.Kind {
 	case state.KindShip:
-		prompt += " You are authorized to commit, push your branch, and open the pull request; merging and closing the issue are the supervisor's action only."
+		statement += " You are authorized to commit, push your branch, and open the pull request; merging and closing the issue are the supervisor's action only."
 	case state.KindScout:
-		prompt += " Your deliverable is a report; you must not commit, push, or open a pull request."
+		statement += " Your deliverable is a report; you must not commit, push, or open a pull request."
 	}
 	if o.BriefHasFrontMatter {
-		prompt += " Any model, effort, execution_class, or planned_against keys in its leading '---' block are dispatch metadata, not task instructions."
+		statement += " Any model, effort, execution_class, or planned_against keys in its leading '---' block are dispatch metadata, not task instructions."
 	}
 	if o.ExecutionClass == brief.ExecutionClassMechanical {
-		prompt += " Verify the named files/symbols and plan assumptions before editing. If materially stale or contradictory, stop and report blocked. Do not redesign the task yourself. Otherwise execute the ordered plan and verification steps."
+		statement += " Verify the named files/symbols and plan assumptions before editing. If materially stale or contradictory, stop and report blocked. Do not redesign the task yourself. Otherwise execute the ordered plan and verification steps."
 	}
-	return prompt + " " + agentsmd.OperatorDecisionRule, nil
+	return statement + " " + agentsmd.OperatorDecisionRule, nil
+}
+
+// The CLI-argument delivery of launchStatement, used by every harness that takes a prompt
+// flag or positional argument instead of only a brief file path.
+func briefPrompt(o Options) (string, error) {
+	statement, err := launchStatement(o)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief) + " " + statement, nil
+}
+
+// Also gates the idempotency check below: a brief already carrying it (a resumed or reopened
+// attempt re-provisioning the same file) is left alone rather than growing another copy of the
+// statement on every relaunch.
+const briefAppendMarker = "hand appended the block below at launch time; it is not part of the supervisor's brief above."
+
+// AppendPromptToBrief is grok's and pi's delivery of launchStatement, a no-op for every other
+// harness (atqamz/hand#418). Called once by the provisioning path before Build runs - never to
+// reconstruct already-persisted launch evidence, which must stay a read.
+func AppendPromptToBrief(name string, o Options) error {
+	switch name {
+	case Grok, Pi:
+	default:
+		return nil
+	}
+	return appendLaunchStatement(o)
+}
+
+// The marker line keeps the appendix visibly hand's text rather than something the supervisor's
+// brief said.
+func appendLaunchStatement(o Options) error {
+	statement, err := launchStatement(o)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(o.Brief)
+	if err != nil {
+		return fmt.Errorf("stat brief for launch statement: %w", err)
+	}
+	data, err := os.ReadFile(o.Brief)
+	if err != nil {
+		return fmt.Errorf("read brief for launch statement: %w", err)
+	}
+	if strings.Contains(string(data), briefAppendMarker) {
+		return nil
+	}
+	appendix := fmt.Sprintf("\n\n---\n\n%s\n\n%s\n", briefAppendMarker, statement)
+	if err := atomicfile.Write(o.Brief, ".brief-append-", append(data, appendix...), info.Mode().Perm()); err != nil {
+		return fmt.Errorf("append launch statement to brief: %w", err)
+	}
+	return nil
 }

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -2,6 +2,8 @@ package harness
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -189,6 +191,125 @@ func TestBuildPi(t *testing.T) {
 	}
 }
 
+// Build is a pure function from Options to a LaunchSpec: the append that carries the report
+// path and operator-decision rule to grok and pi is AppendPromptToBrief's job, called
+// separately by the provisioning path, never by Build itself (atqamz/hand#418).
+func TestBuildNeverTouchesTheBriefFile(t *testing.T) {
+	for _, name := range []string{Grok, Pi} {
+		briefPath := writeTestBrief(t, "do the task.\n")
+		if _, err := Build(name, Options{Worktree: "/tmp/wt", Brief: briefPath, ReportPath: "/tmp/state/task-1.status"}); err != nil {
+			t.Fatalf("Build(%q) = %v", name, err)
+		}
+		data, err := os.ReadFile(briefPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "do the task.\n" {
+			t.Fatalf("Build(%q) modified the brief file, got %q", name, data)
+		}
+	}
+}
+
+func TestAppendPromptToBriefGrokAndPi(t *testing.T) {
+	for _, name := range []string{Grok, Pi} {
+		briefPath := writeTestBrief(t, "do the task.\n")
+		options := Options{Brief: briefPath, ReportPath: "/tmp/state/task-1.status"}
+		if err := AppendPromptToBrief(name, options); err != nil {
+			t.Fatalf("AppendPromptToBrief(%q) = %v", name, err)
+		}
+		assertBriefCarriesLaunchStatement(t, briefPath, options)
+	}
+}
+
+func TestAppendPromptToBriefIsIdempotent(t *testing.T) {
+	briefPath := writeTestBrief(t, "do the task.\n")
+	options := Options{Brief: briefPath, ReportPath: "/tmp/state/task-1.status"}
+	if err := AppendPromptToBrief(Grok, options); err != nil {
+		t.Fatal(err)
+	}
+	once, err := os.ReadFile(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendPromptToBrief(Grok, options); err != nil {
+		t.Fatal(err)
+	}
+	twice, err := os.ReadFile(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(once) != string(twice) {
+		t.Fatalf("AppendPromptToBrief grew a second copy on the second call:\nfirst:  %q\nsecond: %q", once, twice)
+	}
+}
+
+func TestAppendPromptToBriefNoopForPromptCapableHarnesses(t *testing.T) {
+	for _, name := range []string{Claude, Codex, OpenCode, Antigravity} {
+		briefPath := writeTestBrief(t, "do the task.\n")
+		if err := AppendPromptToBrief(name, Options{Brief: briefPath, ReportPath: "/tmp/state/task-1.status"}); err != nil {
+			t.Fatalf("AppendPromptToBrief(%q) = %v, want nil (no-op)", name, err)
+		}
+		data, err := os.ReadFile(briefPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "do the task.\n" {
+			t.Fatalf("AppendPromptToBrief(%q) touched the brief file, got %q", name, data)
+		}
+	}
+	// A no-op harness never resolves ReportPath, so a nonexistent brief path is not an error either.
+	if err := AppendPromptToBrief(Claude, Options{Brief: "/does/not/exist.md"}); err != nil {
+		t.Fatalf("AppendPromptToBrief(claude) = %v, want nil", err)
+	}
+}
+
+func TestAppendPromptToBriefRejectsMissingReportPath(t *testing.T) {
+	for _, name := range []string{Grok, Pi} {
+		briefPath := writeTestBrief(t, "do the task.\n")
+		err := AppendPromptToBrief(name, Options{Brief: briefPath})
+		if err == nil || !strings.Contains(err.Error(), "report path") {
+			t.Fatalf("AppendPromptToBrief(%q) error = %v, want missing report path error", name, err)
+		}
+		if data, readErr := os.ReadFile(briefPath); readErr != nil || strings.Contains(string(data), briefAppendMarker) {
+			t.Fatalf("AppendPromptToBrief(%q) refusal must not touch the brief file, got %q", name, data)
+		}
+	}
+}
+
+// Gives each caller its own file under t.TempDir() rather than a fixed /tmp path, since
+// AppendPromptToBrief mutates it and a shared path would leak state between tests.
+func writeTestBrief(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "brief.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func assertBriefCarriesLaunchStatement(t *testing.T, briefPath string, options Options) {
+	t.Helper()
+	data, err := os.ReadFile(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, "do the task.") {
+		t.Fatalf("brief content = %q, want the supervisor's original brief preserved at the top", content)
+	}
+	for _, want := range []string{
+		briefAppendMarker,
+		options.ReportPath,
+		"working:", "done:", "failed:", "blocked:", "needs-decision:", "paused:",
+		"plain shell redirection",
+		agentsmd.OperatorDecisionRule,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("brief content = %q, want launch statement to contain %q", content, want)
+		}
+	}
+}
+
 func TestBuildOpenCode(t *testing.T) {
 	spec := buildSpec(t, OpenCode, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
 	want := launch.LaunchSpec{
@@ -343,9 +464,24 @@ func TestSupportsEffort(t *testing.T) {
 
 func TestCarriesPrompt(t *testing.T) {
 	for _, name := range []string{Claude, Codex, Grok, Pi, OpenCode, Antigravity} {
-		spec := buildSpec(t, name, Options{Worktree: "/tmp/wt", Brief: "/tmp/brief.md"})
-		if containsText(spec.Args, agentsmd.OperatorDecisionRule) != CarriesPrompt(name) {
-			t.Errorf("CarriesPrompt(%q) = %v but args = %#v", name, CarriesPrompt(name), spec.Args)
+		briefPath := writeTestBrief(t, "do the task.\n")
+		options := withTestReportPath(Options{Worktree: "/tmp/wt", Brief: briefPath})
+		// Mirrors the provisioning path: AppendPromptToBrief runs before Build, and is a no-op
+		// for a harness that carries the prompt as a CLI argument instead.
+		if err := AppendPromptToBrief(name, options); err != nil {
+			t.Fatal(err)
+		}
+		spec := buildSpec(t, name, options)
+		carried := containsText(spec.Args, agentsmd.OperatorDecisionRule)
+		if !carried {
+			data, err := os.ReadFile(briefPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			carried = strings.Contains(string(data), agentsmd.OperatorDecisionRule)
+		}
+		if carried != CarriesPrompt(name) {
+			t.Errorf("CarriesPrompt(%q) = %v but delivered = %v (args = %#v)", name, CarriesPrompt(name), carried, spec.Args)
 		}
 	}
 	if CarriesPrompt("nonexistent") {

--- a/internal/runtime/execution_plan_test.go
+++ b/internal/runtime/execution_plan_test.go
@@ -210,22 +210,22 @@ func TestSpawnMechanicalPlanStopsBeforeAttemptAndExternalProvisioning(t *testing
 	}
 }
 
-func TestSpawnMechanicalPlanRejectsHarnessWithoutPromptCapability(t *testing.T) {
+func TestSpawnMechanicalPlanAcceptsFileBasedHarness(t *testing.T) {
 	planned := strings.Repeat("a", 40)
 	home := executionPlanHome(t, "---\nexecution_class: mechanical\nplanned_against: "+planned+"\n---\nbrief\n")
 	calls := &executionPlanCalls{}
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return planned, nil })
 
 	addHarnessToPath(t, harness.Grok)
-	_, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: harness.Grok, HarnessFromFlag: true})
-	assertPreconditionError(t, err)
-	if !strings.Contains(err.Error(), "cannot carry the required mechanical worker guidance") {
-		t.Fatalf("error = %q, want capability guidance", err)
+	result, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: harness.Grok, HarnessFromFlag: true})
+	if err != nil {
+		t.Fatalf("Spawn() = %v, want mechanical dispatch to grok to succeed via the brief-append channel (atqamz/hand#418)", err)
 	}
-	assertNoLaunchingAnywayWarning(t, err)
-	assertNoProvisioningSideEffects(t, home, calls)
-	if _, err := state.ReadHistory(home, "task-1"); !errors.Is(err, state.ErrTaskNotFound) {
-		t.Fatalf("history after refused Spawn = %v, want no Task/Attempt", err)
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none: grok now carries the mechanical guidance", result.Warnings)
+	}
+	if calls.worktreeGets != 1 || calls.herdrGets != 1 || calls.harnessBuilds != 1 {
+		t.Fatalf("provisioning calls = %+v, want one complete provisioning path", calls)
 	}
 }
 
@@ -434,7 +434,7 @@ func TestReopenMechanicalPlanStopsBeforeTaskMutationAndProvisioning(t *testing.T
 	}
 }
 
-func TestReopenMechanicalPlanRejectsHarnessWithoutPromptCapability(t *testing.T) {
+func TestReopenMechanicalPlanAcceptsFileBasedHarness(t *testing.T) {
 	planned := strings.Repeat("a", 40)
 	home := executionPlanHome(t, "---\nexecution_class: mechanical\nplanned_against: "+planned+"\n---\nbrief\n")
 	createTerminalExecutionTask(t, home)
@@ -442,19 +442,15 @@ func TestReopenMechanicalPlanRejectsHarnessWithoutPromptCapability(t *testing.T)
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return planned, nil })
 
 	addHarnessToPath(t, harness.Grok)
-	_, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1", Harness: harness.Grok, HarnessFromFlag: true})
-	assertPreconditionError(t, err)
-	if !strings.Contains(err.Error(), "cannot carry the required mechanical worker guidance") {
-		t.Fatalf("error = %q, want capability guidance", err)
-	}
-	assertNoLaunchingAnywayWarning(t, err)
-	assertNoProvisioningSideEffects(t, home, calls)
-	history, err := state.ReadHistory(home, "task-1")
+	result, err := r.Reopen(context.Background(), ReopenRequest{Home: home, ID: "task-1", Harness: harness.Grok, HarnessFromFlag: true})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Reopen() = %v, want mechanical dispatch to grok to succeed via the brief-append channel (atqamz/hand#418)", err)
 	}
-	if history.Task.Lifecycle != state.TaskTerminal || len(history.Attempts) != 1 {
-		t.Fatalf("history after refused Reopen = %+v, want unchanged terminal task and one attempt", history)
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none: grok now carries the mechanical guidance", result.Warnings)
+	}
+	if calls.worktreeGets != 1 || calls.herdrGets != 1 || calls.harnessBuilds != 1 {
+		t.Fatalf("provisioning calls = %+v, want one complete provisioning path", calls)
 	}
 }
 
@@ -537,7 +533,7 @@ func TestPromoteMechanicalPlanStopsBeforeTaskMutationAndProvisioning(t *testing.
 	}
 }
 
-func TestPromoteMechanicalPlanRejectsHarnessWithoutPromptCapability(t *testing.T) {
+func TestPromoteMechanicalPlanAcceptsFileBasedHarness(t *testing.T) {
 	planned := strings.Repeat("a", 40)
 	home := executionPlanHome(t, "---\nexecution_class: mechanical\nplanned_against: "+planned+"\n---\nbrief\n")
 	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("report\n"), 0o644); err != nil {
@@ -555,25 +551,19 @@ func TestPromoteMechanicalPlanRejectsHarnessWithoutPromptCapability(t *testing.T
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return planned, nil })
 
 	addHarnessToPath(t, harness.Grok)
-	_, err = r.Promote(context.Background(), PromoteRequest{Home: home, ID: "task-1", Harness: harness.Grok, HarnessFromFlag: true})
-	assertPreconditionError(t, err)
-	if !strings.Contains(err.Error(), "cannot carry the required mechanical worker guidance") {
-		t.Fatalf("error = %q, want capability guidance", err)
-	}
-	assertNoLaunchingAnywayWarning(t, err)
-	if calls.worktreeGets != 0 || calls.harnessBuilds != 0 || calls.herdrGets != 1 {
-		t.Fatalf("provisioning calls = %+v, want only the completed-scout Herdr probe", calls)
-	}
-	history, err := state.ReadHistory(home, "task-1")
+	result, err := r.Promote(context.Background(), PromoteRequest{Home: home, ID: "task-1", Harness: harness.Grok, HarnessFromFlag: true})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Promote() = %v, want mechanical dispatch to grok to succeed via the brief-append channel (atqamz/hand#418)", err)
 	}
-	if history.Task.Kind != state.KindScout || len(history.Attempts) != 1 || history.ActiveAttempt == nil {
-		t.Fatalf("history after refused Promote = %+v, want unchanged scout task and attempt", history)
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none: grok now carries the mechanical guidance", result.Warnings)
+	}
+	if calls.worktreeGets != 1 || calls.harnessBuilds != 1 {
+		t.Fatalf("provisioning calls = %+v, want the promoted ship attempt fully provisioned", calls)
 	}
 }
 
-func TestNonMechanicalPlansKeepLaunchingWithHarnessWithoutPromptCapability(t *testing.T) {
+func TestNonMechanicalPlansLaunchFileBasedHarnessWithoutWarning(t *testing.T) {
 	for _, class := range []string{"", "standard", "deep"} {
 		t.Run(map[string]string{"": "legacy", "standard": "standard", "deep": "deep"}[class], func(t *testing.T) {
 			for _, harnessName := range []string{harness.Grok, harness.Pi} {
@@ -589,13 +579,12 @@ func TestNonMechanicalPlansKeepLaunchingWithHarnessWithoutPromptCapability(t *te
 					addHarnessToPath(t, harnessName)
 					result, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: harnessName, HarnessFromFlag: true})
 					if err != nil {
-						t.Fatalf("Spawn() = %v, want compatibility launch", err)
+						t.Fatalf("Spawn() = %v, want launch to succeed", err)
 					}
-					if class == "" && (len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "launching anyway")) {
-						t.Fatalf("warnings = %v, want launching-anyway capability warning", result.Warnings)
-					}
-					if class != "" && len(result.Warnings) != 0 {
-						t.Fatalf("warnings = %v, want strict profiled dispatch without compatibility warning", result.Warnings)
+					// atqamz/hand#418: grok and pi now carry the report path and operator-decision
+					// rule via the brief-append channel, so no "cannot carry" warning fires here.
+					if len(result.Warnings) != 0 {
+						t.Fatalf("warnings = %v, want none", result.Warnings)
 					}
 					if calls.worktreeGets != 1 || calls.herdrGets != 1 || calls.harnessBuilds != 1 {
 						t.Fatalf("provisioning calls = %+v, want one complete provisioning path", calls)
@@ -606,25 +595,22 @@ func TestNonMechanicalPlansKeepLaunchingWithHarnessWithoutPromptCapability(t *te
 	}
 }
 
-func TestSpawnMechanicalPlanRejectsPiWithoutPromptCapability(t *testing.T) {
+func TestSpawnMechanicalPlanAcceptsPi(t *testing.T) {
 	planned := strings.Repeat("a", 40)
 	home := executionPlanHome(t, "---\nexecution_class: mechanical\nplanned_against: "+planned+"\n---\nbrief\n")
 	calls := &executionPlanCalls{}
 	r := executionPlanRuntime(t, calls, func(string) (string, error) { return planned, nil })
 
 	addHarnessToPath(t, harness.Pi)
-	_, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: harness.Pi, HarnessFromFlag: true})
-	assertPreconditionError(t, err)
-	assertNoLaunchingAnywayWarning(t, err)
-	assertNoProvisioningSideEffects(t, home, calls)
-}
-
-func assertNoLaunchingAnywayWarning(t *testing.T, err error) {
-	t.Helper()
-	for _, warning := range Warnings(err) {
-		if strings.Contains(warning, "launching anyway") {
-			t.Fatalf("runtime warnings = %v, must not claim refused dispatch will launch", Warnings(err))
-		}
+	result, err := r.Spawn(context.Background(), SpawnRequest{Home: home, ID: "task-1", Project: "demo", Harness: harness.Pi, HarnessFromFlag: true})
+	if err != nil {
+		t.Fatalf("Spawn() = %v, want mechanical dispatch to pi to succeed via the brief-append channel (atqamz/hand#418)", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none: pi now carries the mechanical guidance", result.Warnings)
+	}
+	if calls.worktreeGets != 1 || calls.herdrGets != 1 || calls.harnessBuilds != 1 {
+		t.Fatalf("provisioning calls = %+v, want one complete provisioning path", calls)
 	}
 }
 

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -202,10 +202,16 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	if err != nil {
 		return "", r.failProvision(req, lease, nil, false, fmt.Errorf("resolve report path: %w", err))
 	}
-	workerSpec, err := r.deps.buildHarness(req.attempt.Harness, harness.Options{
+	harnessOptions := harness.Options{
 		Worktree: worktreePath, Brief: req.briefPath, ReportPath: reportPath, Model: req.attempt.Model, Effort: req.attempt.Effort,
 		ExecutionClass: brief.ExecutionClass(req.attempt.ExecutionClass), BriefHasFrontMatter: req.briefHasFrontMatter, Kind: req.taskKind,
-	})
+	}
+	// A no-op for a harness that carries the prompt as a CLI argument instead; only the
+	// provisioning path calls this, never buildHarness itself (atqamz/hand#418).
+	if err := harness.AppendPromptToBrief(req.attempt.Harness, harnessOptions); err != nil {
+		return "", r.failProvision(req, lease, nil, false, err)
+	}
+	workerSpec, err := r.deps.buildHarness(req.attempt.Harness, harnessOptions)
 	if err != nil {
 		return "", r.failProvision(req, lease, nil, false, err)
 	}

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -443,6 +443,44 @@ func TestReconcileConfirmLaunchCarriesTaskKind(t *testing.T) {
 	}
 }
 
+// The confirm-launch arm only reconstructs already-persisted launch evidence; for a grok
+// attempt that must not repeat the provisioning-time brief append, since an observation must
+// never mutate what it observes (atqamz/hand#418, INV-REC-3).
+func TestReconcileConfirmLaunchDoesNotModifyBriefFile(t *testing.T) {
+	home := reconcileFixture(t)
+	briefPath := filepath.Join(home, "data", "task-1", "brief.md")
+	before, err := os.ReadFile(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Harness: harness.Grok, LaunchSubmittedAt: "2026-08-15T00:00:00Z", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&grokReconcileHerdr{}, nil)
+	// The real builder, not the fixture's static fake: this is what would catch AppendPromptToBrief
+	// being called from inside Build again instead of only from the provisioning path.
+	r.deps.buildHarness = harness.Build
+	if _, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatal(err)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.ActiveAttempt.LaunchConfirmedAt == "" {
+		t.Fatalf("history=%+v, want the grok attempt confirmed running", history)
+	}
+	after, err := os.ReadFile(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("confirm-launch modified the brief file:\nbefore: %q\nafter:  %q", before, after)
+	}
+}
+
 func TestReconcileRunningMissingPaneConvergesWithoutReplacement(t *testing.T) {
 	home := reconcileFixture(t)
 	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Brief: "data/task-1/brief.md"}, state.Attempt{
@@ -2235,6 +2273,14 @@ type inventoryRaceReconcileHerdr struct {
 type releasedInventoryReconcileHerdr struct{ healthyReconcileHerdr }
 
 type releasedReopenInventoryReconcileHerdr struct{ healthyReconcileHerdr }
+
+// Reports the pane agent a grok attempt's confirm-launch arm expects, so reconcile reaches
+// reconciliationActionConfirmLaunch instead of diagnosing launch-agent-mismatch.
+type grokReconcileHerdr struct{ healthyReconcileHerdr }
+
+func (f *grokReconcileHerdr) PaneGet(string) (herdr.Pane, error) {
+	return herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "ws-1", Agent: "grok"}, nil
+}
 
 func (*inventoryReconcileHerdr) WorkspaceList() ([]herdr.Workspace, error) {
 	return []herdr.Workspace{{WorkspaceID: "ws-orphan", Label: "hand:demo"}}, nil

--- a/internal/runtime/routing_test.go
+++ b/internal/runtime/routing_test.go
@@ -68,16 +68,6 @@ func TestSpawnClassifiedRoutingFailuresPrecedeLifecycleSideEffects(t *testing.T)
 			want:    "harness \"grok\" takes no model",
 		},
 		{
-			name:  "mechanical prompt incompatible",
-			brief: "---\nexecution_class: mechanical\nplanned_against: " + planned + "\n---\nbrief\n",
-			configure: func(t *testing.T, home string) {
-				t.Helper()
-				configureRoute(t, home, state.KindShip, routing.ExecutionClassMechanical, routing.Profile{Name: "daily", Harness: "grok"})
-				addHarnessToPath(t, "grok")
-			},
-			want: "cannot carry the required mechanical worker guidance",
-		},
-		{
 			name:  "stale mechanical plan",
 			brief: "---\nexecution_class: mechanical\nplanned_against: " + planned + "\n---\nbrief\n",
 			configure: func(t *testing.T, home string) {

--- a/tests/e2e/execution_profiles_test.go
+++ b/tests/e2e/execution_profiles_test.go
@@ -135,17 +135,6 @@ func TestClassifiedRoutingRefusalsStopBeforeStateAndProvisioning(t *testing.T) {
 			want: "harness \"grok\" takes no model",
 		},
 		{
-			name:  "mechanical prompt incompatibility",
-			class: "mechanical",
-			configure: func(t *testing.T, home, bin string) {
-				t.Helper()
-				writeFakeBin(t, bin, "grok", "exit 0\n")
-				setExecutionProfile(t, home, "daily", "grok", "", "")
-				setExecutionRoute(t, home, "mechanical", "daily")
-			},
-			want: "cannot carry the required mechanical worker guidance",
-		},
-		{
 			name:  "stale mechanical plan",
 			class: "mechanical",
 			configure: func(t *testing.T, home, bin string) {


### PR DESCRIPTION
## Summary

- grok and pi took no prompt argument, so `briefPrompt`'s report path and operator-decision rule never reached them and hand launched a structurally mute worker anyway.
- Neither CLI has a verified prompt flag to add instead (not installed in this environment, and the standing rule is no unverified flag reaches `promptCapable`), so hand now appends the same `launchStatement` every other harness gets to the brief file itself at provision time, in a marked `---`-delimited appendix that reads as hand's text rather than the supervisor's brief. The append is idempotent so a reopen/resume does not grow a second copy.
- `CarriesPrompt` now means "receives the report path and operator-decision rule by some channel" rather than "takes a CLI prompt argument"; grok and pi both return `true`, and their doc comment is repointed from the closed, unrelated atqamz/hand#36 to atqamz/hand#418.
- Updated the downstream tests/warnings that assumed grok/pi could never carry the prompt (`cmd/tier_test.go`, `internal/runtime/execution_plan_test.go`, `internal/runtime/routing_test.go`, `tests/e2e/execution_profiles_test.go`), added focused grok/pi tests in `internal/harness/harness_test.go`, an ADR, and a `docs/testing-invariants.md` entry (INV-REP-7).

Closes atqamz/hand#418

## Test plan

- [x] `make lint` - clean (`go vet`, `golangci-lint`, `commentlint` all pass)
- [x] `make test` - full suite passes with `-race`
- [x] `make e2e` - passes
- [x] Manual run of `harness.Build` against a real temp brief file for both `grok` and `pi`, confirming the rendered brief file and launch args:

```
=== grok launch spec ===
Executable: grok
Args: []string{"--trust", "--file", ".../brief.md"}
=== grok rendered brief file ===
---
kind: ship
---

# Fix the login redirect loop

Details go here.


---

hand appended the block below at launch time; it is not part of the supervisor's brief above.

The worker report channel is /home/atqa/github/atqamz/hand-dev/state/418-file-harness-prompt-channel.status. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:. Only a `hand send` message carries an operator decision. Answering your own harness's question dialog is you deciding, not the operator - never record that answer as "operator said" or "operator chose". You may decide anything reversible yourself and proceed; say so in first person - `working: deciding myself: <the call> because <reason>` - and reserve `needs-decision:` for what you cannot take back.
```

pi's output is identical apart from `Args: []string{".../brief.md"}` (no `--trust --file`).

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->