### PR TITLE
test(testing-invariants): mutation testing procedure and gate decision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,12 @@ line; a mutant that lives means nothing does, whatever the coverage report says.
 `docs/adr/tests-state-invariants-first-examples-second.md` for why this exists and
 `docs/testing-invariants.md` for the invariants the suite is meant to hold.
 
-It runs per package, on demand, never as part of `make test` or CI. Against 38+ packages whose
-`-race` suite already takes minutes, a full-tree run would take hours and re-running it on every
-push isn't the point - the point is finding out, package by package, where the suite is weaker than
-its coverage number suggests.
+`make mutation` runs per package, on demand, and is never part of `make test`: against 38+ packages
+whose `-race` suite already takes minutes, a full-tree run would take hours, and re-running it on
+every push isn't the point - the point is finding out, package by package, where the suite is weaker
+than its coverage number suggests. Whether (and which of) the packages below belong in CI as an
+actual gate, measured rather than assumed, is decided in
+`docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md`.
 
 ### Package scope
 
@@ -227,8 +229,7 @@ Real numbers, in sweep order, all with `--tags=test` and a cleared test cache:
 *`internal/age`'s 7 "not covered" are confirmed false by `go tool cover -func` (both functions report
 100.0% real statement coverage, boundary values included) - gremlins cannot see coverage for a
 tagless `switch`'s case *conditions*, only their bodies, so a mutant placed on the comparison itself
-reads as uncovered no matter how thoroughly it is exercised. Not a suite gap; see the gate-decision
-record for the full reasoning.
+reads as uncovered no matter how thoroughly it is exercised. Not a suite gap.
 
 The four smallest packages cost well under a second to a couple of seconds regardless of settings.
 Non-race execution plus a warm build cache across mutants cuts cost far more than a CI `-race`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,73 +159,107 @@ Useful flags:
 - `--dry-run` finds and counts mutants without running the suite against any of them - it still
   gathers coverage once, but skips the per-mutant test loop, so it is cheap and safe to run on any
   package to size it before committing to a real run. Run this first on `internal/registry`,
-  `internal/store`, and `internal/runtime`; it turns the estimate table into an exact count before
-  the expensive part starts.
+  `internal/store`, and `internal/runtime`.
 - `--workers=N` / `--test-cpu=N` bound concurrency. On a machine already doing other work, check
   `uptime` and `nproc` first and pick something conservative; gremlins otherwise defaults to using
   the whole machine.
 - `-o results.json` writes a machine-readable report alongside the terminal output.
 
+### Timeout coefficient: measure it, do not guess it
+
+`make mutation` runs `go clean -testcache` before invoking gremlins. This is not optional
+housekeeping - skipping it produces silent false `TIMED OUT` verdicts, and no `--workers` value fixes
+it. Here is why.
+
+Each mutant's timeout is `2s + coefficient x baseline`, where `baseline` is how long gremlins' own
+coverage-gathering pass took (`internal/engine/executor.go` and `internal/coverage/coverage.go` in
+the pinned `v0.6.0` source, in your module cache once installed). That pass is a plain
+`go test -cover -coverprofile=...` with no `-count=1`. On a host that has already tested this
+package's unmodified source with byte-identical content - close to guaranteed when several worktrees
+of the same repo are in play - Go's test cache answers in well under a second, regardless of how long
+the suite actually takes. The coefficient then multiplies a fake number, the resulting timeout is far
+below what a real mutant run needs, and every covered mutant times out - not because anything hung,
+but because gremlins never measured its own baseline for real. More workers make this worse, not
+better, since it was never a concurrency problem.
+
+Confirmed against `internal/store`: gremlins logged its baseline as `177.563505ms`; running its exact
+coverage command by hand reproduced that number twice, both marked `(cached)`; `go clean -testcache`
+then made the identical command take 2.928s with no cache marker - the real figure, off by roughly
+16x from the cached one.
+
+`go clean -testcache` right before gremlins runs makes the baseline real, which is what actually
+fixes this - not a large `--timeout-coefficient`. Size the coefficient from a real measurement, not a
+guess: clear the cache, time a solo run (`go test -tags=test -count=1 ./internal/PKG`), then time N
+concurrent runs at the `--workers` count you intend to use (`for i in $(seq N); do go test -tags=test
+-count=1 -cpu=<test-cpu> ./internal/PKG >/dev/null 2>&1 & done; wait`) - that second number, with
+margin, is what the timeout needs to clear. Do not raise the coefficient past what that calls for: a
+coefficient generous enough to paper over a real hang defeats the point, since a genuinely
+non-terminating mutant timing out is a real kill signal, not a false one, and a timeout that never
+fires stops catching it.
+
+Real baselines measured this way:
+
+| package | real solo baseline | real cost under the workers used | coefficient used | resulting timeout |
+|---|---|---|---|---|
+| `internal/store` | 2.9s | 4.1-4.6s at 6 workers, `--test-cpu=2` | 5 | 16.5s |
+| `internal/runtime` | 19.6s | 49.6-56.5s at 8 workers, `--test-cpu=2` | 9 | ~182s |
+
+`internal/completion` hit this same failure before the cause above was understood - every covered
+mutant timed out even at `--workers=1` (baseline suite runs in 0.085s locally; nothing was slow) -
+and was resolved by raising `--timeout-coefficient` to 100 without yet knowing why that worked. That
+value is larger than the method above would have called for; it works, but a future re-run of that
+package should remeasure properly instead of reusing 100 by habit.
+
 ### How long it takes
 
