### PR TITLE
fix: name checkout in trust refusal

### DIFF
--- a/docs/adr/trust-refusal-releases-the-worktree-slot.md
+++ b/docs/adr/trust-refusal-releases-the-worktree-slot.md
@@ -1,0 +1,39 @@
+# Trust refusal releases the worktree slot
+
+- Date: 2026-08-29
+- Status: accepted
+- Issues: atqamz/hand#491
+- PRs: none
+
+## Context
+
+Codex and Claude can stop a launch on a first-run security prompt that Hand must not answer.
+The refusal needs to identify the concrete checkout so an operator can act on it.
+The launch can already have acquired a Treehouse worktree before the prompt is observed, and the
+normal failed-launch unwind currently returns that worktree and clears its persisted ownership.
+
+Holding the slot would preserve a durable path for `hand status`, but a prompt may never receive an
+operator response and a held pool slot would then leak indefinitely.
+
+## Decision
+
+Trust refusals include the launch specification's concrete checkout path at the refusal call site.
+The prompt catalogue remains static and continues to contain only harness-specific security guidance.
+The existing unwind returns the acquired worktree and clears its persisted ownership after the error
+is composed, so the refusal itself carries the complete path needed for operator action.
+
+## Rejected alternatives
+
+- Holding the worktree until an operator acts would retain status evidence, but would require a new
+  release lifecycle and could strand a scarce pool slot indefinitely when the prompt is ignored.
+- Putting a path placeholder in the prompt catalogue would turn static security-prompt signatures
+  into a formatting template and couple harness definitions to runtime state.
+- Keeping the slot without naming the path would preserve an inaccessible record and would not fix
+  the immediate refusal message.
+
+## Consequences
+
+The launch error names the exact checkout for both managed-settings and directory-trust refusals,
+and the existing cleanup remains bounded and leak-free.
+After cleanup, `hand status` no longer retains the released path, so the error must be preserved by
+the operator while acting on the checkout.

--- a/internal/runtime/launch.go
+++ b/internal/runtime/launch.go
@@ -90,7 +90,7 @@ func confirmLaunch(client herdrClient, paneID, harnessName string, spec launch.L
 				stall = noAgent
 			}
 		case known && prompt.Refuse != "":
