### PR TITLE
feat(cmd): record a PR delivered to a sibling repository with hand pr --cross-repo

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -13,6 +13,9 @@ import (
 )
 
 func newPRCmd() *cobra.Command {
+	var crossRepo bool
+	var reason string
+
 	cmd := &cobra.Command{
 		Use:   "pr <id> <url>",
 		Short: "Record a task's pull request URL",
@@ -21,6 +24,12 @@ func newPRCmd() *cobra.Command {
 			id, url := args[0], args[1]
 			if !state.ValidatePRURL(url) {
 				return &ExitError{Err: fmt.Errorf("invalid PR URL %q: must match https://github.com/<owner>/<repo>/pull/<number>", url), Code: 2}
+			}
+			if crossRepo && reason == "" {
+				return &ExitError{Err: fmt.Errorf("--cross-repo requires --reason describing the deliberate delivery elsewhere"), Code: 2}
+			}
+			if !crossRepo && reason != "" {
+				return &ExitError{Err: fmt.Errorf("--reason applies only to a --cross-repo record"), Code: 2}
 			}
 			fleetHome, err := home.Resolve()
 			if err != nil {
@@ -35,7 +44,7 @@ func newPRCmd() *cobra.Command {
 			if err != nil {
 				return asPrecondition(err)
 			}
-			task, reconcile, err := recordPR(cmd.Context(), fleetHome, task, url)
+			task, reconcile, err := recordPR(cmd.Context(), fleetHome, task, url, crossRepo, reason)
 			if err != nil {
 				return err
 			}
@@ -50,6 +59,9 @@ func newPRCmd() *cobra.Command {
 			doc.Field("id", task.ID)
 			doc.Field("result", result)
 			doc.Field("pr", url)
+			if task.PRCrossRepoReason != "" {
+				doc.Field("cross_repo_reason", task.PRCrossRepoReason)
+			}
 			// A torn-down task has no active attempt for hand merge to act on (atqamz/hand#424): naming
 			// it here would suggest the task is live again, which recording a PR on it must never do.
 			if task.Lifecycle != state.TaskTerminal {
@@ -58,11 +70,13 @@ func newPRCmd() *cobra.Command {
 			return doc.Render(cmd.OutOrStdout())
 		},
 	}
+	cmd.Flags().BoolVar(&crossRepo, "cross-repo", false, "record a PR in a repository other than the project's own or its declared upstream, deliberately")
+	cmd.Flags().StringVar(&reason, "reason", "", "why this PR landed in a different repository, required with --cross-repo")
 	return cmd
 }
 
-func recordPR(ctx context.Context, homeDir string, task state.Task, url string) (state.Task, bool, error) {
-	updated, reconcile, err := runtime.RecordPR(ctx, homeDir, task, url)
+func recordPR(ctx context.Context, homeDir string, task state.Task, url string, crossRepo bool, reason string) (state.Task, bool, error) {
+	updated, reconcile, err := runtime.RecordPR(ctx, homeDir, task, url, crossRepo, reason)
 	if err != nil {
 		return task, false, asPrecondition(err)
 	}

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -446,6 +446,173 @@ func TestPRNotFoundOnUpstreamNamesTheUpstreamRepo(t *testing.T) {
 	}
 }
 
+// atqamz/hand#423: the refusal for a sibling repo has to point at the real escape (--cross-repo),
+// not at declaring an upstream - that would put false fork topology in the registry to record one
+// task's PR.
+func TestPRRefusesSiblingRepoWithoutCrossRepoFlagAndNamesTheRealEscape(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/yes2games/yes2infra.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/yes2games/yes2infra.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "https://github.com/yes2games/butler/pull/92"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+	if strings.Contains(err.Error(), "no upstream is declared") {
+		t.Fatalf("got %v, want the refusal to no longer offer declaring an upstream as the escape", err)
+	}
+	if !strings.Contains(err.Error(), "--cross-repo") || !strings.Contains(err.Error(), "--reason") {
+		t.Fatalf("got %v, want the refusal to name --cross-repo and --reason as the real escape", err)
+	}
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != "" {
+		t.Fatalf("task.PR = %q, want nothing recorded without the opt-in", task.PR)
+	}
+}
+
+func TestPRCrossRepoWithoutReasonRefused(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/yes2games/yes2infra.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/yes2games/yes2infra.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "--cross-repo", "https://github.com/yes2games/butler/pull/92"})
+	err := cmd.Execute()
+	assertExitCode2(t, err)
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != "" {
+		t.Fatalf("task.PR = %q, want nothing recorded without a reason", task.PR)
+	}
+}
+
+// --reason answers a question --cross-repo never asked, so it is refused rather than silently
+// ignored: a same-repo record carrying a reason nobody asked for would be confusing to read back.
+func TestPRReasonWithoutCrossRepoRefused(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/owner/secondhand.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/owner/secondhand.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "--reason", "moved upstream", "https://github.com/owner/secondhand/pull/1"})
+	err := cmd.Execute()
+	assertExitCode2(t, err)
+}
+
+// The case that motivated atqamz/hand#423: the component moved to a sibling repository between
+// brief and delivery, and the worker followed the code there.
+func TestPRRecordsSiblingRepoWithCrossRepoFlagAndReason(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/yes2games/yes2infra.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/yes2games/yes2infra.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	crossRepoPR := "https://github.com/yes2games/butler/pull/92"
+	installFakeGhPRs(t, crossRepoPR)
+
+	cmd := newPRCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	reason := "component moved to yes2games/butler before the worker started; see ADR-0015"
+	cmd.SetArgs([]string{"task-1", "--cross-repo", "--reason", reason, crossRepoPR})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("recording a deliberate cross-repo PR: %v", err)
+	}
+	if !strings.Contains(out.String(), "result: recorded\n") || !strings.Contains(out.String(), "cross_repo_reason: "+reason+"\n") {
+		t.Fatalf("out = %q, want the recorded confirmation to carry the reason", out.String())
+	}
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != crossRepoPR {
+		t.Fatalf("task.PR = %q, want %q", task.PR, crossRepoPR)
+	}
+	if task.PRCrossRepoReason != reason {
+		t.Fatalf("task.PRCrossRepoReason = %q, want %q", task.PRCrossRepoReason, reason)
+	}
+}
+
+// --cross-repo waives exactly the repo-match check, nothing else: a PR that does not exist on
+// GitHub is still refused.
+func TestPRCrossRepoStillRefusesAPRThatDoesNotExistOnGitHub(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/yes2games/yes2infra.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/yes2games/yes2infra.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGhPRView(t, 1)
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "--cross-repo", "--reason", "moved", "https://github.com/yes2games/butler/pull/92"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != "" {
+		t.Fatalf("task.PR = %q, want nothing recorded for a PR gh cannot confirm exists", task.PR)
+	}
+}
+
+// Write-once holds regardless of the opt-in: a cross-repo record does not get a second chance to
+// point somewhere else, cross-repo or not.
+func TestPRCrossRepoWriteOnceRefusesASecondDifferentURL(t *testing.T) {
+	home, clonePath := setupPRHome(t)
+	addOriginRemote(t, clonePath, "https://github.com/yes2games/yes2infra.git")
+	if err := project.Add(home, project.Project{Name: "demo", URL: "https://github.com/yes2games/yes2infra.git", Mode: project.ModeDirectPR}); err != nil {
+		t.Fatal(err)
+	}
+	first := "https://github.com/yes2games/butler/pull/92"
+	if err := state.Write(home, state.Task{ID: "task-1", Project: "demo", PR: first, PRCrossRepoReason: "moved to butler"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPRCmd()
+	cmd.SetArgs([]string{"task-1", "--cross-repo", "--reason", "moved again", "https://github.com/yes2games/butler/pull/93"})
+	err := cmd.Execute()
+	assertExitCode3(t, err)
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != first {
+		t.Fatalf("task.PR = %q, want the original cross-repo PR left untouched", task.PR)
+	}
+}
+
 func TestPRRecordsSuccessfully(t *testing.T) {
 	home, clonePath := setupPRHome(t)
 	addOriginRemote(t, clonePath, "https://github.com/owner/secondhand.git")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -160,16 +160,20 @@ type statusJSON struct {
 	// Set only alongside PRObservation "found", carrying the URL GitHub answered with. Never mirrored
 	// into PR: that field is the durable record alone, so a found-but-unrecorded PR can never render
 	// as though hand merge's durable check would also see it (atqamz/hand#266).
-	PRObservedURL   string        `json:"pr_observed_url,omitempty"`
-	MergeExecuted   bool          `json:"merged"`
-	MergeAnnounced  bool          `json:"pr_merged_observed"`
-	DeliveredAt     string        `json:"delivered_at,omitempty"`
-	DeliveredReason string        `json:"delivered_reason,omitempty"`
-	CreatedAt       string        `json:"created_at"`
-	LastReportAt    string        `json:"last_report_at,omitempty"`
-	Reported        *reportedJSON `json:"reported,omitempty"`
-	ReportHistory   []string      `json:"report_history,omitempty"`
-	Held            *holdJSON     `json:"held,omitempty"`
+	PRObservedURL string `json:"pr_observed_url,omitempty"`
+	// Set only through hand pr's --cross-repo opt-in (atqamz/hand#423): its presence alone marks
+	// PR as a deliberate delivery to a repository other than the project's own or its declared
+	// upstream, so a consumer never has to infer that from the URL.
+	PRCrossRepoReason string        `json:"pr_cross_repo_reason,omitempty"`
+	MergeExecuted     bool          `json:"merged"`
+	MergeAnnounced    bool          `json:"pr_merged_observed"`
+	DeliveredAt       string        `json:"delivered_at,omitempty"`
+	DeliveredReason   string        `json:"delivered_reason,omitempty"`
+	CreatedAt         string        `json:"created_at"`
+	LastReportAt      string        `json:"last_report_at,omitempty"`
+	Reported          *reportedJSON `json:"reported,omitempty"`
+	ReportHistory     []string      `json:"report_history,omitempty"`
+	Held              *holdJSON     `json:"held,omitempty"`
 	// Omitted where a report file exists (found) or genuinely never has (absent), the same way
 	// PRObservation is: a consumer sees "unknown" only where an empty last_report_at is a failed
 	// stat rather than a task that has never reported.
@@ -725,7 +729,7 @@ func (v taskView) json() statusJSON {
 	}
 	return statusJSON{
 		ID: v.task.ID, Project: v.task.Project, Kind: v.task.Kind, ExecutionClass: e.ExecutionClass, Profile: e.RequestedProfile, PlannedAgainst: e.PlannedAgainst, RoutingSource: e.RoutingSource, TaskLifecycle: string(v.task.Lifecycle), AttemptOrdinal: e.Ordinal, AttemptLifecycle: string(e.Lifecycle), Harness: e.Harness, Model: e.Model, Effort: e.Effort,
-		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR, PRObservation: string(v.prObserved), PRObservedURL: v.prObservedURL,
+		AgentState: v.agentState, Worktree: e.Worktree, Herdr: e.Herdr, PR: v.task.PR, PRObservation: string(v.prObserved), PRObservedURL: v.prObservedURL, PRCrossRepoReason: v.task.PRCrossRepoReason,
 		MergeExecuted: v.task.MergeExecuted, MergeAnnounced: v.task.MergeAnnounced,
 		DeliveredAt: v.task.DeliveredAt, DeliveredReason: v.task.DeliveredReason,
 		CreatedAt: v.task.CreatedAt, LastReportAt: v.lastReportAt, LastReportObservation: lastReportObservationJSON(v.lastReportObserved),

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -494,6 +494,75 @@ func TestStatusMergeStateCombinationsRenderDistinguishably(t *testing.T) {
 	}
 }
 
+// atqamz/hand#423, decision 4: a PR recorded through --cross-repo has to read as cross-repo
+// wherever hand status renders it, on both the single-task detail and the fleet view's flags cell,
+// and in --json. A same-repo PR must never carry the marker.
+func TestStatusRendersCrossRepoPRDistinctlyEverywhere(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+
+	reason := "component moved to yes2games/butler before the worker started"
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z",
+		PR:        "https://github.com/yes2games/butler/pull/92", PRCrossRepoReason: reason,
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-2", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: "2026-07-24T10:00:00Z",
+		PR:        "https://github.com/owner/myproj/pull/7",
+	}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pC"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	detail := newStatusCmd()
+	var detailOut bytes.Buffer
+	detail.SetOut(&detailOut)
+	detail.SetArgs([]string{"task-1"})
+	if err := detail.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := detailOut.String()
+	if pr := detailField(t, got, "pr"); !strings.Contains(pr, "https://github.com/yes2games/butler/pull/92") || !strings.Contains(pr, reason) {
+		t.Fatalf("pr = %q, want the URL and the cross-repo reason both rendered", pr)
+	}
+	if flags := strings.Fields(detailField(t, got, "flags")); !slices.Contains(flags, "cross-repo") {
+		t.Fatalf("flags = %v, want cross-repo", flags)
+	}
+
+	fleet := newStatusCmd()
+	var fleetOut bytes.Buffer
+	fleet.SetOut(&fleetOut)
+	fleet.SetArgs(nil)
+	if err := fleet.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	fleetText := fleetOut.String()
+	if flags := fleetFlags(t, fleetText, "task-1"); !slices.Contains(flags, "cross-repo") {
+		t.Fatalf("fleet flags for task-1 = %v, want cross-repo", flags)
+	}
+	if flags := fleetFlags(t, fleetText, "task-2"); slices.Contains(flags, "cross-repo") {
+		t.Fatalf("fleet flags for task-2 = %v, want no cross-repo marker on a same-repo PR", flags)
+	}
+
+	jsonCmd := newStatusCmd()
+	var jsonOut bytes.Buffer
+	jsonCmd.SetOut(&jsonOut)
+	jsonCmd.SetArgs([]string{"task-1", "--json"})
+	if err := jsonCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var doc statusJSON
+	if err := json.Unmarshal(jsonOut.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal --json output: %v", err)
+	}
+	if doc.PRCrossRepoReason != reason {
+		t.Fatalf("PRCrossRepoReason = %q, want %q", doc.PRCrossRepoReason, reason)
+	}
+}
+
 // hand status's half of atqamz/hand#69: a task whose PR a no-mistakes gate opened directly
 // (bypassing hand pr) still shows the PR, once status looks it up by branch.
 func TestStatusSingleTaskDetectsGateOpenedPR(t *testing.T) {

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -116,6 +116,12 @@ func taskFlags(v taskView) []string {
 	case v.task.MergeAnnounced:
 		flags = append(flags, "merged-external")
 	}
+	// A PR recorded through hand pr's --cross-repo opt-in has to read as cross-repo everywhere
+	// hand status renders it (atqamz/hand#423) - a record that looks identical to a normal one
+	// defeats the point of requiring the opt-in.
+	if v.task.PR != "" && v.task.PRCrossRepoReason != "" {
+		flags = append(flags, "cross-repo")
+	}
 	if kind, ok := watcher.GateKind(v.gateObserved); ok {
 		flags = append(flags, kind)
 	}
@@ -234,6 +240,9 @@ var taskFields = []axi.Column[taskView]{
 	}},
 	{Name: "pr", Value: func(v taskView) string {
 		if v.task.PR != "" {
+			if v.task.PRCrossRepoReason != "" {
+				return fmt.Sprintf("%s (cross-repo: %s)", v.task.PR, v.task.PRCrossRepoReason)
+			}
 			return v.task.PR
 		}
 		switch v.prObserved {

--- a/docs/adr/cross-repo-pr-delivery-is-an-explicit-opt-in.md
+++ b/docs/adr/cross-repo-pr-delivery-is-an-explicit-opt-in.md
@@ -1,0 +1,108 @@
+# Cross-repo PR delivery is an explicit opt-in
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#423
+- PRs: none
+
+## Context
+
+`hand pr` refuses a URL whose repo is neither the project's own nor its declared upstream
+(`internal/project/pr.go`, `ValidatePR`). The guard is right: a PR from an unrelated repo must
+never reach task state by accident, since a recorded PR feeds `gh pr merge` directly. But the
+guard has no escape for a delivery that really did land somewhere else.
+
+`butler-broker-allowlist-rujak-release` was dispatched against project `yes2infra`. Between the
+brief being written and the worker starting, `yes2infra#435` deleted the file the brief targeted
+and moved the component to `yes2games/butler` - the same file, the same shape, the same gate,
+verbatim, with an ADR update saying so. The worker followed the code and delivered
+`yes2games/butler#92`. The outcome is correct. `hand pr` refused to record it, and the refusal's
+own text names the only escape it offers: "no upstream is declared for it."
+
+That escape is wrong for this case. `hand project upstream` declares the repo a *fork* opens its
+PRs against - documented as exactly that, and load-bearing for every future PR on the project, not
+just this one. `yes2infra` is not a fork of `butler`; they are sibling repositories in the same
+organization. Declaring `butler` as `yes2infra`'s upstream would write a false topology into the
+registry and change PR resolution for every future `yes2infra` task, to record one task's PR. The
+refusal was steering an operator with a genuine one-off delivery toward a fix that is worse than
+the missing record.
+
+The safety property worth keeping is "not by accident," not "not at all."
+
+## Decision
+
+**`hand pr` grows an explicit `--cross-repo` flag, paired with a required `--reason`.** Passing
+`--cross-repo` waives exactly the one check that compares the URL's repo against the project's own
+repo and its declared upstream (`ValidatePR`'s new `crossRepo` parameter). Every other validation
+runs unchanged: the URL still has to parse, the PR still has to exist and be observable on GitHub
+(`ObserveMergeState`), and `hand pr` is still write-once - a second, different URL is refused
+whether or not `--cross-repo` was used the first time. Nothing about the project registry changes;
+`hand project upstream` still means exactly what it means, and fork PR resolution is untouched.
+
+**The reason is required, not optional.** A cross-repo delivery is always a scope deviation worth
+reading later, and an unrecorded reason is the one thing a later reader could never reconstruct -
+the worker's free-text report is not durable state, and today it is the only place this survives at
+all. `hand pr` refuses `--cross-repo` without `--reason`, and refuses `--reason` without
+`--cross-repo`: the two only mean something together, so one arriving alone is refused rather than
+silently accepted or silently ignored.
+
+**The reason is a durable column, not folded into free text.** `task.pr_cross_repo_reason`
+(`internal/store`, `crossRepoPRVersion`) is empty for every PR recorded against the project's own
+repo or its declared upstream, and carries the operator's text only when `--cross-repo` wrote it.
+Its mere non-emptiness already marks the record as a deliberate delivery elsewhere - no separate
+boolean column, since one could read `true` with an empty reason after a bug elsewhere and no
+column could ever drift out of sync with the other.
+
+**The refusal itself no longer points at `hand project upstream`.** Before this change, a project
+with no declared upstream had its refusal read "... and no upstream is declared for it" - true, but
+read as an instruction, it sent an operator toward writing false topology. The refusal now names
+`--cross-repo`/`--reason` as the escape, and still names the declared upstream when there is one,
+since that remains the right answer for a real fork contribution.
+
+**Every surface `hand status` renders a PR through marks a cross-repo record distinctly.** The
+`pr` field carries the reason inline (`"<url> (cross-repo: <reason>)"`), `taskFlags` gains a
+`cross-repo` token so the fleet view's default columns show it without opting into the `pr` field,
+and `--json` carries `pr_cross_repo_reason` alongside `pr`. A record that looks identical to a
+normal one would defeat the point of requiring the opt-in in the first place.
+
+**The watcher's auto-recording path never sets `crossRepo`.** `autoRecordPR`
+(`internal/watcher/watcher.go`) and `DetectPR`'s branch-based re-detection
+(`internal/runtime/pr.go`) both call `RecordPR`/`ValidatePR` with `crossRepo` hardcoded to `false`.
+A cross-repo delivery is asserted by an operator through the explicit flag, never inferred by hand
+from a worker's report line or from re-detecting a branch it already pushed - the latter can only
+ever find a PR on the project's own repo or its declared upstream, since that is where hand itself
+pushed the branch.
+
+## Rejected alternatives
+
+- **Reusing or extending `hand project upstream`** - the thing this record explicitly rejects. It
+  would conflate "this project is a fork" (a standing topological fact) with "this one task
+  delivered somewhere else" (a one-off event), and the conflation is exactly what made the original
+  escape wrong.
+- **Making the reason optional** - considered, since every other free-text reason in `hand`
+  (`hand deliver --reason`) is required for the same shape of argument, and the issue itself flags
+  this as the reading expected to hold up. An unexplained cross-repo record is unrecoverable later;
+  requiring it costs one flag at the moment the operator already knows the answer.
+- **A boolean `pr_cross_repo` column alongside a separate reason column** - rejected for the
+  possible-drift reason above: two columns can disagree, one column that is either empty or
+  meaningful cannot.
+- **Deriving "is this cross-repo" at render time by comparing the recorded URL's repo against the
+  project's current repo and upstream** - rejected because it re-answers the question with
+  *today's* topology rather than the one true at record time, and because it requires a live git
+  call (`RepoSlug`) per row rendered rather than a stored fact. A project's upstream can change
+  after the PR was recorded; the record must not flip retroactively.
+- **Having `hand` detect a cross-repo delivery on its own** (e.g. from report-line PR mentions or
+  from broader GitHub search) - out of scope by design. The supervisor asserts a cross-repo
+  delivery; `hand` verifies it happened, exactly as it already verifies every other recorded PR.
+
+## Consequences
+
+The atqamz/hand#423 repro completes: `hand pr butler-broker-allowlist-rujak-release --cross-repo
+--reason "..." https://github.com/yes2games/butler/pull/92` records the true outcome instead of
+leaving `pr: unknown` forever, without writing any false fork topology into the registry.
+
+`internal/project/pr.go`'s `ValidatePR` and `internal/runtime/pr.go`'s `RecordPR` both take an
+explicit `crossRepo bool` now; every caller states its intent rather than inheriting a default.
+
+atqamz/hand#422 remains unowned by this change - a different family member (a merge that already
+landed) with no workaround at all, unlike this one's `hand deliver --reason` partial workaround.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -216,14 +216,21 @@ Source: [Unobservable ownership is not a mismatch](adr/unobservable-ownership-is
 ## Pull-request observation and terminal-task release
 
 Source: [Terminal release closes on evidence, not a new escape hatch](adr/terminal-release-closes-on-evidence-not-a-new-escape-hatch.md),
-[Every diagnosis names a reachable treatment](adr/every-diagnosis-names-a-reachable-treatment.md).
+[Every diagnosis names a reachable treatment](adr/every-diagnosis-names-a-reachable-treatment.md),
+[Cross-repo PR delivery is an explicit opt-in](adr/cross-repo-pr-delivery-is-an-explicit-opt-in.md).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
 | INV-PR-1 | A pull request is proven absent only when HEAD is detached, no branch is recorded (durably or live), and no commit is missing from a remote-tracking ref. Any one condition failing leaves the observation unknown. | property | `TestObservePRReportsAbsentWhenDetachedHeadHasNoBranchAndNoLocalOnlyCommits`, `TestObservePRStaysUnknownWhenABranchIsRecordedDespiteDetachedHeadWithNoLocalOnlyCommits`, `TestObservePRStaysUnknownWhenDetachedHeadCarriesALocalOnlyCommit`, `TestObservePRUnaffectedByTheAbsenceProofWhenHeadIsNotDetached` |
 | INV-PR-2 | Recording a pull request changes no task lifecycle column and gains a terminal task no liveness in attention, next-action ranking, or `hand status`. | property | `TestPRRecordsOnATerminalTaskWithoutReopening` |
-| INV-PR-3 | `hand pr` is write-once regardless of task lifecycle: a second, different URL is refused whether the task is open or terminal. | unit | `TestPRRecordsOnATerminalTaskWithoutReopening` |
+| INV-PR-3 | `hand pr` is write-once regardless of task lifecycle: a second, different URL is refused whether the task is open or terminal, and whether or not `--cross-repo` was used. | unit | `TestPRRecordsOnATerminalTaskWithoutReopening`, `TestPRCrossRepoWriteOnceRefusesASecondDifferentURL` |
 | INV-PR-4 | An attempt proven to have produced no committable work releases its worktree without a pull request, and the completion record never claims a merge for it, including across a retry. | unit | `TestTeardownReleasesADetachedWorktreeWithNoBranchAndNoLocalOnlyCommits`, `TestTeardownCircleClosesOnceHandPRRecordsTheEvidenceItAsksFor` |
+| INV-PR-5 | A PR whose repo is neither the project's own nor its declared upstream is refused unless `--cross-repo` is passed, regardless of whether the project declares an upstream at all. | unit | `TestPRRefusesWhenRepoMismatch`, `TestPRRefusesSiblingRepoWithoutCrossRepoFlagAndNamesTheRealEscape` |
+| INV-PR-6 | `--cross-repo` requires `--reason`, and `--reason` is refused without `--cross-repo`: neither is accepted alone. | unit | `TestPRCrossRepoWithoutReasonRefused`, `TestPRReasonWithoutCrossRepoRefused` |
+| INV-PR-7 | `--cross-repo` waives only the repo-match check: the PR still has to exist and be observable on GitHub before it is recorded. | unit | `TestPRCrossRepoStillRefusesAPRThatDoesNotExistOnGitHub` |
+| INV-PR-8 | A fork project's declared-upstream PR is recorded unaffected by the `--cross-repo` opt-in's existence: `hand project upstream` still means what it means, and fork PR resolution is untouched. | unit | `TestPRAcceptsTheDeclaredUpstreamAndStillRefusesAnyOtherRepo` |
+| INV-PR-9 | A PR recorded through `--cross-repo` is distinguishable from a same-repo PR on every surface `hand status` renders a PR through: the `pr` field, the `flags` cell, and `--json`. | unit | `TestStatusRendersCrossRepoPRDistinctlyEverywhere` |
+| INV-PR-10 | Neither `hand pr`'s own branch-based re-detection nor the watcher's auto-recording from a worker's report line ever records a PR cross-repo: the opt-in is asserted only through `hand pr`'s explicit flag. | unit | `TestDetectPRSearchesRenamedRepositoryAfterProjectSetURL` |
 
 ## Output rendering
 

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -11,10 +11,10 @@ import (
 	"github.com/atqamz/hand/internal/state"
 )
 
-// ValidatePR is the single gate every PR URL passes before it is recorded on a task, from
-// `hand pr` or from the watcher auto-recording one a worker embedded in a report line. A
-// recorded PR feeds `gh pr merge` directly, so a foreign repo must never reach task state.
-func ValidatePR(ctx context.Context, homeDir string, p Project, url string) error {
+// ValidatePR is the single gate every PR URL passes before it is recorded on a task. A recorded
+// PR feeds `gh pr merge` directly, so a foreign repo must never reach task state unless crossRepo
+// is true - hand pr's --cross-repo opt-in (atqamz/hand#423), asserted only by an operator.
+func ValidatePR(ctx context.Context, homeDir string, p Project, url string, crossRepo bool) error {
 	repoSlug, err := RepoSlug(homeDir, p)
 	if err != nil {
 		return err
@@ -24,17 +24,15 @@ func ValidatePR(ctx context.Context, homeDir string, p Project, url string) erro
 		return fmt.Errorf("invalid PR URL %q", url)
 	}
 	// urlSlug is never empty here, so an undeclared upstream cannot match it. EqualFold, not
-	// ==: a GitHub slug is unique only up to casing, so folding cannot admit a foreign repo,
-	// while == refuses a landed PR whose canonical casing differs from either declared one.
-	if !strings.EqualFold(urlSlug, repoSlug) && !strings.EqualFold(urlSlug, p.Upstream) {
-		// A fork contribution opens its PR on the declared upstream rather than on the repo hand
-		// pushes to, so p.Upstream passes too - but only because an operator declared it (hand
-		// project upstream), never because the URL's repo looks related to the project's own.
-		return fmt.Errorf("PR %s belongs to %s, not project %s's repo (%s)%s", url, urlSlug, p.Name, repoSlug, upstreamNote(p))
+	// ==: a GitHub slug is unique only up to casing, so folding cannot admit a foreign repo.
+	// crossRepo waives exactly this one check, never the observation below.
+	if !crossRepo && !strings.EqualFold(urlSlug, repoSlug) && !strings.EqualFold(urlSlug, p.Upstream) {
+		// p.Upstream passes too - but only because an operator declared it (hand project
+		// upstream), never because the URL's repo looks related to the project's own.
+		return fmt.Errorf("PR %s belongs to %s, not project %s's repo (%s)%s", url, urlSlug, p.Name, repoSlug, crossRepoNote(p))
 	}
-	// Absence refuses because the PR is not there; an observation that did not complete refuses
-	// too, but must never claim absence: an auth failure reporting "not found" would tell an
-	// operator to fix a URL that was right all along.
+	// An observation that did not complete refuses too, but must never claim absence: an auth
+	// failure reporting "not found" would tell an operator to fix a URL that was right all along.
 	observation := ghutil.ObserveMergeState(ctx, url)
 	if observation.Absent() {
 		return fmt.Errorf("PR %s not found in %s", url, urlSlug)
@@ -45,14 +43,14 @@ func ValidatePR(ctx context.Context, homeDir string, p Project, url string) erro
 	return nil
 }
 
-// Names the declared upstream in a refusal, and its absence in one for a project that has
-// none: an operator whose fork contribution was refused has to tell "the upstream I declared
-// is a different repo" from "this project declares no upstream at all", which is the remedy.
-func upstreamNote(p Project) string {
+// Names the real escapes for a repo mismatch: the declared upstream, when there is one, and
+// --cross-repo/--reason always. atqamz/hand#423: declaring an upstream used to be offered even
+// where doing so would write false topology, so it is named only when one is already declared.
+func crossRepoNote(p Project) string {
 	if p.Upstream == "" {
-		return " and no upstream is declared for it"
+		return "; pass --cross-repo with --reason on `hand pr` if this is a deliberate delivery elsewhere"
 	}
-	return fmt.Sprintf(" or its declared upstream (%s)", p.Upstream)
+	return fmt.Sprintf(" or its declared upstream (%s); pass --cross-repo with --reason on `hand pr` if this is a deliberate delivery elsewhere", p.Upstream)
 }
 
 // RepoSlug derives "owner/repo" from the project clone's own origin remote

--- a/internal/runtime/pr.go
+++ b/internal/runtime/pr.go
@@ -21,7 +21,10 @@ func DetectPR(ctx context.Context, homeDir string, task state.Task, active state
 	if observation.Merged {
 		task.MergeAnnounced = true
 	}
-	updated, _, err := RecordPR(ctx, homeDir, task, observation.URL)
+	// Never crossRepo: re-detection follows the branch hand itself pushed, so anything it finds
+	// already belongs to the project's own repo or its declared upstream (atqamz/hand#423 is
+	// asserted only through hand pr's explicit opt-in, never discovered here).
+	updated, _, err := RecordPR(ctx, homeDir, task, observation.URL, false, "")
 	if err != nil {
 		return task, observation, err
 	}
@@ -90,9 +93,14 @@ func observeDetachedHeadAbsence(worktreePath string) (observation ghutil.PRObser
 	}}, true
 }
 
-func RecordPR(ctx context.Context, homeDir string, task state.Task, url string) (state.Task, bool, error) {
+// crossRepo is hand pr's --cross-repo opt-in (atqamz/hand#423). reason is required whenever
+// crossRepo is true - an unexplained cross-repo record could never be reconstructed later.
+func RecordPR(ctx context.Context, homeDir string, task state.Task, url string, crossRepo bool, reason string) (state.Task, bool, error) {
 	if !state.ValidatePRURL(url) {
 		return task, false, Usage(fmt.Errorf("invalid PR URL %q: must match https://github.com/<owner>/<repo>/pull/<number>", url))
+	}
+	if crossRepo && reason == "" {
+		return task, false, Usage(fmt.Errorf("--cross-repo requires --reason describing the deliberate delivery elsewhere"))
 	}
 	if task.PR != "" && task.PR != url {
 		return task, false, Precondition(fmt.Errorf("task %s already has a different PR recorded: %s", task.ID, task.PR))
@@ -112,10 +120,15 @@ func RecordPR(ctx context.Context, homeDir string, task state.Task, url string) 
 	}
 	ghCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if err := project.ValidatePR(ghCtx, homeDir, projectInfo, url); err != nil {
+	if err := project.ValidatePR(ghCtx, homeDir, projectInfo, url, crossRepo); err != nil {
 		return task, false, Precondition(err)
 	}
-	if err := state.SetTaskPR(homeDir, task.ID, url); err != nil {
+	if crossRepo {
+		if err := state.SetTaskPRCrossRepo(homeDir, task.ID, url, reason); err != nil {
+			return task, false, fmt.Errorf("write task state: %w", err)
+		}
+		task.PRCrossRepoReason = reason
+	} else if err := state.SetTaskPR(homeDir, task.ID, url); err != nil {
 		return task, false, fmt.Errorf("write task state: %w", err)
 	}
 	task.PR = url

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -335,7 +335,7 @@ func TestTeardownCircleClosesOnceHandPRRecordsTheEvidenceItAsksFor(t *testing.T)
 	if task.Lifecycle != state.TaskTerminal {
 		t.Fatalf("task.Lifecycle = %q, want it already terminal - that is the deadlock's shape", task.Lifecycle)
 	}
-	if _, _, err := RecordPR(context.Background(), home, task, pr); err != nil {
+	if _, _, err := RecordPR(context.Background(), home, task, pr, false, ""); err != nil {
 		t.Fatalf("hand pr refused a terminal task: %v", err)
 	}
 

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -322,6 +322,15 @@ func SetTaskPR(homeDir, id, pr string) error {
 	return db.SetTaskPR(id, pr)
 }
 
+func SetTaskPRCrossRepo(homeDir, id, pr, reason string) error {
+	db, err := store.Open(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.SetTaskPRCrossRepo(id, pr, reason)
+}
+
 func SetTaskKind(homeDir, id, kind string) error {
 	db, err := store.Open(homeDir)
 	if err != nil {

--- a/internal/store/schemaversion.go
+++ b/internal/store/schemaversion.go
@@ -161,6 +161,10 @@ var migrations = []string{
 	// already carries the column, so a plain ALTER TABLE would fail wherever a test or a home
 	// builds its fixture from the current schema before stamping an older version onto it.
 	`SELECT 1;`,
+	// ensureTaskPRCrossRepoReasonColumn does the real work below, for the same reason: the base
+	// schema already carries the column, so a plain ALTER TABLE would fail wherever a test or a
+	// home builds its fixture from the current schema before stamping an older version onto it.
+	`SELECT 1;`,
 }
 
 // The version whose migration splits task from attempt. A database already carrying that
@@ -197,6 +201,11 @@ const projectIdentityVersion = fleetIdentityVersion + 1
 // The version whose migration adds attempt.brief_digest, recorded at attempt launch so promote can
 // tell a rewritten ship brief from the scout brief attempt 1 ran against (atqamz/hand#448).
 const briefDigestVersion = projectIdentityVersion + 1
+
+// The version whose migration adds task.pr_cross_repo_reason, carrying the required reason behind
+// hand pr's --cross-repo opt-in (atqamz/hand#423): recording a PR in a repository other than the
+// project's own or its declared upstream.
+const crossRepoPRVersion = briefDigestVersion + 1
 
 // Reports whether the task table already carries the split layout. The attempt table cannot
 // answer this: createSchema builds it on every home before any migration runs, while an
@@ -522,6 +531,11 @@ func (db *DB) applyMigration(version int) error {
 			return err
 		}
 	}
+	if version == crossRepoPRVersion-1 {
+		if err := ensureTaskPRCrossRepoReasonColumn(tx); err != nil {
+			return err
+		}
+	}
 	if err := recordSchemaVersion(tx, version+1); err != nil {
 		return err
 	}
@@ -597,6 +611,20 @@ func ensureAttemptBriefDigestColumn(tx *sql.Tx) error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE attempt ADD COLUMN brief_digest TEXT NOT NULL DEFAULT ''`); err != nil {
 		return fmt.Errorf("add attempt brief_digest column: %w", err)
+	}
+	return nil
+}
+
+func ensureTaskPRCrossRepoReasonColumn(tx *sql.Tx) error {
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task') WHERE name = 'pr_cross_repo_reason'`).Scan(&count); err != nil {
+		return fmt.Errorf("inspect task pr_cross_repo_reason column: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+	if _, err := tx.Exec(`ALTER TABLE task ADD COLUMN pr_cross_repo_reason TEXT NOT NULL DEFAULT ''`); err != nil {
+		return fmt.Errorf("add task pr_cross_repo_reason column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -137,25 +137,29 @@ type Task struct {
 	// Project is the live display name resolved through ProjectID, falling back to the name the
 	// row was written with once no registered project carries that identity any more. ProjectID
 	// is the durable identity: renaming a project never rewrites it (atqamz/hand#388).
-	Project          string        `json:"project"`
-	ProjectID        string        `json:"project_id"`
-	Kind             string        `json:"kind"`
-	Brief            string        `json:"brief"`
-	Lifecycle        TaskLifecycle `json:"lifecycle"`
-	ActiveAttemptID  int64         `json:"active_attempt_id"`
-	PR               string        `json:"pr"`
-	MergeExecuted    bool          `json:"merged"`
-	MergeExecutedAt  string        `json:"merged_at"`
-	ReportOffset     int64         `json:"report_offset"`
-	ReportDigest     string        `json:"report_digest"`
-	MergeAnnounced   bool          `json:"pr_merged_observed"`
-	DeliveredAt      string        `json:"delivered_at"`
-	DeliveredReason  string        `json:"delivered_reason"`
-	CreatedAt        string        `json:"created_at"`
-	RepairCode       string        `json:"repair_code"`
-	RepairReason     string        `json:"repair_reason"`
-	RepairAttemptID  int64         `json:"repair_attempt_id"`
-	RepairObservedAt string        `json:"repair_observed_at"`
+	Project         string        `json:"project"`
+	ProjectID       string        `json:"project_id"`
+	Kind            string        `json:"kind"`
+	Brief           string        `json:"brief"`
+	Lifecycle       TaskLifecycle `json:"lifecycle"`
+	ActiveAttemptID int64         `json:"active_attempt_id"`
+	PR              string        `json:"pr"`
+	// Set only through hand pr's --cross-repo opt-in (atqamz/hand#423): empty for every PR recorded
+	// against the project's own repo or its declared upstream, so its mere presence already marks
+	// the record as a deliberate delivery elsewhere, with no separate boolean to drift out of sync.
+	PRCrossRepoReason string `json:"pr_cross_repo_reason"`
+	MergeExecuted     bool   `json:"merged"`
+	MergeExecutedAt   string `json:"merged_at"`
+	ReportOffset      int64  `json:"report_offset"`
+	ReportDigest      string `json:"report_digest"`
+	MergeAnnounced    bool   `json:"pr_merged_observed"`
+	DeliveredAt       string `json:"delivered_at"`
+	DeliveredReason   string `json:"delivered_reason"`
+	CreatedAt         string `json:"created_at"`
+	RepairCode        string `json:"repair_code"`
+	RepairReason      string `json:"repair_reason"`
+	RepairAttemptID   int64  `json:"repair_attempt_id"`
+	RepairObservedAt  string `json:"repair_observed_at"`
 	// A supervisor's own act, distinct from report_offset/report_digest which record what a watcher has
 	// announced: atqamz/hand#267 keeps the two markers apart because they answer different questions.
 	AcknowledgedAt     string `json:"acknowledged_at"`
@@ -290,6 +294,7 @@ CREATE TABLE IF NOT EXISTS task (
 	lifecycle         TEXT NOT NULL DEFAULT 'open' CHECK (lifecycle IN ('open', 'terminal')),
 	active_attempt_id INTEGER REFERENCES attempt(id),
 	pr                TEXT NOT NULL DEFAULT '',
+	pr_cross_repo_reason TEXT NOT NULL DEFAULT '',
 	merge_executed    INTEGER NOT NULL DEFAULT 0,
 	merge_executed_at TEXT NOT NULL DEFAULT '',
 	merge_announced   INTEGER NOT NULL DEFAULT 0,
@@ -598,6 +603,9 @@ func ReadTaskHistoryReadOnly(homeDir, id string) (TaskHistory, bool, error) {
 	if current == len(migrations) {
 		return db.ReadTaskHistory(id)
 	}
+	if current == briefDigestVersion {
+		return db.readTaskHistoryBeforeCrossRepoReason(id)
+	}
 	if current == projectIdentityVersion {
 		return db.readTaskHistoryBeforeBriefDigest(id)
 	}
@@ -671,7 +679,12 @@ var taskColumnNamesBeforeProjectIdentity = []string{
 	"acknowledged_at", "acknowledged_reason", "acknowledged_offset", "acknowledged_digest",
 }
 
-var taskColumnNames = append(append([]string{}, taskColumnNamesBeforeProjectIdentity...), "project_id")
+// The layout every schema before crossRepoPRVersion stored: pr_cross_repo_reason is appended after
+// project_id, the tail every migration since projectIdentityVersion has grown from, rather than
+// slotted beside pr.
+var taskColumnNamesBeforeCrossRepoReason = append(append([]string{}, taskColumnNamesBeforeProjectIdentity...), "project_id")
+
+var taskColumnNames = append(append([]string{}, taskColumnNamesBeforeCrossRepoReason...), "pr_cross_repo_reason")
 
 var taskColumns = strings.Join(taskColumnNames, ", ")
 
@@ -684,13 +697,18 @@ var taskColumnsBeforeAcknowledgement = strings.Join(taskColumnNamesBeforeProject
 // A task's project name is no longer stored live: rename updates the one project row and
 // nothing else, so every current-schema read resolves the label through the identity and
 // keeps the stored name only as the fallback for a project that is no longer registered.
-var taskSelectColumns = taskSelectList()
+var taskSelectColumns = taskSelectList(taskColumnNames)
+
+// What a database at projectIdentityVersion or briefDigestVersion carries: the project-identity
+// join already applies, but pr_cross_repo_reason does not exist yet on the task table
+// (crossRepoPRVersion added it, atqamz/hand#423).
+var taskSelectColumnsBeforeCrossRepoReason = taskSelectList(taskColumnNamesBeforeCrossRepoReason)
 
 const taskSelectFrom = ` FROM task LEFT JOIN project ON project.id = task.project_id`
 
-func taskSelectList() string {
-	columns := make([]string, 0, len(taskColumnNames))
-	for _, name := range taskColumnNames {
+func taskSelectList(names []string) string {
+	columns := make([]string, 0, len(names))
+	for _, name := range names {
 		if name == "project" {
 			columns = append(columns, "COALESCE(project.name, task.project)")
 			continue
@@ -732,7 +750,7 @@ func taskValues(t Task) []any {
 	return []any{t.ID, t.Project, t.Kind, t.Brief, t.Lifecycle, nullableAttemptID(t.ActiveAttemptID), t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
 		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt,
-		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.ProjectID}
+		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.ProjectID, t.PRCrossRepoReason}
 }
 
 // A caller names the project it is dispatching into; the identity behind that name is looked up
@@ -764,6 +782,24 @@ func nullableAttemptID(id int64) any {
 }
 
 func scanTask(row interface{ Scan(...any) error }) (Task, error) {
+	var t Task
+	var activeID sql.NullInt64
+	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
+		&t.MergeExecuted, &t.MergeExecutedAt, &t.MergeAnnounced, &t.DeliveredAt, &t.DeliveredReason,
+		&t.ReportOffset, &t.ReportDigest, &t.CreatedAt, &t.RepairCode, &t.RepairReason, &t.RepairAttemptID, &t.RepairObservedAt,
+		&t.AcknowledgedAt, &t.AcknowledgedReason, &t.AcknowledgedOffset, &t.AcknowledgedDigest, &t.ProjectID, &t.PRCrossRepoReason)
+	if activeID.Valid {
+		t.ActiveAttemptID = activeID.Int64
+	}
+	if t.Lifecycle == "" {
+		t.Lifecycle = TaskOpen
+	}
+	return t, err
+}
+
+// Reads a task row from a database migrated no further than projectIdentityVersion or
+// briefDigestVersion, one version behind pr_cross_repo_reason (crossRepoPRVersion, atqamz/hand#423).
+func scanTaskBeforeCrossRepoReason(row interface{ Scan(...any) error }) (Task, error) {
 	var t Task
 	var activeID sql.NullInt64
 	err := row.Scan(&t.ID, &t.Project, &t.Kind, &t.Brief, &t.Lifecycle, &activeID, &t.PR,
@@ -923,11 +959,11 @@ func (db *DB) UpdateTask(t Task) error {
 	_, err := db.sql.Exec(`UPDATE task SET project = ?, kind = ?, brief = ?,
 		pr = ?, merge_executed = ?, merge_executed_at = ?, merge_announced = ?, delivered_at = ?, delivered_reason = ?,
 		report_offset = ?, report_digest = ?, created_at = ?, repair_code = ?, repair_reason = ?, repair_attempt_id = ?, repair_observed_at = ?,
-		acknowledged_at = ?, acknowledged_reason = ?, acknowledged_offset = ?, acknowledged_digest = ? WHERE id = ?`,
+		acknowledged_at = ?, acknowledged_reason = ?, acknowledged_offset = ?, acknowledged_digest = ?, pr_cross_repo_reason = ? WHERE id = ?`,
 		t.Project, t.Kind, t.Brief, t.PR,
 		t.MergeExecuted, t.MergeExecutedAt, t.MergeAnnounced, t.DeliveredAt, t.DeliveredReason,
 		t.ReportOffset, t.ReportDigest, t.CreatedAt, t.RepairCode, t.RepairReason, t.RepairAttemptID, t.RepairObservedAt,
-		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.ID)
+		t.AcknowledgedAt, t.AcknowledgedReason, t.AcknowledgedOffset, t.AcknowledgedDigest, t.PRCrossRepoReason, t.ID)
 	if err != nil {
 		return fmt.Errorf("update task %q: %w", t.ID, err)
 	}
@@ -1009,14 +1045,14 @@ func (db *DB) readTaskHistoryBeforeProjectIdentity(id string) (TaskHistory, bool
 	return history, true, nil
 }
 
-// A database at projectIdentityVersion has every task column current, since briefDigestVersion
-// touches only the attempt table, so only the attempt side falls back to the pre-digest reader.
+// A database at projectIdentityVersion has neither the attempt table's brief_digest nor the task
+// table's pr_cross_repo_reason yet, so both sides fall back to their pre-current readers.
 func (db *DB) readTaskHistoryBeforeBriefDigest(id string) (TaskHistory, bool, error) {
 	if db.empty {
 		return TaskHistory{}, false, nil
 	}
-	row := db.sql.QueryRow(`SELECT `+taskSelectColumns+taskSelectFrom+` WHERE task.id = ?`, id)
-	task, err := scanTask(row)
+	row := db.sql.QueryRow(`SELECT `+taskSelectColumnsBeforeCrossRepoReason+taskSelectFrom+` WHERE task.id = ?`, id)
+	task, err := scanTaskBeforeCrossRepoReason(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return TaskHistory{}, false, nil
 	}
@@ -1024,6 +1060,38 @@ func (db *DB) readTaskHistoryBeforeBriefDigest(id string) (TaskHistory, bool, er
 		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
 	}
 	attempts, err := db.listAttemptsBeforeBriefDigest(id)
+	if err != nil {
+		return TaskHistory{}, false, err
+	}
+	history := TaskHistory{Task: task, Attempts: attempts}
+	for i := range attempts {
+		if attempts[i].ID == task.ActiveAttemptID {
+			history.ActiveAttempt = &attempts[i]
+			break
+		}
+	}
+	if task.ActiveAttemptID != 0 && history.ActiveAttempt == nil {
+		return TaskHistory{}, false, fmt.Errorf("read task history %q: active attempt %d not found", id, task.ActiveAttemptID)
+	}
+	return history, true, nil
+}
+
+// A database at briefDigestVersion has the attempt table's brief_digest already but not yet the
+// task table's pr_cross_repo_reason (crossRepoPRVersion, atqamz/hand#423), so only the task side
+// falls back to the pre-cross-repo reader.
+func (db *DB) readTaskHistoryBeforeCrossRepoReason(id string) (TaskHistory, bool, error) {
+	if db.empty {
+		return TaskHistory{}, false, nil
+	}
+	row := db.sql.QueryRow(`SELECT `+taskSelectColumnsBeforeCrossRepoReason+taskSelectFrom+` WHERE task.id = ?`, id)
+	task, err := scanTaskBeforeCrossRepoReason(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TaskHistory{}, false, nil
+	}
+	if err != nil {
+		return TaskHistory{}, false, fmt.Errorf("read task %q: %w", id, err)
+	}
+	attempts, err := db.ListAttempts(id)
 	if err != nil {
 		return TaskHistory{}, false, err
 	}
@@ -1367,6 +1435,9 @@ func ListReconciliationHistoriesReadOnly(homeDir string) ([]TaskHistory, error) 
 	if current == projectIdentityVersion {
 		return db.listReconciliationHistoriesBeforeBriefDigest()
 	}
+	if current == briefDigestVersion {
+		return db.listReconciliationHistoriesBeforeCrossRepoReason()
+	}
 	return db.ListReconciliationHistories()
 }
 
@@ -1421,12 +1492,13 @@ func (db *DB) listReconciliationHistoriesBeforeProjectIdentity() ([]TaskHistory,
 }
 
 // The reconciliation-listing counterpart to readTaskHistoryBeforeBriefDigest: projectIdentityVersion
-// predates attempt.brief_digest, so its attempt side stays on the pre-digest reader.
+// predates both attempt.brief_digest and task.pr_cross_repo_reason, so both sides stay on their
+// pre-current readers.
 func (db *DB) listReconciliationHistoriesBeforeBriefDigest() ([]TaskHistory, error) {
 	if db.empty {
 		return nil, nil
 	}
-	rows, err := db.sql.Query(`SELECT ` + taskSelectColumns + taskSelectFrom + ` WHERE task.lifecycle = 'open' OR task.repair_code <> '' OR EXISTS (
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumnsBeforeCrossRepoReason + taskSelectFrom + ` WHERE task.lifecycle = 'open' OR task.repair_code <> '' OR EXISTS (
 		SELECT 1 FROM attempt
 		WHERE attempt.task_id = task.id
 		AND attempt.lifecycle NOT IN ('provisioning', 'running')
@@ -1442,7 +1514,7 @@ func (db *DB) listReconciliationHistoriesBeforeBriefDigest() ([]TaskHistory, err
 	defer func() { _ = rows.Close() }()
 	var histories []TaskHistory
 	for rows.Next() {
-		task, err := scanTask(rows)
+		task, err := scanTaskBeforeCrossRepoReason(rows)
 		if err != nil {
 			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
 		}
@@ -1453,6 +1525,57 @@ func (db *DB) listReconciliationHistoriesBeforeBriefDigest() ([]TaskHistory, err
 	}
 	for i := range histories {
 		attempts, err := db.listAttemptsBeforeBriefDigest(histories[i].Task.ID)
+		if err != nil {
+			return nil, err
+		}
+		histories[i].Attempts = attempts
+		for j := range attempts {
+			if attempts[j].ID == histories[i].Task.ActiveAttemptID {
+				histories[i].ActiveAttempt = &histories[i].Attempts[j]
+				break
+			}
+		}
+		if histories[i].Task.ActiveAttemptID != 0 && histories[i].ActiveAttempt == nil {
+			return nil, fmt.Errorf("task %q active attempt %d not found", histories[i].Task.ID, histories[i].Task.ActiveAttemptID)
+		}
+	}
+	return histories, nil
+}
+
+// The reconciliation-listing counterpart to readTaskHistoryBeforeCrossRepoReason: briefDigestVersion
+// has attempt.brief_digest already but not yet task.pr_cross_repo_reason (crossRepoPRVersion,
+// atqamz/hand#423), so only the task side falls back to the pre-cross-repo reader.
+func (db *DB) listReconciliationHistoriesBeforeCrossRepoReason() ([]TaskHistory, error) {
+	if db.empty {
+		return nil, nil
+	}
+	rows, err := db.sql.Query(`SELECT ` + taskSelectColumnsBeforeCrossRepoReason + taskSelectFrom + ` WHERE task.lifecycle = 'open' OR task.repair_code <> '' OR EXISTS (
+		SELECT 1 FROM attempt
+		WHERE attempt.task_id = task.id
+		AND attempt.lifecycle NOT IN ('provisioning', 'running')
+		AND (
+			(attempt.worktree <> '' AND attempt.teardown_worktree_state NOT IN ('released', 'abandoned'))
+			OR (attempt.herdr_workspace_id <> '' AND attempt.teardown_herdr_state <> 'released')
+			OR (attempt.teardown_completion_state <> '' AND attempt.teardown_completion_state <> 'appended')
+		)
+	) ORDER BY task.id`)
+	if err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var histories []TaskHistory
+	for rows.Next() {
+		task, err := scanTaskBeforeCrossRepoReason(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+		}
+		histories = append(histories, TaskHistory{Task: task})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list read-only reconciliation tasks: %w", err)
+	}
+	for i := range histories {
+		attempts, err := db.ListAttempts(histories[i].Task.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -2484,6 +2607,14 @@ func (db *DB) TerminalizeTaskAndAttempt(taskID string, attemptID int64, attemptF
 func (db *DB) SetTaskPR(id, pr string) error {
 	result, err := db.sql.Exec(`UPDATE task SET pr = ? WHERE id = ?`, pr, id)
 	return updateTaskFact(result, err, "set PR", id)
+}
+
+// SetTaskPRCrossRepo is SetTaskPR's counterpart for hand pr's --cross-repo opt-in (atqamz/hand#423):
+// it carries the required reason alongside the URL in the same write, so a cross-repo record can
+// never land with the URL set and the reason still empty.
+func (db *DB) SetTaskPRCrossRepo(id, pr, reason string) error {
+	result, err := db.sql.Exec(`UPDATE task SET pr = ?, pr_cross_repo_reason = ? WHERE id = ?`, pr, reason, id)
+	return updateTaskFact(result, err, "set cross-repo PR", id)
 }
 
 func (db *DB) SetTaskKind(id, kind string) error {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -882,7 +882,9 @@ func autoRecordPR(ctx context.Context, home string, t state.Task, url string) er
 
 	ghCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if err := project.ValidatePR(ghCtx, home, proj, url); err != nil {
+	// Never crossRepo: a cross-repo delivery is asserted by an operator through hand pr's
+	// --cross-repo opt-in, never discovered from a worker's report line (atqamz/hand#423).
+	if err := project.ValidatePR(ghCtx, home, proj, url, false); err != nil {
 		return err
 	}
 	return recordAutoPR(home, t.ID, url)

--- a/tests/e2e/pr_test.go
+++ b/tests/e2e/pr_test.go
@@ -70,3 +70,60 @@ func TestPRCommand(t *testing.T) {
 		t.Fatalf("task.PR = %q after refused overwrite, want the original %q untouched", task.PR, url)
 	}
 }
+
+// atqamz/hand#423: a PR delivered to a sibling repository is refused by default and recordable
+// only through the explicit --cross-repo opt-in, with a required --reason.
+func TestPRCommandCrossRepo(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "remote")
+	initGitRepo(t, remote)
+	redirectGitRemote(t, "https://github.com/yes2games/yes2infra.git", remote)
+
+	dir := binDir(t)
+	writeFakeTreehouse(t, dir, filepath.Join(t.TempDir(), "unused-worktree"))
+
+	home := newHome(t)
+	added := runHand(t, home, "project", "add", "https://github.com/yes2games/yes2infra.git", "--mode", "direct-pr")
+	if added.code != 0 {
+		t.Fatalf("project add: exit %d, stderr %q", added.code, added.stderr)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "yes2infra", Kind: state.KindShip, CreatedAt: now}, state.Attempt{Lifecycle: state.AttemptRunning})
+
+	siblingURL := "https://github.com/yes2games/butler/pull/92"
+	faketool.GH{PRs: []faketool.GHPR{{URL: siblingURL, State: "OPEN"}}}.Install(t, dir)
+
+	refused := runHand(t, home, "pr", "task-1", siblingURL)
+	assertInvocation(t, refused, 3, "--cross-repo")
+
+	missingReason := runHand(t, home, "pr", "task-1", "--cross-repo", siblingURL)
+	assertInvocation(t, missingReason, 2, "--reason")
+
+	reason := "component moved to yes2games/butler before the worker started"
+	recorded := runHand(t, home, "pr", "task-1", "--cross-repo", "--reason", reason, siblingURL)
+	if recorded.code != 0 {
+		t.Fatalf("cross-repo pr record: exit %d, stderr %q", recorded.code, recorded.stderr)
+	}
+	if !strings.Contains(recorded.stdout, "cross_repo_reason: "+reason+"\n") {
+		t.Fatalf("recorded stdout = %q, want the reason echoed back", recorded.stdout)
+	}
+
+	task, err := state.Read(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.PR != siblingURL {
+		t.Fatalf("task.PR = %q, want %q", task.PR, siblingURL)
+	}
+	if task.PRCrossRepoReason != reason {
+		t.Fatalf("task.PRCrossRepoReason = %q, want %q", task.PRCrossRepoReason, reason)
+	}
+
+	status := runHand(t, home, "status", "task-1")
+	if status.code != 0 {
+		t.Fatalf("status: exit %d, stderr %q", status.code, status.stderr)
+	}
+	if !strings.Contains(status.stdout, "cross-repo") {
+		t.Fatalf("status stdout = %q, want the cross-repo record visibly marked", status.stdout)
+	}
+}

--- a/tests/e2e/upstream_deliver_test.go
+++ b/tests/e2e/upstream_deliver_test.go
@@ -48,8 +48,9 @@ func TestForkContributionDeliveredNotLanded(t *testing.T) {
 
 	// The two refusals below are the point: hand pr rejects a repo nobody declared, and teardown rejects the
 	// still-open PR until the delivery is recorded. Reverting either half of the change turns one into a pass.
+	// atqamz/hand#423: the refusal offers --cross-repo now, not "declare an upstream" as the escape.
 	undeclared := runHand(t, home, "pr", "task-1", upstreamPR)
-	assertInvocation(t, undeclared, 3, "no upstream is declared for it")
+	assertInvocation(t, undeclared, 3, "--cross-repo")
 
 	declared := runHand(t, home, "project", "upstream", "no-mistakes", "kunchenguid/no-mistakes")
 	if declared.code != 0 {


### PR DESCRIPTION
## Summary

- `hand pr` gains an explicit `--cross-repo` flag paired with a required `--reason`, waiving exactly the repo-match check when a PR genuinely landed in a repository other than the project's own or its declared upstream - never by extending `hand project upstream`, which would write false fork topology into the registry.
- The reason lands in a new `task.pr_cross_repo_reason` column (empty for every ordinary PR), and `hand status` marks a cross-repo record distinctly wherever it renders a PR: the `pr` field, the fleet `flags` cell, and `--json`.
- Neither `hand pr`'s own branch-based re-detection nor the watcher's auto-recording from a worker's report line ever sets the opt-in - a cross-repo delivery is asserted by an operator, never discovered. See `docs/adr/cross-repo-pr-delivery-is-an-explicit-opt-in.md` for the full rationale and rejected alternatives.

Closes atqamz/hand#423

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
ok  	github.com/atqamz/hand/cmd	...
ok  	github.com/atqamz/hand/internal/project	...
ok  	github.com/atqamz/hand/internal/runtime	...
ok  	github.com/atqamz/hand/internal/store	...
ok  	github.com/atqamz/hand/internal/watcher	...
(all packages ok)

$ make e2e
ok  	github.com/atqamz/hand/tests/e2e	66.671s
```

Focused new/updated tests: `cmd/pr_test.go` (refusal names `--cross-repo`, both flags required together, cross-repo record + reason, existence check still enforced, write-once still holds, fork-upstream path unaffected), `cmd/status_test.go` (`TestStatusRendersCrossRepoPRDistinctlyEverywhere`), `tests/e2e/pr_test.go` (`TestPRCommandCrossRepo`), `tests/e2e/upstream_deliver_test.go` (updated refusal-text assertion).

Demonstrated both paths for real, in a scratch fleet home built in `/tmp` (not inside a Treehouse worktree, per atqamz/hand#413) against real GitHub state - project `yes2infra` and the real PR `yes2games/butler#92` from the motivating case:

```
$ hand pr butler-broker-allowlist-rujak-release https://github.com/yes2games/butler/pull/92
error: "PR https://github.com/yes2games/butler/pull/92 belongs to yes2games/butler, not project
        yes2infra's repo (yes2games/yes2infra); pass --cross-repo with --reason on `hand pr` if
        this is a deliberate delivery elsewhere"
kind: precondition
exit: 3

$ hand pr butler-broker-allowlist-rujak-release --cross-repo --reason "yes2infra#435 deleted
    pulumi/worker/config/broker.json and moved the Worker to yes2games/butler before this task
    started; the file, BrokerEntry shape and vitest gate moved verbatim (ADR-0015)" \
    https://github.com/yes2games/butler/pull/92
id: butler-broker-allowlist-rujak-release
result: recorded
pr: "https://github.com/yes2games/butler/pull/92"
cross_repo_reason: "yes2infra#435 deleted pulumi/worker/config/broker.json and moved the Worker
    to yes2games/butler before this task started; the file, BrokerEntry shape and vitest gate
    moved verbatim (ADR-0015)"

$ hand status
tasks[1]{id,state,reported,age,flags}:
  butler-broker-allowlist-rujak-release,unknown,none,just now,cross-repo
```

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->