### PR TITLE
fix(runtime): close the worktree release gate on evidence

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -50,7 +50,11 @@ func newPRCmd() *cobra.Command {
 			doc.Field("id", task.ID)
 			doc.Field("result", result)
 			doc.Field("pr", url)
-			doc.Help("Run `hand merge " + task.ID + "` once this PR's checks are green")
+			// A torn-down task has no active attempt for hand merge to act on (atqamz/hand#424): naming
+			// it here would suggest the task is live again, which recording a PR on it must never do.
+			if task.Lifecycle != state.TaskTerminal {
+				doc.Help("Run `hand merge " + task.ID + "` once this PR's checks are green")
+			}
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}

--- a/cmd/prdetect.go
+++ b/cmd/prdetect.go
@@ -15,9 +15,9 @@ import (
 // attention-is-one-derivation-over-three-channels.md, invariant 1). Empty where no lookup applies.
 func detectPRForStatus(ctx context.Context, home string, history state.TaskHistory) ghutil.PRObservation {
 	t := history.Task
-	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - and a torn-down task's
-	// completion record is already written, so both skip the lookup rather than pay a forge round trip for a
-	// PR recordPR would refuse. The scout half is the short-circuit checkLandedWork opens with.
+	// A scout task never answers for a PR - its deliverable is data/<id>/report.md - and a torn-down
+	// task's completion record is already written, so both skip the lookup rather than pay a forge
+	// round trip a status render has no use for. hand pr can still record one directly (atqamz/hand#424).
 	if t.PR != "" || t.Kind == state.KindScout || t.Lifecycle == state.TaskTerminal {
 		return ghutil.PRObservation{}
 	}

--- a/cmd/task_attempt_test.go
+++ b/cmd/task_attempt_test.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func TestStatusInspectsTerminalTaskAndAttemptHistory(t *testing.T) {
@@ -75,37 +77,87 @@ func terminalTaskHome(t *testing.T) string {
 	return home
 }
 
-// Teardown writes the permanent completion record from the state the task had then, so a
-// delivery or a PR recorded afterwards would sit on the row unread. Both name hand reopen.
-func TestDeliverAndPRRefuseATerminalTask(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		cmd  func() *cobra.Command
-		args []string
-	}{
-		{"deliver", newDeliverCmd, []string{"task-1", "--reason", "handed to upstream"}},
-		{"pr", newPRCmd, []string{"task-1", "https://github.com/o/nsr/pull/7"}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			home := terminalTaskHome(t)
-			cmd := tc.cmd()
-			cmd.SetOut(io.Discard)
-			cmd.SetErr(io.Discard)
-			cmd.SetArgs(tc.args)
-			err := cmd.Execute()
-			if err == nil {
-				t.Fatalf("hand %s accepted a terminal task", tc.name)
-			}
-			if !strings.Contains(err.Error(), "hand reopen task-1") {
-				t.Fatalf("error = %v, want it to name the remedy", err)
-			}
-			got, err := state.Read(home, "task-1")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got.DeliveredAt != "" || got.PR != "" {
-				t.Fatalf("terminal task was written to: %+v", got)
-			}
-		})
+// Teardown writes the permanent completion record from the state the task had then, so a delivery
+// recorded afterwards would sit on the row unread. hand pr is the one exception (atqamz/hand#424):
+// see TestPRRecordsOnATerminalTaskWithoutReopening.
+func TestDeliverRefusesATerminalTask(t *testing.T) {
+	home := terminalTaskHome(t)
+	cmd := newDeliverCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"task-1", "--reason", "handed to upstream"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("hand deliver accepted a terminal task")
+	}
+	if !strings.Contains(err.Error(), "hand reopen task-1") {
+		t.Fatalf("error = %v, want it to name the remedy", err)
+	}
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DeliveredAt != "" {
+		t.Fatalf("terminal task was written to: %+v", got)
+	}
+}
+
+// atqamz/hand#424 ask 1: recording where a torn-down task's work landed is not resuming it, so hand
+// pr is the one write allowed past teardown's completion record. Lifecycle must stay terminal, and
+// taskFlags/needsAttention (the fleet's one attention definition) must never key off task.PR.
+func TestPRRecordsOnATerminalTaskWithoutReopening(t *testing.T) {
+	home := terminalTaskHome(t)
+	registerTerminalTaskProject(t, home)
+	const pr = "https://github.com/owner/repo/pull/7"
+	faketool.GH{PRs: []faketool.GHPR{{Number: 7, URL: pr, Repo: "owner/repo", State: "OPEN"}}}.Install(t, faketool.Bin(t))
+
+	cmd := newPRCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"task-1", pr})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hand pr refused a terminal task: %v", err)
+	}
+	if strings.Contains(out.String(), "hand merge") {
+		t.Fatalf("output = %q, want no hand merge suggestion: the task has no active attempt for it to act on", out.String())
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PR != pr {
+		t.Fatalf("task.PR = %q, want %q recorded", got.PR, pr)
+	}
+	if got.Lifecycle != state.TaskTerminal {
+		t.Fatalf("task.Lifecycle = %q, want it to stay terminal - hand pr must not reopen the task", got.Lifecycle)
+	}
+
+	// Write-once still holds: a second, different URL is refused exactly like an open task's would be.
+	again := newPRCmd()
+	again.SetOut(io.Discard)
+	again.SetErr(io.Discard)
+	again.SetArgs([]string{"task-1", "https://github.com/owner/repo/pull/8"})
+	if err := again.Execute(); err == nil {
+		t.Fatal("hand pr accepted a second, different PR on a task that already has one recorded")
+	}
+
+	view := taskView{task: got}
+	if needsAttention(view) {
+		t.Fatalf("needsAttention(%+v) = true, want a terminal task with a recorded PR to gain no liveness", view)
+	}
+	if flags := taskFlags(view); len(flags) != 0 {
+		t.Fatalf("taskFlags(%+v) = %v, want none: a recorded-but-unmerged PR renders no flag", view, flags)
+	}
+}
+
+func registerTerminalTaskProject(t *testing.T, home string) {
+	t.Helper()
+	clonePath := filepath.Join(home, "projects", "demo")
+	initGitRepo(t, clonePath)
+	runGitIn(t, clonePath, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/owner/repo.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/docs/adr/terminal-release-closes-on-evidence-not-a-new-escape-hatch.md
+++ b/docs/adr/terminal-release-closes-on-evidence-not-a-new-escape-hatch.md
@@ -1,0 +1,108 @@
+# Terminal release closes on evidence, not a new escape hatch
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#424, atqamz/hand#428
+- PRs: none
+
+## Context
+
+`hand teardown` withholds a worktree until commit safety is proven durable. atqamz/hand#424 found
+the refusal text a model of that discipline: it names the observation it ran (`git rev-list --count
+HEAD --not --remotes`), distinguishes "unanswered" from "at risk", and names the missing evidence -
+a recorded pull request. But the remedy it names was unreachable. `hand pr` refused a torn-down task
+("run hand reopen first"), `hand reconcile --abandon-worktree` correctly no-op'd on a lease it could
+still observe, and `hand reopen` was the only door left - which invents a new attempt to record a
+fact about an old one, exactly what the first refusal exists to avoid. Each precondition was
+individually defensible; together they were unsatisfiable.
+
+atqamz/hand#428 found a narrower version of the same shape one step earlier. A pool slot starts on a
+detached HEAD; a branch exists only once a worker creates one. A worker that paused, or was stopped
+before committing, leaves `active.Branch` empty and the worktree detached. `internal/runtime/pr.go`
+answered `unknown` for a pull request there - correctly, since a detached worktree cannot in general
+answer at all. But hand already holds two observations that together disprove a pull request rather
+than leaving it unknown: no branch was ever recorded to have opened one from, and
+`worktree.ObserveCommitSafety`'s own primitive, `git rev-list --count HEAD --not --remotes`, already
+proves no commit here is missing from a remote-tracking ref. `unknown` was a false negative, and it
+was the only thing standing between a provably empty worktree and its release.
+
+Both gates are the same worktree-release gate approached from different callers:
+`resolveWorktreeCommitSafety` (used once a task is already terminal) and `checkLandedWork` (used
+while it is still open). Fixing one without the other leaves the same shape of dead end on the
+caller not fixed.
+
+## Decision
+
+Three changes, each supplying evidence a gate already asks for rather than weakening what counts as
+proof.
+
+**`internal/runtime/pr.go` proves absence from observations hand already holds.**
+`observeDetachedHeadAbsence` composes two primitives - `git.IsDetachedHead` (HEAD names a commit
+directly, not a branch) and `worktree.LocalOnlyCommitCount` (zero commits missing from a
+remote-tracking ref) - and only when durable `active.Branch` is also empty. All three hold or the
+observation stays `ghutil.ObservationUnknown`, unchanged from before. `git.IsDetachedHead` is its own
+primitive rather than a read of `CurrentBranch`'s error, because `CurrentBranch` collapses "detached"
+and "unreadable for any other reason" into one message; the absence proof needs to know which.
+
+**`hand pr` (`RecordPR`) no longer refuses a terminal task.** Recording where work landed is not
+resuming it: the command is already write-once (a second, different URL is still refused) and
+already validates the URL against the project's repo and against GitHub before writing anything.
+`state.SetTaskPR` touches no lifecycle column, so nothing about this write can leave the terminal
+state - there is no code path from "task.PR changed" to "task reopened."
+
+**`checkLandedWork` (teardown.go) treats the same three-condition proof as "nothing to land."** An
+attempt that never created a branch and holds no commit missing from a remote-tracking ref produced
+no committable work, so neither the local-only-merge check nor a PR search has anything to answer.
+This is recorded under the existing `worker-exited-unlanded` disposition - the same one reconcile's
+own convergence already uses for a worker that produced no landed work - rather than a bare boolean,
+because disposition is what survives a retry that skips `checkLandedWork` entirely
+(`active.TeardownDisposition`, read back before any lifecycle decision is made). Without that, a
+retried teardown reaching `completionFor` without ever calling `checkLandedWork` again would fall
+through to its `default` case and record "branch merged" for an attempt that never made one.
+
+## Rejected alternatives
+
+- **A teardown attestation for the commit-safety question** (atqamz/hand#424's second ask): an
+  explicit flag with `--abandon-worktree`'s own discipline - refused wherever the question can be
+  observed, usable only where hand is genuinely blind. Rejected because it adds a second way to
+  satisfy a safety gate, and an attestation is only safe while hand is genuinely blind to the
+  question it answers. `internal/runtime/pr.go`'s fix and `hand pr`'s new reach together shrink that
+  blind spot; adding an attestation anyway would make it the path of least resistance for a question
+  hand can now often answer itself, which is the shape
+  [Every diagnosis names a reachable treatment](every-diagnosis-names-a-reachable-treatment.md)
+  already rejected for other gates.
+- **Weakening `resolveWorktreeCommitSafety` or the commit-safety gate itself** - never on the table.
+  The defect in both issues is that a reachable remedy was missing, not that the gate asked for too
+  much; nothing here changes what counts as proof of durability.
+- **Inferring "no work" in `checkLandedWork` from `task.PR == ""` alone** - already the pre-existing,
+  narrower refusal ("a ship task whose PR was never opened still has its commits") and it must stay
+  narrow: only the full three-condition proof, not a bare empty PR field, licenses skipping the
+  landed-work question, or a branch carrying real unlanded commits would release unrefused.
+  `TestObservePRStaysUnknownWhenABranchIsRecordedDespiteDetachedHeadWithNoLocalOnlyCommits` pins the
+  boundary: a recorded branch still goes to GitHub, never to the local shortcut.
+  `TestTeardownStillRefusesAShipTaskWhosePRWasNeverOpened` (`cmd/teardown_test.go`) is unchanged.
+- **A new `TeardownDisposition` value for "no committable work"** - rejected in favor of reusing
+  `worker-exited-unlanded`, whose outcome text ("unlanded", "no landed work was observed") already
+  describes this case honestly without growing the persisted vocabulary.
+- **Recomputing "no committable work" from the worktree after release** - unsafe: `runTeardown`
+  releases the worktree back to its pool before building the completion record, and a released slot
+  may already be leased to a different attempt by the time a later step would re-inspect it. The
+  proof is read once, inside `checkLandedWork`, before release, and threaded through disposition.
+
+## Consequences
+
+Proven absence of a pull request and an unobservable one stay distinguishable everywhere `observePR`
+answers, exactly as atqamz/hand#407/#415 established for the callers that already existed.
+
+A torn-down task can record where its work landed and gains no liveness by doing so: lifecycle stays
+`terminal`, and `taskFlags`/`needsAttention` (`cmd/statusview.go`, the fleet's one attention
+definition) never key off `task.PR`, so no surface - `hand status`, `hand orient`, next-action
+ranking - starts treating it as actionable.
+
+The atqamz/hand#424 repro completes without `hand reopen`
+(`TestTeardownCircleClosesOnceHandPRRecordsTheEvidenceItAsksFor`), and the atqamz/hand#428 repro
+releases with no flags at all (`TestTeardownReleasesADetachedWorktreeWithNoBranchAndNoLocalOnlyCommits`).
+
+atqamz/hand#422 and atqamz/hand#423 remain unowned by this change: both touch `hand pr`'s validation
+for a different reason (a merge already landed, a cross-repo PR), and neither needed the lifecycle
+gate this record removes.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -185,6 +185,18 @@ Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is
 | INV-POOL-3 | A worktree recorded under its clone keeps the clone as its pool root, so a lease taken before atqamz/hand#427 stays observable and returnable. | property | `TestPoolRootKeepsALegacyWorktreeOnItsOwnClone`, `TestReturnKeepsALegacyWorktreeOnItsOwnClone` |
 | INV-POOL-4 | Pool resolution never follows a foreign recorded worktree path to that path's own pool. | property | `TestReturnNeverFollowsAForeignRecordedPathToItsOwnPool` |
 
+## Pull-request observation and terminal-task release
+
+Source: [Terminal release closes on evidence, not a new escape hatch](adr/terminal-release-closes-on-evidence-not-a-new-escape-hatch.md),
+[Every diagnosis names a reachable treatment](adr/every-diagnosis-names-a-reachable-treatment.md).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-PR-1 | A pull request is proven absent only when HEAD is detached, no branch is recorded (durably or live), and no commit is missing from a remote-tracking ref. Any one condition failing leaves the observation unknown. | property | `TestObservePRReportsAbsentWhenDetachedHeadHasNoBranchAndNoLocalOnlyCommits`, `TestObservePRStaysUnknownWhenABranchIsRecordedDespiteDetachedHeadWithNoLocalOnlyCommits`, `TestObservePRStaysUnknownWhenDetachedHeadCarriesALocalOnlyCommit`, `TestObservePRUnaffectedByTheAbsenceProofWhenHeadIsNotDetached` |
+| INV-PR-2 | Recording a pull request changes no task lifecycle column and gains a terminal task no liveness in attention, next-action ranking, or `hand status`. | property | `TestPRRecordsOnATerminalTaskWithoutReopening` |
+| INV-PR-3 | `hand pr` is write-once regardless of task lifecycle: a second, different URL is refused whether the task is open or terminal. | unit | `TestPRRecordsOnATerminalTaskWithoutReopening` |
+| INV-PR-4 | An attempt proven to have produced no committable work releases its worktree without a pull request, and the completion record never claims a merge for it, including across a retry. | unit | `TestTeardownReleasesADetachedWorktreeWithNoBranchAndNoLocalOnlyCommits`, `TestTeardownCircleClosesOnceHandPRRecordsTheEvidenceItAsksFor` |
+
 ## Output rendering
 
 Source: [Output is TOON by default and JSON is retained](adr/output-is-toon-by-default-and-json-is-retained.md),

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -105,6 +105,19 @@ func CurrentBranch(path string) (string, error) {
 	return branch, nil
 }
 
+// IsDetachedHead reports whether HEAD names a commit directly rather than through a branch: unlike
+// CurrentBranch, unreadable and detached do not collapse into one error - symbolic-ref must find no
+// branch while HEAD still resolves to a real commit (atqamz/hand#428).
+func IsDetachedHead(path string) (bool, error) {
+	if _, err := run(path, "symbolic-ref", "-q", "HEAD"); err == nil {
+		return false, nil
+	}
+	if _, err := run(path, "rev-parse", "--verify", "-q", "HEAD^{commit}"); err != nil {
+		return false, fmt.Errorf("resolve Git HEAD commit: %w", err)
+	}
+	return true, nil
+}
+
 func HeadCommit(path string) (string, error) {
 	out, err := run(path, "rev-parse", "--verify", "HEAD^{commit}")
 	if err != nil {

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -42,6 +42,42 @@ func TestCommonDirReturnsTheMainRepositoryForAWorktree(t *testing.T) {
 	}
 }
 
+func TestIsDetachedHeadReportsFalseOnABranch(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "repo")
+	runGit(t, dir, "init", "-q", "-b", "main")
+	runGit(t, dir, "-c", "user.name=git-test", "-c", "user.email=git-test@example.invalid", "commit", "-q", "--allow-empty", "-m", "baseline")
+
+	detached, err := IsDetachedHead(dir)
+	if err != nil || detached {
+		t.Fatalf("IsDetachedHead() = %v, %v, want false, nil on a branch", detached, err)
+	}
+}
+
+func TestIsDetachedHeadReportsTrueWhenHeadNamesACommitDirectly(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "repo")
+	runGit(t, dir, "init", "-q", "-b", "main")
+	runGit(t, dir, "-c", "user.name=git-test", "-c", "user.email=git-test@example.invalid", "commit", "-q", "--allow-empty", "-m", "baseline")
+	head := strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+	runGit(t, dir, "checkout", "-q", head)
+
+	detached, err := IsDetachedHead(dir)
+	if err != nil || !detached {
+		t.Fatalf("IsDetachedHead() = %v, %v, want true, nil once HEAD is checked out directly", detached, err)
+	}
+}
+
+func TestIsDetachedHeadReportsAnErrorRatherThanDetachedWhenHeadIsUnresolvable(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "not-a-repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	detached, err := IsDetachedHead(dir)
+	if err == nil || detached {
+		t.Fatalf("IsDetachedHead() = %v, %v, want an error and false: an unreadable HEAD is not proof of detachment", detached, err)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	if len(args) > 1 && args[0] == "init" {

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -100,9 +100,9 @@ func RecordPR(ctx context.Context, homeDir string, task state.Task, url string) 
 	if task.PR == url {
 		return task, true, nil
 	}
-	if task.Lifecycle == state.TaskTerminal {
-		return task, false, Precondition(fmt.Errorf("task %s is torn down; run hand reopen %s before recording a PR on it", task.ID, task.ID))
-	}
+	// A torn-down task may still record where its work landed (atqamz/hand#424): this only supplies
+	// evidence, write-once and validated like every other call, and never reopens or reactivates the
+	// task - state.SetTaskPR touches no lifecycle column.
 	projectInfo, exists, err := project.Find(homeDir, task.Project)
 	if err != nil {
 		return task, false, err

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/ghutil"
+	"github.com/atqamz/hand/internal/git"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
+	"github.com/atqamz/hand/internal/worktree"
 )
 
 func DetectPR(ctx context.Context, homeDir string, task state.Task, active state.Attempt, projectInfo project.Project) (state.Task, ghutil.PRObservation, error) {
@@ -41,8 +43,8 @@ func observePR(ctx context.Context, homeDir, recordedPR string, active state.Att
 	}
 
 	// Live worktree state wins when it is determinable, since it is more current than what attempt
-	// creation recorded; the durably stored branch is the fallback, since a detached or torn-down
-	// worktree cannot answer at all - not evidence that no branch, and so no PR, ever existed.
+	// creation recorded; the durably stored branch is the fallback, since a torn-down worktree cannot
+	// answer at all - not evidence that no branch, and so no PR, ever existed.
 	branch := active.Branch
 	var liveErr error
 	if active.Worktree != "" {
@@ -52,6 +54,11 @@ func observePR(ctx context.Context, homeDir, recordedPR string, active state.Att
 		}
 	}
 	if branch == "" {
+		if active.Worktree != "" {
+			if observation, proven := observeDetachedHeadAbsence(active.Worktree); proven {
+				return observation
+			}
+		}
 		return ghutil.UnknownPRObservation("git symbolic-ref --short -q HEAD", fmt.Sprintf("resolve the branch to search for in %s: %v", active.Worktree, liveErr))
 	}
 	repoSlug, err := project.RepoSlug(homeDir, projectInfo)
@@ -63,6 +70,24 @@ func observePR(ctx context.Context, homeDir, recordedPR string, active state.Att
 		targets = append(targets, ghutil.PRSearchTarget{Repo: projectInfo.Upstream, HeadRepo: repoSlug})
 	}
 	return ghutil.ObservePRByBranch(ctx, branch, targets...)
+}
+
+// A detached, branchless worktree disproves a pull request outright, rather than merely failing to
+// name one to search for, once no branch was ever pushed to open it from and no commit here could
+// have reached GitHub except through one (atqamz/hand#428). proven is false on any inconclusive read.
+func observeDetachedHeadAbsence(worktreePath string) (observation ghutil.PRObservation, proven bool) {
+	detached, err := git.IsDetachedHead(worktreePath)
+	if err != nil || !detached {
+		return ghutil.PRObservation{}, false
+	}
+	localOnly, err := worktree.LocalOnlyCommitCount(worktreePath)
+	if err != nil || localOnly != 0 {
+		return ghutil.PRObservation{}, false
+	}
+	return ghutil.PRObservation{State: ghutil.ObservationAbsent, Probe: ghutil.Probe{
+		Command: "git symbolic-ref -q HEAD; " + worktree.LocalOnlyCommitCommand,
+		Reason:  "HEAD is detached, no branch was ever recorded for this attempt, and the worktree holds no commit missing from a remote-tracking ref, so no branch could have opened a pull request and no commit could have reached GitHub except through one",
+	}}, true
 }
 
 func RecordPR(ctx context.Context, homeDir string, task state.Task, url string) (state.Task, bool, error) {

--- a/internal/runtime/pr_test.go
+++ b/internal/runtime/pr_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,106 @@ func detachedHeadWorktreeFixture(t *testing.T, branch string) string {
 	head := gitOutput(t, path, "rev-parse", "HEAD")
 	runRuntimeGit(t, path, "checkout", "-q", head)
 	return path
+}
+
+// A worktree pushed to origin before HEAD detaches there, no branch ever recorded - the pool-slot
+// shape atqamz/hand#428 describes. localOnly commits land after the push, exclusive to this
+// worktree - condition 3 of the absence proof.
+func detachedHeadPushedFixture(t *testing.T, localOnly int) string {
+	t.Helper()
+	root := t.TempDir()
+	path := filepath.Join(root, "worktree")
+	faketool.InitRepo(t, path)
+	remote := filepath.Join(root, "remote.git")
+	runRuntimeGit(t, root, "init", "-q", "--bare", remote)
+	runRuntimeGit(t, path, "remote", "add", "origin", remote)
+	runRuntimeGit(t, path, "push", "-q", "-u", "origin", "main")
+	for i := 0; i < localOnly; i++ {
+		commitFixtureFile(t, path, fmt.Sprintf("local-only-%d", i))
+	}
+	head := gitOutput(t, path, "rev-parse", "HEAD")
+	runRuntimeGit(t, path, "checkout", "-q", head)
+	return path
+}
+
+// atqamz/hand#428: all three conditions hold - HEAD detached, no branch recorded, zero commits
+// exclusive to this worktree - so the absence is proven rather than left unknown.
+func TestObservePRReportsAbsentWhenDetachedHeadHasNoBranchAndNoLocalOnlyCommits(t *testing.T) {
+	home := t.TempDir()
+	worktreePath := detachedHeadPushedFixture(t, 0)
+	proj := prDetectionProjectFixture(t, home)
+	logPath := filepath.Join(t.TempDir(), "gh.log")
+	faketool.GH{Log: logPath}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: worktreePath}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if !observation.Absent() {
+		t.Fatalf("observation = %+v, want proven absent", observation)
+	}
+	if observation.Reason() == "" {
+		t.Fatalf("observation = %+v, want a reason naming the two observations composed into it", observation)
+	}
+	if log, err := os.ReadFile(logPath); err == nil && len(strings.TrimSpace(string(log))) != 0 {
+		t.Fatalf("gh invocation log = %q, want no gh call: the absence is proven from local git state alone", log)
+	}
+}
+
+// Condition 2 fails: a branch is recorded even though the live worktree happens to be detached, so
+// the local-only-commit proof must not be used to conclude absence - GitHub still has to be asked,
+// and here it cannot answer, so the observation stays unknown rather than becoming a false absence.
+func TestObservePRStaysUnknownWhenABranchIsRecordedDespiteDetachedHeadWithNoLocalOnlyCommits(t *testing.T) {
+	home := t.TempDir()
+	worktreePath := detachedHeadPushedFixture(t, 0)
+	proj := prDetectionProjectFixture(t, home)
+	faketool.GH{Responses: []faketool.GHResponse{
+		{Command: "pr list", Stderr: "gh: authentication failed", Exit: 1},
+	}}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: worktreePath, Branch: "topic"}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if observation.Absent() {
+		t.Fatalf("observation = %+v, want unknown: a recorded branch must be searched on GitHub, not concluded absent from local git state alone", observation)
+	}
+	if !observation.Unknown() {
+		t.Fatalf("observation = %+v, want unknown", observation)
+	}
+}
+
+// Condition 3 fails: HEAD is detached and no branch is recorded, but a commit made after the push
+// is exclusive to this worktree, so nothing proves it reached GitHub through any door.
+func TestObservePRStaysUnknownWhenDetachedHeadCarriesALocalOnlyCommit(t *testing.T) {
+	home := t.TempDir()
+	worktreePath := detachedHeadPushedFixture(t, 1)
+	proj := prDetectionProjectFixture(t, home)
+	faketool.GH{}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: worktreePath}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if observation.Absent() {
+		t.Fatalf("observation = %+v, want unknown: a commit exclusive to this worktree is not proof of absence", observation)
+	}
+	if !observation.Unknown() {
+		t.Fatalf("observation = %+v, want unknown", observation)
+	}
+}
+
+// Condition 1 fails: HEAD is not detached, so the absence shortcut never applies and branch-based
+// detection runs exactly as it did before atqamz/hand#428.
+func TestObservePRUnaffectedByTheAbsenceProofWhenHeadIsNotDetached(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(t.TempDir(), "worktree")
+	faketool.InitRepo(t, path)
+	runRuntimeGit(t, path, "checkout", "-q", "-b", "topic")
+	commitFixtureFile(t, path, "feature")
+	proj := prDetectionProjectFixture(t, home)
+	pr := "https://github.com/" + prDetectionRepo + "/pull/3"
+	faketool.GH{PRs: []faketool.GHPR{{Number: 3, URL: pr, Branch: "topic", State: "OPEN", Repo: prDetectionRepo}}}.Install(t, faketool.Bin(t))
+
+	active := state.Attempt{Worktree: path}
+	observation := DetectPRReadOnly(context.Background(), home, active, proj)
+	if !observation.Found() || observation.URL != pr {
+		t.Fatalf("observation = %+v, want the open PR found via the live branch", observation)
+	}
 }
 
 func prDetectionProjectFixture(t *testing.T, home string) project.Project {

--- a/internal/runtime/teardown.go
+++ b/internal/runtime/teardown.go
@@ -95,12 +95,22 @@ func (r *Runtime) Teardown(ctx context.Context, req TeardownRequest) (Result, er
 		if active.Lifecycle == state.AttemptProvisioning && active.Worktree == "" {
 			return fail(Precondition(fmt.Errorf("task %q has launch evidence but no worktree to inspect; rerun with --force to interrupt it", req.ID)))
 		}
-		updated, safeDirt, err := checkLandedWork(ctx, req.Home, task, active)
+		var noCommittableWork bool
+		updated, safeDirt, err := checkLandedWork(ctx, req.Home, task, active, &noCommittableWork)
 		if err != nil {
 			return fail(err)
 		}
 		task = updated
 		dirtWasSafe = safeDirt
+		if noCommittableWork {
+			// The disposition reconcile.go's own worker-exited-unlanded convergence uses (reconcile.go:590):
+			// unlike a bool, it survives a retry that skips checkLandedWork, so completionFor never
+			// invents a merge for an attempt that produced nothing, whichever call appends the record.
+			terminalAttempt, disposition = state.AttemptInterrupted, state.TeardownDispositionWorkerExitedUnlanded
+			if err := state.SetAttemptTeardownDecision(req.Home, req.ID, active.ID, terminalAttempt, disposition); err != nil {
+				return fail(fmt.Errorf("record teardown decision: %w", err))
+			}
+		}
 	}
 	if terminalAttempt == "" {
 		terminalAttempt, disposition = teardownDecision(req.Force, launched, active.Lifecycle, dirtWasSafe)
@@ -403,9 +413,9 @@ func completionFor(t state.Task, disposition string, launched bool, lastReportSt
 }
 
 // Reports whether the task's work is landed, and whether it got there past dirt it judged safe to
-// discard - the caller has to force the worktree return in that case, since treehouse will not clean a
-// dirty worktree on its own.
-func checkLandedWork(ctx context.Context, home string, t state.Task, active state.Attempt) (state.Task, bool, error) {
+// discard - the caller has to force the worktree return in that case. noCommittableWork, read before
+// the worktree is released and unsafe to recompute after, flags the detached-branchless-zero-commit case.
+func checkLandedWork(ctx context.Context, home string, t state.Task, active state.Attempt, noCommittableWork *bool) (state.Task, bool, error) {
 	if t.Kind == state.KindScout {
 		reportPath := filepath.Join("data", t.ID, "report.md")
 		if _, err := os.Stat(filepath.Join(home, reportPath)); err != nil {
@@ -435,6 +445,18 @@ func checkLandedWork(ctx context.Context, home string, t state.Task, active stat
 	// --force keeps its one meaning of discarding work nobody delivered, so both of those still refuse.
 	if t.DeliveredAt != "" {
 		return t, dirtWasSafe, nil
+	}
+
+	// A detached, branchless worktree with no commit missing from a remote-tracking ref produced no
+	// work to land (atqamz/hand#428, observeDetachedHeadAbsence). Checked first: neither landed-work
+	// path below has anything to answer about work that was never made.
+	if t.PR == "" && active.Branch == "" {
+		if _, proven := observeDetachedHeadAbsence(active.Worktree); proven {
+			if noCommittableWork != nil {
+				*noCommittableWork = true
+			}
+			return t, dirtWasSafe, nil
+		}
 	}
 
 	if t.PR == "" {

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -293,6 +293,69 @@ func TestTeardownRefusesTerminalTaskWhenCommitSafetyIsUnprovable(t *testing.T) {
 	}
 }
 
+// The exact deadlock atqamz/hand#424 reports, reproduced and closed: worktree return refuses because
+// commit safety is unprovable and no PR is recorded, hand pr now supplies that evidence despite the
+// task already being terminal, and the retried teardown proves durability and completes - no reopen.
+func TestTeardownCircleClosesOnceHandPRRecordsTheEvidenceItAsksFor(t *testing.T) {
+	home, worktreePath, _ := terminalResourceFixture(t)
+	clonePath := filepath.Join(home, "projects", "demo")
+	faketool.InitRepo(t, clonePath)
+	runRuntimeGit(t, clonePath, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	const pr = "https://github.com/owner/repo/pull/405"
+	faketool.GH{PRs: []faketool.GHPR{{Number: 405, URL: pr, Repo: "owner/repo", State: "MERGED"}}}.Install(t, faketool.Bin(t))
+
+	const pushedHead = "cafef00dcafef00dcafef00dcafef00dcafef00d"
+	client := &teardownHerdr{}
+	returns := 0
+	deps := defaultDependencies()
+	deps.herdr = func() herdrClient { return client }
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	}
+	deps.worktree.observeCommits = func(string) worktree.CommitSafetyObservation {
+		return worktree.CommitSafetyObservation{State: worktree.CommitSafetyUnknown, Probe: worktree.CommitSafetyProbe{
+			Command: "git rev-list --count HEAD --not --remotes", WorkingDir: worktreePath, Head: pushedHead,
+			Reason: "the branch records upstream origin/task-1-branch and no remote-tracking ref for it survives, so what the remote holds is no longer recorded here",
+		}}
+	}
+	deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
+
+	_, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
+	if err == nil || !strings.Contains(err.Error(), "commit safety is not proven") || !strings.Contains(err.Error(), "no pull request is recorded for this task") {
+		t.Fatalf("Teardown() = %v, want the atqamz/hand#424 refusal naming the missing PR", err)
+	}
+	if returns != 0 {
+		t.Fatalf("worktree returns = %d, want no return before the PR is recorded", returns)
+	}
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Lifecycle != state.TaskTerminal {
+		t.Fatalf("task.Lifecycle = %q, want it already terminal - that is the deadlock's shape", task.Lifecycle)
+	}
+	if _, _, err := RecordPR(context.Background(), home, task, pr); err != nil {
+		t.Fatalf("hand pr refused a terminal task: %v", err)
+	}
+
+	deps.prHead = observedPRHead(pushedHead)
+	_, err = (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatalf("Teardown() after hand pr = %v, want the circle closed without hand reopen", err)
+	}
+	if returns != 1 || client.closes != 1 {
+		t.Fatalf("returns=%d closes=%d, want both resources released", returns, client.closes)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Attempts[0].TeardownWorktreeState != state.TeardownResourceReleased {
+		t.Fatalf("worktree state = %+v, want released", history.Attempts[0])
+	}
+}
+
 // atqamz/hand#428: a pool slot whose worker paused before ever creating a branch releases with no
 // flags at all. The completion record must say so honestly rather than falling through to
 // completionFor's "branch merged" default.

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/completion"
+	"github.com/atqamz/hand/internal/faketool"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
@@ -289,6 +290,65 @@ func TestTeardownRefusesTerminalTaskWhenCommitSafetyIsUnprovable(t *testing.T) {
 	}
 	if returns != 0 {
 		t.Fatalf("worktree returns = %d, want no return", returns)
+	}
+}
+
+// atqamz/hand#428: a pool slot whose worker paused before ever creating a branch releases with no
+// flags at all. The completion record must say so honestly rather than falling through to
+// completionFor's "branch merged" default.
+func TestTeardownReleasesADetachedWorktreeWithNoBranchAndNoLocalOnlyCommits(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/owner/repo.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	faketool.InitRepo(t, filepath.Join(home, "projects", "demo"))
+	runRuntimeGit(t, filepath.Join(home, "projects", "demo"), "remote", "add", "origin", "https://github.com/owner/repo.git")
+	worktreePath := detachedHeadPushedFixture(t, 0)
+
+	attempt, err := state.CreateTaskWithAttempt(home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip}, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Worktree: worktreePath, LeaseID: "lease-1",
+		Herdr:             state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+		LaunchSubmittedAt: "2026-08-15T00:00:00Z", LaunchConfirmedAt: "2026-08-15T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.MarkAttemptRunning(home, "task-1", attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &teardownHerdr{}
+	returns := 0
+	deps := defaultDependencies()
+	deps.herdr = func() herdrClient { return client }
+	deps.worktree.observeLease = func(string, string, string) worktree.LeaseObservation {
+		return worktree.LeaseObservation{State: worktree.LeaseExact, LeaseID: "lease-1"}
+	}
+	deps.worktree.returnWithID = func(string, string, string, bool) error { returns++; return nil }
+
+	if _, err := (&Runtime{deps: deps}).Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"}); err != nil {
+		t.Fatalf("Teardown() = %v, want a provably empty attempt released without --force", err)
+	}
+	if returns != 1 || client.closes != 1 {
+		t.Fatalf("returns=%d closes=%d, want both resources released", returns, client.closes)
+	}
+
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.PR != "" {
+		t.Fatalf("task.PR = %q, want none invented for an attempt that never created a branch", history.Task.PR)
+	}
+	records, err := completion.List(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Outcome != "unlanded" {
+		t.Fatalf("completion = %+v, want an honest unlanded outcome, not a fabricated merge", records)
 	}
 }
 

--- a/internal/worktree/commit_safety_test.go
+++ b/internal/worktree/commit_safety_test.go
@@ -95,7 +95,7 @@ func TestObserveCommitSafetyReportsUnknownForEveryUnobservableComparison(t *test
 	})
 	t.Run("no worktree recorded", func(t *testing.T) {
 		observation := ObserveCommitSafety("")
-		if observation.State != CommitSafetyUnknown || observation.Probe.Command != localOnlyCommitCommand {
+		if observation.State != CommitSafetyUnknown || observation.Probe.Command != LocalOnlyCommitCommand {
 			t.Fatalf("observation = %+v, want unknown carrying the probe it would have run", observation)
 		}
 	})

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -185,8 +185,8 @@ type CommitSafetyObservation struct {
 
 // A remote-tracking ref exists only as this clone's record of a ref observed on a remote, so every
 // commit this count reaches is one a remote was seen holding: zero is positive proof the work
-// outlives the worktree, established without a network call.
-const localOnlyCommitCommand = "git rev-list --count HEAD --not --remotes"
+// outlives the worktree. Exported for internal/runtime/pr.go's pull-request absence proof (atqamz/hand#428).
+const LocalOnlyCommitCommand = "git rev-list --count HEAD --not --remotes"
 
 // ObserveCommitSafety reports whether returning a worktree could discard commits held nowhere else
 // and never fails: every cause that stops the comparison being made is CommitSafetyUnknown carrying
@@ -195,7 +195,7 @@ func ObserveCommitSafety(worktreePath string) CommitSafetyObservation {
 	if worktreePath == "" {
 		return unknownCommitSafety(CommitSafetyProbe{}, "no worktree path is recorded")
 	}
-	probe := CommitSafetyProbe{Command: localOnlyCommitCommand, WorkingDir: worktreePath}
+	probe := CommitSafetyProbe{Command: LocalOnlyCommitCommand, WorkingDir: worktreePath}
 	head, err := HeadCommit(worktreePath)
 	if err != nil {
 		return unknownCommitSafety(probe, err.Error())
@@ -206,7 +206,7 @@ func ObserveCommitSafety(worktreePath string) CommitSafetyObservation {
 		return unknownCommitSafety(probe, fmt.Sprintf("list remote-tracking refs: %v", err))
 	}
 	probe.RemoteRefs = len(remotes)
-	count, err := localOnlyCommitCount(worktreePath)
+	count, err := LocalOnlyCommitCount(worktreePath)
 	if err != nil {
 		return unknownCommitSafety(probe, err.Error())
 	}
@@ -225,13 +225,13 @@ func ObserveCommitSafety(worktreePath string) CommitSafetyObservation {
 
 func unknownCommitSafety(probe CommitSafetyProbe, reason string) CommitSafetyObservation {
 	if probe.Command == "" {
-		probe.Command = localOnlyCommitCommand
+		probe.Command = LocalOnlyCommitCommand
 	}
 	probe.Reason = reason
 	return CommitSafetyObservation{State: CommitSafetyUnknown, Probe: probe}
 }
 
-func localOnlyCommitCount(worktreePath string) (int, error) {
+func LocalOnlyCommitCount(worktreePath string) (int, error) {
 	out, err := gitOutput(worktreePath, "rev-list", "--count", "HEAD", "--not", "--remotes")
 	if err != nil {
 		return 0, fmt.Errorf("count commits held only in this worktree: %w", err)


### PR DESCRIPTION
## Summary

- `internal/runtime/pr.go` now proves a pull request absent, rather than answering `unknown`, on a detached worktree with no recorded branch and no commit missing from a remote-tracking ref - the exact evidence `worktree.ObserveCommitSafety` already computes. `checkLandedWork` (`teardown.go`) treats the same three-condition proof as no committable work to land, so `hand teardown` releases such a worktree honestly instead of demanding an unanswerable PR search.
- `hand pr` (`RecordPR`) no longer refuses a terminal task. Recording where work landed is not resuming it: the write stays write-once, still validates the URL against the project and GitHub, and touches no lifecycle column. `hand pr`'s help text no longer suggests `hand merge` on a terminal task, since there is no active attempt left for it to act on.
- Adds an ADR documenting both fixes as the same worktree-release gate approached from different callers, and explicitly rejecting a teardown attestation flag (atqamz/hand#424's second ask) in favor of proving absence from observations hand already holds.

Closes atqamz/hand#424
Closes atqamz/hand#428

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
SECONDHAND_HOME=$(mktemp -d) go test -tags=test -race -timeout=30m ./...
ok      github.com/atqamz/hand/cmd                       138.509s
ok      github.com/atqamz/hand/internal/age              (cached)
ok      github.com/atqamz/hand/internal/agentsmd         (cached)
ok      github.com/atqamz/hand/internal/attention        (cached)
ok      github.com/atqamz/hand/internal/axi              (cached)
ok      github.com/atqamz/hand/internal/brief            (cached)
ok      github.com/atqamz/hand/internal/completion       (cached)
ok      github.com/atqamz/hand/internal/faketool         3.967s
ok      github.com/atqamz/hand/internal/filelock         (cached)
ok      github.com/atqamz/hand/internal/ghutil           3.876s
ok      github.com/atqamz/hand/internal/git              4.538s
ok      github.com/atqamz/hand/internal/harness          (cached)
ok      github.com/atqamz/hand/internal/herdr            5.505s
ok      github.com/atqamz/hand/internal/home              (cached)
ok      github.com/atqamz/hand/internal/integration      1.949s
ok      github.com/atqamz/hand/internal/launch           (cached)
ok      github.com/atqamz/hand/internal/notify           (cached)
ok      github.com/atqamz/hand/internal/orientation      (cached)
ok      github.com/atqamz/hand/internal/project          7.640s
ok      github.com/atqamz/hand/internal/registry         4.560s
ok      github.com/atqamz/hand/internal/routing          (cached)
ok      github.com/atqamz/hand/internal/runtime          97.921s
ok      github.com/atqamz/hand/internal/secondhand       1.025s
ok      github.com/atqamz/hand/internal/selfupdate       3.195s
ok      github.com/atqamz/hand/internal/sessionhook      (cached)
ok      github.com/atqamz/hand/internal/shellquote       (cached)
ok      github.com/atqamz/hand/internal/skill            (cached)
ok      github.com/atqamz/hand/internal/state            (cached)
ok      github.com/atqamz/hand/internal/steering         5.656s
ok      github.com/atqamz/hand/internal/store            (cached)
ok      github.com/atqamz/hand/internal/supervision      (cached)
ok      github.com/atqamz/hand/internal/toolchain        (cached)
ok      github.com/atqamz/hand/internal/watcher          45.726s
ok      github.com/atqamz/hand/internal/workerobs        (cached)
ok      github.com/atqamz/hand/internal/worktree         5.195s
ok      github.com/atqamz/hand/tests/edgepublish         4.459s
ok      github.com/atqamz/hand/tests/release             (cached)
ok      github.com/atqamz/hand/tools/commentlint         (cached)

$ go test -tags=e2e,test -count=1 -timeout=10m ./tests/e2e/...
ok      github.com/atqamz/hand/tests/e2e    79.731s

$ make contract
go test -tags=contract -count=1 -timeout=10m ./tests/contract/...
ok      github.com/atqamz/hand/tests/contract    0.464s
```

A scratch-fleet-home reproduction of both issues' exact repros (with real TOON output) will follow as a comment on this PR.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->