### PR TITLE
fix(home): refuse HAND_HOME and cwd naming different fleet homes

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -751,3 +751,85 @@ func TestInitRefusesATargetInsideAnotherFleetsProjectsTree(t *testing.T) {
 		t.Fatalf("target inside projects/ changed: before=%v after=%v", before, after)
 	}
 }
+
+// atqamz/hand#460 must not block a worker building a scratch home: init's target is always its
+// explicit argument or cwd, never home.Resolve(), so an inherited HAND_HOME naming the live fleet
+// changes nothing about what init does. See docs/adr/two-fleet-homes-in-play-is-a-refusal.md.
+func TestInitBuildsAScratchHomeWhileHandHomeNamesTheLiveFleet(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	liveHome := t.TempDir()
+	seedCmd := newInitCmd()
+	seedCmd.SetArgs([]string{liveHome})
+	if err := seedCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	scratchHome := t.TempDir()
+	t.Chdir(scratchHome)
+	t.Setenv("HAND_HOME", liveHome)
+
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"init"})
+	var out, errOut strings.Builder
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("got %v, want init to build the scratch home even though HAND_HOME names a different, live fleet", err)
+	}
+
+	ok, err := home.IsHome(scratchHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("scratch directory was not initialized")
+	}
+	if !strings.Contains(errOut.String(), "HAND_HOME is set to "+liveHome) {
+		t.Fatalf("stderr = %q, want the existing HAND_HOME-mismatch warning naming %s", errOut.String(), liveHome)
+	}
+}
+
+// The rarer shape: refreshing a scratch home already built, HAND_HOME still unset from it. Here
+// home.Resolve() genuinely hits the ambiguity refusal inside root's PersistentPreRunE, which must
+// still not stop init from reconciling the directory its own argument (or cwd) names.
+func TestInitRefreshesAnExistingScratchHomeWhileHandHomeNamesADifferentLiveFleet(t *testing.T) {
+	t.Setenv("HAND_HOME", "")
+	liveHome := t.TempDir()
+	seedLive := newInitCmd()
+	seedLive.SetArgs([]string{liveHome})
+	if err := seedLive.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	scratchHome := t.TempDir()
+	seedScratch := newInitCmd()
+	seedScratch.SetArgs([]string{scratchHome})
+	if err := seedScratch.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm the refresh actually exercises Resolve()'s ambiguous branch rather than passing
+	// vacuously because cwd resolved to no home at all.
+	t.Chdir(scratchHome)
+	t.Setenv("HAND_HOME", liveHome)
+	if _, err := home.Resolve(); !errors.Is(err, home.ErrAmbiguousHome) {
+		t.Fatalf("home.Resolve() = %v, want it to report the ambiguity this test means to exercise", err)
+	}
+
+	root := newRootCmd(devBuild("test"))
+	root.SetArgs([]string{"init"})
+	var out, errOut strings.Builder
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("got %v, want the refresh to succeed against the scratch home despite the ambiguity home.Resolve() reports internally", err)
+	}
+
+	ok, err := home.IsHome(scratchHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("scratch home lost its markers across the refresh")
+	}
+}

