### PR TITLE
fix(runtime): diagnose a git bundle with no https helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,13 @@ The target must be an empty or absent directory, or a fleet home `hand init` alr
 ### 3. Add or create a project
 
 ```sh
+hand project add git@github.com:you/project.git
 hand project add https://github.com/you/project
 hand project add ~/work/project
 hand project create new-project
 ```
+
+The currently pinned Git carries no https transport helper, so the ssh form above is the reliable default until a bundle that includes one ships; `hand runtime status` reports this as `git_https_ready`.
 
 Remote sources are cloned under the fleet home and prepared for isolated worker worktrees.
 Local Git sources are adopted once into a separate Fleet-managed clone; Hand never executes in or synchronizes with the original checkout.
@@ -270,7 +273,7 @@ Its internal review, test, documentation, lint, PR, and CI stages remain owned b
 Choose a mode when registering a project:
 
 ```sh
-hand project add https://github.com/you/project --mode direct-pr
+hand project add git@github.com:you/project.git --mode direct-pr
 ```
 
 Add an existing local Git project or create a new managed project with the local-only mode:

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -121,6 +121,7 @@ func newDoctorCmd(info selfupdate.BuildInfo) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			findings = append(findings, runtimeHTTPSFindings(runtimeStatus)...)
 			herdrSession := observeCurrentHerdrSession(cmd.Context(), fleetHome)
 			tools := doctorManagedTools(runtimeStatus, projects)
 			integrations, err := integration.DefaultStore().List()
@@ -182,12 +183,23 @@ func doctorRuntimeStatus() (toolchain.Status, error) {
 	if legacyDoctorCompatibility() && !status.Ready && onPath("git") && onPath("treehouse") && onPath("herdr") {
 		status.Ready = true
 		status.Reason = "test-only legacy tool fixture"
+		status.GitHTTPSReady = true
 	}
 	return status, nil
 }
 
 func legacyDoctorCompatibility() bool {
 	return legacyDoctorCompat
+}
+
+// A missing https helper is a warning, not blocking: the bundle is otherwise intact and ssh
+// keeps working, so a fleet home that only clones over ssh must not read as unready with no
+// treatment (hand#440). A runtime that fails Ready already has its own "runtime" blocking entry.
+func runtimeHTTPSFindings(status toolchain.Status) []doctorFinding {
+	if !status.Ready || status.GitHTTPSReady {
+		return nil
+	}
+	return []doctorFinding{{Severity: doctorWarning, Text: "runtime git cannot clone https:// remotes: " + gitHTTPSTreatment("https")}}
 }
 
 func doctorFindings(fleetHome string, histories []state.TaskHistory) ([]doctorFinding, error) {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -19,7 +19,42 @@ import (
 	"github.com/atqamz/hand/internal/skill"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/supervision"
+	"github.com/atqamz/hand/internal/toolchain"
 )
+
+// The doctor half of hand#440: a bundle that is otherwise intact but cannot clone https:// is
+// reported with the ssh treatment, and never joins blocking or flips runtime_ready, so an
+// ssh-only fleet home never reads as unready over a gap it has no way to close itself.
+func TestRuntimeHTTPSFindingsNamesTheSSHTreatmentWithoutJoiningBlocking(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		status       toolchain.Status
+		wantFindings int
+	}{
+		{name: "ready and https-ready reports nothing", status: toolchain.Status{Ready: true, GitHTTPSReady: true}, wantFindings: 0},
+		{name: "ready but https-unready warns with the treatment", status: toolchain.Status{Ready: true, GitHTTPSReady: false}, wantFindings: 1},
+		{name: "not ready at all adds nothing on top of the runtime blocking entry", status: toolchain.Status{Ready: false, GitHTTPSReady: false}, wantFindings: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runtimeHTTPSFindings(tc.status)
+			if len(findings) != tc.wantFindings {
+				t.Fatalf("runtimeHTTPSFindings(%+v) = %+v, want %d finding(s)", tc.status, findings, tc.wantFindings)
+			}
+			if tc.wantFindings == 0 {
+				return
+			}
+			finding := findings[0]
+			if finding.Severity != doctorWarning {
+				t.Fatalf("finding severity = %q, want %q so it never blocks fleet-wide readiness", finding.Severity, doctorWarning)
+			}
+			for _, want := range []string{"git-remote-https", "ssh remote form", "git@host:owner/repo.git"} {
+				if !strings.Contains(finding.Text, want) {
+					t.Fatalf("finding text = %q, want it to mention %q", finding.Text, want)
+				}
+			}
+		})
+	}
+}
 
 func TestDoctorFindingsCoverFleetHealth(t *testing.T) {
 	tests := []struct {

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -607,10 +608,24 @@ func validateProjectMode(mode string) error {
 	}
 }
 
+// Git's own plumbing error for a missing remote-<scheme> helper: unambiguous, since git emits
+// this exact text only when the helper binary cannot be found at all (hand#440).
+var gitRemoteHelperMissing = regexp.MustCompile(`git: 'remote-([A-Za-z0-9+.-]+)' is not a git command\.`)
+
+// Matched against the clone attempt's actual output rather than guessed from the URL, so a
+// URL git config rewrites (insteadOf, an e2e fixture's local remote) is judged by what git
+// really tried, not by a scheme guessed from the input.
+func diagnoseCloneFailure(url string, out []byte) error {
+	if m := gitRemoteHelperMissing.FindSubmatch(out); m != nil {
+		return fmt.Errorf("cannot clone %s: %s", url, gitHTTPSTreatment(string(m[1])))
+	}
+	return fmt.Errorf("git clone failed: %s", string(out))
+}
+
 func gitClone(url, dest string) error {
 	out, err := runManagedCore(context.Background(), "git", "", "clone", url, dest)
 	if err != nil {
-		return fmt.Errorf("git clone failed: %s", string(out))
+		return diagnoseCloneFailure(url, out)
 	}
 	return nil
 }

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -826,6 +826,52 @@ func TestProjectAddRemovesIncompleteCloneOnGitFailure(t *testing.T) {
 	}
 }
 
