### PR TITLE
diagnose stale flake.nix vendorHash on CI failure

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      go-modules:
+        patterns: ["*"]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Lets the self-heal workflow (vendorhash-selfheal.yaml) re-run CI on a Dependabot
+  # branch after it pushes a corrected vendorHash: a GITHUB_TOKEN push does not start a
+  # new run on its own, so that workflow dispatches one explicitly.
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -143,6 +147,35 @@ jobs:
           else
             echo "::warning::could not determine whether vendorHash is stale; see the 'Build flake package' failure above."
           fi
+      - name: Hand the fix to the privileged self-heal workflow
+        if: failure() && github.event.pull_request.user.login == 'dependabot[bot]'
+        # This job's token is read-only on a Dependabot pull_request run regardless of any
+        # permissions: block, and it is the only job that fetches or builds dependency code
+        # the PR controls. It hands off just a hash string; vendorhash-selfheal.yaml, which
+        # has write access, never runs go, nix, or make.
+        run: |
+          if git diff --quiet flake.nix; then
+            echo "vendorHash is already correct; nothing to hand off."
+            exit 0
+          fi
+          hash=$(grep -oP '(?<=vendorHash = ")[^"]+' flake.nix)
+          if ! [[ "$hash" =~ ^sha256-[A-Za-z0-9+/]{43}=$ ]]; then
+            echo "::error::computed vendorHash '$hash' is not a well-formed SRI hash; refusing to hand it off." >&2
+            exit 1
+          fi
+          if ! nix build .#default --no-link; then
+            echo "::error::flake.nix with the recomputed vendorHash still does not build; refusing to hand it off." >&2
+            exit 1
+          fi
+          mkdir -p /tmp/vendorhash-fix
+          printf '%s' "$hash" > /tmp/vendorhash-fix/vendorhash.txt
+      - uses: actions/upload-artifact@v7
+        if: failure() && github.event.pull_request.user.login == 'dependabot[bot]'
+        with:
+          name: vendorhash-fix
+          path: /tmp/vendorhash-fix/vendorhash.txt
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Run built binary
         run: '"$(nix build .#default --no-link --print-out-paths)/bin/hand" --version'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,22 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v22
       - name: Build flake package
         run: nix build .#default --no-link --print-out-paths
+      - name: Diagnose stale vendorHash
+        if: failure()
+        # go.mod/go.sum changes invalidate vendorHash but nothing keeps them in sync;
+        # Dependabot doesn't know flake.nix exists. Recompute and name the fix instead
+        # of leaving the raw Nix hash-mismatch trace as the only signal.
+        run: |
+          if make vendorhash; then
+            if git diff --quiet flake.nix; then
+              echo "::notice::flake.nix's vendorHash already matches go.mod/go.sum; the failure above is unrelated to vendoring."
+            else
+              hash=$(grep -oP '(?<=vendorHash = ")[^"]+' flake.nix)
+              echo "::error file=flake.nix::vendorHash is stale for the current go.mod/go.sum. Run 'make vendorhash' locally and commit the result, or set vendorHash = \"$hash\" directly."
+            fi
+          else
+            echo "::warning::could not determine whether vendorHash is stale; see the 'Build flake package' failure above."
+          fi
       - name: Run built binary
         run: '"$(nix build .#default --no-link --print-out-paths)/bin/hand" --version'
 

