### PR TITLE
test(store): probe v18 cutover writer exclusion and freeze

### DIFF
--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -11,7 +12,7 @@ import (
 	"time"
 )
 
-func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
+func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
 	home := t.TempDir()
 	db, err := Open(home)
 	if err != nil {
@@ -38,8 +39,9 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 	escaped := (&url.URL{Path: path}).EscapedPath()
 	ctx := context.Background()
 
-	// First establish a real read-only SHARED snapshot. While it is held, no
-	// concurrent rollback-journal writer can commit changes to the main DB file.
+	// Establish the committed source snapshot using a genuine read-only SHARED
+	// transaction. A rollback-journal writer may reserve while this lives, but it
+	// cannot commit changes to the main database file.
 	readDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
 	if err != nil {
 		t.Fatal(err)
@@ -67,36 +69,8 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 		t.Fatalf("read guard saw %q, want clean", clean)
 	}
 
-	// The byte-exact archive candidate is made durable before any rw-capable
-	// SQLite gate is opened. The later writer gate must revalidate this digest.
-	archived, err := os.ReadFile(path)
-	if err != nil {
-		_ = readGuard.Close()
-		_ = readDB.Close()
-		t.Fatal(err)
-	}
-	archiveDigest := sha256.Sum256(archived)
-	archivePath := path + ".original-candidate"
-	if err := os.WriteFile(archivePath, archived, 0o600); err != nil {
-		_ = readGuard.Close()
-		_ = readDB.Close()
-		t.Fatal(err)
-	}
-	archivedAgain, err := os.ReadFile(archivePath)
-	if err != nil {
-		_ = readGuard.Close()
-		_ = readDB.Close()
-		t.Fatal(err)
-	}
-	if got := sha256.Sum256(archivedAgain); got != archiveDigest {
-		_ = readGuard.Close()
-		_ = readDB.Close()
-		t.Fatalf("archive candidate digest = %x, want %x", got, archiveDigest)
-	}
-
-	// Race a supported old writer after the archive snapshot. It can obtain a
-	// RESERVED lock and create rollback journal state, but the SHARED reader keeps
-	// the committed main DB bytes equal to the archive until the reader is released.
+	// Race a supported old writer after the SHARED snapshot. It obtains RESERVED
+	// and creates rollback-journal state, but cannot commit while the reader lives.
 	readyPath := path + ".hot-writer-ready"
 	cmd := exec.Command(os.Args[0], "-test.run=^TestCutoverHotJournalWriterHelper$")
 	cmd.Env = append(os.Environ(),
@@ -164,30 +138,21 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 	}
 	<-done
 
-	mainBeforeRelease, err := os.ReadFile(path)
+	mainBeforeGate, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(mainBeforeRelease); got != archiveDigest {
-		t.Fatalf("concurrent writer changed main DB while read snapshot held: archive=%x got=%x", archiveDigest, got)
+	mainDigest := sha256.Sum256(mainBeforeGate)
+	journalBeforeGate, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if _, err := os.ReadFile(journalPath); err != nil {
-		t.Fatalf("expected crashed writer rollback journal: %v", err)
-	}
+	journalDigest := sha256.Sum256(journalBeforeGate)
 
-	// The archive is already durable, so it is safe to release the reader and let
-	// BEGIN IMMEDIATE perform normal crash recovery if needed. A committed writer
-	// in this gap would change hand.db and be caught by the exact digest check below.
-	if _, err := readGuard.ExecContext(ctx, `ROLLBACK`); err != nil {
-		t.Fatal(err)
-	}
-	if err := readGuard.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := readDB.Close(); err != nil {
-		t.Fatal(err)
-	}
-
+	// A SHARED reader and a RESERVED writer gate are compatible. Acquiring the
+	// cutover reservation while the reader still lives closes the future-writer
+	// race without first releasing the snapshot. The existing SHARED lock must
+	// also prevent this acquisition from changing DB or journal bytes.
 	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
 	if err != nil {
 		t.Fatal(err)
@@ -201,7 +166,12 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
 		_ = gate.Close()
 		_ = gateDB.Close()
-		t.Fatalf("acquire writer gate after durable archive candidate: %v", err)
+		t.Fatalf("acquire writer gate while read snapshot is held: %v", err)
+	}
+	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("enable query_only after writer reservation: %v", err)
 	}
 
 	mainAfterGate, err := os.ReadFile(path)
@@ -210,41 +180,109 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 		_ = gateDB.Close()
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(mainAfterGate); got != archiveDigest {
+	if got := sha256.Sum256(mainAfterGate); got != mainDigest {
 		_ = gate.Close()
 		_ = gateDB.Close()
-		t.Fatalf("writer gate/recovery changed committed source bytes: archive=%x active=%x", archiveDigest, got)
+		t.Fatalf("writer-gate acquisition changed main DB before archive: before=%x after=%x", mainDigest, got)
 	}
-	var recovered string
-	if err := gate.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&recovered); err != nil {
+	journalAfterGate, err := os.ReadFile(journalPath)
+	if err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("writer-gate acquisition removed rollback journal before archive: %v", err)
+	}
+	if got := sha256.Sum256(journalAfterGate); got != journalDigest {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("writer-gate acquisition changed rollback journal before archive: before=%x after=%x", journalDigest, got)
+	}
+
+	// Only after the reservation is held is the original DB archived. At this
+	// point future supported writers are excluded, and the SHARED reader still
+	// proves the main DB bytes are the committed snapshot it observed.
+	archivePath := path + ".original-candidate"
+	if err := os.WriteFile(archivePath, mainAfterGate, 0o600); err != nil {
 		_ = gate.Close()
 		_ = gateDB.Close()
 		t.Fatal(err)
 	}
-	if recovered != "clean" {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("writer gate observed recovered value %q, want clean", recovered)
-	}
-	archivedAfterGate, err := os.ReadFile(archivePath)
+	archived, err := os.ReadFile(archivePath)
 	if err != nil {
 		_ = gate.Close()
 		_ = gateDB.Close()
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(archivedAfterGate); got != archiveDigest {
+	if got := sha256.Sum256(archived); got != mainDigest {
 		_ = gate.Close()
 		_ = gateDB.Close()
-		t.Fatalf("archive candidate changed during gate recovery: before=%x after=%x", archiveDigest, got)
+		t.Fatalf("archive candidate digest = %x, want %x", got, mainDigest)
 	}
 
-	// SQLite may leave a non-hot rollback-journal file behind. File existence is
-	// not the safety property. After releasing the writer gate, a new read-only
-	// connection must observe the archived committed state without mutating the DB.
-	if _, err := gate.ExecContext(ctx, `ROLLBACK`); err != nil {
+	// Release only the read snapshot; retain the writer reservation. The gate is
+	// now the sole supported-writer authority. Final query-only reads must still
+	// see the exact committed state whose raw bytes were archived.
+	if _, err := readGuard.ExecContext(ctx, `ROLLBACK`); err != nil {
 		_ = gate.Close()
 		_ = gateDB.Close()
 		t.Fatal(err)
+	}
+	if err := readGuard.Close(); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+	if err := readDB.Close(); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+
+	var recovered string
+	if err := gate.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&recovered); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("query source under writer gate after releasing snapshot: %v", err)
+	}
+	if recovered != "clean" {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("writer gate observed %q, want committed value clean", recovered)
+	}
+	mainBeforeFreeze, err := os.ReadFile(path)
+	if err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(mainBeforeFreeze); got != mainDigest {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("source bytes differ from archive before freeze: archive=%x active=%x", mainDigest, got)
+	}
+
+	// Cross the deliberate one-way mutation boundary only after archive and final
+	// digest proof. This minimal certificate/sentinel composes the hot-journal
+	// case with the full 21-guard freeze proved independently in the companion test.
+	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 0`); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("disable query_only at freeze boundary: %v", err)
+	}
+	certificate := fmt.Sprintf("v1:%x", mainDigest)
+	if _, err := gate.ExecContext(ctx, `INSERT INTO meta (key, value) VALUES ('v19-cutover-freeze', ?)`, certificate); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("write freeze certificate after hot-journal race: %v", err)
+	}
+	if _, err := gate.ExecContext(ctx, `PRAGMA user_version = 22`); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := gate.ExecContext(ctx, `COMMIT`); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("commit freeze boundary after hot-journal race: %v", err)
 	}
 	if err := gate.Close(); err != nil {
 		_ = gateDB.Close()
@@ -254,25 +292,31 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	verifyDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	archivedAfterFreeze, err := os.ReadFile(archivePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	verifyDB.SetMaxOpenConns(1)
+	if got := sha256.Sum256(archivedAfterFreeze); got != mainDigest {
+		t.Fatalf("immutable original archive changed after freeze: before=%x after=%x", mainDigest, got)
+	}
+	verifyDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() { _ = verifyDB.Close() }()
-	var verified string
-	if err := verifyDB.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&verified); err != nil {
-		t.Fatalf("read-only verification after writer-gate recovery: %v", err)
-	}
-	if verified != "clean" {
-		t.Fatalf("read-only verification saw %q, want clean", verified)
-	}
-	mainAfterVerify, err := os.ReadFile(path)
-	if err != nil {
+	var gotCertificate string
+	if err := verifyDB.QueryRow(`SELECT value FROM meta WHERE key = 'v19-cutover-freeze'`).Scan(&gotCertificate); err != nil {
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(mainAfterVerify); got != archiveDigest {
-		t.Fatalf("post-recovery read-only verification changed source bytes: archive=%x active=%x", archiveDigest, got)
+	if gotCertificate != certificate {
+		t.Fatalf("freeze certificate = %q, want %q", gotCertificate, certificate)
+	}
+	var version int
+	if err := verifyDB.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != 22 {
+		t.Fatalf("frozen bridge user_version = %d, want 22", version)
 	}
 }
 

--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -149,10 +149,9 @@ func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
 	}
 	journalDigest := sha256.Sum256(journalBeforeGate)
 
-	// A SHARED reader and a RESERVED writer gate are compatible. Acquiring the
-	// cutover reservation while the reader still lives closes the future-writer
-	// race without first releasing the snapshot. The existing SHARED lock must
-	// also prevent this acquisition from changing DB or journal bytes.
+	// A SHARED reader and RESERVED writer gate are compatible. Acquiring the gate
+	// while the reader lives closes the future-writer race, and the SHARED lock
+	// must prevent gate acquisition from changing DB or journal bytes.
 	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestCutoverReadGuardPreventsHotJournalRecovery(t *testing.T) {
+func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 	home := t.TempDir()
 	db, err := Open(home)
 	if err != nil {
@@ -35,40 +35,68 @@ func TestCutoverReadGuardPreventsHotJournalRecovery(t *testing.T) {
 	}
 
 	path := Path(home)
-	baseline, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	baselineDigest := sha256.Sum256(baseline)
 	escaped := (&url.URL{Path: path}).EscapedPath()
 	ctx := context.Background()
 
-	// Hold a genuine read-only SHARED transaction before a legacy writer can
-	// race the rw-capable cutover gate. A rollback-journal writer may reserve and
-	// create its journal, but it cannot modify the main DB while this reader lives.
+	// First establish a real read-only SHARED snapshot. While it is held, no
+	// concurrent rollback-journal writer can commit changes to the main DB file.
 	readDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
 	if err != nil {
 		t.Fatal(err)
 	}
 	readDB.SetMaxOpenConns(1)
-	defer func() { _ = readDB.Close() }()
 	readGuard, err := readDB.Conn(ctx)
 	if err != nil {
+		_ = readDB.Close()
 		t.Fatal(err)
 	}
-	defer func() { _ = readGuard.Close() }()
 	if _, err := readGuard.ExecContext(ctx, `BEGIN`); err != nil {
+		_ = readGuard.Close()
+		_ = readDB.Close()
 		t.Fatal(err)
 	}
-	defer func() { _, _ = readGuard.ExecContext(ctx, `ROLLBACK`) }()
 	var clean string
 	if err := readGuard.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&clean); err != nil {
+		_ = readGuard.Close()
+		_ = readDB.Close()
 		t.Fatal(err)
 	}
 	if clean != "clean" {
+		_ = readGuard.Close()
+		_ = readDB.Close()
 		t.Fatalf("read guard saw %q, want clean", clean)
 	}
 
+	// The byte-exact archive candidate is made durable before any rw-capable
+	// SQLite gate is opened. The later writer gate must revalidate this digest.
+	archived, err := os.ReadFile(path)
+	if err != nil {
+		_ = readGuard.Close()
+		_ = readDB.Close()
+		t.Fatal(err)
+	}
+	archiveDigest := sha256.Sum256(archived)
+	archivePath := path + ".original-candidate"
+	if err := os.WriteFile(archivePath, archived, 0o600); err != nil {
+		_ = readGuard.Close()
+		_ = readDB.Close()
+		t.Fatal(err)
+	}
+	archivedAgain, err := os.ReadFile(archivePath)
+	if err != nil {
+		_ = readGuard.Close()
+		_ = readDB.Close()
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(archivedAgain); got != archiveDigest {
+		_ = readGuard.Close()
+		_ = readDB.Close()
+		t.Fatalf("archive candidate digest = %x, want %x", got, archiveDigest)
+	}
+
+	// Race a supported old writer after the archive snapshot. It can obtain a
+	// RESERVED lock and create rollback journal state, but the SHARED reader keeps
+	// the committed main DB bytes equal to the archive until the reader is released.
 	readyPath := path + ".hot-writer-ready"
 	cmd := exec.Command(os.Args[0], "-test.run=^TestCutoverHotJournalWriterHelper$")
 	cmd.Env = append(os.Environ(),
@@ -79,6 +107,8 @@ func TestCutoverReadGuardPreventsHotJournalRecovery(t *testing.T) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
+		_ = readGuard.Close()
+		_ = readDB.Close()
 		t.Fatal(err)
 	}
 	done := make(chan error, 1)
@@ -129,28 +159,35 @@ func TestCutoverReadGuardPreventsHotJournalRecovery(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-
 	if err := cmd.Process.Kill(); err != nil {
 		t.Fatal(err)
 	}
 	<-done
 
-	mainBeforeGate, err := os.ReadFile(path)
+	mainBeforeRelease, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(mainBeforeGate); got != baselineDigest {
-		t.Fatalf("concurrent writer changed main DB while read guard held: baseline=%x got=%x", baselineDigest, got)
+	if got := sha256.Sum256(mainBeforeRelease); got != archiveDigest {
+		t.Fatalf("concurrent writer changed main DB while read snapshot held: archive=%x got=%x", archiveDigest, got)
 	}
-	journalBeforeGate, err := os.ReadFile(journalPath)
-	if err != nil {
-		t.Fatal(err)
+	if _, err := os.ReadFile(journalPath); err != nil {
+		t.Fatalf("expected crashed writer rollback journal: %v", err)
 	}
-	journalDigest := sha256.Sum256(journalBeforeGate)
 
-	// Opening the rw-capable gate in the presence of the now-hot journal would
-	// normally trigger rollback recovery. The still-held SHARED guard must make
-	// recovery/gate acquisition fail busy instead, without touching either file.
+	// The archive is already durable, so it is safe to release the reader and let
+	// BEGIN IMMEDIATE perform normal crash recovery if needed. A committed writer
+	// in this gap would change hand.db and be caught by the exact digest check below.
+	if _, err := readGuard.ExecContext(ctx, `ROLLBACK`); err != nil {
+		t.Fatal(err)
+	}
+	if err := readGuard.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := readDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
 	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
 	if err != nil {
 		t.Fatal(err)
@@ -162,59 +199,27 @@ func TestCutoverReadGuardPreventsHotJournalRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = gate.Close() }()
-	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); !isSQLiteBusy(err) {
-		if err == nil {
-			_, _ = gate.ExecContext(ctx, `ROLLBACK`)
-		}
-		t.Fatalf("BEGIN IMMEDIATE with hot journal + read guard = %v, want SQLITE_BUSY without recovery", err)
+	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("acquire writer gate after durable archive candidate: %v", err)
 	}
+	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
 
 	mainAfterGate, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(mainAfterGate); got != baselineDigest {
-		t.Fatalf("failed writer gate changed main DB: baseline=%x got=%x", baselineDigest, got)
-	}
-	journalAfterGate, err := os.ReadFile(journalPath)
-	if err != nil {
-		t.Fatalf("failed writer gate removed hot journal: %v", err)
-	}
-	if got := sha256.Sum256(journalAfterGate); got != journalDigest {
-		t.Fatalf("failed writer gate changed hot journal: before=%x after=%x", journalDigest, got)
-	}
-
-	// Prove the fixture really is a hot journal: once the SHARED guard is gone,
-	// the same rw BEGIN IMMEDIATE is allowed to recover it.
-	if _, err := readGuard.ExecContext(ctx, `ROLLBACK`); err != nil {
-		t.Fatal(err)
-	}
-	if err := readGuard.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err := readDB.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	recoveryDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
-	if err != nil {
-		t.Fatal(err)
-	}
-	recoveryDB.SetMaxOpenConns(1)
-	defer func() { _ = recoveryDB.Close() }()
-	recovery, err := recoveryDB.Conn(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = recovery.Close() }()
-	if _, err := recovery.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		t.Fatalf("recover hot journal after releasing read guard: %v", err)
-	}
-	if _, err := recovery.ExecContext(ctx, `ROLLBACK`); err != nil {
-		t.Fatal(err)
+	if got := sha256.Sum256(mainAfterGate); got != archiveDigest {
+		t.Fatalf("writer gate/recovery changed committed source bytes: archive=%x active=%x", archiveDigest, got)
 	}
 	if _, err := os.Stat(journalPath); !os.IsNotExist(err) {
-		t.Fatalf("rollback journal still exists after unguarded recovery: %v", err)
+		t.Fatalf("hot rollback journal remains after successful writer gate recovery: %v", err)
+	}
+	archivedAfterGate, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(archivedAfterGate); got != archiveDigest {
+		t.Fatalf("archive candidate changed during gate recovery: before=%x after=%x", archiveDigest, got)
 	}
 }
 

--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -1,0 +1,255 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"net/url"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestCutoverReadGuardPreventsHotJournalRecovery(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var journalMode string
+	if err := db.sql.QueryRow(`PRAGMA journal_mode = DELETE`).Scan(&journalMode); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if journalMode != "delete" {
+		_ = db.Close()
+		t.Fatalf("journal_mode = %q, want delete", journalMode)
+	}
+	if _, err := db.sql.Exec(`INSERT INTO meta (key, value) VALUES ('hot-journal-probe', 'clean')`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := Path(home)
+	baseline, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baselineDigest := sha256.Sum256(baseline)
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	ctx := context.Background()
+
+	// Hold a genuine read-only SHARED transaction before a legacy writer can
+	// race the rw-capable cutover gate. A rollback-journal writer may reserve and
+	// create its journal, but it cannot modify the main DB while this reader lives.
+	readDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	readDB.SetMaxOpenConns(1)
+	defer func() { _ = readDB.Close() }()
+	readGuard, err := readDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readGuard.Close() }()
+	if _, err := readGuard.ExecContext(ctx, `BEGIN`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = readGuard.ExecContext(ctx, `ROLLBACK`) }()
+	var clean string
+	if err := readGuard.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&clean); err != nil {
+		t.Fatal(err)
+	}
+	if clean != "clean" {
+		t.Fatalf("read guard saw %q, want clean", clean)
+	}
+
+	readyPath := path + ".hot-writer-ready"
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCutoverHotJournalWriterHelper$")
+	cmd.Env = append(os.Environ(),
+		"HAND_HOT_JOURNAL_HELPER=1",
+		"HAND_HOT_JOURNAL_DB="+path,
+		"HAND_HOT_JOURNAL_READY="+readyPath,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case <-done:
+		default:
+		}
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("hot-journal writer exited before reserving: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			<-done
+			t.Fatal("hot-journal writer did not reserve in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	journalPath := path + "-journal"
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if info, err := os.Stat(journalPath); err == nil && info.Size() > 512 {
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("hot-journal writer exited before creating journal: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			<-done
+			t.Fatal("hot-journal writer did not create a rollback journal in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+
+	mainBeforeGate, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(mainBeforeGate); got != baselineDigest {
+		t.Fatalf("concurrent writer changed main DB while read guard held: baseline=%x got=%x", baselineDigest, got)
+	}
+	journalBeforeGate, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journalDigest := sha256.Sum256(journalBeforeGate)
+
+	// Opening the rw-capable gate in the presence of the now-hot journal would
+	// normally trigger rollback recovery. The still-held SHARED guard must make
+	// recovery/gate acquisition fail busy instead, without touching either file.
+	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDB.SetMaxOpenConns(1)
+	defer func() { _ = gateDB.Close() }()
+	gate, err := gateDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); !isSQLiteBusy(err) {
+		if err == nil {
+			_, _ = gate.ExecContext(ctx, `ROLLBACK`)
+		}
+		t.Fatalf("BEGIN IMMEDIATE with hot journal + read guard = %v, want SQLITE_BUSY without recovery", err)
+	}
+
+	mainAfterGate, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(mainAfterGate); got != baselineDigest {
+		t.Fatalf("failed writer gate changed main DB: baseline=%x got=%x", baselineDigest, got)
+	}
+	journalAfterGate, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatalf("failed writer gate removed hot journal: %v", err)
+	}
+	if got := sha256.Sum256(journalAfterGate); got != journalDigest {
+		t.Fatalf("failed writer gate changed hot journal: before=%x after=%x", journalDigest, got)
+	}
+
+	// Prove the fixture really is a hot journal: once the SHARED guard is gone,
+	// the same rw BEGIN IMMEDIATE is allowed to recover it.
+	if _, err := readGuard.ExecContext(ctx, `ROLLBACK`); err != nil {
+		t.Fatal(err)
+	}
+	if err := readGuard.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := readDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recoveryDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryDB.SetMaxOpenConns(1)
+	defer func() { _ = recoveryDB.Close() }()
+	recovery, err := recoveryDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = recovery.Close() }()
+	if _, err := recovery.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("recover hot journal after releasing read guard: %v", err)
+	}
+	if _, err := recovery.ExecContext(ctx, `ROLLBACK`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(journalPath); !os.IsNotExist(err) {
+		t.Fatalf("rollback journal still exists after unguarded recovery: %v", err)
+	}
+}
+
+func TestCutoverHotJournalWriterHelper(t *testing.T) {
+	if os.Getenv("HAND_HOT_JOURNAL_HELPER") != "1" {
+		return
+	}
+	path := os.Getenv("HAND_HOT_JOURNAL_DB")
+	readyPath := os.Getenv("HAND_HOT_JOURNAL_READY")
+	if path == "" || readyPath == "" {
+		t.Fatal("hot-journal helper missing path environment")
+	}
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	db, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(30000)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(readyPath, []byte("reserved"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.ExecContext(ctx, `UPDATE meta SET value = 'dirty' WHERE key = 'hot-journal-probe'`); err != nil {
+		t.Fatal(err)
+	}
+	// Parent kills this process. Exiting normally would run SQLite rollback and
+	// destroy the hot-journal fixture we need to exercise.
+	time.Sleep(time.Hour)
+}

--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -174,12 +174,10 @@ func TestCutoverPendingExclusiveHandoffSurvivesHotJournal(t *testing.T) {
 	probeDB.SetMaxOpenConns(1)
 	defer func() { _ = probeDB.Close() }()
 	deadline = time.Now().Add(5 * time.Second)
-	pendingObserved := false
-	for !pendingObserved {
+	for {
 		var value string
 		err := probeDB.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&value)
 		if isSQLiteBusy(err) {
-			pendingObserved = true
 			break
 		}
 		if err != nil {

--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -193,33 +193,86 @@ func TestCutoverArchiveBeforeGateSurvivesHotJournalRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 	gateDB.SetMaxOpenConns(1)
-	defer func() { _ = gateDB.Close() }()
 	gate, err := gateDB.Conn(ctx)
 	if err != nil {
+		_ = gateDB.Close()
 		t.Fatal(err)
 	}
-	defer func() { _ = gate.Close() }()
 	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
 		t.Fatalf("acquire writer gate after durable archive candidate: %v", err)
 	}
-	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
 
 	mainAfterGate, err := os.ReadFile(path)
 	if err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if got := sha256.Sum256(mainAfterGate); got != archiveDigest {
+		_ = gate.Close()
+		_ = gateDB.Close()
 		t.Fatalf("writer gate/recovery changed committed source bytes: archive=%x active=%x", archiveDigest, got)
 	}
-	if _, err := os.Stat(journalPath); !os.IsNotExist(err) {
-		t.Fatalf("hot rollback journal remains after successful writer gate recovery: %v", err)
+	var recovered string
+	if err := gate.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&recovered); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+	if recovered != "clean" {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatalf("writer gate observed recovered value %q, want clean", recovered)
 	}
 	archivedAfterGate, err := os.ReadFile(archivePath)
 	if err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if got := sha256.Sum256(archivedAfterGate); got != archiveDigest {
+		_ = gate.Close()
+		_ = gateDB.Close()
 		t.Fatalf("archive candidate changed during gate recovery: before=%x after=%x", archiveDigest, got)
+	}
+
+	// SQLite may leave a non-hot rollback-journal file behind. File existence is
+	// not the safety property. After releasing the writer gate, a new read-only
+	// connection must observe the archived committed state without mutating the DB.
+	if _, err := gate.ExecContext(ctx, `ROLLBACK`); err != nil {
+		_ = gate.Close()
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+	if err := gate.Close(); err != nil {
+		_ = gateDB.Close()
+		t.Fatal(err)
+	}
+	if err := gateDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifyDB.SetMaxOpenConns(1)
+	defer func() { _ = verifyDB.Close() }()
+	var verified string
+	if err := verifyDB.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&verified); err != nil {
+		t.Fatalf("read-only verification after writer-gate recovery: %v", err)
+	}
+	if verified != "clean" {
+		t.Fatalf("read-only verification saw %q, want clean", verified)
+	}
+	mainAfterVerify, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(mainAfterVerify); got != archiveDigest {
+		t.Fatalf("post-recovery read-only verification changed source bytes: archive=%x active=%x", archiveDigest, got)
 	}
 }
 

--- a/internal/store/cutover_hot_journal_test.go
+++ b/internal/store/cutover_hot_journal_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
+func TestCutoverPendingExclusiveHandoffSurvivesHotJournal(t *testing.T) {
 	home := t.TempDir()
 	db, err := Open(home)
 	if err != nil {
@@ -39,9 +39,8 @@ func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
 	escaped := (&url.URL{Path: path}).EscapedPath()
 	ctx := context.Background()
 
-	// Establish the committed source snapshot using a genuine read-only SHARED
-	// transaction. A rollback-journal writer may reserve while this lives, but it
-	// cannot commit changes to the main database file.
+	// Establish a genuine read-only SHARED snapshot. A rollback-journal writer
+	// may reserve while this lives, but cannot commit main-database changes.
 	readDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
 	if err != nil {
 		t.Fatal(err)
@@ -66,11 +65,11 @@ func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
 	if clean != "clean" {
 		_ = readGuard.Close()
 		_ = readDB.Close()
-		t.Fatalf("read guard saw %q, want clean", clean)
+		t.Fatalf("read snapshot saw %q, want clean", clean)
 	}
 
-	// Race a supported old writer after the SHARED snapshot. It obtains RESERVED
-	// and creates rollback-journal state, but cannot commit while the reader lives.
+	// Race a supported old writer after the snapshot. It obtains RESERVED and
+	// creates rollback-journal state, then crashes before it can get EXCLUSIVE.
 	readyPath := path + ".hot-writer-ready"
 	cmd := exec.Command(os.Args[0], "-test.run=^TestCutoverHotJournalWriterHelper$")
 	cmd.Env = append(os.Environ(),
@@ -149,10 +148,10 @@ func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
 	}
 	journalDigest := sha256.Sum256(journalBeforeGate)
 
-	// A SHARED reader and RESERVED writer gate are compatible. Acquiring the gate
-	// while the reader lives closes the future-writer race, and the SHARED lock
-	// must prevent gate acquisition from changing DB or journal bytes.
-	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
+	// Ask SQLite for EXCLUSIVE while the known SHARED snapshot remains held.
+	// A successful waiting writer must first reach PENDING, which blocks new
+	// SHARED readers before the original reader is deliberately released.
+	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(30000)&_pragma=foreign_keys(1)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,129 +161,141 @@ func TestCutoverReadSnapshotAndWriterGateSurviveHotJournal(t *testing.T) {
 		_ = gateDB.Close()
 		t.Fatal(err)
 	}
-	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("acquire writer gate while read snapshot is held: %v", err)
-	}
-	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("enable query_only after writer reservation: %v", err)
-	}
+	exclusive := make(chan error, 1)
+	go func() {
+		_, err := gate.ExecContext(ctx, `BEGIN EXCLUSIVE`)
+		exclusive <- err
+	}()
 
-	mainAfterGate, err := os.ReadFile(path)
+	probeDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
 	if err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
-	if got := sha256.Sum256(mainAfterGate); got != mainDigest {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("writer-gate acquisition changed main DB before archive: before=%x after=%x", mainDigest, got)
-	}
-	journalAfterGate, err := os.ReadFile(journalPath)
-	if err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("writer-gate acquisition removed rollback journal before archive: %v", err)
-	}
-	if got := sha256.Sum256(journalAfterGate); got != journalDigest {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("writer-gate acquisition changed rollback journal before archive: before=%x after=%x", journalDigest, got)
+	probeDB.SetMaxOpenConns(1)
+	defer func() { _ = probeDB.Close() }()
+	deadline = time.Now().Add(5 * time.Second)
+	pendingObserved := false
+	for !pendingObserved {
+		var value string
+		err := probeDB.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&value)
+		if isSQLiteBusy(err) {
+			pendingObserved = true
+			break
+		}
+		if err != nil {
+			t.Fatalf("probe for pending cutover lock: %v", err)
+		}
+		if value != "clean" {
+			t.Fatalf("probe reader saw %q before pending lock, want clean", value)
+		}
+		select {
+		case err := <-exclusive:
+			t.Fatalf("BEGIN EXCLUSIVE returned before original SHARED reader was released: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("BEGIN EXCLUSIVE never established a PENDING lock that blocked new readers")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
-	// Only after the reservation is held is the original DB archived. At this
-	// point future supported writers are excluded, and the SHARED reader still
-	// proves the main DB bytes are the committed snapshot it observed.
+	// Positive PENDING evidence is the handoff point: future old DB readers and
+	// writers are excluded while the original SHARED snapshot still pins bytes.
+	mainPending, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sha256.Sum256(mainPending); got != mainDigest {
+		t.Fatalf("pending handoff changed main DB before archive: before=%x after=%x", mainDigest, got)
+	}
+	journalPending, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatalf("pending handoff removed rollback journal before archive: %v", err)
+	}
+	if got := sha256.Sum256(journalPending); got != journalDigest {
+		t.Fatalf("pending handoff changed rollback journal before archive: before=%x after=%x", journalDigest, got)
+	}
+
 	archivePath := path + ".original-candidate"
-	if err := os.WriteFile(archivePath, mainAfterGate, 0o600); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
+	if err := os.WriteFile(archivePath, mainPending, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	archived, err := os.ReadFile(archivePath)
 	if err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if got := sha256.Sum256(archived); got != mainDigest {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatalf("archive candidate digest = %x, want %x", got, mainDigest)
 	}
 
-	// Release only the read snapshot; retain the writer reservation. The gate is
-	// now the sole supported-writer authority. Final query-only reads must still
-	// see the exact committed state whose raw bytes were archived.
+	// Archive is durable and PENDING bars newcomers, so release only the known
+	// reader and require the already-waiting gate to become EXCLUSIVE.
 	if _, err := readGuard.ExecContext(ctx, `ROLLBACK`); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if err := readGuard.Close(); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if err := readDB.Close(); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
+	}
+	select {
+	case err := <-exclusive:
+		if err != nil {
+			t.Fatalf("BEGIN EXCLUSIVE after releasing known reader: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("BEGIN EXCLUSIVE did not complete after releasing known reader")
+	}
+	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
+	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		t.Fatalf("enable query_only after exclusive gate: %v", err)
+	}
+
+	// EXCLUSIVE must block a fresh legacy read, not just writes. This closes the
+	// read-then-external-effect path used by commands such as project add/create.
+	freshReadDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=ro&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshReadDB.SetMaxOpenConns(1)
+	defer func() { _ = freshReadDB.Close() }()
+	var fresh string
+	if err := freshReadDB.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&fresh); !isSQLiteBusy(err) {
+		t.Fatalf("fresh reader under EXCLUSIVE = value %q, err %v; want SQLITE_BUSY", fresh, err)
 	}
 
 	var recovered string
 	if err := gate.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = 'hot-journal-probe'`).Scan(&recovered); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("query source under writer gate after releasing snapshot: %v", err)
+		t.Fatalf("query source under exclusive gate: %v", err)
 	}
 	if recovered != "clean" {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("writer gate observed %q, want committed value clean", recovered)
+		t.Fatalf("exclusive gate observed %q, want committed value clean", recovered)
 	}
 	mainBeforeFreeze, err := os.ReadFile(path)
 	if err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if got := sha256.Sum256(mainBeforeFreeze); got != mainDigest {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatalf("source bytes differ from archive before freeze: archive=%x active=%x", mainDigest, got)
 	}
 