+// The clone-path half of hand#440: git's own "'remote-https' is not a git command" plumbing
+// error - the exact text a bundle with no remote helper produces, verbatim from the reported
+// failure - must be replaced with the named runtime defect and the ssh treatment.
+func TestDiagnoseCloneFailureNamesMissingHelperInsteadOfPassingGitTextThrough(t *testing.T) {
+	raw := []byte("Cloning into 'repo'...\n" +
+		"warning: templates not found in /dist/git-2.51.0/share/git-core/templates\n" +
+		"git: 'remote-https' is not a git command. See 'git --help'.\n" +
+		"fatal: remote helper 'https' aborted session\n")
+	err := diagnoseCloneFailure("https://example.com/org/repo.git", raw)
+	if err == nil {
+		t.Fatal("diagnoseCloneFailure returned nil for a real git failure")
+	}
+	if strings.Contains(err.Error(), "is not a git command") || strings.Contains(err.Error(), "aborted session") {
+		t.Fatalf("diagnoseCloneFailure = %q, want the named runtime defect rather than git's raw text", err.Error())
+	}
+	for _, want := range []string{"git-remote-https", "ssh remote form", "git@host:owner/repo.git"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("diagnoseCloneFailure = %q, want it to mention %q", err.Error(), want)
+		}
+	}
+}
+
+// A scheme is read from git's own error text, not assumed to be https, so the same fix covers
+// any external helper a future bundle gap might drop - e.g. http, not only the reported scheme.
+func TestDiagnoseCloneFailureReadsTheSchemeFromGitsOwnText(t *testing.T) {
+	raw := []byte("git: 'remote-http' is not a git command. See 'git --help'.\n")
+	err := diagnoseCloneFailure("http://example.com/org/repo.git", raw)
+	if err == nil || !strings.Contains(err.Error(), "git-remote-http)") {
+		t.Fatalf("diagnoseCloneFailure = %v, want it to name git-remote-http", err)
+	}
+}
+
+// An unrelated git failure - one a real git config rewrite (insteadOf, an e2e fixture's local
+// remote) or any other cause could produce - must pass through unchanged: the diagnosis is keyed
+// on git's actual observed failure text, never guessed from the URL's scheme.
+func TestDiagnoseCloneFailureLeavesUnrelatedGitErrorsUnchanged(t *testing.T) {
+	raw := []byte("fatal: repository 'https://example.com/org/repo.git' not found\n")
+	err := diagnoseCloneFailure("https://example.com/org/repo.git", raw)
+	if err == nil || !strings.Contains(err.Error(), "repository 'https://example.com/org/repo.git' not found") {
+		t.Fatalf("diagnoseCloneFailure = %v, want git's original text preserved", err)
+	}
+	if strings.Contains(err.Error(), "git-remote-https") {
+		t.Fatalf("diagnoseCloneFailure = %v, want no false-positive transport diagnosis", err)
+	}
+}
+
 func TestProjectAddRefusesExistingCloneDestination(t *testing.T) {
 	home := t.TempDir()
 	dest := filepath.Join(home, "projects", "repo")

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -39,12 +39,13 @@ func newRuntimeStatusCmd() *cobra.Command {
 			doc.Field("bundle", valueOrNone(status.BundleDir))
 			doc.Field("git", valueOrNone(status.GitPath))
 			doc.Field("git_version", valueOrNone(status.GitVersion))
+			doc.Bool("git_https_ready", status.GitHTTPSReady)
 			doc.Field("treehouse", valueOrNone(status.TreehousePath))
 			doc.Field("treehouse_version", valueOrNone(status.TreehouseVersion))
 			doc.Field("herdr", valueOrNone(status.HerdrPath))
 			doc.Field("herdr_version", valueOrNone(status.HerdrVersion))
 			doc.Field("reason", valueOrNone(status.Reason))
-			doc.Help("Run `hand runtime ensure` to install or repair the exact private Git, Treehouse, and Herdr bundle")
+			doc.Help(runtimeStatusHelp(status)...)
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}
@@ -64,6 +65,7 @@ func newRuntimeEnsureCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("ensure private Secondhand runtime: %w; run `hand runtime status` for diagnostics", err)
 			}
