### PR TITLE
fix(paths): render resolved paths pasteably instead of %q

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/home"
 	"github.com/atqamz/hand/internal/integration"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/spf13/cobra"
@@ -218,14 +219,14 @@ func renameProject(homeDir, oldName, newName string) (renameResult, error) {
 	oldClone := filepath.Join(homeDir, "projects", oldName)
 	newClone := filepath.Join(homeDir, "projects", newName)
 	if info, err := os.Stat(oldClone); err != nil {
-		return renameResult{}, fmt.Errorf("project %q clone %q: %w", oldName, oldClone, err)
+		return renameResult{}, fmt.Errorf("project %q clone %s: %w", oldName, pathdisplay.Context(oldClone), err)
 	} else if !info.IsDir() {
-		return renameResult{}, fmt.Errorf("project %q clone %q is not a directory", oldName, oldClone)
+		return renameResult{}, fmt.Errorf("project %q clone %s is not a directory", oldName, pathdisplay.Context(oldClone))
 	}
 	if _, err := os.Lstat(newClone); err == nil {
-		return renameResult{}, fmt.Errorf("project destination %q already exists", newClone)
+		return renameResult{}, fmt.Errorf("project destination %s already exists", pathdisplay.Context(newClone))
 	} else if !os.IsNotExist(err) {
-		return renameResult{}, fmt.Errorf("check project destination %q: %w", newClone, err)
+		return renameResult{}, fmt.Errorf("check project destination %s: %w", pathdisplay.Context(newClone), err)
 	}
 
 	if err := moveProjectClone(oldClone, newClone); err != nil {
@@ -259,9 +260,9 @@ func repointProject(homeDir, name, url string) (repointResult, error) {
 
 	clonePath := filepath.Join(homeDir, "projects", p.Name)
 	if info, err := os.Stat(clonePath); err != nil {
-		return repointResult{}, fmt.Errorf("project %q clone %q: %w", p.Name, clonePath, err)
+		return repointResult{}, fmt.Errorf("project %q clone %s: %w", p.Name, pathdisplay.Context(clonePath), err)
 	} else if !info.IsDir() {
-		return repointResult{}, fmt.Errorf("project %q clone %q is not a directory", p.Name, clonePath)
+		return repointResult{}, fmt.Errorf("project %q clone %s is not a directory", p.Name, pathdisplay.Context(clonePath))
 	}
 	oldOrigin, err := storedOriginURL(clonePath)
 	if err != nil {
@@ -411,7 +412,7 @@ func newProjectAddCmd() *cobra.Command {
 					return err
 				}
 				if managed {
-					return &ExitError{Err: fmt.Errorf("local project source %q is already a managed Hand project", source.input), Code: 3}
+					return &ExitError{Err: fmt.Errorf("local project source %s is already a managed Hand project", pathdisplay.Context(source.input)), Code: 3}
 				}
 			}
 
@@ -556,7 +557,7 @@ func reserveCloneDestination(path string) error {
 	}
 	if err := os.Mkdir(path, 0o755); err != nil {
 		if os.IsExist(err) {
-			return &ExitError{Err: fmt.Errorf("project destination %q already exists", path), Code: 3}
+			return &ExitError{Err: fmt.Errorf("project destination %s already exists", pathdisplay.Context(path)), Code: 3}
 		}
 		return fmt.Errorf("reserve project destination: %w", err)
 	}

--- a/cmd/project_source.go
+++ b/cmd/project_source.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/project"
 )
 
@@ -64,46 +65,46 @@ func resolveLocalProjectSource(source projectSource) (projectSource, error) {
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("local project source %q: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("local project source %s: %w", pathdisplay.Context(source.input), err)
 	}
 	if !info.IsDir() {
-		return projectSource{}, fmt.Errorf("local project source %q is not a directory", source.input)
+		return projectSource{}, fmt.Errorf("local project source %s is not a directory", pathdisplay.Context(source.input))
 	}
 	root, err := git.ResolveRoot(path)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("local project source %q is not a Git worktree: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("local project source %s is not a Git worktree: %w", pathdisplay.Context(source.input), err)
 	}
 	bare, err := git.IsBare(root)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("inspect local project source %q: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("inspect local project source %s: %w", pathdisplay.Context(source.input), err)
 	}
 	if bare {
-		return projectSource{}, fmt.Errorf("local project source %q is a bare Git repository; Hand requires a non-bare worktree", source.input)
+		return projectSource{}, fmt.Errorf("local project source %s is a bare Git repository; Hand requires a non-bare worktree", pathdisplay.Context(source.input))
 	}
 	if _, err := git.HeadCommit(root); err != nil {
-		return projectSource{}, fmt.Errorf("local project source %q has no committed HEAD; commit a baseline or use `hand project create <name>`: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("local project source %s has no committed HEAD; commit a baseline or use `hand project create <name>`: %w", pathdisplay.Context(source.input), err)
 	}
 	if _, err := git.CurrentBranch(root); err != nil {
-		return projectSource{}, fmt.Errorf("local project source %q must have a checked-out branch: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("local project source %s must have a checked-out branch: %w", pathdisplay.Context(source.input), err)
 	}
 	defaultBranch, err := git.LocalDefaultBranch(root)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("local project source %q has no stable default branch: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("local project source %s has no stable default branch: %w", pathdisplay.Context(source.input), err)
 	}
 	baseline, err := git.BranchCommit(root, defaultBranch)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("local project source %q default branch %q is not committed: %w", source.input, defaultBranch, err)
+		return projectSource{}, fmt.Errorf("local project source %s default branch %q is not committed: %w", pathdisplay.Context(source.input), defaultBranch, err)
 	}
 	dirty, err := git.HasUncommittedChanges(root)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("inspect local project source %q: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("inspect local project source %s: %w", pathdisplay.Context(source.input), err)
 	}
 	if dirty {
 		return projectSource{}, fmt.Errorf("local Git source has uncommitted or untracked changes; Hand adopts committed repository state only; commit, stash, or remove the changes before adding this Project")
 	}
 	locator, err := project.CanonicalFileLocator(root)
 	if err != nil {
-		return projectSource{}, fmt.Errorf("canonicalize local project source %q: %w", source.input, err)
+		return projectSource{}, fmt.Errorf("canonicalize local project source %s: %w", pathdisplay.Context(source.input), err)
 	}
 	source.root = root
 	source.locator = locator
@@ -139,14 +140,14 @@ func prepareAdoptedClone(source projectSource, dest string) error {
 		return err
 	}
 	if bare {
-		return fmt.Errorf("adopted project clone %q is bare", dest)
+		return fmt.Errorf("adopted project clone %s is bare", pathdisplay.Context(dest))
 	}
 	hasAlternates, err := git.HasAlternates(dest)
 	if err != nil {
 		return err
 	}
 	if hasAlternates {
-		return fmt.Errorf("adopted project clone %q uses a shared Git object store", dest)
+		return fmt.Errorf("adopted project clone %s uses a shared Git object store", pathdisplay.Context(dest))
 	}
 	if err := git.RemoveOrigin(dest); err != nil {
 		return err

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/atqamz/hand/internal/axi"
 	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/steering"
 	"github.com/spf13/cobra"
@@ -40,7 +41,7 @@ func newSendCmd() *cobra.Command {
 			if filePath != "" {
 				data, err := os.ReadFile(filePath)
 				if err != nil {
-					return fmt.Errorf("read --file %q: %w", filePath, err)
+					return fmt.Errorf("read --file %s: %w", pathdisplay.Context(filePath), err)
 				}
 				message = strings.TrimRight(string(data), "\n")
 			} else {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/selfupdate"
 )
 
@@ -285,9 +286,9 @@ func TestUpdateWarnsWhenHandHomeIsNotAFleetHome(t *testing.T) {
 	if !strings.Contains(got, "fleet_reconcile: failed\n") {
 		t.Fatalf("got %q, want fleet_reconcile=failed", got)
 	}
-	quotedHome := fmt.Sprintf("%q", notAHome)
-	if !strings.Contains(errOut.String(), "warning: resolve fleet home for reconciliation:") || !strings.Contains(errOut.String(), quotedHome) {
-		t.Fatalf("got stderr %q, want a warning naming %q", errOut.String(), quotedHome)
+	renderedHome := pathdisplay.Context(notAHome)
+	if !strings.Contains(errOut.String(), "warning: resolve fleet home for reconciliation:") || !strings.Contains(errOut.String(), renderedHome) {
+		t.Fatalf("got stderr %q, want a warning naming %q", errOut.String(), renderedHome)
 	}
 }
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -319,13 +319,14 @@ Source: `internal/toolchain` (`Runtime.SupportsGitTransport`, `Store.Status`, `S
 
 ## Pure helpers
 
-Source: `internal/shellquote`, `internal/age`, `cmd/statusview.go`.
+Source: `internal/shellquote`, `internal/pathdisplay`, `internal/age`, `cmd/statusview.go`.
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
 | INV-PURE-1 | For any string, a real shell parses `shellquote.Quote(s)` back to exactly `s`, including spaces, quotes, newlines, and non-ASCII. | property | `TestQuoteRoundTripsPOSIXShellArguments` lands unit cases; property - `TestQuoteRoundTripsAnyStringThroughARealShell` |
 | INV-PURE-2 | `axi.Truncate` never splits a UTF-8 rune: a string within budget returns unchanged, and a string over budget keeps exactly its first `budget` runes as a stable, unsplit prefix - budget bounds the retained prefix, not the returned string, since the recovery annotation is deliberately appended past it - a note that could itself be truncated away would be useless. `Truncate` is meant to be applied to original text exactly once: its only caller, `cmd/status.go:82`, always passes un-truncated text, and re-truncating `Truncate`'s own output corrupts the annotation's reported total rather than merely repeating it - a precondition the next caller needs to see stated, not rediscover. | property | unit - `TestTruncateLeavesShortTextAlone`, `TestTruncateCarriesSizeAndRecoveryHint`, `TestTruncateCountsRunes`, `TestTruncateMustBeAppliedToOriginalTextOnce`; property - `TestTruncateKeepsAnUnsplitPrefixBoundedByBudget` |
 | INV-PURE-3 | Age rendering is monotonic in its input: a larger duration never renders as a smaller age. | property | unit - `TestFormatDuration`, `TestFormatAge`; property - `TestFormatDurationIsMonotonic` |
+| INV-PURE-4 | A path hand itself resolved and names to the operator only as context (never as something typed or run) renders via `pathdisplay.Context`, which delimits with backticks and never escapes the path's own bytes, so it never doubles a separator the way `%q` does on Windows. This does not apply to `%q` on untrusted or adversarial input (e.g. an archive member name), where showing an escaped byte such as a literal backslash is the message's own point, not a rendering defect. | unit | `TestContextDelimitsWithoutEscapingSeparators` |
 
 ## What is deliberately not an invariant
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -12,6 +12,7 @@ import (
 	"github.com/atqamz/hand/internal/atomicfile"
 	"github.com/atqamz/hand/internal/brief"
 	"github.com/atqamz/hand/internal/launch"
+	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/state"
 )
 
@@ -327,7 +328,7 @@ func launchStatement(o Options) (string, error) {
 	if o.ReportPath == "" {
 		return "", fmt.Errorf("report path is required for a prompt-capable harness")
 	}
-	statement := fmt.Sprintf("The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", o.ReportPath)
+	statement := fmt.Sprintf("The worker report channel is %s. Append every state change to that file with plain shell redirection; this is the only way anything you say reaches the supervisor. Use these report prefixes: working:, done:, failed:, blocked:, needs-decision:, paused:.", shellquote.Quote(o.ReportPath))
 	switch o.Kind {
 	case state.KindShip:
 		statement += " You are authorized to commit, push your branch, and open the pull request; merging and closing the issue are the supervisor's action only."

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/launch"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/toolchain"
 )
 
@@ -59,7 +60,7 @@ func NewClient() *Client {
 
 func NewClientAt(path string, env []string) (*Client, error) {
 	if !filepath.IsAbs(path) {
-		return nil, fmt.Errorf("managed Herdr executable %q must be an absolute path", path)
+		return nil, fmt.Errorf("managed Herdr executable %s must be an absolute path", pathdisplay.Context(path))
 	}
 	return &Client{executable: path, env: append([]string(nil), env...)}, nil
 }
@@ -297,7 +298,7 @@ func (c *Client) startServer(ctx context.Context) error {
 		executable = "herdr"
 	}
 	if !filepath.IsAbs(executable) {
-		return fmt.Errorf("managed Herdr executable %q must be an absolute path", executable)
+		return fmt.Errorf("managed Herdr executable %s must be an absolute path", pathdisplay.Context(executable))
 	}
 	cmd := exec.Command(executable, c.wireArgs("server")...)
 	parentEnv := c.env
@@ -335,7 +336,7 @@ func (c *Client) attach(ctx context.Context) error {
 		executable = "herdr"
 	}
 	if !filepath.IsAbs(executable) {
-		return fmt.Errorf("managed Herdr executable %q must be an absolute path", executable)
+		return fmt.Errorf("managed Herdr executable %s must be an absolute path", pathdisplay.Context(executable))
 	}
 	cmd := exec.CommandContext(ctx, executable, "session", "attach", c.session)
 	if c.env != nil {

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/secondhand"
 )
 
@@ -109,10 +110,10 @@ func Resolve() (string, error) {
 	}
 	ok, err := IsHome(handHome)
 	if err != nil {
-		return "", fmt.Errorf("check HAND_HOME %q: %w", handHome, err)
+		return "", fmt.Errorf("check HAND_HOME %s: %w", pathdisplay.Context(handHome), err)
 	}
 	if !ok {
-		return "", fmt.Errorf("HAND_HOME %q %w", handHome, ErrHandHomeInvalid)
+		return "", fmt.Errorf("HAND_HOME %s %w", pathdisplay.Context(handHome), ErrHandHomeInvalid)
 	}
 
 	cwd, err := os.Getwd()
@@ -128,8 +129,8 @@ func Resolve() (string, error) {
 	}
 	if cwdHome != "" && cwdHome != handHome {
 		return "", fmt.Errorf(
-			"%w: HAND_HOME is %q, the working directory is inside %q; unset HAND_HOME to act on the working directory's home, or run from outside %q to act on HAND_HOME's",
-			ErrAmbiguousHome, handHome, cwdHome, cwdHome)
+			"%w: HAND_HOME is %s, the working directory is inside %s; unset HAND_HOME to act on the working directory's home, or run from outside %s to act on HAND_HOME's",
+			ErrAmbiguousHome, pathdisplay.Context(handHome), pathdisplay.Context(cwdHome), pathdisplay.Context(cwdHome))
 	}
 	return handHome, nil
 }

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -2,13 +2,12 @@ package home
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/atqamz/hand/internal/axi"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/secondhand"
 )
 
@@ -263,12 +262,12 @@ func TestResolveRefusesWhenHandHomeAndCwdNameDifferentHomes(t *testing.T) {
 	if !errors.Is(err, ErrAmbiguousHome) {
 		t.Fatalf("got %v, want it to wrap ErrAmbiguousHome", err)
 	}
-	// %q is this package's existing convention for rendering a path in an error (ErrHandHomeInvalid
-	// does the same), so the assertion compares against that same rendering rather than the raw path.
-	if !strings.Contains(err.Error(), fmt.Sprintf("%q", envHome)) {
+	// pathdisplay.Context is this package's convention for naming a path as context in an
+	// error, so the assertion compares against that same rendering rather than the raw path.
+	if !strings.Contains(err.Error(), pathdisplay.Context(envHome)) {
 		t.Fatalf("got %q, want it to name HAND_HOME's value %q", err.Error(), envHome)
 	}
-	if !strings.Contains(err.Error(), fmt.Sprintf("%q", cwdHome)) {
+	if !strings.Contains(err.Error(), pathdisplay.Context(cwdHome)) {
 		t.Fatalf("got %q, want it to name the working directory's home %q", err.Error(), cwdHome)
 	}
 }
@@ -380,7 +379,7 @@ func TestResolveFailsLoudlyWhenHandHomeIsNotAHome(t *testing.T) {
 	if errors.Is(err, ErrNotFound) {
 		t.Fatalf("got %v, want it not to wrap ErrNotFound", err)
 	}
-	if !strings.Contains(err.Error(), axi.Value(notAHome)) {
+	if !strings.Contains(err.Error(), pathdisplay.Context(notAHome)) {
 		t.Fatalf("got %q, want it to name HAND_HOME's value %q", err.Error(), notAHome)
 	}
 	if strings.Contains(err.Error(), ErrNotFound.Error()) {

--- a/internal/integration/catalog.go
+++ b/internal/integration/catalog.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/atqamz/hand/internal/atomicfile"
+	"github.com/atqamz/hand/internal/pathdisplay"
 )
 
 type Capability struct {
@@ -212,7 +213,7 @@ func (s *Store) Install(id, source string) (string, error) {
 		return "", fmt.Errorf("inspect optional capability source: %w", err)
 	}
 	if !info.Mode().IsRegular() || (runtime.GOOS != "windows" && info.Mode()&0111 == 0) {
-		return "", fmt.Errorf("optional capability source %q is not an executable regular file", source)
+		return "", fmt.Errorf("optional capability source %s is not an executable regular file", pathdisplay.Context(source))
 	}
 
 	input, err := os.Open(source)

--- a/internal/pathdisplay/pathdisplay.go
+++ b/internal/pathdisplay/pathdisplay.go
@@ -1,0 +1,11 @@
+// Package pathdisplay renders a filesystem path for a message that names it only as
+// context, never as something the operator is told to type or run - that job belongs to
+// internal/shellquote instead.
+package pathdisplay
+
+// Context delimits path with backticks, hand's existing convention for every other literal
+// token shown to the operator. Backticks need no escaping, so a path renders unchanged
+// instead of %q doubling its separators on Windows.
+func Context(path string) string {
+	return "`" + path + "`"
+}

--- a/internal/pathdisplay/pathdisplay_test.go
+++ b/internal/pathdisplay/pathdisplay_test.go
@@ -1,0 +1,18 @@
+package pathdisplay
+
+import "testing"
+
+func TestContextDelimitsWithoutEscapingSeparators(t *testing.T) {
+	for _, path := range []string{
+		`C:\Users\me\fleet home`,
+		"/home/me/fleet home",
+		"/home/me/plain",
+		"",
+	} {
+		got := Context(path)
+		want := "`" + path + "`"
+		if got != want {
+			t.Fatalf("Context(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/internal/project/locator.go
+++ b/internal/project/locator.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/atqamz/hand/internal/pathdisplay"
 )
 
 func IsFileLocator(value string) bool {
@@ -21,7 +23,7 @@ func CanonicalFileLocator(path string) (string, error) {
 	}
 	resolved, err := filepath.EvalSymlinks(abs)
 	if err != nil {
-		return "", fmt.Errorf("resolve path %q: %w", path, err)
+		return "", fmt.Errorf("resolve path %s: %w", pathdisplay.Context(path), err)
 	}
 	resolved, err = filepath.Abs(resolved)
 	if err != nil {
@@ -62,7 +64,7 @@ func FileLocatorPath(locator string) (string, error) {
 func IsManagedPath(homeDir, path string) (bool, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return false, fmt.Errorf("resolve managed-path candidate %q: %w", path, err)
+		return false, fmt.Errorf("resolve managed-path candidate %s: %w", pathdisplay.Context(path), err)
 	}
 	resolved, err = filepath.Abs(resolved)
 	if err != nil {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -18,6 +18,8 @@ import (
 	"github.com/atqamz/hand/internal/filelock"
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/integration"
+	"github.com/atqamz/hand/internal/pathdisplay"
+	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/store"
 )
 
@@ -525,7 +527,7 @@ func Rename(homeDir, oldName, newName string) error {
 	if err != nil {
 		canonicalHome, err = filepath.Abs(homeDir)
 		if err != nil {
-			return fmt.Errorf("resolve project home %q: %w", homeDir, err)
+			return fmt.Errorf("resolve project home %s: %w", pathdisplay.Context(homeDir), err)
 		}
 	}
 	for _, p := range projects {
@@ -697,7 +699,7 @@ const notGitRepoMarker = "not in a git repository"
 // GateInitCommand is the exact remedy for GateNotInitialized. no-mistakes init is idempotent and
 // repairs a stale working_path in place, so callers should print this verbatim rather than describe it.
 func GateInitCommand(clonePath string) string {
-	return fmt.Sprintf("cd %s && no-mistakes init", clonePath)
+	return fmt.Sprintf("cd %s && no-mistakes init", shellquote.Quote(clonePath))
 }
 
 // GateStatus asks the no-mistakes binary whether clonePath's gate is initialized, rather than

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/atqamz/hand/internal/completion"
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/shellquote"
 	"github.com/atqamz/hand/internal/store"
 )
 
@@ -1034,7 +1035,15 @@ func TestGateStatusMissingClonePath(t *testing.T) {
 
 func TestGateInitCommand(t *testing.T) {
 	got := GateInitCommand("/home/atqa/secondhand/projects/secondhand")
-	want := "cd /home/atqa/secondhand/projects/secondhand && no-mistakes init"
+	want := "cd " + shellquote.Quote("/home/atqa/secondhand/projects/secondhand") + " && no-mistakes init"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGateInitCommandQuotesACloneWithASpace(t *testing.T) {
+	got := GateInitCommand("/home/atqa/secondhand/projects/my app")
+	want := "cd " + shellquote.Quote("/home/atqa/secondhand/projects/my app") + " && no-mistakes init"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/filelock"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/secondhand"
 	"github.com/atqamz/hand/internal/store"
 	_ "modernc.org/sqlite"
@@ -273,7 +274,7 @@ func staleLocators(tx *sql.Tx, selectedHome, fleetID string) ([]Locator, error) 
 		}
 		locatorKey, err := pathKey(locator.Home)
 		if err != nil {
-			return nil, fmt.Errorf("resolve registered Fleet home %q for registry repair: %w", locator.Home, err)
+			return nil, fmt.Errorf("resolve registered Fleet home %s for registry repair: %w", pathdisplay.Context(locator.Home), err)
 		}
 		if locatorKey != selectedKey || locator.FleetID == fleetID {
 			continue

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -13,6 +13,7 @@ import (
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
 	"github.com/atqamz/hand/internal/launch"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/worktree"
 )
@@ -159,7 +160,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	if brief.ExecutionClass(req.attempt.ExecutionClass) == brief.ExecutionClassMechanical {
 		releaseWorktree, err = state.Lock(req.home, "worktree:"+worktreePath)
 		if err != nil {
-			return "", r.failProvision(req, lease, nil, false, fmt.Errorf("lock worktree %q: %w", worktreePath, err))
+			return "", r.failProvision(req, lease, nil, false, fmt.Errorf("lock worktree %s: %w", pathdisplay.Context(worktreePath), err))
 		}
 		defer releaseWorktree()
 		actual, err := r.deps.worktree.headCommit(worktreePath)
@@ -177,7 +178,7 @@ func (r *Runtime) provisionLocked(ctx context.Context, req provisioningRequest) 
 	if releaseWorktree == nil {
 		releaseWorktree, err = state.Lock(req.home, "worktree:"+worktreePath)
 		if err != nil {
-			return "", r.failProvision(req, lease, nil, false, fmt.Errorf("lock worktree %q: %w", worktreePath, err))
+			return "", r.failProvision(req, lease, nil, false, fmt.Errorf("lock worktree %s: %w", pathdisplay.Context(worktreePath), err))
 		}
 		defer releaseWorktree()
 	}

--- a/internal/runtime/reconcile.go
+++ b/internal/runtime/reconcile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/atqamz/hand/internal/ghutil"
 	"github.com/atqamz/hand/internal/harness"
 	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/project"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/workerobs"
@@ -616,8 +617,8 @@ func (r *Runtime) convergeTerminalLifecycle(home string, task state.Task, attemp
 
 func (r *Runtime) unwindFailedProvisioning(home string, task state.Task, attempt state.Attempt, decision reconciliationDecision) error {
 	if !unwindableProvisioning(attempt) {
-		return Precondition(fmt.Errorf("refusing to unwind attempt %d: it records lifecycle %q, worktree %q, lease %s, Herdr identity (%s) and teardown lifecycle %q, so this is not a launch that left nothing behind",
-			attempt.ID, attempt.Lifecycle, attempt.Worktree, leaseOrNone(attempt.LeaseID),
+		return Precondition(fmt.Errorf("refusing to unwind attempt %d: it records lifecycle %q, worktree %s, lease %s, Herdr identity (%s) and teardown lifecycle %q, so this is not a launch that left nothing behind",
+			attempt.ID, attempt.Lifecycle, pathdisplay.Context(attempt.Worktree), leaseOrNone(attempt.LeaseID),
 			herdrIdentityText(attempt.Herdr), attempt.TeardownTerminalAttempt))
 	}
 	return r.terminalizeWithoutRelease(home, task, attempt, decision, "unwound")

--- a/internal/selfupdate/adopt.go
+++ b/internal/selfupdate/adopt.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/atqamz/hand/internal/pathdisplay"
 )
 
 type AdoptionResult struct {
@@ -86,7 +88,7 @@ func Adopt(ctx context.Context, source, target string, want BuildInfo) (Adoption
 
 func absolutePath(path string) (string, error) {
 	if path == "" || !filepath.IsAbs(path) {
-		return "", fmt.Errorf("path must be absolute: %q", path)
+		return "", fmt.Errorf("path must be absolute: %s", pathdisplay.Context(path))
 	}
 	return filepath.Clean(path), nil
 }

--- a/internal/selfupdate/buildinfo.go
+++ b/internal/selfupdate/buildinfo.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/atqamz/hand/internal/pathdisplay"
 )
 
 var readExecutableBuildInfo = ReadExecutableBuildInfo
@@ -19,7 +21,7 @@ var verifyExecutableBuildInfo = verifyExecutableBuildInfoDefault
 // identity before a caller gives it ownership of an install path.
 func ReadExecutableBuildInfo(ctx context.Context, path string) (BuildInfo, error) {
 	if !filepath.IsAbs(path) {
-		return BuildInfo{}, fmt.Errorf("executable path must be absolute: %q", path)
+		return BuildInfo{}, fmt.Errorf("executable path must be absolute: %s", pathdisplay.Context(path))
 	}
 	out, err := exec.CommandContext(ctx, path, "build-info").CombinedOutput()
 	if err != nil {

--- a/internal/toolchain/executor.go
+++ b/internal/toolchain/executor.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/atqamz/hand/internal/pathdisplay"
 )
 
 type ProcessSpec struct {
@@ -174,14 +176,14 @@ func requireExecutable(path string) error {
 		return err
 	}
 	if runtime.GOOS == "windows" && !strings.ContainsAny(filepath.Base(path), ".") {
-		return fmt.Errorf("managed Windows executable %q must include its suffix", path)
+		return fmt.Errorf("managed Windows executable %s must include its suffix", pathdisplay.Context(path))
 	}
 	return nil
 }
 
 func requireAbsolute(path string) error {
 	if path == "" || !filepath.IsAbs(path) {
-		return fmt.Errorf("managed core executable %q must be an absolute path", path)
+		return fmt.Errorf("managed core executable %s must be an absolute path", pathdisplay.Context(path))
 	}
 	return nil
 }

--- a/internal/toolchain/manifest.go
+++ b/internal/toolchain/manifest.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/atqamz/hand/internal/pathdisplay"
 )
 
 //go:embed runtime.lock.json
@@ -142,14 +144,14 @@ func validateExpectedFiles(files []ExpectedFile) error {
 		}
 		clean := pathpkg.Clean(strings.ReplaceAll(file.Path, "\\", "/"))
 		if clean == "." {
-			return fmt.Errorf("expected file path %q is invalid", file.Path)
+			return fmt.Errorf("expected file path %s is invalid", pathdisplay.Context(file.Path))
 		}
 		if _, ok := seen[clean]; ok {
-			return fmt.Errorf("expected file %q is duplicated", file.Path)
+			return fmt.Errorf("expected file %s is duplicated", pathdisplay.Context(file.Path))
 		}
 		seen[clean] = struct{}{}
 		if !file.Regular && !file.Executable {
-			return fmt.Errorf("expected file %q must declare regular or executable", file.Path)
+			return fmt.Errorf("expected file %s must declare regular or executable", pathdisplay.Context(file.Path))
 		}
 	}
 	return nil
@@ -158,11 +160,11 @@ func validateExpectedFiles(files []ExpectedFile) error {
 func validateRelativePath(path, label string) error {
 	portable := strings.ReplaceAll(path, "\\", "/")
 	if path == "" || isPortableAbsolutePath(portable) || strings.ContainsRune(path, 0) {
-		return fmt.Errorf("%s %q is invalid", label, path)
+		return fmt.Errorf("%s %s is invalid", label, pathdisplay.Context(path))
 	}
 	clean := pathpkg.Clean(portable)
 	if clean == ".." || strings.HasPrefix(clean, "../") {
-		return fmt.Errorf("%s %q escapes component", label, path)
+		return fmt.Errorf("%s %s escapes component", label, pathdisplay.Context(path))
 	}
 	return nil
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/atqamz/hand/internal/faketool"
+	"github.com/atqamz/hand/internal/pathdisplay"
 	"github.com/atqamz/hand/internal/state"
 	"github.com/atqamz/hand/internal/toolchain"
 )
@@ -651,7 +652,7 @@ func TestExitCodeTwoOnUsageError(t *testing.T) {
 		{"unknown flag", []string{"spawn", "--bogus", "task-1", "demo"}, "unknown flag: --bogus"},
 		{"conflicting merge methods", []string{"merge", "task-1", "--squash", "--rebase"}, "only one of --squash, --merge, --rebase"},
 		{"merge method with local", []string{"merge", "task-1", "--local", "--squash"}, "cannot be combined with --local"},
-		{"missing local project source", []string{"project", "add", "not-a-url"}, `local project source "not-a-url"`},
+		{"missing local project source", []string{"project", "add", "not-a-url"}, "local project source `not-a-url`"},
 		{"invalid project mode", []string{"project", "add", "https://example.com/demo.git", "--mode", "bogus"}, "invalid project mode"},
 		{"invalid poll interval", []string{"watch", "--poll", "nonsense"}, "invalid poll interval"},
 	}
@@ -805,7 +806,7 @@ func TestExitCodeThreeWhenHandHomeIsNotAFleetHome(t *testing.T) {
 	notAHome := t.TempDir()
 
 	got := runHandEnv(t, home, []string{"HAND_HOME=" + notAHome}, "status")
-	assertInvocation(t, got, 3, fmt.Sprintf("HAND_HOME %q is not a secondhand home", notAHome))
+	assertInvocation(t, got, 3, fmt.Sprintf("HAND_HOME %s is not a secondhand home", pathdisplay.Context(notAHome)))
 }
 
 func TestExitCodeOneOnGeneralError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Every message naming a filesystem path either tells the operator to run it (now wrapped in `internal/shellquote.Quote`) or names it only as context (now wrapped in the new `internal/pathdisplay.Context`, which delimits with backticks without escaping the path's own separators). `%q` doubled a path's backslashes on Windows, so a copied path could not be pasted back.
- Fixes `internal/project.GateInitCommand`, the one run-command site missing `shellquote.Quote` (fixes its two relay call sites in `internal/runtime/dispatch.go` and `internal/project/gaterun.go` for free), and `internal/harness`'s report-channel statement, which embedded the report path bare into a shell redirection instruction.
- `%q` stays wherever the value isn't a resolved filesystem path (names, ids, URLs, branch names) or where escaping untrusted input is the message's own point, e.g. an archive member name during extraction, where a literal backslash is the traversal attempt the code is defending against - left as-is per `internal/toolchain/store.go`'s `safeJoin`.

Closes atqamz/hand#471

## Test plan

- [x] `make lint`
- [x] `make test` (race)
- [x] `make e2e`
- Fixed the tests that asserted a rendered message against a raw path instead of the actual rendering (`internal/home/home_test.go`, `cmd/update_test.go`, `tests/e2e/e2e_test.go`), matching the pattern atqamz/hand#460 already fixed for `internal/home/home_test.go`.
- The Windows-specific defect (`%q` doubling `\` separators) is not exercised by this Linux dev environment's test run; CI's Windows Test job is what actually proves this fix.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->