### PR TITLE
fix(steering): confirm Enter submission by positive composer evidence, not a claim

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,12 +247,15 @@ func renderError(w io.Writer, err error, code int, path string) error {
 			doc.Field("reason", reason)
 		}
 		switch {
+		// Checked before partial: uncertain must win regardless of it, since atqamz/hand#459's stalled-paste
+		// case is both - a composer holding a fragment is not proof nothing landed, so the operator must be
+		// told to go read the pane rather than to just avoid resending the whole message.
+		case sendState == "uncertain" || sendState == "pending":
+			help = []string{"Terminal submission is uncertain; do not blindly retry because the message may already be in the pane"}
 		case partial:
 			help = []string{"The message was not submitted, but text may remain in the composer; do not blindly send the whole message again"}
 		case retrySafe:
 			help = []string{"No terminal submission occurred; retry is safe when the underlying precondition is ready"}
-		case sendState == "uncertain" || sendState == "pending":
-			help = []string{"Terminal submission is uncertain; do not blindly retry because the message may already be in the pane"}
 		}
 	}
 	doc.Help(help...)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -506,6 +506,30 @@ func TestErrorDocumentIncludesSendStateDetails(t *testing.T) {
 	}
 }
 
+// atqamz/hand#459's stalled-paste outcome is both uncertain and partial (PartialComposer): a fragment
+// landing is not proof nothing landed, so the not-submitted-shaped "do not resend the whole message"
+// advice would read as permission to resend a follow-up - the exact duplicate-turn risk this task found.
+func TestErrorDocumentPrefersUncertainAdviceOverPartialComposer(t *testing.T) {
+	var out strings.Builder
+	err := &steering.Error{
+		Cause:           errors.New("send 9 is uncertain: enter-not-confirmed"),
+		Send:            &state.SendAttempt{ID: 9},
+		AttemptID:       3,
+		State:           state.SendUncertain,
+		Reason:          "enter-not-confirmed",
+		PartialComposer: true,
+	}
+	if renderErr := renderError(&out, err, 7, "hand send"); renderErr != nil {
+		t.Fatal(renderErr)
+	}
+	if strings.Contains(out.String(), "do not blindly send the whole message again") {
+		t.Fatalf("error document = %q, want the uncertain warning, not the not-submitted/partial one", out.String())
+	}
+	if !strings.Contains(out.String(), "do not blindly retry because the message may already be in the pane") {
+		t.Fatalf("error document = %q, want the uncertain warning against resending", out.String())
+	}
+}
+
 func TestUsageErrorHelpNamesTheCommandThatRefused(t *testing.T) {
 	var out strings.Builder
 	if err := renderError(&out, errors.New("accepts 2 arg(s), received 1"), 2, "hand hold set"); err != nil {

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -41,7 +41,11 @@ func TestSendHappyPathWhenIdle(t *testing.T) {
 	// "pane send-text"/"pane send-keys" are void commands: real success is empty stdout, not this envelope
 	// (callVoid's doc comment, client.go). callVoid only checks env.Error, which is nil here, so the extra
 	// body is harmless and this still exercises the real success path.
-	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
+	useFastSendConfirmPolling(t)
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", PaneReadUnwrappedSequence: []string{
+		"› hello worker",
+		"hello worker\n\n• Working (1s • esc to interrupt)",
+	}})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -82,8 +86,12 @@ func TestSendReachesRunningAttemptCarryingNoLaunchEvidence(t *testing.T) {
 	// What a pre-split row and a legacy JSON import both look like: running, with no launch stamps to
 	// read. The attempt is genuinely alive, so refusing it would strand every fleet migrated into this
 	// schema (atqamz/hand#194).
+	useFastSendConfirmPolling(t)
 	logPath := filepath.Join(t.TempDir(), "sent.log")
-	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath, PaneReadUnwrappedSequence: []string{
+		"› hello worker",
+		"hello worker\n\n• Working (1s • esc to interrupt)",
+	}})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +141,11 @@ func TestSendFailsWhenPaneNotFound(t *testing.T) {
 func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 	// Same send-text/send-keys envelope simplification as
 	// TestSendHappyPathWhenIdle above.
-	home := setupSendHome(t, faketool.Herdr{PaneStatusSequence: []string{"working", "idle"}})
+	useFastSendConfirmPolling(t)
+	home := setupSendHome(t, faketool.Herdr{PaneStatusSequence: []string{"working", "idle"}, PaneReadUnwrappedSequence: []string{
+		"› hello",
+		"hello\n\n• Working (1s • esc to interrupt)",
+	}})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -146,9 +158,14 @@ func TestSendWaitsWhileBusyThenSends(t *testing.T) {
 }
 
 func TestSendReachesRenderedIdlePromptDespiteWorkingAgentStatus(t *testing.T) {
+	useFastSendConfirmPolling(t)
 	home := setupSendHome(t, faketool.Herdr{
 		PaneStatus:  "working",
 		PaneReadOut: "────────────────────────\n❯\n────────────────────────\n  Opus 5 | 3 shells\n",
+		PaneReadUnwrappedSequence: []string{
+			"› revoke merge authority",
+			"revoke merge authority\n\n• Working (1s • esc to interrupt)",
+		},
 	})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
@@ -190,8 +207,12 @@ func TestSendDoesNotSteerAnAttemptWhileTaskOwnershipIsChanging(t *testing.T) {
 }
 
 func TestSendReadsMessageFromFile(t *testing.T) {
+	useFastSendConfirmPolling(t)
 	logPath := filepath.Join(t.TempDir(), "sent.log")
-	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath})
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", TextLog: logPath, PaneReadUnwrappedSequence: []string{
+		"› line one\nline two",
+		"line one\nline two\n\n• Working (1s • esc to interrupt)",
+	}})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -356,10 +377,38 @@ func TestSendClassifiesStructuredPreTextRejectionAsNotSubmitted(t *testing.T) {
 	}
 }
 