+			httpsReady := runtime.SupportsGitTransport("https")
 			var doc axi.Doc
 			doc.Field("result", "ready")
 			doc.Field("runtime_id", runtime.ID)
@@ -71,13 +73,34 @@ func newRuntimeEnsureCmd() *cobra.Command {
 			doc.Field("bundle", runtime.BundleDir)
 			doc.Field("git", runtime.GitPath)
 			doc.Field("git_version", runtime.GitVersion)
+			doc.Bool("git_https_ready", httpsReady)
 			doc.Field("treehouse", runtime.TreehousePath)
 			doc.Field("treehouse_version", runtime.TreehouseVersion)
 			doc.Field("herdr", runtime.HerdrPath)
 			doc.Field("herdr_version", runtime.HerdrVersion)
+			if !httpsReady {
+				doc.Help(gitHTTPSTreatment("https"))
+			}
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}
+}
+
+// Keeps the generic runtime-repair line first and appends the https transport gap only when the
+// bundle is otherwise intact - `hand runtime ensure` reinstalls the same helper-less Git and
+// would not help there.
+func runtimeStatusHelp(status toolchain.Status) []string {
+	help := []string{"Run `hand runtime ensure` to install or repair the exact private Git, Treehouse, and Herdr bundle"}
+	if status.Ready && !status.GitHTTPSReady {
+		help = append(help, gitHTTPSTreatment("https"))
+	}
+	return help
+}
+
+// The one sentence every surface (runtime status, doctor, project add) uses for a pinned Git
+// that cannot clone a given scheme, so the diagnosis and the way out cannot drift apart (hand#440).
+func gitHTTPSTreatment(scheme string) string {
+	return fmt.Sprintf("the pinned runtime's Git has no %s transport helper (git-remote-%s); use the ssh remote form instead, e.g. `hand project add git@host:owner/repo.git`", scheme, scheme)
 }
 
 func valueOrNone(value string) string {

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -245,6 +245,17 @@ reconcile), `cmd/doctor.go`.
 | INV-AUTH-4 | Every launch path supplies the task's kind to `harness.Build`: spawn, reopen, promote (always ship), and reconcile's confirm-launch arm all carry it through, so INV-AUTH-1/2 hold for a real launch and not only for a prompt built by hand. | unit | `TestSpawnBuildsHarnessCarryingTaskKind`, `TestReopenBuildsHarnessCarryingTaskKind`, `TestPromoteBuildsHarnessCarryingShipKind`, `TestReconcileConfirmLaunchCarriesTaskKind` |
 | INV-AUTH-3 | `hand doctor` names every open ship task whose *last* reported state is `done` with no pull request recorded, and the finding names the command that shows the way out. This does not catch a ship worker that is functionally finished but still reporting `working:` - that case is not mechanically detectable from the report channel alone. | unit | `TestDoctorWarnsForOpenShipTaskReportedDoneWithNoPR` |
 
