### PR TITLE
refactor(store): remove unguarded UpdateAttempt and DeleteTask lifecycle mutators

### DIFF
--- a/cmd/promote_test.go
+++ b/cmd/promote_test.go
@@ -42,6 +42,14 @@ func setupPromoteHome(t *testing.T, oldWorktree, newWorktree string, herdr faket
 // it can only be set at the attempt's creation, same as PlannedAgainst.
 func setupPromoteHomeWithScoutBriefDigest(t *testing.T, oldWorktree, newWorktree string, herdr faketool.Herdr, scoutBriefDigest string) string {
 	t.Helper()
+	return setupPromoteHomeWithScoutAttempt(t, oldWorktree, newWorktree, herdr, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}, BriefDigest: scoutBriefDigest})
+}
+
+// Lets a caller shape the whole scout attempt fixture up front, since atqamz/hand#481 removed
+// UpdateAttempt: every field a test needs on the pre-promotion scout attempt must be set at its
+// creation, not patched onto it afterward.
+func setupPromoteHomeWithScoutAttempt(t *testing.T, oldWorktree, newWorktree string, herdr faketool.Herdr, scoutAttempt state.Attempt) string {
+	t.Helper()
 	useFastLaunchPolling(t)
 	t.Setenv("HAND_HARNESS", harness.Claude)
 	home := t.TempDir()
@@ -62,7 +70,7 @@ func setupPromoteHomeWithScoutBriefDigest(t *testing.T, oldWorktree, newWorktree
 		t.Fatal(err)
 	}
 
-	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Worktree: oldWorktree, Herdr: state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"}, BriefDigest: scoutBriefDigest}); err != nil {
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindScout}, scoutAttempt); err != nil {
 		t.Fatal(err)
 	}
 