-			return fmt.Errorf("worker is waiting on the %s prompt: %s", prompt.Name, prompt.Refuse)
+			return fmt.Errorf("worker is waiting on the %s prompt in checkout %s: %s", prompt.Name, spec.Cwd, prompt.Refuse)
 		case known:
 			if !answered[prompt.Name] {
 				if err := answerFirstRunPrompt(client, paneID, prompt); err != nil {

--- a/internal/runtime/launch_test.go
+++ b/internal/runtime/launch_test.go
@@ -68,6 +68,7 @@ func fakeLaunchPane(t *testing.T, frames ...launchFrame) (keyLog string) {
 
 const (
 	launchEchoFrame       = "$ cd '/tmp/wt' && claude --dangerously-skip-permissions 'Read the brief'"
+	launchCheckoutPath    = "/tmp/trusted-checkout"
 	launchReadyFrame      = "Welcome to Claude Code\n\n> \n  ? for shortcuts"
 	launchBypassOnFrame   = "> \n  secondhand (fm/x)\n  bypass permissions on (shift+tab to cycle)"
 	launchTrustFrame      = "Do you trust the files in this folder?\n> 1. Yes, I trust this folder\n  2. No\n\nEnter to confirm"
@@ -146,13 +147,13 @@ func TestConfirmLaunch(t *testing.T) {
 			name:    "refuses the managed settings prompt instead of answering it",
 			harness: "claude",
 			frames:  []launchFrame{live(launchSettingsFrame)},
-			wantErr: "waiting on the managed settings prompt",
+			wantErr: "waiting on the managed settings prompt in checkout " + launchCheckoutPath,
 		},
 		{
 			name:    "refuses the codex directory trust prompt instead of answering it",
 			harness: "codex",
 			frames:  []launchFrame{{text: launchCodexTrustFrame, agent: "codex"}},
-			wantErr: "waiting on the directory trust prompt",
+			wantErr: "waiting on the directory trust prompt in checkout " + launchCheckoutPath,
 		},
 		{
 			// The refused signature is catalogued after the answerable one, so answering by list
@@ -160,7 +161,7 @@ func TestConfirmLaunch(t *testing.T) {
 			name:    "a refused prompt wins over an answerable one on the same screen",
 			harness: "claude",
 			frames:  []launchFrame{live(launchTrustFrame + "\n" + launchSettingsFrame)},
-			wantErr: "waiting on the managed settings prompt",
+			wantErr: "waiting on the managed settings prompt in checkout " + launchCheckoutPath,
 		},
 		{
 			name:    "an unrecognized dialog keeps resetting the quiet count",
@@ -215,7 +216,7 @@ func TestConfirmLaunch(t *testing.T) {
 			}
 			keyLog := fakeLaunchPane(t, tt.frames...)
 
-			err := confirmLaunch(herdr.NewClient(), "wA:pC", tt.harness, launchSpec{Executable: tt.harness})
+			err := confirmLaunch(herdr.NewClient(), "wA:pC", tt.harness, launchSpec{Executable: tt.harness, Cwd: launchCheckoutPath})
 			switch {
 			case tt.wantErr == "" && err != nil:
 				t.Fatalf("confirmLaunch() = %v, want success", err)

--- a/internal/runtime/neverstarted_test.go
+++ b/internal/runtime/neverstarted_test.go
@@ -22,7 +22,7 @@ func TestAttemptNeverStartedAttestationEndsTheAttemptHonestly(t *testing.T) {
 	paneText := fakeSwitchablePane(t, harness.Codex)
 	paneText("codex ready\n")
 	returns := 0
-	r := unwindRuntime(t, &returns)
+	r, _ := unwindRuntime(t, &returns)
 
 	if _, err := r.Spawn(context.Background(), SpawnRequest{
 		Home: home, ID: "task-1", Project: "demo", Kind: state.KindShip, Harness: harness.Codex, HarnessFromFlag: true,

--- a/internal/runtime/unwind_test.go
+++ b/internal/runtime/unwind_test.go
@@ -42,18 +42,19 @@ func fakeSwitchablePane(t *testing.T, agent string) func(string) {
 
 // The reconcile runtime with the two dependencies this path has to exercise for real: the Herdr client
 // that talks to the installed fake, and the launch confirmation that reads the pane.
-func unwindRuntime(t *testing.T, returns *int) *Runtime {
+func unwindRuntime(t *testing.T, returns *int) (*Runtime, string) {
 	t.Helper()
 	pool := t.TempDir()
+	worktreePath := filepath.Join(pool, "slot-1")
 	r := reconcileRuntime(nil, func(string, string) (worktree.Lease, error) {
-		return worktree.Lease{Path: filepath.Join(pool, "slot-1"), ID: "lease-1"}, nil
+		return worktree.Lease{Path: worktreePath, ID: "lease-1"}, nil
 	})
 	r.deps.herdr = func() herdrClient { return herdr.NewClient() }
 	r.deps.buildHarness = harness.Build
 	r.deps.confirmLaunch = confirmLaunch
 	r.deps.worktree.returnWorktree = func(string, string, bool) error { *returns++; return nil }
 	r.deps.worktree.returnWithID = func(string, string, string, bool) error { *returns++; return nil }
-	return r
+	return r, worktreePath
 }
 
 // The whole path atqamz/hand#254 exists for, driven only through supported commands: a spawn refused
@@ -66,12 +67,12 @@ func TestSpawnRefusedAtTheTrustPromptUnwindsAndSpawnsAgain(t *testing.T) {
 	paneText := fakeSwitchablePane(t, harness.Codex)
 	paneText(launchCodexTrustFrame)
 	returns := 0
-	r := unwindRuntime(t, &returns)
+	r, worktreePath := unwindRuntime(t, &returns)
 
 	_, err := r.Spawn(context.Background(), SpawnRequest{
 		Home: home, ID: "task-1", Project: "demo", Kind: state.KindShip, Harness: harness.Codex, HarnessFromFlag: true,
 	})
-	if err == nil || !strings.Contains(err.Error(), "waiting on the directory trust prompt") {
+	if err == nil || !strings.Contains(err.Error(), "waiting on the directory trust prompt") || !strings.Contains(err.Error(), worktreePath) {
 		t.Fatalf("Spawn() = %v, want the launch refused at the codex directory trust prompt", err)
 	}
 	failed := readOnlyAttempt(t, home)


### PR DESCRIPTION
## Summary
- Include the concrete launch checkout in Claude and Codex trust refusals.
- Release the worktree on refusal as before, with the decision recorded in an ADR.
- Assert refusal paths and bounded unwind cleanup in runtime tests.

Fixes atqamz/hand#491

## Test plan
- make test
- make lint
- make build