### PR TITLE
fix(npm): retry post-publish verification instead of failing a first-ever publish

### DIFF
--- a/.github/scripts/npm-publish-target.sh
+++ b/.github/scripts/npm-publish-target.sh
@@ -23,7 +23,23 @@ integrity=$4
 repo_url=$5
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-outcome="$(bash "$script_dir/npm-registry-check.sh" "$pkg" "$version" "$integrity" "$repo_url")"
+
+# Set by the absent-new-package branch below so the post-publish verification loop
+# further down can read what it just published (atqamz/hand#506): every other path
+# leaves this empty and verify_registry runs unauthenticated, same as before that fix.
+npmrc_dir=""
+trap 'rm -rf "${npmrc_dir}"' EXIT
+
+verify_registry() {
+  if [[ -n "$npmrc_dir" ]]; then
+    NODE_AUTH_TOKEN="$NPM_BOOTSTRAP_TOKEN" NPM_CONFIG_USERCONFIG="$npmrc_dir/.npmrc" \
+      bash "$script_dir/npm-registry-check.sh" "$pkg" "$version" "$integrity" "$repo_url"
+  else
+    bash "$script_dir/npm-registry-check.sh" "$pkg" "$version" "$integrity" "$repo_url"
+  fi
+}
+
+outcome="$(verify_registry)"
 
 case "$outcome" in
   verified-published)
@@ -47,7 +63,6 @@ case "$outcome" in
       echo "npm-publish-target: publishing ${pkg}@${version} as npm user $identity (bootstrap token, first creation)"
       npm publish "$tarball" --access public --provenance
     )
-    rm -rf "$npmrc_dir"
     ;;
   absent-new-version)
     # actions/setup-node's registry-url option is what plants an _authToken entry
@@ -68,9 +83,47 @@ case "$outcome" in
     ;;
 esac
 
-verify="$(bash "$script_dir/npm-registry-check.sh" "$pkg" "$version" "$integrity" "$repo_url")"
-if [[ "$verify" != "verified-published" ]]; then
-  echo "npm-publish-target: ${pkg}@${version} did not verify as published immediately after npm publish succeeded: $verify" >&2
-  exit 1
-fi
-echo "npm-publish-target: ${pkg}@${version} verified published"
+# npm publish above already confirmed the tarball, its provenance, and its dist-tag;
+# the only unproven thing is read-path visibility. The registry's read path is
+# eventually consistent, and a name's first-ever publish was measured taking up to 55
+# minutes to become visible (atqamz/hand#506), so absent-new-package/absent-new-version
+# here mean "not visible yet" and are worth retrying. A nonzero exit is
+# integrity-mismatch or unexpected-ownership; waiting cannot turn either into
+# agreement, so those fail immediately. verify_registry runs under set -e, so its exit
+# status is captured through an if/else rather than a bare assignment.
+verify_budget_seconds="${NPM_PUBLISH_VERIFY_BUDGET_SECONDS:-300}"
+verify_interval_seconds="${NPM_PUBLISH_VERIFY_INTERVAL_SECONDS:-15}"
+verify_elapsed=0
+while true; do
+  if verify="$(verify_registry)"; then
+    verify_status=0
+  else
+    verify_status=$?
+  fi
+
+  if [[ "$verify_status" -ne 0 ]]; then
+    echo "npm-publish-target: ${pkg}@${version} failed verification after npm publish succeeded: $verify" >&2
+    exit "$verify_status"
+  fi
+
+  case "$verify" in
+    verified-published)
+      echo "npm-publish-target: ${pkg}@${version} verified published"
+      exit 0
+      ;;
+    absent-new-package | absent-new-version)
+      if [[ "$verify_elapsed" -ge "$verify_budget_seconds" ]]; then
+        echo "::warning::npm-publish-target: ${pkg}@${version} still reports $verify ${verify_elapsed}s after npm publish succeeded; npm already confirmed the tarball, provenance, and dist-tag, so continuing instead of failing the release. The next run's pre-publish check will catch a real problem before publishing anything."
+        exit 0
+      fi
+      sleep "$verify_interval_seconds"
+      verify_elapsed=$((verify_elapsed + verify_interval_seconds))
+      ;;
+    *)
+      # Reachable only if npm-registry-check.sh's contract changes underneath this
+      # script, same as the unrecognized-outcome case above.
+      echo "npm-publish-target: unrecognized post-publish registry-check outcome: $verify" >&2
+      exit 1
+      ;;
+  esac
+done