-Cost is (mutants gremlins finds in covered code) x (one test-run wall-clock for that package).
-Two real numbers anchor the estimate below: `internal/shellquote` mutation-tested end to end in
-0.46s total for 2 mutants (measured locally, gremlins v0.6.0, `--workers=1`); every package's own
-single-run wall-clock, without gremlins, is visible in any CI test job log as the `ok  <pkg>  <N>s`
-line (`-race`, so a real ceiling rather than what gremlins itself pays - gremlins does not run
-`-race`, and reuses the build cache across mutants, both of which make the real number lower than a
-naive multiplication).
+Real numbers, in sweep order, all with `--tags=test` and a cleared test cache:
 
-Mutant counts below are a static upper bound, not gremlins' own count: an AST walk over each
-package's non-test `.go` files counting nodes matching the five default operators above, with no
-coverage information (gremlins additionally drops any site the test suite never executes, so its
-real "Runnable" count will be at or below this). The walk reproduced `internal/shellquote`'s real
-count exactly (2), which is the only package checked against ground truth.
+| package | total mutants | killed | lived | not covered | wall-clock | settings |
+|---|---|---|---|---|---|---|
+| `internal/shellquote` | 2 | 2 | 0 | 0 | 0.46s | 1 worker |
+| `internal/age` | 9 | 2 | 0 | 7* | 0.59s | 1 worker |
+| `internal/axi` | 6 | 6 | 0 | 0 | 1.3s | 1 worker |
+| `internal/completion` | 31 | 20 | 3 | 8 | 13.4s | 1 worker, coefficient 100 |
+| `internal/registry` | 116 | 106 | 0 | 10 | 32.9s | 8 workers, coefficient 20 |
+| `internal/store` | 829 | 622 | 0 | 207 | 5m30s | 6 workers, coefficient 5 |
+| `internal/runtime` | 832 | see the phase 7 gate-decision record | | | | 8 workers, coefficient 9 |
 
-| package | candidate mutants (ceiling) | single-run wall-clock (`-race`, CI) | estimated total |
-|---|---|---|---|
-| `internal/shellquote` | 2 | 1.3s | measured: 0.46s |
-| `internal/age` | 6 | 1.0s | a few seconds |
-| `internal/axi` | 6 | 1.1s | a few seconds |
-| `internal/completion` | 32 | 1.4s | tens of seconds |
-| `internal/registry` | 116 | 56.9s | tens of minutes, likely under two hours |
-| `internal/store` | 880 | 79.8s | hours |
-| `internal/runtime` | 1001 | 330.0s | plausibly a full day or more at 1 worker |
+*`internal/age`'s 7 "not covered" are confirmed false by `go tool cover -func` (both functions report
+100.0% real statement coverage, boundary values included) - gremlins cannot see coverage for a
+tagless `switch`'s case *conditions*, only their bodies, so a mutant placed on the comparison itself
+reads as uncovered no matter how thoroughly it is exercised. Not a suite gap; see the gate-decision
+record for the full reasoning.
 
-The four smallest packages are not a scheduling concern; their whole per-mutant cost is dominated by
-fixed build overhead that a warm cache erases, which is exactly what the shellquote anchor shows (a
-naive mutants x CI-time multiplication predicts 2.7s; the real run took 0.46s, roughly a sixth of
-that). `internal/registry`, `internal/store`, and `internal/runtime` are different: most of their
-per-run wall-clock is real test execution - SQLite files, faked subprocess tools, timing-sensitive
-waits - that a warm build cache does not shrink, so their naive ceiling (mutants x CI `-race` time)
-is a more trustworthy starting point than the shellquote discount, even though dropping `-race` still
-buys something back. On that basis, `internal/registry` likely fits in the same window as the four
-small packages; `internal/store` and, especially, `internal/runtime` should each get their own
-window and their own `--workers` allocation, not a slice of one shared with the rest - see the phase
-7 gate-decision record in `docs/adr/` for the real measured numbers once those runs have happened.
+The four smallest packages cost well under a second to a couple of seconds regardless of settings.
+`internal/registry` finished in 33 seconds once run for real - non-race execution plus a warm build
+cache across mutants cuts cost far more than a CI `-race` baseline would suggest, for every package
+size, not only tiny ones. `internal/store` and `internal/runtime` are the two that need their own
+`--workers` allocation and a coefficient sized from a real measured baseline (above), not because
+they are slow to kill mutants but because they are large enough that a cache-hit baseline's error is
+large in absolute seconds.
 
 ### Per-package plan
 
-The literal command for each package in scope, in run order - cheapest first, `--dry-run` before any
-full run on a package sized in the tens of minutes or more:
+The commands that actually ran clean, in sweep order - not a starting guess, a record of what worked:
 
 ```sh
 make mutation PKG=./internal/age
 make mutation PKG=./internal/axi
-make mutation PKG=./internal/completion
+make mutation PKG=./internal/completion GREMLINS_FLAGS='--timeout-coefficient=100'
 make mutation PKG=./internal/registry GREMLINS_FLAGS='--dry-run'
-make mutation PKG=./internal/registry GREMLINS_FLAGS='--workers=4 --test-cpu=2'
+make mutation PKG=./internal/registry GREMLINS_FLAGS='--workers=8 --test-cpu=2 --timeout-coefficient=20'
 make mutation PKG=./internal/store GREMLINS_FLAGS='--dry-run'
-make mutation PKG=./internal/store GREMLINS_FLAGS='--workers=8 --test-cpu=2'
+make mutation PKG=./internal/store GREMLINS_FLAGS='--workers=6 --test-cpu=2 --timeout-coefficient=5'
 make mutation PKG=./internal/runtime GREMLINS_FLAGS='--dry-run'
-make mutation PKG=./internal/runtime GREMLINS_FLAGS='--workers=8 --test-cpu=2'
+make mutation PKG=./internal/runtime GREMLINS_FLAGS='--workers=8 --test-cpu=2 --timeout-coefficient=9'
 ```
 
