### PR TITLE
docs(architecture): anchor immutable v19 semantic contracts

### DIFF
--- a/docs/architecture/v19-contracts/323-worker-routing.md
+++ b/docs/architecture/v19-contracts/323-worker-routing.md
@@ -1,0 +1,346 @@
+---
+source_issue: 323
+source_title: "feat(routing): add availability and quota-aware fallback within operator-approved Profiles"
+source_url: https://github.com/atqamz/hand/issues/323
+source_body_updated_at: 2026-09-01T03:05:14Z
+contract_version: v19
+milestone: 0.8.0
+---
+
+# Worker Harness routing contract
+
+This repository snapshot is the frozen v0.8/v19 semantic contract for #323. The GitHub issue remains a tracker surface. The former normative issue comment is incorporated below and is non-normative after this snapshot lands.
+
+## Summary
+
+Freeze the v1-candidate **Worker Harness routing** model around canonical **Plan intent × Plan judgment**, immutable Plan meaning, and immutable per-Attempt resolved execution provenance.
+
+This issue answers exactly one question:
+
+> Given one immutable Plan, which Worker execution policy / Worker Harness / model / effort should a new Attempt use?
+
+It does **not** select or configure the Fleet-level Supervisor Harness.
+
+The operator/runtime topology is:
+
+```text
+Operator
+→ Presentation
+→ Interaction
+  ├─ reasoning-required → Supervisor Harness
+  └─ exact typed input → canonical Hand service
+→ Hand core
+→ Task → Plan → Attempt
+                  ↓
+             Worker Harness
+```
+
+Supervisor Harness selection/runtime policy is a separate configuration/runtime concern owned by #324/#336/#353. The same provider product may serve both roles independently, but the roles and configuration paths must never collapse.
+
+---
+
+# Replace legacy routing vocabulary
+
+Remove the remaining legacy/pre-canonical routing vocabulary:
+
+```text
+Task kind
+scout | ship
+execution_class
+planned_against
+routing_source
+promote
+ambiguous reopen
+one generic harness setting meaning both supervisor and worker
+```
+
+Canonical Worker routing is:
+
+```text
+Plan intent:
+  explore | execute
+
+Plan judgment:
+  mechanical | bounded | substantial
+
+Worker Route key:
+  intent × judgment
+
+Attempt request provenance:
+  profile_override?
+  harness_override?
+  model_override?
+  effort_override?
+
+Attempt final provenance:
+  profile
+  harness
+  model
+  effort
+```
+
+Here `Attempt.harness` always means the **Worker Harness selected for that Attempt**. It does not mean Supervisor Harness.
+
+---
+
+# Core semantic model
+
+## Task does not route execution
+
+Task is the durable operator goal. It has no mutable routing kind that changes as work moves from exploration to implementation.
+
+A Task may contain Plans such as:
+
+```text
+Explore / bounded
+→ Execute / substantial
+→ Explore / mechanical review
+→ Execute / bounded fix
+```
+
+Routing belongs to each immutable Plan.
+
+## Plan owns Worker-routing semantic axes
+
+Every Plan persists exactly one:
+
+```text
+intent   = explore | execute
+judgment = mechanical | bounded | substantial
+```
+
+These fields are immutable. Changing either requires a new Plan through replan/advance semantics; never mutate the existing Plan merely to obtain another Worker Harness.
+
+## Six canonical Worker Route classes
+
+Configuration addresses exactly:
+
+```text
+explore.mechanical
+explore.bounded
+explore.substantial
+execute.mechanical
+execute.bounded
+execute.substantial
+```
+
+Each Worker Route resolves one Worker Profile according to validated current operator policy. These six keys do not apply to Supervisor Harness selection.
+
+Do not keep `scout/ship` or generic `harness` aliases as parallel durable route concepts after the pre-v1 reset. A removed legacy flag/key may produce an actionable migration error, not a second model.
+
+---
+
+# Worker Profiles
+
+A Worker Profile is named **Attempt execution policy**, conceptually containing defaults such as:
+
+```text
+Worker Harness
+model
+effort
+required Worker Harness capabilities
+bounded availability/fallback policy references
+```
+
+Configuration owns current Worker Profile definitions. Canonical Attempt rows own immutable historical resolved provenance. Deleting/changing a Worker Profile never rewrites prior Attempts.
+
+Do not use a Worker Profile to configure Supervisor Harness product/model/effort/wake integration/runtime lifecycle. Those belong to #324's separate Supervisor runtime family.
+
+---
+
+# Deterministic Attempt resolution
+
+For every new Attempt, resolve Worker execution policy before external runtime effects.
+
+Canonical precedence:
+
+```text
+1. validate immutable Plan intent/judgment
+2. resolve exact Worker Route
+3. choose Route Worker Profile unless profile_override supplied
+4. load selected Worker Profile defaults
+5. apply explicit harness/model/effort overrides field-by-field
+6. apply only typed, configured availability fallback
+7. validate Worker Harness/model/effort/capability combination
+8. persist request overrides + final selected values on Attempt
+9. only then proceed to WorktreeCreate / SessionAcquire / Launch effects
+```
+
+There is no silent ignored override. Explicit per-field override wins only for that field.
+
+---
+
+# No `routing_source`; exact fallback provenance
+
+Do not persist one scalar `routing_source`. It is intrinsically lossy because final fields may have different provenance.
+
+The explicit override fields + selected Profile + final values explain the request/final execution policy. If availability fallback changes a value, persist narrowly typed fallback provenance/evidence sufficient to explain that decision.
+
+The exact relational closure incorporated from the former #323 normative comment is:
+
+```text
+AttemptFallbackStep
+→ exact Attempt
+→ ordinal within that Attempt
+→ exact rejected candidate tuple
+→ one typed positive rejection reason
+→ bounded typed observation/evidence digest
+→ observed_at
+```
+
+Baseline fallback reasons are exactly:
+
+```text
+harness-unavailable
+model-unavailable
+quota-exhausted
+capability-unavailable
+combination-unsupported
+```
+
+`unknown` is deliberately **not** a fallback reason. If availability cannot be established positively, resolution returns the owning typed unknown/refusal outcome before external effects rather than recording a candidate as unavailable.
+
+Required invariants:
+
+- `UNIQUE(attempt_id, ordinal)` with deterministic 1..N writer allocation;
+- every fallback row is immutable historical provenance;
+- each row describes a candidate actually rejected before the final selected tuple;
+- no fallback rows are required when the first candidate is selected;
+- final selected values remain on Attempt rather than being inferred from a last fallback row;
+- configuration Route/Profile definitions are not copied into SQLite;
+- no generic routing event/result/source table is introduced;
+- no generic Source/Observation table is introduced solely for routing provenance.
+
+If the chain exhausts, is cyclic/invalid, or remains unknown under policy, fail before WorktreeCreate/SessionAcquire/Launch and do not fabricate a partially routed Attempt solely to persist the failure.
+
+---
+
+# Supervisor Harness separation
+
+This separation is normative.
+
+```text
+Supervisor Harness
+→ hosts Fleet-level reasoning
+→ hand session start once per actual Supervisor Harness runtime/session
+→ hand orient before every Supervisor reasoning turn
+→ may decide to create/retry/replan/advance
+
+Worker Harness
+→ executes exactly one Attempt
+→ selected by Worker Route/Profile/override policy
+→ stored immutably as Attempt provenance
+```
+
+Required invariants:
+
+- selecting a Supervisor Harness does not select the Worker Harness for an Attempt;
+- selecting a Worker Harness does not replace the live Supervisor Harness;
+- changing Supervisor model/effort does not rewrite Worker Route/Profile or Attempt provenance;
+- changing Worker Route/Profile does not restart/reconfigure Supervisor runtime;
+- the same provider product may serve both roles independently;
+- `HAND_ROLE=worker` remains Worker-role enforcement;
+- Supervisor readiness never proves Worker capability, or vice versa;
+- no generic runtime field named only `harness` may drive both roles.
+
+---
+
+# Retry / replan / advance routing
+
+Retry means:
+
+```text
+same immutable Plan
+→ new Attempt
+→ resolve current Worker execution policy again
+```
+
+Old Attempt provenance stays immutable. The new Attempt gets its own request/final Worker provenance. Plan intent/judgment/basis/brief remain unchanged. If requested changes alter Plan meaning, require replan.
+
+Replan/advance create successor Plans with explicit semantics and route their first Attempt independently. There is no `promote scout → ship` shortcut. Explore and Execute are peer Plan intents, not hierarchy levels.
+
+---
+
+# Availability / fallback
+
+Add only deterministic, typed **Worker execution** availability fallback that can be proven before Launch/resource effects wherever feasible.
+
+Requirements:
+
+- fallback chain explicit/configured, finite, cycle-free;
+- capability incompatibility != quota exhaustion;
+- provider/model `unknown` != unavailable;
+- no unbounded probe/retry loop;
+- every candidate validated before selection;
+- final Attempt provenance explains actual Worker execution choice;
+- existing Attempts never mutate;
+- fallback happens before WorktreeCreate / SessionAcquire / Launch when mechanically knowable;
+- inability to observe availability positively returns typed unknown/refusal, not fabricated certainty;
+- Supervisor liveness/availability is never part of Worker fallback.
+
+`Outcome` in routing discussion means a routing-resolution disposition, not a generic canonical Result entity.
+
+---
+
+# Capability and configuration boundary
+
+#324 owns the complete typed config contract. #346 owns role/capability boundaries.
+
+Current mutable Worker routing policy remains configuration authority, not Fleet DB truth. Fleet DB persists historical facts necessary to explain work: Plan intent/judgment, Attempt explicit overrides, selected Profile, final Worker Harness/model/effort, and narrow fallback provenance.
+
+It does not persist a copy of current Route/Profile definitions. Supervisor Harness configuration remains a separate namespace/semantic family.
+
+If legacy config had one generic `harness/model/effort` meaning both Supervisor and Worker defaults, migration must not guess. Map only where meaning is provable; otherwise require explicit operator choice per #324.
+
+---
+
+# Validation before effects
+
+Before Worker resource/Launch effects, reject typed cases such as missing Route/Profile, unsupported Worker Harness/capability, invalid model/effort combination, unsupported override, deterministic availability failure without fallback, unknown availability where positive proof is required, exhausted/cyclic fallback, Plan basis/currentness requiring replan, or role-confused configuration.
+
+Do not begin WorktreeCreate, SessionAcquire, or Launch before discovering a mechanically knowable configuration error.
+
+---
+
+# Required test matrix
+
+Cover all six Worker Routes; route/profile/field override combinations; typed fallback and unknown; retry with changed Worker policy; replan/advance; Supervisor/Worker role collisions including the same product independently configured for both; and invariant that historical Attempts never mutate.
+
+Assert final Attempt state fully explains request/final Worker execution provenance without `routing_source`, and that no Supervisor availability signal influences Worker fallback.
+
+---
+
+# Acceptance criteria
+
+- [ ] This is explicitly **Worker Harness routing**, not generic/Supervisor Harness selection.
+- [ ] Canonical routing key is Plan intent × Plan judgment with exactly six Route classes.
+- [ ] Task kind/scout/ship/execution_class/planned_against/promote are absent from canonical routing semantics.
+- [ ] Plan intent/judgment are immutable.
+- [ ] Retry creates a new Attempt and may re-resolve current Worker policy without mutating old history.
+- [ ] Replan/advance create new Plans with explicit semantic axes.
+- [ ] Attempt stores explicit profile/harness/model/effort overrides and exact final provenance.
+- [ ] `Attempt.harness` unambiguously means Worker Harness.
+- [ ] `routing_source` is absent.
+- [ ] Fallback provenance is exact typed append-only rejected-candidate evidence; `unknown` is not unavailable.
+- [ ] Worker Route/Profile config changes never rewrite historical Attempts.
+- [ ] Supervisor config changes never rewrite Worker routing/Attempt provenance, and Worker routing changes never restart Supervisor implicitly.
+- [ ] Invalid combinations fail before external effects when knowable.
+- [ ] Current Route/Profile config stays config authority rather than duplicated Fleet DB truth.
+- [ ] Ambiguous legacy generic Harness config is never guessed across roles.
+- [ ] Routing APIs expose exact selected provenance or typed outcome; no generic Result/RoutingResult entity exists.
+
+## Architectural outcome
+
+```text
+Task goal
+  ↓
+immutable Plan(intent, judgment, basis, brief)
+  ↓
+Worker Route/Profile + explicit Attempt overrides
+  ↓
+Attempt(final immutable Worker Harness/model/effort provenance)
+  ↓
+Worker Harness execution
+```
+
+Supervisor reasoning remains independently configured and ephemeral. A v0.8 Attempt must explain what the Plan meant, which Worker policy was requested, what was explicitly overridden, what fallback occurred, and which Worker Harness actually executed it—without describing the Supervisor Harness.

