### PR TITLE
docs(npm): record that the bootstrap token was revoked

### DIFF
--- a/docs/npm-trusted-publisher-enrollment.md
+++ b/docs/npm-trusted-publisher-enrollment.md
@@ -103,13 +103,35 @@ name yet.
 
 - The pinned npm CLI (`npm@12.0.2`, see `.github/workflows/release.yaml`) already supports
   OIDC Trusted Publishing; no toolchain change is needed alongside enrollment.
-- `NPM_BOOTSTRAP_TOKEN` stays necessary only for a package name that has never been
-  published before - for example the first platform package created when a new target
-  newly qualifies in `internal/toolchain/runtime.lock.json`. It should not be revoked
-  while any future first-time publish might still need it, but it is no longer used for
-  any name already enrolled here.
+- `NPM_BOOTSTRAP_TOKEN` is needed only for a package name that has never been published
+  before - for example the first platform package created when a new target newly
+  qualifies in `internal/toolchain/runtime.lock.json`. It is never used for a name
+  already enrolled here.
 - Repeat this procedure once for each brand-new package name after its first version
   publishes, since Trusted Publishing is configured per package name, not per scope.
+
+## The bootstrap token no longer exists
+
+As of 2026-08-30 the operator revoked the token on npmjs.com and it was deleted from the
+`npm-publish` environment; `gh secret list --repo atqamz/hand --env npm-publish` returns
+nothing. Every package name this repository owns - `@atqamz/hand`, `@atqamz/hand-linux-x64`,
+`@atqamz/hand-win32-x64` - published through v0.7.2 and is enrolled above, so releases of
+existing names need no token at all.
+
+A release that has to create a *new* package name therefore fails, by design and visibly:
+`.github/scripts/npm-publish-target.sh` refuses before touching the registry with
+`<name> has never been published and NPM_BOOTSTRAP_TOKEN is not set; refusing`. Nothing is
+left half-published.
+
+That happens the first time a currently unqualified target qualifies. As of this record
+`internal/toolchain/runtime.lock.json` marks `darwin/amd64`, `darwin/arm64`, and
+`linux/arm64` unsupported, and `packaging/npm/generate.sh` derives the published set from
+that file, so any of them qualifying introduces a name that has never been published.
+
+When that happens: create a fresh Granular Access Token on npmjs.com scoped to the
+`@atqamz` scope with publish permission, add it as `NPM_BOOTSTRAP_TOKEN` scoped to the
+`npm-publish` environment (never as a repository secret), let the release publish the new
+name, enroll that name with the procedure above, then revoke the token again.
 
 See
 [`docs/adr/npm-publishes-only-runtime-qualified-targets-behind-one-operator-gate.md`](adr/npm-publishes-only-runtime-qualified-targets-behind-one-operator-gate.md)

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -26,10 +26,12 @@ runtime-qualified (today linux/amd64 and windows/amd64), derived at generation t
 rather than tracked as a second list, and its `npm-publish` release job pauses for
 operator approval every release rather than publishing unattended (see
 `docs/adr/npm-publishes-only-runtime-qualified-targets-behind-one-operator-gate.md`).
-The operator must configure the `npm-publish` GitHub Environment (required reviewer,
-`NPM_BOOTSTRAP_TOKEN` scoped to it) before the first release can publish, and must
-complete `docs/npm-trusted-publisher-enrollment.md` after that first release or the
-second one fails at the npm step.
+The operator must configure the `npm-publish` GitHub Environment with a required reviewer,
+and must complete `docs/npm-trusted-publisher-enrollment.md` for each name after its first
+release or the next one fails at the npm step. `NPM_BOOTSTRAP_TOKEN` was needed only to
+create a name that had never been published; every current name is enrolled, so the token
+was revoked and no longer exists. Creating a brand-new package name needs it back for one
+release; that doc carries the procedure.
 
 WinGet and AUR intentionally stay on the prebuilt asset: WinGet has no build step, and an
 AUR `-bin` package is defined as installing a prebuilt binary rather than compiling one


### PR DESCRIPTION
The operator revoked `NPM_BOOTSTRAP_TOKEN` on npmjs.com, and it has been deleted from the `npm-publish` environment:

```
$ gh secret list --repo atqamz/hand --env npm-publish
(empty)
$ gh secret list --repo atqamz/hand
(empty)
```

That is safe now because all three names - `@atqamz/hand`, `@atqamz/hand-linux-x64`, `@atqamz/hand-win32-x64` - published through v0.7.2 and are enrolled in Trusted Publishing, and the token is only ever read on the `absent-new-package` path.

Two documents said the opposite and would have misled a reader:

- `docs/npm-trusted-publisher-enrollment.md` said it "should not be revoked while any future first-time publish might still need it".
- `packaging/README.md` listed it as a prerequisite the operator must configure.

Both now state what actually happens without it - `npm-publish-target.sh` refuses a never-published name before touching the registry, so nothing is left half-published - and carry the procedure for the one case that needs it back: a target currently marked unsupported in `internal/toolchain/runtime.lock.json` (`darwin/amd64`, `darwin/arm64`, `linux/arm64`) qualifying and introducing a package name that has never been published.

The ADR is deliberately untouched. Its sentence about the secret is a dated verified fact that was true on its date, and per `docs/adr/README.md` an accepted record is not rewritten unless its decision boundary is reversed, which this does not do.

`go test ./tests/release/...` and `make lint` pass.