### PR TITLE
fix(runtime): give the managed git a real, empty template directory

### DIFF
--- a/cmd/coreexec.go
+++ b/cmd/coreexec.go
@@ -9,15 +9,6 @@ import (
 	"github.com/atqamz/hand/internal/toolchain"
 )
 
-// Pointing Git at a real, empty template directory silences its "templates not found" warning
-// honestly (hand#464); a blank templateDir means hand could not create one, so args pass through.
-func gitArgsWithTemplate(templateDir string, args []string) []string {
-	if templateDir == "" {
-		return args
-	}
-	return append([]string{"-c", "init.templateDir=" + templateDir}, args...)
-}
-
 func managedCommandFailure(output []byte, err error) string {
 	message := strings.TrimSpace(string(output))
 	if message != "" {
@@ -39,7 +30,7 @@ func runManagedCore(ctx context.Context, name, dir string, args ...string) ([]by
 	switch name {
 	case "git":
 		path = managed.GitPath
-		args = gitArgsWithTemplate(managed.GitTemplateDir, args)
+		args = toolchain.GitArgsWithTemplate(managed.GitTemplateDir, args)
 	case "treehouse":
 		path = managed.TreehousePath
 	default:

--- a/cmd/coreexec.go
+++ b/cmd/coreexec.go
@@ -9,6 +9,15 @@ import (
 	"github.com/atqamz/hand/internal/toolchain"
 )
 
+// Pointing Git at a real, empty template directory silences its "templates not found" warning
+// honestly (hand#464); a blank templateDir means hand could not create one, so args pass through.
+func gitArgsWithTemplate(templateDir string, args []string) []string {
+	if templateDir == "" {
+		return args
+	}
+	return append([]string{"-c", "init.templateDir=" + templateDir}, args...)
+}
+
 func managedCommandFailure(output []byte, err error) string {
 	message := strings.TrimSpace(string(output))
 	if message != "" {
@@ -30,6 +39,7 @@ func runManagedCore(ctx context.Context, name, dir string, args ...string) ([]by
 	switch name {
 	case "git":
 		path = managed.GitPath
+		args = gitArgsWithTemplate(managed.GitTemplateDir, args)
 	case "treehouse":
 		path = managed.TreehousePath
 	default:

--- a/cmd/coreexec_test.go
+++ b/cmd/coreexec_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGitArgsWithTemplatePrependsInitTemplateDir(t *testing.T) {
+	got := gitArgsWithTemplate("/fake/git-templates", []string{"clone", "--no-local", "src", "dst"})
+	want := []string{"-c", "init.templateDir=/fake/git-templates", "clone", "--no-local", "src", "dst"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gitArgsWithTemplate() = %v, want %v", got, want)
+	}
+}
+
+func TestGitArgsWithTemplateLeavesArgsUnchangedWhenNoDirectory(t *testing.T) {
+	args := []string{"init", "--initial-branch=main", "path"}
+	got := gitArgsWithTemplate("", args)
+	if !reflect.DeepEqual(got, args) {
+		t.Fatalf("gitArgsWithTemplate() = %v, want %v unchanged", got, args)
+	}
+}

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -292,14 +292,17 @@ reconcile), `cmd/doctor.go`.
 
 ## Runtime transport readiness
 
-Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`), `cmd/doctor.go`,
-`cmd/runtime.go`, `cmd/project.go` (`gitClone`, `diagnoseCloneFailure`).
+Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`, `Store.runtimeFromCurrent`),
+`cmd/doctor.go`, `cmd/runtime.go`, `cmd/coreexec.go` (`gitArgsWithTemplate`), `cmd/project.go` (`gitClone`,
+`diagnoseCloneFailure`).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
 | INV-RTGIT-1 | A runtime's `git_https_ready` reflects whether `git-remote-https` is present next to the installed git binary, observed from the bundle on disk rather than assumed from the runtime id or version - for a fake bundle with and without the helper. | unit | `TestStatusObservesInstalledRemoteHelperRatherThanRuntimeID` |
 | INV-RTGIT-2 | A bundle missing the https helper is reported as a warning naming the ssh treatment, and never joins `hand doctor`'s blocking list or flips `runtime_ready` - only a runtime that fails its own integrity checks does that. | unit | `TestRuntimeHTTPSFindingsNamesTheSSHTreatmentWithoutJoiningBlocking` |
 | INV-RTGIT-3 | `hand project add` replaces git's own "remote-\<scheme\>' is not a git command" text with the named runtime defect and the ssh treatment; any other git failure, including one a source rewritten by git config resolves without an external helper, passes through unchanged. | unit | `TestDiagnoseCloneFailureNamesMissingHelperInsteadOfPassingGitTextThrough`, `TestDiagnoseCloneFailureReadsTheSchemeFromGitsOwnText`, `TestDiagnoseCloneFailureLeavesUnrelatedGitErrorsUnchanged` |
+| INV-RTGIT-4 | A selected runtime's `GitTemplateDir` names a directory hand has actually created on disk, under the store root, containing nothing - because the pinned bundle ships no templates for it to seed (hand#464), so pointing Git at real emptiness is honest, not hidden. | unit | `TestSelectedRuntimeCarriesAnExistingEmptyGitTemplateDirectory` |
+| INV-RTGIT-5 | Every managed `git` invocation gets `-c init.templateDir=<GitTemplateDir>` prepended ahead of its own arguments when that directory exists, and is left unchanged when it does not - never by matching or filtering Git's warning text. | unit | `TestGitArgsWithTemplatePrependsInitTemplateDir`, `TestGitArgsWithTemplateLeavesArgsUnchangedWhenNoDirectory` |
 
 ## Pure helpers
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -292,9 +292,9 @@ reconcile), `cmd/doctor.go`.
 
 ## Runtime transport readiness
 
-Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`, `Store.runtimeFromCurrent`),
-`cmd/doctor.go`, `cmd/runtime.go`, `cmd/coreexec.go` (`gitArgsWithTemplate`), `cmd/project.go` (`gitClone`,
-`diagnoseCloneFailure`).
+Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`, `Store.runtimeFromCurrent`,
+`GitArgsWithTemplate`), `cmd/doctor.go`, `cmd/runtime.go`, `cmd/coreexec.go`, `internal/worktree/worktree.go`
+(`runCore`), `cmd/project.go` (`gitClone`, `diagnoseCloneFailure`).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -302,7 +302,7 @@ Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`, `S
 | INV-RTGIT-2 | A bundle missing the https helper is reported as a warning naming the ssh treatment, and never joins `hand doctor`'s blocking list or flips `runtime_ready` - only a runtime that fails its own integrity checks does that. | unit | `TestRuntimeHTTPSFindingsNamesTheSSHTreatmentWithoutJoiningBlocking` |
 | INV-RTGIT-3 | `hand project add` replaces git's own "remote-\<scheme\>' is not a git command" text with the named runtime defect and the ssh treatment; any other git failure, including one a source rewritten by git config resolves without an external helper, passes through unchanged. | unit | `TestDiagnoseCloneFailureNamesMissingHelperInsteadOfPassingGitTextThrough`, `TestDiagnoseCloneFailureReadsTheSchemeFromGitsOwnText`, `TestDiagnoseCloneFailureLeavesUnrelatedGitErrorsUnchanged` |
 | INV-RTGIT-4 | A selected runtime's `GitTemplateDir` names a directory hand has actually created on disk, under the store root, containing nothing - because the pinned bundle ships no templates for it to seed (hand#464), so pointing Git at real emptiness is honest, not hidden. | unit | `TestSelectedRuntimeCarriesAnExistingEmptyGitTemplateDirectory` |
-| INV-RTGIT-5 | Every managed `git` invocation gets `-c init.templateDir=<GitTemplateDir>` prepended ahead of its own arguments when that directory exists, and is left unchanged when it does not - never by matching or filtering Git's warning text. | unit | `TestGitArgsWithTemplatePrependsInitTemplateDir`, `TestGitArgsWithTemplateLeavesArgsUnchangedWhenNoDirectory` |
+| INV-RTGIT-5 | Every managed `git` dispatch - `cmd/coreexec.go`'s `runManagedCore` and `internal/worktree/worktree.go`'s `runCore` alike - gets `-c init.templateDir=<GitTemplateDir>` prepended ahead of its own arguments when that directory exists, and is left unchanged when it does not, via the one shared `toolchain.GitArgsWithTemplate` - never by matching or filtering Git's warning text. | unit | `TestGitArgsWithTemplatePrependsInitTemplateDir`, `TestGitArgsWithTemplateLeavesArgsUnchangedWhenNoDirectory` |
 
 ## Pure helpers
 

--- a/internal/toolchain/executor.go
+++ b/internal/toolchain/executor.go
@@ -124,6 +124,10 @@ type Runtime struct {
 	HerdrPath        string
 	HerdrVersion     string
 	GitBin           string
+	// GitTemplateDir is an empty directory hand ensures exists, since the bundle ships no
+	// share/git-core/templates of its own (hand#464). Empty when hand could not create it -
+	// callers treat that as "no template arg to add", not a readiness failure.
+	GitTemplateDir string
 }
 
 func (r Runtime) Process(path string, args ...string) (ProcessSpec, error) {

--- a/internal/toolchain/executor.go
+++ b/internal/toolchain/executor.go
@@ -141,6 +141,16 @@ func (r Runtime) Process(path string, args ...string) (ProcessSpec, error) {
 	return NewProcessSpec(path, args, env)
 }
 
+// GitArgsWithTemplate points a managed git invocation at an existing, empty template directory
+// (hand#464), the one answer every dispatch site shares for what a managed git run carries. A
+// blank templateDir means hand could not create one, so args pass through unchanged.
+func GitArgsWithTemplate(templateDir string, args []string) []string {
+	if templateDir == "" {
+		return args
+	}
+	return append([]string{"-c", "init.templateDir=" + templateDir}, args...)
+}
+
 // SupportsGitTransport reports whether the runtime's Git carries the external remote helper a
 // URL scheme needs, observed as git-remote-<scheme> next to the managed git binary rather than
 // assumed from the runtime id or version (hand#440); ssh, git, and file need no helper.

--- a/internal/toolchain/executor_test.go
+++ b/internal/toolchain/executor_test.go
@@ -1,4 +1,4 @@
-package cmd
+package toolchain
 
 import (
 	"reflect"
@@ -6,17 +6,17 @@ import (
 )
 
 func TestGitArgsWithTemplatePrependsInitTemplateDir(t *testing.T) {
-	got := gitArgsWithTemplate("/fake/git-templates", []string{"clone", "--no-local", "src", "dst"})
+	got := GitArgsWithTemplate("/fake/git-templates", []string{"clone", "--no-local", "src", "dst"})
 	want := []string{"-c", "init.templateDir=/fake/git-templates", "clone", "--no-local", "src", "dst"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("gitArgsWithTemplate() = %v, want %v", got, want)
+		t.Fatalf("GitArgsWithTemplate() = %v, want %v", got, want)
 	}
 }
 
 func TestGitArgsWithTemplateLeavesArgsUnchangedWhenNoDirectory(t *testing.T) {
 	args := []string{"init", "--initial-branch=main", "path"}
-	got := gitArgsWithTemplate("", args)
+	got := GitArgsWithTemplate("", args)
 	if !reflect.DeepEqual(got, args) {
-		t.Fatalf("gitArgsWithTemplate() = %v, want %v unchanged", got, args)
+		t.Fatalf("GitArgsWithTemplate() = %v, want %v unchanged", got, args)
 	}
 }

--- a/internal/toolchain/store.go
+++ b/internal/toolchain/store.go
@@ -634,6 +634,10 @@ func (s *Store) runtimeFromCurrent(current Current, targetName string, target Ta
 	if !ok {
 		return Runtime{}, fmt.Errorf("%w: selected runtime has no Herdr executable", ErrRuntimeNotReady)
 	}
+	templateDir := filepath.Join(s.Root, "runtime", "git-templates")
+	if err := os.MkdirAll(templateDir, 0o700); err != nil {
+		templateDir = ""
+	}
 	return Runtime{
 		ID:               current.RuntimeID,
 		Target:           current.Target,
@@ -645,6 +649,7 @@ func (s *Store) runtimeFromCurrent(current Current, targetName string, target Ta
 		HerdrPath:        *herdrPath,
 		HerdrVersion:     target.Components["herdr"].Version,
 		GitBin:           filepath.Dir(*gitPath),
+		GitTemplateDir:   templateDir,
 	}, nil
 }
 

--- a/internal/toolchain/store_test.go
+++ b/internal/toolchain/store_test.go
@@ -77,6 +77,63 @@ func TestEnsureInstallsRuntimeBelowStoreRoot(t *testing.T) {
 	}
 }
 
+func TestSelectedRuntimeCarriesAnExistingEmptyGitTemplateDirectory(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := filepath.Base(r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("fixture-" + name))
+	}))
+	defer server.Close()
+
+	components := make(map[string]Component, 3)
+	for _, name := range []string{"git", "treehouse", "herdr"} {
+		data := []byte("fixture-" + name)
+		digest := sha256.Sum256(data)
+		file := executableName(name)
+		components[name] = Component{
+			Name: name, Version: "test", Revision: "test", URL: server.URL + "/" + name,
+			SHA256: hex.EncodeToString(digest[:]), Format: "binary", Root: ".",
+			Files: []ExpectedFile{{Path: file, Executable: true, Regular: true}},
+		}
+	}
+	lock := Lock{Schema: 1, GeneratedBy: "store-test", Targets: map[string]Target{
+		runtime.GOOS + "/" + runtime.GOARCH: {Components: components},
+	}}
+	var err error
+	lock.RuntimeID, err = lock.DeterministicID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	store, err := NewStore(root, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.HTTPClient = server.Client()
+	if _, err := store.Ensure(context.Background(), "", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	selected, err := store.Selected("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected.GitTemplateDir == "" {
+		t.Fatal("GitTemplateDir is empty, want an existing directory hand can pass to git as init.templateDir")
+	}
+	if !strings.HasPrefix(selected.GitTemplateDir, filepath.Join(root, "runtime")+string(filepath.Separator)) {
+		t.Fatalf("GitTemplateDir escaped store root: %s", selected.GitTemplateDir)
+	}
+	entries, err := os.ReadDir(selected.GitTemplateDir)
+	if err != nil {
+		t.Fatalf("GitTemplateDir %s does not exist: %v", selected.GitTemplateDir, err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("GitTemplateDir %s has entries %v, want empty so it honestly seeds nothing", selected.GitTemplateDir, entries)
+	}
+}
+
 func TestExtractRejectsArchiveTraversalBeforeWritingOutsideDestination(t *testing.T) {
 	archive := tarGzipFixture(t, "../escape", []byte("unsafe"))
 	destination := t.TempDir()

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -518,6 +518,7 @@ func runCore(tool, dir string, args ...string) ([]byte, []byte, error) {
 	switch tool {
 	case "git":
 		path = managed.GitPath
+		args = toolchain.GitArgsWithTemplate(managed.GitTemplateDir, args)
 	case "treehouse":
 		path = managed.TreehousePath
 	default:


### PR DESCRIPTION
## Summary

- The pinned Git's compiled template path (`/dist/git-2.51.0/share/git-core/templates`) is a build-container path that does not exist once installed, so every `git clone`/`git init` through the managed runtime printed `warning: templates not found in ...`.
- Confirmed against the real installed bundle: it ships no `share/` tree at all (nothing to point at), and hand does not depend on git's default hooks/description/info-exclude - `cmd/project.go`'s `excludeLocally` already tolerates a missing `info/exclude`.
- `Runtime.GitTemplateDir` now names an empty directory hand ensures exists under the store root; `gitArgsWithTemplate` prepends `-c init.templateDir=<dir>` to every managed git invocation. Pointing Git at real, existing emptiness silences the warning honestly - there is genuinely nothing to seed - rather than filtering its stderr text.

Closes atqamz/hand#464

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
...
ok  	github.com/atqamz/hand/cmd	(cached)
ok  	github.com/atqamz/hand/internal/toolchain	1.725s
... (all other packages ok)

$ make e2e
go test -tags=e2e,test -timeout=10m ./tests/e2e/...
ok  	github.com/atqamz/hand/tests/e2e	69.578s
```

Real `git init`/`git clone` through the real installed bundle, before and after:

```
=== BEFORE (no -c init.templateDir) ===
$ git init --initial-branch=main before-init
warning: templates not found in /dist/git-2.51.0/share/git-core/templates
Initialized empty Git repository in .../before-init/.git/

$ git clone --no-local before-init before-clone
Cloning into '.../before-clone'...
warning: templates not found in /dist/git-2.51.0/share/git-core/templates
warning: You appear to have cloned an empty repository.

=== AFTER (-c init.templateDir=<hand-managed empty dir>, exactly what gitArgsWithTemplate now prepends) ===
$ git -c init.templateDir=<dir> init --initial-branch=main after-init
Initialized empty Git repository in .../after-init/.git/

$ git -c init.templateDir=<dir> clone --no-local after-init after-clone
Cloning into '.../after-clone'...
warning: You appear to have cloned an empty repository.
```

- [x] `TestSelectedRuntimeCarriesAnExistingEmptyGitTemplateDirectory` (internal/toolchain)
- [x] `TestGitArgsWithTemplatePrependsInitTemplateDir`, `TestGitArgsWithTemplateLeavesArgsUnchangedWhenNoDirectory` (cmd)
- [x] `docs/testing-invariants.md` gains INV-RTGIT-4/5

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->