--- a/docs/architecture/v19-contracts/324-configuration.md
+++ b/docs/architecture/v19-contracts/324-configuration.md
@@ -1,0 +1,285 @@
+---
+source_issue: 324
+source_title: "refactor(config): freeze typed v1 configuration, precedence, secrets, migration and deprecation rules"
+source_url: https://github.com/atqamz/hand/issues/324
+source_body_updated_at: 2026-09-01T03:05:15Z
+contract_version: v19
+milestone: 0.8.0
+---
+
+# Typed v1 configuration contract
+
+This repository snapshot is the frozen v0.8/v19 semantic contract for #324. The GitHub issue remains a tracker surface.
+
+Configuration owns **current operator policy/defaults**. Canonical Fleet persistence owns durable history and exact facts.
+
+```text
+configuration
+→ current policy/defaults for future resolution
+
+hand.db
+→ Fleet → Project → Task → Plan → Attempt
+→ immutable Worker execution provenance
+→ exact resource/effect/input/evidence history
+
+Supervisor runtime config
+→ ephemeral supervising-agent policy
+→ not Attempt provenance
+→ not workflow currentness
+```
+
+Changing configuration affects future resolution/runtime behavior only through the owning contract. It never rewrites historical Plans, Attempts, resources, effects, WorkerInputs, acknowledgements, reports, or receipts.
+
+---
+
+# Canonical v19 resource boundary
+
+Native Git WorktreeBinding is a **mandatory substrate invariant**, not configuration.
+
+There is no supported fresh-v19 configuration key or policy dimension for:
+
+```text
+isolation_adapter
+isolation_adapter_ref
+worktree_provider
+worktree_adapter
+Treehouse isolation
+Treehouse lease/pool selection
+per-Attempt isolation override
+```
+
+Canonical resource chain is fixed:
+
+```text
+Attempt
+→ WorktreeCreate / builtin/git-worktree
+→ WorktreeBinding
+→ SessionBinding
+→ Launch
+→ ExecutorBinding
+```
+
+Worker Route/Profile resolution may choose Worker Harness/model/effort and, where genuinely supported, Session-provider policy. It does **not** choose how the Attempt worktree is created.
+
+Fresh canonical v19 config containing legacy Isolation/Treehouse-provider keys must be rejected or migrated only when their semantics are provably removable. Never reinterpret them as native Git WorktreeBinding configuration.
+
+Treehouse may appear only as explicit v18 compatibility/reconciliation capability under #348 and the exact historical/release runtime that needs it. That is runtime/cutover capability, not normal v19 operator configuration.
+
+---
+
+# WorkerInput / WorkerWake are not configuration
+
+Canonical post-launch semantic input is:
+
+```text
+WorkerInput
+→ optional WorkerWake
+→ WorkerInputAcknowledgement
+```
+
+None of these is mutable configuration.
+
+Do not put current/pending WorkerInput, payload history, ordinal/cursor, acknowledgement state, WorkerWake state/residual/uncertainty, or current ExecutorBinding target into configuration.
+
+There is no fresh-v19 semantic `Send` configuration or delivery-success state. Current v0.7 Send is transitional release behavior only; it is not a v1 policy primitive to preserve.
+
+WorkerWake provider mechanics are typed capability/runtime implementation. Configuration may select only genuinely supported policy knobs; it never lets an operator replace WorkerWake with arbitrary terminal text/key injection.
+
+---
+
+# Supervisor wake configuration is distinct from WorkerWake
+
+Supervisor host turn delivery under #353/#355 is an ephemeral runtime-integration concern:
+
+```text
+canonical Attention/actionability
+→ Supervisor host wake/re-entry integration
+→ future reasoning opportunity
+→ hand orient
+```
+
+This is **not** canonical WorkerWake.
+
+If configuration exposes Supervisor wake/runtime preferences, names and types must make that distinction explicit. Never use one generic `wake` or `signal` key whose meaning can target either Supervisor runtime re-entry or Worker ExecutorBinding WorkerWake.
+
+Supervisor wake preferences cannot create/modify canonical `worker-wake` rows, WorkerInput acknowledgements, or workflow currentness.
+
+---
+
+# Typed configuration registry
+
+Define one source of truth for key metadata, parsing, validation, defaults, help, redaction, deprecation, and compatibility behavior.
+
+Cover only genuinely configurable policy families, including user/Fleet defaults, Worker Profile definitions, the six Worker Routes from #323, Worker Harness availability/fallback/model/effort policy, supported Session-provider policy, Supervisor Harness runtime policy, Supervisor host integration preferences, Presentation/notification/Source policy, automation policy where landed, update/distribution policy where configurable, and explicit environment overrides.
+
+Do not force canonical/runtime facts into config: Fleet identity; Task/Plan/Attempt current IDs/lifecycle; Workspace/Worktree/Session/Executor bindings; physical identity; external-operation state; WorkerInput/Acknowledgement/Wake/Interrupt; WorkerReports; terminal/qualification/integration evidence; Hold/Backoff/Repair; Decision/Answer; observations; ActionIntent; watcher/runtime ownership/progress; or live Supervisor runtime identity.
+
+---
+
+# Worker routing and immutable Attempt provenance
+
+For a new Attempt:
+
+```text
+immutable Plan intent × judgment
+→ configured Route
+→ selected Worker Profile
+→ Profile defaults
+→ explicit harness/model/effort overrides
+→ capability/fallback validation
+→ immutable final Attempt provenance
+```
+
+Exactly six Route keys:
+
+```text
+explore.mechanical
+explore.bounded
+explore.substantial
+execute.mechanical
+execute.bounded
+execute.substantial
+```
+
+Persist exact requested/resolved Worker execution provenance required by #323/#344/#345. There is no Attempt isolation-adapter provenance.
+
+Config change after Attempt creation never re-resolves that Attempt. Retry creates a new Attempt and may consume current routing policy. Replan/advance creates a new Plan when Plan semantics change.
+
+Do not restore Task kind, `scout/ship`, `execution_class`, `planned_against`, or `routing_source` as canonical config-derived history.
+
+---
+
+# Supervisor Harness configuration is separate
+
+Do not route Fleet Supervisor selection through Plan intent×judgment Worker Routes.
+
+Conceptually separate Supervisor runtime policy may include only where supported:
+
+```text
+supervisor.harness
+supervisor.model
+supervisor.effort
+supervisor runtime/wake-integration preferences
+```
+
+Required invariants:
+
+- choosing a Supervisor provider does not choose that provider for Worker Attempts;
+- changing Supervisor model/effort does not rewrite Attempt provenance;
+- changing Worker Route/Profile does not silently restart/replace Supervisor runtime;
+- the same product may serve both roles independently;
+- unsupported Supervisor capability is diagnosed independently from Worker capability;
+- live Supervisor process/session/thread identity is never config authority;
+- runtime identity/readiness/wake attachment/progress are observations, not config truth.
+
+Lifecycle remains:
+
+```text
+new Supervisor runtime
+→ hand session start once
+
+every reasoning/wake-handling turn
+→ hand orient
+```
+
+Configuration may influence runtime selection/integration but never makes either command workflow authority.
+
+---
+
+# Scope and precedence
+
+Every key documents an explicit semantic owner/scope. Do not invent one universal precedence stack; freeze precedence per semantic family.
+
+Worker Attempt resolution is Plan intent/judgment → Route → Profile → explicit Attempt overrides → typed capability/fallback → immutable final provenance.
+
+Supervisor runtime resolution is explicit invocation override where supported → user/Fleet Supervisor policy → supported default/detection → capability validation → ephemeral Supervisor runtime.
+
+Presentation settings affect rendering/local UI only. No precedence rule may override an already-persisted exact Attempt/Executor/WorkerInput/currentness identity.
+
+---
+
+# Environment variables and daemon inheritance
+
+Environment overrides are narrow, explicit, typed, documented with scope/precedence/inheritance.
+
+`HAND_HOME` is a Fleet locator/invocation context, not Fleet identity. `HAND_ROLE=worker` is runtime role enforcement, not ordinary mutable policy.
+
+Worker environment is the structured #338 LaunchSpec envelope, not an untyped config escape hatch.
+
+Long-lived Herdr daemon ancestry is **not** a configuration source for semantic child identity. Fleet/home/HAND_ROLE/Attempt/report/Harness/model inputs needed by a child are injected explicitly from the current Session/Launch/input-drain/wake contract.
+
+A stale daemon environment cannot override current config or canonical identity.
+
+Exact Fleet-level Herdr named-session identity is derived from canonical `fleet_id`, not a mutable config key or ambient `HERDR_SESSION` authority.
+
+---
+
+# Secrets
+
+Credentials/tokens do not become plain Fleet config merely because an integration needs them. Secret ownership/reference is explicit; diagnostics redact deterministically; absence may be diagnosed without echoing value; Attempt provenance persists only non-secret historical identity; WorkerInput is not a secret-management channel; Supervisor session/account tokens are never workflow state.
+
+---
+
+# Migration / deprecation
+
+Define explicit representation/version behavior for additive keys/defaults, renamed/removed values, unsupported newer representations, warnings/deprecation, ambiguous old generic harness/model/effort settings, legacy Isolation/Treehouse-provider settings, legacy Send/provider steering, and ambiguous generic wake/signal settings.
+
+If an old generic `harness` setting could mean Supervisor or Worker policy, do not guess.
+
+If an old Isolation/Treehouse setting has no canonical v19 equivalent, remove/refuse with migration guidance rather than manufacturing a Worktree provider abstraction.
+
+If an old Send/terminal-steering setting would imply semantic bytes transported through provider terminal input, do not map it to WorkerInput/WorkerWake automatically.
+
+If an old generic wake key cannot distinguish Supervisor re-entry from WorkerWake, refuse/rename rather than infer a target role.
+
+---
+
+# Read-only surfaces
+
+`hand config`, read-only doctor/status, FleetSnapshot, `hand orient`, presentation refresh, and `hand session start` never silently rewrite/migrate config merely by inspection.
+
+Invalid/newer/ambiguous config is reported before external effects. Read-only diagnosis never mutates historical canonical state, creates WorkerInput/WorkerWake, acknowledges anything, or starts provider resources merely to normalize config.
+
+---
+
+# Structured effective-config output
+
+Expose bounded machine-readable effective config with schema/version, redacted values, scope, semantic family, source layer/provenance, deprecated/invalid state, Worker Route/Profile validation, Supervisor capability/readiness where appropriate, and fallback summary.
+
+Current config provenance is not historical Attempt provenance. Live Supervisor runtime identity, exact Worker ExecutorBinding, WorkerInput state, and wake-progress state are not durable config values.
+
+---
+
+# Required tests
+
+Test all six Worker routes, Profile inheritance/overrides, immutable active/old Attempts under config edits, no worktree-provider selection, no WorkerInput/Ack/Wake state in config, no semantic terminal-Send mapping, distinct Supervisor-vs-Worker wake namespaces, role-specific Supervisor selection, same provider independently configured for both roles, ambiguous legacy Harness/Isolation/Send/wake refusal, unsupported newer config refusal before effect, secret redaction, environment precedence/inheritance, and read-only non-mutation.
+
+---
+
+# Acceptance criteria
+
+- [ ] One typed config registry/schema owns validation/default/help/compatibility metadata or equivalent centralized contract.
+- [ ] Configuration and canonical Fleet DB authority are separate.
+- [ ] Native Git WorktreeBinding is fixed core substrate with no selectable config/provider key.
+- [ ] No canonical `isolation_adapter_ref` or Treehouse isolation config survives fresh v19.
+- [ ] Worker Route/Profile resolves only Worker execution policy plus supported Session-provider policy.
+- [ ] Six Plan intent×judgment Routes are the only canonical Worker routing keys.
+- [ ] Supervisor Harness config is explicitly separate from Worker Route/Profile config.
+- [ ] WorkerInput/Acknowledgement/WorkerWake state is never configuration.
+- [ ] No fresh-v19 semantic Send config/transport authority exists.
+- [ ] Supervisor wake/re-entry config and canonical WorkerWake are distinct semantic families.
+- [ ] Existing Plans/Attempts/resources/effects/inputs remain immutable under config edits.
+- [ ] Retry may consume new Worker config only through a new Attempt.
+- [ ] Same provider may serve Supervisor and Worker roles without config collision.
+- [ ] Every key has explicit scope/authority/precedence.
+- [ ] Secrets remain external/redacted.
+- [ ] Environment overrides are allowlisted and role-aware.
+- [ ] Long-lived Herdr environment cannot become stale semantic config source.
+- [ ] Ambiguous legacy Harness/wake settings are never guessed across roles.
+- [ ] Legacy Isolation/Treehouse/terminal-Send settings never manufacture new canonical abstractions.
+- [ ] Unsupported newer config refuses safely before external effects.
+- [ ] Read-only diagnostics do not silently rewrite policy/canonical history or create input/effects.
+
+## Architectural outcome
+
+Configuration is v1-ready only when no mutable knob can silently redefine historical work, semantic input, role boundaries, runtime identity, or Attempt resource ownership.