-	// Cross the deliberate one-way mutation boundary only after archive and final
-	// digest proof. This minimal certificate/sentinel composes the hot-journal
-	// case with the full 21-guard freeze proved independently in the companion test.
+	// Cross the deliberate one-way mutation boundary only after exact archive and
+	// final digest proof. The companion test proves the complete 21-guard set.
 	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 0`); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatalf("disable query_only at freeze boundary: %v", err)
 	}
 	certificate := fmt.Sprintf("v1:%x", mainDigest)
 	if _, err := gate.ExecContext(ctx, `INSERT INTO meta (key, value) VALUES ('v19-cutover-freeze', ?)`, certificate); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("write freeze certificate after hot-journal race: %v", err)
+		t.Fatalf("write freeze certificate after exclusive handoff: %v", err)
 	}
 	if _, err := gate.ExecContext(ctx, `PRAGMA user_version = 22`); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if _, err := gate.ExecContext(ctx, `COMMIT`); err != nil {
-		_ = gate.Close()
-		_ = gateDB.Close()
-		t.Fatalf("commit freeze boundary after hot-journal race: %v", err)
+		t.Fatalf("commit freeze boundary after exclusive handoff: %v", err)
 	}
 	if err := gate.Close(); err != nil {
-		_ = gateDB.Close()
 		t.Fatal(err)
 	}
 	if err := gateDB.Close(); err != nil {

--- a/internal/store/cutover_writer_gate_test.go
+++ b/internal/store/cutover_writer_gate_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"testing"
@@ -87,5 +89,99 @@ func TestCutoverWriterGateCanReserveWithoutMutatingLegacyDB(t *testing.T) {
 	}
 	if afterDigest := sha256.Sum256(after); afterDigest != beforeDigest {
 		t.Fatalf("legacy DB bytes changed while acquiring/releasing writer gate: before=%x after=%x", beforeDigest, afterDigest)
+	}
+}
+
+func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := Path(home)
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	staleDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleDB.SetMaxOpenConns(1)
+	defer func() { _ = staleDB.Close() }()
+	staleWrite, err := staleDB.Prepare(`INSERT INTO meta (key, value) VALUES ('stale-writer', 'committed')
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = staleWrite.Close() }()
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest := sha256.Sum256(before)
+
+	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDB.SetMaxOpenConns(1)
+	defer func() { _ = gateDB.Close() }()
+	ctx := context.Background()
+	gate, err := gateDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
+
+	archivePath := path + ".original"
+	if err := os.WriteFile(archivePath, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	archived, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archivedDigest := sha256.Sum256(archived); archivedDigest != beforeDigest {
+		t.Fatalf("original archive digest = %x, want %x", archivedDigest, beforeDigest)
+	}
+
+	tables := []string{"task", "attempt", "fleet_identity", "meta", "hold", "project", "send_attempt"}
+	operations := []string{"INSERT", "UPDATE", "DELETE"}
+	for _, table := range tables {
+		for _, operation := range operations {
+			name := fmt.Sprintf("v19_freeze_%s_%s", table, operation)
+			statement := fmt.Sprintf(`CREATE TRIGGER %q BEFORE %s ON %q BEGIN SELECT RAISE(ABORT, 'legacy source frozen for v19 cutover'); END`, name, operation, table)
+			if _, err := gate.ExecContext(ctx, statement); err != nil {
+				t.Fatalf("create %s: %v", name, err)
+			}
+		}
+	}
+	if _, err := gate.ExecContext(ctx, `PRAGMA user_version = 22`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gate.ExecContext(ctx, `COMMIT`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := staleWrite.Exec(); err == nil {
+		t.Fatal("prepared pre-freeze legacy write succeeded after frozen bridge commit")
+	}
+	var staleRows int
+	if err := staleDB.QueryRow(`SELECT COUNT(*) FROM meta WHERE key = 'stale-writer'`).Scan(&staleRows); err != nil {
+		t.Fatal(err)
+	}
+	if staleRows != 0 {
+		t.Fatalf("stale writer rows = %d, want 0", staleRows)
+	}
+
+	if _, err := Open(home); !errors.Is(err, ErrSchemaNewer) {
+		t.Fatalf("Open frozen bridge = %v, want ErrSchemaNewer for a v0.7.2-style binary", err)
 	}
 }

--- a/internal/store/cutover_writer_gate_test.go
+++ b/internal/store/cutover_writer_gate_test.go
@@ -133,6 +133,9 @@ func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
+	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		t.Fatalf("enable query_only for source inspection/archive: %v", err)
+	}
 
 	// Source identity is frozen only after the writer reservation exists. The
 	// byte-exact original archive must therefore be read and digested here, not
@@ -152,6 +155,24 @@ func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
 	}
 	if archivedDigest := sha256.Sum256(archived); archivedDigest != beforeDigest {
 		t.Fatalf("original archive digest = %x, want %x", archivedDigest, beforeDigest)
+	}
+
+	// No source mutation is allowed before the exact original archive exists.
+	// From this explicit boundary onward the same reserved transaction may write
+	// only the bounded freeze certificate/guards that make old writers fail closed.
+	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 0`); err != nil {
+		t.Fatalf("disable query_only at explicit freeze boundary: %v", err)
+	}
+	var queryOnly int
+	if err := gate.QueryRowContext(ctx, `PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		t.Fatal(err)
+	}
+	if queryOnly != 0 {
+		t.Fatalf("PRAGMA query_only = %d after freeze boundary, want 0", queryOnly)
+	}
+	certificate := fmt.Sprintf("v1:%x", beforeDigest)
+	if _, err := gate.ExecContext(ctx, `INSERT INTO meta (key, value) VALUES ('v19-cutover-freeze', ?)`, certificate); err != nil {
+		t.Fatalf("write freeze certificate: %v", err)
 	}
 
 	tables := []string{"task", "attempt", "fleet_identity", "meta", "hold", "project", "send_attempt"}