-`internal/shellquote` is already done (2/2 killed, 100% efficacy - recorded in the phase 7
-gate-decision record). The `--workers` values above are a starting point sized for a genuinely quiet
-22-core host with headroom to spare, not a fixed prescription - check `uptime` and `nproc` right
-before the `internal/store` and `internal/runtime` runs specifically and scale down if the host has
-less room than that at the time.
+These settings were measured on an otherwise-quiet 22-core host (see "Timeout coefficient" above for
+how to derive settings for a package not on this list, or for a differently loaded host) - check
+`uptime` and `nproc` before the two large ones regardless, and remeasure rather than reuse these
+numbers unchanged if the host is busy: real per-mutant cost under contention does not scale linearly
+with `--workers`, and `internal/runtime`'s tests are more CPU-bound than `internal/store`'s, so the
+same worker count costs more there.
 
 ### Reading the output
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,20 @@ It runs per package, on demand, never as part of `make test` or CI. Against 38+ 
 push isn't the point - the point is finding out, package by package, where the suite is weaker than
 its coverage number suggests.
 
+### Package scope
+
+Mutation testing here targets exactly the packages atqamz/hand#442 phases 1 through 6 added
+invariant-driven property or model tests to, not the whole tree:
+
+- `internal/shellquote`, `internal/age`, `internal/axi` (phase 1, phase 2)
+- `internal/registry` (phase 3)
+- `internal/store`, `internal/completion` (phase 4, phase 5)
+- `internal/runtime` (phase 6)
+
+These are the packages with a first-class claim that "the tests constrain the behavior" worth
+checking. Extending the scope to another package means adding it to this list deliberately, not
+running gremlins against the whole tree.
+
 ### Tool
 
 [`gremlins`](https://github.com/go-gremlins/gremlins) (pinned `v0.6.0`), chosen over the older
@@ -111,6 +125,19 @@ Install it once per machine:
 ```sh
 go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
 ```
+
+### Operator set
+
+Every run here uses gremlins' shipped default-enabled mutators, unmodified:
+`ARITHMETIC_BASE`, `CONDITIONALS_BOUNDARY`, `CONDITIONALS_NEGATION`, `INCREMENT_DECREMENT`,
+`INVERT_NEGATIVES`. None of gremlins' opt-in extras (`INVERT_ASSIGNMENTS`, `INVERT_BITWISE`,
+`INVERT_BWASSIGN`, `INVERT_LOGICAL`, `INVERT_LOOPCTRL`, `REMOVE_SELF_ASSIGNMENTS`) are enabled.
+
+This is deliberate and settled, not a placeholder: atqamz/hand#442 is explicit that the operator set
+is not something to tune until a package's score already looks good, so every invocation below omits
+every per-mutator flag and takes whatever gremlins ships as default. A package that scores badly on
+the default set is a finding about that package's tests, not a cue to narrow the operators until it
+looks better.
 
 ### Running one package
 
@@ -131,7 +158,9 @@ Useful flags:
 
 - `--dry-run` finds and counts mutants without running the suite against any of them - it still
   gathers coverage once, but skips the per-mutant test loop, so it is cheap and safe to run on any
-  package to size it before committing to a real run.
+  package to size it before committing to a real run. Run this first on `internal/registry`,
+  `internal/store`, and `internal/runtime`; it turns the estimate table into an exact count before
+  the expensive part starts.
 - `--workers=N` / `--test-cpu=N` bound concurrency. On a machine already doing other work, check
   `uptime` and `nproc` first and pick something conservative; gremlins otherwise defaults to using
   the whole machine.
@@ -139,12 +168,64 @@ Useful flags:
 
 ### How long it takes
 