--- a/docs/architecture/v19-contracts/343-external-effects-worker-wake.md
+++ b/docs/architecture/v19-contracts/343-external-effects-worker-wake.md
@@ -1,0 +1,327 @@
+---
+source_issue: 343
+source_title: "docs(architecture): lock external-effect, WorkerWake, idempotency, and reconciliation semantics"
+source_url: https://github.com/atqamz/hand/issues/343
+source_body_updated_at: 2026-08-29T13:06:15Z
+contract_version: v19
+---
+
+# Durable external-operation, idempotency, and reconciliation contract
+
+This repository snapshot is the immutable semantic contract captured from #343. The GitHub issue is a tracker/discussion surface; comments are not normative architecture state.
+
+Normative for #339. #344 owns exact DDL, #345 transaction/currentness composition, #346 adapter capability contracts, #347 read models, and #348 cutover.
+
+Canonical v19 has no semantic `Send`. The exact input/control split is:
+
+```text
+semantic instruction
+→ immutable WorkerInput in SQLite
+
+provider mechanism needed to make exact executor notice pending input
+→ external WorkerWake operation
+```
+
+`WorkerWake` is the one canonical name. Do not keep `Send` or `ExecutorSignal` as aliases.
+
+---
+
+# Authority boundary
+
+SQLite is authoritative for Hand's durable semantic intent, operation identity, claims, canonical WorkerInput, and captured evidence. External systems remain authoritative for their own reality:
+
+```text
+Git        → repository/worktree reality
+filesystem → physical object identity/presence
+provider   → actual provider resources/effects
+Worker     → WorkerReport claims + explicit WorkerInput acknowledgement evidence through Hand protocol
+```
+
+A nil command return, request acceptance, process existence, missing pane/path, timeout, or WorkerReport is never generic success proof.
+
+---
+
+# External operation
+
+One `external_operation` is one durable logical request for one independently decidable external postcondition. Recovery of the same unresolved request reuses the same operation identity; a genuinely new semantic request gets a new identity.
+
+The replacement #344 DDL must republish the exact full operation-kind set. The mandatory vocabulary change is:
+
+```text
+REMOVE: send
+ADD:    worker-wake
+```
+
+Native worktree/session/launch/interrupt/residual/qualification/integration/production/publication operation families remain subject to their existing typed contracts after re-audit.
+
+There is no generic `result`, `delivery`, `partial`, or provider-shaped operation state.
+
+---
+
+# Six operation states
+
+Exactly:
+
+```text
+prepared
+submitted
+succeeded
+rejected
+no-effect
+uncertain
+```
+
+Transitions:
+
+```text
+prepared  → submitted | succeeded | no-effect
+submitted → succeeded | rejected | no-effect | uncertain
+uncertain → succeeded | rejected | no-effect
+```
+
+Meanings:
+
+- `prepared`: complete typed request durable; mutation boundary not durably authorized.
+- `submitted`: durable authorization committed immediately before first external mutation; effect may have happened.
+- `succeeded`: exact desired capability-specific postcondition positively established.
+- `rejected`: provider definitively refused the exact submitted request.
+- `no-effect`: positive evidence proves desired effect did not occur and no safety-relevant residual remains unresolved.
+- `uncertain`: mutation was authorized but strongest evidence cannot classify succeeded/rejected/no-effect.
+
+Timeout/unavailable/unknown never becomes `no-effect` by absence of evidence.
+
+---
+
+# Write-ahead protocol
+
+## Tx A — prepare
+
+```text
+BEGIN IMMEDIATE
+revalidate exact semantic/resource parents
+insert external_operation(prepared)
+insert exactly one matching typed child
+insert required secondary scope claims
+COMMIT
+```
+
+Observe before mutation where useful. A `prepared` operation may settle directly only when positive evidence already proves its exact postcondition or exact no-effect condition without crossing the mutation boundary.
+
+## Tx B — submit
+
+Immediately before the first external mutation:
+
+```text
+BEGIN IMMEDIATE
+revalidate exact operation = prepared
+revalidate typed child + parents + claims
+prepared → submitted
+COMMIT
+```
+
+Only after commit may external mutation begin. Never hold a SQLite write transaction across provider/Git/filesystem mutation.
+
+## Tx C — classify
+
+Observe strongest exact external evidence, then in one writer transaction revalidate the same operation/currentness and apply at most one legal transition plus exact typed evidence/binding updates.
+
+Crash after Tx B is therefore durably distinguishable from “never authorized”.
+
+---
+
+# Operation identity / scope claims
+
+Every operation has immutable exact identity, kind, adapter, request digest, owner/currentness relations, operation key, primary exclusive scope, and typed request child.
+
+`request_digest` covers canonical serialization of all request fields that can change external behavior.
+
+Secondary claims are durable SQLite coordination, e.g. exact workspace/worktree/integration/executor-control scopes. They are acquired only while the owner operation is `prepared`, remain while unresolved, and release only after terminal evidence makes release safe.
+
+Path/display labels never substitute for exact resource identity. Filesystem aliasing may require an additional cross-process physical serialization/observation protocol under #345/#346; SQLite textual claims do not pretend to prove physical identity.
+
+---
+
+# Safe retry / reconciliation
+
+A submitted/uncertain mutating call may be repeated automatically only when #346 positively guarantees provider-enforced idempotency for the same persisted operation key.
+
+Otherwise:
+
+```text
+restart / timeout / lost process memory
+→ observe exact external target first
+→ reconcile same operation
+→ never blind retry
+```
+
+A replacement operation may be created only after the predecessor is terminal and the domain/resource currentness still permits a new request.
+
+Operation history is not resource history. For example, one still-current Attempt may have terminal nonsuccess WorktreeCreate O1 followed by successful O2 without fabricating a new semantic Attempt.
+
+---
+
+# WorkerInput is not an external effect
+
+Creating semantic input is canonical SQLite work under #345/#344:
+
+```text
+exact current Attempt + ExecutorBinding
+→ insert immutable ordered WorkerInput
+→ COMMIT
+```
+
+That commit proves only that Hand durably recorded the instruction for the exact execution generation.
+
+It does not prove:
+
+```text
+WorkerWake happened
+provider accepted wake
+Worker observed input
+Worker acted on input
+WorkerReport/outcome
+```
+
+If crash occurs after WorkerInput commit but before wake preparation/submission, the semantic instruction is still safe and durable. Recovery may create/reconcile a WorkerWake without duplicating WorkerInput.
+
+---
+
+# WorkerWake
+
+`worker-wake` is a narrow provider-facing mechanism operation whose desired postcondition is **mechanism-level**, not semantic instruction delivery.
+
+Typed request names the exact:
+
+```text
+Attempt
+SessionBinding
+ExecutorBinding
+operation key
+bounded wake reason / pending-input boundary required for reconciliation
+```
+
+It carries no arbitrary operator/Answer prose as semantic authority.
+
+A wake may coalesce multiple pending WorkerInputs. The Worker drain path consumes all eligible input for the exact ExecutorBinding in canonical ordinal order. Wake race/completion order never changes semantic input order.
+
+Provider acceptance/triggering can be the strongest mechanism postcondition only when the adapter contract says so; it is still not WorkerInputAcknowledgement.
+
+## Multi-step wake residual
+
+If Herdr/provider wake requires staged terminal bytes + Enter:
+
+- stage only a constant/bounded Hand-owned doorbell, never WorkerInput payload bytes;
+- Tx B occurs before first staged external mutation;
+- represent safety-relevant staged residual through exact typed provider evidence;
+- unresolved residual blocks competing executor-control mutation where required;
+- residual cleanup is its own exact operation under shared executor-control scope;
+- cleanup never rewrites whether WorkerInput exists or whether Worker acknowledged it.
+
+This makes an interactive provider menu unable to reinterpret arbitrary operator semantic bytes as a menu selection.
+
+---
+
+# WorkerInputAcknowledgement
+
+Acknowledgement is immutable evidence naming one exact WorkerInput. It proves only that the Worker observed/drained that exact input under the protocol.
+
+It is not an external-operation success state and never means instruction obeyed, Attempt completed, Decision semantically resolved, or Task/Plan progressed.
+
+No read/render/orient/wake/provider-acceptance path may create acknowledgement implicitly.
+
+---
+
+# Native Git WorktreeCreate / WorktreeRemove
+
+Retain the exact native Git safety contract:
+
+```text
+adapter = builtin/git-worktree
+path is locator, not ownership
+positive common-dir/private-gitdir/lock-reason/HEAD/physical-identity proof
+submitted before mutation
+unknown ownership/registration/preservation → unresolved + Attention/Repair
+```
+
+WorktreeCreate success is positive registered-resource proof, not `git` exit 0. A positively no-effect predecessor may be followed by another create on the same still-current Attempt.
+
+Before WorktreeRemove freshly re-prove exact binding ownership, physical identity, Git registration/admin identity, no open dependent SessionBinding, cleanliness where relevant, and preservation safety. Clean alone is not preservation-safe. Routine cleanup does not use broad `--force`/prune as authority.
+
+---
+
+# Session / Launch / Interrupt
+
+SessionBinding is exact Worker Attempt provider addressability, not Supervisor Harness runtime identity.
+
+Session acquire/release settles only from exact positive provider observation.
+
+Launch commits `submitted` before first provider execution mutation and succeeds only after exact ExecutorBinding establishment is positively proven. Ambiguous launch creates no fabricated executor/Attempt terminality.
+
+Interrupt succeeds only from positive exact executor cessation, never request acceptance.
+
+WorkerWake, Interrupt, and provider residual cleanup use shared executor-control exclusion when their mechanisms could interfere.
+
+---
+
+# Qualification / Integration / Production / Publication
+
+Preserve separation between external operation success and semantic verdict/result evidence:
+
+```text
+qualification operation succeeded
+!= qualification verdict qualified
+```
+
+Integration/Production/Publication remain exact typed operations over exact revisions/artifacts/targets. No generic Result/Delivery persistence.
+
+---
+
+# Reconciliation invariant
+
+For every unresolved operation:
+
+```text
+load exact operation + typed child + claims
+observe exact external subject outside SQLite writer
+classify strongest positive evidence
+BEGIN IMMEDIATE
+revalidate exact operation/current parents/claims
+apply one legal transition/evidence update
+COMMIT
+```
+
+Predecessor evidence settles predecessor only. Unknown never clears ownership, Repair, or scope claims. Cleanup always names exact resource identity and revalidates current external ownership before mutation.
+
+---
+
+# Required crash/race tests
+
+At minimum cover:
+
+- crash after prepare/before submission;
+- crash after submission/before mutation call;
+- crash during/after mutation before local classification;
+- remote/Git success before local receipt;
+- uncertain then later positive reconciliation;
+- provider unavailable during reconciliation;
+- WorktreeCreate submitted then positive no-effect then replacement create;
+- stale cleanup after same path/resource is reallocated to a new exact owner;
+- WorkerInput commit then crash before WorkerWake;
+- WorkerWake accepted then crash before WorkerInputAcknowledgement;
+- multiple concurrent inputs + coalesced/racing wakes preserve ordinal order;
+- unresolved WorkerWake residual vs Interrupt/next wake exclusion;
+- interactive provider menu cannot consume semantic WorkerInput bytes because wake carries only bounded doorbell;
+- stale Attempt/Executor wake/input never retargets successor execution.
+
+---
+
+# Lock conditions
+
+- `WorkerInput` is canonical semantic input, never external `Send`.
+- `WorkerWake` is the only canonical wake noun/operation kind.
+- Six external-operation states only.
+- Submission is durably committed before first external mutation.
+- Unknown/timeout/restart never authorizes blind retry or destructive cleanup.
+- Exact resource identity/currentness is revalidated at every mutation/reconciliation boundary.
+- Provider acceptance never becomes WorkerInput acknowledgement/semantic success.
+- #344 must publish or immutably reference replacement exact DDL matching this contract before #339 implementation.

