### PR TITLE
test(testing-invariants): add property tests for the six INV-OUT rows

### DIFF
--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -659,6 +659,61 @@ func TestDoctorReportsViolationsAndExitsNonZero(t *testing.T) {
 	}
 }
 
+// INV-OUT-4's stdout half: `hand doctor` renders its full report to stdout
+// and still returns an error on a violation, and renderError's separate
+// document (simulated here against its own buffer) never touches it.
+func TestDoctorViolationsKeepStdoutReportAndRenderASeparateErrorDocument(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	if _, err := agentsmd.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.Refresh(home); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, "AGENTS.md")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("\nFixed on 2026-07-29.\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := newDoctorCmd(stableBuild("v0.1.0"))
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	runErr := cmd.Execute()
+	if runErr == nil {
+		t.Fatal("got nil error, want a non-nil error for a perishable-content hit")
+	}
+	report := out.String()
+	if !strings.Contains(report, "violations: 1\n") {
+		t.Fatalf("stdout = %q, want the doctor report with a violation counted", report)
+	}
+
+	var errDoc strings.Builder
+	if renderErr := renderError(&errDoc, runErr, 1, "hand doctor"); renderErr != nil {
+		t.Fatal(renderErr)
+	}
+	if out.String() != report {
+		t.Fatalf("stdout changed after rendering the error document: got %q, want unchanged %q", out.String(), report)
+	}
+	for _, want := range []string{"error: ", "kind: general\n", "exit: 1\n"} {
+		if !strings.Contains(errDoc.String(), want) {
+			t.Fatalf("error document = %q, want %q", errDoc.String(), want)
+		}
+	}
+	if strings.Contains(errDoc.String(), "violations:") {
+		t.Fatalf("error document = %q, want the doctor report's fields to stay out of the error document", errDoc.String())
+	}
+}
+
 func TestDoctorTreatsMissingManagedMarkersAsViolation(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)

--- a/cmd/fields_test.go
+++ b/cmd/fields_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// INV-OUT-6: rejected only when both --fields and --json are requested, for
+// any field set - the general form of status_test.go's
+// TestStatusFieldsWithJSONIsAUsageError.
+func TestRejectFieldsWithJSONRefusesOnlyWhenBothAreRequested(t *testing.T) {
+	fieldName := rapid.StringMatching(`[a-z]{1,8}`)
+
+	rapid.Check(t, func(t *rapid.T) {
+		fields := rapid.SliceOfN(fieldName, 0, 5).Draw(t, "fields")
+		asJSON := rapid.Bool().Draw(t, "json")
+
+		err := rejectFieldsWithJSON(fields, asJSON)
+		combined := len(fields) > 0 && asJSON
+
+		if combined && err == nil {
+			t.Fatalf("rejectFieldsWithJSON(%v, %v) = nil, want a usage error rejecting --fields with --json", fields, asJSON)
+		}
+		if !combined && err != nil {
+			t.Fatalf("rejectFieldsWithJSON(%v, %v) = %v, want nil: --fields and --json were not both requested", fields, asJSON, err)
+		}
+		if err == nil {
+			return
+		}
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+			t.Fatalf("rejectFieldsWithJSON(%v, %v) error = %v, want an ExitError with code 2", fields, asJSON, err)
+		}
+		if !strings.Contains(err.Error(), "--fields") || !strings.Contains(err.Error(), "--json") {
+			t.Fatalf("rejectFieldsWithJSON(%v, %v) error = %q, want it to name both flags", fields, asJSON, err.Error())
+		}
+	})
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/atqamz/hand/internal/store"
 	"github.com/spf13/cobra"
 	_ "modernc.org/sqlite"
