### PR TITLE
fix(orient): corroborate and latch parked before treating it as actionable

### DIFF
--- a/cmd/nextaction_test.go
+++ b/cmd/nextaction_test.go
@@ -238,7 +238,7 @@ func TestClassifyNextActionRanksRuntimeAttentionFromSharedDerivation(t *testing.
 	}{
 		{name: "unreachable", view: taskView{task: state.Task{ID: "unreachable-task"}, unreachable: true}, kind: nextActionUnreachable, reason: "investigate why its worker runtime is unreachable"},
 		{name: "runtime unknown", view: taskView{task: state.Task{ID: "unknown-task"}, attempt: &state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "pane-1"}}, agentState: string(herdr.StatusUnknown)}, kind: nextActionRuntimeUnknown, reason: "investigate why its worker runtime is unknown"},
-		{name: "parked", view: taskView{task: state.Task{ID: "parked-task"}, parked: true}, kind: nextActionParked, reason: "investigate why its worker has been silent"},
+		{name: "parked", view: taskView{task: state.Task{ID: "parked-task"}, parked: true, parkedActionable: true}, kind: nextActionParked, reason: "investigate why its worker has been silent"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := classifyNextAction(configuredWorker, 1, backlogSummary{}, []taskView{test.view}, nil)
@@ -247,6 +247,16 @@ func TestClassifyNextActionRanksRuntimeAttentionFromSharedDerivation(t *testing.
 				t.Fatalf("classifyNextAction() = %#v, want %#v", got, want)
 			}
 		})
+	}
+}
+
+// atqamz/hand#492: the ranking's own guard against regressing back to acting on parked without
+// parkedActionable; the decision itself is covered in cmd/status_test.go.
+func TestClassifyNextActionIgnoresAnUncorroboratedPark(t *testing.T) {
+	view := taskView{task: state.Task{ID: "parked-task"}, parked: true, parkedActionable: false}
+	got := classifyNextAction(configuredWorker, 1, backlogSummary{}, []taskView{view}, nil)
+	if got.Kind == nextActionParked {
+		t.Fatalf("classifyNextAction() = %#v, want an uncorroborated park to never rank as the next action", got)
 	}
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -641,6 +641,7 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 	}
 	active := t.Lifecycle == state.TaskOpen && history.ActiveAttempt != nil && attempt.Lifecycle == state.AttemptRunning
 	reportAt, reportAtObserved := lastReportAt(home, t.ID)