--- a/docs/architecture/v19-contracts/345-lifecycle-currentness-crash-recovery.md
+++ b/docs/architecture/v19-contracts/345-lifecycle-currentness-crash-recovery.md
@@ -1,0 +1,421 @@
+---
+source_issue: 345
+source_title: "docs(architecture): lock lifecycle, WorkerInput currentness, concurrency, and crash recovery"
+source_url: https://github.com/atqamz/hand/issues/345
+source_body_updated_at: 2026-08-29T13:06:16Z
+contract_version: v19
+---
+
+# Lifecycle, transaction, currentness, concurrency, and crash-recovery contract
+
+This repository snapshot is the immutable semantic contract captured from #345. The GitHub issue is a tracker/discussion surface; comments are not normative architecture state.
+
+Normative for #339. #344 owns exact relational DDL; #343 owns external-effect/WorkerWake semantics; #346 owns adapter/runtime observation contracts; #347 owns read models; #348 owns cutover.
+
+Canonical durable hierarchy remains:
+
+```text
+Fleet → Project → Task → Plan → Attempt
+```
+
+Canonical semantic input is `WorkerInput`. Semantic `Send` currentness/race semantics are not part of v19.
+
+---
+
+# Non-negotiable currentness rules
+
+1. SQLite is canonical semantic currentness authority. Process mutexes, PID/ancestry, watcher/supervisor ownership, browser state, Git/filesystem locks, paths, and provider sessions are evidence/coordination only.
+2. Writers that choose current rows, allocate ordinals, create/supersede current children, create WorkerInput, prepare effects, open/close episodes, or accept exact terminal evidence use `BEGIN IMMEDIATE`.
+3. Currentness is exact relational identity + lifecycle/open predicates + lineage + ordinals + exact resource/evidence IDs. No generic `state_version`, conversation epoch, or current-task row.
+4. New per-parent ordinal allocation occurs inside the same writer transaction as insertion; relational UNIQUE is final arbiter.
+5. Semantic updates name the exact old/current predicate and require exactly one row to change. Zero means stale/conflict; never retarget “whatever is current now”.
+6. Revision-bearing canonical insertion positively verifies the exact Git commit in the exact Project repository and revalidates DB currentness before commit.
+7. No external mutation occurs inside a SQLite transaction or before #343 durable submission authorization.
+8. SQLite busy retry retries only the DB transaction, never an unresolved provider/Git effect.
+9. External locks may serialize physical primitives SQLite cannot lock, but DB witnesses are revalidated after lock acquisition.
+10. Read/status/FleetSnapshot/Attention/`hand orient` are mutation-free.
+11. Supervisor runtime ownership/wake coordination never authorizes workflow writes.
+12. Stale UI/direct actions and stale Supervisor actions lose through the same writer predicates.
+
+---
+
+# Task / Plan / Attempt lifecycle
+
+Task:
+
+```text
+active → satisfied | superseded | abandoned
+```
+
+Plan:
+
+```text
+active → satisfied | superseded | abandoned
+```
+
+Attempt:
+
+```text
+active → completed | failed | interrupted
+```
+
+No terminal reopen.
+
+`retry` creates a new Attempt under the same immutable Plan. `replan` supersedes the exact active Plan and creates a successor Plan. `advance` leaves the satisfied predecessor satisfied and creates a successor with explicit lineage.
+
+Plan meaning—intent/judgment/basis/brief/captured WorkspaceBinding/PolicyRevision—is immutable. Attempt freezes resolved Worker Harness/Profile/model/effort/session-adapter provenance.
+
+No stale historical Attempt evidence can satisfy or mutate successor work.
+
+---
+
+# TaskHold
+
+`TaskHold` is immutable Task-level deferral evidence. It is distinct from Decision and from AttemptBackoff.
+
+Baseline kinds are exactly:
+
+```text
+operator
+blocked
+```
+
+Executor/provider-specific limit conditions are not Task-level hold truth; they are represented as AttemptBackoff when they satisfy that contract.
+
+Optional relationships are typed, exact relations rather than overloaded nullable ownership fields:
+
+```text
+TaskHold
+├─ optional blocked-on Task relation
+├─ optional Decision relation when genuine Task deferral and Decision coexist
+└─ optional bounded recheck-not-before relation
+```
+
+Closure is a separate immutable one-to-one `TaskHoldResolution` with exactly:
+
+```text
+released | cancelled | superseded
+```
+
+Open hold is derived by absence of `TaskHoldResolution`. Do not persist `Task.held`, mutable hold state, or a current-hold pointer.
+
+---
+
+# AttemptBackoff
+
+`AttemptBackoff` is one immutable delay/re-observation episode for one exact active Attempt. It is not TaskHold and not semantic Retry.
+
+Baseline reasons are exactly:
+
+```text
+usage-limit
+rate-limit
+provider-transient
+```
+
+Each episode records the exact Attempt, per-Attempt ordinal, `not_before`, bounded evidence digest, and creation evidence. At most one unresolved AttemptBackoff may exist for one Attempt.
+
+Closure is a separate immutable one-to-one `AttemptBackoffResolution` with exactly:
+
+```text
+resumed | cancelled | superseded
+```
+
+`now >= not_before` grants only eligibility to re-observe or apply the owning recovery rule. Elapsed time alone never authorizes Worker steering, Retry, lifecycle progression, or provider mutation. Resume/re-observation revalidates this issue's exact currentness.
+
+An Attempt must not terminalize while an unresolved AttemptBackoff exists. Resolve or supersede that Backoff in the same canonical writer transaction before terminalization.
+
+---
+
+# Repair
+
+`Repair` is immutable diagnosis/reconciliation evidence. It is not mutable lifecycle state on Task, Plan, Attempt, or any resource.
+
+A Repair has:
+
+```text
+repair identity
+stable bounded machine repair_code
+bounded reason/evidence digest
+created_at
+exactly one typed canonical target
+```
+
+The target is a mechanically FK-backed typed sum, not `owner_kind + owner_id` polymorphic text and not nullable path/provider guesses. Baseline target families are:
+
+```text
+Project
+WorkspaceBinding
+Task
+Plan
+Attempt
+external_operation
+WorktreeBinding
+SessionBinding
+ExecutorBinding
+```
+
+#344 owns the exact typed-target relational shape and must enforce exactly one target per Repair.
+
+`repair_code` is a stable machine token. Every code emitted by implementation must have a real supported recovery path; provider-shaped prose is not relational ontology.
+
+Closure is a separate immutable one-to-one `RepairResolution` with exactly:
+
+```text
+repaired
+no-longer-applicable
+superseded
+operator-attested
+```
+
+Resolution carries exact bounded evidence. Open Repair is derived by absence of `RepairResolution`.
+
+`operator-attested` is valid only through the owning resource-specific authority contract. It is scoped authority, not a generic force-clear escape hatch.
+
+---
+
+# Shared Hold / Backoff / Repair invariants
+
+- Insert and resolution writers use `BEGIN IMMEDIATE` plus exact owner/currentness predicates.
+- Evidence and resolution rows are append-only immutable history.
+- Stale Hold/Backoff/Repair evidence never retargets successor Plan/Attempt/resource identities.
+- Open state is derived relationally from evidence minus resolution, never mutable pending/current flags.
+- Presentation, FleetSnapshot, Attention, and SupervisorOrientation may project openness but never own it.
+
+---
+
+# WorkerInput creation/currentness
+
+Creating `WorkerInput` is a canonical semantic write, not provider delivery.
+
+Use one writer transaction requiring the exact current execution generation:
+
+```text
+BEGIN IMMEDIATE
+require exact Task/Plan/Attempt lineage
+require Plan active
+require Attempt active
+require exact open SessionBinding
+require exact established/open ExecutorBinding
+require WorkerInput identity unused
+allocate next ordinal for exact ExecutorBinding
+insert immutable WorkerInput
+COMMIT
+```
+
+The input binds permanently to that exact Attempt/ExecutorBinding.
+
+Required race outcomes:
+
+```text
+input for A1/E1 vs retry/replacement A2/E2
+→ whichever exact semantic commit is valid first wins
+→ stale input writer fails
+→ never retarget to A2/E2
+
+same WorkerInput identity vs replay
+→ one canonical identity; duplicate replay converges/refuses idempotently
+
+same payload + different identity
+→ legal new instruction, ordered after predecessor
+
+concurrent distinct inputs for E1
+→ unique deterministic ordinals
+→ no external wake race may reorder them
+```
+
+If the target later terminalizes, unacknowledged input remains exact historical evidence; it never migrates to a successor.
+
+---
+
+# WorkerInputAcknowledgement currentness
+
+Acknowledgement is an immutable child of one exact WorkerInput. It proves only that Worker execution observed/drained that input according to the protocol.
+
+It may be appended only by the exact acknowledgement writer and exact execution evidence rules chosen in #344/#346.
+
+It never proves:
+
+```text
+instruction obeyed
+semantic success
+Attempt completion
+Decision downstream effect
+Plan/Task progression
+WorkerWake success
+```
+
+No read/render/orient/status/wake/provider-acceptance/WorkerReport path creates acknowledgement implicitly.
+
+Historical acknowledgement, if valid under the exact contract, remains attached to historical input; it never acknowledges a successor input.
+
+---
+
+# WorkerWake composition
+
+After WorkerInput commits, a provider `WorkerWake` may be needed:
+
+```text
+WorkerInput durable
+→ #343 prepare exact WorkerWake
+→ durable submitted before first provider mutation
+→ perform/observe/reconcile mechanism
+```
+
+Crash between input commit and wake loses no semantic instruction. Recovery sees the same pending input and may create/reconcile wake without inserting a replacement WorkerInput.
+
+Crash after provider accepts wake but before WorkerInputAcknowledgement leaves input unacknowledged. Acceptance != acknowledgement.
+
+The Worker drains all eligible inputs for its exact ExecutorBinding in ordinal order. A wake may coalesce many pending inputs.
+
+If WorkerWake, Interrupt, or provider residual cleanup can interfere, they contend under the same exact executor-control operation scope. External control serialization never becomes semantic currentness authority.
+
+---
+
+# Plan immutability versus steering
+
+WorkerInput may clarify or steer execution only within the immutable meaning of the active Plan.
+
+If operator/Supervisor intent materially replaces delegated objective/basis/meaning, do not hide a replan inside WorkerInput. Create the appropriate successor Plan/Attempt first, then target any new input to that exact successor execution.
+
+---
+
+# Native Git WorktreeBinding currentness
+
+Canonical v19 uses exact native Git linked WorktreeBinding; no generic Isolation provider or Treehouse lease identity exists in fresh v19.
+
+Worktree path is locator, not authority.
+
+WorktreeCreate/Remove require exact DB ownership plus fresh Git/filesystem observation at the mutation boundary. Success/cleanup relies on exact common repository, private gitdir, lock reason, HEAD/basis, physical filesystem identity, and preservation conditions required by #343/#346.
+
+Required properties:
+
+- at most one unresolved WorktreeCreate per Attempt;
+- terminal nonsuccess/no-effect create may be followed by a new create on the same still-current Attempt;
+- successful WorktreeBinding prevents later creates;
+- open SessionBinding blocks WorktreeRemove;
+- stale cleanup from old Attempt/operation cannot remove same path reallocated to a different resource identity;
+- unknown ownership/registration/preservation blocks destruction;
+- clean worktree alone is not preservation proof;
+- routine broad `--force`/prune is not ownership authority.
+
+External filesystem/Git serialization aids races but never replaces exact relational witnesses.
+
+---
+
+# Session / Launch / Executor currentness
+
+SessionBinding is exact Attempt-scoped Worker provider addressability, never Supervisor Harness runtime identity.
+
+Launch prerequisites require exact active Attempt + exact open WorktreeBinding + exact open SessionBinding. Launch submits before first provider execution mutation and creates ExecutorBinding only from positive exact establishment evidence.
+
+Ambiguous launch remains unresolved and creates no fabricated ExecutorBinding/Attempt terminality.
+
+One SessionBinding is not silently reused to invent replacement executor identity.
+
+Interrupt terminalizes only from positive exact executor cessation evidence.
+
+---
+
+# WorkerReport / Decision / authority separation
+
+WorkerReport is immutable Attempt-scoped Claim. WorkerReport acknowledgement names one exact report and is distinct from WorkerInputAcknowledgement.
+
+Decision/Answer authority remains #304-owned.
+
+```text
+Decision answered
+→ may create exact Answer-origin WorkerInput
+→ may require WorkerWake
+→ may later receive WorkerInputAcknowledgement
+```
+
+None of those later stages retroactively change what “Decision answered” means.
+
+---
+
+# External-operation composition / recovery
+
+Every provider/Git/filesystem effect follows #343 prepare → observe → submitted-before-mutation → exact classify/reconcile.
+
+Restart/timeout/process loss never grants automatic replay unless #346 proves provider-enforced idempotency for the same operation key.
+
+Reconciliation revalidates exact operation/current parents/claims before committing any resolution. Evidence about predecessor settles predecessor only.
+
+---
+
+# Required race table
+
+At minimum prove:
+
+| race | required result |
+| --- | --- |
+| retry vs retry | one active Attempt/ordinal wins; loser stale |
+| retry vs replan | one semantic commit wins; loser never retargets |
+| replan vs replan | exact predecessor/UNIQUE permits one successor |
+| Task supersede vs supersede | one exact successor |
+| TaskHold insert/resolve vs successor/currentness change | exact old owner predicate wins or stale writer fails; never retarget |
+| AttemptBackoff insert/resolve vs terminalization | terminalization requires unresolved Backoff resolved/superseded first |
+| Repair resolution vs target replacement | exact target/currentness wins or stale resolution fails; never retarget |
+| concurrent WorkerInput | unique exact per-executor ordinals |
+| same WorkerInput identity replay | one canonical identity |
+| WorkerInput vs Attempt/Executor replacement | stale writer fails, never retargets |
+| WorkerInput acknowledgement vs terminalization | exact historical attachment only; never retarget |
+| WorkerWake vs Interrupt/residual cleanup | exact shared executor-control scope |
+| two WorktreeCreates same Attempt | one unresolved; later fresh op only after predecessor terminal nonsuccess |
+| WorktreeRemove vs SessionAcquire | open dependency/currentness prevents unsafe removal |
+| stale cleanup vs reallocated same path | exact identity mismatch blocks mutation |
+| stale Supervisor vs stale direct UI | same domain writer rejects both |
+
+---
+
+# Supervisor runtime coordination
+
+Supervisor runtime/session ownership may fence duplicate reasoning/wake consumption operationally, but never workflow writes.
+
+Canonical counterexample must remain safe:
+
+```text
+S1 orient → sees generation G1
+S2 orient → sees G1
+S1 commits exact G1 transition
+S2 submits stale action derived from G1
+→ exact writer predicate fails stale
+→ never retarget successor G2
+```
+
+Watcher alive, bridge attached, wake accepted, Supervisor re-entry, and `hand orient` completion are distinct operational facts and none substitutes for #345 relational currentness.
+
+---
+
+# Crash-recovery invariants
+
+- SQLite committed history is recovery authority, process memory is not.
+- A crash after #343 `submitted` is not distinguishable as “call never happened”; observe/reconcile first.
+- A crash after WorkerInput commit cannot lose semantic input.
+- A crash after wake acceptance cannot fabricate input acknowledgement.
+- Resource cleanup always re-proves exact current external identity before destruction.
+- Unknown stays unresolved/actionable.
+- Open Hold/Backoff/Repair state is reconstructed from immutable evidence/resolution relations, not mutable convenience flags.
+- Read models remain bounded and mutation-free during recovery/orientation.
+
+---
+
+# Acceptance / lock conditions
+
+- [ ] Exact relational predicates, not session/process/paths, own currentness.
+- [ ] `BEGIN IMMEDIATE` is used for current-child/ordinal/WorkerInput/effect/lifecycle/Hold/Backoff/Repair writers.
+- [ ] TaskHold is immutable Task deferral evidence, distinct from Decision/AttemptBackoff, with separate immutable resolution and no mutable Task hold shortcut.
+- [ ] AttemptBackoff is exact Attempt-scoped delay/re-observation evidence, distinct from Retry, with at most one unresolved episode and no time-based mutation authority.
+- [ ] An Attempt cannot terminalize with unresolved AttemptBackoff.
+- [ ] Repair is immutable reconciliation evidence with exactly one typed canonical target and separate immutable resolution; `operator-attested` is scoped, not generic force-clear authority.
+- [ ] Hold/Backoff/Repair openness is derived relationally and stale evidence never retargets successors.
+- [ ] WorkerInput binds exact active Attempt + ExecutorBinding and never retargets.
+- [ ] Per-executor WorkerInput ordinal allocation is deterministic/concurrency-safe.
+- [ ] WorkerInputAcknowledgement is immutable exact evidence distinct from WorkerReport acknowledgement and action/outcome.
+- [ ] WorkerWake is mechanism only and cannot reorder semantic inputs.
+- [ ] Plan meaning cannot be conversationally replaced through WorkerInput.
+- [ ] Native Worktree cleanup revalidates exact identity/preservation and blocks stale reallocation teardown.
+- [ ] External effects obey #343 durable submission/reconciliation rules.
+- [ ] Supervisor/watcher/runtime coordination never replaces writer currentness.
+- [ ] #344 replacement DDL mechanically supports every relation/index/constraint needed above before #339 implementation.

