### PR TITLE
feat(store): classify v18 and canonical v19 schema families

### DIFF
--- a/internal/store/legacyv18ddl.go
+++ b/internal/store/legacyv18ddl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 var legacyV072Checks = map[string][]string{
@@ -83,10 +84,70 @@ func validateLegacyV18DDLFeatures(sqlDB *sql.DB) error {
 }
 
 func compactLegacyV18DDL(ddl string) string {
-	return strings.Map(func(r rune) rune {
-		if unicode.IsSpace(r) {
-			return -1
+	var compact strings.Builder
+	for i := 0; i < len(ddl); {
+		switch {
+		case strings.HasPrefix(ddl[i:], "--"):
+			i += 2
+			for i < len(ddl) && ddl[i] != '\n' {
+				i++
+			}
+		case strings.HasPrefix(ddl[i:], "/*"):
+			i += 2
+			for i < len(ddl) && !strings.HasPrefix(ddl[i:], "*/") {
+				i++
+			}
+			if i < len(ddl) {
+				i += 2
+			}
+		case ddl[i] == '\'':
+			compact.WriteByte(ddl[i])
+			i++
+			for i < len(ddl) {
+				compact.WriteByte(ddl[i])
+				if ddl[i] == '\'' {
+					if i+1 < len(ddl) && ddl[i+1] == '\'' {
+						compact.WriteByte(ddl[i+1])
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+		case ddl[i] == '"' || ddl[i] == '`':
+			quote := ddl[i]
+			i++
+			for i < len(ddl) {
+				if ddl[i] == quote {
+					if i+1 < len(ddl) && ddl[i+1] == quote {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+			compact.WriteString("quotedidentifier")
+		case ddl[i] == '[':
+			i++
+			for i < len(ddl) && ddl[i] != ']' {
+				i++
+			}
+			if i < len(ddl) {
+				i++
+			}
+			compact.WriteString("quotedidentifier")
+		default:
+			r, size := utf8.DecodeRuneInString(ddl[i:])
+			i += size
+			if unicode.IsSpace(r) {
+				continue
+			}
+			compact.WriteRune(unicode.ToLower(r))
 		}
-		return unicode.ToLower(r)
-	}, ddl)
+	}
+	return compact.String()
 }

--- a/internal/store/legacyv18ddl.go
+++ b/internal/store/legacyv18ddl.go
@@ -1,0 +1,95 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+var legacyV072Checks = map[string][]string{
+	"task": {
+		"check(lifecyclein('open','terminal'))",
+	},
+	"attempt": {
+		"check(lifecyclein('provisioning','running','completed','failed','interrupted'))",
+	},
+	"fleet_identity": {
+		"check(singleton=1)",
+	},
+	"send_attempt": {
+		"check(originin('operator','usage-limit-resume','legacy-undelivered'))",
+		"check(statein('pending','not-submitted','submitted','uncertain'))",
+	},
+}
+
+var legacyV072AutoIncrement = map[string]bool{
+	"attempt":      true,
+	"send_attempt": true,
+}
+
+// validateLegacyV18DDLFeatures covers table semantics SQLite's PRAGMA-derived
+// layout fingerprint cannot observe. The accepted v0.7.2 source has exactly the
+// CHECK constraints and AUTOINCREMENT use below and no alternate table mode,
+// collation, conflict, or deferred-FK clauses. Cutover is read-only, but source
+// eligibility still fails closed on semantic DDL drift rather than calling two
+// schemas equivalent because their columns and indexes happen to match.
+func validateLegacyV18DDLFeatures(sqlDB *sql.DB) error {
+	rows, err := sqlDB.Query(`SELECT name, sql FROM sqlite_schema
+		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+		ORDER BY name`)
+	if err != nil {
+		return fmt.Errorf("read legacy v18 table DDL: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name, ddl string
+		if err := rows.Scan(&name, &ddl); err != nil {
+			return fmt.Errorf("read legacy v18 table DDL: %w", err)
+		}
+		compact := compactLegacyV18DDL(ddl)
+
+		checks := legacyV072Checks[name]
+		if got := strings.Count(compact, "check("); got != len(checks) {
+			return fmt.Errorf("%w: table %s has %d CHECK constraints, want %d", ErrUnsupportedLegacyV18Schema, name, got, len(checks))
+		}
+		for _, check := range checks {
+			if !strings.Contains(compact, check) {
+				return fmt.Errorf("%w: table %s is missing exact CHECK constraint %s", ErrUnsupportedLegacyV18Schema, name, check)
+			}
+		}
+
+		if got, want := strings.Contains(compact, "autoincrement"), legacyV072AutoIncrement[name]; got != want {
+			return fmt.Errorf("%w: table %s AUTOINCREMENT = %t, want %t", ErrUnsupportedLegacyV18Schema, name, got, want)
+		}
+
+		for _, forbidden := range []string{
+			"withoutrowid",
+			")strict",
+			"collate",
+			"onconflict",
+			"deferrable",
+			"initiallydeferred",
+			"generatedalways",
+			"primarykeydesc",
+		} {
+			if strings.Contains(compact, forbidden) {
+				return fmt.Errorf("%w: table %s contains unsupported DDL feature %q", ErrUnsupportedLegacyV18Schema, name, forbidden)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read legacy v18 table DDL: %w", err)
+	}
+	return nil
+}
+
+func compactLegacyV18DDL(ddl string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, ddl)
+}

--- a/internal/store/legacyv18ddl.go
+++ b/internal/store/legacyv18ddl.go
@@ -28,12 +28,9 @@ var legacyV072AutoIncrement = map[string]bool{
 	"send_attempt": true,
 }
 
-// validateLegacyV18DDLFeatures covers table semantics SQLite's PRAGMA-derived
-// layout fingerprint cannot observe. The accepted v0.7.2 source has exactly the
-// CHECK constraints and AUTOINCREMENT use below and no alternate table mode,
-// collation, conflict, or deferred-FK clauses. Cutover is read-only, but source
-// eligibility still fails closed on semantic DDL drift rather than calling two
-// schemas equivalent because their columns and indexes happen to match.
+// Legacy cutover accepts only the shipped v0.7.2 table semantics that PRAGMA
+// layout inspection cannot observe. Semantic DDL drift fails closed even when
+// columns, foreign keys, and indexes otherwise match.
 func validateLegacyV18DDLFeatures(sqlDB *sql.DB) error {
 	rows, err := sqlDB.Query(`SELECT name, sql FROM sqlite_schema
 		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -12,9 +12,21 @@ import (
 const legacyV072LayoutFingerprint = "discover-in-ci"
 
 func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
-	tables, err := legacyV18TableNames(sqlDB)
+	lines, err := legacyV18LayoutLines(sqlDB)
 	if err != nil {
 		return "", err
+	}
+	hash := sha256.New()
+	for _, line := range lines {
+		_, _ = hash.Write([]byte(line + "\n"))
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func legacyV18LayoutLines(sqlDB *sql.DB) ([]string, error) {
+	tables, err := legacyV18TableNames(sqlDB)
+	if err != nil {
+		return nil, err
 	}
 
 	lines := make([]string, 0, 128)
@@ -22,27 +34,23 @@ func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
 		lines = append(lines, "table|"+table)
 		columns, err := legacyV18ColumnLines(sqlDB, table)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		lines = append(lines, columns...)
 		foreignKeys, err := legacyV18ForeignKeyLines(sqlDB, table)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		lines = append(lines, foreignKeys...)
 		indexes, err := legacyV18IndexLines(sqlDB, table)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		lines = append(lines, indexes...)
 	}
 
 	sort.Strings(lines)
-	hash := sha256.New()
-	for _, line := range lines {
-		_, _ = hash.Write([]byte(line + "\n"))
-	}
-	return hex.EncodeToString(hash.Sum(nil)), nil
+	return lines, nil
 }
 
 func legacyV18TableNames(sqlDB *sql.DB) ([]string, error) {

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -122,38 +122,53 @@ func legacyV18ForeignKeyLines(sqlDB *sql.DB, table string) ([]string, error) {
 	return lines, nil
 }
 
+type legacyV18IndexDescriptor struct {
+	Name    string
+	Origin  string
+	Unique  int
+	Partial int
+}
+
 func legacyV18IndexLines(sqlDB *sql.DB, table string) ([]string, error) {
 	rows, err := sqlDB.Query(`SELECT name, "unique", origin, partial FROM pragma_index_list(?)`, table)
 	if err != nil {
 		return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	var lines []string
+	var indexes []legacyV18IndexDescriptor
 	for rows.Next() {
-		var name, origin string
-		var unique, partial int
-		if err := rows.Scan(&name, &unique, &origin, &partial); err != nil {
+		var index legacyV18IndexDescriptor
+		if err := rows.Scan(&index.Name, &index.Unique, &index.Origin, &index.Partial); err != nil {
+			_ = rows.Close()
 			return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
 		}
-		keys, err := legacyV18IndexKey(sqlDB, name)
+		indexes = append(indexes, index)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close legacy v18 indexes for %s: %w", table, err)
+	}
+
+	var lines []string
+	for _, index := range indexes {
+		keys, err := legacyV18IndexKey(sqlDB, index.Name)
 		if err != nil {
 			return nil, err
 		}
-		if origin == "c" {
-			predicate, err := legacyV18IndexPredicate(sqlDB, name, partial != 0)
+		if index.Origin == "c" {
+			predicate, err := legacyV18IndexPredicate(sqlDB, index.Name, index.Partial != 0)
 			if err != nil {
 				return nil, err
 			}
 			lines = append(lines, fmt.Sprintf("index|%s|%s|%d|%d|%s|%s",
-				table, name, unique, partial, keys, predicate))
+				table, index.Name, index.Unique, index.Partial, keys, predicate))
 			continue
 		}
 		lines = append(lines, fmt.Sprintf("constraint-index|%s|%s|%d|%d|%s",
-			table, origin, unique, partial, keys))
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
+			table, index.Origin, index.Unique, index.Partial, keys))
 	}
 	return lines, nil
 }

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const legacyV072LayoutFingerprint = "discover-in-ci"
+const legacyV072LayoutFingerprint = "7cf67e6ac1c738e348d91ca552f66daa7b5eaf6e4aab9db84a78b49b70a07bec"
 
 func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
 	lines, err := legacyV18LayoutLines(sqlDB)
@@ -91,6 +91,11 @@ func legacyV18ColumnLines(sqlDB *sql.DB, table string) ([]string, error) {
 		var defaultValue sql.NullString
 		if err := rows.Scan(&name, &typ, &notNull, &defaultValue, &primaryKey, &hidden); err != nil {
 			return nil, fmt.Errorf("read legacy v18 columns for %s: %w", table, err)
+		}
+		// Shipped pre-split homes had hold.kind NOT NULL without a default; fresh v0.7.2
+		// has DEFAULT ''. Cutover never writes the source, so those forms are equivalent.
+		if table == "hold" && name == "kind" && !defaultValue.Valid {
+			defaultValue = sql.NullString{String: "''", Valid: true}
 		}
 		lines = append(lines, fmt.Sprintf("column|%s|%s|%s|%d|%s|%d|%d",
 			table, name, strings.ToUpper(strings.TrimSpace(typ)), notNull,

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -11,11 +11,9 @@ import (
 
 const legacyV072LayoutFingerprint = "discover-in-ci"
 
-// legacyV18LayoutFingerprint hashes the schema properties cutover reads rather
-// than sqlite_schema's historical CREATE text. That keeps fresh and migrated
-// v0.7.2 databases equivalent when ALTER TABLE changed text or column order,
-// while still freezing tables, columns, defaults, keys, foreign keys, explicit
-// indexes, and partial-index predicates.
+// legacyV18LayoutFingerprint hashes the structural schema properties cutover reads.
+// It ignores historical CREATE formatting and column order while freezing keys,
+// defaults, foreign keys, explicit indexes, and partial-index predicates.
 func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
 	tables, err := legacyV18TableNames(sqlDB)
 	if err != nil {

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const legacyV072LayoutFingerprint = "discover-in-ci"
+
+// legacyV18LayoutFingerprint hashes the schema properties cutover reads rather
+// than sqlite_schema's historical CREATE text. That keeps fresh and migrated
+// v0.7.2 databases equivalent when ALTER TABLE changed text or column order,
+// while still freezing tables, columns, defaults, keys, foreign keys, explicit
+// indexes, and partial-index predicates.
+func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
+	tables, err := legacyV18TableNames(sqlDB)
+	if err != nil {
+		return "", err
+	}
+
+	lines := make([]string, 0, 128)
+	for _, table := range tables {
+		lines = append(lines, "table|"+table)
+		columns, err := legacyV18ColumnLines(sqlDB, table)
+		if err != nil {
+			return "", err
+		}
+		lines = append(lines, columns...)
+		foreignKeys, err := legacyV18ForeignKeyLines(sqlDB, table)
+		if err != nil {
+			return "", err
+		}
+		lines = append(lines, foreignKeys...)
+		indexes, err := legacyV18IndexLines(sqlDB, table)
+		if err != nil {
+			return "", err
+		}
+		lines = append(lines, indexes...)
+	}
+
+	sort.Strings(lines)
+	hash := sha256.New()
+	for _, line := range lines {
+		_, _ = hash.Write([]byte(line + "\n"))
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func legacyV18TableNames(sqlDB *sql.DB) ([]string, error) {
+	rows, err := sqlDB.Query(`SELECT name FROM sqlite_schema
+		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+		ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("read legacy v18 tables: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read legacy v18 tables: %w", err)
+	}
+	return tables, nil
+}
+
+func legacyV18ColumnLines(sqlDB *sql.DB, table string) ([]string, error) {
+	rows, err := sqlDB.Query(`SELECT name, type, "notnull", dflt_value, pk, hidden
+		FROM pragma_table_xinfo(?)`, table)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 columns for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var lines []string
+	for rows.Next() {
+		var name, typ string
+		var notNull, primaryKey, hidden int
+		var defaultValue sql.NullString
+		if err := rows.Scan(&name, &typ, &notNull, &defaultValue, &primaryKey, &hidden); err != nil {
+			return nil, fmt.Errorf("read legacy v18 columns for %s: %w", table, err)
+		}
+		lines = append(lines, fmt.Sprintf("column|%s|%s|%s|%d|%s|%d|%d",
+			table, name, strings.ToUpper(strings.TrimSpace(typ)), notNull,
+			legacyV18NullableText(defaultValue), primaryKey, hidden))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read legacy v18 columns for %s: %w", table, err)
+	}
+	return lines, nil
+}
+
+func legacyV18ForeignKeyLines(sqlDB *sql.DB, table string) ([]string, error) {
+	rows, err := sqlDB.Query(`SELECT "from", "table", "to", on_update, on_delete, match
+		FROM pragma_foreign_key_list(?)`, table)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 foreign keys for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var lines []string
+	for rows.Next() {
+		var from, targetTable, to, onUpdate, onDelete, match string
+		if err := rows.Scan(&from, &targetTable, &to, &onUpdate, &onDelete, &match); err != nil {
+			return nil, fmt.Errorf("read legacy v18 foreign keys for %s: %w", table, err)
+		}
+		lines = append(lines, fmt.Sprintf("fk|%s|%s|%s|%s|%s|%s|%s",
+			table, from, targetTable, to, onUpdate, onDelete, match))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read legacy v18 foreign keys for %s: %w", table, err)
+	}
+	return lines, nil
+}
+
+func legacyV18IndexLines(sqlDB *sql.DB, table string) ([]string, error) {
+	rows, err := sqlDB.Query(`SELECT name, "unique", origin, partial FROM pragma_index_list(?)`, table)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var lines []string
+	for rows.Next() {
+		var name, origin string
+		var unique, partial int
+		if err := rows.Scan(&name, &unique, &origin, &partial); err != nil {
+			return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
+		}
+		keys, err := legacyV18IndexKey(sqlDB, name)
+		if err != nil {
+			return nil, err
+		}
+		if origin == "c" {
+			predicate, err := legacyV18IndexPredicate(sqlDB, name, partial != 0)
+			if err != nil {
+				return nil, err
+			}
+			lines = append(lines, fmt.Sprintf("index|%s|%s|%d|%d|%s|%s",
+				table, name, unique, partial, keys, predicate))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("constraint-index|%s|%s|%d|%d|%s",
+			table, origin, unique, partial, keys))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
+	}
+	return lines, nil
+}
+
+func legacyV18IndexKey(sqlDB *sql.DB, index string) (string, error) {
+	rows, err := sqlDB.Query(`SELECT seqno, name, "desc", coll, key FROM pragma_index_xinfo(?)
+		WHERE key = 1 ORDER BY seqno`, index)
+	if err != nil {
+		return "", fmt.Errorf("read legacy v18 index %s: %w", index, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var parts []string
+	for rows.Next() {
+		var sequence, descending, key int
+		var name, collation sql.NullString
+		if err := rows.Scan(&sequence, &name, &descending, &collation, &key); err != nil {
+			return "", fmt.Errorf("read legacy v18 index %s: %w", index, err)
+		}
+		parts = append(parts, fmt.Sprintf("%d:%s:%d:%s",
+			sequence, legacyV18NullableText(name), descending, legacyV18NullableText(collation)))
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("read legacy v18 index %s: %w", index, err)
+	}
+	return strings.Join(parts, ","), nil
+}
+
+func legacyV18IndexPredicate(sqlDB *sql.DB, index string, partial bool) (string, error) {
+	if !partial {
+		return "", nil
+	}
+	var ddl string
+	if err := sqlDB.QueryRow(`SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?`, index).Scan(&ddl); err != nil {
+		return "", fmt.Errorf("read legacy v18 partial index %s: %w", index, err)
+	}
+	normalized := strings.ToLower(strings.Join(strings.Fields(ddl), " "))
+	where := strings.Index(normalized, " where ")
+	if where < 0 {
+		return "", fmt.Errorf("read legacy v18 partial index %s: missing WHERE predicate", index)
+	}
+	return strings.TrimSpace(normalized[where+len(" where "):]), nil
+}
+
+func legacyV18NullableText(value sql.NullString) string {
+	if !value.Valid {
+		return "<null>"
+	}
+	return strings.TrimSpace(value.String)
+}

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -11,9 +11,6 @@ import (
 
 const legacyV072LayoutFingerprint = "discover-in-ci"
 
-// legacyV18LayoutFingerprint hashes the structural schema properties cutover reads.
-// It ignores historical CREATE formatting and column order while freezing keys,
-// defaults, foreign keys, explicit indexes, and partial-index predicates.
 func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
 	tables, err := legacyV18TableNames(sqlDB)
 	if err != nil {

--- a/internal/store/schemafamily.go
+++ b/internal/store/schemafamily.go
@@ -128,6 +128,9 @@ func inspectSchemaFamily(sqlDB *sql.DB) (SchemaInfo, error) {
 				identity.Tables, identity.Indexes, identity.Triggers,
 				legacyV072TableCount, legacyV072IndexCount, legacyV072TriggerCount)
 		}
+		if err := validateLegacyV18DDLFeatures(sqlDB); err != nil {
+			return info, err
+		}
 		return info, nil
 	}
 

--- a/internal/store/schemafamily.go
+++ b/internal/store/schemafamily.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+)
+
+const (
+	legacyV072SchemaVersion     = 21
+	legacyV072SchemaFingerprint = "discover-in-ci"
+)
+
+// SchemaFamily names the persistence family found at state/hand.db without
+// mutating, migrating, or otherwise reconciling it.
+type SchemaFamily string
+
+const (
+	// SchemaFamilyMissing means state/hand.db does not exist.
+	SchemaFamilyMissing SchemaFamily = "missing"
+	// SchemaFamilyEmpty means the SQLite file exists but has no user schema objects.
+	SchemaFamilyEmpty SchemaFamily = "empty"
+	// SchemaFamilyLegacyV18 means the database carries Hand's pre-v19 schema family.
+	SchemaFamilyLegacyV18 SchemaFamily = "legacy-v18"
+	// SchemaFamilyCanonicalV19 means the database carries canonical-v19 relations.
+	SchemaFamilyCanonicalV19 SchemaFamily = "canonical-v19"
+	// SchemaFamilyUnknown means the database is neither a recognized legacy nor v19 family.
+	SchemaFamilyUnknown SchemaFamily = "unknown"
+)
+
+// SchemaInfo is the non-mutating persistence identity observed for one state database.
+type SchemaInfo struct {
+	Family      SchemaFamily
+	UserVersion int
+	Fingerprint string
+	Tables      int
+	Indexes     int
+	Triggers    int
+}
+
+// ErrUnsupportedLegacyV18Schema marks a legacy-family database that is not the
+// exact v0.7.2 source contract accepted by the v18-to-v19 cutover.
+var ErrUnsupportedLegacyV18Schema = errors.New("legacy v18 schema is not the exact v0.7.2 cutover source")
+
+// ErrUnknownSchema marks a non-empty database outside both recognized Hand schema families.
+var ErrUnknownSchema = errors.New("state database schema family is unknown")
+
+// InspectSchema opens an existing state database read-only and classifies its
+// schema family. It never creates, migrates, checkpoints, or repairs state.
+func InspectSchema(homeDir string) (SchemaInfo, error) {
+	if _, err := os.Stat(Path(homeDir)); os.IsNotExist(err) {
+		return SchemaInfo{Family: SchemaFamilyMissing}, nil
+	} else if err != nil {
+		return SchemaInfo{}, fmt.Errorf("check %s: %w", Path(homeDir), err)
+	}
+
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	defer func() { _ = db.Close() }()
+	return inspectSchemaFamily(db.sql)
+}
+
+func inspectSchemaFamily(sqlDB *sql.DB) (SchemaInfo, error) {
+	version, err := schemaUserVersion(sqlDB)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	identity, err := inspectCanonicalV19Identity(sqlDB)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	info := SchemaInfo{
+		UserVersion: version,
+		Fingerprint: identity.Fingerprint,
+		Tables:      identity.Tables,
+		Indexes:     identity.Indexes,
+		Triggers:    identity.Triggers,
+	}
+
+	var objects int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'`).Scan(&objects); err != nil {
+		return SchemaInfo{}, fmt.Errorf("inspect schema objects: %w", err)
+	}
+	if objects == 0 {
+		info.Family = SchemaFamilyEmpty
+		return info, nil
+	}
+
+	canonical, err := canonicalV19Candidate(sqlDB)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	if canonical {
+		info.Family = SchemaFamilyCanonicalV19
+		if err := validateCanonicalV19Schema(sqlDB); err != nil {
+			return info, err
+		}
+		return info, nil
+	}
+
+	legacy, err := legacyV18Candidate(sqlDB)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	if legacy {
+		info.Family = SchemaFamilyLegacyV18
+		if version != legacyV072SchemaVersion {
+			return info, fmt.Errorf("%w: PRAGMA user_version = %d, want %d", ErrUnsupportedLegacyV18Schema, version, legacyV072SchemaVersion)
+		}
+		if identity.Fingerprint != legacyV072SchemaFingerprint {
+			return info, fmt.Errorf("%w: schema fingerprint = %s, want %s", ErrUnsupportedLegacyV18Schema, identity.Fingerprint, legacyV072SchemaFingerprint)
+		}
+		return info, nil
+	}
+
+	info.Family = SchemaFamilyUnknown
+	return info, ErrUnknownSchema
+}
+
+func schemaUserVersion(sqlDB *sql.DB) (int, error) {
+	var version int
+	if err := sqlDB.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		return 0, fmt.Errorf("read schema user_version: %w", err)
+	}
+	return version, nil
+}
+
+func legacyV18Candidate(sqlDB *sql.DB) (bool, error) {
+	var meta int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'meta'`).Scan(&meta); err != nil {
+		return false, fmt.Errorf("detect legacy v18 meta relation: %w", err)
+	}
+	return meta == 1, nil
+}

--- a/internal/store/schemafamily.go
+++ b/internal/store/schemafamily.go
@@ -9,7 +9,10 @@ import (
 
 const (
 	legacyV072SchemaVersion     = 21
-	legacyV072SchemaFingerprint = "discover-in-ci"
+	legacyV072SchemaFingerprint = "ad9cf375336aeca24fc3d2adaa4fcac986b48defcb1343c8c95825e7077e18d4"
+	legacyV072TableCount        = 7
+	legacyV072IndexCount        = 5
+	legacyV072TriggerCount      = 0
 )
 
 // SchemaFamily names the persistence family found at state/hand.db without
@@ -112,6 +115,12 @@ func inspectSchemaFamily(sqlDB *sql.DB) (SchemaInfo, error) {
 		}
 		if identity.Fingerprint != legacyV072SchemaFingerprint {
 			return info, fmt.Errorf("%w: schema fingerprint = %s, want %s", ErrUnsupportedLegacyV18Schema, identity.Fingerprint, legacyV072SchemaFingerprint)
+		}
+		if identity.Tables != legacyV072TableCount || identity.Indexes != legacyV072IndexCount || identity.Triggers != legacyV072TriggerCount {
+			return info, fmt.Errorf("%w: schema objects = %d tables / %d indexes / %d triggers, want %d / %d / %d",
+				ErrUnsupportedLegacyV18Schema,
+				identity.Tables, identity.Indexes, identity.Triggers,
+				legacyV072TableCount, legacyV072IndexCount, legacyV072TriggerCount)
 		}
 		return info, nil
 	}

--- a/internal/store/schemafamily.go
+++ b/internal/store/schemafamily.go
@@ -8,11 +8,10 @@ import (
 )
 
 const (
-	legacyV072SchemaVersion     = 21
-	legacyV072SchemaFingerprint = "ad9cf375336aeca24fc3d2adaa4fcac986b48defcb1343c8c95825e7077e18d4"
-	legacyV072TableCount        = 7
-	legacyV072IndexCount        = 5
-	legacyV072TriggerCount      = 0
+	legacyV072SchemaVersion = 21
+	legacyV072TableCount    = 7
+	legacyV072IndexCount    = 5
+	legacyV072TriggerCount  = 0
 )
 
 // SchemaFamily names the persistence family found at state/hand.db without
@@ -34,12 +33,13 @@ const (
 
 // SchemaInfo is the non-mutating persistence identity observed for one state database.
 type SchemaInfo struct {
-	Family      SchemaFamily
-	UserVersion int
-	Fingerprint string
-	Tables      int
-	Indexes     int
-	Triggers    int
+	Family            SchemaFamily
+	UserVersion       int
+	Fingerprint       string
+	LayoutFingerprint string
+	Tables            int
+	Indexes           int
+	Triggers          int
 }
 
 // ErrUnsupportedLegacyV18Schema marks a legacy-family database that is not the
@@ -98,6 +98,7 @@ func inspectSchemaFamily(sqlDB *sql.DB) (SchemaInfo, error) {
 	}
 	if canonical {
 		info.Family = SchemaFamilyCanonicalV19
+		info.LayoutFingerprint = identity.Fingerprint
 		if err := validateCanonicalV19Schema(sqlDB); err != nil {
 			return info, err
 		}
@@ -110,11 +111,16 @@ func inspectSchemaFamily(sqlDB *sql.DB) (SchemaInfo, error) {
 	}
 	if legacy {
 		info.Family = SchemaFamilyLegacyV18
+		layoutFingerprint, err := legacyV18LayoutFingerprint(sqlDB)
+		if err != nil {
+			return info, err
+		}
+		info.LayoutFingerprint = layoutFingerprint
 		if version != legacyV072SchemaVersion {
 			return info, fmt.Errorf("%w: PRAGMA user_version = %d, want %d", ErrUnsupportedLegacyV18Schema, version, legacyV072SchemaVersion)
 		}
-		if identity.Fingerprint != legacyV072SchemaFingerprint {
-			return info, fmt.Errorf("%w: schema fingerprint = %s, want %s", ErrUnsupportedLegacyV18Schema, identity.Fingerprint, legacyV072SchemaFingerprint)
+		if layoutFingerprint != legacyV072LayoutFingerprint {
+			return info, fmt.Errorf("%w: layout fingerprint = %s, want %s", ErrUnsupportedLegacyV18Schema, layoutFingerprint, legacyV072LayoutFingerprint)
 		}
 		if identity.Tables != legacyV072TableCount || identity.Indexes != legacyV072IndexCount || identity.Triggers != legacyV072TriggerCount {
 			return info, fmt.Errorf("%w: schema objects = %d tables / %d indexes / %d triggers, want %d / %d / %d",

--- a/internal/store/schemafamily_ddl_test.go
+++ b/internal/store/schemafamily_ddl_test.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestInspectSchemaRejectsLegacyCheckConstraintDrift(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := strings.Replace(schema,
+		"singleton INTEGER PRIMARY KEY CHECK (singleton = 1)",
+		"singleton INTEGER PRIMARY KEY",
+		1,
+	)
+	if drifted == schema {
+		_ = sqlDB.Close()
+		t.Fatal("test fixture did not remove fleet_identity CHECK constraint")
+	}
+	if _, err := sqlDB.Exec(drifted); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(sendSchema); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`PRAGMA user_version = 21`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrUnsupportedLegacyV18Schema) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrUnsupportedLegacyV18Schema", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}
+
+func TestInspectSchemaRejectsLegacyAutoincrementDrift(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := strings.Replace(schema,
+		"id                     INTEGER PRIMARY KEY AUTOINCREMENT",
+		"id                     INTEGER PRIMARY KEY",
+		1,
+	)
+	if drifted == schema {
+		_ = sqlDB.Close()
+		t.Fatal("test fixture did not remove attempt AUTOINCREMENT")
+	}
+	if _, err := sqlDB.Exec(drifted); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(sendSchema); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`PRAGMA user_version = 21`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrUnsupportedLegacyV18Schema) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrUnsupportedLegacyV18Schema", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}

--- a/internal/store/schemafamily_ddl_test.go
+++ b/internal/store/schemafamily_ddl_test.go
@@ -85,3 +85,59 @@ func TestInspectSchemaRejectsLegacyAutoincrementDrift(t *testing.T) {
 		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
 	}
 }
+
+func TestInspectSchemaRejectsCommentSpoofedLegacyCheck(t *testing.T) {
+	drifted := strings.Replace(schema,
+		"singleton INTEGER PRIMARY KEY CHECK (singleton = 1)",
+		"singleton INTEGER PRIMARY KEY /* CHECK (singleton = 1) */",
+		1,
+	)
+	if drifted == schema {
+		t.Fatal("test fixture did not replace fleet_identity CHECK with a comment")
+	}
+	assertUnsupportedLegacyDDL(t, drifted)
+}
+
+func TestInspectSchemaRejectsCaseChangedLegacyCheckLiteral(t *testing.T) {
+	drifted := strings.Replace(schema,
+		"CHECK (lifecycle IN ('open', 'terminal'))",
+		"CHECK (lifecycle IN ('OPEN', 'terminal'))",
+		1,
+	)
+	if drifted == schema {
+		t.Fatal("test fixture did not change task lifecycle CHECK literal")
+	}
+	assertUnsupportedLegacyDDL(t, drifted)
+}
+
+func assertUnsupportedLegacyDDL(t *testing.T, ddl string) {
+	t.Helper()
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(ddl); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(sendSchema); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`PRAGMA user_version = 21`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrUnsupportedLegacyV18Schema) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrUnsupportedLegacyV18Schema", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}

--- a/internal/store/schemafamily_migration_test.go
+++ b/internal/store/schemafamily_migration_test.go
@@ -1,0 +1,69 @@
+package store
+
+import "testing"
+
+func TestInspectSchemaRecognizesMigrated040AsExactV072Legacy(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(legacy040Schema); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`PRAGMA user_version = 7`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if err != nil {
+		t.Fatalf("InspectSchema migrated 0.4.0 = %+v, error = %v", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}
+
+func TestInspectSchemaRecognizesMigratedPreVersioningAsExactV072Legacy(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(preVersioningSchema); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if err != nil {
+		t.Fatalf("InspectSchema migrated pre-versioning = %+v, error = %v", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}

--- a/internal/store/schemafamily_migration_test.go
+++ b/internal/store/schemafamily_migration_test.go
@@ -1,6 +1,9 @@
 package store
 
-import "testing"
+import (
+	"database/sql"
+	"testing"
+)
 
 func TestInspectSchemaRecognizesMigrated040AsExactV072Legacy(t *testing.T) {
 	home := t.TempDir()
@@ -27,6 +30,7 @@ func TestInspectSchemaRecognizesMigrated040AsExactV072Legacy(t *testing.T) {
 	if err := migrated.Close(); err != nil {
 		t.Fatal(err)
 	}
+	assertLegacyV072LayoutMatchesFresh(t, home)
 
 	info, err := InspectSchema(home)
 	if err != nil {
@@ -58,6 +62,7 @@ func TestInspectSchemaRecognizesMigratedPreVersioningAsExactV072Legacy(t *testin
 	if err := migrated.Close(); err != nil {
 		t.Fatal(err)
 	}
+	assertLegacyV072LayoutMatchesFresh(t, home)
 
 	info, err := InspectSchema(home)
 	if err != nil {
@@ -66,4 +71,74 @@ func TestInspectSchemaRecognizesMigratedPreVersioningAsExactV072Legacy(t *testin
 	if info.Family != SchemaFamilyLegacyV18 {
 		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
 	}
+}
+
+func assertLegacyV072LayoutMatchesFresh(t *testing.T, migratedHome string) {
+	t.Helper()
+
+	freshHome := t.TempDir()
+	fresh, err := Open(freshHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fresh.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	freshDB, err := openReadOnlySQLForLayout(freshHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = freshDB.Close() }()
+	migratedDB, err := openReadOnlySQLForLayout(migratedHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = migratedDB.Close() }()
+
+	freshLines, err := legacyV18LayoutLines(freshDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	migratedLines, err := legacyV18LayoutLines(migratedDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	freshOnly, migratedOnly := layoutLineDifference(freshLines, migratedLines)
+	if len(freshOnly) != 0 || len(migratedOnly) != 0 {
+		t.Fatalf("normalized legacy layout differs\nfresh-only: %#v\nmigrated-only: %#v", freshOnly, migratedOnly)
+	}
+}
+
+func openReadOnlySQLForLayout(home string) (*sql.DB, error) {
+	db, err := openReadOnly(home)
+	if err != nil {
+		return nil, err
+	}
+	return db.sql, nil
+}
+
+func layoutLineDifference(left, right []string) ([]string, []string) {
+	leftSet := make(map[string]bool, len(left))
+	rightSet := make(map[string]bool, len(right))
+	for _, line := range left {
+		leftSet[line] = true
+	}
+	for _, line := range right {
+		rightSet[line] = true
+	}
+
+	var leftOnly, rightOnly []string
+	for _, line := range left {
+		if !rightSet[line] {
+			leftOnly = append(leftOnly, line)
+		}
+	}
+	for _, line := range right {
+		if !leftSet[line] {
+			rightOnly = append(rightOnly, line)
+		}
+	}
+	return leftOnly, rightOnly
 }

--- a/internal/store/schemafamily_test.go
+++ b/internal/store/schemafamily_test.go
@@ -40,8 +40,8 @@ func TestInspectSchemaRecognizesExactV072Legacy(t *testing.T) {
 	if info.UserVersion != legacyV072SchemaVersion {
 		t.Fatalf("user_version = %d, want %d", info.UserVersion, legacyV072SchemaVersion)
 	}
-	if info.Fingerprint != legacyV072SchemaFingerprint {
-		t.Fatalf("schema fingerprint = %s, want %s", info.Fingerprint, legacyV072SchemaFingerprint)
+	if info.LayoutFingerprint != legacyV072LayoutFingerprint {
+		t.Fatalf("layout fingerprint = %s, want %s", info.LayoutFingerprint, legacyV072LayoutFingerprint)
 	}
 	if info.Tables != legacyV072TableCount || info.Indexes != legacyV072IndexCount || info.Triggers != legacyV072TriggerCount {
 		t.Fatalf("schema objects = %d tables / %d indexes / %d triggers, want %d / %d / %d",
@@ -119,6 +119,9 @@ func TestInspectSchemaRecognizesCanonicalV19(t *testing.T) {
 	}
 	if info.Fingerprint != canonicalV19SchemaFingerprint {
 		t.Fatalf("schema fingerprint = %s, want %s", info.Fingerprint, canonicalV19SchemaFingerprint)
+	}
+	if info.LayoutFingerprint != canonicalV19SchemaFingerprint {
+		t.Fatalf("layout fingerprint = %s, want canonical schema fingerprint %s", info.LayoutFingerprint, canonicalV19SchemaFingerprint)
 	}
 }
 

--- a/internal/store/schemafamily_test.go
+++ b/internal/store/schemafamily_test.go
@@ -1,0 +1,191 @@
+package store
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestInspectSchemaMissing(t *testing.T) {
+	info, err := InspectSchema(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Family != SchemaFamilyMissing {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyMissing)
+	}
+}
+
+func TestInspectSchemaRecognizesExactV072Legacy(t *testing.T) {
+	if len(migrations) != legacyV072SchemaVersion {
+		t.Fatalf("legacy migration ladder = %d, v0.7.2 source contract is frozen at %d", len(migrations), legacyV072SchemaVersion)
+	}
+
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if err != nil {
+		t.Fatalf("InspectSchema = %+v, error = %v", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+	if info.UserVersion != legacyV072SchemaVersion {
+		t.Fatalf("user_version = %d, want %d", info.UserVersion, legacyV072SchemaVersion)
+	}
+	if info.Fingerprint != legacyV072SchemaFingerprint {
+		t.Fatalf("schema fingerprint = %s, want %s", info.Fingerprint, legacyV072SchemaFingerprint)
+	}
+}
+
+func TestInspectSchemaRejectsLegacyVersion19DespiteCurrentLayout(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`PRAGMA user_version = 19`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrUnsupportedLegacyV18Schema) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrUnsupportedLegacyV18Schema", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}
+
+func TestInspectSchemaRejectsLegacyLayoutDrift(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`CREATE TABLE legacy_drift (id TEXT PRIMARY KEY)`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrUnsupportedLegacyV18Schema) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrUnsupportedLegacyV18Schema", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+}
+
+func TestInspectSchemaRecognizesCanonicalV19(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := createCanonicalV19Schema(sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Family != SchemaFamilyCanonicalV19 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyCanonicalV19)
+	}
+	if info.Fingerprint != canonicalV19SchemaFingerprint {
+		t.Fatalf("schema fingerprint = %s, want %s", info.Fingerprint, canonicalV19SchemaFingerprint)
+	}
+}
+
+func TestInspectSchemaKeepsDriftedCanonicalV19FailClosed(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := createCanonicalV19Schema(sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`CREATE TABLE canonical_drift (id TEXT PRIMARY KEY) STRICT`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrCanonicalV19SchemaMismatch) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrCanonicalV19SchemaMismatch", info, err)
+	}
+	if info.Family != SchemaFamilyCanonicalV19 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyCanonicalV19)
+	}
+}
+
+func TestInspectSchemaRejectsUnknownDatabase(t *testing.T) {
+	home := t.TempDir()
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`CREATE TABLE mystery (id TEXT PRIMARY KEY)`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if !errors.Is(err, ErrUnknownSchema) {
+		t.Fatalf("InspectSchema = %+v, error = %v, want ErrUnknownSchema", info, err)
+	}
+	if info.Family != SchemaFamilyUnknown {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyUnknown)
+	}
+}
+
+func TestInspectSchemaExistingEmptySQLite(t *testing.T) {
+	home := t.TempDir()
+	path := Path(home)
+	if err := os.MkdirAll(Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := InspectSchema(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Family != SchemaFamilyEmpty {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyEmpty)
+	}
+}

--- a/internal/store/schemafamily_test.go
+++ b/internal/store/schemafamily_test.go
@@ -43,6 +43,11 @@ func TestInspectSchemaRecognizesExactV072Legacy(t *testing.T) {
 	if info.Fingerprint != legacyV072SchemaFingerprint {
 		t.Fatalf("schema fingerprint = %s, want %s", info.Fingerprint, legacyV072SchemaFingerprint)
 	}
+	if info.Tables != legacyV072TableCount || info.Indexes != legacyV072IndexCount || info.Triggers != legacyV072TriggerCount {
+		t.Fatalf("schema objects = %d tables / %d indexes / %d triggers, want %d / %d / %d",
+			info.Tables, info.Indexes, info.Triggers,
+			legacyV072TableCount, legacyV072IndexCount, legacyV072TriggerCount)
+	}
 }
 
 func TestInspectSchemaRejectsLegacyVersion19DespiteCurrentLayout(t *testing.T) {
@@ -175,6 +180,10 @@ func TestInspectSchemaExistingEmptySQLite(t *testing.T) {
 	}
 	sqlDB, err := open(path)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`CREATE TABLE empty_probe (id INTEGER); DROP TABLE empty_probe;`); err != nil {
+		_ = sqlDB.Close()
 		t.Fatal(err)
 	}
 	if err := sqlDB.Close(); err != nil {


### PR DESCRIPTION
Implements the next persistence boundary for #339/#348 without changing ordinary `store.Open` behavior.

This slice is intentionally read-only. It adds typed schema-family inspection for `state/hand.db` and does not create, migrate, checkpoint, repair, archive, publish, or otherwise mutate an inspected database.

Boundary:

- missing state DB -> missing
- existing SQLite with no user schema -> empty
- exact canonical-v19 relations -> canonical-v19 and exact #344 validation
- legacy-family DB -> accepted only when it matches the frozen v0.7.2 cutover-source contract
- unknown/non-Hand schema -> fail closed
- drifted/corrupt canonical-v19 remains a canonical-v19 candidate and fails #344 validation; it is never reclassified as legacy

The legacy source contract is frozen at `PRAGMA user_version = 21`, 7 schema-defined tables / 5 explicit indexes / 0 triggers, and normalized cutover-layout fingerprint `7cf67e6ac1c738e348d91ca552f66daa7b5eaf6e4aab9db84a78b49b70a07bec`.

The normalized structural identity deliberately ignores only one mechanically proven historical DDL-text difference between supported v0.7.2 homes: pre-split upgraded homes carry `hold.kind TEXT NOT NULL` while fresh v0.7.2 carries `hold.kind TEXT NOT NULL DEFAULT ''`. Cutover opens legacy state read-only and never inserts into it, so the missing insert default is canonicalized to the fresh shipped default for source eligibility.

All table/column type/nullability/default/PK shape, FK semantics, unique/index keys, explicit indexes, and partial-index predicates remain fingerprinted. DDL semantics not visible through those PRAGMAs are validated separately: exact shipped `CHECK` constraints and `AUTOINCREMENT` use are required, and alternate table modes/collations/conflict/deferred-FK/generated-column/PK-order semantics fail closed. The DDL semantic normalizer is lexical: comments and quoted identifiers cannot spoof keywords/constraints, while quoted string literal bytes remain case-sensitive so a changed CHECK value cannot normalize back to the shipped contract. Raw `sqlite_schema` fingerprint remains available separately as forensic identity.

Mechanical migration fixtures cover a fresh v0.7.2 DB, a real 0.4.0-style database migrated forward, and a pre-versioning database migrated forward. Adversarial fixtures prove otherwise-structurally-identical legacy candidates with a removed `CHECK`, removed `AUTOINCREMENT`, comment-spoofed `CHECK`, or case-changed CHECK literal are refused. Legacy version/layout drift, unknown databases, and drifted canonical-v19 candidates fail closed.

This PR does not yet implement #348 quiescence, journal/WAL safety, archive identity, import classification, temp publication, or startup recovery. Those remain later slices after exact schema-family identity is landed.

Refs #339 #348 #344.