### PR TITLE
fix(watcher): stop failing an arm when a task is torn down mid-probe

### DIFF
--- a/cmd/supervision.go
+++ b/cmd/supervision.go
@@ -201,7 +201,9 @@ func newClaudeStopCmd() *cobra.Command {
 				if markErr := ledger.MarkBridgeError(harness.Claude, waitErr.Error()); markErr != nil {
 					return markErr
 				}
-				return &ExitError{Err: fmt.Errorf("hand supervisor wake bridge failed monitoring: %v; run `hand doctor` in the fleet home", waitErr), Code: 2}
+				// `hand doctor` never inspects pane reachability, so it cannot see this condition -
+				// `hand status` is what actually observes an unreachable pane (atqamz/hand#455).
+				return &ExitError{Err: fmt.Errorf("hand supervisor wake bridge failed monitoring: %v; run `hand status` in the fleet home to see which task's pane is unreachable", waitErr), Code: 2}
 			default:
 				return waitErr
 			}

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -159,7 +159,8 @@ Source: [One watcher per fleet home, guarded by an flock](adr/one-watcher-per-fl
 [Watcher takeover is generation-attributed](adr/watcher-takeover-is-generation-attributed.md),
 [The until-event exit is the delivery](adr/the-until-event-exit-is-the-delivery.md),
 [Arming a watch observes before it waits](adr/arming-a-watch-observes-before-it-waits.md),
-[A contended refusal names its recorded holder](adr/a-contended-refusal-names-its-recorded-holder.md).
+[A contended refusal names its recorded holder](adr/a-contended-refusal-names-its-recorded-holder.md),
+`internal/watcher/watcher.go` (`probeAllTasks`, `attemptStillNeedsArm`; atqamz/hand#455).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -171,6 +172,8 @@ Source: [One watcher per fleet home, guarded by an flock](adr/one-watcher-per-fl
 | INV-WATCH-6 | Delivery, an empty window, and an unprobeable task have distinct exit codes, and each is reachable. | property | unaudited |
 | INV-WATCH-7 | A contended refusal names the durably recorded holder - pid and generation - and never asserts an identity the owner record does not carry; an unreadable or absent record is reported as such, not guessed. | property | unit - `TestAcquireRefusesASecondWatcherAndNamesTheRecordedHolder`, `TestContendNamesABridgeHolderAndOffersNoTakeover`, `TestContendWithNoRecordSaysSoRatherThanGuessingAHolder`, `TestContendWithAMalformedRecordSaysSoRatherThanGuessingAHolder`; e2e - `TestWatchNamesALiveSupervisionBridgeHolderAndOffersNoTakeover` |
 | INV-WATCH-8 | `--takeover` is offered, and attempted, only against a holder recorded as able to honor it; a recorded bridge holder refuses immediately instead of waiting out the takeover grace. | property | unit - `TestContendNamesABridgeHolderAndOffersNoTakeover`, `TestTakeoverAgainstABridgeHolderFailsFastWithoutWaitingOutTheGrace` |
+| INV-WATCH-9 | Tearing a task down never fails an arm: an attempt already marked mid-teardown at the histories snapshot is skipped without a probe, and a teardown that commits after the snapshot but before that task's probe is caught by a fresh re-read on a not-found pane. | property | unit - `TestProbeAllTasksSkipsATornDownAttemptWithoutProbingItsPane`, `TestProbeAllTasksClosesTheRaceWhenATeardownCommitsAfterTheHistoriesSnapshot` |
+| INV-WATCH-10 | A pane missing for an open task not being torn down still fails the arm and still names that task, even through the same not-found path INV-WATCH-9 forgives. | property | unit - `TestProbeAllTasksFailsWhenAnOpenTasksPaneIsGoneWithoutATeardown` |
 
 ## Locks and schema
 
@@ -248,6 +251,7 @@ Source: [Every diagnosis names a reachable treatment](adr/every-diagnosis-names-
 | INV-DIAG-1 | Every reachable stuck state has an entry naming the supported commands that leave it, or is explicitly marked undiagnosed. | property | unaudited |
 | INV-DIAG-2 | A persisted repair reason carries its treatment text with the task id substituted, so a refusal and the way out cannot drift apart. | property | unaudited |
 | INV-DIAG-3 | Every treatment falls in exactly one of the three classes. | property | unaudited |
+| INV-DIAG-4 | The Claude wake-bridge refusal on an arm failure names a treatment that can actually observe the condition (`hand status`, which checks pane reachability), never one that cannot (`hand doctor`, which does not). | property | unaudited |
 
 ## Launch-level delivery authorization
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -219,7 +219,11 @@ func RunUntilEvent(ctx context.Context, cfg Config, out, errOut io.Writer) error
 	}
 	cfg.FleetID = fleetID
 
-	if err := probeAllTasks(ctx, cfg.Home, client, cfg.Targets); err != nil {
+	armHistories, err := state.ListOpenHistories(cfg.Home)
+	if err != nil {
+		return fmt.Errorf("list tasks: %w", err)
+	}
+	if err := probeAllTasks(ctx, cfg.Home, client, cfg.Targets, armHistories); err != nil {
 		return err
 	}
 
@@ -288,12 +292,9 @@ func connect(ctx context.Context, client *herdr.Client) error {
 }
 
 // Confirms every running task's pane answers before RunUntilEvent arms; provisioning has no pane
-// contract yet and is intentionally left for a later tick after launch confirmation.
-func probeAllTasks(ctx context.Context, home string, client *herdr.Client, targets []TargetBinding) error {
-	histories, err := state.ListOpenHistories(home)
-	if err != nil {
-		return fmt.Errorf("list tasks: %w", err)
-	}
+// contract yet and is intentionally left for a later tick after launch confirmation. histories is a
+// snapshot the caller already read, so a teardown can commit against it before this reaches that task.
+func probeAllTasks(ctx context.Context, home string, client *herdr.Client, targets []TargetBinding, histories []state.TaskHistory) error {
 	done := make(chan error, 1)
 	go func() {
 		for _, history := range histories {
@@ -307,7 +308,21 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client, targe
 			if history.ActiveAttempt.Lifecycle == state.AttemptProvisioning {
 				continue
 			}
+			// releaseHerdr (internal/runtime/teardown.go) marks this "releasing" strictly before it
+			// closes the pane, so an attempt already carrying the mark needs no probe - mirrors the
+			// provisioning skip above: this pane contract no longer describes anything to watch.
+			if history.ActiveAttempt.TeardownHerdrState != "" {
+				continue
+			}
 			if _, err := client.PaneGetContext(ctx, history.ActiveAttempt.Herdr.PaneID); err != nil {
+				// pane_not_found is ambiguous from a stale snapshot: a teardown can commit its herdr
+				// mark, written strictly before the pane closes, in the gap between the snapshot read
+				// and this probe. A fresh read settles it either way.
+				if errors.Is(err, herdr.ErrNotFound) {
+					if needed, rerr := attemptStillNeedsArm(home, history.Task.ID, history.ActiveAttempt.ID); rerr == nil && !needed {
+						continue
+					}
+				}
 				done <- fmt.Errorf("%w: %s: %v", ErrArmFailed, history.Task.ID, err)
 				return
 			}
@@ -324,6 +339,26 @@ func probeAllTasks(ctx context.Context, home string, client *herdr.Client, targe
 		}
 		return err
 	}
+}
+
+// Re-reads one task fresh to tell a real arm failure apart from a teardown that committed after
+// probeAllTasks's histories snapshot was taken. Only the same attempt, still open and still carrying
+// no teardown mark, still needs the failure reported; anything else is no longer this arm's to watch.
+func attemptStillNeedsArm(home, taskID string, probedAttemptID int64) (bool, error) {
+	history, err := state.ReadHistory(home, taskID)
+	if err != nil {
+		if errors.Is(err, state.ErrTaskNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if history.Task.Lifecycle != state.TaskOpen {
+		return false, nil
+	}
+	if history.ActiveAttempt == nil || history.ActiveAttempt.ID != probedAttemptID {
+		return false, nil
+	}
+	return history.ActiveAttempt.TeardownHerdrState == "", nil
 }
 
 func connectContextError(ctx context.Context) error {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -3366,6 +3366,182 @@ func TestRunUntilEventFailsToArmWhenATaskCannotBeProbed(t *testing.T) {
 	}
 }
 
+// atqamz/hand#455: a task the supervisor tore down deliberately must never fail an arm, whether the
+// teardown mark is already on the histories snapshot armProbe reads (this test) or commits after it
+// (TestProbeAllTasksClosesTheRaceWhenATeardownCommitsAfterTheHistoriesSnapshot, below).
+func TestProbeAllTasksSkipsATornDownAttemptWithoutProbingItsPane(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{{ID: "wA:t1", Label: "task-1", Pane: "p1"}}}},
+		PaneStatus: "working",
+		Log:        callLog, LogCommands: []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}}); err != nil {
+		t.Fatal(err)
+	}
+	// task-2's pane ("p-gone") is deliberately never registered with the fake: if probeAllTasks ever
+	// called PaneGetContext for it, the call log below would catch it.
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-2", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p-gone"}}); err != nil {
+		t.Fatal(err)
+	}
+	_, attempt2 := readTaskAttempt(t, home, "task-2")
+	if err := state.SetAttemptTeardownResourceState(home, "task-2", attempt2.ID, state.AttemptRunning, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+
+	histories, err := state.ListOpenHistories(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := probeAllTasks(context.Background(), home, herdr.NewClient(), nil, histories); err != nil {
+		t.Fatalf("probeAllTasks = %v, want nil: a torn-down attempt must not fail the arm", err)
+	}
+	data, _ := os.ReadFile(callLog)
+	if strings.Contains(string(data), "p-gone") {
+		t.Fatalf("pane-get calls = %q, want the torn-down attempt's pane never probed", data)
+	}
+	if !strings.Contains(string(data), "p1") {
+		t.Fatalf("pane-get calls = %q, want the remaining open task still probed", data)
+	}
+}
+
+// The failure mode reported in atqamz/hand#455: teardown's herdr-release mark commits after the
+// histories snapshot was taken but before this task's probe runs. The snapshot has to be taken while
+// task-2 was still genuinely open and unmarked - a pre-torn-down fixture would not exercise this.
+func TestProbeAllTasksClosesTheRaceWhenATeardownCommitsAfterTheHistoriesSnapshot(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{
+			ID: "wA", Label: "watch", Tabs: []faketool.HerdrTab{
+				{ID: "wA:t1", Label: "task-1", Pane: "p1"},
+				{ID: "wA:t2", Label: "task-2", Pane: "p-gone"},
+			},
+		}},
+		PaneStatus: "working",
+		// Only p-gone's probe answers not-found - real herdr's shape for a closed pane, per
+		// internal/runtime/resources.go's isHerdrNotFound: a JSON error envelope on stdout, exit 0.
+		Responses: []faketool.HerdrResponse{{
+			Command: "pane get", Args: []string{"p-gone"},
+			Stdout: `{"id":"cli:pane:get","error":{"code":"pane_not_found","message":"pane p-gone not found"}}`,
+		}},
+		Log: callLog, LogCommands: []string{"pane get"},
+	}.Install(t, faketool.Bin(t))
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-2", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p-gone"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The stale snapshot: both tasks genuinely open, task-2's attempt genuinely running and carrying
+	// no teardown mark yet.
+	histories, err := state.ListOpenHistories(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The race: a concurrent `hand teardown task-2` commits its herdr-release mark after the snapshot
+	// above was taken, using the same primitive teardown.go itself calls.
+	_, attempt2 := readTaskAttempt(t, home, "task-2")
+	if err := state.SetAttemptTeardownResourceState(home, "task-2", attempt2.ID, state.AttemptRunning, "herdr", state.TeardownResourceReleasing); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := probeAllTasks(context.Background(), home, herdr.NewClient(), nil, histories); err != nil {
+		t.Fatalf("probeAllTasks = %v, want nil: a teardown that commits after the histories snapshot must not fail the arm", err)
+	}
+	data, _ := os.ReadFile(callLog)
+	if !strings.Contains(string(data), "p1") {
+		t.Fatalf("pane-get calls = %q, want the remaining open task still watched", data)
+	}
+}
+
+// A pane missing for an open task that is not being torn down is still a real arm failure, even
+// through the same not-found path the race above must forgive: attemptStillNeedsArm's re-read has to
+// tell the two apart rather than forgiving every not-found probe.
+func TestProbeAllTasksFailsWhenAnOpenTasksPaneIsGoneWithoutATeardown(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, paneGoneStatus)
+	writeFakeHerdr(t, statusFile)
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}}); err != nil {
+		t.Fatal(err)
+	}
+	histories, err := state.ListOpenHistories(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = probeAllTasks(context.Background(), home, herdr.NewClient(), nil, histories)
+	if !errors.Is(err, ErrArmFailed) {
+		t.Fatalf("probeAllTasks = %v, want ErrArmFailed: no teardown explains this task's missing pane", err)
+	}
+	if !strings.Contains(err.Error(), "task-1") {
+		t.Fatalf("err = %q, want it to name task-1", err.Error())
+	}
+}
+
+// Unchanged branches: a live pane arms normally, and a provisioning attempt is still skipped without
+// ever being probed.
+func TestProbeAllTasksArmsForAnOpenTaskWithALivePane(t *testing.T) {
+	writeFakeHerdrForPanes(t, "p1")
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}}); err != nil {
+		t.Fatal(err)
+	}
+	histories, err := state.ListOpenHistories(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := probeAllTasks(context.Background(), home, herdr.NewClient(), nil, histories); err != nil {
+		t.Fatalf("probeAllTasks = %v, want nil for a live pane", err)
+	}
+}
+
+func TestProbeAllTasksSkipsAProvisioningAttemptWithoutProbingItsPane(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "pane-get-calls")
+	t.Setenv("HERDR_CALL_LOG", callLog)
+	faketool.Herdr{Log: callLog, LogCommands: []string{"pane get"}}.Install(t, faketool.Bin(t))
+
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Kind: state.KindShip}, state.Attempt{Lifecycle: state.AttemptProvisioning}); err != nil {
+		t.Fatal(err)
+	}
+	histories, err := state.ListOpenHistories(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := probeAllTasks(context.Background(), home, herdr.NewClient(), nil, histories); err != nil {
+		t.Fatalf("probeAllTasks = %v, want nil: a provisioning attempt has no pane contract yet", err)
+	}
+	if data, readErr := os.ReadFile(callLog); readErr == nil && len(data) != 0 {
+		t.Fatalf("pane-get calls = %q, want none for a provisioning attempt", data)
+	}
+}
+
 // Holds resume to what the live path already does: a free-text line appended after a real report
 // explains nothing, so it must not erase the report it follows. Reading it back as "never reported"
 // turns the next quiet pane into idle-unreported, replacing the explanation with a bare stop.


