### PR TITLE
fix(registry): make test isolation unforgettable, add prune, refuse managed-tree homes

### DIFF
--- a/cmd/fleet.go
+++ b/cmd/fleet.go
@@ -61,6 +61,73 @@ func newFleetCmd() *cobra.Command {
 		},
 	}
 	cmd.AddCommand(newFleetHerdrCmd())
+	cmd.AddCommand(newFleetPruneCmd())
+	return cmd
+}
+
+// Opt-in only, and only ever by classification: bare `hand fleet prune` reports the Fleets it would
+// drop and drops nothing; --apply removes exactly those. Never a side effect of any other command,
+// and never anything short of the current classification (see registry.MissingFleets).
+func newFleetPruneCmd() *cobra.Command {
+	var apply bool
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Report or remove registered Fleets classified missing",
+		Args:  usageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registryPath, err := registry.Path()
+			if err != nil {
+				return err
+			}
+			currentHome, _ := home.Resolve()
+
+			var fleets []registry.Fleet
+			if apply {
+				registryDB, err := registry.OpenAt(registryPath)
+				if err != nil {
+					return err
+				}
+				defer func() { _ = registryDB.Close() }()
+				fleets, err = registryDB.Prune(currentHome)
+				if err != nil {
+					return err
+				}
+			} else {
+				registryDB, err := registry.OpenReadOnlyAt(registryPath)
+				switch {
+				case errors.Is(err, registry.ErrRegistryMissing):
+				case err != nil:
+					return err
+				default:
+					defer func() { _ = registryDB.Close() }()
+					fleets, err = registryDB.MissingFleets(currentHome)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			doc := axi.Doc{}
+			doc.Field("registry", registryPath)
+			doc.Bool("applied", apply)
+			label := "candidates"
+			if apply {
+				label = "removed"
+			}
+			rows := make([][]string, 0, len(fleets))
+			for _, fleet := range fleets {
+				rows = append(rows, []string{fleet.ID, fleet.Home, string(fleet.State), strings.Join(fleet.Locations, "\n")})
+			}
+			doc.Rows(label, []string{"id", "home", "state", "locations"}, rows)
+			if apply {
+				doc.Help("Run `hand fleet` to confirm the registry now holds only what these Fleets left behind")
+			} else {
+				doc.Help("Run `hand fleet prune --apply` to remove exactly these Fleets; nothing was changed")
+			}
+			return doc.Render(cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "remove the reported Fleets instead of only reporting them")
 	return cmd
 }
 

--- a/cmd/fleet_test.go
+++ b/cmd/fleet_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -97,4 +98,127 @@ func TestFleetListsHomesWhenExplicitContextIsInvalid(t *testing.T) {
 
 func testNow() (now time.Time) {
 	return time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC)
+}
+
+// Registers a ready, an existing-but-unreadable, and a missing Fleet in the registry rooted at
+// userHome, and returns their ids in that order.
+func seedFleetHomes(t *testing.T, userHome string) (readyID, unreadableID, missingID string) {
+	t.Helper()
+	setTestUserHome(t, userHome)
+	registryDB, err := registry.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+
+	register := func(home string) string {
+		db, err := store.Open(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fleetID, err := db.FleetID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := registryDB.Register(home, fleetID, testNow()); err != nil {
+			t.Fatal(err)
+		}
+		return fleetID
+	}
+
+	readyHome := filepath.Join(userHome, "ready")
+	readyID = register(readyHome)
+
+	unreadableHome := filepath.Join(userHome, "unreadable")
+	unreadableID = register(unreadableHome)
+	if err := os.Remove(store.Path(unreadableHome)); err != nil {
+		t.Fatal(err)
+	}
+
+	missingHome := filepath.Join(userHome, "missing")
+	missingID = register(missingHome)
+	if err := os.RemoveAll(missingHome); err != nil {
+		t.Fatal(err)
+	}
+	return readyID, unreadableID, missingID
+}
+
+func TestFleetPruneReportsWithoutMutatingByDefault(t *testing.T) {
+	userHome := t.TempDir()
+	_, _, missingID := seedFleetHomes(t, userHome)
+	t.Setenv("HAND_HOME", "")
+	t.Chdir(t.TempDir())
+
+	root := newRootCmd(devBuild("test"))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"fleet", "prune"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "applied: false") || !strings.Contains(out.String(), "candidates[1]") || !strings.Contains(out.String(), missingID) {
+		t.Fatalf("fleet prune output = %q, want one unapplied missing candidate %s", out.String(), missingID)
+	}
+
+	registryDB, err := registry.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	fleets, err := registryDB.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, fleet := range fleets {
+		if fleet.ID == missingID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("fleets after dry-run prune = %+v, want %s still registered", fleets, missingID)
+	}
+}
+
+func TestFleetPruneApplyRemovesOnlyMissingEntries(t *testing.T) {
+	userHome := t.TempDir()
+	readyID, unreadableID, missingID := seedFleetHomes(t, userHome)
+	t.Setenv("HAND_HOME", "")
+	t.Chdir(t.TempDir())
+
+	root := newRootCmd(devBuild("test"))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"fleet", "prune", "--apply"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "applied: true") || !strings.Contains(out.String(), "removed[1]") || !strings.Contains(out.String(), missingID) {
+		t.Fatalf("fleet prune --apply output = %q, want exactly %s removed", out.String(), missingID)
+	}
+
+	registryDB, err := registry.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+	fleets, err := registryDB.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remaining := make(map[string]bool, len(fleets))
+	for _, fleet := range fleets {
+		remaining[fleet.ID] = true
+	}
+	if remaining[missingID] {
+		t.Fatalf("fleets after prune --apply = %+v, want %s gone", fleets, missingID)
+	}
+	if !remaining[readyID] || !remaining[unreadableID] {
+		t.Fatalf("fleets after prune --apply = %+v, want %s and %s to survive", fleets, readyID, unreadableID)
+	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/atqamz/hand/internal/skill"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/toolchain"
+	"github.com/atqamz/hand/internal/worktree"
 	"github.com/spf13/cobra"
 )
 
@@ -195,6 +196,9 @@ func newInitCmd() *cobra.Command {
 // Also reports whether target is Hand's own source tree, which init adopts and every later
 // command reports as such whether or not this call was the one that adopted it.
 func preflightInitTarget(target string) (bool, error) {
+	if err := refuseManagedTreeHome(target); err != nil {
+		return false, err
+	}
 	info, err := os.Stat(target)
 	if os.IsNotExist(err) {
 		return false, nil
@@ -260,6 +264,56 @@ func isHandSourceTree(target string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// Refuses to let target become a Fleet home inside territory Hand already manages: a Treehouse
+// worktree pool slot, or another Fleet's project clone under projects/ (atqamz/hand#413). Checked
+// against the filesystem, not the registry, so a stale or absent entry cannot look safe.
+func refuseManagedTreeHome(target string) error {
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("resolve init target %s: %w", target, err)
+	}
+	abs = filepath.Clean(abs)
+
+	pools, err := worktree.PoolsRoot()
+	if err != nil {
+		return err
+	}
+	if withinTree(pools, abs) {
+		return &ExitError{Code: 3, Err: fmt.Errorf(
+			"init target %s is inside Hand's own Treehouse worktree pool at %s; a pool slot is leased and returned, never a Fleet home - choose a target outside it",
+			abs, pools)}
+	}
+
+	for dir := abs; ; {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+		if filepath.Base(dir) == "projects" {
+			ok, err := home.IsHome(parent)
+			if err != nil {
+				return fmt.Errorf("inspect %s: %w", parent, err)
+			}
+			if ok {
+				return &ExitError{Code: 3, Err: fmt.Errorf(
+					"init target %s is inside the managed project tree of Fleet home %s; a worker gets its own worktree there instead - choose a target outside projects/",
+					abs, parent)}
+			}
+		}
+		dir = parent
+	}
+}
+
+// Reports whether path is root or sits inside it, comparing cleaned absolute strings without
+// resolving symlinks - the same rule internal/worktree's own pool-membership check uses.
+func withinTree(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
 }
 
 func handOwnedRuntimeRoot() (string, error) {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -694,5 +695,54 @@ func TestInitRefusesASubdirectoryOfHandSourceTree(t *testing.T) {
 	}
 	if after := snapshotInitTarget(t, target); !reflect.DeepEqual(after, before) {
 		t.Fatalf("source subdirectory changed: before=%v after=%v", before, after)
+	}
+}
+
+func TestInitRefusesATargetInsideHandsTreehousePool(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	runtimeRoot := filepath.Join(t.TempDir(), ".secondhand")
+	if err := os.MkdirAll(runtimeRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SECONDHAND_HOME", runtimeRoot)
+	target := filepath.Join(runtimeRoot, "pools", "hand-abc123", ".treehouse", "slug", "1", "hand")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotInitTarget(t, target)
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{target})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 || !strings.Contains(err.Error(), "Treehouse worktree pool") {
+		t.Fatalf("init error = %v, want a code-3 Treehouse worktree pool refusal", err)
+	}
+	if after := snapshotInitTarget(t, target); !reflect.DeepEqual(after, before) {
+		t.Fatalf("pool slot changed: before=%v after=%v", before, after)
+	}
+}
+
+func TestInitRefusesATargetInsideAnotherFleetsProjectsTree(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	fleetHome := t.TempDir()
+	if _, err := store.Open(fleetHome); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(fleetHome, "projects", "someproj", "worktree")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotInitTarget(t, target)
+
+	cmd := newInitCmd()
+	cmd.SetArgs([]string{target})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 || !strings.Contains(err.Error(), "managed project tree") {
+		t.Fatalf("init error = %v, want a code-3 managed project tree refusal", err)
+	}
+	if after := snapshotInitTarget(t, target); !reflect.DeepEqual(after, before) {
+		t.Fatalf("target inside projects/ changed: before=%v after=%v", before, after)
 	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -726,7 +726,11 @@ func TestInitRefusesATargetInsideHandsTreehousePool(t *testing.T) {
 func TestInitRefusesATargetInsideAnotherFleetsProjectsTree(t *testing.T) {
 	t.Setenv("HAND_HOME", "")
 	fleetHome := t.TempDir()
-	if _, err := store.Open(fleetHome); err != nil {
+	db, err := store.Open(fleetHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
 	target := filepath.Join(fleetHome, "projects", "someproj", "worktree")
@@ -737,7 +741,7 @@ func TestInitRefusesATargetInsideAnotherFleetsProjectsTree(t *testing.T) {
 
 	cmd := newInitCmd()
 	cmd.SetArgs([]string{target})
-	err := cmd.Execute()
+	err = cmd.Execute()
 	var exitErr *ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 || !strings.Contains(err.Error(), "managed project tree") {
 		t.Fatalf("init error = %v, want a code-3 managed project tree refusal", err)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -726,11 +726,12 @@ func TestInitRefusesATargetInsideHandsTreehousePool(t *testing.T) {
 func TestInitRefusesATargetInsideAnotherFleetsProjectsTree(t *testing.T) {
 	t.Setenv("HAND_HOME", "")
 	fleetHome := t.TempDir()
-	db, err := store.Open(fleetHome)
-	if err != nil {
+	// refuseManagedTreeHome only checks home.IsHome's marker files, never opens a database, so the
+	// fixture matches: no sqlite handle survives the test to block Windows' TempDir cleanup.
+	if err := os.MkdirAll(filepath.Join(fleetHome, "state"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Close(); err != nil {
+	if err := os.WriteFile(filepath.Join(fleetHome, "state", "hand.db"), nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	target := filepath.Join(fleetHome, "projects", "someproj", "worktree")
@@ -741,7 +742,7 @@ func TestInitRefusesATargetInsideAnotherFleetsProjectsTree(t *testing.T) {
 
 	cmd := newInitCmd()
 	cmd.SetArgs([]string{target})
-	err = cmd.Execute()
+	err := cmd.Execute()
 	var exitErr *ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 || !strings.Contains(err.Error(), "managed project tree") {
 		t.Fatalf("init error = %v, want a code-3 managed project tree refusal", err)

--- a/docs/adr/a-test-build-cannot-resolve-the-real-secondhand-root.md
+++ b/docs/adr/a-test-build-cannot-resolve-the-real-secondhand-root.md
@@ -1,0 +1,76 @@
+# A test build cannot resolve the real Secondhand infrastructure root
+
+- Date: 2026-08-28
+- Status: accepted
+- Issue: atqamz/hand#413
+- Pull requests: none
+
+## Context
+
+`internal/secondhand.Home()` is the one place every component that reads or writes under
+`~/.secondhand` - the registry, the private runtime, the worktree pools - resolves that root from.
+Before this change it always consulted `SECONDHAND_HOME` first and fell back to the operator's real
+`$HOME/.secondhand` when the variable was unset. `make test` set `SECONDHAND_HOME` to a fresh
+`mktemp -d` for the whole suite, and several packages' own `TestMain` set it again more narrowly, so
+isolation held as long as every test entry point remembered to do so.
+
+It did not always. `hand`'s own test suite left 3366 dead rows in the operator's real
+`~/.secondhand/registry.db` - `/tmp/.../TestXxx.../002` homes from runs that, by the time they were
+found, could no longer be attributed to a specific invocation. The mechanism that made this possible
+was not a missing override in any one test; it was that `Home()` had a code path that succeeded by
+falling back to the real root, and success there is silent. A convention that every test must
+remember to set one environment variable, with no enforcement if it doesn't, is the shape of bug this
+issue exists to close, not a fix for it.
+
+## Decision
+
+`Home()` still reads `SECONDHAND_HOME` first. When it is unset, `Home()` checks
+`internal/testtag.Present` - the existing compile-time constant that is `true` only in a binary built
+with the `test` tag - and if it is true, `Home()` returns `ErrHomeNotOverridden` instead of falling
+back to `os.UserHomeDir()`. The fallback branch that resolves the real root is unreachable code in any
+test binary's control flow once `SECONDHAND_HOME` is unset; it is not merely unexercised by
+convention. Every package that reaches `Home()` in a `-tags=test` build - directly or through
+`registry.Register`, `worktree.PoolsRoot`, or anything else layered on it - now fails loudly instead
+of succeeding quietly against the operator's real infrastructure.
+
+`cmd/init.go`'s `registerFleet` already surfaces a `registry.Open`/`registry.Register` error as a
+failed `hand init`, so this refusal reaches the command layer as a real, non-zero-exit failure rather
+than a value some caller discards.
+
+`internal/secondhand`'s own test package additionally runs under `testtag.Main`, so `go test` on it
+without `-tags=test` refuses immediately rather than silently exercising a different contract - the
+same convention `internal/git`, `internal/worktree`, and other packages that guard "tests must not do
+X" already use.
+
+## Rejected alternatives
+
+- Trusting `make test`'s `SECONDHAND_HOME=$(mktemp -d)` alone: it isolates a `go test ./...` run
+  launched exactly that way, but does nothing for a single package run directly, an IDE test runner,
+  or any future test entry point that does not go through the Makefile - exactly the gap the 3366 rows
+  came from.
+- A per-package `TestMain` convention (what `cmd`, `internal/registry`, and `tests/e2e` already do):
+  real and necessary for setting an isolated value, but it cannot make a *missing* one fail, because a
+  package with no `TestMain` at all falls straight through to the same silent default.
+  This decision does not replace those `TestMain`s - they still supply the actual isolated path - it
+  closes the gap they leave when a package has none.
+- A new dedicated build-tag pair mirroring `internal/testtag`'s own `present_prod.go` /
+  `present_testmode.go` split, applied to `secondhand.Home()` itself: it would work, but it would
+  duplicate the exact enforcement `internal/testtag` already provides and had already been reused
+  successfully as `testtag.Main` in several packages' `TestMain`s.
+
+## Consequences
+
+A test build can still choose *where* isolation points - the override is not fixed - but it can no
+longer choose *not to* isolate by omission. The 3-line production fallback (`SECONDHAND_HOME` unset,
+`testtag.Present` false, resolve `$HOME/.secondhand`) is exercised only by a real `hand` binary and
+`go build`/`go vet`, never by `go test -tags=test`, mirroring how `internal/testtag`'s own
+`present_prod.go` is not separately unit-tested either; both are trivial enough that compiling
+successfully under the untagged build is the check.
+
+Any future code that resolves `~/.secondhand` by a path other than `secondhand.Home()` sits outside
+this guarantee. There is one such path today: `hand init` refuses to register a home inside Hand's own
+Treehouse worktree pool (`worktree.PoolsRoot()`, itself derived from `secondhand.Home()`) or inside
+another Fleet's `projects/` tree, checked structurally against the filesystem rather than against the
+registry - consistent with
+[The landed-work guard reads the work, not the record](the-landed-work-guard-reads-the-work-not-the-record.md)
+- so that a stale or absent registry can never make an unsafe target look safe.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -76,7 +76,9 @@ Source: [hand init is the canonical fleet reconciler](adr/hand-init-is-the-canon
 
 ## Registry and fleet identity
 
-Source: [Fleet identity and user registry](adr/fleet-identity-and-user-registry.md), `internal/registry`.
+Source: [Fleet identity and user registry](adr/fleet-identity-and-user-registry.md),
+[A test build cannot resolve the real Secondhand infrastructure root](adr/a-test-build-cannot-resolve-the-real-secondhand-root.md),
+`internal/registry`.
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -84,9 +86,9 @@ Source: [Fleet identity and user registry](adr/fleet-identity-and-user-registry.
 | INV-REG-2 | A home's fleet identity is never reissued or rewritten by any registry operation. | property | unaudited |
 | INV-REG-3 | Entry classification is a function of (stored rows, observed filesystem), and reading it mutates nothing. | property | unaudited |
 | INV-REG-4 | Losing or deleting the registry changes no fleet identity; re-registering a home restores the identity its own `state/hand.db` carries. | property | unaudited |
-| INV-REG-5 | Pruning removes only entries already classified `missing`, and never the current home. | property | not yet implemented - atqamz/hand#413 |
-| INV-REG-6 | A full test run adds zero entries to the operator's real user registry. Reaching it from a test is impossible, not merely discouraged. | property | violated today - atqamz/hand#413 |
-| INV-REG-7 | A fleet home inside a Treehouse worktree, or inside another fleet's managed tree, is refused rather than registered. | property | violated today - atqamz/hand#413 |
+| INV-REG-5 | Pruning removes only entries already classified `missing`, and never the current home. | property | `TestMissingFleetsNamesOnlyEntriesClassifiedMissing`, `TestPruneRemovesOnlyEntriesClassifiedMissingAndNeverTheCurrentHome`, `TestFleetPruneApplyRemovesOnlyMissingEntries` |
+| INV-REG-6 | A full test run adds zero entries to the operator's real user registry. Reaching it from a test is impossible, not merely discouraged. | property | `TestHomeRefusesWithoutOverrideUnderTestBuild` |
+| INV-REG-7 | A fleet home inside a Treehouse worktree, or inside another fleet's managed tree, is refused rather than registered. | property | `TestInitRefusesATargetInsideHandsTreehousePool`, `TestInitRefusesATargetInsideAnotherFleetsProjectsTree` |
 
 ## Project identity and the completion store
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -471,6 +471,61 @@ func lastKnownHome(db *sql.DB, id string, locations []string) string {
 	return ""
 }
 
+// MissingFleets reports every registered Fleet identity classified missing, excluding the current
+// home even if classification could somehow call it missing. Not unreadable, not ambiguous, not a
+// duplicate: only StateMissing qualifies, per docs/adr/every-diagnosis-names-a-reachable-treatment.md.
+func (r *Registry) MissingFleets(currentHome string) ([]Fleet, error) {
+	fleets, err := r.List(currentHome)
+	if err != nil {
+		return nil, err
+	}
+	var missing []Fleet
+	for _, fleet := range fleets {
+		if fleet.State == StateMissing && !fleet.Current {
+			missing = append(missing, fleet)
+		}
+	}
+	return missing, nil
+}
+
+// Prune removes every Fleet MissingFleets would name for the same currentHome: its full registry row
+// and every locator. It re-classifies under the write lock rather than trusting a caller-supplied
+// list, so nothing but what this call itself still finds missing at delete time is ever removed.
+func (r *Registry) Prune(currentHome string) ([]Fleet, error) {
+	var removed []Fleet
+	err := r.withWriteLock(func() error {
+		candidates, err := r.MissingFleets(currentHome)
+		if err != nil {
+			return err
+		}
+		if len(candidates) == 0 {
+			return nil
+		}
+		tx, err := r.sql.Begin()
+		if err != nil {
+			return fmt.Errorf("begin registry prune: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		for _, fleet := range candidates {
+			if _, err := tx.Exec(`DELETE FROM fleet_locator WHERE fleet_id = ?`, fleet.ID); err != nil {
+				return fmt.Errorf("prune Fleet locators for %s: %w", fleet.ID, err)
+			}
+			if _, err := tx.Exec(`DELETE FROM fleet_registry WHERE fleet_id = ?`, fleet.ID); err != nil {
+				return fmt.Errorf("prune Fleet registry row for %s: %w", fleet.ID, err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit registry prune: %w", err)
+		}
+		removed = candidates
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return removed, nil
+}
+
 type DuplicateError struct {
 	FleetID string
 	Current string

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -690,3 +690,116 @@ func TestPreflightRefusesARegisteredDuplicateBeforeRuntime(t *testing.T) {
 		t.Fatalf("Preflight() = %v, want DuplicateError", err)
 	}
 }
+
+// Registers home as a fresh Fleet and returns its identity.
+func seedFleet(t *testing.T, registryDB *Registry, home string) string {
+	t.Helper()
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID, err := db.FleetID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := registryDB.Register(home, fleetID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	return fleetID
+}
+
+func TestMissingFleetsNamesOnlyEntriesClassifiedMissing(t *testing.T) {
+	root := t.TempDir()
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+
+	readyHome := filepath.Join(root, "ready")
+	seedFleet(t, registryDB, readyHome)
+
+	unreadableHome := filepath.Join(root, "unreadable")
+	seedFleet(t, registryDB, unreadableHome)
+	if err := os.Remove(store.Path(unreadableHome)); err != nil {
+		t.Fatal(err)
+	}
+
+	missingHome := filepath.Join(root, "missing")
+	missingID := seedFleet(t, registryDB, missingHome)
+	if err := os.RemoveAll(missingHome); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := registryDB.MissingFleets(readyHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != missingID || candidates[0].State != StateMissing {
+		t.Fatalf("MissingFleets() = %+v, want exactly the missing Fleet %s", candidates, missingID)
+	}
+}
+
+func TestPruneRemovesOnlyEntriesClassifiedMissingAndNeverTheCurrentHome(t *testing.T) {
+	root := t.TempDir()
+	registryDB, err := OpenAt(filepath.Join(root, "registry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = registryDB.Close() }()
+
+	readyHome := filepath.Join(root, "ready")
+	readyID := seedFleet(t, registryDB, readyHome)
+
+	unreadableHome := filepath.Join(root, "unreadable")
+	unreadableID := seedFleet(t, registryDB, unreadableHome)
+	if err := os.Remove(store.Path(unreadableHome)); err != nil {
+		t.Fatal(err)
+	}
+
+	missingHome := filepath.Join(root, "missing")
+	missingID := seedFleet(t, registryDB, missingHome)
+	if err := os.RemoveAll(missingHome); err != nil {
+		t.Fatal(err)
+	}
+
+	// Prune runs from the ready Fleet's own home. classify() can never mark a Current locator
+	// missing, so this also covers "never remove the current home" as far as it is reachable.
+	removed, err := registryDB.Prune(readyHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0].ID != missingID {
+		t.Fatalf("Prune() = %+v, want exactly the missing Fleet %s removed", removed, missingID)
+	}
+
+	fleets, err := registryDB.List(readyHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remaining := make(map[string]State, len(fleets))
+	for _, fleet := range fleets {
+		remaining[fleet.ID] = fleet.State
+	}
+	if _, stillThere := remaining[missingID]; stillThere {
+		t.Fatalf("fleets after prune = %#v, want %s gone", remaining, missingID)
+	}
+	if remaining[readyID] != StateReady {
+		t.Fatalf("fleets after prune = %#v, want %s still ready", remaining, readyID)
+	}
+	if remaining[unreadableID] != StateUnreadable {
+		t.Fatalf("fleets after prune = %#v, want %s still unreadable", remaining, unreadableID)
+	}
+
+	// A second Prune, with nothing left to remove, is a true no-op.
+	second, err := registryDB.Prune(readyHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("second Prune() = %+v, want nothing left to remove", second)
+	}
+}

--- a/internal/secondhand/home.go
+++ b/internal/secondhand/home.go
@@ -2,22 +2,34 @@
 package secondhand
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/atqamz/hand/internal/testtag"
 )
 
+// ErrHomeNotOverridden is wrapped into Home's error when a test build finds no SECONDHAND_HOME set.
+// A single missed override once cost the operator's real registry 3366 dead rows (atqamz/hand#413):
+// the fallback below must be unreachable from a test binary, not merely unused by convention.
+var ErrHomeNotOverridden = errors.New("SECONDHAND_HOME is not set")
+
 func Home() (string, error) {
-	if configured := os.Getenv("SECONDHAND_HOME"); configured != "" {
-		path, err := filepath.Abs(configured)
-		if err != nil {
-			return "", fmt.Errorf("resolve SECONDHAND_HOME: %w", err)
+	configured := os.Getenv("SECONDHAND_HOME")
+	if configured == "" {
+		if testtag.Present {
+			return "", fmt.Errorf("%w: a test build must not resolve the operator's real Secondhand infrastructure root; set SECONDHAND_HOME before any code that reaches it runs (`make test`, `make e2e` and this repo's package TestMains already do)", ErrHomeNotOverridden)
 		}
-		return filepath.Clean(path), nil
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home for Secondhand infrastructure: %w", err)
+		}
+		return filepath.Join(home, ".secondhand"), nil
 	}
-	home, err := os.UserHomeDir()
+	path, err := filepath.Abs(configured)
 	if err != nil {
-		return "", fmt.Errorf("resolve user home for Secondhand infrastructure: %w", err)
+		return "", fmt.Errorf("resolve SECONDHAND_HOME: %w", err)
 	}
-	return filepath.Join(home, ".secondhand"), nil
+	return filepath.Clean(path), nil
 }

--- a/internal/secondhand/home_test.go
+++ b/internal/secondhand/home_test.go
@@ -1,9 +1,16 @@
 package secondhand
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
 )
+
+func TestMain(m *testing.M) {
+	testtag.Main(m.Run)
+}
 
 func TestHomeUsesExplicitInfrastructureRoot(t *testing.T) {
 	configured := filepath.Join(t.TempDir(), "Secondhand 測試")
@@ -25,21 +32,17 @@ func TestHomeUsesExplicitInfrastructureRoot(t *testing.T) {
 	}
 }
 
-func TestHomeUsesCanonicalUserRootWithoutOverride(t *testing.T) {
-	configured := filepath.Join(t.TempDir(), "operator")
+// This suite only ever runs under the test build tag (TestMain above refuses otherwise), so this
+// proves the enforced half of the contract: without SECONDHAND_HOME, Home() must refuse rather than
+// silently resolve the operator's real infrastructure root. See atqamz/hand#413.
+func TestHomeRefusesWithoutOverrideUnderTestBuild(t *testing.T) {
+	operatorHome := filepath.Join(t.TempDir(), "operator")
 	t.Setenv("SECONDHAND_HOME", "")
-	t.Setenv("HOME", configured)
-	t.Setenv("USERPROFILE", configured)
+	t.Setenv("HOME", operatorHome)
+	t.Setenv("USERPROFILE", operatorHome)
 
-	got, err := Home()
-	if err != nil {
-		t.Fatal(err)
-	}
-	want, err := filepath.Abs(filepath.Join(configured, ".secondhand"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != filepath.Clean(want) {
-		t.Fatalf("Home() = %q, want %q", got, filepath.Clean(want))
+	_, err := Home()
+	if !errors.Is(err, ErrHomeNotOverridden) {
+		t.Fatalf("Home() error = %v, want ErrHomeNotOverridden", err)
 	}
 }

--- a/internal/worktree/testtag_test.go
+++ b/internal/worktree/testtag_test.go
@@ -1,11 +1,32 @@
 package worktree
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/atqamz/hand/internal/testtag"
 )
 
+// Some tests here (TestPoolRootDiffersPerClone and friends) call poolRoot/PoolsRoot directly rather
+// than through faketool.Bin, so the package needs its own isolated SECONDHAND_HOME regardless of
+// whether the invoking `go test` was wrapped by `make test` (atqamz/hand#413).
 func TestMain(m *testing.M) {
-	testtag.Main(m.Run)
+	if !testtag.Present {
+		testtag.Refuse()
+	}
+	root, err := os.MkdirTemp("", "hand-worktree-test-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("SECONDHAND_HOME", filepath.Join(root, "Secondhand 測試")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_ = os.RemoveAll(root)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(root)
+	os.Exit(code)
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -420,6 +420,17 @@ func withTreehouseRoot(clonePath, recordedWorktreePath string, args ...string) (
 	return append([]string{"--root", root}, args...), nil
 }
 
+// PoolsRoot is the directory every clone's worktree pool lives under - the one path that identifies
+// any slot Hand's own pools could ever create. Exported for cmd/init.go's managed-tree refusal
+// (atqamz/hand#413): no Fleet home may be registered inside it.
+func PoolsRoot() (string, error) {
+	infra, err := secondhand.Home()
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree pool root: %w", err)
+	}
+	return filepath.Join(infra, "pools"), nil
+}
+
 // Where this clone's pool lives. Before atqamz/hand#427 it was the clone itself, which put every
 // worker worktree under the fleet home and fed the worker the supervisor's own CLAUDE.md. A digest
 // of the clone path keys it instead: one pool per fleet home and project, outside every home.
@@ -427,12 +438,12 @@ func poolRoot(clonePath, recordedWorktreePath string) (string, error) {
 	if recordedWorktreePath != "" && withinPath(clonePath, recordedWorktreePath) {
 		return clonePath, nil
 	}
-	infra, err := secondhand.Home()
+	root, err := PoolsRoot()
 	if err != nil {
-		return "", fmt.Errorf("resolve worktree pool root: %w", err)
+		return "", err
 	}
 	digest := sha256.Sum256([]byte(filepath.Clean(clonePath)))
-	return filepath.Join(infra, "pools", fmt.Sprintf("%s-%x", filepath.Base(clonePath), digest[:6])), nil
+	return filepath.Join(root, fmt.Sprintf("%s-%x", filepath.Base(clonePath), digest[:6])), nil
 }
 
 // Reports whether path is root or sits inside it, comparing the recorded strings without resolving


### PR DESCRIPTION
## Summary

- `secondhand.Home()` now refuses (`ErrHomeNotOverridden`) instead of falling back to the operator's real `~/.secondhand` when `SECONDHAND_HOME` is unset in a `-tags=test` binary - the fallback branch that leaked 3366 rows into the real registry is unreachable in a test build, not merely unset by convention. Trace, before any code change, is in this issue's discussion.
- `hand fleet prune` reports (default) or removes (`--apply`) Fleets already classified `missing` - never `ready`, never `unreadable`, never the current home. `registry.MissingFleets`/`registry.Prune` are the underlying API.
- `hand init` now refuses to register a home inside Hand's own Treehouse worktree pool (`worktree.PoolsRoot()`) or inside another Fleet's `projects/` tree, checked structurally against the filesystem rather than the registry, per `docs/adr/the-landed-work-guard-reads-the-work-not-the-record.md`.
- Fix direction 4 from the issue (`hand fleet` summary-by-default) is left out of scope, as a separate UX decision.
- `docs/adr/a-test-build-cannot-resolve-the-real-secondhand-root.md` records the isolation-mechanism decision; `docs/testing-invariants.md` INV-REG-5/6/7 now point at their tests instead of reading "violated today"/"not yet implemented".

Closes atqamz/hand#413

## Test plan

From this worktree, real output:

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .
$ make test
SECONDHAND_HOME=$(mktemp -d) go test -tags=test -race -timeout=30m ./...
ok  	github.com/atqamz/hand/cmd	149.433s
...
ok  	github.com/atqamz/hand/internal/registry	7.283s
ok  	github.com/atqamz/hand/internal/secondhand	1.043s
ok  	github.com/atqamz/hand/internal/worktree	7.087s
(all packages ok)
$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	68.823s
```

Manual demo in a scratch registry created for this PR (`SECONDHAND_HOME` pointed at a throwaway temp dir, never `~/.secondhand`): seeded a `ready`, an existing-but-unreadable, and a `missing` Fleet, then:

```
$ hand fleet prune
applied: false
candidates[1]{id,home,state,locations}:
  f_e7e937c7897555c2a2b9f8115089d54e,.../missing,missing,.../missing
help[1]:
  - Run `hand fleet prune --apply` to remove exactly these Fleets; nothing was changed

$ hand fleet prune --apply
applied: true
removed[1]{id,home,state,locations}:
  f_e7e937c7897555c2a2b9f8115089d54e,.../missing,missing,.../missing

$ hand fleet
fleets[2]{id,home,state,current,locations}:
  f_...,.../ready,ready,false,.../ready
  f_...,.../unreadable,unreadable,false,.../unreadable
```

The ready and unreadable rows survived untouched; a second `--apply` was a true no-op (`removed[0]`). Also demoed both registration refusals (a Treehouse pool slot and a Fleet's `projects/` tree) returning `exit: 3`, `kind: precondition`, with a `help` line.

The real `~/.secondhand/registry.db` mtime is unchanged across this entire session (checked before and after every step) - nothing in this PR's tests or manual verification ever wrote to it.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->