+	"pgregory.net/rapid"
 )
 
 func devBuild(version string) selfupdate.BuildInfo {
@@ -481,6 +482,73 @@ func TestErrorDocumentNamesTheKindBehindEveryExitCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Both *testing.T and *rapid.T satisfy this, so a helper works the same
+// inside a rapid.Check property as in a plain test.
+type fataler interface {
+	Fatalf(format string, args ...any)
+}
+
+// An unquoted value can never itself start with a literal `"`, since Value
+// quotes anything that contains one.
+func decodeErrorFieldValue(t fataler, line string) string {
+	raw := strings.TrimPrefix(line, "error: ")
+	if !strings.HasPrefix(raw, `"`) {
+		return raw
+	}
+	v, err := strconv.Unquote(raw)
+	if err != nil {
+		t.Fatalf("unquote %q: %v", raw, err)
+	}
+	return v
+}
+
+func countLinesWithPrefix(doc, prefix string) int {
+	n := 0
+	for _, line := range strings.Split(doc, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// INV-OUT-4's document shape, for any error text and exit code, including
+// one outside the nine the application defines. Doctor_test.go's
+// TestDoctorViolationsKeepStdoutReportAndRenderASeparateErrorDocument covers the stdout half.
+func TestRenderErrorAlwaysWritesExactlyOneDocumentWithErrorKindAndExit(t *testing.T) {
+	tricky := rapid.RuneFrom([]rune{',', ':', '"', '\n', '\r', '\t', ' ', '\\', 'é', '日'})
+	boring := rapid.RuneFrom([]rune("abcXYZ019"))
+	body := rapid.StringOfN(rapid.OneOf(boring, tricky), 1, 40, -1)
+
+	rapid.Check(t, func(t *rapid.T) {
+		msg := body.Draw(t, "msg")
+		code := rapid.IntRange(-5, 15).Draw(t, "code")
+
+		var out strings.Builder
+		if err := renderError(&out, errors.New(msg), code, "hand spawn"); err != nil {
+			t.Fatal(err)
+		}
+		doc := out.String()
+
+		for _, prefix := range []string{"error: ", "kind: ", "exit: "} {
+			if n := countLinesWithPrefix(doc, prefix); n != 1 {
+				t.Fatalf("error document = %q, %d lines start with %q, want exactly 1", doc, n, prefix)
+			}
+		}
+
+		lines := strings.SplitN(doc, "\n", 4)
+		if gotMsg := decodeErrorFieldValue(t, lines[0]); gotMsg != msg {
+			t.Fatalf("error document = %q, error field decoded to %q, want the original %q", doc, gotMsg, msg)
+		}
+		if wantKind := "kind: " + errorKind(code); lines[1] != wantKind {
+			t.Fatalf("error document = %q, kind line = %q, want %q", doc, lines[1], wantKind)
+		}
+		if wantExit := "exit: " + strconv.Itoa(code); lines[2] != wantExit {
+			t.Fatalf("error document = %q, exit line = %q, want %q", doc, lines[2], wantExit)
+		}
+	})
 }
 
 // atqamz/hand#460: the refusal's help line names both ways forward rather than the generic

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -273,12 +273,12 @@ Source: [Output is TOON by default and JSON is retained](adr/output-is-toon-by-d
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
-| INV-OUT-1 | A rendered block's `[N]` always equals the number of rows that follow it. | property | unaudited |
-| INV-OUT-2 | Rendering is total: arbitrary field values, including quotes, newlines, commas, and non-ASCII, render to a document that parses back to the same values. | property | unaudited |
-| INV-OUT-3 | An empty result renders its header with a count of `0` rather than nothing. | property | unaudited |
-| INV-OUT-4 | Every failure writes exactly one document carrying `error`, `kind`, and `exit`, and a command that already produced stdout keeps it. | property | unaudited |
-| INV-OUT-5 | Field selection is a projection: it changes which fields appear and never their values or their order relative to each other. | property | unaudited |
-| INV-OUT-6 | A request combining TOON-only field selection with JSON is rejected, never silently honoured in part. | property | unaudited |
+| INV-OUT-1 | A rendered block's `[N]` always equals the number of rows that follow it. | property | `TestRowsHeaderCountAgreesWithRenderedRowCount` |
+| INV-OUT-2 | Rendering is total: arbitrary field values, including quotes, newlines, commas, and non-ASCII, render to a document that parses back to the same values. | property | `TestFieldValueRoundTripsThroughRender`, `TestRowValuesRoundTripThroughRender` - scoped to `Field`/`Rows` values; `List` items are not field values and are documented-lossy on embedded newlines (`oneLine`) |
+| INV-OUT-3 | An empty result renders its header with a count of `0` rather than nothing. | property | unit - `TestEmptyRowsBlockKeepsCountAndSchema`, `TestTableOnNoItemsStillEmitsSchema`; property - `TestEmptyRowsRenderCountZeroWithSchemaHeader` |
+| INV-OUT-4 | Every failure writes exactly one document carrying `error`, `kind`, and `exit`, and a command that already produced stdout keeps it. | property | `TestRenderErrorAlwaysWritesExactlyOneDocumentWithErrorKindAndExit` covers the document shape; `TestDoctorViolationsKeepStdoutReportAndRenderASeparateErrorDocument` (cmd layer, a real command) covers the stdout-survives-the-error-path half, which has no meaningful generated-input space |
+| INV-OUT-5 | Field selection is a projection: it changes which fields appear and never their values or their order relative to each other. | property | `TestFieldSelectionProjectsValuesUnchangedInRequestedOrder` |
+| INV-OUT-6 | A request combining TOON-only field selection with JSON is rejected, never silently honoured in part. | property | unit - `TestStatusFieldsWithJSONIsAUsageError`; property - `TestRejectFieldsWithJSONRefusesOnlyWhenBothAreRequested` |
 
 ## Diagnosis and treatment
 

--- a/internal/axi/axi_test.go
+++ b/internal/axi/axi_test.go
@@ -247,6 +247,60 @@ func TestRowsHeaderCountAgreesWithRenderedRowCount(t *testing.T) {
 	})
 }
 
+// Checks the parser against literals two other tests already assert byte
+// for byte, not documents Render produced - a self round trip would still
+// close over a parser lenient in the same place a renderer bug hid.
+func TestParserDecodesHandWrittenLiteralDocuments(t *testing.T) {
+	doc := "count: 2\n" +
+		"tasks[2]{id,state}:\n" +
+		"  fix-login,busy\n" +
+		"  ship-docs,idle\n" +
+		"help[1]:\n" +
+		"  - Run `hand status <id>` for detail\n"
+
+	if got := parseFieldValue(t, doc, "count"); got != "2" {
+		t.Fatalf("count field = %q, want %q", got, "2")
+	}
+	_, rows := parseRowsBlock(t, doc, "tasks")
+	want := [][]string{{"fix-login", "busy"}, {"ship-docs", "idle"}}
+	if len(rows) != len(want) {
+		t.Fatalf("parsed %d rows, want %d", len(rows), len(want))
+	}
+	for i := range want {
+		for j := range want[i] {
+			if rows[i][j] != want[i][j] {
+				t.Fatalf("row %d cell %d = %q, want %q", i, j, rows[i][j], want[i][j])
+			}
+		}
+	}
+
+	// Each field's value here is TestValueQuotesOnlyWhatWouldBeAmbiguous's
+	// own literal "want" column for that case, typed again rather than
+	// derived from calling Value.
+	quoted := "a: \"a,b\"\n" +
+		"b: \"say \\\"hi\\\"\"\n" +
+		"c: \"two\\nlines\"\n" +
+		"d: \" padded \"\n"
+	for key, want := range map[string]string{
+		"a": "a,b",
+		"b": `say "hi"`,
+		"c": "two\nlines",
+		"d": " padded ",
+	} {
+		if got := parseFieldValue(t, quoted, key); got != want {
+			t.Fatalf("field %q = %q, want %q", key, got, want)
+		}
+	}
+
+	// A quoted cell may itself carry a literal comma - hand-typed to check
+	// splitTOONCells' quote-boundary handling, not Render's.
+	commaInQuotedCell := "items[1]{a,b}:\n  \"x,y\",z\n"
+	_, commaRows := parseRowsBlock(t, commaInQuotedCell, "items")
+	if len(commaRows) != 1 || commaRows[0][0] != "x,y" || commaRows[0][1] != "z" {
+		t.Fatalf("parsed row = %v, want [[x,y z]]", commaRows)
+	}
+}
+
 // INV-OUT-2: rendering a Field is total over arbitrary values, including
 // quotes, newlines, commas, and non-ASCII - the document that results always
 // parses back to the same value.
@@ -298,9 +352,18 @@ func TestEmptyRowsRenderCountZeroWithSchemaHeader(t *testing.T) {
 
 		var d Doc
 		d.Rows(name, fields, nil)
-		want := fmt.Sprintf("%s[0]{%s}:\n", name, strings.Join(fields, ","))
-		if got := d.String(); got != want {
-			t.Fatalf("Render() = %q, want %q", got, want)
+		doc := d.String()
+
+		declared, rows := parseRowsBlock(t, doc, name)
+		if declared != 0 {
+			t.Fatalf("Render() = %q, header declares %d rows, want 0", doc, declared)
+		}
+		if len(rows) != 0 {
+			t.Fatalf("Render() = %q, %d rows rendered after an empty result, want 0", doc, len(rows))
+		}
+		gotFields := rowsSchemaFields(t, doc, name)
+		if strings.Join(gotFields, ",") != strings.Join(fields, ",") {
+			t.Fatalf("Render() = %q, schema fields = %v, want %v", doc, gotFields, fields)
 		}
 	})
 }

--- a/internal/axi/axi_test.go
+++ b/internal/axi/axi_test.go
@@ -214,3 +214,133 @@ func TestTableOnNoItemsStillEmitsSchema(t *testing.T) {
 		t.Fatalf("Render() = %q", got)
 	}
 }