--- a/cmd/precondition.go
+++ b/cmd/precondition.go
@@ -24,6 +24,7 @@ var preconditionSentinels = []error{
 	project.ErrNotFound,
 	home.ErrNotFound,
 	home.ErrHandHomeInvalid,
+	home.ErrAmbiguousHome,
 }
 
 func asPrecondition(err error) error {

--- a/cmd/precondition_test.go
+++ b/cmd/precondition_test.go
@@ -1,14 +1,25 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/home"
 )
 
 func TestAsPreconditionClassifiesEnsureTimeout(t *testing.T) {
 	err := asPrecondition(&herdr.SessionEnsureError{Cause: herdr.ErrEnsureTimeout})
 	if code := exitCodeFor(t, err); code != 3 {
 		t.Fatalf("exit code = %d, want 3 for Ensure timeout (err = %v)", code, err)
+	}
+}
+
+// atqamz/hand#460: an ambiguous fleet home is a precondition failure like any other home
+// resolution problem (home.ErrNotFound, home.ErrHandHomeInvalid), not a general error.
+func TestAsPreconditionClassifiesAmbiguousHome(t *testing.T) {
+	err := asPrecondition(fmt.Errorf("resolve fleet home: %w", home.ErrAmbiguousHome))
+	if code := exitCodeFor(t, err); code != 3 {
+		t.Fatalf("exit code = %d, want 3 for an ambiguous home (err = %v)", code, err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -229,6 +229,9 @@ func renderError(w io.Writer, err error, code int, path string) error {
 	doc.Field("kind", errorKind(code))
 	doc.Int("exit", code)
 	help := errorHelp(code, path)
+	if errors.Is(err, home.ErrAmbiguousHome) {
+		help = []string{"Unset HAND_HOME to act on the working directory's home instead, or run this command from outside that directory to act on HAND_HOME's home instead"}
+	}
 	var details interface {
 		SendFields() (int64, int64, string, string, bool, bool)
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/registry"
 	"github.com/atqamz/hand/internal/selfupdate"
 	"github.com/atqamz/hand/internal/state"
@@ -478,6 +480,26 @@ func TestErrorDocumentNamesTheKindBehindEveryExitCode(t *testing.T) {
 				t.Fatalf("error document = %q, want it to start with %q", out.String(), want)
 			}
 		})
+	}
+}
+
+// atqamz/hand#460: the refusal's help line names both ways forward rather than the generic
+// precondition filler, per docs/adr/every-diagnosis-names-a-reachable-treatment.md.
+func TestErrorDocumentNamesBothWaysForwardForAnAmbiguousHome(t *testing.T) {
+	var out strings.Builder
+	err := fmt.Errorf(
+		"%w: HAND_HOME is %q, the working directory is inside %q; unset HAND_HOME to act on the working directory's home, or run from outside %q to act on HAND_HOME's",
+		home.ErrAmbiguousHome, "/live", "/scratch", "/scratch")
+	if renderErr := renderError(&out, err, 3, "hand status"); renderErr != nil {
+		t.Fatal(renderErr)
+	}
+	for _, want := range []string{"kind: precondition\n", "exit: 3\n", "Unset HAND_HOME", "run this command from outside"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("error document = %q, want %q", out.String(), want)
+		}
+	}
+	if strings.Contains(out.String(), "Nothing changed: this refuses until the state it names is fixed") {
+		t.Fatalf("error document = %q, want the specific two-way help, not the generic precondition filler", out.String())
 	}
 }
 

