### PR TITLE
fix(steering): anchor Tab confirmation on the composer's last block

### DIFF
--- a/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
+++ b/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
@@ -94,6 +94,39 @@ check ran its full bounded poll and correctly reported `not-submitted` / `compos
 with `RetrySafe` false - confirmed against both the CLI output and a direct pane read afterward. No
 poll-window or retry-behavior change of any kind is part of this amendment.
 
+A second, independent live reproduction - from the operator's own supervision loop, not this task's
+testing, and later corroborated on a second, unrelated worker (different task, worktree, and model
+profile), for four false `not-submitted` verdicts across two workers in total - surfaced a third pane
+shape: the queue label still on screen, the hosting turn still running, a background terminal attached,
+and the queued message itself shown truncated with an ellipsis under `codexQueuedMarker`, exactly as
+codex renders a long queued item. Reproducing that shape alone (busy turn, background terminal, intact
+label, ellipsis-truncated preview, greyed composer placeholder) against the unfixed binary, six times
+running, did not reproduce a failure - the label being present and correct was not sufficient by itself.
+Instrumenting the confirmation poll to log each read's raw text found the actual trigger: the same or
+overlapping message content already sitting in that worker's scrollback, promoted to ordinary "›"
+history from an earlier send, above the currently-intact label. `codexQueuedMarker`'s truncation
+(`text[:idx]`) excludes only what comes after the label; it does nothing about an older copy above it,
+and `composerRetains`'s chunk search finds that older copy regardless of whether the current queue
+attempt itself succeeded. A control send of never-before-seen text, under the identical busy-turn,
+background-terminal, host-CPU-load conditions, confirmed correctly within two poll iterations -
+isolating scrollback repetition, not turn state or system load, as the necessary trigger. The background
+terminal itself was checked separately and is incidental, not causal: both operator workers were holding
+one, but a plain (non-`--force`) send treats an attached background terminal as an indefinitely busy
+composer and simply waits out its own timeout without ever reaching the Tab path, which is why `--force`
+was the only way either worker's send got text in at all - the terminal explains why `--force` was
+needed, not why the confirmation was wrong. The same repeated-content trigger, on the unfixed binary,
+reproduced identically against a busy turn holding no background terminal at all, generating nothing but
+streamed reasoning text. `lastComposerBlock` is unaffected by this mechanism for the same structural
+reason it is unaffected by the first: it never looks at anything before the composer's own final block,
+so an older copy anywhere earlier in scrollback, however similar, cannot be found by a search that never
+reaches it - with or without a background terminal attached. Verified directly: the fixed binary
+correctly reported `submitted` against the identical poisoned-scrollback, busy, host-loaded pane, both
+with and without a background terminal attached, each confirmed against a direct pane read showing the
+message genuinely and correctly queued. `TestComposerRetains`'s "an earlier copy already sits in history
+above an intact, still-visible queue label" case pins this - run against a reconstruction of the old
+truncation logic directly, it returns `true`, reproducing the exact defect, where the current code
+returns `false`.
+
 ## Rejected alternatives
 
 Confirming the Enter path the same way was tried and reverted. `composerRetains` cannot distinguish a message still sitting unsent at the live composer from the identical text remaining visible as a `>`-prefixed history line after a genuinely successful send, because Herdr's read window carries both without marking which is which the way `codexQueuedMarker` marks a queue. The failure was not rare - it reproduced on the next live Enter send tried - and its retry compounded it into an actual duplicate message delivered to the worker, not merely a wrong label. Fixing this needs either a narrower read window (whose tradeoffs against atqamz/hand#420's own interior-slice-corruption evidence are unverified) or a positive "the harness reacted" signal in place of an absence check; both are undeveloped and belong to the still-open atqamz/hand#420, not this decision.
@@ -110,4 +143,4 @@ Retrying a send that failed to confirm was built, live-tested, and removed: its 
 
 atqamz/hand#426 is closed by this decision. atqamz/hand#420 is not: an Enter send still reports `submitted` on the strength of two RPCs alone, exactly as [Steering records terminal submission uncertainty](steering-records-terminal-submission-uncertainty.md) already described, and stays open for a signal that survives an accepted message remaining visible in history. The amendment above is that signal; #420 is closed as of it.
 
-atqamz/hand#478 is closed by the second amendment above: the Tab path's confirmation no longer depends on `codexQueuedMarker` still being on screen, so a hosting turn ending mid-poll no longer reads as a stuck composer.
+atqamz/hand#478 is closed by the second amendment above: the Tab path's confirmation no longer depends on `codexQueuedMarker` still being on screen or on nothing resembling the sent text appearing earlier in scrollback, so neither a hosting turn ending mid-poll nor an older, already-delivered copy of similar text sitting in history reads as a stuck composer.

--- a/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
+++ b/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
@@ -63,6 +63,23 @@ genuinely stuck, and interrupted-back-to-composer). `lastComposerBlock` isolates
 disappear. A message under the queue label still confirms, for the same reason as before: it precedes
 the final block, never sits inside it. `codexQueuedMarker` is removed with nothing left referencing it.
 
+`lastComposerBlock` anchors on the *last* `"\n›"`, which raises an obvious question: what if the sent
+message's own content contains a line starting with that glyph? The anchor would then fall inside the
+message instead of at the composer's true start, `composerRetains` would search only the tail from
+there on, and if that tail is short enough to fall under `confirmChunkSize/2`, a genuinely stuck message
+could read as not retained - the false-submitted direction the issue calls strictly worse than the bug
+it fixes. Checked directly against the rig rather than by reading the renderer: codex indents every line
+of a composer or history entry after its first with two leading spaces, whether that line comes from a
+literal newline in the sent text or from the terminal's own soft-wrap - and `recent-unwrapped` reverses
+soft-wrap breaks before hand ever reads them, so a wrap-induced "›" can never surface as a fresh line at
+all. Typed multi-line unsent text directly into a live, uncommitted composer - the glyph on an interior
+line, on a short final line, and separated from the first line by a blank line - and every line after
+the first rendered with the indent intact, never flush at column 0. Separately swept five candidate wrap
+columns with the glyph placed at each and never once saw the unwrapped read produce a raw `"\n›"` from a
+soft wrap. A `"\n›"` with nothing between the newline and the glyph is therefore only ever a genuine
+entry boundary - the live composer's own start, or a promoted history line's - never something a
+message's own content can produce, regardless of what characters it contains.
+
 Live-validated against a real codex worker in a scratch fleet, across 270-plus sends. The confirmed-
 delivered half has the organic reproduction above as its live evidence, plus a `send_test.go` case built
 from text reconstructed off that reproduction's own post-transition pane read. A live capture separately

--- a/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
+++ b/docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md
@@ -2,7 +2,8 @@
 
 Date: 2026-08-28
 Status: accepted
-Issues: atqamz/hand#426, atqamz/hand#420 (closed by the amendment below), atqamz/hand#459.
+Issues: atqamz/hand#426, atqamz/hand#420 (closed by the amendment below), atqamz/hand#459,
+atqamz/hand#478 (closed by the second amendment below).
 Pull requests: none
 
 ## Context
@@ -31,6 +32,51 @@ Live-validated against a real codex worker: idle and mid-turn, small and 2-6KB m
 
 atqamz/hand#420 and atqamz/hand#426 are both closed by this amendment. The Tab/queue path above is unchanged.
 
+### Amendment - 2026-08-29 (atqamz/hand#478)
+
+The Tab/queue path above was itself the same class of bug the first amendment fixed for Enter, for the
+same underlying reason: `composerRetains`'s truncation excluded text under `codexQueuedMarker`
+("Queued follow-up inputs"), and that marker is not there to exclude once its hosting turn ends and
+codex dequeues the message. Caught organically during this task's own live testing, using the unfixed
+binary against a real codex worker: a mid-turn `hand send` queued cleanly (marker observed, echoing the
+message), then reported `not-submitted` / `composer-retains-message` after the full 10-second poll -
+while the pane transcript, read back afterward, showed the shell command run and the reply delivered,
+in full, exactly once, with no retry and no duplicate. Direct rapid pane reads bypassing `hand` entirely
+then bracketed the mechanism to single-digit milliseconds: the instant the hosting turn ends, codex
+drops the queue label and re-renders the same text as an ordinary "›"-prefixed history line -
+content-identical to a message still sitting unsent - while a fresh empty composer has already opened
+beneath it. A truncation keyed to the label goes blind at exactly that moment, because the label is
+gone by the time the history line exists, so nothing excludes the promoted text from the search.
+
+Two fixes were weighed, the two the issue posed. Porting Enter's `composerHasTail` shape verbatim does
+not work here: Tab is chosen only while codex is busy, and a busy pane's own spinner and elapsed-time
+counter redraw every tick regardless of whether anything was queued, so "differs from a pre-key
+baseline" is nearly always true within one poll interval and cannot serve Enter's role of "the harness
+reacted." Worse, the tail match itself cannot tell a fragment still sitting at the live composer from
+the identical fragment sitting under the queue label or already promoted to history, since all three
+are the same text - Tab's problem is where the fragment is, not whether it exists. Patching the
+truncation to key on something sturdier than the vanishing label - the issue's other framing - had a
+direct answer once the mechanism was in hand: codex always renders the live composer as the final
+"›"-prefixed block, busy or idle, in every state observed (queued-and-waiting, promoted-and-processing,
+genuinely stuck, and interrupted-back-to-composer). `lastComposerBlock` isolates exactly that block;
+`composerRetains`'s Tab check now searches only it, rather than everything up to a label that can
+disappear. A message under the queue label still confirms, for the same reason as before: it precedes
+the final block, never sits inside it. `codexQueuedMarker` is removed with nothing left referencing it.
+
+Live-validated against a real codex worker in a scratch fleet, across 270-plus sends. The confirmed-
+delivered half has the organic reproduction above as its live evidence, plus a `send_test.go` case built
+from text reconstructed off that reproduction's own post-transition pane read. A live capture separately
+bracketed the transition itself to single-digit milliseconds, and hand's own Tab-to-first-read gap is of
+a similar order, so aiming a second live `hand send` at that same gap through external timing alone did
+not also land an end-to-end pass under the fixed binary within this task's testing budget - the risk
+that leaves is bounded by the unit-level proof against the reconstructed real text, not by an
+aspiration. The genuine-non-delivery half was reproduced end-to-end under the fixed binary:
+interrupting codex's own turn a few hundred milliseconds after a real `hand send --force` pressed Tab
+returns the just-queued message to the live composer, unqueued, exactly where it started, and the fixed
+check ran its full bounded poll and correctly reported `not-submitted` / `composer-retains-message`
+with `RetrySafe` false - confirmed against both the CLI output and a direct pane read afterward. No
+poll-window or retry-behavior change of any kind is part of this amendment.
+
 ## Rejected alternatives
 
 Confirming the Enter path the same way was tried and reverted. `composerRetains` cannot distinguish a message still sitting unsent at the live composer from the identical text remaining visible as a `>`-prefixed history line after a genuinely successful send, because Herdr's read window carries both without marking which is which the way `codexQueuedMarker` marks a queue. The failure was not rare - it reproduced on the next live Enter send tried - and its retry compounded it into an actual duplicate message delivered to the worker, not merely a wrong label. Fixing this needs either a narrower read window (whose tradeoffs against atqamz/hand#420's own interior-slice-corruption evidence are unverified) or a positive "the harness reacted" signal in place of an absence check; both are undeveloped and belong to the still-open atqamz/hand#420, not this decision.
@@ -46,3 +92,5 @@ Retrying a send that failed to confirm was built, live-tested, and removed: its 
 `hand send`'s cost is unchanged from before this task for every non-codex harness. A codex-harness pane costs one extra exec to choose Enter or Tab; if Tab is chosen, confirming it costs one more in the common case of an immediate clear, or more within the bounded poll if it is not immediate.
 
 atqamz/hand#426 is closed by this decision. atqamz/hand#420 is not: an Enter send still reports `submitted` on the strength of two RPCs alone, exactly as [Steering records terminal submission uncertainty](steering-records-terminal-submission-uncertainty.md) already described, and stays open for a signal that survives an accepted message remaining visible in history. The amendment above is that signal; #420 is closed as of it.
+
+atqamz/hand#478 is closed by the second amendment above: the Tab path's confirmation no longer depends on `codexQueuedMarker` still being on screen, so a hosting turn ending mid-poll no longer reads as a stuck composer.

--- a/internal/steering/send.go
+++ b/internal/steering/send.go
@@ -110,11 +110,6 @@ func ConfigureSendConfirmPollingForTest(interval, timeout time.Duration, readLin
 // chooseSubmitKey only ever reads it for the codex harness.
 const codexQueueDiscriminator = "tab to queue message"
 
-// What codex prints above the composer once Tab has queued a message: the message itself, echoed back
-// verbatim under this label (live-verified against a real busy codex pane). Without excluding it,
-// composerRetains would misread a successful queue as the composer still stuck holding the message.
-const codexQueuedMarker = "Queued follow-up inputs"
-
 // Picks Enter, or Tab for a codex pane showing its own queue discriminator. The read is unconditional
 // now: its text doubles as submissionOutcome's pre-key baseline for the Enter path (atqamz/hand#459). A
 // read failure still falls back to Enter but is reported so submissionOutcome lands on Uncertain.
@@ -138,14 +133,22 @@ func stripWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), "")
 }
 
-// Reports whether text still shows a recognizable fragment of sent. When key is "Tab", a successful
-// queue echoes sent verbatim under codexQueuedMarker - expected confirmation, not a stuck composer -
-// so that marker and everything after it is excluded from the comparison first.
+// Codex renders the live composer as the final "›"-prefixed block, busy or idle. atqamz/hand#478:
+// a dequeued message is re-rendered as an ordinary "›" history line first, so only the last such
+// block is ever the composer - anything before it, marker-queued or already history, is not stuck.
+func lastComposerBlock(text string) string {
+	if idx := strings.LastIndex(text, "\n›"); idx >= 0 {
+		return text[idx+1:]
+	}
+	return text
+}
+
+// Reports whether text still shows a recognizable fragment of sent. When key is "Tab", only the live
+// composer's own final block (lastComposerBlock) can answer that; a fragment anywhere else - queued
+// under codex's label, or already promoted to history - is not a stuck composer.
 func composerRetains(text, sent, key string) bool {
 	if key == "Tab" {
-		if idx := strings.Index(text, codexQueuedMarker); idx >= 0 {
-			text = text[:idx]
-		}
+		text = lastComposerBlock(text)
 	}
 	haystack := stripWhitespace(text)
 	needle := stripWhitespace(sent)
@@ -325,8 +328,8 @@ func enterConfirms(client Client, paneID, sent, preKeyText string) (confirmed, r
 	return confirmed, lastText != preKeyText, nil
 }
 
-// Tab gets a composer-content confirmation because codexQueuedMarker gives composerRetains a real
-// truncation point. Enter instead requires the pre-key baseline and a positive tail match (enterConfirms)
+// Tab confirms via the composer's own final-block position (lastComposerBlock), needing no baseline.
+// Enter has no such anchor, so it needs the pre-key baseline and a positive tail match (enterConfirms)
 // - preKeyErr non-nil means that baseline read failed, so the send is honestly uncertain, not confirmed.
 func submissionOutcome(client Client, paneID, message, key, preKeyText string, preKeyErr error) (state.SendState, string, bool, bool) {
 	if key == "Tab" {

--- a/internal/steering/send_test.go
+++ b/internal/steering/send_test.go
@@ -558,6 +558,75 @@ func TestExecuteDoesNotConfirmCodexTabWhenMessageStaysInTheLiveComposer(t *testi
 	}
 }
 
+// Live reproduction of atqamz/hand#478, caught by rapid direct pane reads against a real codex worker:
+// the instant a Tab-queued message's hosting turn ended, codex dropped "Queued follow-up inputs" and
+// re-rendered the same text as an ordinary "›" history line, above a fresh empty composer.
+func TestExecuteConfirmsCodexTabWhenItsHostingTurnEndedDuringThePoll(t *testing.T) {
+	useFastSendConfirmPolling(t)
+	home, _ := newSteeringHome(t)
+	db, err := store.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateTask(state.Task{ID: "task-codex", Lifecycle: state.TaskOpen}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateAttempt(state.Attempt{TaskID: "task-codex", Lifecycle: state.AttemptRunning, Harness: "codex",
+		Herdr: state.Herdr{Session: "session-1", WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1"}}); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	const message = "please pause and wait for review"
+	pane := &testPane{
+		pane: herdr.Pane{PaneID: "pane-1", TabID: "tab-1", WorkspaceID: "workspace-1", AgentStatus: herdr.StatusWorking},
+		readResponses: []string{
+			"• Working (8s • esc to interrupt)\n\ntab to queue message   92% context left",
+			"• Ran sleep 8 && echo natural-done\n  └ natural-done\n\n───────────────────────────\n\n" +
+				"› " + message + "\n\n\n› \n\ngpt-5.6-luna max",
+		},
+	}
+	result, err := Execute(Request{Home: home, TaskID: "task-codex", Message: message, Origin: state.SendOriginOperator, Client: pane, Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Send.State != state.SendSubmitted {
+		t.Fatalf("result = %+v, want submitted: the turn ending mid-poll promoted the queued message to history, it did not lose it", result.Send)
+	}
+	if len(pane.textCalls) != 1 || len(pane.keyCalls) != 1 {
+		t.Fatalf("calls=%v/%v, want no retry", pane.textCalls, pane.keyCalls)
+	}
+}
+
+func TestLastComposerBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "no composer line at all falls back to the full text", text: "• Ran go test ./...\n  ok", want: "• Ran go test ./...\n  ok"},
+		{name: "a single composer line at the very start is already the whole text", text: "› hello", want: "› hello"},
+		{
+			name: "history above, live composer below: only the last block is kept",
+			text: "› first turn, now history\n\n• done\n\n› second turn, still live",
+			want: "› second turn, still live",
+		},
+		{
+			// atqamz/hand#478: a dequeued message promoted to a "›" history line must not be mistaken
+			// for the live composer just because it starts with the same glyph the composer uses.
+			name: "a dequeued message promoted to history is not the final block",
+			text: "• Ran sleep 8\n  └ done\n\n› promoted queued message\n\n› \n\ngpt-5.6-luna max",
+			want: "› \n\ngpt-5.6-luna max",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lastComposerBlock(tt.text); got != tt.want {
+				t.Fatalf("lastComposerBlock() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestComposerRetains(t *testing.T) {
 	const sent = "Please stop and wait for review before merging this pull request, thanks in advance."
 	tests := []struct {
@@ -597,6 +666,15 @@ func TestComposerRetains(t *testing.T) {
 			text: "› " + sent + "\n\ntab to queue message   90% context left",
 			key:  "Tab",
 			want: true,
+		},
+		{
+			// atqamz/hand#478: live-reproduced by reading a real codex pane the instant a queued
+			// message's hosting turn ended. The queue label is already gone, and the message now reads
+			// as an ordinary "›" history line - but it precedes the true final block, an empty composer.
+			name: "queue label gone, message promoted to history, fresh composer beneath it",
+			text: "• Ran sleep 8\n  └ done\n\n› " + sent + "\n\n\n› \n\ngpt-5.6-luna max",
+			key:  "Tab",
+			want: false,
 		},
 		{
 			// The exclusion is specific to a Tab attempt; an Enter attempt gets no special-casing even

--- a/internal/steering/send_test.go
+++ b/internal/steering/send_test.go
@@ -617,6 +617,14 @@ func TestLastComposerBlock(t *testing.T) {
 			text: "• Ran sleep 8\n  └ done\n\n› promoted queued message\n\n› \n\ngpt-5.6-luna max",
 			want: "› \n\ngpt-5.6-luna max",
 		},
+		{
+			// Live-verified against a real composer: a sent message's own line starting with "›" is
+			// rendered indented ("  › ..."), never flush at column 0, so it can never be mistaken for
+			// the composer's own boundary. If it could, a stuck message would wrongly read as gone.
+			name: "the message's own glyph-prefixed line is indented, not a false composer boundary",
+			text: "› a genuinely stuck long unsent instruction line here\n  › ok",
+			want: "› a genuinely stuck long unsent instruction line here\n  › ok",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/steering/send_test.go
+++ b/internal/steering/send_test.go
@@ -685,6 +685,15 @@ func TestComposerRetains(t *testing.T) {
 			want: false,
 		},
 		{
+			// Live-reproduced under real CPU load against a long-lived worker: an earlier send of the
+			// same text already promoted to history, with the label still on screen and intact below it.
+			// A truncation keyed on the label's position alone would still see this older copy above it.
+			name: "an earlier copy already sits in history above an intact, still-visible queue label",
+			text: "› " + sent + "\n\n• Queued follow-up inputs\n  ↳ " + sent + "\n\n› \n",
+			key:  "Tab",
+			want: false,
+		},
+		{
 			// The exclusion is specific to a Tab attempt; an Enter attempt gets no special-casing even
 			// if the literal label string appears somewhere unrelated.
 			name: "the queued label text is irrelevant when the key was Enter, not Tab",


### PR DESCRIPTION
## Summary

- `composerRetains`'s Tab check excluded text under codex's "Queued follow-up inputs" label to avoid misreading a successful queue as a stuck composer. That label is gone the instant its hosting turn ends: codex re-renders the same message as an ordinary "›" history line first, indistinguishable by content from a message still sitting unsent, so the check went blind and reported `not-submitted` for a message that was in fact delivered.
- `lastComposerBlock` anchors the check on codex's own final "›"-prefixed block instead - always the live composer, busy or idle - so a fragment found anywhere before it (queued under the label, or already promoted to history) is confirmation, not a stuck composer. `codexQueuedMarker` is removed with nothing left referencing it.
- The genuine non-delivery case is unchanged in behavior: a message that never leaves the live composer still reports `not-submitted` with `RetrySafe` false.

Fixes atqamz/hand#478

## Test plan

- [x] `make lint` (gofmt, go vet, golangci-lint, commentlint)
- [x] `make test` (`go test -race ./...`)
- [x] `make e2e`
- [x] `make contract`
- [x] Live-validated against a real codex 0.147.0 worker in a scratch fleet, 300+ sends: an organic reproduction of the exact bug was caught with the unfixed binary (mid-turn send queued, timed out `not-submitted`/`composer-retains-message`, while the pane transcript afterward showed the shell command run and the reply delivered in full exactly once) - direct rapid pane reads bypassing `hand` then bracketed the marker-to-history-line transition to single-digit milliseconds, which the new `send_test.go` case reconstructs. The genuine-non-delivery half was reproduced end to end against the fixed binary by interrupting a queued turn mid-poll: the message returns to the live composer, unqueued, and the fixed check correctly reports `not-submitted` after its full bounded poll.
- [x] See the amended ADR (`docs/adr/codex-tab-queue-submission-is-confirmed-by-composer-content.md`) for why Enter's `composerHasTail` shape was rejected for Tab and what was verified live.