-// atqamz/hand#420: Enter has no working confirmation signal (a live-verified limitation - see
-// internal/steering's TestExecuteSubmitsOnEnterWithoutReadingTheComposerBack), so an Enter send stays
-// claim-based end to end through the full CLI: it reports sent even with unrelated text still on screen.
-func TestSendReportsSentOnEnterRegardlessOfComposerContent(t *testing.T) {
+// atqamz/hand#420, wired through the full CLI: an accepted message stays visible forever as a history
+// line indistinguishable from one still unsent. Enter must still confirm here since new content
+// appeared and the tail is present - a pure absence check would misread this as stuck.
+func TestSendReportsSentOnEnterDespiteComposerStillShowingTheMessage(t *testing.T) {
+	useFastSendConfirmPolling(t)
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatus: "idle",
+		PaneReadUnwrappedSequence: []string{
+			"› stop and wait for review",
+			"stop and wait for review\n\n• Working (1s • esc to interrupt)",
+		},
+	})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "stop and wait for review"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("got %v, want Enter's confirmed result", err)
+	}
+
+	sends, err := state.ListSends(home, "task-1")
+	if err != nil || len(sends) != 1 || sends[0].State != state.SendSubmitted || sends[0].ReasonCode != "text-and-enter-confirmed" {
+		t.Fatalf("sends=%+v err=%v, want one submitted send with the confirmed reason", sends, err)
+	}
+}
+
+// The CLI-level analogue of the internal not-confirmed case: the composer never shows any reaction to
+// Enter at all, so hand must report not-submitted rather than a false submitted claim (atqamz/hand#420).
+func TestSendReportsNotSubmittedWhenComposerShowsNoReactionToEnter(t *testing.T) {
+	useFastSendConfirmPolling(t)
 	home := setupSendHome(t, faketool.Herdr{
 		PaneStatus:           "idle",
 		PaneReadUnwrappedOut: "› stop and wait for review",
@@ -370,13 +419,45 @@ func TestSendReportsSentOnEnterRegardlessOfComposerContent(t *testing.T) {
 
 	cmd := newSendCmd()
 	cmd.SetArgs([]string{"task-1", "stop and wait for review"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("got %v, want Enter's claim-based sent result", err)
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("got %v, want ExitError code 6", err)
 	}
 
 	sends, err := state.ListSends(home, "task-1")
-	if err != nil || len(sends) != 1 || sends[0].State != state.SendSubmitted || sends[0].ReasonCode != "text-and-enter-accepted" {
-		t.Fatalf("sends=%+v err=%v, want one submitted send with the plain accepted reason", sends, err)
+	if err != nil || len(sends) != 1 || sends[0].State != state.SendNotSubmitted || sends[0].ReasonCode != "enter-not-confirmed" {
+		t.Fatalf("sends=%+v err=%v, want one not-submitted send with the enter-not-confirmed reason", sends, err)
+	}
+}
+
+// The CLI-level analogue of the internal stalled-fragment case: the composer changed after Enter, so
+// something demonstrably happened, but never grew the sent message's own tail. That is positive evidence
+// unlike no reaction at all, so it lands on uncertain rather than not-submitted (atqamz/hand#459).
+func TestSendMarksEnterUncertainWhenComposerReactsWithoutTheTail(t *testing.T) {
+	useFastSendConfirmPolling(t)
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatus: "idle",
+		PaneReadUnwrappedSequence: []string{
+			"› stop and wait for review",
+			"stop and wait for rev",
+		},
+	})
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newSendCmd()
+	cmd.SetArgs([]string{"task-1", "stop and wait for review"})
+	err := cmd.Execute()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("got %v, want ExitError code 7", err)
+	}
+
+	sends, err := state.ListSends(home, "task-1")
+	if err != nil || len(sends) != 1 || sends[0].State != state.SendUncertain || sends[0].ReasonCode != "enter-not-confirmed" {
+		t.Fatalf("sends=%+v err=%v, want one uncertain send with the enter-not-confirmed reason", sends, err)
 	}
 }
 
@@ -440,7 +521,15 @@ func TestSendDoesNotCreateRecordWhenComposerStaysBusy(t *testing.T) {
 }
 
 func TestSendForceBypassesBusyComposerAndKeepsDurableRecord(t *testing.T) {
-	home := setupSendHome(t, faketool.Herdr{PaneStatus: "working", PaneReadOut: "working...\nesc to interrupt (15s)\n  3 shells\n"})
+	useFastSendConfirmPolling(t)
+	home := setupSendHome(t, faketool.Herdr{
+		PaneStatus:  "working",
+		PaneReadOut: "working...\nesc to interrupt (15s)\n  3 shells\n",
+		PaneReadUnwrappedSequence: []string{
+			"› revoke merge authority",
+			"revoke merge authority\n\n• Working (1s • esc to interrupt)",
+		},
+	})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}); err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +547,11 @@ func TestSendForceBypassesBusyComposerAndKeepsDurableRecord(t *testing.T) {
 }
 
 func TestSendKeepsLegacyTraceOutOfTheNewSendAuthority(t *testing.T) {
-	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle"})
+	useFastSendConfirmPolling(t)
+	home := setupSendHome(t, faketool.Herdr{PaneStatus: "idle", PaneReadUnwrappedSequence: []string{
+		"› hello",
+		"hello\n\n• Working (1s • esc to interrupt)",
+	}})
 	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1"}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}, SendUndeliveredMessage: "an earlier abandoned steer", SendUndeliveredAt: "2026-08-01T00:00:00Z"}); err != nil {
 		t.Fatal(err)
 	}

--- a/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
+++ b/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
@@ -1,8 +1,8 @@
-# Codex's Tab queue is confirmed by composer content, Enter is not yet
+# Codex's Tab queue is confirmed by composer content, so is Enter
 
 Date: 2026-08-28
 Status: accepted
-Issues: atqamz/hand#426. atqamz/hand#420 stays open - see Rejected alternatives.
+Issues: atqamz/hand#426, atqamz/hand#420 (closed by the amendment below), atqamz/hand#459.
 Pull requests: none
 
 ## Context
@@ -19,6 +19,18 @@ Enter gets no composer-content confirmation. Once Text and Enter both return suc
 
 For a codex-harness pane, Enter is replaced with Tab when the pane currently shows codex's own on-screen "tab to queue message" text - a codex UI fact live-verified against a real busy pane, not applied to any other harness or condition.
 
+### Amendment - 2026-08-29
+
+atqamz/hand#459 built the positive signal the Rejected alternatives section called for. `chooseSubmitKey`'s pane read is no longer codex-only: it runs unconditionally and its result becomes `submissionOutcome`'s pre-key baseline for the Enter path too, one exec serving both the key choice and the later comparison. `enterConfirms` then polls, at the same cadence `composerConfirms` uses, until a read differs from that baseline *and* holds the sent message's own tail (`composerHasTail`: the last `confirmChunkSize` runes of the message, whitespace-stripped) - never until the message goes absent, which is exactly the check the original attempt reverted. An accepted message remaining visible as history no longer matters, because the poll watches for the tail's arrival and a reaction, not for the sent text's departure.
+
+A large `PaneSendText` can still stall mid-delivery, live-measured to leave an early fragment sitting in the composer for many seconds - the same defect atqamz/hand#420 tracked. `composerHasTail` requires the tail specifically, so a stalled prefix never confirms. Two designs preceded this one and were rejected on evidence: a pre-Enter settle-wait that polled composer growth before pressing the key could not distinguish a short message that had already fully arrived from a long one stalled at the same size, since both stop growing within roughly 150ms; and a byte-size threshold for when to worry about the stall was rejected once natural prose was measured to sustain a materially higher stall boundary than repetitive filler at the same byte count, making any fixed number both unjustified and unnecessary once the check is tail-based rather than size-gated. Chunking `PaneSendText` below the measured stall boundary was considered and filed separately as atqamz/hand#472; this amendment does not implement it.
+
+An unconfirmed Enter send is now split by what was actually observed, not collapsed into one outcome. A composer that never differed from its pre-key baseline is `not-submitted` with reason `enter-not-confirmed`: Enter registered nothing. A composer that changed but never grew the tail is `uncertain` with the same reason: something happened, just not provably all of it, and a stalled fragment is evidence a send is not provably absent, so it cannot carry the certainty a true no-op does. `cmd`'s rendered advice was fixed to match: it now selects the uncertain warning before checking whether the composer holds a partial fragment, because every prior not-submitted-with-a-fragment case had also been not-submitted in state, and that ordering had never been exercised against an uncertain-and-partial outcome until this one existed.
+
+Live-validated against a real codex worker: idle and mid-turn, small and 2-6KB messages, several times each, reading `send_state`/`send_reason` from the store rather than CLI output. Nine sends, zero duplicate deliveries. Two idle-large sends stalled and were correctly not confirmed. A stalled send was also observed to complete later, invisibly, as a side effect of unrelated subsequent traffic to the same pane - reproduced three times, independent of this amendment's own code: it is a property of the transport, not of the confirmation logic, and the same stale-send-completes-later behavior would occur, unobserved, against the unpatched claim-based Enter path too. Fixing that would need the pre-send busy-wait gate to recognize a composer holding an unconfirmed leftover fragment as a form of busy distinct from `AgentStatus`, which touches pre-send gating this amendment does not. It is a known, accepted limitation: neither `not-submitted` nor `uncertain` is ever retried automatically here, and the operator-facing advice for both tells the operator to inspect the pane rather than resend, specifically because of this.
+
+atqamz/hand#420 and atqamz/hand#426 are both closed by this amendment. The Tab/queue path above is unchanged.
+
 ## Rejected alternatives
 
 Confirming the Enter path the same way was tried and reverted. `composerRetains` cannot distinguish a message still sitting unsent at the live composer from the identical text remaining visible as a `>`-prefixed history line after a genuinely successful send, because Herdr's read window carries both without marking which is which the way `codexQueuedMarker` marks a queue. The failure was not rare - it reproduced on the next live Enter send tried - and its retry compounded it into an actual duplicate message delivered to the worker, not merely a wrong label. Fixing this needs either a narrower read window (whose tradeoffs against atqamz/hand#420's own interior-slice-corruption evidence are unverified) or a positive "the harness reacted" signal in place of an absence check; both are undeveloped and belong to the still-open atqamz/hand#420, not this decision.
