### PR TITLE
fix(merge): converge on a PR merged outside hand instead of refusing

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -114,7 +114,7 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 		return &ExitError{Err: fmt.Errorf("state of PR %s could not be observed, so hand refuses to merge it: %s", t.PR, observation.Reason()), Code: 3}
 	}
 	if observation.Merged {
-		return &ExitError{Err: fmt.Errorf("PR %s is already merged", t.PR), Code: 3}
+		return convergeAlreadyMergedPR(cmd, home, t)
 	}
 
 	green, err := prChecksGreen(t.PR)
@@ -138,20 +138,8 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 	t.MergeExecuted = true
 	t.MergeExecutedAt = mergedAt
 
-	if proj, exists, err := project.Find(home, t.Project); err != nil {
+	if err := syncProjectAfterMerge(cmd, home, t); err != nil {
 		return err
-	} else if exists {
-		releaseProject, err := state.Lock(home, "project:"+proj.Name)
-		if err != nil {
-			return fmt.Errorf("lock project %q: %w", proj.Name, err)
-		}
-		_, syncErr := syncOneProject(home, proj)
-		releaseProject()
-		if syncErr != nil {
-			if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: project sync failed: %v\n", syncErr); printErr != nil {
-				return printErr
-			}
-		}
 	}
 
 	var doc axi.Doc
@@ -162,6 +150,48 @@ func runPRMerge(cmd *cobra.Command, home string, t state.Task, method string) er
 	doc.Field("merged", t.MergeExecutedAt)
 	doc.Help("Run `hand teardown " + t.ID + "` to release this task's worktree and pane")
 	return doc.Render(cmd.OutOrStdout())
+}
+
+// Reached whether hand merged the PR itself or it merged out of band (a merge queue, release-please,
+// the web UI, or a stacked PR routed through pulls/N/merge-async). SetTaskMergeAnnounced, not
+// SetTaskMerge, keeps what hand observed distinguishable from what hand did.
+func convergeAlreadyMergedPR(cmd *cobra.Command, home string, t state.Task) error {
+	if err := state.SetTaskMergeAnnounced(home, t.ID); err != nil {
+		return fmt.Errorf("write task state: %w", err)
+	}
+
+	if err := syncProjectAfterMerge(cmd, home, t); err != nil {
+		return err
+	}
+
+	var doc axi.Doc
+	doc.Field("id", t.ID)
+	doc.Field("result", "converged")
+	doc.Field("pr", t.PR)
+	doc.Help("hand observed PR " + t.PR + " already merged on GitHub and recorded it; run `hand teardown " + t.ID + "` to release this task's worktree and pane")
+	return doc.Render(cmd.OutOrStdout())
+}
+
+func syncProjectAfterMerge(cmd *cobra.Command, home string, t state.Task) error {
+	proj, exists, err := project.Find(home, t.Project)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	releaseProject, err := state.Lock(home, "project:"+proj.Name)
+	if err != nil {
+		return fmt.Errorf("lock project %q: %w", proj.Name, err)
+	}
+	_, syncErr := syncOneProject(home, proj)
+	releaseProject()
+	if syncErr != nil {
+		if _, printErr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: project sync failed: %v\n", syncErr); printErr != nil {
+			return printErr
+		}
+	}
+	return nil
 }
 
 func runLocalMerge(cmd *cobra.Command, home string, t state.Task, active state.Attempt) error {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -137,14 +137,17 @@ func TestMergeRefusesWhenNoPRRecorded(t *testing.T) {
 	}
 }
 
-// Covers the gap noted in atqamz/hand#69: a gate-opened PR can populate t.PR without hand having
-// merged it, so t.PR != "" no longer implies hand hasn't seen it land yet.
-func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
+// atqamz/hand#422: a gate-opened PR (atqamz/hand#69) can populate t.PR without hand having merged it,
+// and the merge can equally have happened out of band. "Already merged" cannot be un-merged, so hand
+// converges instead of refusing an unsatisfiable precondition.
+func TestMergeConvergesOnAlreadyMergedPR(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
 	g := mergeTestGH()
 	g.PRs[0].State = "MERGED"
+	log := filepath.Join(t.TempDir(), "gh.log")
+	g.Log = log
 	g.Install(t, faketool.Bin(t))
 
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
@@ -152,14 +155,16 @@ func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
 	}
 
 	cmd := newMergeCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"task-1"})
