### PR TITLE
fix(steering): chunk PaneSendText writes below the measured stall boundary

### DIFF
--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2155,6 +2155,9 @@ func TestStatusFlagsPartialSendAfterFreshRead(t *testing.T) {
 		// A confirmation read, not a structured herdr rejection, is what proves this one - but it is the
 		// same partial shape (text staged, submission did not happen) and gets the same treatment.
 		{name: "composer retains message after retry", send: state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonComposerRetainsMessage}, wantFlag: "send-partial", wantAttention: true, wantSendAttention: true},
+		// atqamz/hand#472: a chunk written mid-send whose tail never confirmed, so the submit key was
+		// never chosen. Same partial shape as the two rows above - text staged, submission did not happen.
+		{name: "text chunk not confirmed", send: state.SendAttempt{State: state.SendNotSubmitted, ReasonCode: state.SendReasonTextChunkNotConfirmed}, wantFlag: "send-partial", wantAttention: true, wantSendAttention: true},
 		// Retry-safe before-acceptance rejections now raise send-not-submitted at the task level
 		// (atqamz/hand#419) even though internal/store.SendNeedsAttention, a narrower per-send
 		// predicate this brief does not touch, still reports false for this reason code.

--- a/docs/adr/chunked-send-delivery-is-paced-by-a-settle-pause-not-chunk-size-alone.md
+++ b/docs/adr/chunked-send-delivery-is-paced-by-a-settle-pause-not-chunk-size-alone.md
@@ -1,0 +1,116 @@
+# Chunked send delivery is paced by a settle pause, not chunk size alone
+
+Date: 2026-08-29
+Status: accepted
+Issues: atqamz/hand#472
+Pull requests: none
+
+## Context
+
+atqamz/hand#420 and atqamz/hand#459 established that a large `hand send` can leave the composer holding
+only a prefix: `PaneSendText` stalls mid-delivery above roughly 1kB of rendered content, a hard stop rather
+than a trickle, and #459 made a stalled send finalize honestly (`uncertain` or `not-submitted`) instead of
+falsely claiming `submitted`. Neither fixed delivery itself - a channel that correctly reports failure on
+this fleet's ordinary 1-3kB steering messages is still a broken channel. atqamz/hand#472 is that fix.
+
+## Decision
+
+Chunking lives in `internal/steering`, not in `internal/herdr.PaneSendText`. `PaneSendText`'s only real
+production caller today is `steering.Execute` (`internal/watcher/usagelimit.go`'s `limitPane` interface
+only reaches it by passing its client through `steering.Execute`, never directly), and `steering` already
+owns every piece the fix needs: `composerHasTail` and the bounded poll-and-confirm machinery #459 built,
+the `Client` interface, and the confirm-cadence constants. `herdr` stays what the issue itself calls it - a
+one-shot wrapper with no chunking - rather than duplicating confirmation policy one layer down.
+
+`sendMessage` splits the message into pieces of `sendChunkSize` (512) bytes, cut only at rune boundaries,
+and sends them with `PaneSendText` one at a time. Each piece is confirmed with `chunkConfirms` before the
+next is sent, using the exact tail check `composerHasTail` (#459) already uses to confirm Enter: poll until
+the piece's tail appears, never until anything goes absent. The submit key is chosen and pressed only after
+`sendMessage` reports every piece confirmed - a chunk that never confirms means `sendMessage` returns before
+`Execute` ever reaches `chooseSubmitKey` or `PaneSendKeys`, so a failed chunk cannot become a genuine partial
+submission the way an extra nudge could. A message that fits in one chunk takes the exact call sequence it
+took before chunking existed: one `PaneSendText`, no confirmation read added, so a short send costs what it
+costs today.
+
+`chunkConfirms` checks the tail of the *cumulative* text sent so far, not the isolated chunk. A chunk
+boundary landing mid-blank-line - routine in this fleet's Markdown briefs and reviews - strips to an empty
+needle on its own, which `composerHasTail` always reports absent by construction; checking the cumulative
+text lets the tail reach back into the nearest real content automatically, with no separate empty-chunk
+case. Caught in review before this shipped, by inspection rather than by a failing test.
+
+512 bytes is chosen from atqamz/hand#459's own live measurements, not tuned to a boundary already shown to
+move: repetitive filler stalled near 1kB, and prose that separately cleared 1965 and 1667 bytes stalled once
+concatenated to 3634 bytes. 512 sits under half of the smallest failure seen.
+
+Live validation (real codex 0.147.0, scratch fleet home in a temp directory) found chunk size alone is not
+the whole story. A payload built from many near-identical templated sentences - the same "repetitive filler"
+shape atqamz/hand#459 already measured as the worst case - reliably stalls once enough of it has accumulated
+in the composer, reproduced on three separate fresh panes with no prior scrollback. At 512-byte chunks with
+no pause between them the ceiling was about 4.1kB; at 256-byte chunks, about 8.1-11.6kB. Halving the chunk
+size roughly doubled the byte ceiling while quadrupling the chunk count, which rules out both a fixed byte
+ceiling (it moved) and a fixed chunk-count ceiling (it would have stayed put) - the remaining candidate is a
+rate the harness accepts per unit time, and smaller chunks bought headroom only as a side effect of the
+extra confirmation round trips slowing delivery down.
+
+`interChunkSettle` (300ms, reusing `sendConfirmPolling`'s existing interval rather than a new number) pauses
+before every chunk after the first. Keeping the chunk size at 512 bytes and adding the pause let the exact
+12077-byte payload that failed at both 512-byte and 256-byte chunks with no pause deliver whole and correct;
+pushed further, a fresh 20159-byte purely-repetitive payload also delivered clean. That is roughly five
+times the original chunk-size-only ceiling, confirmed against the real shipped binary, not only the
+experimental one the hypothesis was first tested against. The pause is skipped for a single-chunk message,
+so it never touches the short-send cost the issue's own acceptance bar protects.
+
+Every realistic payload tried - 1kB and 3kB idle sends (several each), one genuine mid-turn 3kB send under
+`--force` while the worker was actively `Working`, and a dedicated 4.5kB payload of varied, non-repetitive
+review-style prose - delivered whole, correct, and exactly once, with zero failures, at 512 bytes with the
+settle pause. The residual ceiling is specific to adversarially repetitive, mechanically templated text
+accumulating past several kB in one message, not to the natural-language traffic this fleet actually sends.
+
+## Rejected alternatives
+
+**Chunking inside `herdr.PaneSendText`.** Every real caller already goes through `steering.Execute`, and the
+confirmation apparatus chunking needs (`composerHasTail`, the bounded poll, the `Client` interface) already
+lives in `steering`. Moving chunking to `herdr` would mean duplicating that machinery one layer down, or
+promoting it out of `steering` for a second caller that does not exist, for no caller `herdr` does not
+already serve through `steering`.
+
+**Shrinking chunk size further instead of pacing.** Tried live: 256-byte chunks with no pause pushed the
+repetitive-content ceiling from about 4.1kB to about 8.1-11.6kB, a real improvement but not proportional to
+the size cut, and it doubles round-trip cost on every ordinary multi-chunk send whether or not that send
+would ever have needed the extra margin. The chunk-count-vs-byte-ceiling comparison is what identified the
+constraint as a rate rather than a size, and a rate is not a dial chunk size alone can turn - see the
+Decision above.
+
+**Confirming per-chunk against the isolated chunk text.** `composerHasTail` reports a message absent when
+its whitespace-stripped form is empty, which a chunk landing entirely inside a blank-line run - a routine
+shape in Markdown - produces on its own. Confirming against the cumulative sent-so-far text instead makes
+the tail reach back into the nearest real content with no special case, and needs no new confirmation
+primitive beyond what #459 already built.
+
+**Treating any single sub-chunk-size stall as fully disqualifying (closing this only with a stop-and-escalate
+report).** The issue's own verification bar - a 3kB send arriving whole, submitting once, confirmed - was
+met repeatedly, including on realistic prose past that bound. An adversarial repetitive-filler payload
+failing safely (refused, not corrupted, honestly reported) is a documented residual limitation, not evidence
+that chunking fails to solve what the issue is about.
+
+## Consequences
+
+A short send (fits in one chunk) costs exactly what it cost before this change: one `PaneSendText` call, no
+added confirmation read, no settle pause. A send needing chunking now costs one `PaneSendText` plus one
+confirmation read per chunk, plus a 300ms pause before each chunk after the first - live-measured at about
+2.18s for a realistic 3kB send, against about 10.06s for the same shape of send before this change (which
+spent that time on a confirmation poll that timed out without ever seeing the full text arrive, and finalized
+`uncertain` rather than delivering).
+
+The residual limitation: a message built from long runs of near-identical, highly repetitive text can still
+exceed what the harness accepts in one continuous exchange, even chunked and paced. Such a send fails safely
+- the submit key is never chosen or sent, nothing is duplicated, and the composer is left holding exactly the
+confirmed prefix, with `state.SendReasonTextChunkNotConfirmed` (`not-submitted`, not retry-safe) recorded
+honestly. Natural-language steering messages in the sizes this fleet actually sends were never observed to
+trigger it.
+
+A failed chunked send still leaves the pre-existing gap atqamz/hand#472's own brief named and explicitly did
+not ask this change to close: `internal/steering/send.go`'s busy-composer gate waits on `AgentStatus ==
+working`, and a pane holding an unconfirmed leftover fragment reports `idle` for the whole time it sits
+there. A subsequent `hand send` to that pane proceeds immediately rather than refusing, at the same cost as
+an ordinary idle send - it does not inherit any protection from the failed chunked send that came before it.

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -66,6 +66,7 @@ const (
 	SendReasonEnterRejectedAfterTextStaged = store.SendReasonEnterRejectedAfterTextStaged
 	SendReasonComposerRetainsMessage       = store.SendReasonComposerRetainsMessage
 	SendReasonEnterNotConfirmed            = store.SendReasonEnterNotConfirmed
+	SendReasonTextChunkNotConfirmed        = store.SendReasonTextChunkNotConfirmed
 )
 
 func SendNeedsAttention(send SendAttempt) bool { return store.SendNeedsAttention(send) }

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -244,9 +244,9 @@ func ConfigureInterChunkSettleForTest(delay time.Duration) func() {
 	return func() { interChunkSettle = previous }
 }
 
-// Splits message into pieces no larger than size bytes, cut only at rune boundaries (ranging over a
-// string yields each rune's start offset, so slicing there never splits a multi-byte rune). A message
-// that already fits returns unchanged, so a send that never needs chunking costs nothing extra.
+// Splits message into pieces of at least size bytes, cut only at rune boundaries (ranging over a
+// string yields each rune's start offset; the cut lands at the first one at or past size, so a chunk
+// can run a few bytes over). The last piece is whatever remains; a message that already fits is unchanged.
 func chunkMessage(message string, size int) []string {
 	if len(message) <= size {
 		return []string{message}

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -222,6 +222,96 @@ func composerHasTail(text, sent string) bool {
 	return strings.Contains(haystack, string(runes))
 }
 
+// Bounds each PaneSendText call comfortably below the smallest measured stall (atqamz/hand#472): filler
+// stalled near 1kB, and prose that separately cleared 1965 and 1667 bytes stalled once concatenated to
+// 3634 bytes - the boundary moves with content, so this sits under half the smallest failure seen.
+var sendChunkSize = 512
+
+func ConfigureSendChunkSizeForTest(size int) func() {
+	previous := sendChunkSize
+	sendChunkSize = size
+	return func() { sendChunkSize = previous }
+}
+
+// The pause before each chunk after the first (atqamz/hand#472, live-measured): repetitive content
+// stalling around 4kB at this chunk size with no pause delivered past 20kB once every write paused here -
+// a rate the harness accepts, not a size alone. Reuses sendConfirmPolling's interval, not a second number.
+var interChunkSettle = sendConfirmPolling.Interval
+
+func ConfigureInterChunkSettleForTest(delay time.Duration) func() {
+	previous := interChunkSettle
+	interChunkSettle = delay
+	return func() { interChunkSettle = previous }
+}
+
+// Splits message into pieces no larger than size bytes, cut only at rune boundaries (ranging over a
+// string yields each rune's start offset, so slicing there never splits a multi-byte rune). A message
+// that already fits returns unchanged, so a send that never needs chunking costs nothing extra.
+func chunkMessage(message string, size int) []string {
+	if len(message) <= size {
+		return []string{message}
+	}
+	chunks := make([]string, 0, len(message)/size+1)
+	start := 0
+	for i := range message {
+		if i-start >= size {
+			chunks = append(chunks, message[start:i])
+			start = i
+		}
+	}
+	return append(chunks, message[start:])
+}
+
+// Confirms progress the way submissionOutcome confirms post-key: poll until sentSoFar's tail appears.
+// sentSoFar is the cumulative text through this chunk, not the chunk alone - a boundary landing
+// mid-blank-line (routine in this fleet's Markdown) strips to an empty needle, which never confirms.
+func chunkConfirms(client Client, paneID, sentSoFar string) (bool, error) {
+	confirmed, _, err := pollUntilObserved(client, paneID, func(text string) bool {
+		return composerHasTail(text, sentSoFar)
+	})
+	return confirmed, err
+}
+
+// Non-nil means sendMessage decided the send before ever reaching the submit key: a chunk's PaneSendText
+// call itself failed, or its confirmation poll never found the chunk's tail.
+type chunkOutcome struct {
+	state   state.SendState
+	reason  string
+	partial bool
+}
+
+// Writes message in sendChunkSize pieces, confirming each before the next so the submit key is chosen
+// only once the whole text is present (atqamz/hand#472). A single-chunk message costs exactly what it
+// did before chunking existed. Non-nil return means the send is decided; Execute must not press a key.
+func sendMessage(client Client, paneID, message string) *chunkOutcome {
+	chunks := chunkMessage(message, sendChunkSize)
+	var sentSoFar strings.Builder
+	for i, chunk := range chunks {
+		if i > 0 {
+			time.Sleep(interChunkSettle)
+		}
+		if err := client.PaneSendText(paneID, chunk); err != nil {
+			partial := i > 0
+			if herdr.IsPreSideEffectRejection(err) || herdr.IsProcessNotStarted(err) {
+				return &chunkOutcome{state: state.SendNotSubmitted, reason: rejectionReason(err, state.SendReasonTextRejectedBeforeAcceptance), partial: partial}
+			}
+			return &chunkOutcome{state: state.SendUncertain, reason: "text-outcome-ambiguous", partial: partial}
+		}
+		if len(chunks) == 1 {
+			return nil
+		}
+		sentSoFar.WriteString(chunk)
+		confirmed, err := chunkConfirms(client, paneID, sentSoFar.String())
+		if err != nil {
+			return &chunkOutcome{state: state.SendUncertain, reason: "composer-confirmation-read-failed"}
+		}
+		if !confirmed {
+			return &chunkOutcome{state: state.SendNotSubmitted, reason: state.SendReasonTextChunkNotConfirmed, partial: true}
+		}
+	}
+	return nil
+}
+
 // Confirms Enter by positive evidence the harness reacted, not by its own text going absent: an accepted
 // message stays visible forever as history, so an absence check races that redraw (atqamz/hand#420,
 // atqamz/hand#459). reacted distinguishes a pure no-op (nothing happened) from a stalled paste (something did).
@@ -373,11 +463,8 @@ func Execute(req Request) (Result, error) {
 	if req.Faults.BeforeText != nil {
 		return Result{}, pendingError(send, req.Faults.BeforeText, "before-text")
 	}
-	if err := req.Client.PaneSendText(current.Herdr.PaneID, req.Message); err != nil {
-		if herdr.IsPreSideEffectRejection(err) || herdr.IsProcessNotStarted(err) {
-			return finalize(req, send, state.SendNotSubmitted, rejectionReason(err, state.SendReasonTextRejectedBeforeAcceptance), false, false)
-		}
-		return finalize(req, send, state.SendUncertain, "text-outcome-ambiguous", false, false)
+	if outcome := sendMessage(req.Client, current.Herdr.PaneID, req.Message); outcome != nil {
+		return finalize(req, send, outcome.state, outcome.reason, false, outcome.partial)
 	}
 	if req.Faults.AfterText != nil {
 		return Result{}, pendingError(send, req.Faults.AfterText, "text-succeeded-before-enter")

--- a/internal/steering/send_test.go
+++ b/internal/steering/send_test.go
@@ -2,6 +2,7 @@ package steering
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -281,6 +282,8 @@ func useFastSendConfirmPolling(t *testing.T) {
 	t.Helper()
 	restore := ConfigureSendConfirmPollingForTest(time.Millisecond, 50*time.Millisecond, 400)
 	t.Cleanup(restore)
+	restoreSettle := ConfigureInterChunkSettleForTest(time.Millisecond)
+	t.Cleanup(restoreSettle)
 }
 
 // Positive evidence, not absence: an accepted message stays visible forever as a history line
@@ -610,6 +613,183 @@ func TestComposerRetains(t *testing.T) {
 				t.Fatalf("composerRetains() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestChunkMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		size    int
+		want    []string
+	}{
+		{name: "fits in one chunk, returned unchanged", message: "abc", size: 5, want: []string{"abc"}},
+		{name: "exact multiple of size", message: "abcdefghij", size: 5, want: []string{"abcde", "fghij"}},
+		{name: "remainder trails as a short final chunk", message: "abcdefghi", size: 4, want: []string{"abcd", "efgh", "i"}},
+		{
+			// Ranging over a string yields each rune's start offset, so a cut can only ever land there -
+			// this multi-byte content would corrupt under a naive byte-offset slice.
+			name:    "cuts only at rune boundaries, never inside a multi-byte rune",
+			message: "ab日本語cd", size: 4,
+			want: []string{"ab日", "本語", "cd"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chunkMessage(tt.message, tt.size)
+			if len(got) != len(tt.want) {
+				t.Fatalf("chunkMessage() = %q, want %q", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("chunkMessage() = %q, want %q", got, tt.want)
+				}
+			}
+			if joined := strings.Join(got, ""); joined != tt.message {
+				t.Fatalf("chunks rejoin to %q, want original %q", joined, tt.message)
+			}
+		})
+	}
+}
+
+// The exact shape flagged in review: a chunk boundary landing mid-blank-line (routine in this fleet's
+// Markdown) strips to an empty needle on its own, which composerHasTail always reports absent.
+// chunkConfirms takes the cumulative text so far, so the tail reaches back into real content instead.
+func TestChunkConfirmsReachesPastAWhitespaceOnlyChunkIntoEarlierContent(t *testing.T) {
+	if composerHasTail("› first paragraph here", "\n\n") {
+		t.Fatal("composerHasTail on a whitespace-only chunk in isolation should never confirm")
+	}
+	restore := ConfigureSendConfirmPollingForTest(time.Millisecond, 5*time.Millisecond, 400)
+	t.Cleanup(restore)
+	pane := &testPane{readResponses: []string{"› first paragraph here"}}
+	confirmed, err := chunkConfirms(pane, "pane-1", "first paragraph here\n\n")
+	if err != nil || !confirmed {
+		t.Fatalf("chunkConfirms(cumulative) = %t, %v, want confirmed via the earlier real content", confirmed, err)
+	}
+}
+
+// End-to-end version of the same fix: chunkMessage("AAAAAA\n\nBBBBBB", 2) really does produce a
+// whitespace-only chunk ("\n\n") sandwiched between real content, and the full send still reaches and
+// presses the submit key exactly once.
+func TestExecuteSendsAWhitespaceOnlyChunkWithoutStallingConfirmation(t *testing.T) {
+	restoreSize := ConfigureSendChunkSizeForTest(2)
+	t.Cleanup(restoreSize)
+	useFastSendConfirmPolling(t)
+	home, attempt := newSteeringHome(t)
+	const message = "AAAAAA\n\nBBBBBB"
+	pane := &testPane{
+		pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{
+			"› AA", "› AAAA", "› AAAAAA", "› AAAAAA", "› AAAAAABB", "› AAAAAABBBB", "› AAAAAABBBBBB",
+			"› AAAAAABBBBBB",
+			"AAAAAABBBBBB\n\n• new agent activity",
+		},
+	}
+	result, err := Execute(Request{Home: home, TaskID: "task-1", Message: message, Origin: state.SendOriginOperator, Client: pane})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Send.State != state.SendSubmitted || result.Send.AttemptID != attempt.ID {
+		t.Fatalf("result = %+v, want submitted despite a whitespace-only chunk mid-send", result.Send)
+	}
+	wantChunks := []string{"AA", "AA", "AA", "\n\n", "BB", "BB", "BB"}
+	if len(pane.textCalls) != len(wantChunks) {
+		t.Fatalf("text calls = %q, want %q", pane.textCalls, wantChunks)
+	}
+	for i := range wantChunks {
+		if pane.textCalls[i] != wantChunks[i] {
+			t.Fatalf("text calls = %q, want %q", pane.textCalls, wantChunks)
+		}
+	}
+	if len(pane.keyCalls) != 1 || pane.keyCalls[0][0] != "Enter" {
+		t.Fatalf("key calls = %v, want a single Enter only after every chunk confirmed", pane.keyCalls)
+	}
+}
+
+func TestExecuteSendsChunkedTextConfirmingEachChunkBeforeTheSubmitKey(t *testing.T) {
+	restoreSize := ConfigureSendChunkSizeForTest(5)
+	t.Cleanup(restoreSize)
+	useFastSendConfirmPolling(t)
+	home, attempt := newSteeringHome(t)
+	const message = "abcdefghij" // chunkMessage(_, 5) -> "abcde", "fghij"
+	pane := &testPane{
+		pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{
+			"› abcde",                            // confirms chunk 1
+			"› abcdefghij",                       // confirms chunk 2 (the whole message, now fully present)
+			"› abcdefghij",                       // chooseSubmitKey's pre-key baseline
+			"abcdefghij\n\n• new agent activity", // enterConfirms: reacted and holds the tail
+		},
+	}
+	result, err := Execute(Request{Home: home, TaskID: "task-1", Message: message, Origin: state.SendOriginOperator, Client: pane})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Send.State != state.SendSubmitted || result.Send.AttemptID != attempt.ID {
+		t.Fatalf("result = %+v, want submitted", result.Send)
+	}
+	if len(pane.textCalls) != 2 || pane.textCalls[0] != "abcde" || pane.textCalls[1] != "fghij" {
+		t.Fatalf("text calls = %q, want the two chunks in order", pane.textCalls)
+	}
+	if len(pane.keyCalls) != 1 || pane.keyCalls[0][0] != "Enter" {
+		t.Fatalf("key calls = %v, want a single Enter chosen only after both chunks confirmed", pane.keyCalls)
+	}
+	if pane.readCalls != 4 {
+		t.Fatalf("readCalls = %d, want exactly 4: one confirm per chunk, one pre-key baseline, one post-key confirm", pane.readCalls)
+	}
+}
+
+// The hard constraint this issue is built around: a chunk that never confirms must not leave a half
+// message that a later key press turns into a genuine partial submission. sendMessage must return before
+// Execute ever reaches chooseSubmitKey or PaneSendKeys.
+func TestExecuteFailsWithoutPressingSubmitKeyWhenAChunkNeverConfirms(t *testing.T) {
+	restoreSize := ConfigureSendChunkSizeForTest(5)
+	t.Cleanup(restoreSize)
+	restorePoll := ConfigureSendConfirmPollingForTest(time.Millisecond, 5*time.Millisecond, 400)
+	t.Cleanup(restorePoll)
+	restoreSettle := ConfigureInterChunkSettleForTest(time.Millisecond)
+	t.Cleanup(restoreSettle)
+	home, _ := newSteeringHome(t)
+	const message = "abcdefghij" // chunkMessage(_, 5) -> "abcde", "fghij"
+	pane := &testPane{
+		pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		// Confirms chunk 1, then never advances - chunk 2's tail ("fghij") never appears.
+		readResponses: []string{"› abcde"},
+	}
+	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: message, Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || sendErr.State != state.SendNotSubmitted || sendErr.Reason != state.SendReasonTextChunkNotConfirmed || !sendErr.PartialComposer {
+		t.Fatalf("err=%v, want not-submitted text-chunk-not-confirmed partial", err)
+	}
+	if len(pane.textCalls) != 2 || pane.textCalls[0] != "abcde" || pane.textCalls[1] != "fghij" {
+		t.Fatalf("text calls = %q, want both chunks written even though the second never confirmed", pane.textCalls)
+	}
+	if len(pane.keyCalls) != 0 {
+		t.Fatalf("key calls = %v, want the submit key never chosen or sent", pane.keyCalls)
+	}
+}
+
+// A read failure mid-chunk-confirmation is the same honest uncertainty the Enter and Tab paths already
+// give a read failure - not a claim about what the composer holds either way.
+func TestExecuteMarksChunkConfirmationReadFailureUncertain(t *testing.T) {
+	restoreSize := ConfigureSendChunkSizeForTest(5)
+	t.Cleanup(restoreSize)
+	useFastSendConfirmPolling(t)
+	home, _ := newSteeringHome(t)
+	const message = "abcdefghij" // chunkMessage(_, 5) -> "abcde", "fghij"
+	pane := &testPane{
+		pane:          herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusIdle},
+		readResponses: []string{"› abcde"},
+		readErr:       errors.New("herdr pane read: transport lost"),
+		readErrFrom:   2, // chunk 1's confirmation read succeeds; chunk 2's fails
+	}
+	_, err := Execute(Request{Home: home, TaskID: "task-1", Message: message, Origin: state.SendOriginOperator, Client: pane})
+	var sendErr *Error
+	if err == nil || !errors.As(err, &sendErr) || sendErr.State != state.SendUncertain || sendErr.Reason != "composer-confirmation-read-failed" {
+		t.Fatalf("err=%v, want uncertain composer-confirmation-read-failed", err)
+	}
+	if len(pane.textCalls) != 2 || len(pane.keyCalls) != 0 {
+		t.Fatalf("calls=%v/%v, want both chunks written and no submit key", pane.textCalls, pane.keyCalls)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -112,6 +112,10 @@ const (
 	// SendNotSubmitted when the composer never reacted at all, or SendUncertain when it did react but not
 	// completely - a stalled paste is evidence something landed, just not provably all of it.
 	SendReasonEnterNotConfirmed = "enter-not-confirmed"
+	// Marks a chunked PaneSendText write (atqamz/hand#472) whose own tail never appeared in the composer
+	// within the bounded poll. Always SendNotSubmitted: no submit key is ever chosen once this fires, so
+	// there is no submission ambiguity to hedge - only whether the composer holds an unsent remnant.
+	SendReasonTextChunkNotConfirmed = "text-chunk-not-confirmed"
 )
 
 type SendOrigin string
@@ -245,7 +249,8 @@ func SendNeedsAttention(send SendAttempt) bool {
 	}
 	return strings.HasPrefix(send.ReasonCode, SendReasonEnterRejectedAfterTextStaged) ||
 		strings.HasPrefix(send.ReasonCode, SendReasonComposerRetainsMessage) ||
-		strings.HasPrefix(send.ReasonCode, SendReasonEnterNotConfirmed)
+		strings.HasPrefix(send.ReasonCode, SendReasonEnterNotConfirmed) ||
+		strings.HasPrefix(send.ReasonCode, SendReasonTextChunkNotConfirmed)
 }
 
 func SendRetrySafe(send SendAttempt) bool {


### PR DESCRIPTION
## Summary

- `PaneSendText` stalls mid-delivery on multi-kilobyte sends - not at a fixed byte count but a content-sensitive boundary (filler content near 1kB; prose that separately cleared 1965 and 1667 bytes stalled once concatenated to 3634 bytes). `sendMessage` (`internal/steering`, not `herdr` - `PaneSendText`'s only real caller is `steering.Execute`, and `steering` already owns the confirmation machinery) now writes the message in 512-byte chunks, confirming each chunk's *cumulative* sent-so-far tail against the composer before sending the next, and only reaches `chooseSubmitKey` once every chunk is confirmed present.
- Confirmation checks the cumulative text, not the isolated chunk: a chunk boundary landing mid-blank-line (routine in this fleet's Markdown) strips to an empty needle that `composerHasTail` can never confirm on its own.
- Live validation found chunk size alone doesn't bound the failure. Adversarially repetitive content still stalled around 4.1kB at 512-byte chunks (8.1-11.6kB at 256-byte chunks - headroom bought only by the extra confirmation round trips slowing delivery, not a real fix). A 300ms settle pause before each chunk after the first, at the *unchanged* 512-byte size, pushed the same failing payloads through at 12077 and 20159 bytes with no further failures.

A chunked send that fails does so safely, but leaves state worth stating plainly: the submit key is never chosen, nothing is duplicated, and the composer is left holding exactly the confirmed prefix (`state.SendReasonTextChunkNotConfirmed`, `not-submitted`). That failure is invisible to the busy-composer gate - a pane sitting on an unconfirmed leftover fragment reports `idle`, not `working`, so the next `hand send` to that pane proceeds immediately rather than refusing, at ordinary idle-send cost. Full evidence and rejected alternatives are in the new ADR: `docs/adr/chunked-send-delivery-is-paced-by-a-settle-pause-not-chunk-size-alone.md`.

Closes atqamz/hand#472

## Test plan

- [x] `make lint` (gofmt, go vet, golangci-lint, commentlint)
- [x] `make test` (`go test -race ./...`)
- [x] `make e2e`
- [x] `make contract`
- [x] Live-validated against a real codex worker (0.147.0) in a scratch fleet home: 1kB/3kB/6kB idle sends (several reps each) and one genuine mid-turn 3kB send under `--force` while the worker was actively `Working`, reading `send_state`/`send_reason` from the store rather than CLI output, checking the pane directly for duplicates and truncation after each - zero duplicates, zero truncation on realistic payloads
- [x] Wall-clock for a 3kB send: ~10.06s before (spent on a confirmation poll that timed out without the full text ever arriving, finalizing `uncertain`) -> ~2.18s after; a short single-chunk send is unaffected (~58ms, no confirmation read added)
- [x] Rate-vs-size isolated with two controlled experiments against adversarially repetitive filler: chunk size alone (256B vs 512B) only moved the failure ceiling, never removed it; adding the 300ms settle pause at the original 512-byte size did

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->