### PR TITLE
docs(testing-invariants): record registered-clone worktree binding invariants

### DIFF
--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -192,7 +192,9 @@ Source: [Lock pathnames are permanent rendezvous points](adr/lock-pathnames-are-
 Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is-not-a-mismatch.md),
 [Mechanical plans verify acquired HEAD](adr/mechanical-plans-verify-acquired-head.md),
 [The landed-work guard reads the work, not the record](adr/the-landed-work-guard-reads-the-work-not-the-record.md),
-[The worktree pool lives outside every fleet home](adr/the-worktree-pool-lives-outside-every-fleet-home.md).
+[The worktree pool lives outside every fleet home](adr/the-worktree-pool-lives-outside-every-fleet-home.md),
+`internal/worktree/worktree.go` (`Get`), `cmd/doctor.go` (`doctorWorktreeFindings`), decided in
+atqamz/hand#404 and atqamz/hand#421.
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -208,6 +210,8 @@ Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is
 | INV-POOL-2 | Two clones never share a pool root, so one fleet's slots cannot alias another's. | property | `TestPoolRootDiffersPerClone` |
 | INV-POOL-3 | A worktree recorded under its clone keeps the clone as its pool root, so a lease taken before atqamz/hand#427 stays observable and returnable. | property | `TestPoolRootKeepsALegacyWorktreeOnItsOwnClone`, `TestReturnKeepsALegacyWorktreeOnItsOwnClone` |
 | INV-POOL-4 | Pool resolution never follows a foreign recorded worktree path to that path's own pool. | property | `TestReturnNeverFollowsAForeignRecordedPathToItsOwnPool` |
+| INV-POOL-5 | Acquisition never hands back a lease whose worktree is rooted in a Git repository other than the registered clone, even when a distinct, same-named repository is reachable nearby. | unit | `TestGetRejectsAWorktreeFromAnotherRegisteredClone` |
+| INV-POOL-6 | `hand doctor` reports a task's worktree rooted outside its registered clone as an error, not a warning, for any such task, so the command fails rather than merely noting it. | unit | `TestDoctorFindsWorktreeUsingAnotherFleetClone`, `TestDoctorFindsWorktreeUsingTheFleetHomeCheckout` |
 
 ## Output rendering
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -211,7 +211,7 @@ atqamz/hand#404 and atqamz/hand#421.
 | INV-POOL-3 | A worktree recorded under its clone keeps the clone as its pool root, so a lease taken before atqamz/hand#427 stays observable and returnable. | property | `TestPoolRootKeepsALegacyWorktreeOnItsOwnClone`, `TestReturnKeepsALegacyWorktreeOnItsOwnClone` |
 | INV-POOL-4 | Pool resolution never follows a foreign recorded worktree path to that path's own pool. | property | `TestReturnNeverFollowsAForeignRecordedPathToItsOwnPool` |
 | INV-POOL-5 | Acquisition never hands back a lease whose worktree is rooted in a Git repository other than the registered clone, even when a distinct, same-named repository is reachable nearby. | unit | `TestGetRejectsAWorktreeFromAnotherRegisteredClone` |
-| INV-POOL-6 | `hand doctor` reports a task's worktree rooted outside its registered clone as an error, not a warning, for any such task, so the command fails rather than merely noting it. | unit | `TestDoctorFindsWorktreeUsingAnotherFleetClone`, `TestDoctorFindsWorktreeUsingTheFleetHomeCheckout` |
+| INV-POOL-6 | `hand doctor` reports a task's worktree rooted outside its registered clone as an error, not a warning, for any such task, so the command fails rather than merely noting it. | property | `TestDoctorFindsWorktreeUsingAnotherFleetClone`, `TestDoctorFindsWorktreeUsingTheFleetHomeCheckout` land unit cases; property form unaudited |
 
 ## Output rendering
 


### PR DESCRIPTION
## Summary

- Establish-first result: atqamz/hand#421's defect does not reproduce on `main`. atqamz/hand#404 (merged 2026-08-27, the day after #421 was filed) already made `worktree.Get()` reject a lease whose worktree common-dir differs from the registered clone's `.git`, and already made `doctorWorktreeFindings` report that mismatch as `doctorError`, not a warning. Both are covered by existing tests (`TestGetRejectsAWorktreeFromAnotherRegisteredClone`; `TestDoctorFindsWorktreeUsingAnotherFleetClone`, `TestDoctorFindsWorktreeUsingTheFleetHomeCheckout`).
- Per the brief, ask 1 "becomes a regression test proving the binding is to the registered clone" - that test already exists; I confirmed by temporarily removing the `Get()` common-dir check that `TestGetRejectsAWorktreeFromAnotherRegisteredClone` genuinely fails without it, then reverted. Ask 2 ("doctor fails, not warns") is likewise already true and already tested.
- What was missing was documentation: `docs/testing-invariants.md` had no entry for either behavior. This PR adds `INV-POOL-5` (acquisition-side) and `INV-POOL-6` (doctor-side), citing the existing tests, plus a source line since neither behavior has a standalone ADR (it was decided directly in #404's PR body).
- No production code changes. `internal/worktree/worktree.go`'s `Get()` and `cmd/doctor.go`'s `doctorWorktreeFindings` are unchanged, per the brief's locked decision to change severity only if needed (it already is `doctorError`) and never the comparison logic.

Closes atqamz/hand#421

## Test plan

- `make lint` - clean (`go vet`, `golangci-lint`, `commentlint`)
- `make test` - full race-enabled suite passes: `ok github.com/atqamz/hand/... ` across all packages including `internal/worktree` and `cmd`
- `make e2e` - `ok github.com/atqamz/hand/tests/e2e 100.451s`
- Mutation check: commented out the `CommonDir` comparison in `worktree.Get()`, reran `TestGetRejectsAWorktreeFromAnotherRegisteredClone` - it failed (`Get() error = <nil>, want a registered-clone mismatch`), confirming it is a genuine regression guard; reverted with `git checkout --`.
- Real, non-mocked reproduction in a scratch fleet home under `/tmp` (not `/home/atqa/github/atqamz/hand-dev` or any other real fleet, per the brief's non-goals): built a source repo `demo`, ran a real `hand` binary to `hand init` a fresh fleet home, `hand runtime ensure` (real git/treehouse/herdr bundle), then `hand project add <source> --mode local-only`, which does a real `git clone --no-local` into `<fleet>/projects/demo`. Left the original source repo in place as the trap - same leaf name ("demo"), fully reachable, exactly the shape of the operator checkout in #421. Called `worktree.Get(clonePath, ...)` against the real treehouse binary:
  ```
  cat <slot>/.git => gitdir: <fleet>/projects/demo/.git/worktrees/demo
  ```
  Bound to the registered managed clone; the trap source repo's `.git/worktrees/` was never created, i.e. acquisition ignored it entirely.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->