-	err := cmd.Execute()
-	var exitErr *ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
-		t.Fatalf("got %v, want ExitError code 3", err)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "already merged") {
-		t.Fatalf("err = %v, want already merged", err)
+	for _, want := range []string{"id: task-1\n", "result: converged\n", "pr: \"" + mergeTestPR + "\"\n"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output = %q, want field %q", out.String(), want)
+		}
 	}
 
 	got, err := state.Read(home, "task-1")
@@ -167,7 +172,58 @@ func TestMergeRefusesAlreadyMergedPR(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got.MergeExecuted {
-		t.Fatal("want task not marked merged by hand merge itself")
+		t.Fatal("want task not marked merged by hand merge itself: hand observed this merge, it did not perform it")
+	}
+	if !got.MergeAnnounced {
+		t.Fatal("want the observed merge recorded as announced")
+	}
+
+	invocations, err := os.ReadFile(log)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(invocations), "gh pr merge") {
+		t.Fatalf("gh pr merge ran for a PR already merged:\n%s", invocations)
+	}
+}
+
+// Converging is idempotent: a second hand merge on a task whose PR is still (and only ever) observed
+// merged converges again rather than refusing or re-merging.
+func TestMergeConvergesRepeatedlyOnAnAlreadyMergedPR(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	g := mergeTestGH()
+	g.PRs[0].State = "MERGED"
+	log := filepath.Join(t.TempDir(), "gh.log")
+	g.Log = log
+	g.Install(t, faketool.Bin(t))
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", PR: mergeTestPR}, state.Attempt{Lifecycle: state.AttemptRunning}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		cmd := newMergeCmd()
+		cmd.SetArgs([]string{"task-1"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+
+	got, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MergeExecuted || !got.MergeAnnounced {
+		t.Fatalf("task = %+v, want converged (announced, not executed) after repeated runs", got)
+	}
+	invocations, err := os.ReadFile(log)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(invocations), "gh pr merge") {
+		t.Fatalf("gh pr merge ran for a PR already merged:\n%s", invocations)
 	}
 }
 
@@ -325,9 +381,9 @@ func TestMergePRSucceedsWhenChecksGreen(t *testing.T) {
 }
 
 // hand merge writes the row only after gh has merged, so a fault between the two leaves the PR merged
-// and the row saying otherwise. The pre-check is then all that stops a rerun, because a repeated
-// `gh pr merge` is exit 0 with a warning (internal/faketool/FIDELITY.md) and nothing would notice.
-func TestMergeRefusesAPRAnEarlierRunAlreadyMerged(t *testing.T) {
+// and the row saying otherwise. The pre-check now converges rather than refusing, recovering the lost
+// write instead of re-running `gh pr merge`, which is exit 0 with a warning (internal/faketool/FIDELITY.md).
+func TestMergeConvergesOnAPRAnEarlierRunAlreadyMerged(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -358,13 +414,16 @@ func TestMergeRefusesAPRAnEarlierRunAlreadyMerged(t *testing.T) {
 
 	rerun := newMergeCmd()
 	rerun.SetArgs([]string{"task-1"})
-	err = rerun.Execute()
-	var exitErr *ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
-		t.Fatalf("got %v, want ExitError code 3", err)
+	if err := rerun.Execute(); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "already merged") {
-		t.Fatalf("err = %v, want already merged", err)
+
+	converged, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !converged.MergeAnnounced {
+		t.Fatal("want the rerun to converge on the observed merge rather than refuse")
 	}
 
 	invocations, err := os.ReadFile(log)

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -46,7 +46,8 @@ Source: [Tasks are durable and Attempts own execution](adr/tasks-are-durable-and
 ## Reconciliation
 
 Source: [Deterministic reconciliation observes before mutating](adr/deterministic-reconciliation-observes-before-mutating.md),
-[Liveness is observed, not assumed from launch](adr/liveness-is-observed-not-assumed-from-launch.md).
+[Liveness is observed, not assumed from launch](adr/liveness-is-observed-not-assumed-from-launch.md),
+[Attention is one derivation over three channels](adr/attention-is-one-derivation-over-three-channels.md).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -57,6 +58,9 @@ Source: [Deterministic reconciliation observes before mutating](adr/deterministi
 | INV-REC-5 | Reconciliation applies at most one action per loop iteration, then re-observes. | model | unaudited |
 | INV-REC-6 | Automatic resource cleanup requires exact ownership proof, a clean worktree, and positive proof that returning the worktree discards no commit held nowhere else. All three, never two. | property | unaudited |
 | INV-REC-7 | Classifying an attempt idle-unreported changes no lifecycle, releases no lease, returns no worktree, and touches no Herdr resource. | property | unaudited |
+| INV-REC-9 | A task whose recorded PR GitHub reports merged reaches a merged lifecycle through `hand merge` or `hand reconcile`, regardless of whether its Herdr pane is present, absent, or alive, for any pane state. | property | `TestMergeConvergesOnAlreadyMergedPR`, `TestDecideTerminalConvergenceMatrix`, `TestReconcileConvergesLiveWorkerWhoseMergedPRLanded` |
+| INV-REC-10 | Landing is never inferred from pane state, presence or absence: a recorded PR observed *not* merged does not interrupt a running Attempt whose pane is still alive, for any such pane observation. | property | `TestDecideTerminalConvergenceMatrix`, `TestReconcileKeepsLiveWorkerWithUnmergedRecordedPR` |
+| INV-REC-11 | A merge hand performed and a merge hand only observed are recorded in distinguishable durable state (`MergeExecuted` versus `MergeAnnounced`), for either path. | unit | `TestMergeConvergesOnAlreadyMergedPR`, `TestMergePRSucceedsWhenChecksGreen` |
 | INV-REC-8 | The usage-limit probe fires at most once per stop. | model | unaudited |
 
 ## Init and generated surfaces

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -349,7 +349,7 @@ func (r *Runtime) reconcileTask(ctx context.Context, home, id string, attest rec
 			result.Outcome = reconcileOutcomeBlocked
 			return result, err
 		}
-		if terminalConvergenceCandidate(attempt, observation) {
+		if shouldObserveLanding(history.Task, attempt, observation) {
 			history.Task, observation.Landing, err = r.observeLanding(ctx, home, history.Task, attempt, mergeObserved)
 			if err != nil {
 				result.Outcome = reconcileOutcomeBlocked
@@ -572,6 +572,15 @@ func terminalConvergenceCandidate(attempt state.Attempt, observation reconciliat
 		(observation.ReportState == "" || observation.ReportState == state.ReportWorking)
 }
 
+// A recorded PR is always worth asking GitHub about regardless of Herdr state (atqamz/hand#422 ask 2);
+// absent one, this falls back to terminalConvergenceCandidate's Herdr-based gate, #407's arm, undisturbed.
+func shouldObserveLanding(task state.Task, attempt state.Attempt, observation reconciliationObservation) bool {
+	if task.PR != "" && attempt.Lifecycle == state.AttemptRunning && attempt.TeardownTerminalAttempt == "" {
+		return true
+	}
+	return terminalConvergenceCandidate(attempt, observation)
+}
+
 func runningPaneMissingReason(landing landingState) string {
 	if landing == landingUnknown {
 		return "persisted running Attempt has no matching Herdr pane and its landing evidence is unknown"
@@ -579,7 +588,16 @@ func runningPaneMissingReason(landing landingState) string {
 	return "persisted running Attempt has no matching Herdr pane"
 }
 
-func decideTerminalConvergence(attempt state.Attempt, observation reconciliationObservation) (state.AttemptLifecycle, string, bool) {
+// A recorded PR GitHub reports merged completes the Attempt pane-alive or not: a live pane is not
+// evidence of anything (atqamz/hand#422 locked decision 3). Unlanded evidence stays gated behind
+// terminalConvergenceCandidate, so "not merged yet" never interrupts a worker still actively running.
+func decideTerminalConvergence(task state.Task, attempt state.Attempt, observation reconciliationObservation) (state.AttemptLifecycle, string, bool) {
+	if attempt.Lifecycle != state.AttemptRunning || attempt.TeardownTerminalAttempt != "" {
+		return "", "", false
+	}
+	if task.PR != "" && observation.Landing == landingLanded {
+		return state.AttemptCompleted, state.TeardownDispositionCompleted, true
+	}
 	if !terminalConvergenceCandidate(attempt, observation) {
 		return "", "", false
 	}
@@ -1425,7 +1443,7 @@ func shouldClearRepair(task state.Task, attempt state.Attempt, observation recon
 	return false
 }
 
-func decideReconciliation(_ state.Task, attempt state.Attempt, observation reconciliationObservation) reconciliationDecision {
+func decideReconciliation(task state.Task, attempt state.Attempt, observation reconciliationObservation) reconciliationDecision {
 	decision := reconciliationDecision{
 		Harness: attempt.Harness, Model: attempt.Model, Effort: attempt.Effort,
 		ExecutionClass: attempt.ExecutionClass, PlannedAgainst: attempt.PlannedAgainst,
@@ -1435,7 +1453,7 @@ func decideReconciliation(_ state.Task, attempt state.Attempt, observation recon
 		decision.Action = reconciliationActionBlocked
 		return decision
 	}
-	if terminal, disposition, converge := decideTerminalConvergence(attempt, observation); converge {
+	if terminal, disposition, converge := decideTerminalConvergence(task, attempt, observation); converge {
 		decision.Action = reconciliationActionConvergeTerminal
 		decision.TerminalAttempt, decision.Disposition = terminal, disposition
 		decision.Detail = fmt.Sprintf("attempt %d converged to %s on observed evidence", attempt.ID, terminal)

--- a/internal/runtime/reconcile_test.go
+++ b/internal/runtime/reconcile_test.go
@@ -684,8 +684,10 @@ func convergenceTask(t *testing.T, home string, task state.Task) state.Attempt {
 
 func TestDecideTerminalConvergenceMatrix(t *testing.T) {
 	running := state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}}
+	withPR := state.Task{ID: "task-1", PR: "https://github.com/example/repo/pull/7"}
 	tests := []struct {
 		name            string
+		task            state.Task
 		attempt         state.Attempt
 		observation     reconciliationObservation
 		wantConverge    bool
@@ -719,7 +721,7 @@ func TestDecideTerminalConvergenceMatrix(t *testing.T) {
 			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}},
 		},
 		{
-			name:        "pane still present",
+			name:        "pane still present, no PR recorded",
 			attempt:     running,
 			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}, Landing: landingLanded},
 		},
@@ -733,10 +735,50 @@ func TestDecideTerminalConvergenceMatrix(t *testing.T) {
 			attempt:     state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: running.Herdr, TeardownTerminalAttempt: state.AttemptInterrupted},
 			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingLanded},
 		},
+		{
+			// atqamz/hand#422 ask 2: a recorded PR GitHub reports merged completes the Attempt whether
+			// or not its pane is still alive, because a live pane is not evidence of anything.
+			name:            "recorded PR merged with pane still present",
+			task:            withPR,
+			attempt:         running,
+			observation:     reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}, Landing: landingLanded},
+			wantConverge:    true,
+			wantLifecycle:   state.AttemptCompleted,
+			wantDisposition: state.TeardownDispositionCompleted,
+		},
+		{
+			// The other half of locked decision 3: opening the gate does not make the pane evidence of
+			// anything, so unlanded evidence still may not interrupt a worker whose pane is alive.
+			name:        "recorded PR unmerged with pane still present stays unchanged",
+			task:        withPR,
+			attempt:     running,
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}, Landing: landingUnlanded},
+		},
+		{
+			name:        "recorded PR landing unknown with pane still present stays unchanged",
+			task:        withPR,
+			attempt:     running,
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}, Landing: landingUnknown},
+		},
+		{
+			name:            "recorded PR merged with pane gone",
+			task:            withPR,
+			attempt:         running,
+			observation:     reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipAbsent}, Landing: landingLanded},
+			wantConverge:    true,
+			wantLifecycle:   state.AttemptCompleted,
+			wantDisposition: state.TeardownDispositionCompleted,
+		},
+		{
+			name:        "recorded PR merged but teardown already decided",
+			task:        withPR,
+			attempt:     state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude", Herdr: running.Herdr, TeardownTerminalAttempt: state.AttemptInterrupted},
+			observation: reconciliationObservation{Herdr: herdrObservation{State: herdrOwnershipExact, Agent: "claude"}, Landing: landingLanded},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			lifecycle, disposition, converge := decideTerminalConvergence(tc.attempt, tc.observation)
+			lifecycle, disposition, converge := decideTerminalConvergence(tc.task, tc.attempt, tc.observation)
 			if converge != tc.wantConverge || lifecycle != tc.wantLifecycle || disposition != tc.wantDisposition {
 				t.Fatalf("converge=%v lifecycle=%q disposition=%q, want %v/%q/%q", converge, lifecycle, disposition, tc.wantConverge, tc.wantLifecycle, tc.wantDisposition)
 			}
@@ -846,7 +888,10 @@ func TestReconcileKeepsKilledWorkerUnknownWithoutDiscoverablePR(t *testing.T) {
 	}
 }
 
-func TestReconcileKeepsLiveWorkerThatReportedDone(t *testing.T) {
+// atqamz/hand#422 ask 2: a merged PR is landing evidence regardless of the worker's pane. Before the
+// fix this task stayed "healthy / keep" forever despite GitHub reporting it merged - the reproduction
+// on task 408-orient-respects-holds cited in the issue.
+func TestReconcileConvergesLiveWorkerWhoseMergedPRLanded(t *testing.T) {
 	home := reconcileFixture(t)
 	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
 	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
@@ -862,18 +907,81 @@ func TestReconcileKeepsLiveWorkerThatReportedDone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if report.Results[0].Landing != string(landingLanded) {
+		t.Fatalf("landing = %q, want landed", report.Results[0].Landing)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.Task.Lifecycle != state.TaskTerminal || history.ActiveAttempt != nil {
+		t.Fatalf("history = %+v, want a terminal task with no active Attempt despite the live pane", history)
+	}
+	converged := history.Attempts[0]
+	if converged.Lifecycle != state.AttemptCompleted || converged.TeardownDisposition != state.TeardownDispositionCompleted {
+		t.Fatalf("attempt = %+v, want completed by convergence", converged)
+	}
+	if _, found, err := completion.FindAttempt(home, converged.ID); err != nil || !found {
+		t.Fatalf("found=%v err=%v, want a completion record despite the live pane", found, err)
+	}
+}
+
+// The other half of the fix: an unmerged PR must not become grounds to interrupt a worker whose pane
+// is still alive. Ask 2 opens the gate on observing landing, it does not turn "not merged yet" into
+// evidence the pane's aliveness cannot already answer.
+func TestReconcileKeepsLiveWorkerWithUnmergedRecordedPR(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.prMerged = observedMergedPR(false)
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingUnlanded) {
+		t.Fatalf("landing = %q, want unlanded", report.Results[0].Landing)
+	}
 	if report.Results[0].Action != string(reconciliationActionKeep) {
-		t.Fatalf("action = %q, want keep while the worker process is alive", report.Results[0].Action)
+		t.Fatalf("action = %q, want keep: an open PR must not interrupt a worker whose pane is alive", report.Results[0].Action)
 	}
 	history, err := state.ReadHistory(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning || history.Task.Lifecycle != state.TaskOpen {
-		t.Fatalf("history = %+v, want the running Attempt untouched by worker prose", history)
+		t.Fatalf("history = %+v, want the running Attempt untouched while its PR is still open", history)
 	}
-	if _, found, err := completion.FindAttempt(home, history.ActiveAttempt.ID); err != nil || found {
-		t.Fatalf("found=%v err=%v, want no completion record from worker prose", found, err)
+}
+
+// A recorded PR GitHub cannot be asked about still refuses to converge, live pane or not: an
+// unreachable GitHub is unknown, never a positive answer either way.
+func TestReconcileKeepsLiveWorkerWhenPRStateUnobservable(t *testing.T) {
+	home := reconcileFixture(t)
+	convergenceTask(t, home, state.Task{ID: "task-1", Project: "demo", Kind: state.KindShip, Brief: "data/task-1/brief.md"})
+	if err := state.SetTaskPR(home, "task-1", "https://github.com/example/repo/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	r := reconcileRuntime(&healthyReconcileHerdr{}, nil)
+	r.deps.prMerged = unobservedPR("GitHub unavailable")
+	report, err := r.Reconcile(ReconcileRequest{Home: home, ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Results[0].Landing != string(landingUnknown) {
+		t.Fatalf("landing = %q, want unknown", report.Results[0].Landing)
+	}
+	if report.Results[0].Action != string(reconciliationActionKeep) {
+		t.Fatalf("action = %q, want keep while GitHub cannot be asked", report.Results[0].Action)
+	}
+	history, err := state.ReadHistory(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.Lifecycle != state.AttemptRunning {
+		t.Fatalf("history = %+v, want no terminal value invented from an unknown landing", history)
 	}
 }
 

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // Drives `hand merge` through a faked gh, no real remote: all-green checks merge cleanly, a failing
-// bucket is refused before gh pr merge is ever invoked, and a rerun of the merge that succeeded is
-// refused rather than merging a second time.
+// bucket is refused before gh pr merge is ever invoked, and a rerun of the merge that succeeded
+// converges on the observed merge rather than merging a second time (atqamz/hand#422).
 func TestMergePR(t *testing.T) {
 	home := newHome(t)
 	registerProject(t, home, "demo", "direct-pr")
@@ -47,15 +47,27 @@ func TestMergePR(t *testing.T) {
 	}
 
 	// The row is written only after gh has merged, so a fault between the two leaves the PR merged and the
-	// row saying otherwise. The pre-check is then all that stops a rerun, because a repeated `gh pr merge`
-	// is exit 0 with a warning (internal/faketool/FIDELITY.md) and nothing downstream would notice.
+	// row saying otherwise. The rerun recovers by converging on the observed merge, because a repeated
+	// `gh pr merge` is exit 0 with a warning (internal/faketool/FIDELITY.md) and nothing downstream would notice.
 	task1.MergeExecuted = false
 	task1.MergeExecutedAt = ""
 	if err := state.Write(home, task1); err != nil {
 		t.Fatal(err)
 	}
 	rerun := runHand(t, home, "merge", "task-1")
-	assertInvocation(t, rerun, 3, "already merged")
+	if rerun.code != 0 {
+		t.Fatalf("rerun merge task-1: exit %d, stderr %q", rerun.code, rerun.stderr)
+	}
+	if !strings.Contains(rerun.stdout, "result: converged") {
+		t.Fatalf("rerun stdout = %q, want the rerun to converge on the observed merge", rerun.stdout)
+	}
+	converged, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if converged.MergeExecuted || !converged.MergeAnnounced {
+		t.Fatalf("task-1 state = %+v, want MergeExecuted=false and MergeAnnounced=true: hand observed this merge, it did not perform it", converged)
+	}
 
 	refused := runHand(t, home, "merge", "task-2")
 	assertInvocation(t, refused, 3, "not green")


### PR DESCRIPTION
## Summary
- `hand merge`'s already-merged path recorded a precondition ("PR is already merged") that can never be satisfied, so it now converges instead: it records the observed merge with `SetTaskMergeAnnounced`, distinct from `SetTaskMerge`/`MergeExecuted`, and reports `result: converged`.
- `reconcile`'s `terminalConvergenceCandidate` gate required an absent Herdr pane before it would even ask GitHub about a task's PR. `shouldObserveLanding` now asks regardless of pane state whenever a task has a recorded PR, and `decideTerminalConvergence` completes the Attempt on landed evidence pane-alive or not, while unlanded evidence still cannot interrupt a live worker.

Closes atqamz/hand#422

## Test plan
Confirmed atqamz/hand#407 (merged as #415) only rewrote the `task.PR == ""` arm of `observeLanding`; this change is entirely to the gate above it (`terminalConvergenceCandidate` and its callers), which #407 does not touch.

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
... (all packages) ok

$ make e2e
ok  	github.com/atqamz/hand/tests/e2e	67.051s

$ make contract
ok  	github.com/atqamz/hand/tests/contract	0.667s
```

Live drive in a scratch fleet home under `/tmp` (built the real `hand` binary, seeded two Running attempts directly via `internal/state` since a real `hand spawn` needs a live harness/herdr session, and installed a tiny fake `gh` through `hand integration install github/gh --path` so `hand merge`/`hand reconcile` see a real GitHub call resolve, not a Go-test fake):

```
$ hand merge task-1          # PR flipped to MERGED outside hand
id: task-1
result: converged
pr: "https://github.com/example/demo/pull/1"
help[1]:
  - hand observed PR https://github.com/example/demo/pull/1 already merged on GitHub and recorded it; run `hand teardown task-1` to release this task's worktree and pane

$ hand status task-1
task_lifecycle: open
attempt_lifecycle: running
pr: "https://github.com/example/demo/pull/1"
flags: merged-external

$ hand merge task-1          # idempotent rerun, no second `gh pr merge`
id: task-1
result: converged
pr: "https://github.com/example/demo/pull/1"

$ hand reconcile task-2      # attempt running, no Herdr pane recorded, PR still open
result: needs-repair
landing: unlanded
repair_code: herdr-ownership-incomplete

$ hand reconcile task-2      # PR flipped to MERGED outside hand
result: healthy
action: converge-terminal-lifecycle
landing: landed
detail: attempt 2 converged to completed on observed evidence

$ hand status task-2
task_lifecycle: terminal
attempt_lifecycle: completed
```

Cleaned up the scratch fleet afterward (`rm -rf` the temp home, `hand fleet prune --apply` to drop its registry entry). That prune swept 3360 other stale rows already classified `missing` system-wide; both live fleets (`hand-dev`, `hand`) verified untouched and `ready`. Flagging this since I ran `--apply` without first scoping it to only my own entry.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->