--- a/.github/workflows/vendorhash-selfheal.yaml
+++ b/.github/workflows/vendorhash-selfheal.yaml
@@ -1,0 +1,108 @@
+# This workflow has write access to the repository. It must never run `go`, `nix`,
+# `make`, or anything else driven by a Dependabot pull request's own content: that job
+# (ci.yaml's nix-build job) keeps a read-only token specifically because it is the one
+# that fetches and builds dependency code the PR controls. This workflow only consumes
+# the bare hash string that job hands off as a build artifact, validates its shape
+# against a strict regex, and writes it into flake.nix with plain git/sed. Every value
+# that decides WHERE it pushes (branch, commit SHA) comes from the workflow_run event
+# payload, which is GitHub's own record of what ran - never from the artifact, which
+# was produced inside the untrusted job and so is untrusted input.
+#
+# github.actor / triggering_actor are not reliable for identifying Dependabot here: on
+# this repo, a Dependabot pull_request run's first-party GITHUB_TOKEN restrictions mean
+# the run can require a maintainer to approve it, and GitHub then records that approver,
+# not dependabot[bot], as the run's actor. So this workflow looks up the open pull
+# request for the branch and checks its actual author instead.
+name: Self-heal stale vendorHash
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: read
+
+jobs:
+  self-heal:
+    name: Refresh flake.nix vendorHash for a Dependabot go.mod bump
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/go_modules/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the branch's open pull request was actually opened by Dependabot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          author=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH&state=open" --jq '.[0].user.login // empty')
+          if [ "$author" != "dependabot[bot]" ]; then
+            echo "::error::refusing to act: $BRANCH's open pull request author is '$author', not dependabot[bot]" >&2
+            exit 1
+          fi
+
+      - name: Download the recomputed hash
+        uses: actions/download-artifact@v8
+        with:
+          name: vendorhash-fix
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: fix
+
+      - name: Validate, apply, and push
+        id: apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+
+          hash=$(cat fix/vendorhash.txt)
+          if ! [[ "$hash" =~ ^sha256-[A-Za-z0-9+/]{43}=$ ]]; then
+            echo "::error::'$hash' is not a well-formed Nix SRI sha256 hash; refusing to write it into flake.nix." >&2
+            exit 1
+          fi
+
+          git clone --branch "$BRANCH" --single-branch \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" repo
+          cd repo
+
+          current_sha=$(git rev-parse HEAD)
+          if [ "$current_sha" != "$EXPECTED_SHA" ]; then
+            echo "$BRANCH moved from $EXPECTED_SHA to $current_sha since this run started; skipping so a fresh CI run on the new commit can handle it instead."
+            exit 0
+          fi
+
+          sed -i "s|vendorHash = \"[^\"]*\"|vendorHash = \"$hash\"|" flake.nix
+
+          files=$(git diff --name-only)
+          if [ "$files" != "flake.nix" ]; then
+            echo "::error::expected exactly one changed file (flake.nix), got: $files" >&2
+            exit 1
+          fi
+          stat=$(git diff --numstat -- flake.nix)
+          added=$(awk '{print $1}' <<<"$stat")
+          removed=$(awk '{print $2}' <<<"$stat")
+          if [ "$added" != "1" ] || [ "$removed" != "1" ]; then
+            echo "::error::expected exactly one changed line in flake.nix, got +$added -$removed" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore(nix): refresh vendorHash for $(basename "$BRANCH")"
+          git push origin "HEAD:$BRANCH"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Re-run CI on the corrected commit
+        if: steps.apply.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yaml --repo "${{ github.repository }}" --ref "${{ github.event.workflow_run.head_branch }}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt lint e2e contract contract-live install clean
+.PHONY: build test fmt lint e2e contract contract-live install clean vendorhash
 
 VERSION ?= dev
 CHANNEL ?= dev
@@ -30,6 +30,26 @@ contract:
 
 contract-live:
 	go test -tags=contract,contractlive -count=1 -timeout=10m ./tests/contract/...
+
+# FAKE_VENDOR_HASH is nixpkgs' lib.fakeHash: a well-formed sha256 SRI hash that
+# no real fixed-output derivation will ever produce, so the build below is
+# guaranteed to fail and report the real hash in its "got:" line.
+FAKE_VENDOR_HASH := sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+vendorhash:
+	@backup=$$(mktemp); cp flake.nix "$$backup"; \
+	sed -i 's|vendorHash = "[^"]*"|vendorHash = "$(FAKE_VENDOR_HASH)"|' flake.nix; \
+	log=$$(mktemp); \
+	nix build .#default --no-link >"$$log" 2>&1; \
+	got=$$(grep -oP 'got:\s+\Ksha256-\S+' "$$log" | tail -1); \
+	if [ -z "$$got" ]; then \
+		echo "could not compute vendorHash; nix build did not fail on a hash mismatch:" >&2; \
+		cat "$$log" >&2; \
+		cp "$$backup" flake.nix; rm -f "$$backup" "$$log"; exit 1; \
+	fi; \
+	sed -i "s|vendorHash = \"$(FAKE_VENDOR_HASH)\"|vendorHash = \"$$got\"|" flake.nix; \
+	rm -f "$$backup" "$$log"; \
+	echo "flake.nix vendorHash updated to $$got"
 
 install: build
 	cp hand $(GOPATH)/bin/ 2>/dev/null || cp hand ~/.local/bin/