+	parked, parkedActionable := taskParked(home, t, e, agentState, reportedState, bounds)
 	v := taskView{
 		task:               t,
 		attempt:            attempt,
@@ -655,7 +656,8 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 		unacked:            unacked,
 		unannounced:        unannounced,
 		unreachable:        active && !reachable,
-		parked:             active && taskParked(home, t, e, reportedState, bounds),
+		parked:             active && parked,
+		parkedActionable:   active && parkedActionable,
 		reported:           reportedFrom(last, len(lines) > 0, readErr),
 	}
 	if attempt != nil {
@@ -680,15 +682,24 @@ func buildTaskView(home string, client *herdr.Client, history state.TaskHistory,
 
 // Reports whether an open task's active pane has gone silent past its last reported state's bound,
 // the status-side counterpart ClassifyParked never had (atqamz/hand#32, atqamz/hand#268's
-// disagreement 2). Degrades to false on any read fault, like lastReportAt's own stat failure.
-func taskParked(home string, t state.Task, attempt state.Attempt, reportedState string, bounds watcher.ParkedBounds) bool {
+// disagreement 2), and separately whether that verdict is corroborated enough to be actionable (atqamz/hand#492).
+func taskParked(home string, t state.Task, attempt state.Attempt, agentState, reportedState string, bounds watcher.ParkedBounds) (parked, actionable bool) {
 	silentSince, err := watcher.ReportEvidenceTime(home, t, attempt)
 	if err != nil {
-		return false
+		return false, false
 	}
-	// A one-shot render has no short, known interval baseline, so it defers corroboration to hand watch.
 	naive := watcher.Parked(reportedState, t.DeliveredAt, silentSince, time.Now(), bounds)
-	return naive
+	if !naive {
+		return false, false
+	}
+	// A pane this render observed working or blocked is the runtime observation `hand reconcile` calls
+	// `liveness: working`, one-shot and needing no baseline. A watcher's own durable confirmation of
+	// this exact episode (AlreadyAnnounced) means this render is not the first to find it either way.
+	live := herdr.Status(agentState) == herdr.StatusWorking || herdr.Status(agentState) == herdr.StatusBlocked
+	if live || watcher.AlreadyAnnounced(attempt, silentSince) {
+		return true, false
+	}
+	return true, true
 }
 
 // Reads config/parked-*-bound, shared by newWatchCmd, once per render rather than once per task, so a

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -969,7 +971,7 @@ func TestStatusFleetFlagsUnreachablePaneAndCountsAttention(t *testing.T) {
 // atqamz/hand#268's disagreement 2: KindParked existed only in hand watch, and atqamz/hand#32's own
 // pane rendered plain "state: idle" with no counterpart at all. A busy pane isolates the new
 // condition from unreportedStop, which requires the pane to be not-busy.
-func TestStatusFleetFlagsParkedPaneAndCountsAttention(t *testing.T) {
+func TestStatusFleetFlagsParkedPane(t *testing.T) {
 	home := t.TempDir()
 	t.Chdir(home)
 	mkFleetDirs(t, home)
@@ -993,8 +995,10 @@ func TestStatusFleetFlagsParkedPaneAndCountsAttention(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out.String(), "attention: 1\n") {
-		t.Fatalf("got %q, want attention: 1 for a pane silent past the parked bound", out.String())
+	// atqamz/hand#492: a pane this render observed busy corroborates the silence as an ordinary long
+	// turn, so it stays out of the fleet's shared attention count even though the raw flag still shows.
+	if !strings.Contains(out.String(), "attention: 0\n") {
+		t.Fatalf("got %q, want attention: 0 for a silence a busy pane corroborates as not stuck", out.String())
 	}
 	got := fleetFlags(t, out.String(), "task-1")
 	if !slices.Contains(got, "parked") {
@@ -1002,6 +1006,50 @@ func TestStatusFleetFlagsParkedPaneAndCountsAttention(t *testing.T) {
 	}
 	if slices.Contains(got, "unreported") {
 		t.Fatalf("flags = %v, want no unreported: the pane is busy, so only parked explains this", got)
+	}
+}
+
+// atqamz/hand#492: without a busy pane to corroborate it, or a watcher's own confirmation on record,
+// the naive parked verdict is all there is - and per the issue's own constraint, that must still
+// reach the supervisor rather than being suppressed for lack of stronger evidence.
+func TestStatusFleetFlagsParkedPaneAndCountsAttentionWhenUncorroborated(t *testing.T) {
+	home := t.TempDir()
+	t.Chdir(home)
+	mkFleetDirs(t, home)
+	writeFakeHerdrPaneStatus(t, "idle")
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "parked-other-bound"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeTaskAttempt(t, home, state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-5 * time.Second).UTC().Format(time.RFC3339)}, state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}, LastReportState: state.ReportWorking}); err != nil {
+		t.Fatal(err)
+	}
+	reportPath := state.ReportPath(home, "task-1")
+	if err := os.WriteFile(reportPath, []byte("working: still on the migration\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	silentSince := time.Now().Add(-5 * time.Second)
+	if err := os.Chtimes(reportPath, silentSince, silentSince); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "attention: 1\n") {
+		t.Fatalf("got %q, want attention: 1 for an idle pane silent past the parked bound with nothing to corroborate it", out.String())
+	}
+	got := fleetFlags(t, out.String(), "task-1")
+	if !slices.Contains(got, "parked") {
+		t.Fatalf("flags = %v, want parked", got)
 	}
 }
 
@@ -1024,11 +1072,211 @@ func TestTaskParkedUsesNaiveOneShotFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	bounds := watcher.ParkedBounds{Other: 20 * time.Minute}
-	if taskParked(home, task, attempt, state.ReportWorking, watcher.ParkedBounds{Other: 40 * time.Minute}) {
+	if parked, _ := taskParked(home, task, attempt, string(herdr.StatusIdle), state.ReportWorking, watcher.ParkedBounds{Other: 40 * time.Minute}); parked {
 		t.Fatal("one-shot status reported parked before the time bound was crossed")
 	}
-	if !taskParked(home, task, attempt, state.ReportWorking, bounds) {
+	parked, actionable := taskParked(home, task, attempt, string(herdr.StatusIdle), state.ReportWorking, bounds)
+	if !parked {
 		t.Fatal("one-shot status did not preserve the naive parked verdict")
+	}
+	if !actionable {
+		t.Fatal("an idle pane past its bound with no watcher confirmation on record should still be actionable")
+	}
+}
+
+// atqamz/hand#492: a pane this render observed working or blocked is the same runtime observation
+// `hand reconcile` calls `liveness: working` for the same attempt - strong enough to keep the naive
+// verdict out of a supervisor's work queue, though it still renders in `hand status`.
+func TestTaskParkedCorroboratesAgainstALivePaneObservedThisRender(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	task := state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)}
+	attempt := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}
+	if err := writeTaskAttempt(t, home, task, attempt); err != nil {
+		t.Fatal(err)
+	}
+	reportPath := state.ReportPath(home, task.ID)
+	if err := os.WriteFile(reportPath, []byte("working: still on the migration\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	silentSince := time.Now().Add(-30 * time.Minute)
+	if err := os.Chtimes(reportPath, silentSince, silentSince); err != nil {
+		t.Fatal(err)
+	}
+	bounds := watcher.ParkedBounds{Other: 20 * time.Minute}
+
+	for _, live := range []herdr.Status{herdr.StatusWorking, herdr.StatusBlocked} {
+		parked, actionable := taskParked(home, task, attempt, string(live), state.ReportWorking, bounds)
+		if !parked {
+			t.Fatalf("agent_status %q: parked = false, want the naive verdict preserved for hand status", live)
+		}
+		if actionable {
+			t.Fatalf("agent_status %q: actionable = true, want a live pane to keep this out of the work queue", live)
+		}
+	}
+	if parked, actionable := taskParked(home, task, attempt, string(herdr.StatusUnknown), state.ReportWorking, bounds); !parked || !actionable {
+		t.Fatalf("agent_status unknown: parked=%t actionable=%t, want both true - unknown corroborates nothing", parked, actionable)
+	}
+}
+
+// atqamz/hand#492's own reproduction: a worker mid-turn past its report silence bound is demonstrably
+// alive by `hand reconcile`'s own account, and the fleet decision orient's next action reads must not
+// contradict it inside the same binary.
+func TestOrientDoesNotFlagParkedWhileReconcileFindsALiveWorker(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	t.Setenv("HAND_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config", "parked-other-bound"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	task := state.Task{ID: "283-npm-distribution", Project: "demo", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)}
+	launchConfirmedAt := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	attempt := state.Attempt{Lifecycle: state.AttemptRunning, Harness: "claude",
+		Herdr:             state.Herdr{WorkspaceID: "ws-1", TabID: "tab-1", PaneID: "pane-1"},
+		LaunchSubmittedAt: launchConfirmedAt, LaunchConfirmedAt: launchConfirmedAt}
+	if err := writeTaskAttempt(t, home, task, attempt); err != nil {
+		t.Fatal(err)
+	}
+	reportPath := state.ReportPath(home, task.ID)
+	if err := os.WriteFile(reportPath, []byte("working: still on the migration\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	silentSince := time.Now().Add(-2 * time.Second)
+	if err := os.Chtimes(reportPath, silentSince, silentSince); err != nil {
+		t.Fatal(err)
+	}
+	faketool.Herdr{
+		Workspaces: []faketool.HerdrWorkspace{{ID: "ws-1", Label: "hand:demo", Tabs: []faketool.HerdrTab{{ID: "tab-1", Label: task.ID, Pane: "pane-1"}}}},
+		PaneAgent:  "claude", PaneStatus: "working",
+	}.Install(t, faketool.Bin(t))
+
+	reconcileCmd := newReconcileCmd()
+	var reconcileOut bytes.Buffer
+	reconcileCmd.SetOut(&reconcileOut)
+	reconcileCmd.SetArgs([]string{task.ID})
+	if err := reconcileCmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(reconcileOut.Bytes(), []byte("liveness: working")) {
+		t.Fatalf("reconcile output = %q, want liveness: working for a worker mid-turn", reconcileOut.String())
+	}
+
+	client, err := currentHerdrClient(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	views, holds, _, err := fleetViews(context.Background(), io.Discard, home, client, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	next := classifyNextAction(workerConfig{harness: "claude"}, 1, backlogSummary{}, views, holds)
+	if next.Kind == nextActionParked {
+		t.Fatalf("next action = %#v, want orient to not call a worker parked while hand reconcile just called the same attempt liveness: working", next)
+	}
+}
+
+// atqamz/hand#492: without the latch, three simultaneously silent-but-live workers each re-present as
+// fresh parked work on every orient, so the noise scales with fleet size, not just per task.
+func TestOrientActionableCountScalesDownOnceAWatcherHasAnnouncedEverySimultaneousPark(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	bounds := watcher.ParkedBounds{Other: 20 * time.Minute}
+	ids := []string{"task-a", "task-b", "task-c"}
+	silentSince := time.Now().Add(-30 * time.Minute)
+
+	for _, id := range ids {
+		task := state.Task{ID: id, Project: "myproj", Kind: state.KindShip,
+			CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)}
+		attempt := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}
+		if err := writeTaskAttempt(t, home, task, attempt); err != nil {
+			t.Fatal(err)
+		}
+		reportPath := state.ReportPath(home, id)
+		if err := os.WriteFile(reportPath, []byte("working: still on the migration\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(reportPath, silentSince, silentSince); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	countActionable := func() int {
+		count := 0
+		for _, id := range ids {
+			attempt := readTaskAttempt(t, home, id)
+			task, err := state.Read(home, id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parked, actionable := taskParked(home, task, attempt, string(herdr.StatusIdle), state.ReportWorking, bounds)
+			if !parked {
+				t.Fatalf("task %s: parked = false, want the naive bound crossed for every task in this fixture", id)
+			}
+			if actionable {
+				count++
+			}
+		}
+		return count
+	}
+
+	if got := countActionable(); got != len(ids) {
+		t.Fatalf("actionable count = %d before any watcher confirmation, want all %d fresh episodes presented", got, len(ids))
+	}
+
+	for _, id := range ids {
+		attempt := readTaskAttempt(t, home, id)
+		if err := state.UpdateAttemptObservation(home, id, attempt.ID, state.AttemptRunning,
+			"", "", false, "", "", silentSince.UTC().Format(time.RFC3339Nano), "", 0, 0, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := countActionable(); got != 0 {
+		t.Fatalf("actionable count = %d once every episode is durably announced, want 0 - the fleet-wide noise atqamz/hand#492's latch fix removes", got)
+	}
+}
+
+// atqamz/hand#492: a one-shot render has no in-memory latch of its own, but reading
+// attempt.ParkedFiredFor back is what keeps an already-announced episode from reading as fresh work.
+func TestTaskParkedIsNotActionableOnceAWatcherHasAlreadyAnnouncedTheSameEpisode(t *testing.T) {
+	home := t.TempDir()
+	mkFleetDirs(t, home)
+	task := state.Task{ID: "task-1", Project: "myproj", Kind: state.KindShip,
+		CreatedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)}
+	reportPath := state.ReportPath(home, task.ID)
+	if err := os.WriteFile(reportPath, []byte("working: still on the migration\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	silentSince := time.Now().Add(-30 * time.Minute)
+	if err := os.Chtimes(reportPath, silentSince, silentSince); err != nil {
+		t.Fatal(err)
+	}
+	bounds := watcher.ParkedBounds{Other: 20 * time.Minute}
+
+	fresh := state.Attempt{Lifecycle: state.AttemptRunning, Herdr: state.Herdr{PaneID: "wA:pB"}}
+	if err := writeTaskAttempt(t, home, task, fresh); err != nil {
+		t.Fatal(err)
+	}
+	if parked, actionable := taskParked(home, task, fresh, string(herdr.StatusIdle), state.ReportWorking, bounds); !parked || !actionable {
+		t.Fatalf("no watcher has confirmed this episode yet: parked=%t actionable=%t, want both true", parked, actionable)
+	}
+
+	announced := fresh
+	announced.ParkedFiredFor = silentSince.UTC().Format(time.RFC3339Nano)
+	if parked, actionable := taskParked(home, task, announced, string(herdr.StatusIdle), state.ReportWorking, bounds); !parked || actionable {
+		t.Fatalf("a watcher already announced this exact episode: parked=%t actionable=%t, want parked but not fresh work", parked, actionable)
+	}
+
+	stale := fresh
+	stale.ParkedFiredFor = silentSince.Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	if parked, actionable := taskParked(home, task, stale, string(herdr.StatusIdle), state.ReportWorking, bounds); !parked || !actionable {
+		t.Fatalf("the recorded latch is for a different, earlier episode: parked=%t actionable=%t, want both true", parked, actionable)
 	}
 }
 
@@ -1054,7 +1302,7 @@ func TestTaskParkedAndGateRunAppliesStopOnceTheTaskIsDelivered(t *testing.T) {
 	}
 	bounds := watcher.ParkedBounds{Done: 20 * time.Minute, Other: 20 * time.Minute}
 
-	if !taskParked(home, task, attempt, state.ReportDone, bounds) {
+	if parked, _ := taskParked(home, task, attempt, string(herdr.StatusIdle), state.ReportDone, bounds); !parked {
 		t.Fatal("an undelivered task past its bound was not flagged parked, want the existing done-bounded behavior intact")
 	}
 	if !gateRunApplies(task, true) {
@@ -1062,7 +1310,7 @@ func TestTaskParkedAndGateRunAppliesStopOnceTheTaskIsDelivered(t *testing.T) {
 	}
 
 	task.DeliveredAt = "2026-08-17T00:00:00Z"
-	if taskParked(home, task, attempt, state.ReportDone, bounds) {
+	if parked, _ := taskParked(home, task, attempt, string(herdr.StatusIdle), state.ReportDone, bounds); parked {
 		t.Fatal("a delivered task was still flagged parked, want the silence exempt")
 	}
 	if gateRunApplies(task, true) {

--- a/cmd/statusview.go
+++ b/cmd/statusview.go
@@ -37,9 +37,12 @@ type taskView struct {
 	// computed only for an open task's one running attempt; see buildTaskView.
 	unreachable bool
 	parked      bool
-	latestSend  *state.SendAttempt
-	held        bool
-	hold        state.Hold
+	// Whether parked belongs in a supervisor's work queue rather than only in this render: see
+	// taskParked and atqamz/hand#492. Meaningless when parked is false.
+	parkedActionable bool
+	latestSend       *state.SendAttempt
+	held             bool
+	hold             state.Hold
 	// What hold.BlockedOn resolves to right now, meaningful only when held && hold.Kind ==
 	// state.HoldKindBlocked - see resolveBlocker in status.go (atqamz/hand#417).
 	holdBlocker blockerState
@@ -158,6 +161,7 @@ func taskAttentionEvidence(v taskView) attention.Evidence {
 		RuntimeUnknown:   runtimeUnknown(v),
 		Unreachable:      v.unreachable,
 		Parked:           v.parked,
+		ParkedActionable: v.parkedActionable,
 		Repair:           v.task.RepairCode != "",
 		ReportClaim:      v.reportedState != "",
 		ReportedState:    v.reportedState,

--- a/docs/adr/attention-is-one-derivation-over-three-channels.md
+++ b/docs/adr/attention-is-one-derivation-over-three-channels.md
@@ -161,3 +161,9 @@ Announcement and acknowledgement are now distinct words and output fields.
 `ghutil.ObservationState` becomes the vocabulary a new observation reuses rather than restates, so the count of found/absent/unknown types stops growing with the count of things hand observes.
 Any new attention condition is one edit that both `hand status` and `hand watch` inherit, and a consumer that wants less filters rather than redefines.
 A disagreement between channels becomes something a supervisor can read directly instead of discovering when a later command refuses a precondition.
+
+atqamz/hand#492 found `KindParked`'s naive, uncorroborated verdict presented as actionable on every `hand orient`, forever, because `cmd/status.go`'s `taskParked` had neither `ClassifyParked`'s pane corroboration nor its latch.
+The fix stays inside invariant 5 rather than opening a fourth channel: `attention.Evidence` gained one field, `ParkedActionable`, and `taskAttentionEvidence` derives it from two facts a one-shot render already has cheaply - a pane this same render observed working or blocked, the same runtime observation `hand reconcile` calls `liveness: working`, and `attempt.ParkedFiredFor`, the durable half of `ClassifyParked`'s own latch that a watcher has already confirmed and announced.
+`hand status` and `hand orient` were free to diverge here - a status render showing an uncorroborated park is arguably honest reporting, where an orient next-action is an instruction - but they were kept unified instead: both read `Derive`'s one `Actionable` verdict, so a corrected fact reaches both audiences rather than becoming a second definition to keep in sync.
+Only actionability changed.
+The naive verdict itself still renders as `hand status`'s `parked` flag unconditionally, since that display was already legitimate reporting and raising `parked-other-bound` was never the fix.

--- a/internal/attention/attention.go
+++ b/internal/attention/attention.go
@@ -45,6 +45,9 @@ type Evidence struct {
 	RuntimeUnknown   bool
 	Unreachable      bool
 	Parked           bool
+	// Whether the naive Parked verdict is corroborated enough to be actionable rather than only
+	// reported, meaningless when Parked is false (atqamz/hand#492).
+	ParkedActionable bool
 	Repair           bool
 	SendUncertain    bool
 	SendPending      bool
@@ -95,7 +98,7 @@ func Derive(e Evidence) []Subject {
 		add(KindUnreachable, "worker runtime is unreachable", ProvenanceRuntime, true)
 	}
 	if e.Parked {
-		add(KindParked, "worker has exceeded its report silence bound", ProvenanceRuntime, true)
+		add(KindParked, "worker has exceeded its report silence bound", ProvenanceRuntime, e.ParkedActionable)
 	}
 	if e.Repair {
 		add(KindNeedsRepair, "task needs repair", ProvenanceRepair, true)

--- a/internal/attention/attention_test.go
+++ b/internal/attention/attention_test.go
@@ -117,6 +117,29 @@ func TestDeriveOmitsHoldSatisfiedWhenNotSet(t *testing.T) {
 	}
 }
 
+// atqamz/hand#492: Parked alone is not enough to earn a supervisor's attention - the naive verdict
+// still renders (Parked stays a subject either way), but only a corroborated one is actionable.
+func TestDeriveRequiresParkedActionableForAttention(t *testing.T) {
+	uncorroborated := Derive(Evidence{ID: "task-1", Parked: true})
+	if len(uncorroborated) != 1 || uncorroborated[0].Kind != KindParked {
+		t.Fatalf("subjects = %#v, want one uncorroborated parked subject", uncorroborated)
+	}
+	if uncorroborated[0].Actionable {
+		t.Fatal("an uncorroborated park is actionable")
+	}
+	if NeedsAttention(Evidence{ID: "task-1", Parked: true}) {
+		t.Fatal("an uncorroborated park needs attention")
+	}
+
+	corroborated := Derive(Evidence{ID: "task-1", Parked: true, ParkedActionable: true})
+	if len(corroborated) != 1 || !corroborated[0].Actionable {
+		t.Fatalf("subjects = %#v, want a corroborated, actionable parked subject", corroborated)
+	}
+	if !NeedsAttention(Evidence{ID: "task-1", Parked: true, ParkedActionable: true}) {
+		t.Fatal("a corroborated park does not need attention")
+	}
+}
+
 func TestUnreportedRuntimeMatchesWatcherCatchUpRule(t *testing.T) {
 	for _, test := range []struct {
 		runtime, reported string

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -412,6 +412,14 @@ func Parked(lastReportState, deliveredAt string, silentSince, now time.Time, bou
 	return now.Sub(silentSince) >= bound
 }
 
+// AlreadyAnnounced is the durable half of ClassifyParked's own latch, exported so cmd/statusview.go
+// can ask it too: a one-shot render has no in-memory ts.ParkedFiredFor, but attempt.ParkedFiredFor
+// already carries whichever watcher last confirmed and announced this episode (atqamz/hand#492).
+func AlreadyAnnounced(a state.Attempt, silentSince time.Time) bool {
+	fired := parkedFiredSeed(a)
+	return !fired.IsZero() && fired.Equal(silentSince)
+}
+
 // mtime is deliberately never reset to "now" on resume: --until-event restarts on
 // every delivered event, and a busy fleet would otherwise erase the clock before
 // it ever completes once.

--- a/internal/watcher/events_test.go
+++ b/internal/watcher/events_test.go
@@ -579,6 +579,26 @@ func TestClassifyParkedFiresOncePerEpisodeAndResetsOnGrowth(t *testing.T) {
 	}
 }
 
+// atqamz/hand#492: the durable read-back of the same latch
+// TestClassifyParkedFiresOncePerEpisodeAndResetsOnGrowth exercises from the in-memory side.
+func TestAlreadyAnnounced(t *testing.T) {
+	silentSince := time.Now().Add(-30 * time.Minute)
+	if AlreadyAnnounced(state.Attempt{}, silentSince) {
+		t.Fatal("an attempt with no recorded latch is already announced")
+	}
+	announced := state.Attempt{ParkedFiredFor: silentSince.UTC().Format(time.RFC3339Nano)}
+	if !AlreadyAnnounced(announced, silentSince) {
+		t.Fatal("an attempt latched for this exact silence instant is not already announced")
+	}
+	stale := state.Attempt{ParkedFiredFor: silentSince.Add(-time.Hour).UTC().Format(time.RFC3339Nano)}
+	if AlreadyAnnounced(stale, silentSince) {
+		t.Fatal("a latch recorded for a different, earlier episode reads as already announced")
+	}
+	if AlreadyAnnounced(state.Attempt{ParkedFiredFor: "not-a-time"}, silentSince) {
+		t.Fatal("an unparseable latch reads as already announced")
+	}
+}
+
 func TestClassifyReportLineAgainstDogfoodData(t *testing.T) {
 	home := t.TempDir()
 	ts := NewTaskState(herdr.StatusWorking, time.Now())


### PR DESCRIPTION
## Summary

- `taskParked` (cmd/status.go) recomputed the naive silence-bound check on every render, with neither `ClassifyParked`'s pane corroboration nor its `ParkedFiredFor` latch, so `orient`'s `orientation_actionable`/`next_action` kept presenting the same uncorroborated park as fresh work on every cycle - even for a demonstrably live worker.
- `taskParked` now also reports whether the naive verdict is actionable: a pane this same render observed `working`/`blocked` (the same evidence `hand reconcile` calls `liveness: working`), or a watcher's own durable confirmation of the same silence episode (`attempt.ParkedFiredFor`), both keep it out of a supervisor's work queue without suppressing the naive flag `hand status` already renders.
- `internal/attention.Evidence` gained one shared field, `ParkedActionable`, so `hand status` and `hand orient` stay on one definition of attention per `docs/adr/attention-is-one-derivation-over-three-channels.md` instead of diverging - documented that decision in the ADR.

Fixes atqamz/hand#492

## Test plan

- [x] `go test -tags=test ./...`
- [x] `go test -tags=test -race ./cmd/... ./internal/attention/... ./internal/watcher/...`
- [x] `make lint` (gofmt, go vet, golangci-lint, commentlint)
- [x] New regression test reproducing the issue's exact repro: a worker mid-turn past its report silence bound, showing `hand reconcile` answers `liveness: working` while `orient`'s decision no longer calls it `parked` (`TestOrientDoesNotFlagParkedWhileReconcileFindsALiveWorker`)
- [x] New fleet-scale test showing the latch removes noise proportional to fleet size, not just per task (`TestOrientActionableCountScalesDownOnceAWatcherHasAnnouncedEverySimultaneousPark`)