@@ -33,4 +45,4 @@ Retrying a send that failed to confirm was built, live-tested, and removed: its 
 
 `hand send`'s cost is unchanged from before this task for every non-codex harness. A codex-harness pane costs one extra exec to choose Enter or Tab; if Tab is chosen, confirming it costs one more in the common case of an immediate clear, or more within the bounded poll if it is not immediate.
 
-atqamz/hand#426 is closed by this decision. atqamz/hand#420 is not: an Enter send still reports `submitted` on the strength of two RPCs alone, exactly as [Steering records terminal submission uncertainty](steering-records-terminal-submission-uncertainty.md) already described, and stays open for a signal that survives an accepted message remaining visible in history.
+atqamz/hand#426 is closed by this decision. atqamz/hand#420 is not: an Enter send still reports `submitted` on the strength of two RPCs alone, exactly as [Steering records terminal submission uncertainty](steering-records-terminal-submission-uncertainty.md) already described, and stays open for a signal that survives an accepted message remaining visible in history. The amendment above is that signal; #420 is closed as of it.

--- a/docs/adr/steering-records-terminal-submission-uncertainty.md
+++ b/docs/adr/steering-records-terminal-submission-uncertainty.md
@@ -1,7 +1,7 @@
 # Steering records terminal submission uncertainty
 
 Date: 2026-08-15