-It scales with (number of covered mutants) x (one test-run wall-clock for that package). Measured
-anchor: `internal/shellquote` (9 lines of source, 2 mutants) completes in under half a second.
-`internal/store` and `internal/runtime` are multiple orders of magnitude larger and their suites are
-already minutes long under `-race`; gremlins runs each mutant's test pass without `-race`, but a run
-across either package is still expected to take minutes, not seconds. See `docs/adr/` for the phase 7
-gate-decision record, which carries real measured per-package numbers.
+Cost is (mutants gremlins finds in covered code) x (one test-run wall-clock for that package).
+Two real numbers anchor the estimate below: `internal/shellquote` mutation-tested end to end in
+0.46s total for 2 mutants (measured locally, gremlins v0.6.0, `--workers=1`); every package's own
+single-run wall-clock, without gremlins, is visible in any CI test job log as the `ok  <pkg>  <N>s`
+line (`-race`, so a real ceiling rather than what gremlins itself pays - gremlins does not run
+`-race`, and reuses the build cache across mutants, both of which make the real number lower than a
+naive multiplication).
+
+Mutant counts below are a static upper bound, not gremlins' own count: an AST walk over each
+package's non-test `.go` files counting nodes matching the five default operators above, with no
+coverage information (gremlins additionally drops any site the test suite never executes, so its
+real "Runnable" count will be at or below this). The walk reproduced `internal/shellquote`'s real
+count exactly (2), which is the only package checked against ground truth.
+
+| package | candidate mutants (ceiling) | single-run wall-clock (`-race`, CI) | estimated total |
+|---|---|---|---|
+| `internal/shellquote` | 2 | 1.3s | measured: 0.46s |
+| `internal/age` | 6 | 1.0s | a few seconds |
+| `internal/axi` | 6 | 1.1s | a few seconds |
+| `internal/completion` | 32 | 1.4s | tens of seconds |
+| `internal/registry` | 116 | 56.9s | tens of minutes, likely under two hours |
+| `internal/store` | 880 | 79.8s | hours |
+| `internal/runtime` | 1001 | 330.0s | plausibly a full day or more at 1 worker |
+
+The four smallest packages are not a scheduling concern; their whole per-mutant cost is dominated by
+fixed build overhead that a warm cache erases, which is exactly what the shellquote anchor shows (a
+naive mutants x CI-time multiplication predicts 2.7s; the real run took 0.46s, roughly a sixth of
+that). `internal/registry`, `internal/store`, and `internal/runtime` are different: most of their
+per-run wall-clock is real test execution - SQLite files, faked subprocess tools, timing-sensitive
+waits - that a warm build cache does not shrink, so their naive ceiling (mutants x CI `-race` time)
+is a more trustworthy starting point than the shellquote discount, even though dropping `-race` still
+buys something back. On that basis, `internal/registry` likely fits in the same window as the four
+small packages; `internal/store` and, especially, `internal/runtime` should each get their own
+window and their own `--workers` allocation, not a slice of one shared with the rest - see the phase
+7 gate-decision record in `docs/adr/` for the real measured numbers once those runs have happened.
+
+### Per-package plan
+
+The literal command for each package in scope, in run order - cheapest first, `--dry-run` before any
+full run on a package sized in the tens of minutes or more:
+
+```sh
+make mutation PKG=./internal/age
+make mutation PKG=./internal/axi
+make mutation PKG=./internal/completion
+make mutation PKG=./internal/registry GREMLINS_FLAGS='--dry-run'
+make mutation PKG=./internal/registry GREMLINS_FLAGS='--workers=4 --test-cpu=2'
+make mutation PKG=./internal/store GREMLINS_FLAGS='--dry-run'
+make mutation PKG=./internal/store GREMLINS_FLAGS='--workers=8 --test-cpu=2'
+make mutation PKG=./internal/runtime GREMLINS_FLAGS='--dry-run'
+make mutation PKG=./internal/runtime GREMLINS_FLAGS='--workers=8 --test-cpu=2'
+```
+
+`internal/shellquote` is already done (2/2 killed, 100% efficacy - recorded in the phase 7
+gate-decision record). The `--workers` values above are a starting point sized for a genuinely quiet
+22-core host with headroom to spare, not a fixed prescription - check `uptime` and `nproc` right
+before the `internal/store` and `internal/runtime` runs specifically and scale down if the host has
+less room than that at the time.
 
 ### Reading the output
 
@@ -163,20 +244,6 @@ Each mutant gets one line: the mutant kind, and the file:line:col it was applied
 The summary line reports two percentages: **test efficacy** (killed / (killed + lived) - the number
 that matters) and **mutator coverage** ((killed + lived) / total mutants found - how much of the
 mutated surface any test reaches at all).
-
-### Package scope
-
-Mutation testing here targets exactly the packages atqamz/hand#442 phases 1 through 6 added
-invariant-driven property or model tests to, not the whole tree:
-
-- `internal/shellquote`, `internal/age`, `internal/axi` (phase 1, phase 2)
-- `internal/registry` (phase 3)
-- `internal/store`, `internal/completion` (phase 4, phase 5)
-- `internal/runtime` (phase 6)
-
-These are the packages with a first-class claim that "the tests constrain the behavior" worth
-checking. Extending the scope to another package means adding it to this list deliberately, not
-running gremlins against the whole tree.
 
 ## Reporting issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Real numbers, in sweep order, all with `--tags=test` and a cleared test cache:
 | `internal/completion` | 31 | 20 | 3 | 8 | 13.4s | 1 worker, coefficient 100 |
 | `internal/registry` | 116 | 106 | 0 | 10 | 32.9s | 8 workers, coefficient 20 |
 | `internal/store` | 829 | 622 | 0 | 207 | 5m30s | 6 workers, coefficient 5 |
-| `internal/runtime` | 832 | see the phase 7 gate-decision record | | | | 8 workers, coefficient 9 |
+| `internal/runtime` | 832 | 716 | 0 | 116 | 10m14s | 8 workers, coefficient 9 |
 
 *`internal/age`'s 7 "not covered" are confirmed false by `go tool cover -func` (both functions report
 100.0% real statement coverage, boundary values included) - gremlins cannot see coverage for a
@@ -231,12 +231,14 @@ reads as uncovered no matter how thoroughly it is exercised. Not a suite gap; se
 record for the full reasoning.
 
 The four smallest packages cost well under a second to a couple of seconds regardless of settings.
-`internal/registry` finished in 33 seconds once run for real - non-race execution plus a warm build
-cache across mutants cuts cost far more than a CI `-race` baseline would suggest, for every package
-size, not only tiny ones. `internal/store` and `internal/runtime` are the two that need their own
-`--workers` allocation and a coefficient sized from a real measured baseline (above), not because
-they are slow to kill mutants but because they are large enough that a cache-hit baseline's error is
-large in absolute seconds.
+Non-race execution plus a warm build cache across mutants cuts cost far more than a CI `-race`
+baseline would suggest, for every package size, not only tiny ones: `internal/registry` finished in
+33 seconds, `internal/store` (829 mutants) in 5m30s, and `internal/runtime` (832 mutants, the
+package whose own suite alone takes 20s to run once) in 10m14s - all three with sized `--workers`
+and a coefficient from a real measured baseline (above). The full six-package sweep, run in sequence
+rather than all at once, fits inside a single quiet hour on a 22-core host with room to spare; it
+does not need to be split across separate windows the way a naive `-race`-baseline estimate would
+suggest.
 
 ### Per-package plan
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,100 @@ User or contributor guidance belongs in README.md or this file.
 
 `go run ./tools/commentlint .` runs the check alone and prints one `file:line:column` per violation.
 