@@ -181,6 +202,20 @@ func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
 	}
 	if staleRows != 0 {
 		t.Fatalf("stale writer rows = %d, want 0", staleRows)
+	}
+	var gotCertificate string
+	if err := staleDB.QueryRow(`SELECT value FROM meta WHERE key = 'v19-cutover-freeze'`).Scan(&gotCertificate); err != nil {
+		t.Fatal(err)
+	}
+	if gotCertificate != certificate {
+		t.Fatalf("freeze certificate = %q, want %q", gotCertificate, certificate)
+	}
+	archivedAfter, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archivedDigest := sha256.Sum256(archivedAfter); archivedDigest != beforeDigest {
+		t.Fatalf("original archive changed after freeze: got %x want %x", archivedDigest, beforeDigest)
 	}
 
 	if _, err := Open(home); !errors.Is(err, ErrSchemaNewer) {

--- a/internal/store/cutover_writer_gate_test.go
+++ b/internal/store/cutover_writer_gate_test.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestCutoverWriterGateCanReserveWithoutMutatingLegacyDB(t *testing.T) {
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest := sha256.Sum256(before)
+
+	path := Path(home)
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDB.SetMaxOpenConns(1)
+	defer func() { _ = gateDB.Close() }()
+
+	ctx := context.Background()
+	gate, err := gateDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+
+	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE with query_only = %v; cannot reserve legacy writer slot without allowing data mutation", err)
+	}
+	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
+
+	var queryOnly int
+	if err := gate.QueryRowContext(ctx, `PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		t.Fatal(err)
+	}
+	if queryOnly != 1 {
+		t.Fatalf("PRAGMA query_only = %d, want 1", queryOnly)
+	}
+	if _, err := gate.ExecContext(ctx, `CREATE TABLE forbidden_cutover_write (id INTEGER)`); err == nil {
+		t.Fatal("query_only connection allowed a source mutation")
+	}
+
+	writerDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writerDB.SetMaxOpenConns(1)
+	defer func() { _ = writerDB.Close() }()
+	writer, err := writerDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+	if _, err := writer.ExecContext(ctx, `BEGIN IMMEDIATE`); !isSQLiteBusy(err) {
+		if err == nil {
+			_, _ = writer.ExecContext(ctx, `ROLLBACK`)
+		}
+		t.Fatalf("second writer BEGIN IMMEDIATE = %v, want SQLITE_BUSY while cutover gate is held", err)
+	}
+
+	if _, err := gate.ExecContext(ctx, `ROLLBACK`); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDigest := sha256.Sum256(after); afterDigest != beforeDigest {
+		t.Fatalf("legacy DB bytes changed while acquiring/releasing writer gate: before=%x after=%x", beforeDigest, afterDigest)
+	}
+}

--- a/internal/store/cutover_writer_gate_test.go
+++ b/internal/store/cutover_writer_gate_test.go
@@ -222,3 +222,43 @@ func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
 		t.Fatalf("Open frozen bridge = %v, want ErrSchemaNewer for a v0.7.2-style binary", err)
 	}
 }
+
+func TestLegacyOpenCannotMutateCanonicalV19(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(Dir(home), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := createCanonicalV19Schema(sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest := sha256.Sum256(before)
+
+	legacy, openErr := Open(home)
+	if legacy != nil {
+		_ = legacy.Close()
+	}
+	after, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterDigest := sha256.Sum256(after)
+	if afterDigest != beforeDigest {
+		t.Fatalf("v0.7.2-style Open mutated canonical v19 before failing: err=%v before=%x after=%x", openErr, beforeDigest, afterDigest)
+	}
+	if openErr == nil {
+		t.Fatal("v0.7.2-style Open accepted canonical v19; old writers are not excluded after publication")
+	}
+}

--- a/internal/store/cutover_writer_gate_test.go
+++ b/internal/store/cutover_writer_gate_test.go
@@ -117,12 +117,6 @@ func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
 	}
 	defer func() { _ = staleWrite.Close() }()
 
-	before, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	beforeDigest := sha256.Sum256(before)
-
 	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
 	if err != nil {
 		t.Fatal(err)
@@ -140,6 +134,14 @@ func TestFrozenLegacyBridgeBlocksPreparedStaleWriter(t *testing.T) {
 	}
 	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
 
+	// Source identity is frozen only after the writer reservation exists. The
+	// byte-exact original archive must therefore be read and digested here, not
+	// during an optimistic preflight another process could race.
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest := sha256.Sum256(before)
 	archivePath := path + ".original"
 	if err := os.WriteFile(archivePath, before, 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/store/cutover_writer_gate_test.go
+++ b/internal/store/cutover_writer_gate_test.go
@@ -27,7 +27,7 @@ func TestCutoverWriterGateCanReserveWithoutMutatingLegacyDB(t *testing.T) {
 
 	path := Path(home)
 	escaped := (&url.URL{Path: path}).EscapedPath()
-	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)&_pragma=query_only(1)")
+	gateDB, err := sql.Open("sqlite", "file:"+escaped+"?mode=rw&_pragma=busy_timeout(0)&_pragma=foreign_keys(1)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,9 +42,12 @@ func TestCutoverWriterGateCanReserveWithoutMutatingLegacyDB(t *testing.T) {
 	defer func() { _ = gate.Close() }()
 
 	if _, err := gate.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		t.Fatalf("BEGIN IMMEDIATE with query_only = %v; cannot reserve legacy writer slot without allowing data mutation", err)
+		t.Fatalf("BEGIN IMMEDIATE = %v; cannot reserve legacy writer slot", err)
 	}
 	defer func() { _, _ = gate.ExecContext(ctx, `ROLLBACK`) }()
+	if _, err := gate.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		t.Fatalf("enable query_only after reserving writer slot: %v", err)
+	}
 
 	var queryOnly int
 	if err := gate.QueryRowContext(ctx, `PRAGMA query_only`).Scan(&queryOnly); err != nil {


### PR DESCRIPTION
Diagnostic proof for #524 only. Draft; not an architecture change and not intended to merge.

Mechanical evidence established at exact head `5f985170f6ece5d60fc9f083bfef70b0d8bbc667`:

1. `PRAGMA query_only=1` before a SQLite write transaction is not viable: the production driver returns `SQLITE_READONLY`.
2. `BEGIN IMMEDIATE → query_only=1` blocks writers but is insufficient for cutover because RESERVED still admits new readers.
3. Exact v0.7.2 `hand project add/create` proves why reader admission matters: it can read authoritative DB state, then clone/legacy-Treehouse mutate before eventual DB registration.
4. A read-only SHARED snapshot can remain held while a second pinned connection requests `BEGIN EXCLUSIVE`; the waiting EXCLUSIVE establishes a reader barrier before the known SHARED reader is released.
5. The barrier is positively observed by requiring a fresh `mode=ro` reader to fail `SQLITE_BUSY`; that observation is not ownership proof by itself.
6. A rollback-journal writer raced after the SHARED snapshot can create journal state and be hard-killed without changing the committed main DB candidate; archive candidate bytes remain stable while SHARED+barrier coexist.
7. After releasing only the known SHARED reader, OUR already-requested `BEGIN EXCLUSIVE` completes; post-acquisition source state/digest must remain candidate-identical or production cutover must refuse.
8. `query_only=1` on the acquired EXCLUSIVE connection preserves the no-mutation inspection boundary; `query_only=0` is crossed only after immutable-original evidence is durable.
9. A one-way frozen bridge with exact original digest certificate, 21 unconditional guards over the seven exact v0.7.2 tables, and mechanism sentinel `user_version=22` blocks a prepared stale writer and makes a fresh v0.7.2 `Open` fail closed.
10. Released-v0.7.2-equivalent `Open` against exact canonical #344 v19 fails without changing DB bytes; the numeric `user_version=19` overlap does not require #344 relock.

CI run 1046 passed Contract, Lint, Nix x86_64, Ubuntu x64/ARM, Windows, macOS ARM/Intel, and E2E on this exact head.

Architecture consequence: revision-2 #348 must use `SHARED snapshot → observed new-reader barrier → OUR EXCLUSIVE → exact digest/state + Fleet-local lock/provider quiescence → immutable original archive → one-way freeze`. `BEGIN IMMEDIATE`, archive-before-gate, and PENDING observation alone are explicitly rejected as sufficient authority boundaries.

PR #526 consumes this evidence. Keep this diagnostic PR draft/non-authoritative and do not merge it into production code.

Canonical #344 DDL impact: **NONE**.