+
+// Biases toward the runes Value treats specially - separator, quote,
+// boundary/embedded whitespace, non-ASCII - since a uniform rapid.String()
+// almost never produces them.
+func toonValueGen() *rapid.Generator[string] {
+	tricky := rapid.RuneFrom([]rune{',', ':', '"', '\n', '\r', '\t', ' ', '\\', 'é', '日', '🎉', '\u0085'})
+	boring := rapid.RuneFrom([]rune("abcXYZ019"))
+	mixed := rapid.StringOfN(rapid.OneOf(boring, tricky), 0, 24, -1)
+	return rapid.OneOf(rapid.String(), mixed)
+}
+
+// INV-OUT-1: a rendered block's [N] always equals the number of rows that
+// follow it, checked by an independent count of the rendered lines rather
+// than by re-reading the header Render itself computed from len(rows).
+func TestRowsHeaderCountAgreesWithRenderedRowCount(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 20).Draw(t, "n")
+		rows := make([][]string, n)
+		for i := range rows {
+			rows[i] = []string{fmt.Sprintf("r%d", i)}
+		}
+		var d Doc
+		d.Rows("items", []string{"v"}, rows)
+		declared, parsed := parseRowsBlock(t, d.String(), "items")
+		if declared != n {
+			t.Fatalf("Render() = %q, header declares %d rows, want %d", d.String(), declared, n)
+		}
+		if len(parsed) != n {
+			t.Fatalf("Render() = %q, %d row lines actually follow the header, want %d", d.String(), len(parsed), n)
+		}
+	})
+}
+
+// INV-OUT-2: rendering a Field is total over arbitrary values, including
+// quotes, newlines, commas, and non-ASCII - the document that results always
+// parses back to the same value.
+func TestFieldValueRoundTripsThroughRender(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		value := toonValueGen().Draw(t, "value")
+		var d Doc
+		d.Field("f", value)
+		if got := parseFieldValue(t, d.String(), "f"); got != value {
+			t.Fatalf("Field(%q) rendered %q, parsed back %q", value, d.String(), got)
+		}
+	})
+}
+
+// INV-OUT-2 for row cells: the same totality claim over a Rows block's
+// values - the "field values" the invariant map's Output rendering section
+// names.
+func TestRowValuesRoundTripThroughRender(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(1, 4).Draw(t, "cols")
+		values := make([]string, n)
+		fields := make([]string, n)
+		for i := range values {
+			values[i] = toonValueGen().Draw(t, fmt.Sprintf("v%d", i))
+			fields[i] = fmt.Sprintf("f%d", i)
+		}
+
+		var d Doc
+		d.Rows("items", fields, [][]string{values})
+		_, rows := parseRowsBlock(t, d.String(), "items")
+		if len(rows) != 1 {
+			t.Fatalf("Render() = %q, parsed %d rows, want 1", d.String(), len(rows))
+		}
+		for i, want := range values {
+			if rows[0][i] != want {
+				t.Fatalf("Render() = %q, cell %d parsed back %q, want %q", d.String(), i, rows[0][i], want)
+			}
+		}
+	})
+}
+
+// INV-OUT-3: an empty result renders its header with a count of 0 rather
+// than nothing, for any block name and field set - the general form of
+// TestEmptyRowsBlockKeepsCountAndSchema and TestTableOnNoItemsStillEmitsSchema above.
+func TestEmptyRowsRenderCountZeroWithSchemaHeader(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		name := rapid.StringMatching(`[a-z][a-z_]{0,9}`).Draw(t, "name")
+		fields := rapid.SliceOfN(rapid.StringMatching(`[a-z][a-z_]{0,7}`), 0, 5).Draw(t, "fields")
+
+		var d Doc
+		d.Rows(name, fields, nil)
+		want := fmt.Sprintf("%s[0]{%s}:\n", name, strings.Join(fields, ","))
+		if got := d.String(); got != want {
+			t.Fatalf("Render() = %q, want %q", got, want)
+		}
+	})
+}
+
+type projRow map[string]string
+
+// INV-OUT-5: field selection is a projection. Select narrows which columns
+// Table renders, in the order requested, but never touches a selected
+// field's own value or which field a rendered cell belongs to.
+func TestFieldSelectionProjectsValuesUnchangedInRequestedOrder(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		names := rapid.SliceOfNDistinct(rapid.StringMatching(`[a-z][a-z_]{0,6}`), 1, 6, func(s string) string { return s }).Draw(t, "names")
+		values := make(map[string]string, len(names))
+		cols := make([]Column[projRow], len(names))
+		for i, name := range names {
+			values[name] = toonValueGen().Draw(t, "value_"+name)
+			field := name
+			cols[i] = Column[projRow]{Name: field, Value: func(r projRow) string { return r[field] }}
+		}
+		item := projRow(values)
+
+		perm := rapid.Permutation(names).Draw(t, "perm")
+		k := rapid.IntRange(1, len(perm)).Draw(t, "k")
+		want := perm[:k]
+
+		selected, err := Select(cols, want)
+		if err != nil {
+			t.Fatalf("Select(%v) error = %v", want, err)
+		}
+		var d Doc
+		Table(&d, "items", []projRow{item}, selected)
+		_, rows := parseRowsBlock(t, d.String(), "items")
+		if len(rows) != 1 || len(rows[0]) != len(want) {
+			t.Fatalf("Render() = %q, want exactly one row of %d cells", d.String(), len(want))
+		}
+		for i, name := range want {
+			if rows[0][i] != values[name] {
+				t.Fatalf("Render() = %q, field %q at position %d = %q, want %q unchanged from the source item",
+					d.String(), name, i, rows[0][i], values[name])
+			}
+		}
+	})
+}