--- a/docs/architecture/v19-contracts/346-capability-adapters.md
+++ b/docs/architecture/v19-contracts/346-capability-adapters.md
@@ -1,0 +1,323 @@
+---
+source_issue: 346
+source_title: "docs(architecture): lock WorkerInput/WorkerWake and canonical capability-adapter boundaries"
+source_url: https://github.com/atqamz/hand/issues/346
+source_body_updated_at: 2026-08-29T13:06:17Z
+contract_version: v19
+---
+
+# Canonical capability and adapter contract
+
+This repository snapshot is the immutable semantic contract captured from #346. The GitHub issue is a tracker/discussion surface; comments are not normative architecture state.
+
+Normative for #339. Capabilities define semantic responsibility; adapters implement one capability without importing provider topology into Hand's ontology.
+
+Owning specs:
+
+- #343 external effects / WorkerWake / reconciliation;
+- #344 exact relational schema;
+- #345 lifecycle/currentness/concurrency;
+- #347 read models;
+- #348 cutover;
+- #338 Worker Harness LaunchSpec;
+- #353/#355 Supervisor runtime lifecycle/wake integration.
+
+Canonical v19 has no `Send` capability. Semantic input is `WorkerInput`; provider notification is `WorkerWake`.
+
+---
+
+# Canonical vocabulary
+
+| Term | Exact meaning |
+| --- | --- |
+| Fleet | one canonical orchestration tenant/home/DB |
+| Project | opaque durable Git-backed body of work |
+| WorkspaceBinding | immutable Project→repository-location history + physical identity evidence |
+| Task | immutable operator goal |
+| Plan | immutable delegated meaning/basis |
+| Attempt | one execution of one Plan with immutable resolved Worker provenance |
+| Supervisor Harness | ephemeral Fleet-level reasoning/runtime integration; not workflow entity |
+| Worker Harness | executes one exact Attempt and returns #338 LaunchSpec |
+| WorktreeBinding | exact Attempt-scoped native Git linked worktree |
+| SessionBinding | exact Attempt-scoped Worker provider addressability; not Supervisor session |
+| ExecutorBinding | exact Worker execution established by Launch |
+| WorkerInput | immutable ordered canonical semantic instruction for one exact ExecutorBinding |
+| WorkerInputAcknowledgement | immutable proof that Worker observed/drained one exact WorkerInput; not proof of action/outcome |
+| WorkerWake | narrow provider mechanism allowing exact executor to observe pending WorkerInput; no semantic payload authority |
+| Interrupt | exact executor-control effect whose success proves cessation |
+| WorkerReport | immutable Worker Claim; not provider observation or acknowledgement |
+| Observation | typed external/Git/filesystem/provider evidence |
+| Attention | pure derived current actionable projection |
+| SupervisorOrientation | bounded current read consumed by `hand orient` |
+
+Never interchange SessionBinding with Supervisor runtime, paths with physical identity, WorkerInput with wake, wake acceptance with acknowledgement, WorkerReport with Observation, or Worker/Supervisor Harness roles.
+
+No generic Result/Delivery/Isolation/ProviderResult entity.
+
+---
+
+# Adapter identity / common contract
+
+`adapter_ref` exists only for genuinely replaceable provider semantics.
+
+Core examples:
+
+```text
+builtin/git-worktree  → WorktreeCreate/Remove
+herdr                 → Session / Launch / WorkerWake / Interrupt provider mechanics
+```
+
+Treehouse is not a canonical v19 Worktree/Isolation adapter. Fresh v19 has no lease/pool/generic Isolation ontology.
+
+Common provider-facing shape is conceptually:
+
+```text
+Validate(exact canonical input)
+Observe(exact subject) → found | absent | unknown + typed evidence
+Prepare(exact input)  → deterministic request, no mutation
+Perform(operation_key, persisted request) → typed provider disposition
+```
+
+Every adapter must document:
+
+- exact first mutation boundary;
+- strongest positive success/postcondition it can prove;
+- idempotency guarantee for same operation key: yes/no;
+- stable external identity/ownership evidence used for destructive actions;
+- `unknown` behavior;
+- typed minimal extension evidence;
+- secret redaction;
+- native platform behavior.
+
+Provider acceptance never implies semantic success unless the capability's desired postcondition is exactly mechanism acceptance—and even then it cannot imply WorkerInputAcknowledgement or Worker action.
+
+---
+
+# WorkerInput capability boundary
+
+Semantic input persistence belongs to Hand core/SQLite:
+
+```text
+exact current Attempt + exact ExecutorBinding
+→ insert ordered immutable WorkerInput
+→ semantic instruction durable
+```
+
+Provider adapters do not decide whether semantic input exists and do not own payload-delivery truth.
+
+A Worker runtime must expose one exact provider-neutral drain path that reads all eligible pending WorkerInputs for its exact ExecutorBinding in canonical ordinal order.
+
+No provider terminal/composer heuristic is canonical input state.
+
+---
+
+# WorkerWake adapter
+
+Use exactly `WorkerWake` / operation kind `worker-wake`.
+
+Input names exact:
+
+```text
+Attempt
+SessionBinding
+ExecutorBinding
+operation key
+bounded mechanism reason/pending boundary
+```
+
+It carries no arbitrary operator/Decision semantic prose.
+
+Success means only the strongest mechanism postcondition the adapter can positively establish, e.g. exact host accepted/triggered the wake where that is genuinely observable. It is never equivalent to:
+
+```text
+WorkerInputAcknowledgement
+Worker read all pending input
+Worker obeyed instruction
+WorkerReport outcome
+Attempt progress
+```
+
+One wake may coalesce multiple inputs. Worker drain order remains canonical ordinal order regardless of wake completion order.
+
+If Herdr/provider requires staged terminal bytes/keys, use one constant/bounded Hand-owned doorbell—not WorkerInput payload bytes—and expose exact residual observation/cleanup under #343.
+
+This makes ordinary semantic input structurally safe when a provider UI is sitting on an interactive menu/prompt: semantic operator bytes never enter the terminal control stream.
+
+Qualify separately:
+
+```text
+worker_input_drain
+worker_wake
+worker_wake idempotency/reconciliation
+interrupt
+executor observation
+```
+
+A provider may support Worker execution but degraded/unsupported automatic wake. Canonical WorkerInput remains durable/visible; do not fabricate consumption.
+
+---
+
+# Native Git Worktree capability
+
+Canonical v19 Attempt worktree is native Git, `adapter_ref=builtin/git-worktree`.
+
+WorktreeCreate success positively proves exact registered path, common repository, private gitdir, `hand:v1:<binding-id>` lock reason, exact basis HEAD, and physical filesystem identity. Git exit 0 is insufficient.
+
+WorktreeRemove requires fresh exact ownership/registration/physical identity + no open SessionBinding + preservation safety. Unknown/mismatch blocks destruction. Clean is not sufficient to prove preservation safety. Routine `--force`/broad prune is not canonical cleanup authority.
+
+Path/branch/task labels are locators/display only. Stale teardown cannot remove a same-path resource reallocated under a new exact identity.
+
+---
+
+# Session / Herdr environment boundary
+
+SessionBinding is exact Worker provider container/addressability, not ExecutorBinding and never Supervisor session/conversation.
+
+Session acquisition/release requires exact Worktree/currentness and positive provider postcondition evidence.
+
+Long-lived Herdr daemon must be semantic-environment neutral:
+
+```text
+shared daemon
+→ mechanism-only environment
+
+exact child Session/Launch/drain/wake
+→ Fleet/home/HAND_ROLE/Attempt/report/Harness/model values injected explicitly
+```
+
+Daemon PID/ancestry/environment is observation, never identity authority. Cross-Fleet environment contamination is a correctness failure.
+
+---
+
+# Worker Harness
+
+Worker Harness executes one exact Attempt.
+
+Input:
+
+```text
+immutable Plan meaning
+immutable resolved Attempt Worker provenance
+exact WorktreeBinding cwd
+runtime envelope
+```
+
+Output is exact #338 structured:
+
+```text
+LaunchSpec { executable, argv[], env{}, cwd }
+```
+
+No shell-source contract. Worker Harness does not choose/create/remove Worktree, own Session topology, mutate Plan meaning, own Attention, or run supervisor bootstrap under Worker role.
+
+Initial launch instruction is part of LaunchSpec semantics; post-launch ordinary semantic steering uses WorkerInput, not a Harness-private inbox/terminal authority.
+
+---
+
+# Supervisor Harness
+
+Supervisor Harness hosts Fleet-level reasoning only:
+
+```text
+new actual runtime/session
+→ hand session start once
+
+every operator/wake reasoning turn
+→ hand orient
+→ fresh SupervisorOrientation
+→ reason
+→ exact canonical Hand operation
+→ #345 writer revalidates
+```
+
+No canonical supervisor_session/conversation/current-task memory. Replacement runtime loses zero workflow truth.
+
+Harness products may be `worker-only`, `supervisor-capable`, or both; role capability is explicit and independent.
+
+Keep runtime health dimensions distinct:
+
+```text
+runtime identity/addressability
+bootstrap integration readiness
+watcher liveness
+wake-delivery attachment
+wake-delivery progress
+orientation/reasoning progress
+```
+
+A live PID/lock/watch is never proof the control loop is healthy.
+
+---
+
+# Launch / Executor / Interrupt
+
+Launch binds exact active Attempt + open WorktreeBinding + open SessionBinding + exact LaunchSpec request/digest. #343 submission precedes first provider start mutation. Success requires positive exact ExecutorBinding establishment.
+
+Ambiguous launch creates no fabricated executor/Attempt terminality.
+
+Interrupt targets exact ExecutorBinding. Success means positive cessation, not request acceptance. WorkerWake/Interrupt/residual cleanup share exact executor-control exclusion where mechanics interfere.
+
+---
+
+# Decision / Answer delivery
+
+Standalone Decision/Answer remains #304 authority protocol.
+
+If an Answer must reach Worker:
+
+```text
+Answer durable
+→ exact Answer-origin WorkerInput durable
+→ WorkerWake mechanism if needed
+→ WorkerInputAcknowledgement independently proves Worker observed input
+```
+
+Provider acceptance and terminal keystrokes never become operator authority.
+
+---
+
+# Worker routing / configuration
+
+#323 Route/Profile config is Worker Attempt configuration only: Worker Harness/model/effort and supported session/provider policy. It never selects a Worktree/Isolation provider.
+
+Attempt freezes requested/resolved Worker provenance once. Supervisor Harness model/config is a separate runtime family and never rewrites Attempt history.
+
+---
+
+# Provider extension rule
+
+Persist provider extension evidence only when core facts are insufficient to address exact external identity, observe exact postcondition, prove ownership, reconcile ambiguity, or explain a safety-relevant unknown.
+
+Extensions are typed/minimal/FK-bound. No arbitrary provider JSON, duplicated lifecycle, UI state, daemon ancestry, or Supervisor conversation state.
+
+---
+
+# Replacement / substitutability tests
+
+Reject #339 if:
+
+- adding/replacing Worker Harness requires schema changes beyond immutable provider provenance;
+- adding Supervisor Harness requires Task/Plan/Attempt schema;
+- provider adapter invents private currentness/Attention;
+- semantic WorkerInput bytes are delivered through provider interactive terminal control flow;
+- WorkerWake acceptance is treated as input acknowledgement;
+- one wake per message can reorder semantic inputs;
+- Treehouse/generic Isolation reappears in fresh v19;
+- path/PID/label becomes destructive identity;
+- long-lived Herdr environment leaks Fleet/Attempt identity across children;
+- Worker/Supervisor roles are inferred only from executable name.
+
+---
+
+# Lock conditions
+
+- [ ] WorkerInput, WorkerInputAcknowledgement, and WorkerWake are the exact canonical nouns.
+- [ ] `Send` and `ExecutorSignal` aliases are absent from canonical v19.
+- [ ] WorkerWake is mechanism-only; semantic bytes stay in SQLite WorkerInput.
+- [ ] Drain is exact-executor, ordered, and wake-coalescing-safe.
+- [ ] Native Git Worktree ownership/cleanup uses exact identity + observation.
+- [ ] Session/Executor/Supervisor runtime identities remain separate.
+- [ ] Herdr daemon environment neutrality is explicit and testable.
+- [ ] Worker/Supervisor Harness capabilities are role-separated.
+- [ ] Adapter idempotency/unknown/destructive ownership contracts are explicit.
+- [ ] #344 replacement DDL matches these boundaries before #339 starts.