@@ -199,37 +207,31 @@ func TestPromoteUnknownDetectedHarnessFailsBeforeWorktreeAcquisition(t *testing.
 func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	oldWt := filepath.Join(t.TempDir(), "old-wt")
 	newWt := filepath.Join(t.TempDir(), "new-wt")
-	home := setupPromoteHome(t, oldWt, newWt, promoteHerdr(harness.Codex, "done"))
+	stale := time.Now().Add(-6 * time.Hour).UTC().Format(time.RFC3339)
+	scoutAttempt := state.Attempt{
+		Lifecycle:          state.AttemptRunning,
+		Worktree:           oldWt,
+		Herdr:              state.Herdr{WorkspaceID: "wA", TabID: "wA:tOld", PaneID: "wA:pOld"},
+		DoneVerified:       true,
+		LeaseID:            "lease-old",
+		StatusChangedAt:    stale,
+		StatusChangedFor:   "working",
+		LastReportState:    state.ReportDone,
+		LastReportNote:     "scout findings",
+		UsageLimitRetryAt:  "2026-08-03T01:00:00Z",
+		UsageLimitAttempts: 2,
+	}
+	home := setupPromoteHomeWithScoutAttempt(t, oldWt, newWt, promoteHerdr(harness.Codex, "done"), scoutAttempt)
 
 	scout, err := state.Read(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	scoutAttempt, err := state.ActiveAttempt(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	initialScoutAttempt := scoutAttempt
-	scoutAttempt.DoneVerified = true
-	scoutAttempt.Harness = harness.Claude
-	scoutAttempt.Model = "scout-model"
-	scoutAttempt.Effort = "scout-effort"
-	scoutAttempt.LeaseID = "lease-old"
 	scout.ReportOffset = 42
 	scout.ReportDigest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-	stale := time.Now().Add(-6 * time.Hour).UTC().Format(time.RFC3339)
-	scoutAttempt.StatusChangedAt = stale
-	scoutAttempt.StatusChangedFor = "working"
-	scoutAttempt.LastReportState = state.ReportDone
-	scoutAttempt.LastReportNote = "scout findings"
 	scout.DeliveredAt = "2026-08-03T00:00:00Z"
 	scout.DeliveredReason = "report at data/task-1/report.md, no code to land"
-	scoutAttempt.UsageLimitRetryAt = "2026-08-03T01:00:00Z"
-	scoutAttempt.UsageLimitAttempts = 2
 	if err := state.Write(home, scout); err != nil {
-		t.Fatal(err)
-	}
-	if err := state.UpdateAttempt(home, scoutAttempt); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.SetHold(home, state.Hold{ID: "task-1", Kind: state.HoldKindLimit, Reason: "out of quota"}); err != nil {
@@ -308,7 +310,7 @@ func TestPromoteResetsPaneScopedMarkersButCarriesReportOffset(t *testing.T) {
 	if len(history.Attempts) != 2 || history.Attempts[0].Lifecycle != state.AttemptCompleted || history.Attempts[1].Lifecycle != state.AttemptRunning {
 		t.Fatalf("promotion attempt lineage = %+v", history.Attempts)
 	}
-	if history.Attempts[0].Harness != initialScoutAttempt.Harness || history.Attempts[0].Model != initialScoutAttempt.Model || history.Attempts[0].Effort != initialScoutAttempt.Effort || history.Attempts[0].Worktree != scoutAttempt.Worktree || history.Attempts[0].LeaseID != scoutAttempt.LeaseID {
+	if history.Attempts[0].Harness != scoutAttempt.Harness || history.Attempts[0].Model != scoutAttempt.Model || history.Attempts[0].Effort != scoutAttempt.Effort || history.Attempts[0].Worktree != scoutAttempt.Worktree || history.Attempts[0].LeaseID != scoutAttempt.LeaseID {
 		t.Fatalf("scout attempt was overwritten: %+v", history.Attempts[0])
 	}
 	if history.Task.ReportOffset != scout.ReportOffset || history.Task.ReportDigest != scout.ReportDigest {

--- a/cmd/spawn_test.go
+++ b/cmd/spawn_test.go
@@ -465,9 +465,9 @@ func TestSpawnDetectsWorktreeCollisionAgainstARowWithNoLeaseIdentity(t *testing.
 	}
 }
 
-// A row left behind by a teardown whose state.Delete failed still names the pool
-// slot treehouse has since freed and handed out again. Under a lease of its own
-// that is not a collision, and the spawn has to go through.
+// A stale task row still names the pool slot treehouse has since freed and handed
+// out again. Under a lease of its own that is not a collision, and the spawn has
+// to go through.
 func TestSpawnAllowsAReusedWorktreePathUnderAFreshLease(t *testing.T) {
 	wt := filepath.Join(t.TempDir(), "wt")
 	home := setupSpawnHome(t, wt, defaultSpawnHerdr("claude"))

--- a/internal/runtime/teardown_test.go
+++ b/internal/runtime/teardown_test.go
@@ -187,15 +187,9 @@ func TestTeardownRetryAfterCompletionAppendDoesNotRepeatCleanup(t *testing.T) {
 }
 
 func TestTeardownReportsIncompleteHerdrOwnership(t *testing.T) {
-	home, _ := teardownFixture(t, false)
-	history, err := state.ReadHistory(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	history.ActiveAttempt.Herdr.PaneID = "pane-only"
-	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
+	home, _ := teardownFixtureWithAttempt(t, false, func(a *state.Attempt) {
+		a.Herdr.PaneID = "pane-only"
+	})
 
 	result, err := New().Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
 	if err != nil {
@@ -462,16 +456,10 @@ func TestTeardownDoesNotUseAnOlderSameSecondCompletion(t *testing.T) {
 // Covers atqamz/hand#235: the worker's own self-reported failure, not the teardown act, is what a
 // completion record must attribute a failed outcome to.
 func TestTeardownReportsGenuineWorkerFailureAsFailedOutcome(t *testing.T) {
-	home, _ := teardownFixture(t, false)
-	history, err := state.ReadHistory(home, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	history.ActiveAttempt.LastReportState = state.ReportFailed
-	history.ActiveAttempt.LastReportNote = "tests would not pass"
-	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
+	home, _ := teardownFixtureWithAttempt(t, false, func(a *state.Attempt) {
+		a.LastReportState = state.ReportFailed
+		a.LastReportNote = "tests would not pass"
+	})
 
 	result, err := New().Teardown(context.Background(), TeardownRequest{Home: home, ID: "task-1"})
 	if err != nil {
@@ -516,15 +504,9 @@ func TestTeardownForceOnASuccessfulTaskIsNotRecordedAsFailed(t *testing.T) {
 // way - a genuine self-reported failure still reads as failed, a task nobody reported failed still
 // does not, and the two stay distinct in the same durable ledger shape.
 func TestTeardownDistinguishesGenuineFailureFromForcedSuccessInDurableState(t *testing.T) {
-	failedHome, _ := teardownFixture(t, false)
-	history, err := state.ReadHistory(failedHome, "task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	history.ActiveAttempt.LastReportState = state.ReportFailed
-	if err := state.UpdateAttempt(failedHome, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
+	failedHome, _ := teardownFixtureWithAttempt(t, false, func(a *state.Attempt) {
+		a.LastReportState = state.ReportFailed
+	})
 	if _, err := New().Teardown(context.Background(), TeardownRequest{Home: failedHome, ID: "task-1", Force: true}); err != nil {
 		t.Fatalf("Teardown() = %v", err)
 	}
@@ -851,29 +833,24 @@ func TestTeardownRefusesARecycledWorktreeLeaseOnFirstReturn(t *testing.T) {
 
 func leasedTeardownFixture(t *testing.T) (string, string, state.Attempt) {
 	t.Helper()
-	home, worktreePath := teardownFixture(t, true)
-	history, err := state.ReadHistory(home, "task-1")
+	home, worktreePath := teardownFixtureWithAttempt(t, true, func(a *state.Attempt) {
+		a.LeaseID = "lease-1"
+	})
+	attempt, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	history.ActiveAttempt.LeaseID = "lease-1"
-	if err := state.UpdateAttempt(home, *history.ActiveAttempt); err != nil {
-		t.Fatal(err)
-	}
-	return home, worktreePath, *history.ActiveAttempt
+	return home, worktreePath, attempt
 }
 
 func terminalResourceFixture(t *testing.T) (string, string, state.Attempt) {
 	t.Helper()
-	home, worktreePath := teardownFixture(t, true)
-	history, err := state.ReadHistory(home, "task-1")
+	home, worktreePath := teardownFixtureWithAttempt(t, true, func(a *state.Attempt) {
+		a.LeaseID = "lease-1"
+		a.Herdr = state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}
+	})
+	attempt, err := state.ActiveAttempt(home, "task-1")
 	if err != nil {
-		t.Fatal(err)
-	}
-	attempt := *history.ActiveAttempt
-	attempt.LeaseID = "lease-1"
-	attempt.Herdr = state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"}
-	if err := state.UpdateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}
 	if err := state.SetAttemptTeardownDecision(home, "task-1", attempt.ID, state.AttemptCompleted, state.TeardownDispositionCompleted); err != nil {
@@ -1134,6 +1111,14 @@ func runRuntimeGit(t *testing.T, dir string, args ...string) {
 
 func teardownFixture(t *testing.T, withWorktree bool) (string, string) {
 	t.Helper()
+	return teardownFixtureWithAttempt(t, withWorktree, nil)
+}
+
+// Lets a caller shape the active attempt beyond teardownFixture's defaults. atqamz/hand#481
+// removed UpdateAttempt, so a test that needs the fixture attempt in a specific shape must ask
+// for it at creation rather than patching it on afterward.
+func teardownFixtureWithAttempt(t *testing.T, withWorktree bool, configureAttempt func(*state.Attempt)) (string, string) {
+	t.Helper()
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "data", "task-1"), 0o755); err != nil {
 		t.Fatal(err)
@@ -1154,9 +1139,13 @@ func teardownFixture(t *testing.T, withWorktree bool) (string, string) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := state.CreateAttempt(home, state.Attempt{
+	attempt := state.Attempt{
 		TaskID: "task-1", Lifecycle: state.AttemptRunning, Worktree: path, CreatedAt: "2026-08-14T00:00:00Z",
-	}); err != nil {
+	}
+	if configureAttempt != nil {
+		configureAttempt(&attempt)
+	}
+	if _, err := state.CreateAttempt(home, attempt); err != nil {
 		t.Fatal(err)
 	}
 	return home, worktree

--- a/internal/state/task.go
+++ b/internal/state/task.go
@@ -3,7 +3,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/atqamz/hand/internal/filelock"
@@ -11,8 +10,7 @@ import (
 )
 
 // ErrTaskNotFound is wrapped into errors returned by the task and history readers
-// and by Delete when no task row exists for the given ID, rendering as
-// `task "<id>" not found`.
+// when no task row exists for the given ID, rendering as `task "<id>" not found`.
 var ErrTaskNotFound = store.ErrTaskNotFound
 
 // ErrTaskActive is wrapped into errors returned by Claim when the task is
@@ -260,15 +258,6 @@ func CreateAttempt(homeDir string, a Attempt) (Attempt, error) {
 	}
 	defer func() { _ = db.Close() }()
 	return db.CreateAttempt(a)
-}
-
-func UpdateAttempt(homeDir string, a Attempt) error {
-	db, err := store.Open(homeDir)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = db.Close() }()
-	return db.UpdateAttempt(a)
 }
 
 func TransitionAttempt(homeDir string, id int64, from, to AttemptLifecycle) error {
@@ -678,27 +667,4 @@ func ListOpenHistoriesReadOnly(homeDir string) ([]TaskHistory, error) {
 	}
 	defer func() { _ = db.Close() }()
 	return db.ListOpenTaskHistories()
-}
-
-// Delete removes a task's row along with its report channel at state/<id>.status, leaving
-// the durable deliverables in data/<id>/. That file is the volatile wake log: a respawn
-// under a used ID starts at report_offset 0, so a surviving log replays as new lines.
-func Delete(homeDir, id string) error {
-	if err := ValidateID(id); err != nil {
-		return err
-	}
-	// A replayed log re-raises resolved decisions, absorbs a genuine unexplained stop, and
-	// auto-records a PR URL out of an old done line onto a task nobody recorded it for.
-	if err := os.Remove(ReportPath(homeDir, id)); err != nil && !os.IsNotExist(err) {
-		// Failing here leaves nothing durable gone yet, so the whole command is retryable.
-		// Removing the row first would strand the caller with the state gone and no way to
-		// retry (see internal/runtime/teardown.go's guarded path).
-		return fmt.Errorf("remove report channel %q: %w", id, err)
-	}
-	db, err := store.Open(homeDir)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = db.Close() }()
-	return db.DeleteTask(id)
 }

--- a/internal/state/task_test.go
+++ b/internal/state/task_test.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"bufio"
-	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -313,47 +312,6 @@ func TestListFailsClosedOnMalformedState(t *testing.T) {
 	}
 }
 
-func TestDelete(t *testing.T) {
-	dir := t.TempDir()
-	if err := Write(dir, Task{ID: "fix-login"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := Delete(dir, "fix-login"); err != nil {
-		t.Fatal(err)
-	}
-	if exists, err := Exists(dir, "fix-login"); err != nil || exists {
-		t.Fatalf("Exists after delete = %v, %v, want false, nil", exists, err)
-	}
-}
-
-// Pins the cleanup a respawn depends on: a new task under a used ID starts at
-// report_offset 0, so a surviving wake log replays as this run's - re-raising resolved
-// decisions and auto-recording a PR URL out of the previous run's done line.
-func TestDeleteRemovesTheReportChannel(t *testing.T) {
-	dir := t.TempDir()
-	if err := Write(dir, Task{ID: "fix-login"}); err != nil {
-		t.Fatal(err)
-	}
-	report := ReportPath(dir, "fix-login")
-	if err := os.WriteFile(report, []byte("done: PR https://github.com/a/b/pull/1\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := Delete(dir, "fix-login"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(report); !os.IsNotExist(err) {
-		t.Fatalf("stat report after delete = %v, want it gone", err)
-	}
-}
-
-func TestDeleteMissingTask(t *testing.T) {
-	dir := t.TempDir()
-	if err := Delete(dir, "missing"); err == nil {
-		t.Fatal("expected error for missing task")
-	}
-}
-
 func TestRejectsUnsafeIDs(t *testing.T) {
 	dir := t.TempDir()
 	for _, id := range []string{"../escape", "nested/task", "", "."} {
@@ -489,34 +447,6 @@ func waitForHolderReady(t *testing.T, r io.Reader) bool {
 		return line == "acquired"
 	case <-time.After(10 * time.Second):
 		return false
-	}
-}
-
-// Reclaiming the pathname would need proof no process can still hold or open
-// the old inode, which does not exist; see
-// docs/adr/lock-pathnames-are-permanent-rendezvous-points.md.
-func TestLockPathnameSurvivesDelete(t *testing.T) {
-	home := t.TempDir()
-	if err := CreateTask(home, Task{ID: "task-1"}); err != nil {
-		t.Fatal(err)
-	}
-	release, err := Lock(home, "task:task-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	release()
-
-	path := filepath.Join(store.Dir(home), fmt.Sprintf(".%x.lock", sha256.Sum256([]byte("task:task-1"))))
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("lock pathname must exist before Delete: %v", err)
-	}
-
-	if err := Delete(home, "task-1"); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("lock pathname must survive Delete: %v", err)
 	}
 }
 

--- a/internal/store/attempt_test.go
+++ b/internal/store/attempt_test.go
@@ -58,44 +58,6 @@ func TestTaskAndAttemptHaveSeparateIdentityAndExecutionOwnership(t *testing.T) {
 	}
 }
 
-func TestAttemptUpdatesPreserveExecutionSnapshot(t *testing.T) {
-	db, _ := openTemp(t)
-	created, err := db.CreateTaskWithAttempt(Task{ID: "task-1", Lifecycle: TaskOpen}, Attempt{
-		TaskID: "task-1", Lifecycle: AttemptProvisioning, Harness: "claude", Model: "opus", Effort: "high",
-		ExecutionClass: "deep", PlannedAgainst: "plan-1", RequestedProfile: "brain", RoutingSource: "route",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.RecordAttemptWorktree("task-1", created.ID, "/tmp/wt", "", "lease-1"); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.RecordAttemptHerdr("task-1", created.ID, Herdr{PaneID: "pane-1"}, "2026-08-14T00:00:00Z"); err != nil {
-		t.Fatal(err)
-	}
-	updated, found, err := db.ReadAttempt(created.ID)
-	if err != nil || !found {
-		t.Fatalf("ReadAttempt = %+v, %v, %v", updated, found, err)
-	}
-	updated.Harness = "other"
-	updated.Model = "other-model"
-	updated.Effort = "other-effort"
-	updated.ExecutionClass = "mechanical"
-	updated.PlannedAgainst = "plan-2"
-	updated.RequestedProfile = "other-profile"
-	updated.RoutingSource = "explicit-profile"
-	if err := db.UpdateAttempt(updated); err != nil {
-		t.Fatal(err)
-	}
-	got, found, err := db.ReadAttempt(created.ID)
-	if err != nil || !found {
-		t.Fatalf("ReadAttempt = %+v, %v, %v", got, found, err)
-	}
-	if got.Harness != "claude" || got.Model != "opus" || got.Effort != "high" || got.ExecutionClass != "deep" || got.PlannedAgainst != "plan-1" || got.RequestedProfile != "brain" || got.RoutingSource != "route" {
-		t.Fatalf("execution snapshot changed after update: %+v", got)
-	}
-}
-
 func TestAttemptOrdinalIncrementsPerTaskAndHistoryIsRetained(t *testing.T) {
 	db, _ := openTemp(t)
 	if err := db.CreateTask(Task{ID: "task-1", Lifecycle: TaskOpen}); err != nil {

--- a/internal/store/hold_test.go
+++ b/internal/store/hold_test.go
@@ -9,6 +9,16 @@ import (
 	"pgregory.net/rapid"
 )
 
+// Removes a task row by raw SQL: atqamz/hand#481 removed the unguarded DeleteTask, since deleting
+// task rows is not a production operation (docs/adr/tasks-are-durable-and-attempts-own-execution.md),
+// but this file's hold tests still pin the schema fact that a hold outlives its task row.
+func deleteTaskRow(t *testing.T, db *DB, id string) {
+	t.Helper()
+	if _, err := db.sql.Exec(`DELETE FROM task WHERE id = ?`, id); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func sampleHold() Hold {
 	return Hold{
 		ID: "fix-login", Kind: HoldKindOperator, Reason: "race condition needs a call",
@@ -95,7 +105,7 @@ func TestReadHoldReadOnlySupportsSchemaBeforeInferred(t *testing.T) {
 
 // Pins the decision that makes a hold cover the motivating case: its own row keyed by an
 // arbitrary id, not a foreign key into task, so a hold set on a task torn down with its
-// question open still answers "what needs the operator" after DeleteTask.
+// question open still answers "what needs the operator" after its task row is gone.
 func TestHoldSurvivesWithNoTaskRowBehindIt(t *testing.T) {
 	db, _ := openTemp(t)
 	if err := db.CreateTask(Task{ID: "fix-login"}); err != nil {
@@ -104,9 +114,7 @@ func TestHoldSurvivesWithNoTaskRowBehindIt(t *testing.T) {
 	if err := db.SetHold(sampleHold()); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.DeleteTask("fix-login"); err != nil {
-		t.Fatal(err)
-	}
+	deleteTaskRow(t, db, "fix-login")
 
 	_, found, err := db.ReadHold("fix-login")
 	if err != nil || !found {
@@ -243,7 +251,7 @@ func TestHumanAuthoredHoldSurvivesAnyTaskLifecycleAroundIt(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		id := "task-" + rapid.StringMatching(`[a-z0-9]{1,16}`).Draw(t, "id")
 		_ = db.ClearHold(id)
-		_ = db.DeleteTask(id)
+		_, _ = db.sql.Exec(`DELETE FROM task WHERE id = ?`, id)
 
 		hold := Hold{
 			ID:        id,
@@ -276,7 +284,7 @@ func TestHumanAuthoredHoldSurvivesAnyTaskLifecycleAroundIt(t *testing.T) {
 			if err := db.SetHold(hold); err != nil {
 				t.Fatal(err)
 			}
-			if err := db.DeleteTask(id); err != nil {
+			if _, err := db.sql.Exec(`DELETE FROM task WHERE id = ?`, id); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2346,26 +2346,6 @@ func scanSend(row sendScanner) (SendAttempt, error) {
 	return send, err
 }
 
-func (db *DB) UpdateAttempt(a Attempt) error {
-	_, err := db.sql.Exec(`UPDATE attempt SET task_id = ?, ordinal = ?, lifecycle = ?,
-		worktree = ?, lease_id = ?, herdr_session = ?, herdr_workspace_id = ?, herdr_tab_id = ?, herdr_pane_id = ?,
-		created_at = ?, pane_started_at = ?, launch_submitted_at = ?, launch_confirmed_at = ?, status_changed_at = ?, status_changed_for = ?, done_verified = ?,
-		last_report_state = ?, last_report_note = ?, send_undelivered_message = ?, send_undelivered_at = ?,
-		parked_fired_for = ?, usage_limit_retry_at = ?, usage_limit_attempts = ?, teardown_terminal_attempt = ?, teardown_disposition = ?,
-		teardown_herdr_state = ?, teardown_worktree_state = ?, teardown_completion_state = ?, usage_limit_episode = ?, usage_limit_stuck_episode = ? WHERE id = ?`,
-		a.TaskID, a.Ordinal, a.Lifecycle, a.Worktree, a.LeaseID,
-		a.Herdr.Session, a.Herdr.WorkspaceID, a.Herdr.TabID, a.Herdr.PaneID, a.CreatedAt, a.PaneStartedAt,
-		a.LaunchSubmittedAt, a.LaunchConfirmedAt,
-		a.StatusChangedAt, a.StatusChangedFor, a.DoneVerified, a.LastReportState, a.LastReportNote,
-		a.SendUndeliveredMessage, a.SendUndeliveredAt, a.ParkedFiredFor, a.UsageLimitRetryAt, a.UsageLimitAttempts,
-		a.TeardownTerminalAttempt, a.TeardownDisposition, a.TeardownHerdrState, a.TeardownWorktreeState, a.TeardownCompletionState,
-		a.UsageLimitEpisode, a.UsageLimitStuckEpisode, a.ID)
-	if err != nil {
-		return fmt.Errorf("update attempt %d: %w", a.ID, err)
-	}
-	return nil
-}
-
 func (db *DB) TransitionAttempt(id int64, from, to AttemptLifecycle) error {
 	if !validAttemptTransition(from, to) {
 		return fmt.Errorf("%w: attempt %s -> %s", ErrInvalidTransition, from, to)
@@ -2944,21 +2924,6 @@ func (db *DB) TaskExists(id string) (bool, error) {
 		return false, fmt.Errorf("check task %q: %w", id, err)
 	}
 	return true, nil
-}
-
-func (db *DB) DeleteTask(id string) error {
-	res, err := db.sql.Exec(`DELETE FROM task WHERE id = ?`, id)
-	if err != nil {
-		return fmt.Errorf("delete task %q: %w", id, err)
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("delete task %q: %w", id, err)
-	}
-	if affected == 0 {
-		return fmt.Errorf("task %q %w", id, ErrTaskNotFound)
-	}
-	return nil
 }
 
 func (db *DB) ListProjects() ([]Project, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -130,23 +130,6 @@ func TestReadTaskReportsAMissingTaskWithoutAnError(t *testing.T) {
 	}
 }
 
-func TestDeleteTask(t *testing.T) {
-	db, _ := openTemp(t)
-	if err := writeSample(db); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.DeleteTask("fix-login"); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.DeleteTask("fix-login"); !errors.Is(err, ErrTaskNotFound) {
-		t.Fatalf("second delete = %v, want ErrTaskNotFound", err)
-	}
-	exists, err := db.TaskExists("fix-login")
-	if err != nil || exists {
-		t.Fatalf("TaskExists = %v, %v", exists, err)
-	}
-}
-
 func TestProjectsKeepRegistrationOrder(t *testing.T) {
 	db, _ := openTemp(t)
 	for _, name := range []string{"nsr", "universe", "yes2infra"} {

--- a/internal/watcher/usagelimit_test.go
+++ b/internal/watcher/usagelimit_test.go
@@ -63,8 +63,11 @@ func limitHold(t *testing.T, home, id string) (state.Hold, bool) {
 func setLimitRetryAt(t *testing.T, home, id string, at time.Time) {
 	t.Helper()
 	_, attempt := readTaskAttempt(t, home, id)
-	attempt.UsageLimitRetryAt = at.UTC().Format(time.RFC3339)
-	if err := state.UpdateAttempt(home, attempt); err != nil {
+	if err := state.UpdateAttemptObservation(home, id, attempt.ID, attempt.Lifecycle,
+		attempt.StatusChangedAt, attempt.StatusChangedFor, attempt.DoneVerified,
+		attempt.LastReportState, attempt.LastReportNote, attempt.ParkedFiredFor,
+		at.UTC().Format(time.RFC3339), attempt.UsageLimitAttempts,
+		attempt.UsageLimitEpisode, attempt.UsageLimitStuckEpisode); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1807,6 +1807,83 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	}
 }
 
+// The ship's first probe reads the same "working" the scout last held, so no
+// observed transition reseeds ChangedAt - which is why the forget rule cannot be
+// conditioned on one.
+func TestTickDropsTheCachedDwellWhenPromoteMovesTheTaskToANewPane(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := t.TempDir()
+	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout,
+		CreatedAt: dwelling}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
+		StatusChangedAt: dwelling, StatusChangedFor: "working"},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: 20 * time.Minute}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+
+	_, attempt := readTaskAttempt(t, home, "task-1")
+	restamp := time.Now().UTC().Format(time.RFC3339)
+	// hand promote's own rewrite: a fresh attempt with its own pane takes over the task,
+	// carrying no observed status of its own yet - it never rewrites the scout attempt's row.
+	shipAttempt, err := state.PromoteTask(home, "task-1", attempt.ID, attempt.Lifecycle, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{PaneID: "p2"},
+		StatusChangedAt: restamp, LaunchConfirmedAt: restamp,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionAttempt(home, shipAttempt.ID, state.AttemptProvisioning, state.AttemptRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	// One tick for the watcher to notice the new attempt identity and reseed its tracking - a
+	// promote gives the same task ID a new attempt, which this tick treats as a first sighting
+	// rather than a continuation of the scout's cached dwell.
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+
+	// Moves report_offset, which is what makes the next tick write task state at all.
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("working: starting the ship run\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if strings.Contains(buf.String(), "stale task-1") {
+		t.Fatalf("out = %q, want no stale: the ship's dwell starts at the promotion, not at the scout's last observed transition", buf.String())
+	}
+
+	_, gotAttempt := readTaskAttempt(t, home, "task-1")
+	if gotAttempt.StatusChangedAt == dwelling {
+		t.Fatal("status_changed_at = the scout's stamp, want the cached scout dwell not written back over promote's restamp")
+	}
+	stamped, err := time.Parse(time.RFC3339, gotAttempt.StatusChangedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restamped, err := time.Parse(time.RFC3339, restamp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stamped.Before(restamped) {
+		t.Fatalf("status_changed_at = %q, want no earlier than promote's restamp %q", gotAttempt.StatusChangedAt, restamp)
+	}
+	if gotAttempt.StatusChangedFor != "working" {
+		t.Fatalf("status_changed_for = %q, want the status the ship's dwell was stamped for", gotAttempt.StatusChangedFor)
+	}
+}
+
 // The latches are what make each announcement fire only once, so any one of them
 // surviving a promote silences that announcement for the ship's own pane.
 func TestForgetPaneScopedCacheClearsEveryPaneAnchoredLatch(t *testing.T) {
@@ -3522,6 +3599,101 @@ func TestTickResumesTheLastStateAfterATrailingMalformedLine(t *testing.T) {
 	_, attempt := readTaskAttempt(t, home, "task-1")
 	if attempt.LastReportState != state.ReportNeedsDecision || !strings.Contains(attempt.LastReportNote, "which base branch?") {
 		t.Fatalf("LastReportState/Note = %q/%q, want the worker's own question left intact", attempt.LastReportState, attempt.LastReportNote)
+	}
+}
+
+// Keys tracking on identity rather than on ID. A teardown and respawn between two ticks is a
+// different task, and inheriting the previous run's TaskState suppresses the new one's verified done
+// for good: syncTaskState writes that inherited done_verified onto the fresh JSON.
+func TestTickReseedsARespawnedTaskID(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	setStatus(t, statusFile, "working")
+	writeFakeHerdr(t, statusFile)
+
+	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
+	reportMD := filepath.Join(home, "data", "task-1", "report.md")
+	if err := os.MkdirAll(filepath.Dir(reportMD), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reportMD, []byte("findings"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
+	client := herdr.NewClient()
+	states := make(map[string]*TaskState)
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: finished\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if !strings.Contains(buf.String(), "done task-1: finished") {
+		t.Fatalf("output = %q, want the first run's verified done", buf.String())
+	}
+
+	firstRun, err := state.ActiveAttempt(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", firstRun.ID, firstRun.Lifecycle, state.AttemptCompleted); err != nil {
+		t.Fatal(err)
+	}
+	// Same hazard as a surviving report channel, one layer in, so the scout's report.md and the
+	// volatile wake log both go with the torn-down run - a surviving log would replay as this
+	// run's, and a surviving deliverable would misreport what the second run actually produced.
+	if err := os.Remove(reportMD); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(state.ReportPath(home, "task-1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SetTaskReportState(home, "task-1", 0, "", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.ReopenTask(home, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{PaneID: "p1"},
+		LaunchConfirmedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	respawned, err := state.ActiveAttempt(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TransitionAttempt(home, respawned.ID, state.AttemptProvisioning, state.AttemptRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	// One tick for the watcher to notice the reopened task's new attempt identity and reseed
+	// its tracking, before either report exists for this run.
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+
+	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: round two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if !strings.Contains(buf.String(), "reported-done task-1: round two") {
+		t.Fatalf("output = %q, want the respawned task's own done report read from offset 0", buf.String())
+	}
+
+	_, respawnedAttempt := readTaskAttempt(t, home, "task-1")
+	if respawnedAttempt.DoneVerified {
+		t.Fatal("done_verified inherited by a respawned ID, want the previous run's announcement not carried over")
+	}
+
+	if err := os.WriteFile(reportMD, []byte("findings again"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
+	if !strings.Contains(buf.String(), "done task-1: round two") {
+		t.Fatalf("output = %q, want the respawned task's verified done announced too", buf.String())
 	}
 }
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1749,18 +1749,22 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 		t.Fatal("task.DoneVerified = false, want the scout's announcement persisted")
 	}
 
-	// hand promote: same rewrite internal/runtime/promote.go makes - kind and pane change,
-	// CreatedAt and the report channel do not - with the DoneVerified reset this
-	// test exists to cover.
-	task.Kind = state.KindShip
-	attempt.Herdr.PaneID = "p2"
-	attempt.DoneVerified = false
-	if err := state.Write(home, task); err != nil {
+	// hand promote's own rewrite: task kind flips to ship and a fresh attempt with its own pane
+	// takes over, DoneVerified starting false again - it never rewrites the scout attempt's row.
+	shipAttempt, err := state.PromoteTask(home, "task-1", attempt.ID, attempt.Lifecycle, state.Attempt{
+		TaskID: "task-1", Lifecycle: state.AttemptProvisioning, Herdr: state.Herdr{PaneID: "p2"}, LaunchConfirmedAt: "2026-08-14T00:00:00Z",
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := state.UpdateAttempt(home, attempt); err != nil {
+	if err := state.TransitionAttempt(home, shipAttempt.ID, state.AttemptProvisioning, state.AttemptRunning); err != nil {
 		t.Fatal(err)
 	}
+
+	// One tick to let the watcher observe the ship's fresh pane before its report exists,
+	// exactly as it would after a real promote's brand-new pane comes up.
+	buf.Reset()
+	tick(ctx, cfg, client, states, &buf, io.Discard)
 
 	// The ship's own report line lands on the same continuous report stream,
 	// before any merge evidence exists - the ordinary ordering ClassifyDeferredDone
@@ -1800,74 +1804,6 @@ func TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker(t 
 	tick(ctx, cfg, client, states, &buf, io.Discard)
 	if !hasEventLine(buf.String(), "done task-1: ship work") {
 		t.Fatalf("out = %q, want the ship's own verified done announced", buf.String())
-	}
-}
-
-// The ship's first probe reads the same "working" the scout last held, so no
-// observed transition reseeds ChangedAt - which is why the forget rule cannot be
-// conditioned on one.
-func TestTickDropsTheCachedDwellWhenPromoteMovesTheTaskToANewPane(t *testing.T) {
-	statusFile := filepath.Join(t.TempDir(), "status")
-	setStatus(t, statusFile, "working")
-	writeFakeHerdr(t, statusFile)
-
-	home := t.TempDir()
-	dwelling := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
-	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout,
-		CreatedAt: dwelling}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"},
-		StatusChangedAt: dwelling, StatusChangedFor: "working"},
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: 20 * time.Minute}
-	client := herdr.NewClient()
-	states := make(map[string]*TaskState)
-	ctx := context.Background()
-
-	var buf bytes.Buffer
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-
-	promoted, attempt := readTaskAttempt(t, home, "task-1")
-	promoted.Kind = state.KindShip
-	attempt.Herdr.PaneID = "p2"
-	attempt.StatusChangedAt = time.Now().UTC().Format(time.RFC3339)
-	attempt.StatusChangedFor = ""
-	if err := state.Write(home, promoted); err != nil {
-		t.Fatal(err)
-	}
-	if err := state.UpdateAttempt(home, attempt); err != nil {
-		t.Fatal(err)
-	}
-
-	// Moves report_offset, which is what makes the next tick write task state at all.
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("working: starting the ship run\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	buf.Reset()
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-	if strings.Contains(buf.String(), "stale task-1") {
-		t.Fatalf("out = %q, want no stale: the ship's dwell starts at the promotion, not at the scout's last observed transition", buf.String())
-	}
-
-	_, gotAttempt := readTaskAttempt(t, home, "task-1")
-	if gotAttempt.StatusChangedAt == dwelling {
-		t.Fatal("status_changed_at = the scout's stamp, want the cached scout dwell not written back over promote's restamp")
-	}
-	stamped, err := time.Parse(time.RFC3339, gotAttempt.StatusChangedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	restamped, err := time.Parse(time.RFC3339, attempt.StatusChangedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stamped.Before(restamped) {
-		t.Fatalf("status_changed_at = %q, want no earlier than promote's restamp %q", gotAttempt.StatusChangedAt, attempt.StatusChangedAt)
-	}
-	if gotAttempt.StatusChangedFor != "working" {
-		t.Fatalf("status_changed_for = %q, want the status the ship's dwell was stamped for", gotAttempt.StatusChangedFor)
 	}
 }
 
@@ -2299,7 +2235,11 @@ func TestTickForgetsTornDownTasks(t *testing.T) {
 		t.Fatalf("states = %+v, want task-1 tracked", states)
 	}
 
-	if err := state.Delete(home, "task-1"); err != nil {
+	attempt, err := state.ActiveAttempt(home, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.TerminalizeTaskAndAttempt(home, "task-1", attempt.ID, attempt.Lifecycle, state.AttemptCompleted); err != nil {
 		t.Fatal(err)
 	}
 	tick(ctx, cfg, client, states, &buf, io.Discard)
@@ -3582,79 +3522,6 @@ func TestTickResumesTheLastStateAfterATrailingMalformedLine(t *testing.T) {
 	_, attempt := readTaskAttempt(t, home, "task-1")
 	if attempt.LastReportState != state.ReportNeedsDecision || !strings.Contains(attempt.LastReportNote, "which base branch?") {
 		t.Fatalf("LastReportState/Note = %q/%q, want the worker's own question left intact", attempt.LastReportState, attempt.LastReportNote)
-	}
-}
-
-// Keys tracking on identity rather than on ID. A teardown and respawn between two ticks is a
-// different task, and inheriting the previous run's TaskState suppresses the new one's verified done
-// for good: syncTaskState writes that inherited done_verified onto the fresh JSON.
-func TestTickReseedsARespawnedTaskID(t *testing.T) {
-	statusFile := filepath.Join(t.TempDir(), "status")
-	setStatus(t, statusFile, "working")
-	writeFakeHerdr(t, statusFile)
-
-	home := setupWatcherHome(t, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}})
-	reportMD := filepath.Join(home, "data", "task-1", "report.md")
-	if err := os.MkdirAll(filepath.Dir(reportMD), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(reportMD, []byte("findings"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := Config{Home: home, PollInterval: time.Hour, StaleThreshold: time.Hour}
-	client := herdr.NewClient()
-	states := make(map[string]*TaskState)
-	ctx := context.Background()
-
-	var buf bytes.Buffer
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: finished\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	buf.Reset()
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-	if !strings.Contains(buf.String(), "done task-1: finished") {
-		t.Fatalf("output = %q, want the first run's verified done", buf.String())
-	}
-
-	if err := state.Delete(home, "task-1"); err != nil {
-		t.Fatal(err)
-	}
-	// Same hazard as a surviving report channel, one layer in, so the scout's report.md goes with the
-	// state row.
-	if err := os.Remove(reportMD); err != nil {
-		t.Fatal(err)
-	}
-	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "nsr", Kind: state.KindScout,
-
-		CreatedAt: time.Now().UTC().Add(time.Minute).Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "p1"}},
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	buf.Reset()
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-	if err := os.WriteFile(state.ReportPath(home, "task-1"), []byte("done: round two\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-	if !strings.Contains(buf.String(), "reported-done task-1: round two") {
-		t.Fatalf("output = %q, want the respawned task's own done report read from offset 0", buf.String())
-	}
-
-	_, respawnedAttempt := readTaskAttempt(t, home, "task-1")
-	if respawnedAttempt.DoneVerified {
-		t.Fatal("done_verified inherited by a respawned ID, want the previous run's announcement not carried over")
-	}
-
-	if err := os.WriteFile(reportMD, []byte("findings again"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	buf.Reset()
-	tick(ctx, cfg, client, states, &buf, io.Discard)
-	if !strings.Contains(buf.String(), "done task-1: round two") {
-		t.Fatalf("output = %q, want the respawned task's verified done announced too", buf.String())
 	}
 }
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -662,9 +662,9 @@ func TestCheckCollisionDetectsAConflictOnLeaseIdentity(t *testing.T) {
 	}
 }
 
-// Teardown returns the worktree before state.Delete, so a failed Delete leaves a row still naming
-// path P while treehouse has freed P and handed it to the next task under a lease of its own. That
-// is not a collision, and refusing the spawn over it was the bug.
+// A stale task row can still name path P while treehouse has freed P and handed it to the next
+// task under a lease of its own. That is not a collision, and refusing the spawn over it was the
+// bug.
 func TestCheckCollisionAllowsAReusedPathUnderAFreshLease(t *testing.T) {
 	home := t.TempDir()
 	writeCollisionTask(t, home, "stale-task", "/tmp/wt-shared", "lease-1")

--- a/tests/e2e/collision_test.go
+++ b/tests/e2e/collision_test.go
@@ -67,8 +67,8 @@ func TestSpawnDetectsWorktreeCollision(t *testing.T) {
 }
 
 // The other branch, end to end: a real treehouse recycles a returned pool slot's path under a brand-new
-// lease identity, and a task row still naming that path - left behind by a teardown whose state.Delete
-// failed - must not abort the spawn that legitimately acquired it.
+// lease identity, and a stale task row still naming that path must not abort the spawn that
+// legitimately acquired it.
 func TestSpawnAllowsARecycledWorktreePathUnderAFreshLease(t *testing.T) {
 	home, dir := setupCollisionHome(t)
 	sharedWorktree := filepath.Join(home, "wt-shared")

--- a/tests/e2e/send_test.go
+++ b/tests/e2e/send_test.go
@@ -178,9 +178,11 @@ func TestWatcherRestartAfterResumeSideEffectDoesNotResend(t *testing.T) {
 	registerProject(t, home, "demo", "direct-pr")
 	seedSendTask(t, home)
 	_, attempt := readTaskAttempt(t, home, "task-1")
-	attempt.UsageLimitEpisode = 1
-	attempt.UsageLimitRetryAt = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
-	if err := state.UpdateAttempt(home, attempt); err != nil {
+	if err := state.UpdateAttemptObservation(home, "task-1", attempt.ID, attempt.Lifecycle,
+		attempt.StatusChangedAt, attempt.StatusChangedFor, attempt.DoneVerified,
+		attempt.LastReportState, attempt.LastReportNote, attempt.ParkedFiredFor,
+		time.Now().Add(-time.Minute).UTC().Format(time.RFC3339), attempt.UsageLimitAttempts,
+		1, attempt.UsageLimitStuckEpisode); err != nil {
 		t.Fatal(err)
 	}
 	logPath := filepath.Join(t.TempDir(), "pane.log")

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -586,8 +586,11 @@ func TestWatchResumesAUsageLimitedWorkerAndLeavesOthersAlone(t *testing.T) {
 	// The restart: the stamp the first run wrote moved into the past, which is the one thing that makes an
 	// attempt due without waiting out the ten-minute floor. It covers the durability too - a watcher that
 	// came up fresh still knows this worker is limited and when it may be poked.
-	limitedAttempt.UsageLimitRetryAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
-	if err := state.UpdateAttempt(home, limitedAttempt); err != nil {
+	if err := state.UpdateAttemptObservation(home, "limited", limitedAttempt.ID, limitedAttempt.Lifecycle,
+		limitedAttempt.StatusChangedAt, limitedAttempt.StatusChangedFor, limitedAttempt.DoneVerified,
+		limitedAttempt.LastReportState, limitedAttempt.LastReportNote, limitedAttempt.ParkedFiredFor,
+		time.Now().UTC().Add(-time.Minute).Format(time.RFC3339), limitedAttempt.UsageLimitAttempts,
+		limitedAttempt.UsageLimitEpisode, limitedAttempt.UsageLimitStuckEpisode); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

- Removed `store.DB.UpdateAttempt`, `store.DB.DeleteTask`, and their `internal/state` wrappers (`state.UpdateAttempt`, `state.Delete`): neither had a production caller, and each sits beside a guarded sibling that already covers the legitimate use (`TransitionAttempt`, `TerminalizeTaskAndAttempt`).
- Every test caller moved to a guarded primitive, or to setting the field at attempt creation instead of patching it in afterward. Three hold tests moved to raw SQL for a schema-level fact the store API has no reason to expose. A few tests pinned the removed methods' own behavior directly and had no substitute at all; those are deleted.

## Caller migrations

**Moved to a guarded primitive** - these were exercising a real transition or observation, not just seeding a fixture:

- `internal/watcher/watcher_test.go` `TestTickAnnouncesTheShipsOwnVerifiedDoneAfterPromoteResetsTheStaleMarker`: used to fake "hand promote" by rewriting the scout attempt's Herdr/DoneVerified in place. Now calls the real `state.PromoteTask` (completes the scout attempt, creates a genuine new ship attempt) followed by `state.TransitionAttempt` (provisioning -> running, since `PromoteTask` requires a promoted attempt to start provisioning). Exercises the real production write path instead of a shortcut `internal/runtime/promote.go` never actually takes.
- `internal/watcher/watcher_test.go` `TestTickDropsTheCachedDwellWhenPromoteMovesTheTaskToANewPane`: same fix, same reasoning - promotes for real via `state.PromoteTask` + `state.TransitionAttempt` instead of rewriting the running scout attempt's Herdr in place. (I deleted this one in an earlier push on the theory that a running attempt's pane changing was unreachable; that was wrong on two counts - a *promoted* attempt is a fresh attempt with its own pane, which is exactly what `PromoteTask` produces, and the watcher's ownership-changed tracking correctly reseeds the dwell clock at the new attempt's first sighting rather than inheriting the scout's cached one. Restored and rewritten rather than left deleted.)
- `internal/watcher/watcher_test.go` `TestTickForgetsTornDownTasks`: `state.Delete` -> `state.TerminalizeTaskAndAttempt`. `tick()` only watches `ListOpenHistories`, so a terminalized (not deleted) task disappears from its working set the same way a deleted one did - same observable effect, durable row.
- `internal/watcher/watcher_test.go` `TestTickReseedsARespawnedTaskID`: also restored after an earlier wrongful deletion. Now tears down and respawns the same task ID via `state.TerminalizeTaskAndAttempt` + `state.ReopenTask` (the ADR-sanctioned respawn path - a durable row continuing under a fresh attempt, not delete-and-recreate), with `state.SetTaskReportState(id, 0, "", false)` resetting the report cursor for the new run. All three already existed with production callers; none of this needed the removed `DeleteTask` or a new escape hatch.
- `internal/watcher/usagelimit_test.go` `setLimitRetryAt`, `tests/e2e/send_test.go`, `tests/e2e/watch_test.go`: all rewrote `UsageLimitRetryAt`/`UsageLimitEpisode` on an already-running attempt mid-test. Moved to `state.UpdateAttemptObservation`, passing through the attempt's current values for every other field it also writes so nothing but the field under test changes.

**Moved to attempt-creation time** - these never exercised a transition; the attempt's `Lifecycle` was constant from creation to assertion in every case, and the "mutation" was only ever used to seed pre-existing state a later command/tick would read and reset or carry forward:

- `cmd/promote_test.go` `TestPromoteResetsPaneScopedMarkersButCarriesReportOffset`: added `setupPromoteHomeWithScoutAttempt`, a variant of the existing setup helper that takes the full scout `Attempt` instead of a fixed one, so `DoneVerified`/`LeaseID`/`StatusChanged*`/`LastReport*`/`UsageLimit*` are set once at `CreateAttempt` instead of created-then-patched. (Also dropped `Harness`/`Model`/`Effort` from the fixture - `UpdateAttempt`'s SET clause never actually touched those three columns, so they were always dead assignments; `attempt_test.go`'s now-deleted `TestAttemptUpdatesPreserveExecutionSnapshot` pinned exactly that.)
- `internal/runtime/teardown_test.go` (5 call sites): added `teardownFixtureWithAttempt`, taking a `func(*state.Attempt)` to shape the fixture attempt before creation, replacing "create with defaults, then read-modify-`UpdateAttempt`" everywhere in this file.

I'm confident these are safe: in every one of these cases the field being set was consumed read-only by the code under test (teardown's decision logic, promote's carry-forward/reset logic), never itself the subject of a lifecycle check.

**Raw SQL in a white-box test** - `internal/store/hold_test.go` (3 call sites, `db.DeleteTask`): these pin that a `hold` row has no foreign key to `task` and survives the task row vanishing entirely - a schema fact, not an application behavior. Replaced with a small `deleteTaskRow` test helper doing `DELETE FROM task WHERE id = ?` directly against `db.sql`. This is package-internal (`package store`) test code, not a new exported escape hatch.

**Deleted outright** - no guarded primitive substitutes because the exact behavior under test no longer exists:

- `internal/store/attempt_test.go` `TestAttemptUpdatesPreserveExecutionSnapshot` and `internal/store/store_test.go` `TestDeleteTask`: pinned `UpdateAttempt`'s/`DeleteTask`'s own SQL behavior directly.
- `internal/state/task_test.go` `TestDelete`, `TestDeleteRemovesTheReportChannel`, `TestDeleteMissingTask`, `TestLockPathnameSurvivesDelete`: same - pinned `state.Delete`'s own contract (including the ADR-referencing lock-pathname-survives-a-deletion case, which has no deletion left to survive).

## Step 4 audit

The brief asked me to deliberately look for other unguarded lifecycle mutators of the same shape (no production caller, guarded sibling already present) while I was in here, not just delete the two the issue named. I found one candidate and did not fold it into this PR: `store.DB.UpdateTask` / `state.Write` / `state.UpdateTask` is a similarly-shaped blind full-row update with zero production callers (`state.Write`'s update branch is exercised only by ~60 test call sites across the repo) and field-specific guarded setters already exist for nearly every column it touches (`SetTaskPR`, `SetTaskDelivery`, `SetTaskMerge`, `SetTaskReportState`, `SetTaskAcknowledgement`, `SetTaskRepair`, ...). It doesn't set `lifecycle` itself though, so it can't revive a terminal task or otherwise defeat a lifecycle check the way `UpdateAttempt` could - a narrower hazard than what #481 names, and ~60 call sites make it a much larger, differently-risked change than this issue's scope. Leaving as future work rather than pulling it in here; happy to file the issue once this lands.

I did not find any other candidate beyond that one.

Closes atqamz/hand#481

## Test plan

- [x] `make lint`
- [x] `make test` (race detector, full suite)
- [x] `make e2e`