+## Mutation testing
+
+Mutation testing judges the tests, not the code: it changes one line of production behavior at a
+time and checks whether any test fails. A mutant the suite kills means some test constrains that
+line; a mutant that lives means nothing does, whatever the coverage report says. See
+`docs/adr/tests-state-invariants-first-examples-second.md` for why this exists and
+`docs/testing-invariants.md` for the invariants the suite is meant to hold.
+
+It runs per package, on demand, never as part of `make test` or CI. Against 38+ packages whose
+`-race` suite already takes minutes, a full-tree run would take hours and re-running it on every
+push isn't the point - the point is finding out, package by package, where the suite is weaker than
+its coverage number suggests.
+
+### Tool
+
+[`gremlins`](https://github.com/go-gremlins/gremlins) (pinned `v0.6.0`), chosen over the older
+`go-mutesting`: `go-mutesting` has no tagged release since 2021 (its latest resolvable version is a
+2021-06-10 pseudo-version), while gremlins ships regular tagged releases, understands Go build tags
+natively, and exposes `--workers`/`--test-cpu` to bound how much of the machine a run is allowed to
+use - necessary on a dev box already running other work.
+
+gremlins is a standalone CLI, never imported by hand's code, so it is not a `go.mod` dependency.
+Install it once per machine:
+
+```sh
+go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+```
+
+### Running one package
+
+```sh
+gremlins unleash --tags=test ./internal/shellquote
+```
+
+or, equivalently:
+
+```sh
+make mutation PKG=./internal/shellquote
+```
+
+`--tags=test` is required: hand's suite installs its external-tool fakes behind that build tag (see
+"Making changes" above), and gremlins otherwise mutates and tests an incomplete build.
+
+Useful flags:
+
+- `--dry-run` finds and counts mutants without running the suite against any of them - it still
+  gathers coverage once, but skips the per-mutant test loop, so it is cheap and safe to run on any
+  package to size it before committing to a real run.
+- `--workers=N` / `--test-cpu=N` bound concurrency. On a machine already doing other work, check
+  `uptime` and `nproc` first and pick something conservative; gremlins otherwise defaults to using
+  the whole machine.
+- `-o results.json` writes a machine-readable report alongside the terminal output.
+
+### How long it takes
+
+It scales with (number of covered mutants) x (one test-run wall-clock for that package). Measured
+anchor: `internal/shellquote` (9 lines of source, 2 mutants) completes in under half a second.
+`internal/store` and `internal/runtime` are multiple orders of magnitude larger and their suites are
+already minutes long under `-race`; gremlins runs each mutant's test pass without `-race`, but a run
+across either package is still expected to take minutes, not seconds. See `docs/adr/` for the phase 7
+gate-decision record, which carries real measured per-package numbers.
+
+### Reading the output
+
+Each mutant gets one line: the mutant kind, and the file:line:col it was applied to. Terminal states:
+
+- `KILLED` - a test failed with the mutation in place. Good: something constrains this line.
+- `LIVED` - every test still passed. A finding: nothing the suite runs would notice this line
+  changing. Read the surrounding test(s) and decide whether a test is missing, or whether the line
+  genuinely carries no behavior worth constraining.
+- `NOT COVERED` - no test executes this line at all. Different from `LIVED`: this is a coverage gap,
+  not a suite-strength gap.
+- `TIMED OUT` - the mutation likely produced an infinite loop or similar; treated as killed for
+  scoring purposes but worth a glance.
+- `NOT VIABLE` - the mutated code doesn't compile; not a finding, just discarded.
+
+The summary line reports two percentages: **test efficacy** (killed / (killed + lived) - the number
+that matters) and **mutator coverage** ((killed + lived) / total mutants found - how much of the
+mutated surface any test reaches at all).
+
+### Package scope
+
+Mutation testing here targets exactly the packages atqamz/hand#442 phases 1 through 6 added
+invariant-driven property or model tests to, not the whole tree:
+
+- `internal/shellquote`, `internal/age`, `internal/axi` (phase 1, phase 2)
+- `internal/registry` (phase 3)
+- `internal/store`, `internal/completion` (phase 4, phase 5)
+- `internal/runtime` (phase 6)
+
+These are the packages with a first-class claim that "the tests constrain the behavior" worth
+checking. Extending the scope to another package means adding it to this list deliberately, not
+running gremlins against the whole tree.
+
 ## Reporting issues
 
 Open a GitHub issue with repro steps, OS, arch, and hand --version.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt lint e2e contract contract-live install clean vendorhash
+.PHONY: build test fmt lint e2e contract contract-live install clean vendorhash mutation
 
 VERSION ?= dev
 CHANNEL ?= dev
@@ -30,6 +30,13 @@ contract:
 
 contract-live:
 	go test -tags=contract,contractlive -count=1 -timeout=10m ./tests/contract/...