--- a/tests/npmpublish/fakenpm/main.go
+++ b/tests/npmpublish/fakenpm/main.go
@@ -44,7 +44,10 @@ func run(args []string) int {
 		fmt.Fprintln(os.Stderr, "fakenpm:", err)
 		return 2
 	}
-	appendLog(state, args)
+	// Every subcommand gets the same trailing marker, not just publish, so a test can
+	// tell whether a *view* call (post-publish verification) ran authenticated - the
+	// bug atqamz/hand#506 fixed was specific to verification, not to publish itself.
+	appendLog(state, append(append([]string{}, args...), "authtoken="+fmt.Sprint(os.Getenv("NODE_AUTH_TOKEN") != "")))
 	if len(args) == 0 {
 		fmt.Fprintln(os.Stderr, "fakenpm: no subcommand given")
 		return 2

--- a/tests/npmpublish/npmpublish_test.go
+++ b/tests/npmpublish/npmpublish_test.go
@@ -136,6 +136,35 @@ func TestPublishTargetTakesTheBootstrapPathOnlyForATrulyNewPackage(t *testing.T)
 	}
 }
 
+func TestPublishTargetVerifiesTheBootstrapPathAuthenticated(t *testing.T) {
+	state := t.TempDir()
+	tarball := seedTarball(t, "@atqamz/hand-linux-x64", "0.7.0", "sha512-fresh", repoURL)
+
+	cmd := exec.Command("bash", scriptPath(t, "npm-publish-target.sh"),
+		"@atqamz/hand-linux-x64", "0.7.0", tarball, "sha512-fresh", repoURL)
+	cmd.Env = append(fakeNpmEnv(t, state), "NPM_BOOTSTRAP_TOKEN=bootstrap-secret-value")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("npm-publish-target.sh: %v: %s", err, out)
+	}
+
+	// The bootstrap token used to live only inside the subshell running `npm publish`,
+	// so post-publish verification ran unauthenticated (atqamz/hand#506): the
+	// pre-publish view must stay unauthenticated, every view after it must not.
+	views := callsWithPrefix(t, readCallsLog(t, state), "view")
+	if len(views) < 2 {
+		t.Fatalf("calls = %v, want at least a pre-publish and a post-publish view call", views)
+	}
+	if !strings.Contains(views[0], "authtoken=false") {
+		t.Fatalf("pre-publish view call = %q, want it unauthenticated", views[0])
+	}
+	for _, v := range views[1:] {
+		if !strings.Contains(v, "authtoken=true") {
+			t.Fatalf("post-publish view call = %q, want it authenticated with the bootstrap token", v)
+		}
+	}
+}
+
 func TestPublishTargetRefusesANewPackageWithoutTheBootstrapToken(t *testing.T) {
 	state := t.TempDir()
 	tarball := seedTarball(t, "@atqamz/hand-linux-x64", "0.7.0", "sha512-fresh", repoURL)
@@ -325,6 +354,17 @@ func containsCall(calls []string, word string) bool {
 		}
 	}
 	return false