--- a/docs/architecture/v19-contracts/347-read-models-attention-orientation.md
+++ b/docs/architecture/v19-contracts/347-read-models-attention-orientation.md
@@ -1,0 +1,414 @@
+---
+source_issue: 347
+source_title: "docs(architecture): lock WorkerInput-aware read models, Attention, and supervisor orientation"
+source_url: https://github.com/atqamz/hand/issues/347
+source_body_updated_at: 2026-08-29T13:06:18Z
+contract_version: v19
+---
+
+# Canonical read model, WorkerReport replay, WorkerInput visibility, Attention, and SupervisorOrientation
+
+This repository snapshot is the immutable semantic contract captured from #347. The GitHub issue is a tracker/discussion surface; comments are not normative architecture state.
+
+Normative for #339. Read models are disposable, deterministic projections over #344 canonical rows plus explicitly timestamped #346 observations. They never become a second workflow database and never authorize mutation.
+
+Canonical v19 has no semantic `Send` read model. WorkerInput, WorkerInputAcknowledgement, and WorkerWake remain distinct facts.
+
+---
+
+# Truth families stay separate
+
+```text
+Git/filesystem/provider Observation
+!= WorkerReport Claim
+!= WorkerReport Acknowledgement
+!= WorkerInput
+!= WorkerInputAcknowledgement
+!= WorkerWake mechanism state
+!= semantic lifecycle/effect truth
+!= operator authority
+```
+
+Examples:
+
+- Worker `done` is a Claim, not Attempt/Plan/Task completion;
+- WorkerInput durable does not mean Worker observed it;
+- WorkerWake accepted does not mean WorkerInput acknowledged;
+- WorkerInputAcknowledgement does not mean the instruction was obeyed;
+- reading/rendering never acknowledges anything;
+- cleanup does not prove executor terminality.
+
+---
+
+# WorkerReport ingestion / replay
+
+Preserve the exact WorkerReport contract:
+
+```text
+<state>: <note>
+```
+
+with exact semantic states:
+
+```text
+working | paused | blocked | needs-decision | done | failed
+```
+
+Complete-record identity remains based on exact source-prefix evidence, not cursor authority:
+
+```text
+(attempt_id, source_prefix_digest)
+```
+
+`source_end_offset` is evidence only. Acknowledgement names one exact immutable WorkerReport ID.
+
+Correctness requires full-source replay capability after checkpoint loss/contradiction, but steady-state ingestion may use a disposable positively verified prefix checkpoint. That checkpoint is mechanism state only and may never become report/currentness/acknowledgement authority.
+
+`hand orient` must not rescan arbitrarily large historical report files every turn. Recovery replay remains available when checkpoint proof fails.
+
+---
+
+# WorkerInput read model
+
+FleetSnapshot/SupervisorOrientation may expose bounded **current** WorkerInput facts derived from immutable canonical rows:
+
+```text
+worker_input_id
+exact attempt_id
+exact executor_binding_id
+ordinal
+origin_kind / bounded origin reference
+created_at
+acknowledged   // DERIVED from exact WorkerInputAcknowledgement existence
+age / bounded summary
+```
+
+Do not persist or project mutable authority such as:
+
+```text
+pending=true
+handled=true
+input_read
+last_input_cursor
+last_worker_input_seen
+current_input
+needs_wake
+```
+
+Unacknowledged/pending is relationally derived from:
+
+```text
+exact WorkerInput
+MINUS exact WorkerInputAcknowledgement
+PLUS exact target/currentness facts
+```
+
+Historical input for a superseded/terminal execution remains historical evidence. It must not manufacture current Attention merely because it is unacknowledged.
+
+Required distinction:
+
+```text
+current WorkerInput unacknowledged
+!= WorkerWake unresolved/degraded
+!= executor dead
+!= Worker ignored instruction
+!= instruction failed
+```
+
+Surface contradictions/unknowns explicitly rather than collapsing them into one generic `pending`/`stalled` state.
+
+---
+
+# WorkerInputAcknowledgement
+
+WorkerInputAcknowledgement is a distinct relation from WorkerReport Acknowledgement.
+
+Only the exact WorkerInput acknowledgement writer may append it.
+
+None of these acknowledge WorkerInput:
+
+```text
+FleetSnapshot/status rendering
+hand orient
+WorkerWake requested/submitted/accepted
+executor state change
+WorkerReport arrival
+Decision answered/resolved
+notification delivery
+```
+
+Acknowledgement proves only exact Worker observation/drain under the protocol, not action/compliance/outcome.
+
+---
+
+# WorkerWake / executor-control projection
+
+Read models expose unresolved/recent WorkerWake mechanism state separately from semantic input:
+
+```text
+exact worker-wake operation identity
+exact Attempt / SessionBinding / ExecutorBinding
+prepared|submitted|succeeded|rejected|no-effect|uncertain
+bounded mechanism evidence/diagnostic
+residual observation where provider mechanics can leave one
+```
+
+A provider wake may coalesce many WorkerInputs. No read model derives semantic input order from wake order.
+
+If provider wake uses staged terminal material, only the bounded Hand-owned doorbell/residual mechanism is represented. Semantic WorkerInput payload bytes never become terminal residual authority.
+
+WorkerWake/Interrupt/residual-cleanup safety obligations remain exact external-operation facts under #343.
+
+---
+
+# Hold / Backoff / Repair projection
+
+TaskHold, AttemptBackoff, and Repair semantics are owned by #345; exact relations are owned by #344.
+
+Read models derive openness only from immutable evidence minus the corresponding immutable resolution relation. They never persist mutable `held`, `backoff_active`, `repair_pending`, current-pointer, or equivalent authority.
+
+A historical unresolved-looking row that is no longer a current actionable obligation must not be retargeted to successor work. Genuine unresolved historical safety obligations remain visible explicitly.
+
+---
+
+# FleetSnapshot
+
+Conceptual projection:
+
+```text
+FleetSnapshot
+  fleet_id
+  db_read_at
+  projects[]
+    Project
+    current WorkspaceBinding + physical identity observation
+    current PolicyRevision
+    bounded Git/workspace observations
+    active Tasks[]
+      exact Task + lineage leaf
+      active/satisfied Plan facts
+      latest/active Attempt
+      WorktreeBinding / SessionBinding / ExecutorBinding evidence
+      latest bounded WorkerReports + exact report acknowledgements
+      bounded current WorkerInputs + derived input acknowledgements
+      unresolved WorkerWake / Interrupt / resource/effect operations
+      accepted TerminalReceipt / Qualification / Integration facts
+      open Holds / Backoffs / Repairs
+      exact available actions + opaque currentness
+  unresolved_historical_obligations[]
+  counts
+  explicit bounds/continuations
+```
+
+Every active Task is represented. Historical detail may be bounded, but unresolved safety obligations are never history-bounded away.
+
+An old terminal Attempt with unresolved WorktreeRemove, SessionRelease, WorkerWake residual, uncertain operation, or Repair remains visible after successor work begins.
+
+---
+
+# Snapshot timing / read-only semantics
+
+SQLite facts come from one consistent read transaction tagged `db_read_at`.
+
+External Git/filesystem/provider observations occur outside that DB snapshot and carry independent `observed_at` plus `found|absent|unknown` and exact ownership/diagnostic evidence where needed.
+
+The combined projection is never claimed atomically observed. #345 writer revalidation remains mandatory.
+
+FleetSnapshot/Attention/orient construction never:
+
+```text
+acknowledges WorkerReport
+acknowledges WorkerInput
+creates WorkerInput
+creates/retries WorkerWake
+settles operations
+retries/replans/advances
+answers Decision
+repairs/cleans resources
+claims Supervisor workflow ownership
+performs migration/cutover
+```
+
+---
+
+# Set-oriented hot query plan
+
+Primary snapshot/orientation must use a bounded number of indexed set queries, not SQL/process calls per Task.
+
+At minimum the #344 replacement DDL/query-plan proof must support:
+
+1. Fleet + Projects + current WorkspaceBinding/current PolicyRevision;
+2. active Tasks and exact lineage leaves;
+3. active/satisfied Plans + latest/active Attempts;
+4. open WorktreeBinding/SessionBinding/ExecutorBinding;
+5. TerminalReceipt/Qualification/Integration summaries;
+6. latest bounded WorkerReports + exact report acknowledgements;
+7. current WorkerInputs for current ExecutorBindings ordered by ordinal;
+8. unacknowledged WorkerInputs via exact acknowledgement anti-join/existence;
+9. unresolved/latest WorkerWake and other external operations + scope claims;
+10. open Holds/Backoffs/Repairs/Decisions;
+11. bounded requested history with continuation.
+
+`hand orient` must not scan all historical WorkerInput/ack or obligation rows every turn.
+
+External observations should be grouped by strongest actual identity (e.g. repository/common-dir, provider/session grouping) rather than N+1 per rendered Task.
+
+---
+
+# Attention is pure derivation
+
+There is no canonical Attention table, mutable inbox, persisted next-action queue, or `unannounced` flag.
+
+Conceptual item:
+
+```text
+AttentionItem
+  priority
+  code
+  exact project/task/plan/attempt IDs where applicable
+  exact evidence_id or deterministic exact composite
+  bounded reason
+  observation refs/timestamps where relevant
+  available action kinds
+  opaque exact-currentness witness per action
+```
+
+Stable identity is exact evidence/currentness, never prose, timestamps, browser/Supervisor session, pane labels, report offsets, or wake count.
+
+Priority classes remain conceptually:
+
+| Priority | Class |
+| ---: | --- |
+| 10 | safety uncertainty / unresolved external effect / destructive-ownership ambiguity |
+| 20 | explicit operator decision / current handling-worthy exact evidence |
+| 30 | semantic progression |
+| 40 | safe retry/resume |
+| 50 | exact historical cleanup |
+
+Equal-priority order is deterministic by exact canonical identities.
+
+---
+
+# WorkerInput Attention rules
+
+A **current** WorkerInput that remains unacknowledged beyond an owning bounded policy/mechanism condition may contribute Attention.
+
+Keep separate Attention/evidence for:
+
+```text
+current semantic input unacknowledged
+WorkerWake path degraded/unresolved
+executor observation unknown/dead
+provider residual blocking next control
+```
+
+Never infer “Worker ignored instruction” or “instruction failed” from missing acknowledgement alone.
+
+Historical unacknowledged input must not remain current Attention after its exact Attempt/Executor is superseded/terminal except where an explicit historical safety/audit obligation genuinely remains.
+
+---
+
+# Worktree / resource safety Attention
+
+Native Git WorktreeBinding remains canonical v19 Attempt resource identity.
+
+Priority safety Attention includes unresolved create/remove, exact path/common-dir/private-gitdir/lock-reason/HEAD/physical-identity contradiction, alias/replacement ambiguity, open Session dependency, uncommitted/preservation-unsafe cleanup, and unknown destructive ownership.
+
+Path missing or clean worktree alone is never cleanup permission.
+
+Legacy Treehouse may appear only as explicit v18 reconciliation/cutover Attention under #348, never fresh v19 identity.
+
+---
+
+# SupervisorOrientation
+
+SupervisorOrientation is a bounded Hand-owned projection for Fleet-level reasoning:
+
+```text
+FleetSnapshot + Attention + bounded runtime diagnostics
+→ hand orient
+→ Supervisor Harness
+→ reason
+→ exact canonical operation
+→ #345 writer revalidates
+```
+
+It owns no conversation history, current-task memory, acknowledgement cursor, provider lifecycle, or authorization.
+
+Deleting/replacing Supervisor runtime loses zero canonical truth.
+
+Canonical Supervisor lifecycle:
+
+```text
+new Supervisor Harness runtime/session
+→ hand session start once
+→ runtime bootstrap / wake-delivery integration only
+
+every reasoning turn
+→ hand orient
+→ fresh SupervisorOrientation
+```
+
+Keep operational health dimensions separate where surfaced:
+
+```text
+runtime identity/addressability
+bootstrap/integration readiness
+watcher liveness
+wake-delivery attachment
+wake-delivery progress
+orientation/reasoning progress
+```
+
+A live process/lock/watcher is not proof of progress or delivery health.
+
+---
+
+# Watcher semantics
+
+Watcher is level/current-state hint infrastructure:
+
+```text
+ingest newly observable report material using verified mechanism checkpoint
+read canonical DB
+observe required external sources
+derive current Attention/monitor predicates
+if level true → wake
+else arm
+on event/timeout/restart → repeat from authority
+```
+
+Events/wakes are hints. Missed/duplicate/stale events and checkpoint loss cannot alter semantic truth.
+
+A Supervisor wake always leads to fresh `hand orient` before reasoning/action.
+
+---
+
+# Presentation / Interaction
+
+Status/board/TUI/GUI/mobile/notifications consume the same projection families and own no workflow truth.
+
+Already-exact typed actions may call canonical Hand services directly; reasoning-required input flows through Supervisor Harness. Both rely on exact #345 currentness.
+
+Presentation refresh is mutation-free.
+
+---
+
+# Acceptance / rejection criteria
+
+- [ ] WorkerReport full replay remains correctness fallback while steady-state ingestion is bounded/incremental only under positive checkpoint proof.
+- [ ] WorkerReport acknowledgement and WorkerInputAcknowledgement remain distinct exact immutable evidence.
+- [ ] Current WorkerInput visibility is derived from exact rows/ack existence, never mutable pending/cursor state.
+- [ ] Historical unacknowledged input cannot manufacture current successor Attention.
+- [ ] WorkerWake state/residual is separate from WorkerInput semantic state.
+- [ ] Provider wake acceptance never becomes input acknowledgement.
+- [ ] Hold/Backoff/Repair openness is derived relationally, never mutable read-model authority.
+- [ ] FleetSnapshot represents all active Tasks and unresolved safety obligations.
+- [ ] Snapshot/orient DB work is set-oriented and indexed, including current/unacknowledged WorkerInput and open-obligation hot paths.
+- [ ] `hand orient` remains bounded and does not scan full report/input/obligation history by design.
+- [ ] Attention remains pure deterministic derivation with exact identity/currentness.
+- [ ] Native Worktree identity/preservation ambiguity remains safety Attention.
+- [ ] Supervisor runtime liveness/attachment/progress dimensions remain separate.
+- [ ] Rendering performs no acknowledgement/mutation/effect settlement.
+- [ ] No generic Result/Delivery/Isolation/persisted current-task/pending-input authority appears.
+- [ ] #344 replacement DDL/query-plan proof supports these hot paths before #339 starts.