+## Runtime transport readiness
+
+Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`), `cmd/doctor.go`,
+`cmd/runtime.go`, `cmd/project.go` (`gitClone`, `diagnoseCloneFailure`).
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-RTGIT-1 | A runtime's `git_https_ready` reflects whether `git-remote-https` is present next to the installed git binary, observed from the bundle on disk rather than assumed from the runtime id or version - for a fake bundle with and without the helper. | unit | `TestStatusObservesInstalledRemoteHelperRatherThanRuntimeID` |
+| INV-RTGIT-2 | A bundle missing the https helper is reported as a warning naming the ssh treatment, and never joins `hand doctor`'s blocking list or flips `runtime_ready` - only a runtime that fails its own integrity checks does that. | unit | `TestRuntimeHTTPSFindingsNamesTheSSHTreatmentWithoutJoiningBlocking` |
+| INV-RTGIT-3 | `hand project add` replaces git's own "remote-\<scheme\>' is not a git command" text with the named runtime defect and the ssh treatment; any other git failure, including one a source rewritten by git config resolves without an external helper, passes through unchanged. | unit | `TestDiagnoseCloneFailureNamesMissingHelperInsteadOfPassingGitTextThrough`, `TestDiagnoseCloneFailureReadsTheSchemeFromGitsOwnText`, `TestDiagnoseCloneFailureLeavesUnrelatedGitErrorsUnchanged` |
+
 ## Pure helpers
 
 Source: `internal/shellquote`, `internal/age`, `cmd/statusview.go`.

--- a/internal/toolchain/executor.go
+++ b/internal/toolchain/executor.go
@@ -137,6 +137,24 @@ func (r Runtime) Process(path string, args ...string) (ProcessSpec, error) {
 	return NewProcessSpec(path, args, env)
 }
 
+// SupportsGitTransport reports whether the runtime's Git carries the external remote helper a
+// URL scheme needs, observed as git-remote-<scheme> next to the managed git binary rather than
+// assumed from the runtime id or version (hand#440); ssh, git, and file need no helper.
+func (r Runtime) SupportsGitTransport(scheme string) bool {
+	if r.GitBin == "" {
+		return false
+	}
+	path := filepath.Join(r.GitBin, executableName("git-remote-"+scheme))
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	if info.Mode()&0o111 == 0 && !strings.HasSuffix(strings.ToLower(path), ".exe") {
+		return false
+	}
+	return true
+}
+
 func requireExecutable(path string) error {
 	if err := requireAbsolute(path); err != nil {
 		return err

--- a/internal/toolchain/store.go
+++ b/internal/toolchain/store.go
@@ -56,7 +56,10 @@ type Status struct {
 	TreehouseVersion string
 	HerdrPath        string
 	HerdrVersion     string
-	Reason           string
+	// GitHTTPSReady is observed independently of Ready: whether the installed Git carries a
+	// git-remote-https helper, not whether the bundle as a whole is intact (hand#440).
+	GitHTTPSReady bool
+	Reason        string
 }
 
 func NewStore(root string, lock Lock) (*Store, error) {
@@ -125,6 +128,7 @@ func (s *Store) Status(goos, goarch string) (Status, error) {
 		TreehouseVersion: runtime.TreehouseVersion,
 		HerdrPath:        runtime.HerdrPath,
 		HerdrVersion:     runtime.HerdrVersion,
+		GitHTTPSReady:    runtime.SupportsGitTransport("https"),
 	}, nil
 }
 

--- a/internal/toolchain/store_test.go
+++ b/internal/toolchain/store_test.go
@@ -182,14 +182,22 @@ func TestStatusRejectsBundleWithoutImmutableArtifacts(t *testing.T) {
 
 func tarGzipFixture(t *testing.T, name string, data []byte) string {
 	t.Helper()
+	path := tarGzipFixtureFiles(t, map[string][]byte{name: data})
+	return path
+}
+
+func tarGzipFixtureFiles(t *testing.T, files map[string][]byte) string {
+	t.Helper()
 	var archive bytes.Buffer
 	gzipWriter := gzip.NewWriter(&archive)
 	tarWriter := tar.NewWriter(gzipWriter)
-	if err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o700, Size: int64(len(data))}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tarWriter.Write(data); err != nil {
-		t.Fatal(err)
+	for name, data := range files {
+		if err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o700, Size: int64(len(data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tarWriter.Write(data); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := tarWriter.Close(); err != nil {
 		t.Fatal(err)
@@ -202,4 +210,84 @@ func tarGzipFixture(t *testing.T, name string, data []byte) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+// The fake-bundle case hand#440 asks for: a Git payload missing git-remote-https must read as
+// https-unready by what is actually on disk, and installing the helper must flip it back -
+// detection by observation, not by pinning which runtime ids are broken.
+func TestStatusObservesInstalledRemoteHelperRatherThanRuntimeID(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		withHelper bool
+	}{
+		{name: "helper missing from the bundle reads https-unready", withHelper: false},
+		{name: "helper present in the bundle reads https-ready", withHelper: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gitFiles := map[string][]byte{executableName("git"): []byte("fixture-git")}
+			expectedFiles := []ExpectedFile{{Path: executableName("git"), Executable: true, Regular: true}}
+			if tc.withHelper {
+				gitFiles[executableName("git-remote-https")] = []byte("fixture-git-remote-https")
+				expectedFiles = append(expectedFiles, ExpectedFile{Path: executableName("git-remote-https"), Executable: true, Regular: true})
+			}
+			gitArchive, err := os.ReadFile(tarGzipFixtureFiles(t, gitFiles))
+			if err != nil {
+				t.Fatal(err)
+			}
+			gitDigest := sha256.Sum256(gitArchive)
+
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				if r.URL.Path == "/git.tar.gz" {
+					_, _ = w.Write(gitArchive)
+					return
+				}
+				_, _ = w.Write([]byte("fixture-" + filepath.Base(r.URL.Path)))
+			}))
+			defer server.Close()
+
+			components := map[string]Component{
+				"git": {
+					Name: "git", Version: "test", Revision: "test", URL: server.URL + "/git.tar.gz",
+					SHA256: hex.EncodeToString(gitDigest[:]), Format: "tar.gz", Root: ".", Files: expectedFiles,
+				},
+			}
+			for _, name := range []string{"treehouse", "herdr"} {
+				data := []byte("fixture-" + name)
+				digest := sha256.Sum256(data)
+				components[name] = Component{
+					Name: name, Version: "test", Revision: "test", URL: server.URL + "/" + name,
+					SHA256: hex.EncodeToString(digest[:]), Format: "binary", Root: ".",
+					Files: []ExpectedFile{{Path: executableName(name), Executable: true, Regular: true}},
+				}
+			}
+			lock := Lock{Schema: 1, GeneratedBy: "store-test", Targets: map[string]Target{
+				runtime.GOOS + "/" + runtime.GOARCH: {Components: components},
+			}}
+			lock.RuntimeID, err = lock.DeterministicID()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			store, err := NewStore(t.TempDir(), lock)
+			if err != nil {
+				t.Fatal(err)
+			}
+			store.HTTPClient = server.Client()
+			if _, err := store.Ensure(context.Background(), "", ""); err != nil {
+				t.Fatal(err)
+			}
+
+			status, err := store.Status("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !status.Ready {
+				t.Fatalf("status = %+v, want the otherwise-intact bundle to still read Ready", status)
+			}
+			if status.GitHTTPSReady != tc.withHelper {
+				t.Fatalf("status.GitHTTPSReady = %v, want %v", status.GitHTTPSReady, tc.withHelper)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- The pinned Git (an external release from `darkvertex/static-git` that hand only consumes, not something this repo builds) ships no `git-remote-*` helpers, so `hand project add https://...` fails with a raw git plumbing error while `hand runtime ensure`/`hand doctor` still report `ready: true`. Confirmed against the real installed bundle that pointing `GIT_EXEC_PATH` at it changes nothing: the helper is absent from the payload, not merely mis-pointed-to.
- `Runtime.SupportsGitTransport` observes `git-remote-<scheme>` next to the managed git binary (no version pinning), and `Store.Status` carries it as `GitHTTPSReady`, kept independent of `Ready` so a fleet home that only clones over ssh never reads as unready with no treatment. `hand runtime status`/`ensure` and `hand doctor` (a non-blocking warning) now name the ssh form as the treatment.
- `hand project add`'s clone path replaces git's "is not a git command" text with that same diagnosis, matched against git's actual failure output rather than guessed from the URL scheme, so a source a git config rewrite resolves without an external helper (as e2e's own fixtures do) is left untouched.