+
+# Not part of `make test`: mutation testing runs per package, on demand. See
+# CONTRIBUTING.md's "Mutation testing" section for the tool, install command, and package scope.
+mutation:
+	@test -n "$(PKG)" || { echo "usage: make mutation PKG=./internal/foo [GREMLINS_FLAGS='--dry-run']" >&2; exit 1; }
+	@command -v gremlins >/dev/null 2>&1 || { echo "gremlins not found; see CONTRIBUTING.md's Mutation testing section for the install command" >&2; exit 1; }
+	gremlins unleash --tags=test $(GREMLINS_FLAGS) $(PKG)
 
 # FAKE_VENDOR_HASH is nixpkgs' lib.fakeHash: a well-formed sha256 SRI hash that
 # no real fixed-output derivation will ever produce, so the build below is

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ contract-live:
 mutation:
 	@test -n "$(PKG)" || { echo "usage: make mutation PKG=./internal/foo [GREMLINS_FLAGS='--dry-run']" >&2; exit 1; }
 	@command -v gremlins >/dev/null 2>&1 || { echo "gremlins not found; see CONTRIBUTING.md's Mutation testing section for the install command" >&2; exit 1; }
+	go clean -testcache
 	gremlins unleash --tags=test $(GREMLINS_FLAGS) $(PKG)
 
 # FAKE_VENDOR_HASH is nixpkgs' lib.fakeHash: a well-formed sha256 SRI hash that

--- a/docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md
+++ b/docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md
@@ -44,8 +44,8 @@ wherever this runs, including in CI - not only during local, repeated iteration.
 score is not 100% and, as currently written, never can be: one of its three survivors is
 behaviorally identical to the code it replaced, for every input, so no test - however strong - could
 ever kill it. A gate stated as "efficacy >= N%" either sets N below 100 for every package (weakening
-the five packages that currently earn a perfect score for no reason) or blocks `completion` forever
-on a mutant that is not a defect. The only correct threshold is per-mutant identity: does a specific
+the six other packages, all of which currently earn a perfect score, for no reason) or blocks
+`completion` forever on a mutant that is not a defect. The only correct threshold is per-mutant identity: does a specific
 `file:line:col` + operator that was `KILLED` before now come back `LIVED`. That requires diffing
 `-o results.json` output against a stored baseline, not comparing one aggregate number.
 
@@ -99,6 +99,14 @@ to add an entry, and that assertion can be wrong. That cost is accepted because 
 after this whole sweep) and because the alternative - a threshold - fails silently in exactly the case
 that matters most.
 
+**`internal/completion`'s baseline is not generated yet.** Two of its three current survivors are
+atqamz/hand#498's real, open findings, not accepted equivalences. Generating the baseline from
+today's tree would record both as accepted `LIVED` alongside the genuine equivalent mutant, which
+turns a still-open bug into gate policy indistinguishable from the one entry that actually belongs
+there. `completion` joins the always-on gate only once atqamz/hand#498 lands and both survivors come
+back `KILLED`, at which point its baseline has exactly one entry: the equivalent mutant. See
+Consequences for the general rule this is one case of.
+
 **`internal/store` and `internal/runtime` do not gate on every push.** At an estimated 8-20 minutes
 apiece on CI-sized hardware, blocking every PR - including ones that touch neither package - on this
 cost is not justified by what phase 7 actually found: both packages are already at 100% test
@@ -131,14 +139,23 @@ of this decision first.
 
 ## Consequences
 
-Five packages get a real, cheap, always-on regression check the moment the workflow lands. The two
-expensive packages keep the protection phase 7 already gave them (both at 100% today) without an
-ongoing CI tax, at the cost of a regression there surfacing on the next scheduled run or touching PR
-rather than immediately - an accepted latency given neither package is currently in a bad state to
-begin with.
+Four packages get a real, cheap, always-on regression check the moment the workflow lands;
+`internal/completion` joins them once atqamz/hand#498 lands, not before. The two expensive packages
+keep the protection phase 7 already gave them (both at 100% today) without an ongoing CI tax, at the
+cost of a regression there surfacing on the next scheduled run or touching PR rather than immediately
+- an accepted latency given neither package is currently in a bad state to begin with.
 
 The baseline file this gate depends on has to be regenerated deliberately whenever a mutant's
 identity legitimately changes (a line moves, an operator's mutation changes, `completion`'s equivalent
 mutant is refactored away) - an unreviewed regeneration would silently accept a real regression as
 the new normal, the same failure mode `docs/adr/tests-state-invariants-first-examples-second.md`
 already warns about for the invariant map itself.
+
+The same hazard sits at first generation, not only at regeneration, and `completion` is the case in
+point: a baseline generated from today's tree would capture atqamz/hand#498's two open survivors as
+accepted `LIVED` entries, because generation cannot distinguish "nothing better exists yet" from "this
+is genuinely equivalent" - only the person generating it can, and only by already knowing which
+survivors are which. The general rule this ADR commits to: a baseline is never generated, first time
+or regeneration, for a package with a known-open survivor that has not been positively judged
+equivalent. Every baseline entry records a judgment made before the baseline existed, never one made
+by the act of writing it.