--- a/internal/axi/parse_test.go
+++ b/internal/axi/parse_test.go
@@ -71,6 +71,20 @@ func quotedTokenEnd(s string) int {
 	return len(s)
 }
 
+// Finds name's rows header line and returns the lines after it, for both
+// parseRowsBlock and rowsSchemaFields to read independently.
+func findRowsHeader(tb fataler, doc, name string) (header string, body []string) {
+	lines := strings.Split(doc, "\n")
+	prefix := name + "["
+	for i, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			return line, lines[i+1:]
+		}
+	}
+	tb.Fatalf("no rows block %q in document %q", name, doc)
+	return "", nil
+}
+
 func rowsHeaderCount(tb fataler, header string) int {
 	open := strings.IndexByte(header, '[')
 	close := strings.IndexByte(header, ']')
@@ -84,31 +98,38 @@ func rowsHeaderCount(tb fataler, header string) int {
 	return n
 }
 
+// Reads the schema names between { and } in name's header.
+func rowsSchemaFields(tb fataler, doc, name string) []string {
+	header, _ := findRowsHeader(tb, doc, name)
+	open := strings.IndexByte(header, '{')
+	close := strings.IndexByte(header, '}')
+	if open < 0 || close < open {
+		tb.Fatalf("malformed rows header %q", header)
+	}
+	inner := header[open+1 : close]
+	if inner == "" {
+		return nil
+	}
+	return strings.Split(inner, ",")
+}
+
 // Stops only at the next line not indented by two spaces, independent of
 // the header's own declared count, so a caller can compare the two
 // (INV-OUT-1) instead of trusting the header.
 func parseRowsBlock(tb fataler, doc, name string) (declared int, rows [][]string) {
-	lines := strings.Split(doc, "\n")
-	header := name + "["
-	for i, line := range lines {
-		if !strings.HasPrefix(line, header) {
-			continue
+	header, body := findRowsHeader(tb, doc, name)
+	declared = rowsHeaderCount(tb, header)
+	for _, line := range body {
+		cell, ok := strings.CutPrefix(line, "  ")
+		if !ok {
+			break
 		}
-		declared = rowsHeaderCount(tb, line)
-		for _, body := range lines[i+1:] {
-			cell, ok := strings.CutPrefix(body, "  ")
-			if !ok {
-				break
-			}
-			cells := splitTOONCells(cell)
-			decoded := make([]string, len(cells))
-			for c, raw := range cells {
-				decoded[c] = decodeTOONValue(tb, raw)
-			}
-			rows = append(rows, decoded)
+		cells := splitTOONCells(cell)
+		decoded := make([]string, len(cells))
+		for c, raw := range cells {
+			decoded[c] = decodeTOONValue(tb, raw)
 		}
-		return declared, rows
+		rows = append(rows, decoded)
 	}
-	tb.Fatalf("no rows block %q in document %q", name, doc)
-	return 0, nil
+	return declared, rows
 }

--- a/internal/axi/parse_test.go
+++ b/internal/axi/parse_test.go
@@ -1,0 +1,114 @@
+package axi
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Both *testing.T and *rapid.T satisfy this, so a helper works the same
+// inside a rapid.Check property as in a plain test.
+type fataler interface {
+	Fatalf(format string, args ...any)
+}
+
+// An unquoted value can never itself start with `"` - Value quotes anything
+// that contains one - so that leading byte alone tells raw and quoted tokens
+// apart.
+func decodeTOONValue(tb fataler, token string) string {
+	if !strings.HasPrefix(token, `"`) {
+		return token
+	}
+	v, err := strconv.Unquote(token)
+	if err != nil {
+		tb.Fatalf("unquote %q: %v", token, err)
+	}
+	return v
+}
+
+func parseFieldValue(tb fataler, doc, key string) string {
+	prefix := key + ": "
+	for _, line := range strings.Split(doc, "\n") {
+		if v, ok := strings.CutPrefix(line, prefix); ok {
+			return decodeTOONValue(tb, v)
+		}
+	}
+	tb.Fatalf("no field %q in document %q", key, doc)
+	return ""
+}
+
+// A leading `"` opens a Go-quoted token that may itself carry a literal
+// comma - the same assumption Value's quoting guarantees for an unquoted
+// cell, which can never contain one.
+func splitTOONCells(line string) []string {
+	var cells []string
+	for len(line) > 0 {
+		if line[0] == '"' {
+			end := quotedTokenEnd(line)
+			cells = append(cells, line[:end])
+			line = strings.TrimPrefix(line[end:], ",")
+			continue
+		}
+		if i := strings.IndexByte(line, ','); i >= 0 {
+			cells = append(cells, line[:i])
+			line = line[i+1:]
+			continue
+		}
+		cells = append(cells, line)
+		line = ""
+	}
+	return cells
+}
+
+func quotedTokenEnd(s string) int {
+	for i := 1; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++
+		case '"':
+			return i + 1
+		}
+	}
+	return len(s)
+}
+
+func rowsHeaderCount(tb fataler, header string) int {
+	open := strings.IndexByte(header, '[')
+	close := strings.IndexByte(header, ']')
+	if open < 0 || close < open {
+		tb.Fatalf("malformed rows header %q", header)
+	}
+	n, err := strconv.Atoi(header[open+1 : close])
+	if err != nil {
+		tb.Fatalf("malformed row count in %q: %v", header, err)
+	}
+	return n
+}
+
+// Stops only at the next line not indented by two spaces, independent of
+// the header's own declared count, so a caller can compare the two
+// (INV-OUT-1) instead of trusting the header.
+func parseRowsBlock(tb fataler, doc, name string) (declared int, rows [][]string) {
+	lines := strings.Split(doc, "\n")
+	header := name + "["
+	for i, line := range lines {
+		if !strings.HasPrefix(line, header) {
+			continue
+		}
+		declared = rowsHeaderCount(tb, line)
+		for _, body := range lines[i+1:] {
+			cell, ok := strings.CutPrefix(body, "  ")
+			if !ok {
+				break
+			}
+			cells := splitTOONCells(cell)
+			decoded := make([]string, len(cells))
+			for c, raw := range cells {
+				decoded[c] = decodeTOONValue(tb, raw)
+			}
+			rows = append(rows, decoded)
+		}
+		return declared, rows
+	}
+	tb.Fatalf("no rows block %q in document %q", name, doc)
+	return 0, nil
+}


### PR DESCRIPTION
## Summary

- Add property tests for the six INV-OUT rows (`internal/axi` output rendering, phase 2 of atqamz/hand#442): rendered row counts agree with their header, `Field`/`Rows` values round-trip through render, an empty result keeps its schema header, field selection is a pure projection, `--fields`+`--json` is always rejected together, and every failure writes exactly one `error`/`kind`/`exit` document without disturbing stdout a command already wrote.
- No TOON parser existed anywhere in the tree; `internal/axi/parse_test.go` adds a minimal test-only one (Field lines and Rows cells only, not List blocks) so INV-OUT-2's round-trip claim is actually checked rather than asserted by construction.
- Update the six `INV-OUT-*` coverage cells in `docs/testing-invariants.md`. All six rows tested true exactly as stated; none needed correction, unlike phase 1's INV-PURE-2.

Part of atqamz/hand#442.

## Test plan

```
$ make lint
go vet ./...
golangci-lint run
0 issues.
go run ./tools/commentlint .
# clean

$ make test
# all packages pass, 2m16s wall clock on Linux (cmd 122s / internal/runtime 97s dominate, unrelated to this change)

$ make e2e
ok  	github.com/atqamz/hand/tests/e2e	66.427s
```

Added runtime: all six new properties together run in well under 10ms combined (Linux), each in-process with no subprocess or filesystem I/O. `TestDoctorViolationsKeepStdoutReportAndRenderASeparateErrorDocument` reuses the existing `hand doctor` fixture setup and adds negligible time to that package.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->