Closes atqamz/hand#440

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
SECONDHAND_HOME=$(mktemp -d) go test -tags=test -race -timeout=30m ./...
ok  	github.com/atqamz/hand/cmd	...
ok  	github.com/atqamz/hand/internal/toolchain	...
... (all packages ok)

$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	70.628s
```

Real behavior against the currently installed pinned bundle (`HAND_HOME` unset, scratch fleet home):

```
$ hand runtime status
target: linux/amd64
runtime_id: rd2343fe130ff5ba2
ready: true
...
git_https_ready: false
...
help[2]:
  - Run `hand runtime ensure` to install or repair the exact private Git, Treehouse, and Herdr bundle
  - the pinned runtime's Git has no https transport helper (git-remote-https); use the ssh remote form instead, e.g. `hand project add git@host:owner/repo.git`

$ hand doctor
runtime_ready: true
...
ready: true
blocking[0]:
findings[2]{line,severity,finding}:
  none,warning,"routing falls back to legacy defaults without explicit intent: harness \"claude\""
  none,warning,"runtime git cannot clone https:// remotes: the pinned runtime's Git has no https transport helper (git-remote-https); use the ssh remote form instead, e.g. `hand project add git@host:owner/repo.git`"

$ hand project add https://github.com/atqamz/hand
error: "cannot clone https://github.com/atqamz/hand: the pinned runtime's Git has no https transport helper (git-remote-https); use the ssh remote form instead, e.g. `hand project add git@host:owner/repo.git`"
kind: general
exit: 1

$ hand project add git@github.com:atqamz/hand.git
name: hand
result: added
mode: direct-pr
...
```

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->