--- a/docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md
+++ b/docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md
@@ -1,0 +1,114 @@
+# Mutation score gates the packages cheap enough to block on
+
+- Date: 2026-08-29
+- Status: accepted
+- Issues: atqamz/hand#442
+- PRs: none
+
+## Context
+
+Phase 7 of atqamz/hand#442 ran gremlins v0.6.0 against the seven packages phases 1 through 6 added
+invariant-driven property or model tests to: `internal/shellquote`, `internal/age`, `internal/axi`,
+`internal/registry`, `internal/completion`, `internal/store`, `internal/runtime`. Every package
+scored 100% test efficacy except `internal/completion` (86.96%, three LIVED mutants: two real gaps
+filed as atqamz/hand#498, one - `migrated++` versus `migrated--` in `MigrateProjectIdentity` - an
+equivalent mutant no test can ever kill, since the value it changes is only ever compared against
+zero). Real, measured wall-clock, sequentially, on an otherwise-quiet 22-core host:
+
+| package | mutants | wall-clock |
+|---|---|---|
+| `internal/shellquote` | 2 | 0.46s |
+| `internal/age` | 9 | 0.59s |
+| `internal/axi` | 6 | 1.3s |
+| `internal/completion` | 31 | 13.4s |
+| `internal/registry` | 116 | 32.9s |
+| `internal/store` | 829 | 5m30s |
+| `internal/runtime` | 832 | 10m14s |
+
+Full detail, including the settings that produced these numbers, is in CONTRIBUTING.md's "Mutation
+testing" section.
+
+Two things surfaced while measuring this that bear directly on whether a gate is trustworthy, not
+only on whether it is affordable:
+
+**gremlins' own timeout can be wrong by an order of magnitude, silently.** It times its per-mutant
+timeout from a coverage-gathering pass that never passes `-count=1`. On a host that has already
+tested a package's unmodified source - true of any CI runner restoring a `setup-go` cache, which this
+repository's own CI already does - that pass is a Go test-cache hit in well under a second, regardless
+of how long the suite actually takes. `internal/store`'s first real run this way reported 595 of 622
+covered mutants `TIMED OUT`; its true baseline was 2.9s, its cached one 177ms. The fix
+(`go clean -testcache` before every invocation, now baked into `make mutation`) is necessary
+wherever this runs, including in CI - not only during local, repeated iteration.
+
+**A percentage threshold cannot distinguish a real gap from an equivalent mutant.** `completion`'s
+score is not 100% and, as currently written, never can be: one of its three survivors is
+behaviorally identical to the code it replaced, for every input, so no test - however strong - could
+ever kill it. A gate stated as "efficacy >= N%" either sets N below 100 for every package (weakening
+the five packages that currently earn a perfect score for no reason) or blocks `completion` forever
+on a mutant that is not a defect. The only correct threshold is per-mutant identity: does a specific
+`file:line:col` + operator that was `KILLED` before now come back `LIVED`. That requires diffing
+`-o results.json` output against a stored baseline, not comparing one aggregate number.
+
+CI's runners (`ubuntu-latest`, standard GitHub-hosted, 4 vCPU) are far smaller than the 22-core host
+these numbers were measured on. Reruning the same packages with `--workers` sized to 4 cores instead
+of 6-8 would cost proportionally more for the two large packages - a rough scale-up puts
+`internal/store` near 8-9 minutes and `internal/runtime` near 20 minutes on CI hardware, though this
+is an extrapolation, not a second measurement on that hardware.
+
+## Decision
+
+The gate is split by measured cost, not applied uniformly across the scoped packages:
+
+**`internal/shellquote`, `internal/age`, `internal/axi`, `internal/completion`, and
+`internal/registry` gate every push and PR.** Combined, they measured under 50 seconds - negligible
+next to this repository's existing multi-minute `-race` suite, cheap enough that scoping the trigger
+to changed paths would save nothing worth the added workflow complexity. The gate compares each
+mutant's `KILLED`/`LIVED` outcome against a checked-in baseline keyed by `file:line:col` and operator;
+a mutant that flips from `KILLED` to `LIVED` fails the build, a `NOT COVERED` count that grows is
+reported but does not fail it (that is a coverage question, which this issue explicitly is not
+about), and `completion`'s one known equivalent mutant is recorded in the baseline as an accepted
+`LIVED` rather than chased.
+
+**`internal/store` and `internal/runtime` do not gate on every push.** At an estimated 8-20 minutes
+apiece on CI-sized hardware, blocking every PR - including ones that touch neither package - on this
+cost is not justified by what phase 7 actually found: both packages are already at 100% test
+efficacy, so the gate's entire job for them today is detecting a future regression, not fixing a
+present gap. That is better served by running them only when a PR's diff touches
+`internal/store/**` or `internal/runtime/**`, or on a schedule (e.g. nightly against `main`), non-
+blocking, filing or updating a tracking issue on a new survivor rather than failing the workflow that
+found it. This keeps the expensive packages' protection real without taxing unrelated work.
+
+Implementing the workflow change itself is left for a follow-up: it needs validating against real
+GitHub Actions infrastructure (cache interaction, matrix job cost) that cannot be confirmed from a
+local checkout, and this phase's own instructions hold off on pushing or opening a PR pending review
+of this decision first.
+
+## Rejected alternatives
+
+- **Gate all seven packages uniformly.** Rejected on measured cost: `store` and `runtime` together
+  are two to three orders of magnitude more expensive than the other five, and paying that on every
+  push regardless of what changed is not what the numbers justify.
+- **An aggregate efficacy percentage threshold (e.g. "fail under 95%").** Rejected because it cannot
+  tell a real survivor from an equivalent mutant - see `completion` above - and because it would let
+  a package regress from 100% down to the threshold without the gate ever noticing, which a per-
+  mutant baseline diff does not allow.
+- **No gate at all, fully manual forever.** Rejected now that cost is measured rather than assumed:
+  five of the seven packages are cheap enough that not gating them leaves free protection on the
+  table for negligible cost.
+- **Extend mutation testing to the full 38+-package tree.** Out of scope per atqamz/hand#442 itself;
+  the packages tested here are the ones with a first-class claim that "the tests constrain the
+  behavior," which is what makes a survivor there a meaningful finding rather than noise.
+
+## Consequences
+
+Five packages get a real, cheap, always-on regression check the moment the workflow lands. The two
+expensive packages keep the protection phase 7 already gave them (both at 100% today) without an
+ongoing CI tax, at the cost of a regression there surfacing on the next scheduled run or touching PR
+rather than immediately - an accepted latency given neither package is currently in a bad state to
+begin with.
+
+The baseline file this gate depends on has to be regenerated deliberately whenever a mutant's
+identity legitimately changes (a line moves, an operator's mutation changes, `completion`'s equivalent
+mutant is refactored away) - an unreviewed regeneration would silently accept a real regression as
+the new normal, the same failure mode `docs/adr/tests-state-invariants-first-examples-second.md`
+already warns about for the invariant map itself.

