### PR TITLE
fix(promote): refuse to launch a ship attempt against an unrevised brief

### DIFF
--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
@@ -29,7 +30,17 @@ func promoteHerdr(agent, status string) faketool.Herdr {
 	}
 }
 
+const promoteScoutBriefContent = "implement the fix"
+
 func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faketool.Herdr) string {
+	t.Helper()
+	return setupPromoteHomeWithScoutBriefDigest(t, oldWorktree, newWorktree, herdr, "")
+}
+
+// scoutBriefDigest lets a caller simulate a scout attempt launched under atqamz/hand#448's digest
+// tracking, without going through UpdateAttempt: BriefDigest is write-once execution identity, so
+// it can only be set at the attempt's creation, same as PlannedAgainst.
+func setupPromoteHomeWithScoutBriefDigest(t *testing.T, oldWorktree, newWorktree string, herdr faketool.Herdr, scoutBriefDigest string) string {
 	t.Helper()
 	useFastLaunchPolling(t)
 	t.Setenv("HAND_HARNESS", harness.Claude)
@@ -41,7 +52,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "report.md"), []byte("scout findings"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "brief.md"), []byte("implement the fix"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(home, "data", "task-1", "brief.md"), []byte(promoteScoutBriefContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := project.Add(home, project.Project{Name: "myproj", URL: "https://example.com/myproj.git", Mode: project.ModeDirectPR}); err != nil {
@@ -51,7 +62,7 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 		t.Fatal(err)
 	}
 
-	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}, BriefDigest: scoutBriefDigest}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -518,6 +529,148 @@ func TestPromoteFailureKeepsPreexistingWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(string(calls), "tab close wA:tNew") {
 		t.Fatalf("calls = %q, want only the new tab closed", calls)
+	}
+}
+
+// atqamz/hand#448: a promoted scout must not silently launch a ship attempt against the brief
+// that told the scout not to ship. Refusal is total - it names the file and treats no state,
+// so a retry after rewriting the brief is exactly the promote below.
+func TestPromoteRefusesWhenBriefIsUnchangedSinceScoutLaunch(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	scratchBrief := filepath.Join(t.TempDir(), "brief.md")
+	if err := os.WriteFile(scratchBrief, []byte(promoteScoutBriefContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scoutDigest, err := brief.Digest(scratchBrief)
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := setupPromoteHomeWithScoutBriefDigest(t, oldWt, newWt, promoteHerdr("claude", "done"), scoutDigest)
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err = cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want ExitError code 3", err)
+	}
+	if !strings.Contains(err.Error(), "data/task-1/brief.md") || !strings.Contains(err.Error(), "rewrite it as a ship brief") {
+		t.Fatalf("error = %q, want it to name the brief path and the rewrite treatment", err.Error())
+	}
+
+	got, readErr := state.Read(home, "task-1")
+	if readErr != nil || got.Kind != state.KindScout {
+		t.Fatalf("task after refusal = %#v, %v, want unchanged scout", got, readErr)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Attempts) != 1 || history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("attempts after refusal = %+v, want the scout attempt untouched and no ship attempt started", history.Attempts)
+	}
+}
+
+// The companion path: once the supervisor actually rewrites the brief, its new digest no longer
+// matches what the scout attempt recorded, and promote launches exactly as it does today.
+func TestPromoteSucceedsWhenBriefWasRewrittenSinceScoutLaunch(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	scratchBrief := filepath.Join(t.TempDir(), "brief.md")
+	if err := os.WriteFile(scratchBrief, []byte(promoteScoutBriefContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scoutDigest, err := brief.Digest(scratchBrief)
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := setupPromoteHomeWithScoutBriefDigest(t, oldWt, newWt, promoteHerdr("claude", "done"), scoutDigest)
+	briefPath := filepath.Join(home, "data", "task-1", "brief.md")
+	if err := os.WriteFile(briefPath, []byte("implement the fix, then commit, push, and open a PR"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Kind != state.KindShip || history.ActiveAttempt == nil {
+		t.Fatalf("history after promotion = %+v, want ship with active attempt", history)
+	}
+	rewrittenDigest, err := brief.Digest(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt.BriefDigest != rewrittenDigest {
+		t.Fatalf("ship attempt BriefDigest = %q, want the rewritten brief's digest %q recorded at launch", history.ActiveAttempt.BriefDigest, rewrittenDigest)
+	}
+}
+
+// The branch most likely to be got wrong: an attempt recorded before hand tracked brief digests
+// carries an empty one, which is "no evidence either way", not "unchanged". Refusing it would
+// refuse every task promoted before this feature existed.
+func TestPromoteSucceedsWhenScoutAttemptPredatesBriefDigestRecording(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr("claude", "done"))
+
+	scoutAttempt := readTaskAttempt(t, home, "task-1")
+	if scoutAttempt.BriefDigest != "" {
+		t.Fatalf("scout attempt BriefDigest = %q, want empty for this fixture", scoutAttempt.BriefDigest)
+	}
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Kind != state.KindShip || history.ActiveAttempt == nil {
+		t.Fatalf("history after promotion = %+v, want ship with active attempt despite an unchanged brief, since attempt 1 predates digest recording", history)
+	}
+}
+
+// atqamz/hand#418 has hand itself append a launch statement to a grok/pi brief at provision time,
+// after the scout attempt's digest is already recorded. The appendix alone must not make an
+// otherwise-untouched brief look revised, or promote would never refuse for those harnesses.
+func TestPromoteRefusesWhenOnlyHandsOwnAppendixWasAddedSinceScoutLaunch(t *testing.T) {
+	oldWt := filepath.Join(t.TempDir(), "old-wt")
+	newWt := filepath.Join(t.TempDir(), "new-wt")
+	scratchBrief := filepath.Join(t.TempDir(), "brief.md")
+	if err := os.WriteFile(scratchBrief, []byte(promoteScoutBriefContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scoutDigest, err := brief.Digest(scratchBrief)
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := setupPromoteHomeWithScoutBriefDigest(t, oldWt, newWt, promoteHerdr("claude", "done"), scoutDigest)
+	briefPath := filepath.Join(home, "data", "task-1", "brief.md")
+	appended := promoteScoutBriefContent + "\n\n---\n\n" + brief.AppendMarker + "\n\nThe worker report channel is /tmp/task-1.status.\n"
+	if err := os.WriteFile(briefPath, []byte(appended), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPromoteCmd()
+	cmd.SetArgs([]string{"task-1"})
+	err = cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("got %v, want ExitError code 3: hand's own appendix must not read as a supervisor revision", err)
+	}
+	if !strings.Contains(err.Error(), "data/task-1/brief.md") || !strings.Contains(err.Error(), "rewrite it as a ship brief") {
+		t.Fatalf("error = %q, want it to name the brief path and the rewrite treatment", err.Error())
 	}
 }
 

--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -555,7 +555,7 @@ func TestPromoteRefusesWhenBriefIsUnchangedSinceScoutLaunch(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
 		t.Fatalf("got %v, want ExitError code 3", err)
 	}
-	if !strings.Contains(err.Error(), "data/task-1/brief.md") || !strings.Contains(err.Error(), "rewrite it as a ship brief") {
+	if !strings.Contains(err.Error(), filepath.Join("data", "task-1", "brief.md")) || !strings.Contains(err.Error(), "rewrite it as a ship brief") {
 		t.Fatalf("error = %q, want it to name the brief path and the rewrite treatment", err.Error())
 	}
 
@@ -669,7 +669,7 @@ func TestPromoteRefusesWhenOnlyHandsOwnAppendixWasAddedSinceScoutLaunch(t *testi
 	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
 		t.Fatalf("got %v, want ExitError code 3: hand's own appendix must not read as a supervisor revision", err)
 	}
-	if !strings.Contains(err.Error(), "data/task-1/brief.md") || !strings.Contains(err.Error(), "rewrite it as a ship brief") {
+	if !strings.Contains(err.Error(), filepath.Join("data", "task-1", "brief.md")) || !strings.Contains(err.Error(), "rewrite it as a ship brief") {
 		t.Fatalf("error = %q, want it to name the brief path and the rewrite treatment", err.Error())
 	}
 }

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/project"
@@ -268,6 +269,29 @@ func TestSpawnPersistsResolvedNotDeclaredTierValues(t *testing.T) {
 	}
 	if active.Effort != "brief-effort" {
 		t.Fatalf("got effort %q, want the brief's declared value since no flag or config overrides it", active.Effort)
+	}
+}
+
+// atqamz/hand#448: promote later compares this digest against the brief on disk to tell whether
+// the supervisor rewrote it, so it has to be captured at the moment the attempt actually launches.
+func TestSpawnRecordsBriefDigestAtLaunch(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "wt")
+	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))
+	briefPath := filepath.Join(home, "data", "task-1", "brief.md")
+
+	cmd := newSpawnCmd()
+	cmd.SetArgs([]string{"task-1", "myproj"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := brief.Digest(briefPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := readTaskAttempt(t, home, "task-1")
+	if active.BriefDigest != want {
+		t.Fatalf("active.BriefDigest = %q, want the launched brief's digest %q", active.BriefDigest, want)
 	}
 }
 

--- a/docs/adr/promote-refuses-to-launch-against-an-unrevised-brief.md
+++ b/docs/adr/promote-refuses-to-launch-against-an-unrevised-brief.md
@@ -38,6 +38,13 @@ existed, which is a worse failure than the one being fixed.
 A digest proves the supervisor touched the brief deliberately. It cannot judge whether the new
 brief is a *good* ship brief, and does not try to - that limit is deliberate, not an oversight.
 
+The digest excludes hand's own appendix to a grok or pi brief (atqamz/hand#418): that append
+happens at provision time, after the launching attempt's own digest is already recorded, so a
+later comparison that hashed the whole file would read hand's edit as a supervisor revision and
+never refuse for exactly the harnesses the append targets. `internal/brief.Digest` strips
+everything from that appendix's marker onward before hashing, so only supervisor-authored bytes
+are compared on either side.
+
 ## Rejected alternatives
 
 **Promote without launching.** Splits one command into two for every promotion, including the ones

--- a/docs/adr/promote-refuses-to-launch-against-an-unrevised-brief.md
+++ b/docs/adr/promote-refuses-to-launch-against-an-unrevised-brief.md
@@ -1,0 +1,61 @@
+# Promote refuses to launch against an unrevised brief
+
+Date: 2026-08-28
+
+Status: accepted
+
+Issues: atqamz/hand#448
+
+Pull requests: none
+
+## Context
+
+`hand promote` turns a completed scout into a ship task and launches the ship attempt against the
+same path, `data/<id>/brief.md`, that the scout attempt read. A scout brief says what a scout brief
+has to say - investigate, do not change behavior, no commit, no push, no PR - and promotion reuses
+whichever text sits at that path without checking whether anyone rewrote it for the ship attempt.
+
+This was observed in this fleet: the scout for atqamz/hand#410 was promoted, and attempt 2 launched
+against the scout brief before the supervisor could rewrite it. The worker was not blocked and
+reported nothing unusual, because it read a coherent brief and obeyed it. The failure is quiet -
+recovered only because the supervisor happened to check the attempt state within the minute.
+
+## Decision
+
+Hand records a digest of the brief at attempt launch, alongside `planned_against` on the `attempt`
+row, which already records commit provenance for the same reason: to answer "what was this attempt
+launched against" without re-deriving it from mutable state.
+
+`hand promote` compares the scout attempt's recorded digest against the current digest of
+`data/<id>/brief.md`. If they match, promote refuses, names `data/<id>/brief.md`, and says to
+rewrite it as a ship brief - launching nothing. If they differ, promote launches exactly as it does
+today, and the new ship attempt records its own digest of the brief it launched against.
+
+An attempt recorded before this change carries no digest. An empty digest is read as "no evidence
+either way", not as "unchanged" - refusing it would refuse every task promoted before this feature
+existed, which is a worse failure than the one being fixed.
+
+A digest proves the supervisor touched the brief deliberately. It cannot judge whether the new
+brief is a *good* ship brief, and does not try to - that limit is deliberate, not an oversight.
+
+## Rejected alternatives
+
+**Promote without launching.** Splits one command into two for every promotion, including the ones
+where the supervisor already rewrote the brief correctly. It solves the problem by removing the
+convenience of dispatching from the same command, rather than by checking the precondition that was
+actually missing.
+
+**A separate `data/<id>/ship-brief.md`.** Changes the path convention the bundled skill documents in
+`references/planning-and-briefs.md` for every ship task, not only promoted ones. Widest blast radius
+for the same guarantee a digest check gives at the cost of one column.
+
+## Consequences
+
+Every attempt launch - `hand spawn`, `hand reopen`, and `hand promote` - now records a digest of the
+brief it launched against, on the same `attempt` row that already records the harness, model, and
+`planned_against` for that launch. Nothing reads this digest except promote's own comparison; it is
+not surfaced as routing provenance.
+
+A supervisor that promotes with an unrevised brief gets a refusal naming the file to rewrite, not a
+worker that silently investigates instead of shipping. A supervisor that already rewrote the brief
+sees no change in behavior.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -30,6 +30,7 @@ An unaudited line is a question, not a claim that coverage is missing.
 ## Task and Attempt lifecycle
 
 Source: [Tasks are durable and Attempts own execution](adr/tasks-are-durable-and-attempts-own-execution.md),
+[Promote refuses to launch against an unrevised brief](adr/promote-refuses-to-launch-against-an-unrevised-brief.md),
 `internal/store`, `internal/runtime`.
 
 | id | invariant | layer | coverage |
@@ -42,6 +43,8 @@ Source: [Tasks are durable and Attempts own execution](adr/tasks-are-durable-and
 | INV-TASK-6 | `hand reopen` on a terminal task creates a new attempt and mutates no existing one. | model | unaudited |
 | INV-TASK-7 | Promotion preserves the scout attempt and creates the next one. | model | unaudited |
 | INV-TASK-8 | An existing attempt's execution identity - harness, model, effort, execution class, planned-against commit, requested profile, routing source - is write-once. Nothing reroutes it after creation. | model | unaudited |
+| INV-TASK-9 | Promote refuses, and launches no attempt, when the scout attempt's recorded brief digest equals the brief's current digest. A scout attempt recorded before digest tracking existed (an empty digest) is never treated as unchanged. | unit | `TestPromoteRefusesWhenBriefIsUnchangedSinceScoutLaunch`, `TestPromoteSucceedsWhenBriefWasRewrittenSinceScoutLaunch`, `TestPromoteSucceedsWhenScoutAttemptPredatesBriefDigestRecording` |
+| INV-TASK-10 | Every attempt launch records a digest of the brief it launched against, alongside `planned_against`. | unit | `TestSpawnRecordsBriefDigestAtLaunch` |
 
 ## Reconciliation
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -45,6 +45,7 @@ Source: [Tasks are durable and Attempts own execution](adr/tasks-are-durable-and
 | INV-TASK-8 | An existing attempt's execution identity - harness, model, effort, execution class, planned-against commit, requested profile, routing source - is write-once. Nothing reroutes it after creation. | model | unaudited |
 | INV-TASK-9 | Promote refuses, and launches no attempt, when the scout attempt's recorded brief digest equals the brief's current digest. A scout attempt recorded before digest tracking existed (an empty digest) is never treated as unchanged. | unit | `TestPromoteRefusesWhenBriefIsUnchangedSinceScoutLaunch`, `TestPromoteSucceedsWhenBriefWasRewrittenSinceScoutLaunch`, `TestPromoteSucceedsWhenScoutAttemptPredatesBriefDigestRecording` |
 | INV-TASK-10 | Every attempt launch records a digest of the brief it launched against, alongside `planned_against`. | unit | `TestSpawnRecordsBriefDigestAtLaunch` |
+| INV-TASK-11 | Hand's own brief appendix (grok/pi launch delivery) never changes the brief digest, whether the appendix is already present or freshly appended. | unit | `TestAppendPromptToBriefLeavesBriefDigestUnchanged`, `TestDigestUnaffectedByHandsOwnAppendix`, `TestDigestChangesWhenSupervisorEditsPrecedeHandsAppendix`, `TestPromoteRefusesWhenOnlyHandsOwnAppendixWasAddedSinceScoutLaunch` |
 
 ## Reconciliation
 

--- a/internal/brief/brief.go
+++ b/internal/brief/brief.go
@@ -3,6 +3,8 @@ package brief
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -107,6 +109,30 @@ func validObjectID(value string) bool {
 		}
 	}
 	return true
+}
+
+// AppendMarker identifies the appendix hand writes to a grok or pi brief at launch time
+// (atqamz/hand#418). It must stay byte-identical to internal/harness's own copy: Digest strips
+// from this marker's enclosing delimiter onward, so hand's own edit is never read as a revision.
+const AppendMarker = "hand appended the block below at launch time; it is not part of the supervisor's brief above."
+
+// The exact bytes appendLaunchStatement (internal/harness) prepends to AppendMarker, so stripping
+// from the start of this delimiter reproduces precisely the bytes that preceded hand's append.
+const appendBoundary = "\n\n---\n\n" + AppendMarker
+
+// Digest fingerprints a brief's supervisor-authored bytes, so a later reader can tell whether the
+// supervisor touched it since a prior read - the same question planned_against answers for the
+// project's commit. A trailing appendix hand wrote to the file itself is excluded (see AppendMarker).
+func Digest(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read brief %s: %w", path, err)
+	}
+	if idx := strings.Index(string(data), appendBoundary); idx >= 0 {
+		data = data[:idx]
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func unquote(value string) string {

--- a/internal/brief/brief.go
+++ b/internal/brief/brief.go
@@ -112,12 +112,12 @@ func validObjectID(value string) bool {
 }
 
 // AppendMarker identifies the appendix hand writes to a grok or pi brief at launch time
-// (atqamz/hand#418). It must stay byte-identical to internal/harness's own copy: Digest strips
-// from this marker's enclosing delimiter onward, so hand's own edit is never read as a revision.
+// (atqamz/hand#418). This is its one definition: the code that performs the append imports it
+// rather than declaring its own copy, so Digest's boundary detection below cannot drift from it.
 const AppendMarker = "hand appended the block below at launch time; it is not part of the supervisor's brief above."
 
-// The exact bytes appendLaunchStatement (internal/harness) prepends to AppendMarker, so stripping
-// from the start of this delimiter reproduces precisely the bytes that preceded hand's append.
+// The exact bytes the append path prepends to AppendMarker, so stripping from the start of this
+// delimiter reproduces precisely the bytes that preceded hand's own append.
 const appendBoundary = "\n\n---\n\n" + AppendMarker
 
 // Digest fingerprints a brief's supervisor-authored bytes, so a later reader can tell whether the

--- a/internal/brief/brief_test.go
+++ b/internal/brief/brief_test.go
@@ -288,3 +288,37 @@ func TestParseMissingBrief(t *testing.T) {
 		t.Fatal("expected error for missing brief")
 	}
 }
+
+func TestDigestUnaffectedByHandsOwnAppendix(t *testing.T) {
+	supervisorContent := "implement the fix"
+	plain := writeBrief(t, supervisorContent)
+	want, err := Digest(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	appended := writeBrief(t, supervisorContent+"\n\n---\n\n"+AppendMarker+"\n\nThe worker report channel is /tmp/task-1.status.\n")
+	got, err := Digest(appended)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("Digest(appended) = %q, want %q: hand's own appendix must not change the digest", got, want)
+	}
+}
+
+func TestDigestChangesWhenSupervisorEditsPrecedeHandsAppendix(t *testing.T) {
+	rewritten := writeBrief(t, "ship it"+"\n\n---\n\n"+AppendMarker+"\n\nThe worker report channel is /tmp/task-1.status.\n")
+	original := writeBrief(t, "implement the fix"+"\n\n---\n\n"+AppendMarker+"\n\nThe worker report channel is /tmp/task-1.status.\n")
+	rewrittenDigest, err := Digest(rewritten)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalDigest, err := Digest(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewrittenDigest == originalDigest {
+		t.Fatal("Digest must still distinguish two different supervisor-authored briefs that both carry hand's appendix")
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -353,11 +353,6 @@ func briefPrompt(o Options) (string, error) {
 	return fmt.Sprintf("Read the brief at %s and carry out the task it describes.", o.Brief) + " " + statement, nil
 }
 
-// Also gates the idempotency check below: a brief already carrying it (a resumed or reopened
-// attempt re-provisioning the same file) is left alone rather than growing another copy of the
-// statement on every relaunch.
-const briefAppendMarker = "hand appended the block below at launch time; it is not part of the supervisor's brief above."
-
 // AppendPromptToBrief is grok's and pi's delivery of launchStatement, a no-op for every other
 // harness (atqamz/hand#418). Called once by the provisioning path before Build runs - never to
 // reconstruct already-persisted launch evidence, which must stay a read.
@@ -385,10 +380,12 @@ func appendLaunchStatement(o Options) error {
 	if err != nil {
 		return fmt.Errorf("read brief for launch statement: %w", err)
 	}
-	if strings.Contains(string(data), briefAppendMarker) {
+	// Also gates the append: a brief already carrying the marker (a resumed or reopened attempt
+	// re-provisioning the same file) is left alone rather than growing a second copy.
+	if strings.Contains(string(data), brief.AppendMarker) {
 		return nil
 	}
-	appendix := fmt.Sprintf("\n\n---\n\n%s\n\n%s\n", briefAppendMarker, statement)
+	appendix := fmt.Sprintf("\n\n---\n\n%s\n\n%s\n", brief.AppendMarker, statement)
 	if err := atomicfile.Write(o.Brief, ".brief-append-", append(data, appendix...), info.Mode().Perm()); err != nil {
 		return fmt.Errorf("append launch statement to brief: %w", err)
 	}

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -221,6 +221,31 @@ func TestAppendPromptToBriefGrokAndPi(t *testing.T) {
 	}
 }
 
+// atqamz/hand#448: promote compares brief.Digest from before and after this append runs, so the
+// two can never disagree about what "unchanged" means. Produces the appendix through the real
+// path rather than a hand-written literal, so a format drift here would fail this test directly.
+func TestAppendPromptToBriefLeavesBriefDigestUnchanged(t *testing.T) {
+	for _, name := range []string{Grok, Pi} {
+		t.Run(name, func(t *testing.T) {
+			briefPath := writeTestBrief(t, "implement the fix.\n")
+			before, err := brief.Digest(briefPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := AppendPromptToBrief(name, Options{Brief: briefPath, ReportPath: "/tmp/state/task-1.status"}); err != nil {
+				t.Fatal(err)
+			}
+			after, err := brief.Digest(briefPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after != before {
+				t.Fatalf("Digest after AppendPromptToBrief(%q) = %q, want %q unchanged", name, after, before)
+			}
+		})
+	}
+}
+
 func TestAppendPromptToBriefIsIdempotent(t *testing.T) {
 	briefPath := writeTestBrief(t, "do the task.\n")
 	options := Options{Brief: briefPath, ReportPath: "/tmp/state/task-1.status"}
@@ -270,7 +295,7 @@ func TestAppendPromptToBriefRejectsMissingReportPath(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "report path") {
 			t.Fatalf("AppendPromptToBrief(%q) error = %v, want missing report path error", name, err)
 		}
-		if data, readErr := os.ReadFile(briefPath); readErr != nil || strings.Contains(string(data), briefAppendMarker) {
+		if data, readErr := os.ReadFile(briefPath); readErr != nil || strings.Contains(string(data), brief.AppendMarker) {
 			t.Fatalf("AppendPromptToBrief(%q) refusal must not touch the brief file, got %q", name, data)
 		}
 	}
@@ -298,7 +323,7 @@ func assertBriefCarriesLaunchStatement(t *testing.T, briefPath string, options O
 		t.Fatalf("brief content = %q, want the supervisor's original brief preserved at the top", content)
 	}
 	for _, want := range []string{
-		briefAppendMarker,
+		brief.AppendMarker,
 		options.ReportPath,
 		"working:", "done:", "failed:", "blocked:", "needs-decision:", "paused:",
 		"plain shell redirection",

--- a/internal/routing/resolver.go
+++ b/internal/routing/resolver.go
@@ -16,6 +16,7 @@ type Request struct {
 	Kind                TaskKind
 	Declaration         brief.Declaration
 	BriefHasFrontMatter bool
+	BriefDigest         string
 	Profile             string
 	ProfileFromFlag     bool
 	Harness             string
@@ -59,6 +60,7 @@ type ResolvedRoute struct {
 	ExecutionClass      brief.ExecutionClass
 	PlannedAgainst      string
 	BriefHasFrontMatter bool
+	BriefDigest         string
 	Warnings            []string
 }
 
@@ -136,6 +138,7 @@ func Resolve(request Request, config Config, legacy LegacyDefaults, availability
 		ExecutionClass:      request.Declaration.ExecutionClass,
 		PlannedAgainst:      request.Declaration.PlannedAgainst,
 		BriefHasFrontMatter: request.BriefHasFrontMatter,
+		BriefDigest:         request.BriefDigest,
 	}
 	if request.Declaration.ExecutionClass == "" && !request.ProfileFromFlag {
 		return resolveLegacy(request, legacy, availability, result)

--- a/internal/runtime/dispatch.go
+++ b/internal/runtime/dispatch.go
@@ -91,6 +91,10 @@ func resolveExecution(homeDir, briefPath, kind, profile string, profileFromFlag 
 	if err != nil {
 		return routing.ResolvedRoute{}, classifyResolutionError(fmt.Errorf("parse brief %s: %w", briefPath, err), harnessName, harnessProvided)
 	}
+	digest, err := brief.Digest(briefPath)
+	if err != nil {
+		return routing.ResolvedRoute{}, classifyResolutionError(err, harnessName, harnessProvided)
+	}
 	detectedHarness := ""
 	includeRouting := declaration.ExecutionClass != "" || profileFromFlag
 	if !harnessProvided && !includeRouting {
@@ -108,6 +112,7 @@ func resolveExecution(homeDir, briefPath, kind, profile string, profileFromFlag 
 		Kind:                routing.TaskKind(kind),
 		Declaration:         declaration,
 		BriefHasFrontMatter: frontMatter,
+		BriefDigest:         digest,
 		Profile:             profile,
 		ProfileFromFlag:     profileFromFlag,
 		Harness:             harnessName,

--- a/internal/runtime/promote.go
+++ b/internal/runtime/promote.go
@@ -111,6 +111,12 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 	task = latest.Task
 	scout = *latest.ActiveAttempt
 
+	// An empty digest means the scout attempt predates digest recording, not that its brief is
+	// unchanged: refusing it would refuse every task promoted before this check existed.
+	if scout.BriefDigest != "" && scout.BriefDigest == route.BriefDigest {
+		return fail(Precondition(fmt.Errorf("brief at %s is unchanged since the scout attempt launched; rewrite it as a ship brief before promoting", briefRel)))
+	}
+
 	var releaseProject func()
 	if route.ExecutionClass == brief.ExecutionClassMechanical {
 		releaseProject, err = state.Lock(req.Home, "project:"+projectInfo.Name)
@@ -126,7 +132,7 @@ func (r *Runtime) Promote(ctx context.Context, req PromoteRequest) (Result, erro
 	createdAt := r.deps.now().Format(time.RFC3339)
 	shipAttempt, err := state.PromoteTask(req.Home, req.ID, scout.ID, scout.Lifecycle, state.Attempt{
 		TaskID: req.ID, Lifecycle: state.AttemptProvisioning, Harness: route.Harness, Model: route.Model, Effort: route.Effort,
-		ExecutionClass: string(route.ExecutionClass), PlannedAgainst: route.PlannedAgainst, RequestedProfile: route.Profile, RoutingSource: string(route.Source), CreatedAt: createdAt,
+		ExecutionClass: string(route.ExecutionClass), PlannedAgainst: route.PlannedAgainst, BriefDigest: route.BriefDigest, RequestedProfile: route.Profile, RoutingSource: string(route.Source), CreatedAt: createdAt,
 	})
 	if err != nil {
 		return fail(fmt.Errorf("write promoted provisioning state: %w", err))

--- a/internal/runtime/reopen.go
+++ b/internal/runtime/reopen.go
@@ -109,7 +109,7 @@ func (r *Runtime) Reopen(ctx context.Context, req ReopenRequest) (Result, error)
 	createdAt := r.deps.now().Format(time.RFC3339)
 	attempt, err := state.ReopenTask(req.Home, state.Attempt{
 		TaskID: req.ID, Lifecycle: state.AttemptProvisioning, Harness: route.Harness, Model: route.Model, Effort: route.Effort,
-		ExecutionClass: string(route.ExecutionClass), PlannedAgainst: route.PlannedAgainst, RequestedProfile: route.Profile, RoutingSource: string(route.Source), CreatedAt: createdAt,
+		ExecutionClass: string(route.ExecutionClass), PlannedAgainst: route.PlannedAgainst, BriefDigest: route.BriefDigest, RequestedProfile: route.Profile, RoutingSource: string(route.Source), CreatedAt: createdAt,
 	})
 	if err != nil {
 		return fail(fmt.Errorf("write reopened provisioning state: %w", err))

--- a/internal/runtime/spawn.go
+++ b/internal/runtime/spawn.go
@@ -86,7 +86,7 @@ func (r *Runtime) Spawn(ctx context.Context, req SpawnRequest) (Result, error) {
 		ID: req.ID, Project: projectInfo.Name, Kind: kind, Brief: briefRel, Lifecycle: state.TaskOpen, CreatedAt: createdAt,
 	}, state.Attempt{
 		TaskID: req.ID, Lifecycle: state.AttemptProvisioning, Harness: route.Harness, Model: route.Model, Effort: route.Effort,
-		ExecutionClass: string(route.ExecutionClass), PlannedAgainst: route.PlannedAgainst, RequestedProfile: route.Profile, RoutingSource: string(route.Source), CreatedAt: createdAt,
+		ExecutionClass: string(route.ExecutionClass), PlannedAgainst: route.PlannedAgainst, BriefDigest: route.BriefDigest, RequestedProfile: route.Profile, RoutingSource: string(route.Source), CreatedAt: createdAt,
 	})
 	if err != nil {
 		return fail(fmt.Errorf("write provisioning state: %w", err))

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -157,6 +157,10 @@ var migrations = []string{
 	// placeholders above: the base schema already carries project.id and task.project_id, so a home
 	// built from it and stamped backward replays this step without a duplicate-column error.
 	`SELECT 1;`,
+	// ensureAttemptBriefDigestColumn does the real work below, for the same reason: the base schema
+	// already carries the column, so a plain ALTER TABLE would fail wherever a test or a home
+	// builds its fixture from the current schema before stamping an older version onto it.
+	`SELECT 1;`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -189,6 +193,10 @@ const fleetIdentityVersion = acknowledgedMetadataVersion + 1
 // The last version that identified a project by its mutable name: its task table has no
 // project_id, and its project table no surrogate id (atqamz/hand#388).
 const projectIdentityVersion = fleetIdentityVersion + 1
+
+// The version whose migration adds attempt.brief_digest, recorded at attempt launch so promote can
+// tell a rewritten ship brief from the scout brief attempt 1 ran against (atqamz/hand#448).
+const briefDigestVersion = projectIdentityVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -509,6 +517,11 @@ func (db *DB) applyMigration(version int) error {
 			return err
 		}
 	}
+	if version == briefDigestVersion-1 {
+		if err := ensureAttemptBriefDigestColumn(tx); err != nil {
+			return err
+		}
+	}
 	if err := recordSchemaVersion(tx, version+1); err != nil {
 		return err
 	}
@@ -570,6 +583,20 @@ func ensureAttemptBranchColumn(tx *sql.Tx) error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE attempt ADD COLUMN branch TEXT NOT NULL DEFAULT ''`); err != nil {
 		return fmt.Errorf("add attempt branch column: %w", err)
+	}
+	return nil
+}
+
+func ensureAttemptBriefDigestColumn(tx *sql.Tx) error {
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('attempt') WHERE name = 'brief_digest'`).Scan(&count); err != nil {
+		return fmt.Errorf("inspect attempt brief_digest column: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+	if _, err := tx.Exec(`ALTER TABLE attempt ADD COLUMN brief_digest TEXT NOT NULL DEFAULT ''`); err != nil {
+		return fmt.Errorf("add attempt brief_digest column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -174,6 +174,7 @@ type Attempt struct {
 	Effort                  string           `json:"effort"`
 	ExecutionClass          string           `json:"execution_class"`
 	PlannedAgainst          string           `json:"planned_against"`
+	BriefDigest             string           `json:"brief_digest"`
 	RequestedProfile        string           `json:"requested_profile"`
 	RoutingSource           string           `json:"routing_source"`
 	Worktree                string           `json:"worktree"`
@@ -316,6 +317,7 @@ CREATE TABLE IF NOT EXISTS attempt (
 	effort                 TEXT NOT NULL DEFAULT '',
 	execution_class        TEXT NOT NULL DEFAULT '',
 	planned_against        TEXT NOT NULL DEFAULT '',
+	brief_digest           TEXT NOT NULL DEFAULT '',
 	requested_profile      TEXT NOT NULL DEFAULT '',
 	routing_source        TEXT NOT NULL DEFAULT '',
 	worktree               TEXT NOT NULL DEFAULT '',
@@ -596,6 +598,9 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
+	if current == projectIdentityVersion {
+		return db.readTaskHistoryBeforeBriefDigest(id)
+	}
 	if current == fleetIdentityVersion || current == acknowledgedMetadataVersion {
 		return db.readTaskHistoryBeforeProjectIdentity(id)
 	}
@@ -703,17 +708,21 @@ var attemptColumnNames = []string{
 	"status_changed_at", "status_changed_for", "done_verified", "last_report_state", "last_report_note",
 	"send_undelivered_message", "send_undelivered_at", "parked_fired_for", "usage_limit_retry_at", "usage_limit_attempts",
 	"teardown_terminal_attempt", "teardown_disposition", "teardown_herdr_state", "teardown_worktree_state", "teardown_completion_state",
-	"usage_limit_episode", "usage_limit_stuck_episode", "branch",
+	"usage_limit_episode", "usage_limit_stuck_episode", "branch", "brief_digest",
 }
 
 var attemptColumns = strings.Join(attemptColumnNames, ", ")
 
-// -3 excludes usage_limit_episode, usage_limit_stuck_episode and branch: all three were added
-// after the send schema, in that order, at the tail of attemptColumnNames.
-var attemptColumnsBeforeSend = strings.Join(attemptColumnNames[:len(attemptColumnNames)-3], ", ")
+// -4 excludes usage_limit_episode, usage_limit_stuck_episode, branch and brief_digest: all four
+// were added after the send schema, in that order, at the tail of attemptColumnNames.
+var attemptColumnsBeforeSend = strings.Join(attemptColumnNames[:len(attemptColumnNames)-4], ", ")
 
-var attemptColumnNamesBeforeRouting = append(append([]string{}, attemptColumnNames[:7]...), attemptColumnNames[11:len(attemptColumnNames)-3]...)
+var attemptColumnNamesBeforeRouting = append(append([]string{}, attemptColumnNames[:7]...), attemptColumnNames[11:len(attemptColumnNames)-4]...)
 var attemptColumnsBeforeRouting = strings.Join(attemptColumnNamesBeforeRouting, ", ")
+
+// The column list a database carries at projectIdentityVersion, the version immediately before
+// briefDigestVersion added the tail column below.
+var attemptColumnsBeforeBriefDigest = strings.Join(attemptColumnNames[:len(attemptColumnNames)-1], ", ")
 
 func placeholders(count int) string {
 	return strings.TrimSuffix(strings.Repeat("?, ", count), ", ")
@@ -830,10 +839,25 @@ func attemptValues(a Attempt) []any {
 		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
 		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts,
 		a.TeardownTerminalAttempt, a.TeardownDisposition, a.TeardownHerdrState, a.TeardownWorktreeState, a.TeardownCompletionState,
-		a.UsageLimitEpisode, a.UsageLimitStuckEpisode, a.Branch}
+		a.UsageLimitEpisode, a.UsageLimitStuckEpisode, a.Branch, a.BriefDigest}
 }
 
 func scanAttempt(row interface{ Scan(...any) error }) (Attempt, error) {
+	var a Attempt
+	err := row.Scan(&a.ID, &a.TaskID, &a.Ordinal, &a.Lifecycle, &a.Harness, &a.Model, &a.Effort,
+		&a.ExecutionClass, &a.PlannedAgainst, &a.RequestedProfile, &a.RoutingSource, &a.Worktree, &a.LeaseID,
+		&a.Herdr.Session, &a.Herdr.WorkspaceID, &a.Herdr.TabID, &a.Herdr.PaneID, &a.CreatedAt, &a.PaneStartedAt,
+		&a.LaunchSubmittedAt, &a.LaunchConfirmedAt,
+		&a.StatusChangedAt, &a.StatusChangedFor, &a.DoneVerified, &a.LastReportState, &a.LastReportNote,
+		&a.SendUndeliveredMessage, &a.SendUndeliveredAt, &a.ParkedFiredFor, &a.UsageLimitRetryAt, &a.UsageLimitAttempts,
+		&a.TeardownTerminalAttempt, &a.TeardownDisposition, &a.TeardownHerdrState, &a.TeardownWorktreeState, &a.TeardownCompletionState,
+		&a.UsageLimitEpisode, &a.UsageLimitStuckEpisode, &a.Branch, &a.BriefDigest)
+	return a, err
+}
+
+// The reader for a database at projectIdentityVersion, one version behind briefDigestVersion: every
+// attempt column except the tail one that version adds.
+func scanAttemptBeforeBriefDigest(row interface{ Scan(...any) error }) (Attempt, error) {
 	var a Attempt
 	err := row.Scan(&a.ID, &a.TaskID, &a.Ordinal, &a.Lifecycle, &a.Harness, &a.Model, &a.Effort,
 		&a.ExecutionClass, &a.PlannedAgainst, &a.RequestedProfile, &a.RoutingSource, &a.Worktree, &a.LeaseID,
@@ -969,6 +993,37 @@ func (db *DB) readTaskHistoryBeforeProjectIdentity(id string) (TaskHistory, bool
 		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
 	}
 	attempts, err := db.ListAttempts(id)
+	if err != nil {
+		return TaskHistory{}, false, err
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
+// A database at projectIdentityVersion has every task column current, since briefDigestVersion
+// touches only the attempt table, so only the attempt side falls back to the pre-digest reader.
+func (db *DB) readTaskHistoryBeforeBriefDigest(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
+	row := db.sql.QueryRow(`SELECT `+taskSelectColumns+taskSelectFrom+` WHERE task.id = ?`, id)
+	task, err := scanTask(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
+	}
+	attempts, err := db.listAttemptsBeforeBriefDigest(id)
 	if err != nil {
 		return TaskHistory{}, false, err
 	}
@@ -1178,6 +1233,26 @@ func (db *DB) listAttemptsBeforeSend(taskID string) ([]Attempt, error) {
 	return attempts, nil
 }
 
+func (db *DB) listAttemptsBeforeBriefDigest(taskID string) ([]Attempt, error) {
+	rows, err := db.sql.Query(`SELECT `+attemptColumnsBeforeBriefDigest+` FROM attempt WHERE task_id = ? ORDER BY ordinal`, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list attempts for task %q: %w", taskID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var attempts []Attempt
+	for rows.Next() {
+		attempt, err := scanAttemptBeforeBriefDigest(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list attempts for task %q: %w", taskID, err)
+		}
+		attempts = append(attempts, attempt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list attempts for task %q: %w", taskID, err)
+	}
+	return attempts, nil
+}
+
 func (db *DB) ListOpenTaskHistories() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
@@ -1289,6 +1364,9 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	if current == repairMetadataVersion || current == sendSchemaVersion {
 		return db.listReconciliationHistoriesBeforeSend()
 	}
+	if current == projectIdentityVersion {
+		return db.listReconciliationHistoriesBeforeBriefDigest()
+	}
 	return db.ListReconciliationHistories()
 }
 
@@ -1325,6 +1403,56 @@ func (db *DB) listReconciliationHistoriesBeforeProjectIdentity() ([]TaskHistory,
 	}
 	for i := range histories {
 		attempts, err := db.ListAttempts(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("task %q active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
+}
+
+// The reconciliation-listing counterpart to readTaskHistoryBeforeBriefDigest: projectIdentityVersion
+// predates attempt.brief_digest, so its attempt side stays on the pre-digest reader.
+func (db *DB) listReconciliationHistoriesBeforeBriefDigest() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` WHERE task.lifecycle = 'open' OR task.repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY task.id`)
+	if err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.listAttemptsBeforeBriefDigest(histories[i].Task.ID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- Records a digest of the brief at attempt launch (`hand spawn`, `hand reopen`, `hand promote`), alongside `planned_against` on the same `attempt` row.
- `hand promote` refuses, and launches nothing, when the scout attempt's recorded digest still matches `data/<id>/brief.md`'s current digest - naming the file and "rewrite it as a ship brief" as the treatment. An attempt recorded before this change carries no digest and is never treated as unchanged.
- The digest excludes hand's own grok/pi launch-statement appendix (atqamz/hand#418, in review as of this writing), so that append at provision time is never mistaken for a supervisor revision.
- Adds an ADR and a `docs/testing-invariants.md` entry per the repo's convention.

Closes atqamz/hand#448

## Test plan

- [x] `make lint` - clean (`go vet`, `golangci-lint`, `commentlint`)
- [x] `make test` - full suite passes with `-race`
- [x] `make e2e` - passes
- [x] Manual scratch-fleet demonstration via a temporary e2e test (deleted after use):
  - Promote against the untouched scout brief:
    ```
    $ hand promote task-1
    exit 3
    error: brief at data/task-1/brief.md is unchanged since the scout attempt launched; rewrite it as a ship brief before promoting
    ```
  - Promote after rewriting the brief:
    ```
    $ hand promote task-1
    exit 0
    result: promoted
    kind: ship
    was: scout
    ```

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->