### PR TITLE
fix(npm): read npm 12's array-shaped npm view document

### DIFF
--- a/.github/scripts/npm-registry-check.sh
+++ b/.github/scripts/npm-registry-check.sh
@@ -52,11 +52,23 @@ query() {
   npm view "$1" "${@:2}" --json 2>/dev/null
 }
 
+# npm 12 wraps a successful `npm view --json` document in an array holding one entry per
+# version the spec matched; npm 11 and earlier printed it bare (both observed against the
+# real registry). Every query below names an exact version or a bare package name, so
+# either shape carries exactly one document.
+field() {
+  jq -r --arg key "$2" 'if type == "array" then .[0] else . end | .[$key] // empty' "$1"
+}
+
+error_field() {
+  jq -r --arg key "$2" 'if type == "array" then .[0] else . end | .error[$key]? // empty' "$1" 2>/dev/null || printf ''
+}
+
 version_doc=$(mktemp)
 trap 'rm -f "$version_doc"' EXIT
 if query "${pkg}@${version}" name version dist.integrity repository.url > "$version_doc"; then
-  got_integrity=$(jq -r '."dist.integrity" // empty' "$version_doc")
-  got_repo=$(jq -r '."repository.url" // empty' "$version_doc")
+  got_integrity=$(field "$version_doc" dist.integrity)
+  got_repo=$(field "$version_doc" repository.url)
   if [[ "$got_integrity" != "$want_integrity" ]]; then
     stop integrity-mismatch "${pkg}@${version} registry dist.integrity ($got_integrity) != local pack integrity ($want_integrity)"
   fi
@@ -67,8 +79,8 @@ if query "${pkg}@${version}" name version dist.integrity repository.url > "$vers
   exit 0
 fi
 
-code=$(jq -r '.error.code // empty' "$version_doc" 2>/dev/null || printf '')
-summary=$(jq -r '.error.summary // empty' "$version_doc" 2>/dev/null || printf '')
+code=$(error_field "$version_doc" code)
+summary=$(error_field "$version_doc" summary)
 if [[ "$code" != "E404" ]]; then
   stop ambiguous "registry query for ${pkg}@${version} answered code=${code:-<none>} summary=${summary:-<none>}"
 fi
@@ -79,13 +91,13 @@ case "$summary" in
     # confirm this existing name is still ours before treating it as safe to extend.
     name_doc=$(mktemp)
     trap 'rm -f "$version_doc" "$name_doc"' EXIT
-    # A single field argument makes npm view print a bare scalar instead of an object
-    # (observed against the real registry), so a second field is requested purely to
-    # keep the dotted-key object shape the parsing below expects.
+    # A single field argument makes npm view drop the dotted-key mapping and print the
+    # bare value instead (npm 11 a scalar, npm 12 an array of scalars), so a second
+    # field is requested purely to keep the keyed shape the parsing below expects.
     if ! query "$pkg" name repository.url > "$name_doc"; then
       stop ambiguous "registry query for existing package ${pkg} failed after its version was reported absent"
     fi
-    existing_repo=$(jq -r '."repository.url" // empty' "$name_doc")
+    existing_repo=$(field "$name_doc" repository.url)
     if [[ "$existing_repo" != "$want_repo" ]]; then
       stop unexpected-ownership "${pkg} already exists with repository.url ($existing_repo) != expected ($want_repo)"
     fi

--- a/tests/npmpublish/fakenpm/main.go
+++ b/tests/npmpublish/fakenpm/main.go
@@ -125,22 +125,29 @@ func writeFields(name, version string, entry versionState, pkg packageState, fie
 		"dist.integrity": entry.Integrity,
 		"repository.url": pkg.RepositoryURL,
 	}
+	var doc any
 	if len(fields) == 1 {
-		fmt.Println(quoteJSON(values[fields[0]]))
-		return 0
+		doc = values[fields[0]]
+	} else {
+		out := map[string]string{}
+		for _, f := range fields {
+			out[f] = values[f]
+		}
+		doc = out
 	}
-	out := map[string]string{}
-	for _, f := range fields {
-		out[f] = values[f]
+	if arrayViewShape() {
+		doc = []any{doc}
 	}
-	data, _ := json.MarshalIndent(out, "", "  ")
+	data, _ := json.MarshalIndent(doc, "", "  ")
 	fmt.Println(string(data))
 	return 0
 }
 