--- a/docs/adr/two-fleet-homes-in-play-is-a-refusal.md
+++ b/docs/adr/two-fleet-homes-in-play-is-a-refusal.md
@@ -1,0 +1,91 @@
+# Two fleet homes in play is a refusal, not a silent choice
+
+- Date: 2026-08-28
+- Status: accepted
+- Issues: atqamz/hand#460
+- PRs: none
+
+## Context
+
+`internal/runtime/provision.go` sets `HAND_HOME` in every managed worker's environment,
+deliberately, so the worker knows the home its report channel belongs to. `internal/home.Resolve()`
+checked `HAND_HOME` before ever looking at the working directory, and stopped there the moment it
+found HAND_HOME to name a real fleet home.
+
+A worker that builds a scratch fleet home to verify a change to provisioning, teardown, holds, or
+steering end to end, and `cd`s into it, does not thereby isolate anything: `HAND_HOME` is still set
+to the live supervising home, and every bare `hand` command reads that variable first. This was
+caught read-only, during final verification for atqamz/hand#420: a worker ran `hand status` from
+inside its scratch directory, expecting it to act on the scratch home, and it listed the live
+fleet's seven real tasks instead. The worker then checked the live fleet's task and project lists by
+hand and confirmed nothing had changed - but `hand spawn`, `hand teardown`, `hand merge` or
+`hand hold` would not have stopped to ask.
+
+Scratch fleet homes are not a rare shape. They are how this class of change gets verified, and
+supervisor briefs actively ask for them.
+
+"Always pass `HAND_HOME` explicitly" is not a fix, for the same reason atqamz/hand#413 rejected it
+for the Secondhand root: an override a caller can forget to set is the bug, not the remedy for it.
+The worker in the incident above did not forget in the sense of being careless - they held the
+scratch home in mind and reasoned about it as the target, and `HAND_HOME` still won because nothing
+made the two disagree loudly.
+
+## Decision
+
+When `HAND_HOME` is set, `Resolve()` now also asks whether the working directory sits inside a
+*different* valid fleet home. If it does, `Resolve()` refuses with `ErrAmbiguousHome`, naming both
+paths and the two ways to proceed: unset `HAND_HOME` to act on the working directory's home, or run
+the command from outside that directory to act on `HAND_HOME`'s. Nothing picks a winner. The
+refusal renders through the ordinary `error`/`kind`/`exit`/`help` document every `hand` command
+already produces for a precondition failure, with a help line naming both remedies rather than the
+generic precondition filler text.
+
+**cwd never wins.** Making the working directory outrank `HAND_HOME` when the two disagree would
+reproduce the identical hazard in the other direction: a worker whose shell happens to be sitting
+inside some fleet home, running a command meant for the one named in its environment, would act on
+the wrong one just as silently. `HAND_HOME` is set on purpose by provisioning specifically so a
+worker's commands are not at the mercy of what directory a shell happens to be in; a resolver that
+overrides it based on cwd defeats the reason it exists.
+
+**The two unambiguous shapes stay exactly as fast as before.** A worker's cwd is a Treehouse
+worktree pool slot, never a fleet home: [The worktree pool lives outside every fleet
+home](the-worktree-pool-lives-outside-every-fleet-home.md) keeps a pool disjoint from every home in
+one direction, and `refuseManagedTreeHome` (atqamz/hand#413) keeps a fleet home from ever being
+created inside a pool in the other. Together they let `Resolve()` rule out "cwd is a different home"
+with a single path comparison against `worktree.PoolsRoot()` - no stat call - before it ever reaches
+for the ancestor walk. A cwd already inside `HAND_HOME` is ruled out the same cheap way. Only a
+working directory outside both pays for the walk, and it pays exactly the walk `Resolve()` always
+performed when `HAND_HOME` was unset; nothing about the "every managed worker" shape got slower.
+
+**`hand init` is unaffected, on purpose.** Its target is always its explicit argument or the working
+directory, resolved directly in `resolveInitHome`, never through `home.Resolve()`. A worker building
+a scratch home, or refreshing one it already built, while its inherited `HAND_HOME` still names the
+live fleet, keeps working exactly as before: init reconciles the directory it was told to, and its
+own pre-existing `warnHandHomeMismatch` warning (unrelated to this change) still says that every
+*other* command will read `HAND_HOME` instead. Root's `PersistentPreRunE` does call
+`home.Resolve()` ahead of every command including `init`, but every step gated behind that call
+already excludes `cmd.Name() == "init"` - a fact this decision leans on rather than duplicates - so
+an ambiguous result from that call changes nothing about what `init` does.
+
+## Rejected alternatives
+
+- **cwd wins when the two disagree.** Rejected above: it is the same failure mode pointed the other
+  way, and `HAND_HOME`'s entire purpose in a worker's environment is to not depend on cwd.
+- **A `--home` flag, or "always pass `HAND_HOME` explicitly."** Discipline is not the fix; an
+  instruction a caller can forget to follow reproduces the bug it was meant to prevent, which is
+  exactly what atqamz/hand#413 already concluded for the Secondhand root.
+- **Warn instead of refuse.** A warning a script's stdout-consuming caller never reads is silence
+  with extra steps. The near-miss this fixes was read-only specifically because a human was watching
+  the output; `hand spawn` or `hand teardown` invoked from automation would not have had one.
+- **Refuse whenever `HAND_HOME` is set and cwd is inside *any* home, even the same one.** This would
+  turn the ordinary case of a worker or supervisor invoking `hand` from inside the very home
+  `HAND_HOME` already names into a refusal, which is not ambiguous and has nothing to diagnose.
+
+## Consequences
+
+No `hand` command can act on a fleet home other than the one its invocation unambiguously names. An
+invocation that already was unambiguous - `HAND_HOME` unset, `HAND_HOME` matching cwd's home, or cwd
+outside every home entirely (every managed worker) - behaves exactly as it did before this change,
+at the same cost. An invocation naming two different homes now fails loudly, before touching either
+one, and names the two ways out. `hand init`'s own target resolution and its existing
+`HAND_HOME`-mismatch warning are untouched.

--- a/docs/adr/two-fleet-homes-in-play-is-a-refusal.md
+++ b/docs/adr/two-fleet-homes-in-play-is-a-refusal.md
@@ -52,7 +52,7 @@ worktree pool slot, never a fleet home: [The worktree pool lives outside every f
 home](the-worktree-pool-lives-outside-every-fleet-home.md) keeps a pool disjoint from every home in
 one direction, and `refuseManagedTreeHome` (atqamz/hand#413) keeps a fleet home from ever being
 created inside a pool in the other. Together they let `Resolve()` rule out "cwd is a different home"
-with a single path comparison against `worktree.PoolsRoot()` - no stat call - before it ever reaches
+with a single path comparison against `secondhand.PoolsRoot()` - no stat call - before it ever reaches
 for the ancestor walk. A cwd already inside `HAND_HOME` is ruled out the same cheap way. Only a
 working directory outside both pays for the walk, and it pays exactly the walk `Resolve()` always
 performed when `HAND_HOME` was unset; nothing about the "every managed worker" shape got slower.

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -86,13 +86,13 @@ Source: [hand init is the canonical fleet reconciler](adr/hand-init-is-the-canon
 
 Source: [Two fleet homes in play is a refusal, not a silent choice](adr/two-fleet-homes-in-play-is-a-refusal.md),
 [The worktree pool lives outside every fleet home](adr/the-worktree-pool-lives-outside-every-fleet-home.md),
-`internal/home/home.go` (`Resolve`), `internal/runtime/provision.go`.
+`internal/home/home.go` (`Resolve`), `internal/secondhand/home.go` (`PoolsRoot`), `internal/runtime/provision.go`.
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
 | INV-HOME-1 | `Resolve` refuses with `ErrAmbiguousHome`, naming both paths, whenever `HAND_HOME` is set and the working directory sits inside a fleet home other than the one `HAND_HOME` names. | unit | `TestResolveRefusesWhenHandHomeAndCwdNameDifferentHomes` |
 | INV-HOME-2 | `Resolve` stays silent and returns `HAND_HOME` unchanged when the working directory's nearest fleet home is the same one `HAND_HOME` names, when the working directory has no fleet home above it at all, or when `HAND_HOME` is unset. | unit | `TestResolveStaysSilentWhenHandHomeAndCwdNameTheSameHome`, `TestResolveStaysSilentWhenHandHomeSetAndCwdInsideNoHome` |
-| INV-HOME-3 | A working directory inside the Treehouse worktree pool never triggers the ambiguity walk: `Resolve` returns `HAND_HOME` from a path comparison against `worktree.PoolsRoot()` alone, so every managed worker's invocation pays no extra cost. | unit | `TestResolveUsesTheWorktreePoolShortcutWhenHandHomeIsSet` |
+| INV-HOME-3 | A working directory inside the Treehouse worktree pool never triggers the ambiguity walk: `Resolve` returns `HAND_HOME` from a path comparison against `secondhand.PoolsRoot()` alone, so every managed worker's invocation pays no extra cost. | unit | `TestResolveUsesTheWorktreePoolShortcutWhenHandHomeIsSet` |
 | INV-HOME-4 | `hand init`'s target is never `home.Resolve()`'s result: building or refreshing a fleet home is unaffected by an ambiguous or merely different `HAND_HOME`. | unit | `TestInitBuildsAScratchHomeWhileHandHomeNamesTheLiveFleet`, `TestInitRefreshesAnExistingScratchHomeWhileHandHomeNamesADifferentLiveFleet` |
 
 ## Usage-limit signatures

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -82,6 +82,19 @@ Source: [hand init is the canonical fleet reconciler](adr/hand-init-is-the-canon
 | INV-INIT-5 | A non-empty directory is adopted if and only if its `go.mod` declares hand's own module path. | property | phase 0 of atqamz/hand#436 landed unit tests; property form unaudited |
 | INV-INIT-6 | Preflight refusal is total: a refused target has no byte changed, including the private runtime root. | property | unaudited |
 
+## Home resolution
+
+Source: [Two fleet homes in play is a refusal, not a silent choice](adr/two-fleet-homes-in-play-is-a-refusal.md),
+[The worktree pool lives outside every fleet home](adr/the-worktree-pool-lives-outside-every-fleet-home.md),
+`internal/home/home.go` (`Resolve`), `internal/runtime/provision.go`.
+
+| id | invariant | layer | coverage |
+|---|---|---|---|
+| INV-HOME-1 | `Resolve` refuses with `ErrAmbiguousHome`, naming both paths, whenever `HAND_HOME` is set and the working directory sits inside a fleet home other than the one `HAND_HOME` names. | unit | `TestResolveRefusesWhenHandHomeAndCwdNameDifferentHomes` |
+| INV-HOME-2 | `Resolve` stays silent and returns `HAND_HOME` unchanged when the working directory's nearest fleet home is the same one `HAND_HOME` names, when the working directory has no fleet home above it at all, or when `HAND_HOME` is unset. | unit | `TestResolveStaysSilentWhenHandHomeAndCwdNameTheSameHome`, `TestResolveStaysSilentWhenHandHomeSetAndCwdInsideNoHome` |
+| INV-HOME-3 | A working directory inside the Treehouse worktree pool never triggers the ambiguity walk: `Resolve` returns `HAND_HOME` from a path comparison against `worktree.PoolsRoot()` alone, so every managed worker's invocation pays no extra cost. | unit | `TestResolveUsesTheWorktreePoolShortcutWhenHandHomeIsSet` |
+| INV-HOME-4 | `hand init`'s target is never `home.Resolve()`'s result: building or refreshing a fleet home is unaffected by an ambiguous or merely different `HAND_HOME`. | unit | `TestInitBuildsAScratchHomeWhileHandHomeNamesTheLiveFleet`, `TestInitRefreshesAnExistingScratchHomeWhileHandHomeNamesADifferentLiveFleet` |
+
 ## Usage-limit signatures
 
 Source: [Usage-limit detection is a harness capability](adr/usage-limit-detection-is-a-harness-capability.md),

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/atqamz/hand/internal/worktree"
+	"github.com/atqamz/hand/internal/secondhand"
 )
 
 // ErrNotFound is wrapped into the error Resolve returns when the working
@@ -160,7 +160,7 @@ func cannotBeADifferentHome(cwd, handHome string) bool {
 	if withinTree(handHome, cwd) {
 		return true
 	}
-	pools, err := worktree.PoolsRoot()
+	pools, err := secondhand.PoolsRoot()
 	if err != nil {
 		return false
 	}

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/atqamz/hand/internal/worktree"
 )
 
 // ErrNotFound is wrapped into the error Resolve returns when the working
@@ -19,6 +22,11 @@ var ErrNotFound = errors.New("not inside a secondhand home; run `hand init` or s
 // not name a fleet home. Separate from ErrNotFound because the remedy differs: an
 // operator who already set HAND_HOME is not helped by being told to set it.
 var ErrHandHomeInvalid = errors.New("is not a secondhand home; check the path or unset HAND_HOME to search up from the working directory")
+
+// ErrAmbiguousHome is wrapped into Resolve's error when HAND_HOME names one fleet home and the
+// working directory sits inside a different one (atqamz/hand#460). See
+// docs/adr/two-fleet-homes-in-play-is-a-refusal.md for why neither side may win silently.
+var ErrAmbiguousHome = errors.New("HAND_HOME and the working directory name two different fleet homes, with no stated precedence")
 
 // IsHome reports whether dir is a fleet home, the one definition the resolver, hand
 // init and agentsmd's refresh share. The marker is state/hand.db, not state/ itself: a
@@ -73,33 +81,63 @@ func matchesMarkers(dir string, markers []homeMarker) (bool, error) {
 }
 
 // Resolve finds the fleet home a command runs against: HAND_HOME if set, else the nearest
-// ancestor of the working directory (itself included) that IsHome accepts. A HAND_HOME that
-// is not a home fails loudly, because a silent walk-up dispatches into the wrong fleet.
+// ancestor of the working directory that IsHome accepts. A home differing from HAND_HOME refuses
+// with ErrAmbiguousHome; see docs/adr/two-fleet-homes-in-play-is-a-refusal.md for why and at what cost.
 func Resolve() (string, error) {
-	if handHome := os.Getenv("HAND_HOME"); handHome != "" {
-		// Absolute, because commands derive the paths they hand to subprocesses running
-		// elsewhere from this, and a relative HAND_HOME would name a different home for
-		// every working directory it is read from.
-		handHome, err := filepath.Abs(handHome)
+	handHome := os.Getenv("HAND_HOME")
+	if handHome == "" {
+		cwd, err := os.Getwd()
 		if err != nil {
-			return "", fmt.Errorf("resolve HAND_HOME: %w", err)
+			return "", fmt.Errorf("get working directory: %w", err)
 		}
-		ok, err := IsHome(handHome)
+		found, err := nearestAncestorHome(cwd)
 		if err != nil {
-			return "", fmt.Errorf("check HAND_HOME %q: %w", handHome, err)
+			return "", err
 		}
-		if !ok {
-			return "", fmt.Errorf("HAND_HOME %q %w", handHome, ErrHandHomeInvalid)
+		if found == "" {
+			return "", ErrNotFound
 		}
-		return handHome, nil
+		return found, nil
+	}
+
+	// Absolute, because commands derive the paths they hand to subprocesses running
+	// elsewhere from this, and a relative HAND_HOME would name a different home for
+	// every working directory it is read from.
+	handHome, err := filepath.Abs(handHome)
+	if err != nil {
+		return "", fmt.Errorf("resolve HAND_HOME: %w", err)
+	}
+	ok, err := IsHome(handHome)
+	if err != nil {
+		return "", fmt.Errorf("check HAND_HOME %q: %w", handHome, err)
+	}
+	if !ok {
+		return "", fmt.Errorf("HAND_HOME %q %w", handHome, ErrHandHomeInvalid)
 	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get working directory: %w", err)
 	}
+	if cannotBeADifferentHome(cwd, handHome) {
+		return handHome, nil
+	}
+	cwdHome, err := nearestAncestorHome(cwd)
+	if err != nil {
+		return "", err
+	}
+	if cwdHome != "" && cwdHome != handHome {
+		return "", fmt.Errorf(
+			"%w: HAND_HOME is %q, the working directory is inside %q; unset HAND_HOME to act on the working directory's home, or run from outside %q to act on HAND_HOME's",
+			ErrAmbiguousHome, handHome, cwdHome, cwdHome)
+	}
+	return handHome, nil
+}
 
-	for dir := cwd; ; {
+// Walks up from dir, itself included, returning the first ancestor IsHome accepts, or "" if none
+// does; a caller turns that into ErrNotFound or into "no cwd home to conflict with HAND_HOME".
+func nearestAncestorHome(dir string) (string, error) {
+	for {
 		ok, err := IsHome(dir)
 		if err != nil {
 			return "", err
@@ -109,8 +147,32 @@ func Resolve() (string, error) {
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", ErrNotFound
+			return "", nil
 		}
 		dir = parent
 	}
+}
+
+// Reports, without a single stat call, whether cwd is provably not a fleet home other than
+// handHome: either cwd sits inside handHome, or inside the Treehouse pool (INV-POOL-1, INV-REG-7).
+// A "no" answer, including one from a PoolsRoot lookup failure, only sends the caller to the walk.
+func cannotBeADifferentHome(cwd, handHome string) bool {
+	if withinTree(handHome, cwd) {
+		return true
+	}
+	pools, err := worktree.PoolsRoot()
+	if err != nil {
+		return false
+	}
+	return withinTree(pools, cwd)
+}
+
+// Reports whether path is root or sits inside it, comparing cleaned absolute strings without
+// resolving symlinks - the same rule cmd's own pool-membership check uses.
+func withinTree(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
 }

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/axi"
-	"github.com/atqamz/hand/internal/worktree"
+	"github.com/atqamz/hand/internal/secondhand"
 )
 
 // Builds a home carrying the marker IsHome checks, state/hand.db.
@@ -295,7 +295,8 @@ func TestResolveStaysSilentWhenHandHomeAndCwdNameTheSameHome(t *testing.T) {
 // is not, and never can be, a fleet home of its own (INV-POOL-1, INV-REG-7). Must resolve to
 // HAND_HOME silently, via the pools-root shortcut rather than a walk up cwd's ancestors.
 func TestResolveUsesTheWorktreePoolShortcutWhenHandHomeIsSet(t *testing.T) {
-	pools, err := worktree.PoolsRoot()
+	t.Setenv("SECONDHAND_HOME", t.TempDir())
+	pools, err := secondhand.PoolsRoot()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -2,6 +2,7 @@ package home
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -262,10 +263,12 @@ func TestResolveRefusesWhenHandHomeAndCwdNameDifferentHomes(t *testing.T) {
 	if !errors.Is(err, ErrAmbiguousHome) {
 		t.Fatalf("got %v, want it to wrap ErrAmbiguousHome", err)
 	}
-	if !strings.Contains(err.Error(), envHome) {
+	// %q is this package's existing convention for rendering a path in an error (ErrHandHomeInvalid
+	// does the same), so the assertion compares against that same rendering rather than the raw path.
+	if !strings.Contains(err.Error(), fmt.Sprintf("%q", envHome)) {
 		t.Fatalf("got %q, want it to name HAND_HOME's value %q", err.Error(), envHome)
 	}
-	if !strings.Contains(err.Error(), cwdHome) {
+	if !strings.Contains(err.Error(), fmt.Sprintf("%q", cwdHome)) {
 		t.Fatalf("got %q, want it to name the working directory's home %q", err.Error(), cwdHome)
 	}
 }

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/worktree"
 )
 
 // Builds a home carrying the marker IsHome checks, state/hand.db.
@@ -242,7 +243,10 @@ func TestResolveFailsLoudlyWithNoHomeAnywhereInTheTree(t *testing.T) {
 	}
 }
 
-func TestResolvePrefersHandHomeOverCwd(t *testing.T) {
+// atqamz/hand#460: HAND_HOME no longer silently outranks a cwd that is itself a different fleet
+// home. Two homes in play with no stated precedence is a diagnosis, not something Resolve may
+// pick a side on - the near-miss this replaces was exactly this shape, read via `hand status`.
+func TestResolveRefusesWhenHandHomeAndCwdNameDifferentHomes(t *testing.T) {
 	cwdHome := t.TempDir()
 	makeHome(t, cwdHome)
 	t.Chdir(cwdHome)
@@ -251,12 +255,84 @@ func TestResolvePrefersHandHomeOverCwd(t *testing.T) {
 	makeHome(t, envHome)
 	t.Setenv("HAND_HOME", envHome)
 
+	_, err := Resolve()
+	if err == nil {
+		t.Fatal("got nil error, want a refusal")
+	}
+	if !errors.Is(err, ErrAmbiguousHome) {
+		t.Fatalf("got %v, want it to wrap ErrAmbiguousHome", err)
+	}
+	if !strings.Contains(err.Error(), envHome) {
+		t.Fatalf("got %q, want it to name HAND_HOME's value %q", err.Error(), envHome)
+	}
+	if !strings.Contains(err.Error(), cwdHome) {
+		t.Fatalf("got %q, want it to name the working directory's home %q", err.Error(), cwdHome)
+	}
+}
+
+// The common shape untouched by the refusal: HAND_HOME and cwd agree, because cwd sits inside
+// the very home HAND_HOME names. Nothing here should differ from resolving HAND_HOME alone.
+func TestResolveStaysSilentWhenHandHomeAndCwdNameTheSameHome(t *testing.T) {
+	fleetHome := t.TempDir()
+	makeHome(t, fleetHome)
+	nested := filepath.Join(fleetHome, "projects", "myapp")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	t.Setenv("HAND_HOME", fleetHome)
+
 	got, err := Resolve()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != envHome {
-		t.Fatalf("got %q, want %q", got, envHome)
+	if got != fleetHome {
+		t.Fatalf("got %q, want %q", got, fleetHome)
+	}
+}
+
+// Every managed worker's shape (atqamz/hand#460): HAND_HOME set, cwd a Treehouse pool slot that
+// is not, and never can be, a fleet home of its own (INV-POOL-1, INV-REG-7). Must resolve to
+// HAND_HOME silently, via the pools-root shortcut rather than a walk up cwd's ancestors.
+func TestResolveUsesTheWorktreePoolShortcutWhenHandHomeIsSet(t *testing.T) {
+	pools, err := worktree.PoolsRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slot := filepath.Join(pools, "myapp-abc123", "1", "myapp")
+	if err := os.MkdirAll(slot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(slot)
+
+	fleetHome := t.TempDir()
+	makeHome(t, fleetHome)
+	t.Setenv("HAND_HOME", fleetHome)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != fleetHome {
+		t.Fatalf("got %q, want %q", got, fleetHome)
+	}
+}
+
+// A worker whose cwd sits outside both HAND_HOME and the worktree pool - a plain scratch
+// directory with no fleet home anywhere above it - is unambiguous too, and must stay silent.
+func TestResolveStaysSilentWhenHandHomeSetAndCwdInsideNoHome(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	fleetHome := t.TempDir()
+	makeHome(t, fleetHome)
+	t.Setenv("HAND_HOME", fleetHome)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != fleetHome {
+		t.Fatalf("got %q, want %q", got, fleetHome)
 	}
 }
 

--- a/internal/home/testtag_test.go
+++ b/internal/home/testtag_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/atqamz/hand/internal/testtag"
 )
 
-// Resolve now consults worktree.PoolsRoot() (atqamz/hand#460) whenever HAND_HOME is set, so this
-// package needs its own isolated SECONDHAND_HOME regardless of whether the invoking `go test` was
-// wrapped by `make test` (atqamz/hand#413), the same reason internal/worktree's TestMain exists.
+// Resolve now consults secondhand.Home() (atqamz/hand#460) whenever HAND_HOME is set, so this
+// package needs its own isolated SECONDHAND_HOME, the same reason internal/worktree's TestMain exists.
 func TestMain(m *testing.M) {
 	if !testtag.Present {
 		testtag.Refuse()

--- a/internal/home/testtag_test.go
+++ b/internal/home/testtag_test.go
@@ -1,0 +1,32 @@
+package home
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/atqamz/hand/internal/testtag"
+)
+
+// Resolve now consults worktree.PoolsRoot() (atqamz/hand#460) whenever HAND_HOME is set, so this
+// package needs its own isolated SECONDHAND_HOME regardless of whether the invoking `go test` was
+// wrapped by `make test` (atqamz/hand#413), the same reason internal/worktree's TestMain exists.
+func TestMain(m *testing.M) {
+	if !testtag.Present {
+		testtag.Refuse()
+	}
+	root, err := os.MkdirTemp("", "hand-home-test-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("SECONDHAND_HOME", filepath.Join(root, "Secondhand 測試")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_ = os.RemoveAll(root)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(root)
+	os.Exit(code)
+}

--- a/internal/secondhand/home.go
+++ b/internal/secondhand/home.go
@@ -33,3 +33,14 @@ func Home() (string, error) {
 	}
 	return filepath.Clean(path), nil
 }
+
+// PoolsRoot is the directory every clone's Treehouse worktree pool lives under. It depends on
+// nothing but Home, so a caller that only needs to test path membership - internal/home's ambiguity
+// check, cmd/init.go's managed-tree refusal - does not have to import internal/worktree to get it.
+func PoolsRoot() (string, error) {
+	infra, err := Home()
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree pool root: %w", err)
+	}
+	return filepath.Join(infra, "pools"), nil
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -468,15 +468,11 @@ func withTreehouseRoot(clonePath, recordedWorktreePath string, args ...string) (
 	return append([]string{"--root", root}, args...), nil
 }
 
-// PoolsRoot is the directory every clone's worktree pool lives under - the one path that identifies
-// any slot Hand's own pools could ever create. Exported for cmd/init.go's managed-tree refusal
-// (atqamz/hand#413): no Fleet home may be registered inside it.
+// PoolsRoot is the directory every clone's worktree pool lives under. Exported for cmd/init.go's
+// managed-tree refusal (atqamz/hand#413): no Fleet home may be registered inside it. Delegates to
+// internal/secondhand so a caller needing only the path need not import this package for it.
 func PoolsRoot() (string, error) {
-	infra, err := secondhand.Home()
-	if err != nil {
-		return "", fmt.Errorf("resolve worktree pool root: %w", err)
-	}
-	return filepath.Join(infra, "pools"), nil
+	return secondhand.PoolsRoot()
 }
 
 // Where this clone's pool lives. Before atqamz/hand#427 it was the clone itself, which put every


### PR DESCRIPTION
## Summary

- `internal/home.Resolve()` now refuses (`ErrAmbiguousHome`, exit 3) when `HAND_HOME` is set and the working directory sits inside a *different* valid fleet home, naming both paths and the two ways forward.
- The two unambiguous shapes stay exactly as fast as before: cwd inside the same home as `HAND_HOME`, or cwd inside no home at all (every managed worker's shape) - the latter proven with a path comparison against `worktree.PoolsRoot()`, no stat call, before any ancestor walk.
- `hand init` is unaffected: its target is always the explicit argument or cwd, never `home.Resolve()`, so building or refreshing a scratch fleet home while `HAND_HOME` still names the live one keeps working.

Closes atqamz/hand#460

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .

$ make test
ok  	github.com/atqamz/hand/cmd	184.661s
ok  	github.com/atqamz/hand/internal/home	1.227s
ok  	github.com/atqamz/hand/internal/runtime	138.906s
... (all packages ok)

$ make e2e
ok  	github.com/atqamz/hand/tests/e2e	82.614s
```

Manual demonstration (scratch fleet homes in a temp dir, `SECONDHAND_HOME` sandboxed, no operator registry touched):

```
$ cd $DEMO/homeA
$ HAND_HOME=$DEMO/homeB hand status
error: "HAND_HOME and the working directory name two different fleet homes, with no stated precedence: HAND_HOME is \"$DEMO/homeB\", the working directory is inside \"$DEMO/homeA\"; unset HAND_HOME to act on the working directory's home, or run from outside \"$DEMO/homeA\" to act on HAND_HOME's"
kind: precondition
exit: 3
help[1]:
  - Unset HAND_HOME to act on the working directory's home instead, or run this command from outside that directory to act on HAND_HOME's home instead

$ HAND_HOME=$DEMO/homeA hand status
count: 0
attention: 0
held: 0
...
exit=0
```

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->