### PR TITLE
docs(architecture): anchor v19 contracts to permanent main revision

### DIFF
--- a/docs/architecture/v19-contracts/manifest.md
+++ b/docs/architecture/v19-contracts/manifest.md
@@ -2,10 +2,10 @@
 
 This manifest anchors the repository-owned semantic contract snapshots used by the v0.8.0 / canonical v19 implementation.
 
-Snapshot revision containing the complete contract set, before this manifest commit:
+Permanent `main` revision containing the complete contract set:
 
 ```text
-4cbc97490b6a793b3cc4abcd890f504496f40960
+6699745bb451e3daca072b4c958e5b79f31e4775
 ```
 
 The GitHub issue bodies remain tracker/review surfaces. For the snapshots listed below, the repository file at the snapshot revision is the immutable semantic evidence. A later issue-body edit cannot retroactively change that evidence. Comments are never normative architecture state.


### PR DESCRIPTION
Follow-up to #521.

The semantic snapshot blobs are unchanged. This only replaces the feature-branch snapshot revision with permanent `main` revision `6699745bb451e3daca072b4c958e5b79f31e4775`, which contains the exact same contract set after squash merge.

Contract-set SHA-256 remains `dff7a465722683c11f7c2c0df2970af452c0693c6b9501d49fa45cf91c2f3c36`.

DDL impact: **NONE**. #344 artifacts/bytes/hashes/fingerprint are untouched.