-func quoteJSON(s string) string {
-	data, _ := json.Marshal(s)
-	return string(data)
+// npm 12 wraps a successful `npm view --json` document in an array where npm 11 and
+// earlier printed it bare. Release CI pins npm 12, so the array is the default and the
+// object shape is opt-in, letting one test table prove both are read (atqamz/hand#511).
+func arrayViewShape() bool {
+	return os.Getenv("FAKE_NPM_VIEW_SHAPE") != "object"
 }
 
 func cmdWhoami(state string) int {

--- a/tests/npmpublish/npmpublish_test.go
+++ b/tests/npmpublish/npmpublish_test.go
@@ -91,20 +91,25 @@ func TestRegistryCheckDistinguishesEveryEnumeratedOutcome(t *testing.T) {
 			wantExit:    1,
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			state := t.TempDir()
-			tt.seed(t, state)
-			cmd := exec.Command("bash", script, "@atqamz/hand-linux-x64", "0.7.0", tt.integrity, repoURL)
-			cmd.Env = fakeNpmEnv(t, state)
-			out, err := cmd.CombinedOutput()
-			exit := exitCode(t, err)
-			if exit != tt.wantExit {
-				t.Fatalf("exit = %d, want %d; output = %s", exit, tt.wantExit, out)
-			}
-			if got := firstLine(out); got != tt.wantOutcome {
-				t.Fatalf("outcome = %q, want %q; full output = %s", got, tt.wantOutcome, out)
-			}
-		})
+		// npm 12 - what release CI pins - wraps a successful `npm view --json` document
+		// in an array where npm 11 printed it bare; reading only the bare shape aborted
+		// the v0.7.1 npm publish before it published anything (atqamz/hand#511).
+		for _, shape := range []string{"array", "object"} {
+			t.Run(tt.name+"/"+shape+" view document", func(t *testing.T) {
+				state := t.TempDir()
+				tt.seed(t, state)
+				cmd := exec.Command("bash", script, "@atqamz/hand-linux-x64", "0.7.0", tt.integrity, repoURL)
+				cmd.Env = append(fakeNpmEnv(t, state), "FAKE_NPM_VIEW_SHAPE="+shape)
+				out, err := cmd.CombinedOutput()
+				exit := exitCode(t, err)
+				if exit != tt.wantExit {
+					t.Fatalf("exit = %d, want %d; output = %s", exit, tt.wantExit, out)
+				}
+				if got := firstLine(out); got != tt.wantOutcome {
+					t.Fatalf("outcome = %q, want %q; full output = %s", got, tt.wantOutcome, out)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #511.

## The failure

v0.7.1's npm-publish job died 3 seconds in, before publishing anything:

```
jq: error (at /tmp/tmp.8kB6X2424G:6): Cannot index array with string "repository.url"
##[error]Process completed with exit code 5.
```

npm 12 always prints a successful `npm view --json` document as an array with one entry per
version the spec matched; npm 11 and earlier printed it bare when the spec matched exactly
one version. `release.yaml` pins `npm@12.0.2` and `tests/release` enforces that pin, so the
workflow always gets the array and `npm-registry-check.sh`'s `."repository.url"` readers
never matched.

0.7.0 escaped it because all three names were brand new, so every check took the
`absent-new-package` branch, which reads only the error document. Error documents are
unchanged in npm 12.

## The change

- `npm-registry-check.sh` reads every document through one unwrapping reader, at both parse
  sites: the name-level query behind `absent-new-version` (where v0.7.1 died) and the
  version-specific query behind `verified-published` (same reader, reached by the
  post-publish retry loop from #506). Error fields go through the same reader.
- `fakenpm` emits the npm 12 array by default with the older object shape opt-in via
  `FAKE_NPM_VIEW_SHAPE=object`, and the outcome table runs under both.

The npm pin is untouched; the parsing tolerates both shapes instead.

## Verification

Against the current `main` script, the new table fails exactly the five cases that parse a
success document, with the CI error, and passes the two that do not:

```
--- FAIL: .../name_exists,_exact_version_absent,_ownership_matches/array_view_document
--- FAIL: .../name_exists,_exact_version_absent,_ownership_does_not_match/array_view_document
--- FAIL: .../exact_version_present_and_matching/array_view_document
--- FAIL: .../exact_version_present,_integrity_mismatch/array_view_document
--- FAIL: .../exact_version_present,_integrity_matches_but_repository_does_not/array_view_document
```

Against the real registry with `npm@12.0.2` installed locally, the fixed script classifies:

| query | outcome |
| --- | --- |
| `@atqamz/hand-linux-x64@0.7.1` | `absent-new-version` (0) |
| `@atqamz/hand-linux-x64@0.7.0` with the real integrity | `verified-published` (0) |
| `@atqamz/hand-linux-x64@0.7.0` with a wrong integrity | `integrity-mismatch` (1) |
| `@atqamz/hand@0.7.1` | `absent-new-package` (0) |
| `express@4.18.2` against hand's repo url | `integrity-mismatch` (1) |

`go test ./tests/npmpublish/... ./tests/release/...`, `make lint`, and
`shellcheck .github/scripts/*.sh` all pass.