--- a/docs/architecture/v19-contracts/348-cutover-archive.md
+++ b/docs/architecture/v19-contracts/348-cutover-archive.md
@@ -1,0 +1,370 @@
+---
+source_issue: 348
+source_title: "docs(architecture): lock v18→v19 cutover, WorkerInput non-fabrication, and legacy archival semantics"
+source_url: https://github.com/atqamz/hand/issues/348
+source_body_updated_at: 2026-08-29T13:06:19Z
+contract_version: v19
+---
+
+# Canonical persistence cutover and legacy archival contract
+
+This repository snapshot is the immutable semantic contract captured from #348. The GitHub issue is a tracker/discussion surface; comments are not normative architecture state.
+
+Normative for #339. Legacy canonical source accepted for automatic cutover is the supported v18 Fleet DB; target is the **replacement v19 schema that #344 must relock**.
+
+**#348 must not pin the withdrawn pre-WorkerInput #344 DDL/hash/fingerprint.** The current target identifiers are whatever exact replacement payload #344 publishes or immutably references at relock time.
+
+Cutover is side-by-side fresh canonical build + immutable legacy archive. It imports only facts v18 can positively prove and fabricates no Task/Plan/Attempt/resource/input/effect history from ambiguous legacy evidence.
+
+---
+
+# Authority rule
+
+At startup, database validity outranks marker prose and user-local registry projection.
+
+A valid canonical v19 active DB means at least:
+
+```text
+state/hand.db opens read-only
+user_version = 19
+exact current #344 schema fingerprint/object contract matches
+integrity_check = ok
+foreign_key_check = empty
+Fleet singleton/identity structurally valid
+```
+
+When true, active canonical DB is authority even if cutover marker is stale/missing or registry projection is degraded.
+
+Never overwrite a valid canonical DB from marker/archive.
+
+A corrupt/structurally invalid v19 DB is not silently replaced from legacy archive because it may contain newer canonical work. Fail closed for explicit recovery.
+
+---
+
+# Supported automatic source
+
+Automatic cutover accepts exactly the shipped/supported v18 source contract, including exact schema/layout fingerprint and safe rollback-journal state.
+
+Reject older/newer/unknown/mismatched/recovery-needing/WAL-active sources before source mutation.
+
+Do not run an old migration ladder merely to manufacture v18 semantics for import.
+
+Read-only surfaces (`status`, Presentation, `hand orient`, `hand session start`, etc.) never perform cutover, schema migration, WAL checkpoint, marker writes, or registry repair. They report typed legacy/recovery-required state.
+
+---
+
+# Inter-process / SQLite source safety
+
+Cutover uses one cross-process Fleet MigrationLock. Under it, reopen/re-read source and establish one consistent read transaction using read-only/query-only SQLite with foreign keys enabled.
+
+Refuse when source safety cannot be established, including unsupported journal mode, active WAL/SHM, unresolved journal, integrity/FK failure, or inability to exclude supported Hand writers.
+
+Never open source read-write, checkpoint, VACUUM, rollback, or mutate merely to make migration easier.
+
+---
+
+# Quiescence / refusal
+
+Canonical v19 cannot truthfully import unresolved active v18 runtime state.
+
+Refuse automatic cutover while any safety-relevant legacy fact is live/nonterminal/ambiguous, including:
+
+```text
+open/nonterminal Task or execution
+unresolved launch/executor terminality
+unresolved Treehouse lease/worktree ownership/release
+unresolved Herdr session/executor ownership/termination
+pending/ambiguous legacy semantic Send or staged terminal input residual
+open safety Repair/Hold/Backoff controlling future work
+unresolved external effect
+repository/workspace identity/revision ambiguity
+```
+
+Provider unavailable is `unknown`, never permission to forget state.
+
+Legacy runtime must reconcile/terminalize first; then cutover may retry.
+
+---
+
+# Migration identity / archive
+
+Derive deterministic migration identity from exact Fleet identity + exact source DB digest under a documented versioned algorithm.
+
+Use deterministic same-volume paths for:
+
+```text
+active state/hand.db
+canonical temp sibling
+cutover marker
+immutable archive directory
+original legacy hand.db archive
+manifest
+allowed semantic sidecars
+```
+
+Never overwrite an existing archive identity unless exact digests prove it is the same evidence.
+
+Archive preserves forensic truth, not current authority.
+
+Manifest records exact source/archive digests, Fleet ID, v18 version, target v19 contract identity from the **current relocked #344 payload**, imported Project/workspace evidence, observed physical identities/revisions, and sidecar digests.
+
+Exclude repositories, credentials, tokens, caches, binaries, private-runtime bundles, and unrelated files.
+
+---
+
+# Import classification
+
+Every legacy fact is exactly one of:
+
+```text
+provably importable
+derivable-and-positively-verified-at-cutover
+archive-only
+blocking/ambiguous
+discarded mechanism cache
+```
+
+Nothing becomes canonical merely because a legacy column/file exists.
+
+## Fleet
+
+Preserve exact durable Fleet identity. Never remint because registry/path differs.
+
+## Projects / WorkspaceBinding / PolicyRevision
+
+Import only positively established current Project repository binding/policy facts that can be normalized into canonical v19 without inventing history.
+
+For each imported Project positively verify:
+
+```text
+canonical Fleet-relative repository locator
+exact Git repository
+physical filesystem identity
+exact commit revision
+no locator/physical alias with another imported Project
+```
+
+Legacy display name/URL/mode/upstream are provenance/policy inputs only, not Project identity.
+
+Do not invent ProjectAcquisition/Relocation effects Hand did not perform.
+
+## Task / Plan / Attempt / runtime history
+
+Terminal v18 execution history is archive-only unless an exact target relation is independently provable under this spec.
+
+Do **not** synthesize canonical:
+
+```text
+Task
+Plan
+Attempt
+WorktreeBinding
+SessionBinding
+ExecutorBinding
+TerminalReceipt
+WorkerReport / WorkerReportAcknowledgement
+WorkerInput / WorkerInputAcknowledgement
+WorkerWake
+Interrupt
+Qualification / Integration
+Production / Artifact / Publication
+```
+
+from terminal legacy task/runtime/prose/cursor history.
+
+If operator wants an old goal pursued again after cutover, create a new canonical Task.
+
+---
+
+# WorkerInput non-fabrication rule
+
+Legacy v18 terminal text/report/pane/status/Send history does not prove the exact canonical tuple required for WorkerInput:
+
+```text
+WorkerInput identity
+exact target Attempt
+exact target ExecutorBinding
+per-executor ordinal
+semantic origin
+exact acknowledgement evidence
+```
+
+Therefore:
+
+```text
+legacy prose / pane / send-like state
+→ archive under normal legacy evidence rules where required
+→ create ZERO fabricated WorkerInput rows
+→ create ZERO fabricated WorkerInputAcknowledgement rows
+→ create ZERO fabricated WorkerWake operations
+```
+
+If unresolved staged input/semantic Send residual or a live exact legacy executor cannot be reconciled positively, cutover is blocked rather than translating ambiguity into new canonical input/wake history.
+
+This is mandatory even if a legacy field happens to contain the exact same payload bytes.
+
+---
+
+# Legacy Treehouse rule
+
+Treehouse lease/pool identity is never translated into native v19 WorktreeBinding.
+
+```text
+terminal/quiescent legacy Treehouse evidence
+→ archive-only
+
+unresolved Treehouse ownership/release
+→ blocks cutover
+```
+
+Fresh v19 WorktreeBinding requires its own native Git operation identity, binding ID, exact registered/common-dir/private-gitdir/lock-reason/HEAD/physical identity evidence and cannot be reverse-invented from Treehouse history.
+
+---
+
+# Fresh canonical temp DB
+
+Build a new deterministic temp DB only after source/archive/import evidence is established.
+
+Conceptually:
+
+1. create empty temp DB;
+2. execute **exact current replacement #344 DDL** from the exact authority #344 identifies;
+3. insert exact Fleet singleton/identity;
+4. insert migration/import evidence with source/archive/manifest digests;
+5. insert only allowed Project/WorkspaceBinding/PolicyRevision/import/archive facts;
+6. create zero fabricated canonical execution/input/effect history;
+7. set `PRAGMA user_version=19` only after target construction;
+8. require exact current #344 fingerprint/object contract;
+9. require FK check empty and integrity `ok`;
+10. close/flush temp before publication.
+
+No provider/Git/registry/network mutation occurs between final temp validation and canonical DB publication except the exact filesystem publication primitives.
+
+---
+
+# Marker is advisory only
+
+Cutover marker records deterministic recovery evidence/phase, expected source/archive/temp/target contract identities, and paths.
+
+Marker is never authority. Corrupt/missing/stale marker cannot override a valid canonical DB or digest-validated archive/temp evidence.
+
+---
+
+# Publication / durability
+
+Keep publication same-volume and crash-safe.
+
+POSIX: fsync completed files before rename and fsync relevant parent directories after publication boundaries.
+
+Windows: close handles, flush completed files, use same-volume write-through rename/move semantics, and treat sharing violations as bounded stop/retry—not copy-over/delete fallback.
+
+Do not pretend Windows and POSIX durability primitives are identical.
+
+Publication sequence conceptually:
+
+```text
+validate+flush archive evidence + canonical temp
+→ persist advisory prepared marker
+→ atomically archive original active v18 DB
+→ reopen/hash/validate final archive
+→ ensure archive evidence exactly matches temp import plan
+→ atomically publish canonical temp as state/hand.db
+→ reopen active v19 read-only and validate exact current #344 contract/FK/integrity/Fleet/import evidence
+→ canonical DB becomes authority
+→ registry projection reconciles separately/idempotently
+```
+
+If final archived source digest differs from snapshot used to build temp, do not publish stale temp.
+
+Archive contains the original legacy DB file, not only a logical export.
+
+---
+
+# Startup recovery matrix
+
+Required deterministic outcomes:
+
+```text
+valid canonical v19 active
+→ canonical wins; repair marker/registry only as projections
+
+valid recognized v18 active
+→ legacy wins; resume only exact matching cutover evidence under MigrationLock
+
+active missing + valid archive + matching valid canonical temp
+→ publish exact temp after full validation
+
+active missing + valid archive + temp absent/invalid
+→ rebuild fresh temp from exact archive evidence then publish
+
+corrupt/invalid canonical v19 active
+→ fail closed; no automatic archive restore/down-conversion
+
+unknown/newer schema
+→ refuse before mutation
+
+marker conflicts with files
+→ cryptographic/schema evidence outranks marker; if unique authority cannot be proven, refuse
+```
+
+No mtime-based authority selection.
+
+---
+
+# Registry projection boundary
+
+User-local `registry.db` remains discovery/projection only.
+
+After canonical identity is positively known:
+
+- preserve canonical `fleet_id` regardless of stale locator claims;
+- reconcile/retire only provably stale same-home locator projections through supported registry operations;
+- unrelated Fleet ambiguity cannot make this Fleet's DB identity ambiguous;
+- projection failure after successful canonical publication leaves canonical DB authoritative and reports degraded/repair-required state;
+- test/disposable cutover must use isolated Secondhand infrastructure root and never mutate operator production registry.
+
+Incidents #357–#360 are regression inputs to this boundary, not justification for a registry table inside Fleet DB.
+
+---
+
+# Required crash/adversarial tests
+
+At minimum inject:
+
+- every marker/archive/temp/publication rename/flush boundary;
+- two concurrent migration processes;
+- source changes between initial read snapshot and final archive publication;
+- unexpected destination exists;
+- Windows sharing violations;
+- POSIX rename/dir-fsync crash windows;
+- corrupt temp and corrupt active canonical DB;
+- WAL/SHM/journal refusal;
+- Project locator/physical alias;
+- unresolved Treehouse resource;
+- unresolved legacy Send/staged input residual;
+- exact zero fabricated WorkerInput/Acknowledgement/WorkerWake rows;
+- valid canonical DB + stale old registry locator preserves canonical Fleet ID;
+- valid Fleet A + unrelated ambiguous Fleet B does not block A;
+- test cutover leaves real user registry unchanged.
+
+Every case proves one unique authority and no silent deletion/overwrite/fabrication.
+
+---
+
+# Acceptance / lock conditions
+
+- [ ] Target schema identity comes only from the replacement relocked #344 payload; withdrawn old hash/fingerprint is not implementation authority.
+- [ ] Valid canonical v19 DB outranks marker/archive/registry projection.
+- [ ] Automatic source acceptance is exact, read-only, quiescent, and fail-closed.
+- [ ] Original v18 DB is preserved as immutable archive evidence.
+- [ ] Only positively provable Fleet/Project/workspace/policy facts are imported.
+- [ ] Terminal legacy execution/resource/report/send history is archive-only unless independently proven importable.
+- [ ] ZERO fabricated WorkerInput/WorkerInputAcknowledgement/WorkerWake from legacy prose/send-like state.
+- [ ] Legacy Treehouse identity is never mapped into native WorktreeBinding.
+- [ ] Unresolved Treehouse/Herdr/input/effect ownership blocks cutover.
+- [ ] Publication/recovery is crash-safe on POSIX and native Windows.
+- [ ] Registry remains projection; stale same-home locator never remints Fleet identity.
+- [ ] Test cutover cannot reach operator production registry.
+- [ ] #344 replacement DDL/fingerprint/query proof is validated before v19 publication.
+
+No automatic downgrade is provided once a valid v19 Fleet exists.