+}
+
+func callsWithPrefix(t *testing.T, calls []string, prefix string) []string {
+	t.Helper()
+	var matched []string
+	for _, c := range calls {
+		if strings.HasPrefix(c, prefix+" ") {
+			matched = append(matched, c)
+		}
+	}
+	return matched
 }
 
 func onlyPublishCall(t *testing.T, calls []string) string {

--- a/tests/npmpublish/retry_test.go
+++ b/tests/npmpublish/retry_test.go
@@ -17,12 +17,17 @@ import (
 const stubRegistryCheckScript = `#!/usr/bin/env bash
 # Pops the next "outcome:exit" line from $STUB_OUTCOMES on each call, clamping to the
 # last line once exhausted, so a test can script an exact sequence across
-# npm-publish-target.sh's repeated invocations of its checker.
+# npm-publish-target.sh's repeated invocations of its checker. Reads the file into an
+# array with a while/read loop rather than mapfile, which macOS's system bash (3.2)
+# does not have - the CI runners this stub must also work under.
 set -euo pipefail
 idx_file="$STUB_STATE/idx"
 idx=0
 [[ -f "$idx_file" ]] && idx=$(<"$idx_file")
-mapfile -t lines < "$STUB_OUTCOMES"
+lines=()
+while IFS= read -r outcome_line || [[ -n "$outcome_line" ]]; do
+  lines+=("$outcome_line")
+done < "$STUB_OUTCOMES"
 line_no=$idx
 if (( line_no >= ${#lines[@]} )); then
   line_no=$((${#lines[@]} - 1))

--- a/tests/npmpublish/retry_test.go
+++ b/tests/npmpublish/retry_test.go
@@ -1,0 +1,131 @@
+// npm-publish-target.sh's post-publish retry loop (atqamz/hand#506) reacts to registry
+// outcomes real npm cannot be made to produce on demand: absent-then-verified, or never
+// catching up. These tests run the real script against a stub npm-registry-check.sh
+// that plays back a scripted sequence; the checker's own classification is covered
+// separately, by TestRegistryCheckDistinguishesEveryEnumeratedOutcome.
+package npmpublish
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const stubRegistryCheckScript = `#!/usr/bin/env bash
+# Pops the next "outcome:exit" line from $STUB_OUTCOMES on each call, clamping to the
+# last line once exhausted, so a test can script an exact sequence across
+# npm-publish-target.sh's repeated invocations of its checker.
+set -euo pipefail
+idx_file="$STUB_STATE/idx"
+idx=0
+[[ -f "$idx_file" ]] && idx=$(<"$idx_file")
+mapfile -t lines < "$STUB_OUTCOMES"
+line_no=$idx
+if (( line_no >= ${#lines[@]} )); then
+  line_no=$((${#lines[@]} - 1))
+fi
+echo $((idx + 1)) > "$idx_file"
+line="${lines[$line_no]}"
+outcome="${line%%:*}"
+exit_code="${line#*:}"
+printf 'call %s outcome=%s auth=%s\n' "$idx" "$outcome" "${NODE_AUTH_TOKEN:+set}" >> "$STUB_STATE/calls.log"
+printf '%s\n' "$outcome"
+exit "$exit_code"
+`
+
+// Copies the real npm-publish-target.sh next to the scripted stub above; script_dir is
+// derived from BASH_SOURCE at run time, so the stub must live beside it to be picked up.
+func newStubCheckerScriptDir(t *testing.T, outcomes []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	real, err := os.ReadFile(scriptPath(t, "npm-publish-target.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(dir, "npm-publish-target.sh"), string(real))
+	mustWriteFile(t, filepath.Join(dir, "npm-registry-check.sh"), stubRegistryCheckScript)
+	if err := os.MkdirAll(filepath.Join(dir, "stub-state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(dir, "outcomes.txt"), strings.Join(outcomes, "\n")+"\n")
+	return dir
+}
+
+func runStubbedPublishTarget(t *testing.T, outcomes []string, extraEnv ...string) (out string, elapsed time.Duration, calls []string, err error) {
+	t.Helper()
+	scriptDir := newStubCheckerScriptDir(t, outcomes)
+	stubState := filepath.Join(scriptDir, "stub-state")
+	tarball := seedTarball(t, "@atqamz/hand-linux-x64", "0.7.0", "sha512-fresh", repoURL)
+
+	cmd := exec.Command("bash", filepath.Join(scriptDir, "npm-publish-target.sh"),
+		"@atqamz/hand-linux-x64", "0.7.0", tarball, "sha512-fresh", repoURL)
+	cmd.Env = append(fakeNpmEnv(t, t.TempDir()),
+		"STUB_OUTCOMES="+filepath.Join(scriptDir, "outcomes.txt"),
+		"STUB_STATE="+stubState,
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+
+	start := time.Now()
+	raw, runErr := cmd.CombinedOutput()
+	return string(raw), time.Since(start), readCallsLog(t, stubState), runErr
+}
+
+func TestPublishTargetRetriesUntilTheRegistryCatchesUpThenVerifies(t *testing.T) {
+	out, elapsed, calls, err := runStubbedPublishTarget(t,
+		[]string{"absent-new-version:0", "absent-new-version:0", "absent-new-version:0", "verified-published:0"},
+		"NPM_PUBLISH_VERIFY_INTERVAL_SECONDS=1", "NPM_PUBLISH_VERIFY_BUDGET_SECONDS=60")
+	if err != nil {
+		t.Fatalf("npm-publish-target.sh: %v: %s", err, out)
+	}
+	if !strings.Contains(out, "verified published") {
+		t.Fatalf("output = %s, want it to report verified published", out)
+	}
+	if len(calls) != 4 {
+		t.Fatalf("calls = %v, want exactly 4 (1 pre-publish + 3 post-publish retries)", calls)
+	}
+	if elapsed < 2*time.Second {
+		t.Fatalf("elapsed = %s, want at least 2s: two absent outcomes must each cost one sleep", elapsed)
+	}
+}
+
+func TestPublishTargetFailsImmediatelyOnANonzeroPostPublishOutcome(t *testing.T) {
+	out, elapsed, calls, err := runStubbedPublishTarget(t,
+		[]string{"absent-new-version:0", "integrity-mismatch:1"},
+		"NPM_PUBLISH_VERIFY_INTERVAL_SECONDS=5", "NPM_PUBLISH_VERIFY_BUDGET_SECONDS=60")
+	if err == nil {
+		t.Fatalf("npm-publish-target.sh succeeded despite a post-publish integrity-mismatch; output = %s", out)
+	}
+	if !strings.Contains(out, "integrity-mismatch") {
+		t.Fatalf("output = %s, want it to name the integrity-mismatch outcome", out)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v, want exactly 2 (1 pre-publish + 1 post-publish, no retry on a hard-stop outcome)", calls)
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("elapsed = %s, want under one interval: a hard-stop outcome must not sleep at all", elapsed)
+	}
+}
+
+func TestPublishTargetWarnsAndSucceedsWhenTheVerifyBudgetRunsOut(t *testing.T) {
+	out, elapsed, calls, err := runStubbedPublishTarget(t,
+		[]string{"absent-new-version:0", "absent-new-version:0"},
+		"NPM_PUBLISH_VERIFY_INTERVAL_SECONDS=1", "NPM_PUBLISH_VERIFY_BUDGET_SECONDS=2")
+	if err != nil {
+		t.Fatalf("npm-publish-target.sh: %v: %s", err, out)
+	}
+	if !strings.Contains(out, "::warning::") {
+		t.Fatalf("output = %s, want a GitHub Actions ::warning:: annotation", out)
+	}
+	if !strings.Contains(out, "@atqamz/hand-linux-x64@0.7.0") {
+		t.Fatalf("output = %s, want the warning to name the package and version", out)
+	}
+	if len(calls) != 4 {
+		t.Fatalf("calls = %v, want exactly 4 (1 pre-publish + 3 post-publish before the 2s budget elapses)", calls)
+	}
+	if elapsed < 2*time.Second {
+		t.Fatalf("elapsed = %s, want at least the 2s budget to have been spent retrying before giving up", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary
- Retry `npm-publish-target.sh`'s post-publish verification with a five-minute budget instead of failing on the first look: a first-ever package's registry visibility is eventually consistent, and v0.7.0 measured `@atqamz/hand-linux-x64` still unreadable ~40 minutes after a successful `npm publish`.
- Only retry `absent-new-package`/`absent-new-version`; fail immediately on `integrity-mismatch`/`unexpected-ownership` (waiting cannot fix those), and warn-and-continue (exit 0) if the budget runs out, since `npm publish` already confirmed the tarball, provenance, and dist-tag.
- Fix the bootstrap-token branch so post-publish verification calls are authenticated too - previously the token only lived inside the subshell that ran `npm publish`, so the verification right after it ran unauthenticated.

Closes atqamz/hand#506

## Test plan
- [x] Added `tests/npmpublish/retry_test.go`: runs the real `npm-publish-target.sh` against a scripted stub `npm-registry-check.sh`, covering the retry-then-verify path, the immediate-fail path on a nonzero checker exit, and the warn-and-continue path on budget exhaustion (asserting exact call counts and elapsed time, not just exit codes).
- [x] Added `TestPublishTargetVerifiesTheBootstrapPathAuthenticated`, extending `fakenpm` to record auth-token presence on every call so the auth-scope fix is checked directly.
- [x] Confirmed all four new tests fail against the pre-fix script - one reproduces the exact v0.7.0 log line - and pass against the fix.
- [x] `go test ./tests/npmpublish/... ./tests/release/...`
- [x] `make lint` (gofmt, go vet, golangci-lint, commentlint)
- [x] `shellcheck .github/scripts/*.sh` (unchanged from baseline: one pre-existing, intentional SC2016 info on the literal `${NODE_AUTH_TOKEN}` written into the generated `.npmrc`)

<!-- hand:pipeline-region:start -->

<!-- hand:pipeline-region:end -->