-Status: superseded in part by [Codex's Tab queue is confirmed by composer content, Enter is not yet](codex-tab-queue-submission-is-confirmed-by-composer-content.md), which redefines what `submitted` certifies for a codex Tab/queue send only; the account of a plain Enter send below, and the `pending`/`uncertain` terminality and lock-ordering decisions, still stand
+Status: superseded in part by [Codex's Tab queue is confirmed by composer content, so is Enter](codex-tab-queue-submission-is-confirmed-by-composer-content.md), whose 2026-08-29 amendment redefines what `submitted` certifies for the plain Enter path too, not only the codex Tab/queue send its original decision covered; the `pending`/`uncertain` terminality and lock-ordering decisions below still stand
 Issues: atqamz/hand#197, atqamz/hand#176
 Pull requests: atqamz/hand#230
 

--- a/docs/testing-invariants.md
+++ b/docs/testing-invariants.md
@@ -131,7 +131,7 @@ Source: [A project is identified by a surrogate id, not its name](adr/a-project-
 Source: [The report channel is the only outcome signal](adr/the-report-channel-is-the-only-outcome-signal.md),
 [Attention is one derivation over three channels](adr/attention-is-one-derivation-over-three-channels.md),
 [A file-only harness gets the launch statement appended to its brief](adr/a-file-only-harness-gets-the-launch-statement-appended-to-its-brief.md),
-[Codex's Tab queue is confirmed by composer content, Enter is not yet](adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md).
+[Codex's Tab queue is confirmed by composer content, so is Enter](adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md).
 
 | id | invariant | layer | coverage |
 |---|---|---|---|
@@ -145,9 +145,13 @@ Source: [The report channel is the only outcome signal](adr/the-report-channel-i
 | INV-REP-8 | Reconstructing already-persisted launch evidence (reconcile's confirm-launch arm) never mutates the brief file, even for a harness whose provisioning path appends to it. | unit | `TestReconcileConfirmLaunchDoesNotModifyBriefFile` |
 | INV-REP-9 | A codex Tab/queue send reaches `submitted` only once the pane's composer is observed to no longer hold a recognizable fragment of what was sent (excluding its own queued-message echo). Two successful external calls (Text, then Tab) are never sufficient on their own for this path. | unit | `TestExecuteDoesNotConfirmCodexTabWhenMessageStaysInTheLiveComposer` (the two calls succeed and the send still lands on `not-submitted`) |
 | INV-REP-10 | A codex Tab/queue send hand could not confirm is distinguishable by why: observed still holding the sent message (`not-submitted`) is a different fact from the confirmation read itself failing (`uncertain`). Neither is ever reported as `submitted`. | unit | `TestExecuteDoesNotConfirmCodexTabWhenMessageStaysInTheLiveComposer`, `TestExecuteMarksCodexTabConfirmationReadFailureUncertain` |
-| INV-REP-11 | Enter has no composer-content confirmation: once Text and Enter both return success, the send is `submitted` regardless of what the composer shows afterward, and the pane is never read back to check. This is a known limitation, not a design goal - atqamz/hand#420 tracks giving Enter a working signal. | unit | `TestExecuteSubmitsOnEnterWithoutReadingTheComposerBack`, `TestSendReportsSentOnEnterRegardlessOfComposerContent` |
+| INV-REP-11 | Enter reaches `submitted` only via positive evidence the harness reacted: the composer's content after the key must differ from its pre-key baseline *and* hold the sent message's own tail. The message's own text remaining visible is never sufficient by itself - an accepted message can stay visible as history indefinitely, so absence is not a signal (atqamz/hand#420, atqamz/hand#459). | unit | `TestExecuteConfirmsEnterDespiteAcceptedMessageRemainingVisibleAsHistory`, `TestSendReportsSentOnEnterDespiteComposerStillShowingTheMessage` |
 | INV-REP-12 | A codex Tab/queue composer that clears within the bounded confirmation poll - including a worker that consumes and finishes before hand's first read - confirms as `submitted`, with no resend on any path. | unit | `TestExecuteConfirmsCodexQueuedMessageDespiteItsOwnEchoAboveTheComposer` |
 | INV-REP-13 | The submit key is Tab instead of Enter only for a codex-harness pane currently showing codex's own queue-instead-of-submit text; no other harness's submit key is ever conditioned on pane content. | unit | `TestExecuteSendsTabInsteadOfEnterWhenCodexAdvertisesQueueing`, `TestExecuteConfirmsCodexQueuedMessageDespiteItsOwnEchoAboveTheComposer`, `TestExecuteDoesNotConfirmCodexTabWhenMessageStaysInTheLiveComposer` |
+| INV-REP-14 | An Enter send hand could not confirm is distinguishable by why, and the two are never the same `SendState`: a composer that never differed from its pre-key baseline (nothing happened) is `not-submitted`; a composer that changed but never grew the sent message's own tail (something happened, just not provably all of it) is `uncertain`, the same as a confirmation read failure. | unit | `TestExecuteDoesNotConfirmEnterWhenComposerShowsNoReaction`, `TestExecuteDoesNotConfirmEnterWhenOnlyAPartialFragmentArrived`, `TestSendReportsNotSubmittedWhenComposerShowsNoReactionToEnter`, `TestSendMarksEnterUncertainWhenComposerReactsWithoutTheTail` |
+| INV-REP-15 | A read failure choosing the submit key, or during the Enter confirmation poll itself, is reported as `uncertain` rather than confirmed blind against a baseline it never actually obtained. | unit | `TestExecuteMarksEnterPreKeyReadFailureUncertain`, `TestExecuteMarksEnterConfirmationReadFailureUncertain` |
+| INV-REP-16 | The operator-facing advice for a send outcome is chosen from send state before the partial-composer flag: an `uncertain` outcome always warns against blind retry, even when the composer also holds a recognizable fragment, because a fragment landing is evidence something happened, not proof nothing did - the two facts must never collapse into the resend-shaped advice meant for a plain `not-submitted`. | unit | `TestErrorDocumentPrefersUncertainAdviceOverPartialComposer` |
+| INV-REP-17 | Confirming a small, idle Enter send costs exactly the reads decision 4 budgeted for it: the pre-key baseline read `chooseSubmitKey` already took, plus one poll read that confirms on the first try - never an extra exec beyond that pair for the common case. | unit | `TestExecuteSubmitsAndFinalizesExactAttempt` |
 
 ## Orientation and currentness
 
@@ -332,8 +336,10 @@ here so nobody encodes one as a test.
 - **A green CI run means the change is safe.** It means the suite did not object. Whether the suite
   can object is what mutation testing measures, and atqamz/hand#442 exists because that is currently
   unmeasured.
-- **`hand send` confirming submission means every submit key confirms.** Only the codex Tab/queue
-  substitution does. Enter has no marker to distinguish an accepted message's own history from a
-  still-unsent composer, so it stays claim-based - two successful external calls are the whole signal -
-  until atqamz/hand#420 gives it a working one. See
-  [Codex's Tab queue is confirmed by composer content, Enter is not yet](adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md).
+- **A `not-submitted` or `uncertain` verdict means the message never reached the pane.** It means hand
+  did not observe delivery within its bounded confirmation poll, not that delivery provably never
+  happened. A send hand gave up on can still complete afterward, invisibly, as a side effect of
+  unrelated later traffic to the same pane - live-reproduced three times against atqamz/hand#459 - which
+  is exactly why neither verdict is retried automatically, and why an operator reacting to either is
+  told to go read the pane rather than to resend. See
+  [Codex's Tab queue is confirmed by composer content, so is Enter](adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md).

--- a/internal/faketool/herdr.go
+++ b/internal/faketool/herdr.go
@@ -59,55 +59,60 @@ type Herdr struct {
 	// needs the post-send confirmation read to see different text than PaneReadOut/Frames answer the
 	// default `recent` source with. Empty falls back to the same PaneReadOut/Frames logic as `recent`.
 	PaneReadUnwrappedOut string
-	PaneStatusFile       string
-	Frames               []HerdrFrame
-	Responses            []HerdrResponse
-	Hang                 []string
-	Unreachable          bool
-	KeyLog               string
-	TextLog              string
-	Log                  string
-	LogCommands          []string
-	PaneAgentEnv         bool
-	PaneReadFileEnv      bool
-	KeyLogEnv            bool
-	TextLogEnv           bool
-	ReadLogEnv           bool
-	AllowUnknownPane     bool
-	MutateBeforeHang     bool
+	// PaneReadUnwrappedSequence answers successive `pane read --source recent-unwrapped` calls in order,
+	// holding the last entry once exhausted - like PaneStatusSequence, but keyed to its own counter since
+	// one send does one PaneGet but several PaneReadUnwrapped calls. Wins over PaneReadUnwrappedOut.
+	PaneReadUnwrappedSequence []string
+	PaneStatusFile            string
+	Frames                    []HerdrFrame
+	Responses                 []HerdrResponse
+	Hang                      []string
+	Unreachable               bool
+	KeyLog                    string
+	TextLog                   string
+	Log                       string
+	LogCommands               []string
+	PaneAgentEnv              bool
+	PaneReadFileEnv           bool
+	KeyLogEnv                 bool
+	TextLogEnv                bool
+	ReadLogEnv                bool
+	AllowUnknownPane          bool
+	MutateBeforeHang          bool
 }
 
 const herdrDefaultPaneRead = "Welcome to Claude Code\n> \n  ? for shortcuts\n"
 
 type herdrSpec struct {
-	Workspaces           []HerdrWorkspace
-	Creates              []HerdrWorkspace
-	TabCreates           []HerdrTab
-	PaneAgent            string
-	ProcessAgent         string
-	ProcessAgents        []string
-	PaneStatus           string
-	PaneStatusSequence   []string
-	PaneReadOut          string
-	PaneReadUnwrappedOut string
-	PaneStatusFile       string
-	Frames               []HerdrFrame
-	Responses            []HerdrResponse
-	Hang                 []string
-	Unreachable          bool
-	KeyLog               string
-	TextLog              string
-	StateDir             string
-	Log                  string
-	LogCommands          []string
-	PaneAgentEnv         bool
-	PaneReadFileEnv      bool
-	KeyLogEnv            bool
-	TextLogEnv           bool
-	ReadLogEnv           bool
-	AllowUnknownPane     bool
-	MutateBeforeHang     bool
-	activeSession        string
+	Workspaces                []HerdrWorkspace
+	Creates                   []HerdrWorkspace
+	TabCreates                []HerdrTab
+	PaneAgent                 string
+	ProcessAgent              string
+	ProcessAgents             []string
+	PaneStatus                string
+	PaneStatusSequence        []string
+	PaneReadOut               string
+	PaneReadUnwrappedOut      string
+	PaneReadUnwrappedSequence []string
+	PaneStatusFile            string
+	Frames                    []HerdrFrame
+	Responses                 []HerdrResponse
+	Hang                      []string
+	Unreachable               bool
+	KeyLog                    string
+	TextLog                   string
+	StateDir                  string
+	Log                       string
+	LogCommands               []string
+	PaneAgentEnv              bool
+	PaneReadFileEnv           bool
+	KeyLogEnv                 bool
+	TextLogEnv                bool
+	ReadLogEnv                bool
+	AllowUnknownPane          bool
+	MutateBeforeHang          bool
+	activeSession             string
 }
 
 type herdrTabRef struct {
@@ -133,9 +138,10 @@ func (h Herdr) Install(t *testing.T, bin string) {
 	installConfig(t, bin, "herdr", "herdr", herdrSpec{
 		Workspaces: h.Workspaces, Creates: h.Creates, TabCreates: h.TabCreates,
 		PaneAgent: h.PaneAgent, ProcessAgent: h.ProcessAgent, ProcessAgents: h.ProcessAgents, PaneStatus: h.PaneStatus, PaneReadOut: h.PaneReadOut,
-		PaneReadUnwrappedOut: h.PaneReadUnwrappedOut,
-		PaneStatusSequence:   h.PaneStatusSequence,
-		PaneStatusFile:       h.PaneStatusFile, Frames: h.Frames, Responses: h.Responses,
+		PaneReadUnwrappedOut:      h.PaneReadUnwrappedOut,
+		PaneReadUnwrappedSequence: h.PaneReadUnwrappedSequence,
+		PaneStatusSequence:        h.PaneStatusSequence,
+		PaneStatusFile:            h.PaneStatusFile, Frames: h.Frames, Responses: h.Responses,
 		Hang: h.Hang, Unreachable: h.Unreachable, KeyLog: h.KeyLog, TextLog: h.TextLog,
 		StateDir: state, Log: h.Log, LogCommands: h.LogCommands,
 		PaneAgentEnv: h.PaneAgentEnv, PaneReadFileEnv: h.PaneReadFileEnv,
@@ -586,8 +592,14 @@ func herdrPaneRead(spec herdrSpec, tabs []herdrTabRef, args []string) int {
 		return herdrError("pane_not_found", "pane "+args[2]+" not found", "cli:pane:read")
 	}
 	read := spec.PaneReadOut
-	if flagValue(args, "--source") == "recent-unwrapped" && spec.PaneReadUnwrappedOut != "" {
-		read = spec.PaneReadUnwrappedOut
+	if flagValue(args, "--source") == "recent-unwrapped" {
+		switch {
+		case len(spec.PaneReadUnwrappedSequence) > 0:
+			index := herdrUnwrappedReadAdvance(spec.StateDir, len(spec.PaneReadUnwrappedSequence))
+			read = spec.PaneReadUnwrappedSequence[index]
+		case spec.PaneReadUnwrappedOut != "":
+			read = spec.PaneReadUnwrappedOut
+		}
 	}
 	if spec.ReadLogEnv {
 		if path := os.Getenv("PANE_LOG"); path != "" {
@@ -784,6 +796,14 @@ func herdrProcessFrameAdvance(state string, count int) int {
 func herdrStatusAdvance(state string, count int) int {
 	current := herdrCounter(state, "statuses")
 	if err := atomicWrite(herdrCounterPath(state, "statuses"), strconv.Itoa(current+1)+"\n"); err != nil {
+		return min(current, count-1)
+	}
+	return min(current, count-1)
+}
+
+func herdrUnwrappedReadAdvance(state string, count int) int {
+	current := herdrCounter(state, "unwrapped-reads")
+	if err := atomicWrite(herdrCounterPath(state, "unwrapped-reads"), strconv.Itoa(current+1)+"\n"); err != nil {
 		return min(current, count-1)
 	}
 	return min(current, count-1)

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -65,6 +65,7 @@ const (
 	SendReasonTextRejectedBeforeAcceptance = store.SendReasonTextRejectedBeforeAcceptance
 	SendReasonEnterRejectedAfterTextStaged = store.SendReasonEnterRejectedAfterTextStaged
 	SendReasonComposerRetainsMessage       = store.SendReasonComposerRetainsMessage
+	SendReasonEnterNotConfirmed            = store.SendReasonEnterNotConfirmed
 )
 
 func SendNeedsAttention(send SendAttempt) bool { return store.SendNeedsAttention(send) }

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -115,21 +115,18 @@ const codexQueueDiscriminator = "tab to queue message"
 // composerRetains would misread a successful queue as the composer still stuck holding the message.
 const codexQueuedMarker = "Queued follow-up inputs"
 
-// Picks Enter, or Tab for a codex pane currently showing its own queue discriminator - conditioned on
-// harness identity, never applied to another harness. A read failure falls back to Enter rather than
-// turning an unrelated read problem into a submit failure.
-func chooseSubmitKey(client Client, paneID, harnessName string) string {
-	if harnessName != harness.Codex {
-		return "Enter"
-	}
+// Picks Enter, or Tab for a codex pane showing its own queue discriminator. The read is unconditional
+// now: its text doubles as submissionOutcome's pre-key baseline for the Enter path (atqamz/hand#459). A
+// read failure still falls back to Enter but is reported so submissionOutcome lands on Uncertain.
+func chooseSubmitKey(client Client, paneID, harnessName string) (key, preKeyText string, err error) {
 	text, err := client.PaneReadUnwrapped(paneID, sendConfirmPolling.ReadLines)
 	if err != nil {
-		return "Enter"
+		return "Enter", "", err
 	}
-	if strings.Contains(strings.ToLower(text), codexQueueDiscriminator) {
-		return "Tab"
+	if harnessName == harness.Codex && strings.Contains(strings.ToLower(text), codexQueueDiscriminator) {
+		return "Tab", text, nil
 	}
-	return "Enter"
+	return "Enter", text, nil
 }
 
 // The fixed-size fragment composerRetains looks for. A live reproduction of atqamz/hand#420 found a
@@ -178,40 +175,94 @@ func composerRetains(text, sent, key string) bool {
 	return false
 }
 
-// Polls the pane until it no longer holds a recognizable fragment of sent, or the bounded timeout
-// elapses.
-func composerConfirms(client Client, paneID, sent, key string) (bool, error) {
+// Polls the pane, at the shared cadence, until observe reports a positive read or the bounded timeout
+// elapses, returning the last text read alongside whether it confirmed. Shared by the Tab and Enter
+// paths, which differ only in what one read must show.
+func pollUntilObserved(client Client, paneID string, observe func(text string) bool) (bool, string, error) {
 	deadline := time.Now().Add(sendConfirmPolling.Timeout)
+	var lastText string
 	for {
 		text, err := client.PaneReadUnwrapped(paneID, sendConfirmPolling.ReadLines)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
-		if !composerRetains(text, sent, key) {
-			return true, nil
+		lastText = text
+		if observe(text) {
+			return true, lastText, nil
 		}
 		if time.Now().After(deadline) {
-			return false, nil
+			return false, lastText, nil
 		}
 		time.Sleep(sendConfirmPolling.Interval)
 	}
 }
 
-// Only the Tab path gets a composer-content confirmation: codexQueuedMarker gives composerRetains a
-// real truncation point there. Enter has none - an accepted message stays visible as a live-verified
-// ">" history line, so the same check would misreport ordinary sends as not-submitted (atqamz/hand#420).
-func submissionOutcome(client Client, paneID, message, key string) (state.SendState, string, bool, bool) {
-	if key != "Tab" {
-		return state.SendSubmitted, "text-and-enter-accepted", true, false
+// Polls the pane until it no longer holds a recognizable fragment of sent, or the bounded timeout
+// elapses.
+func composerConfirms(client Client, paneID, sent, key string) (bool, error) {
+	confirmed, _, err := pollUntilObserved(client, paneID, func(text string) bool {
+		return !composerRetains(text, sent, key)
+	})
+	return confirmed, err
+}
+
+// Reports whether text holds the tail of sent specifically, not just any surviving fragment. A large
+// PaneSendText can stall for seconds with only an early chunk in the composer (atqamz/hand#459); the
+// tail is the one fragment that can only be present once everything before it arrived too.
+func composerHasTail(text, sent string) bool {
+	haystack := stripWhitespace(text)
+	needle := stripWhitespace(sent)
+	if needle == "" {
+		return false
 	}
-	confirmed, err := composerConfirms(client, paneID, message, key)
+	runes := []rune(needle)
+	if len(runes) > confirmChunkSize {
+		runes = runes[len(runes)-confirmChunkSize:]
+	}
+	return strings.Contains(haystack, string(runes))
+}
+
+// Confirms Enter by positive evidence the harness reacted, not by its own text going absent: an accepted
+// message stays visible forever as history, so an absence check races that redraw (atqamz/hand#420,
+// atqamz/hand#459). reacted distinguishes a pure no-op (nothing happened) from a stalled paste (something did).
+func enterConfirms(client Client, paneID, sent, preKeyText string) (confirmed, reacted bool, err error) {
+	confirmed, lastText, err := pollUntilObserved(client, paneID, func(text string) bool {
+		return text != preKeyText && composerHasTail(text, sent)
+	})
+	if err != nil {
+		return false, false, err
+	}
+	return confirmed, lastText != preKeyText, nil
+}
+
+// Tab gets a composer-content confirmation because codexQueuedMarker gives composerRetains a real
+// truncation point. Enter instead requires the pre-key baseline and a positive tail match (enterConfirms)
+// - preKeyErr non-nil means that baseline read failed, so the send is honestly uncertain, not confirmed.
+func submissionOutcome(client Client, paneID, message, key, preKeyText string, preKeyErr error) (state.SendState, string, bool, bool) {
+	if key == "Tab" {
+		confirmed, err := composerConfirms(client, paneID, message, key)
+		if err != nil {
+			return state.SendUncertain, "composer-confirmation-read-failed", false, false
+		}
+		if confirmed {
+			return state.SendSubmitted, "text-and-tab-queued", true, false
+		}
+		return state.SendNotSubmitted, state.SendReasonComposerRetainsMessage, false, true
+	}
+	if preKeyErr != nil {
+		return state.SendUncertain, "composer-confirmation-read-failed", false, false
+	}
+	confirmed, reacted, err := enterConfirms(client, paneID, message, preKeyText)
 	if err != nil {
 		return state.SendUncertain, "composer-confirmation-read-failed", false, false
 	}
 	if confirmed {
-		return state.SendSubmitted, "text-and-tab-queued", true, false
+		return state.SendSubmitted, "text-and-enter-confirmed", true, false
 	}
-	return state.SendNotSubmitted, state.SendReasonComposerRetainsMessage, false, true
+	if reacted {
+		return state.SendUncertain, state.SendReasonEnterNotConfirmed, false, true
+	}
+	return state.SendNotSubmitted, state.SendReasonEnterNotConfirmed, false, true
 }
 
 func Execute(req Request) (Result, error) {
@@ -334,7 +385,7 @@ func Execute(req Request) (Result, error) {
 	if req.Faults.BeforeEnter != nil {
 		return Result{}, pendingError(send, req.Faults.BeforeEnter, "before-enter")
 	}
-	key := chooseSubmitKey(req.Client, current.Herdr.PaneID, current.Harness)
+	key, preKeyText, keyReadErr := chooseSubmitKey(req.Client, current.Herdr.PaneID, current.Harness)
 	if err := req.Client.PaneSendKeys(current.Herdr.PaneID, key); err != nil {
 		if herdr.IsPreSideEffectRejection(err) || herdr.IsProcessNotStarted(err) {
 			return finalize(req, send, state.SendNotSubmitted, rejectionReason(err, state.SendReasonEnterRejectedAfterTextStaged), false, true)
@@ -345,7 +396,7 @@ func Execute(req Request) (Result, error) {
 		return Result{}, pendingError(send, req.Faults.AfterEnter, "enter-succeeded-before-finalization")
 	}
 
-	next, reason, submitted, partial := submissionOutcome(req.Client, current.Herdr.PaneID, req.Message, key)
+	next, reason, submitted, partial := submissionOutcome(req.Client, current.Herdr.PaneID, req.Message, key, preKeyText, keyReadErr)
 
 	if req.Faults.BeforePersist != nil {
 		return Result{}, &Error{Cause: fmt.Errorf("terminal submission returned success, but durable send finalization failed: %w", req.Faults.BeforePersist), Send: &send, AttemptID: current.ID, State: state.SendPending, Reason: "durable-finalization-unresolved", FinalizationFault: true}

--- a/internal/steering/send_test.go
+++ b/internal/steering/send_test.go
@@ -75,7 +75,10 @@ func newSteeringHome(t *testing.T) (string, state.Attempt) {
 
 func TestExecuteSubmitsAndFinalizesExactAttempt(t *testing.T) {
 	home, attempt := newSteeringHome(t)
-	pane := &testPane{pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle}}
+	pane := &testPane{
+		pane:          herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{"› hello", "hello\n\n• new agent activity"},
+	}
 	result, err := Execute(Request{Home: home, TaskID: "task-1", Message: "hello", Origin: state.SendOriginOperator, Client: pane,
 		Now: func() time.Time { return time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC) }})
 	if err != nil {
@@ -86,6 +89,11 @@ func TestExecuteSubmitsAndFinalizesExactAttempt(t *testing.T) {
 	}
 	if len(pane.textCalls) != 1 || pane.textCalls[0] != "hello" || len(pane.keyCalls) != 1 || len(pane.keyCalls[0]) != 1 || pane.keyCalls[0][0] != "Enter" {
 		t.Fatalf("external calls = text %v keys %v", pane.textCalls, pane.keyCalls)
+	}
+	// One read to choose the key (reused as the pre-key baseline) and one to confirm: decision 4's "one
+	// more exec" cost for an idle composer that confirms on the first read.
+	if pane.readCalls != 2 {
+		t.Fatalf("readCalls = %d, want exactly 2", pane.readCalls)
 	}
 }
 
@@ -173,7 +181,10 @@ func TestExecuteDoesNotUseHistoricalPendingForCurrentAttempt(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = db.Close()
-	pane := &testPane{pane: herdr.Pane{PaneID: second.Herdr.PaneID, TabID: second.Herdr.TabID, WorkspaceID: second.Herdr.WorkspaceID, AgentStatus: herdr.StatusIdle}}
+	pane := &testPane{
+		pane:          herdr.Pane{PaneID: second.Herdr.PaneID, TabID: second.Herdr.TabID, WorkspaceID: second.Herdr.WorkspaceID, AgentStatus: herdr.StatusIdle},
+		readResponses: []string{"› new", "new\n\n• new agent activity"},
+	}
 	if _, err := Execute(Request{Home: home, TaskID: "task-1", Message: "new", Origin: state.SendOriginOperator, Client: pane}); err != nil {
 		t.Fatal(err)
 	}
@@ -272,27 +283,136 @@ func useFastSendConfirmPolling(t *testing.T) {
 	t.Cleanup(restore)
 }
 
-// Live testing against a real codex worker found Enter has no working confirmation signal: an accepted
-// message stays visible as a ">" history line, so a content check there would misreport ordinary sends
-// as not-submitted (atqamz/hand#420). Enter stays claim-based and never reads the pane back to check.
-func TestExecuteSubmitsOnEnterWithoutReadingTheComposerBack(t *testing.T) {
+// Positive evidence, not absence: an accepted message stays visible forever as a history line
+// indistinguishable from one still unsent, so an absence check races that redraw (atqamz/hand#420,
+// atqamz/hand#459). Here new content also appeared and the tail is present, so Enter still confirms.
+func TestExecuteConfirmsEnterDespiteAcceptedMessageRemainingVisibleAsHistory(t *testing.T) {
 	home, attempt := newSteeringHome(t)
 	pane := &testPane{
-		pane:          herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
-		readResponses: []string{"hello still sitting in the composer, unmoved"},
+		pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{
+			"› hello",
+			"› hello\n\n› \n\n• Working (1s • esc to interrupt)",
+		},
 	}
 	result, err := Execute(Request{Home: home, TaskID: "task-1", Message: "hello", Origin: state.SendOriginOperator, Client: pane})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.Send.State != state.SendSubmitted || result.Send.AttemptID != attempt.ID {
-		t.Fatalf("result = %+v, want submitted: Enter is claim-based", result.Send)
+		t.Fatalf("result = %+v, want submitted despite the message remaining visible", result.Send)
 	}
-	if got, found, readErr := state.LatestSend(home, "task-1", attempt.ID); readErr != nil || !found || got.ReasonCode != "text-and-enter-accepted" {
-		t.Fatalf("latest send = %+v found=%v err=%v, want the plain accepted reason", got, found, readErr)
+	if got, found, readErr := state.LatestSend(home, "task-1", attempt.ID); readErr != nil || !found || got.ReasonCode != "text-and-enter-confirmed" {
+		t.Fatalf("latest send = %+v found=%v err=%v, want the confirmed reason", got, found, readErr)
 	}
-	if pane.readCalls != 0 {
-		t.Fatalf("readCalls = %d, want zero: Enter never reads the pane back", pane.readCalls)
+}
+
+// atqamz/hand#426's shape generalized to Enter: the composer shows byte-identical content before and
+// after the key, meaning Enter produced no observed reaction at all. Confirming here would be exactly
+// the false "submitted" claim atqamz/hand#420 is about.
+func TestExecuteDoesNotConfirmEnterWhenComposerShowsNoReaction(t *testing.T) {
+	restore := ConfigureSendConfirmPollingForTest(time.Millisecond, 0, 400)
+	t.Cleanup(restore)
+	home, _ := newSteeringHome(t)
+	pane := &testPane{
+		pane:          herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{"› hello"},
+	}
+	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: "hello", Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || sendErr.State != state.SendNotSubmitted || sendErr.Reason != state.SendReasonEnterNotConfirmed {
+		t.Fatalf("err=%v, want not-submitted enter-not-confirmed", err)
+	}
+}
+
+// atqamz/hand#459's live-measured stall: a large PaneSendText can leave only an early fragment in the
+// composer for many seconds, drifting further on Enter without ever completing. This lands on Uncertain,
+// not not-submitted: the drift is positive evidence something landed, just never provably all of it.
+func TestExecuteDoesNotConfirmEnterWhenOnlyAPartialFragmentArrived(t *testing.T) {
+	restore := ConfigureSendConfirmPollingForTest(time.Millisecond, 5*time.Millisecond, 400)
+	t.Cleanup(restore)
+	home, _ := newSteeringHome(t)
+	const sent = "please read the whole review before replying, thanks very much for the help"
+	pane := &testPane{
+		pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{
+			"› please read the whole review before",
+			"please read the whole review before\nreplying, thanks",
+			"please read the whole review before\nreplying, thanks very",
+		},
+	}
+	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: sent, Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || sendErr.State != state.SendUncertain || sendErr.Reason != state.SendReasonEnterNotConfirmed {
+		t.Fatalf("err=%v, want uncertain enter-not-confirmed: something landed, just never the tail", err)
+	}
+}
+
+// A read failure choosing the key leaves no baseline to compare against - confirming blind would be
+// worse than admitting uncertainty, so this never reaches enterConfirms at all.
+func TestExecuteMarksEnterPreKeyReadFailureUncertain(t *testing.T) {
+	home, _ := newSteeringHome(t)
+	pane := &testPane{
+		pane:    herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readErr: errors.New("herdr pane read: transport lost"),
+	}
+	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: "hello", Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || sendErr.State != state.SendUncertain || sendErr.Reason != "composer-confirmation-read-failed" {
+		t.Fatalf("err=%v, want uncertain composer-confirmation-read-failed", err)
+	}
+	if len(pane.keyCalls) != 1 || pane.keyCalls[0][0] != "Enter" {
+		t.Fatalf("key calls = %v, want Enter still chosen despite the read failure", pane.keyCalls)
+	}
+}
+
+// A read failure during the confirmation poll itself (as opposed to choosing the key) is the same
+// honest uncertainty, reached through enterConfirms this time.
+func TestExecuteMarksEnterConfirmationReadFailureUncertain(t *testing.T) {
+	useFastSendConfirmPolling(t)
+	home, _ := newSteeringHome(t)
+	pane := &testPane{
+		pane:          herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{"› hello"},
+		readErr:       errors.New("herdr pane read: transport lost"),
+		readErrFrom:   2,
+	}
+	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: "hello", Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || sendErr.State != state.SendUncertain || sendErr.Reason != "composer-confirmation-read-failed" {
+		t.Fatalf("err=%v, want uncertain composer-confirmation-read-failed", err)
+	}
+}
+
+func TestComposerHasTail(t *testing.T) {
+	const sent = "Please stop and wait for review before merging this pull request, thanks in advance."
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "short message must match in full, not just a fragment", text: "› Please stop and wait", want: false},
+		{name: "full message present", text: "› " + sent, want: true},
+		{name: "empty pane", text: "", want: false},
+		{
+			// The live-measured atqamz/hand#459 stall: an early fragment survives but the tail never
+			// arrived. An any-chunk search would wrongly confirm this; the tail check must not.
+			name: "early fragment survives, tail never arrived",
+			text: "› Please stop and wait for review before merging this",
+			want: false,
+		},
+		{
+			name: "a terminal-wrapped line break lands inside the tail",
+			text: "› Please stop and wait for review\nbefore merging this pull request, thanks in\nadvance.",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := composerHasTail(tt.text, sent); got != tt.want {
+				t.Fatalf("composerHasTail() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -494,6 +614,7 @@ func TestComposerRetains(t *testing.T) {
 }
 
 func TestExecuteReportsDurableFinalizationFailureWithoutRepeatingExternalCalls(t *testing.T) {
+	useFastSendConfirmPolling(t)
 	home, _ := newSteeringHome(t)
 	pane := &testPane{pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle}}
 	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: "hello", Origin: state.SendOriginOperator, Client: pane,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -106,8 +106,12 @@ const (
 	SendReasonEnterRejectedAfterTextStaged = "enter-rejected-after-text-staged"
 	// Marks a codex Tab/queue send where Text and Tab both returned success, but the composer still
 	// visibly held a recognizable fragment of the message (atqamz/hand#426): text landed, the queue
-	// did not. Enter never produces this reason - it has no confirmation signal yet (atqamz/hand#420).
+	// did not. Enter never produces this reason - it has its own, below (atqamz/hand#459).
 	SendReasonComposerRetainsMessage = "composer-retains-message"
+	// Marks an Enter send whose confirmation poll never saw the sent message's tail. Pairs with
+	// SendNotSubmitted when the composer never reacted at all, or SendUncertain when it did react but not
+	// completely - a stalled paste is evidence something landed, just not provably all of it.
+	SendReasonEnterNotConfirmed = "enter-not-confirmed"
 )
 
 type SendOrigin string
@@ -240,7 +244,8 @@ func SendNeedsAttention(send SendAttempt) bool {
 		return false
 	}
 	return strings.HasPrefix(send.ReasonCode, SendReasonEnterRejectedAfterTextStaged) ||
-		strings.HasPrefix(send.ReasonCode, SendReasonComposerRetainsMessage)
+		strings.HasPrefix(send.ReasonCode, SendReasonComposerRetainsMessage) ||
+		strings.HasPrefix(send.ReasonCode, SendReasonEnterNotConfirmed)
 }
 
 func SendRetrySafe(send SendAttempt) bool {

--- a/tests/e2e/fakes_test.go
+++ b/tests/e2e/fakes_test.go
@@ -150,9 +150,9 @@ func writeFakeHerdrWatch(t *testing.T, dir, statusDir, logPath string) {
 	// result object on exit 0, real failure a non-zero exit plus a diagnostic on stderr (the same contract
 	// cmd/status_test.go's writeFakeHerdrPaneStatus documents), which the "unreachable" sentinel reproduces.
 	quotedStatusDir, quotedLog := shellSingleQuote(statusDir), shellSingleQuote(logPath)
-	// The reported agent comes from statusDir/<id>.agent, empty unless a test calls setPaneAgent, which keeps
-	// a scenario that never mentions an agent out of every harness-capability path. "pane read" answers with
-	// statusDir/<id>.text - bare stdout, not a result envelope (client.go's PaneRead) - and the steers void.
+	// The agent comes from statusDir/<id>.agent, set only via setPaneAgent. "pane read" answers with
+	// statusDir/<id>.text (bare stdout, not a result envelope - client.go's PaneRead); send-text overwrites
+	// it and send-keys Enter appends a marker, so a confirmation poll (atqamz/hand#459) sees a reaction.
 	body := fmt.Sprintf(`  "workspace list") echo '{"result":{"workspaces":[]}}' ;;
   "pane get")
     status=$(cat %s/"$3" 2>/dev/null || echo idle)
@@ -168,9 +168,15 @@ func writeFakeHerdrWatch(t *testing.T, dir, statusDir, logPath string) {
     echo "herdr pane read $3" >> %s
     cat %s/"$3".text 2>/dev/null
     ;;
-  "pane send-text") echo "herdr pane send-text $3 $4" >> %s ;;
-  "pane send-keys") echo "herdr pane send-keys $3 $4" >> %s ;;`,
-		quotedStatusDir, quotedStatusDir, quotedLog, quotedLog, quotedStatusDir, quotedLog, quotedLog)
+  "pane send-text")
+    echo "herdr pane send-text $3 $4" >> %s
+    printf '%%s' "$4" > %s/"$3".text
+    ;;
+  "pane send-keys")
+    echo "herdr pane send-keys $3 $4" >> %s
+    if [ "$4" = "Enter" ]; then printf '\n\n[accepted]' >> %s/"$3".text; fi
+    ;;`,
+		quotedStatusDir, quotedStatusDir, quotedLog, quotedLog, quotedStatusDir, quotedLog, quotedStatusDir, quotedLog, quotedStatusDir)
 	// Each "pane get" is logged after the status read, never before: a test waiting on the Nth poll before
 	// publishing would otherwise still be racing that poll's read. The failing branch logs too, so waiting on
 	// the Nth probe works for a dark pane - one taken down and brought back mid-poll - as for a healthy one.
@@ -178,22 +184,29 @@ func writeFakeHerdrWatch(t *testing.T, dir, statusDir, logPath string) {
 }
 
 // A herdr fake for the send scenario: "pane get" reports whatever status sits in statusDir/<pane-id>, so a
-// test can free a busy composer while `hand send` is waiting on it, and "pane send-text"/"pane send-keys"
-// answer with the empty stdout real herdr gives a void command (client.go's callVoid doc comment).
+// test can free a busy composer while `hand send` is waiting on it. send-text/send-keys drive a per-pane
+// composer file like writeFakeHerdrWatch's, giving the Enter confirmation poll a real reaction to observe.
 func writeFakeHerdrSend(t *testing.T, dir, statusDir, logPath string) {
 	t.Helper()
 	// Every invocation is logged with the pid of the hand process that made it, which is what lets a test tell
 	// two concurrent senders apart; each pane status read is logged after the read, for the same reason
 	// writeFakeHerdrWatch does it.
-	quotedLog := shellSingleQuote(logPath)
+	quotedStatusDir, quotedLog := shellSingleQuote(statusDir), shellSingleQuote(logPath)
 	body := fmt.Sprintf(`  "pane get")
     status=$(cat %s/"$3" 2>/dev/null || echo idle)
     echo "sender=$PPID pane get $3" >> %s
     printf '{"result":{"pane":{"pane_id":"%%s","tab_id":"t-1","workspace_id":"w-1","agent":"claude","agent_status":"%%s"}}}\n' "$3" "$status"
     ;;
-  "pane send-text") echo "sender=$PPID pane send-text $4" >> %s ;;
-  "pane send-keys") echo "sender=$PPID pane send-keys $4" >> %s ;;`,
-		shellSingleQuote(statusDir), quotedLog, quotedLog, quotedLog)
+  "pane read") cat %s/"$3".composer 2>/dev/null ;;
+  "pane send-text")
+    echo "sender=$PPID pane send-text $4" >> %s
+    printf '%%s' "$4" > %s/"$3".composer
+    ;;
+  "pane send-keys")
+    echo "sender=$PPID pane send-keys $4" >> %s
+    if [ "$4" = "Enter" ]; then printf '\n\n[accepted]' >> %s/"$3".composer; fi
+    ;;`,
+		quotedStatusDir, quotedLog, quotedStatusDir, quotedLog, quotedStatusDir, quotedLog, quotedStatusDir)
 	writeFakeDispatch(t, dir, "herdr", "", "$1 $2", body)
 }
 


### PR DESCRIPTION
## Summary

- Enter used to report `submitted` once Text and Enter both returned success, with no check of what the pane actually did - a large `PaneSendText` can stall mid-delivery and hand would still claim success.
- `chooseSubmitKey`'s pane read is now unconditional and doubles as the pre-key baseline for `enterConfirms`, which polls until the composer both differs from that baseline and holds the sent message's own tail: positive evidence of a reaction, not an absence check, since an accepted message can stay visible as history indefinitely.
- An unconfirmed Enter send is split by what was observed - no reaction at all is `not-submitted`, a reaction without the tail is `uncertain` - and `cmd`'s rendered advice now checks send state before the partial-composer flag so an `uncertain` outcome always warns against blind retry.

No retry is added on top of this: a `not-submitted` or `uncertain` send can still complete later, invisibly, as a side effect of unrelated traffic to the same pane. This was reproduced three times live against a real codex worker and is a documented, accepted limitation (see the amended ADR) rather than something this change attempts to fix, since doing so would require touching pre-send busy-wait gating.

Closes atqamz/hand#459
Closes atqamz/hand#420

## Test plan

- [x] `make lint` (gofmt, go vet, golangci-lint, commentlint)
- [x] `make test` (`go test -race ./...`)
- [x] `make e2e`
- [x] `make contract`
- [x] Live-validated against a real codex worker in a scratch fleet home: idle and mid-turn sends, small and 2-6KB, several reps each, reading `send_state`/`send_reason` from the store and checking the pane for duplicate delivery after each send - zero duplicates across nine sends, two genuine large-payload stalls correctly caught as not confirmed

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->