--- a/docs/architecture/v19-contracts/manifest.md
+++ b/docs/architecture/v19-contracts/manifest.md
@@ -1,0 +1,67 @@
+# v19 semantic contract manifest
+
+This manifest anchors the repository-owned semantic contract snapshots used by the v0.8.0 / canonical v19 implementation.
+
+Snapshot revision containing the complete contract set, before this manifest commit:
+
+```text
+4cbc97490b6a793b3cc4abcd890f504496f40960
+```
+
+The GitHub issue bodies remain tracker/review surfaces. For the snapshots listed below, the repository file at the snapshot revision is the immutable semantic evidence. A later issue-body edit cannot retroactively change that evidence. Comments are never normative architecture state.
+
+`#344` is intentionally **not duplicated** here. Exact canonical relational authority remains its existing immutable artifact mechanism:
+
+```text
+immutable commit: 67ca4b35b773ef25ac9ff88cd1b16213153ed498
+DDL: docs/architecture/v19.sql.gz
+Git blob: d529d7a687db8d0266d5592ade9520c04766bf43
+stored gzip SHA-256: 6e92cb72ad52c135a0cb8ae8f6352f1ff2c938a289ae1e313a9ce1d6a9e42399
+reconstructed DDL SHA-256: 81118c2e982be7e08c0f8bf3bbb980e2ec4c5bffbbc7d419e9952732ad36c58a
+schema fingerprint: 8726f0875845d610553928e6bb56fc5566019a6667d81e29a94ee3d3d45ef3b8
+proof: docs/architecture/v19-proof.py.gz
+relock manifest: docs/architecture/v19-relock.md
+```
+
+`#304` is also intentionally not replaced by this manifest. Its issue body is the sole current semantic statement for Decision/Answer authority; its historical comment is audit history only. If #304 is later moved to a repository snapshot, that must be an explicit authority transfer rather than an accidental second source.
+
+## Snapshot set
+
+| Issue | Title / contract | Path | Git blob SHA-1 |
+| ---: | --- | --- | --- |
+| #323 | Worker Harness routing / typed fallback | `docs/architecture/v19-contracts/323-worker-routing.md` | `6b2ce258a9e72412bcbb1cd625963806400e227b` |
+| #324 | typed v1 configuration / role separation | `docs/architecture/v19-contracts/324-configuration.md` | `e322eb6bf08b3648c1a298e13b6fc4b8a2e19f7b` |
+| #343 | external effects / WorkerWake / reconciliation | `docs/architecture/v19-contracts/343-external-effects-worker-wake.md` | `76be8f08e60ba1819df71669edf9cb3af3c34b14` |
+| #345 | lifecycle / currentness / concurrency / crash recovery | `docs/architecture/v19-contracts/345-lifecycle-currentness-crash-recovery.md` | `1039bb9fe69fb84f4b2357c05e6dcbfc6dfb3254` |
+| #346 | capability / adapter boundaries | `docs/architecture/v19-contracts/346-capability-adapters.md` | `859b80207a625fb4be8f5ff1a5eaf336bb7e8c77` |
+| #347 | read models / Attention / SupervisorOrientation | `docs/architecture/v19-contracts/347-read-models-attention-orientation.md` | `72a9905c84e376b8cd5a07ff2c0643b244e97d14` |
+| #348 | v18→v19 cutover / archive / non-fabrication | `docs/architecture/v19-contracts/348-cutover-archive.md` | `c5c8045698ca8bea3b093d1adbe13d0b87c651d0` |
+
+Git blob SHA-1 is the deterministic content digest for each repository object. The contract-set digest below is SHA-256 over the UTF-8 concatenation, in the table's issue order, of:
+
+```text
+<basename> NUL <git-blob-sha1> LF
+```
+
+Contract-set SHA-256:
+
+```text
+dff7a465722683c11f7c2c0df2970af452c0693c6b9501d49fa45cf91c2f3c36
+```
+
+## Authority graph
+
+Use these categories precisely:
+
+1. **Current normative architecture**: this snapshot set, #344's exact immutable DDL/proof artifact, and #304's current issue body for Decision/Answer authority.
+2. **Historical landed prerequisites**: closed work such as #338 LaunchSpec, #340 monitoring/stale-wake safety, and #353/#355 Supervisor runtime integration where the required invariant is already consumed/restated by current v19 contracts. They remain audit evidence; they do not compete as current v19 authority.
+3. **Implementation dependencies**: open implementation slices whose completion is required by sequencing but which do not define architecture merely by blocking another issue.
+4. **Release qualification evidence**: #305 qualifies one exact release candidate/tag/source/runtime matrix after implementation; passing it does not redefine architecture.
+
+A semantic cross-reference does not imply a sequencing dependency. A historical prerequisite does not become current normative authority merely because current contracts cite it.
+
+## Change policy
+
+Do not edit a frozen snapshot in place and pretend the old evidence changed. A semantic change requires a new versioned snapshot set and manifest anchor. If the change affects canonical table/constraint/trigger/index/operation-kind semantics or any byte of the #344 DDL, the #344 relock discipline is mandatory before implementation continues.
+
+Documentation-only authority cleanup that does not change the frozen semantics or #344 bytes has DDL impact: **NONE**.


### PR DESCRIPTION
## Scope

Repository-own the mutable issue-body architecture contracts before further v0.8 implementation.

- snapshots #343, #345, #346, #347, #348 as versioned semantic contracts;
- freezes Model-A #323 Worker routing and #324 typed configuration contracts;
- incorporates #323's former normative fallback-provenance comment into the repository contract;
- adds a manifest anchored to snapshot revision `4cbc97490b6a793b3cc4abcd890f504496f40960` with per-file Git blob digests and contract-set SHA-256;
- classifies current normative architecture vs historical landed prerequisites vs implementation dependencies vs release qualification evidence;
- explicitly leaves #344 on its existing immutable exact-DDL/proof mechanism;
- explicitly leaves #304's current issue body as the sole Decision/Answer semantic statement.

## DDL impact

**NONE.** No canonical v19 DDL bytes, hashes, fingerprint, proof artifact, or production schema code change.

## Follow-up after merge

Tracker bodies for the frozen contracts can point at the immutable repository evidence instead of claiming issue-body mutability as architecture authority. #304's historical comment is already demoted to non-normative audit history. #323/#324 are now in milestone 0.8.0.