### PR DESCRIPTION
## Summary

- `probeAllTasks` (armProbe) now skips an attempt already carrying teardown's herdr-release mark, and re-reads a task fresh on a `pane_not_found` probe failure before declaring `ErrArmFailed` - closing the race where a concurrent `hand teardown` commits between the histories snapshot and this task's probe turn.
- The Claude wake-bridge's arm-failed refusal now points at `hand status` instead of `hand doctor`, which never inspects pane reachability and could never see the condition it was telling the operator to check.

A static check on the attempt's own `Lifecycle` field (the issue's other suggested direction) cannot close this race and is not included: `ListOpenHistories` only returns tasks whose lifecycle is still `open`, and `TerminalizeTaskAndAttempt` commits both the task and the attempt terminal in one transaction, so a terminal `Lifecycle` can never appear in that snapshot. Only a fresh re-read, taken after the probe has already failed, can see what committed since the snapshot was read. This is explained in the commit message and in code comments.

Closes atqamz/hand#455

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
...
ok  	github.com/atqamz/hand/internal/watcher	60.699s
ok  	github.com/atqamz/hand/cmd	138.407s
... (all packages ok)

$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	102.271s
```

New focused tests in `internal/watcher/watcher_test.go`, all passing:
- `TestProbeAllTasksSkipsATornDownAttemptWithoutProbingItsPane` - an attempt already marked mid-teardown in the histories snapshot is never probed.
- `TestProbeAllTasksClosesTheRaceWhenATeardownCommitsAfterTheHistoriesSnapshot` - the actual reported race: a stale snapshot with a genuinely open, non-terminal attempt, and a teardown mark committed (via the same primitive `hand teardown` uses) after the snapshot but before the probe. Arms successfully and the remaining task is still probed.
- `TestProbeAllTasksFailsWhenAnOpenTasksPaneIsGoneWithoutATeardown` - the re-read must not swallow a genuine failure: still fails, still names the task.
- `TestProbeAllTasksArmsForAnOpenTaskWithALivePane`, `TestProbeAllTasksSkipsAProvisioningAttemptWithoutProbingItsPane` - unchanged branches.

Also manually verified red-before/green-after against the real compiled `hand` binary in a scratch fleet home built by `t.TempDir()` (outside this worktree, per atqamz/hand#413): a two-task fleet with task-2 marked mid-teardown and its pane answering `pane_not_found` failed `hand watch --until-event` with `kind: arm-failed` before this change, and passes - delivering task-1's event - after it. That verification script was throwaway and is not part of this PR.

`docs/testing-invariants.md` gained `INV-WATCH-9`, `INV-WATCH-10`, and `INV-DIAG-4` for the new invariants.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->