--- a/docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md
+++ b/docs/adr/mutation-score-gates-the-packages-cheap-enough-to-block-on.md
@@ -64,10 +64,40 @@ The gate is split by measured cost, not applied uniformly across the scoped pack
 next to this repository's existing multi-minute `-race` suite, cheap enough that scoping the trigger
 to changed paths would save nothing worth the added workflow complexity. The gate compares each
 mutant's `KILLED`/`LIVED` outcome against a checked-in baseline keyed by `file:line:col` and operator;
-a mutant that flips from `KILLED` to `LIVED` fails the build, a `NOT COVERED` count that grows is
+a mutant that flips from `KILLED` to `LIVED` fails the build, and a `NOT COVERED` count that grows is
 reported but does not fail it (that is a coverage question, which this issue explicitly is not
-about), and `completion`'s one known equivalent mutant is recorded in the baseline as an accepted
-`LIVED` rather than chased.
+about).
+
+**Equivalent mutants are handled by a suppression list, not a threshold or a per-run human read.**
+This has to be answered explicitly, not left implicit in "diff against a baseline," because a gate
+that recommends itself without an answer here is recommending a permanent false failure: `completion`
+cannot reach 100% as currently written, ever, at any level of test quality, because one of its three
+survivors - `migrated++` versus `migrated--` in `MigrateProjectIdentity` - is behaviorally identical
+to the code it replaced for every input (`migrated` is only ever compared against zero; both
+operators move it away from zero identically once anything is migrated). No test, however strong,
+can kill a mutation that changes nothing observable. Three ways to answer what the gate does with
+that:
+
+- **A suppression list** (the decision here): the checked-in baseline records this exact mutant -
+  `internal/completion/completion.go:149:11`, `INCREMENT_DECREMENT` - as an accepted `LIVED`, with the
+  reason inline (why it is equivalent, not merely why it was tolerated). A new, different survivor
+  anywhere in the package is not in that list, so it fails the gate on its own merits. Adding an entry
+  is a normal reviewed code change to the baseline file, which is where a human judges "is this
+  actually equivalent" - exactly once, at the moment someone makes that claim, not on every run after.
+- **A count threshold** ("`completion` may have up to N survivors"), rejected: it verifies how many,
+  not which. A real new gap introduced alongside this equivalent mutant being (hypothetically) fixed
+  stays invisible as long as the total count does not change - the budget the equivalent mutant was
+  quietly spending gets spent by a real regression instead, and the gate has no way to tell the
+  difference. This is strictly weaker than identity-based suppression for the same cost.
+- **A human read on every run** (no automated pass/fail, someone looks at the survivor list each
+  time), rejected as the sole mechanism: it is not a gate, it is the manual process mutation testing
+  here exists to make repeatable. It remains the right fallback for a survivor that is *not* already
+  in the suppression list - which is exactly what "fails the gate" routes to.
+
+The suppression list is reviewed maintenance, not free: someone has to positively assert equivalence
+to add an entry, and that assertion can be wrong. That cost is accepted because it is rare (one entry
+after this whole sweep) and because the alternative - a threshold - fails silently in exactly the case
+that matters most.
 
 **`internal/store` and `internal/runtime` do not gate on every push.** At an estimated 8-20 minutes
 apiece on CI-sized hardware, blocking every PR - including ones that touch neither package - on this


### PR DESCRIPTION
## Summary

- Runs gremlins v0.6.0 for real against all seven packages phases 1-6 added invariant-driven tests to. Six score 100% test efficacy; `internal/completion` has 2 real gaps (filed as atqamz/hand#498) and 1 equivalent mutant.
- Documents the procedure in `CONTRIBUTING.md` with the real numbers the runs actually produced, including a gremlins/Go test-cache interaction that silently reports every covered mutant as `TIMED OUT` unless the cache is cleared first - fixed at the source in `make mutation`, not just noted.
- Records the measured gate decision in a new ADR: gate the five packages cheap enough to block on (under 50s combined) via a per-mutant baseline diff, with equivalent mutants handled by a reviewed suppression list rather than a threshold or a per-run human read; leave `internal/store` and `internal/runtime` (8-20 minutes estimated on CI's real hardware) off the blocking path.

Part of atqamz/hand#442

## The numbers behind the recommendation

- `internal/registry`: `CONTRIBUTING.md`'s own pre-run estimate, based on CI's `-race` per-package time, said "tens of minutes, likely under two hours." The real run, 8 workers, took 33 seconds.
- `internal/store`: 622 of 829 mutants killed, 0 survived, in 5m30s once run correctly.
- Getting to "correctly" mattered. The first real run of `internal/store` reported 595 of 622 mutants `TIMED OUT`. gremlins times its own per-mutant timeout from a coverage-gathering pass that never disables Go's test cache; on this host, that pass replayed a cached result in 177ms instead of running for real (confirmed by hand: the identical command took 2.928s after `go clean -testcache`), so the derived timeout was roughly 16x too tight - a worker-count problem it looked like, but wasn't. `make mutation` now clears the test cache before every invocation so this can't happen silently again, including in CI, which restores its own Go cache via `actions/setup-go`.

## Test plan
- [x] `make lint`
- [x] `make test`

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->