### PR DESCRIPTION
## Summary

Three layered changes, so a Dependabot Go bump reaches a green `Nix build` with no human editing `flake.nix`:

- **`.github/dependabot.yaml`**: group all `gomod` updates into one PR. Two dependency PRs open at once meant the second one's correct `vendorHash` was only knowable after the first merged (atqamz/hand#446 needed two recomputes); grouping removes that case outright.
- **`.github/workflows/ci.yaml`**: `make vendorhash` (recomputes the correct hash via nixpkgs' fakeHash trick) plus a diagnostic step on `Nix build` failure that names the file/field/command instead of a raw Nix hash-mismatch trace.
- **`.github/workflows/vendorhash-selfheal.yaml`**: a credential-free self-heal path for real Dependabot PRs. The read-only-token `nix-build` job - the only one that ever fetches/builds dependency code the PR controls - hands off just a recomputed hash string as a build artifact once it's proven the fix builds. A separate, `workflow_run`-triggered, write-scoped workflow (which always runs the trusted default-branch copy of itself) never runs `go`, `nix`, or `make`; it independently verifies the branch's open PR was authored by `dependabot[bot]`, takes the branch/SHA only from the `workflow_run` event payload (never the artifact), re-validates the hash against a strict SRI shape, and refuses to push unless exactly one file changed by exactly one line. It then dispatches a fresh CI run, since a `GITHUB_TOKEN` push doesn't start one on its own.

Closes atqamz/hand#483

### Directions considered

- **Drop the `vendorHash` pin (checked-in vendor directory):** rejected with a measurement. `go mod vendor` against this repo's actual deps produced a 141MB, 2117-file tree - too costly to check into a small CLI repo permanently.
- **Self-healing CI:** initially rejected on a wrong premise (thought it needed a new PAT). It doesn't - re-verified against GitHub's current docs and a live throwaway probe: `workflow_run` gets a write-scoped `GITHUB_TOKEN` regardless of the upstream Dependabot `pull_request` run's restricted token. Built as described above once that held up, with the operator's two added conditions (validate the artifact's hash shape strictly; never trust the artifact for branch/SHA) incorporated.
- **Message-only diagnostic:** kept regardless, as the fallback signal and as what a human sees while working through any case the self-heal path doesn't cover.

Also found along the way, not acted on: this repo's branch ruleset has no required-status-checks rule at all today, so a red `Nix build` has never technically blocked merging here - the operator is raising that separately. And `github.actor`/`triggering_actor` on this repo's real Dependabot CI runs is the human approver, not `dependabot[bot]` (this repo can require approval to run a Dependabot PR's workflow) - both workflows key off the PR's actual author instead.

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] `nix build .#default`
- [x] Reproduced the failure: bumped `golang.org/x/sys` and `modernc.org/sqlite` in `go.mod`/`go.sum` without touching `flake.nix`; confirmed `nix build .#default` fails.
- [x] Ran `make vendorhash` against that change; confirmed it computes a hash that makes `nix build .#default` succeed.
- [x] Set a deliberately wrong (but well-formed) `vendorHash`; confirmed `nix build .#default` still fails with the standard hash-mismatch error - a wrong hash is never green.
- [x] `actionlint` passes clean on both changed/added workflow files.
- [x] Simulated the self-heal apply/push logic against a real scratch git repo: happy path (clone/patch/commit/push) succeeds; a simulated Dependabot force-push race is correctly refused; an extra unexpected file change is correctly refused; the hash-shape regex accepts real SRI hashes and rejects malformed/injection-shaped strings.
- [x] Live CI run on this branch is fully green, including `Nix build (x86_64-linux)`, which exercises the new workflow YAML.
- [ ] Unproven until a real Dependabot PR arrives: whether `workflow_run` actually fires and gates correctly for a run whose upstream event came from a Dependabot-authored PR in this repo, and whether the dispatched CI re-run surfaces as checks on that PR. Both are backed by GitHub's current docs and (for the latter) a corroborating community report, but `workflow_dispatch`/`workflow_run` registration requires the workflow file to already be on the default branch, so this could not be exercised end-to-end from a branch.

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->
