### PR TITLE
docs(architecture): anchor v19 contract manifest revision 2

### DIFF
--- a/docs/architecture/v19-contracts/manifest-v2.md
+++ b/docs/architecture/v19-contracts/manifest-v2.md
@@ -1,0 +1,80 @@
+# v19 semantic contract manifest — revision 2
+
+This manifest is the current repository-owned semantic contract anchor for the v0.8.0 / canonical v19 implementation. It supersedes `docs/architecture/v19-contracts/manifest.md` only as the **current manifest** because #348 cutover semantics were deliberately relocked. The revision-1 manifest and its #348 snapshot remain immutable historical evidence.
+
+Permanent `main` revision containing the complete revision-2 contract set:
+
+```text
+899e7a9aa2e383d3b3f91689fe5a897c5bab59ec
+```
+
+The GitHub issue bodies remain tracker/review surfaces. For the snapshots listed below, the repository file at the anchor revision is immutable semantic evidence. A later issue-body edit cannot retroactively change that evidence. Comments are never normative architecture state.
+
+`#344` is intentionally **not duplicated or changed** by this relock. Exact canonical relational authority remains its existing immutable artifact mechanism:
+
+```text
+immutable commit: 67ca4b35b773ef25ac9ff88cd1b16213153ed498
+DDL: docs/architecture/v19.sql.gz
+Git blob: d529d7a687db8d0266d5592ade9520c04766bf43
+stored gzip SHA-256: 6e92cb72ad52c135a0cb8ae8f6352f1ff2c938a289ae1e313a9ce1d6a9e42399
+reconstructed DDL SHA-256: 81118c2e982be7e08c0f8bf3bbb980e2ec4c5bffbbc7d419e9952732ad36c58a
+schema fingerprint: 8726f0875845d610553928e6bb56fc5566019a6667d81e29a94ee3d3d45ef3b8
+proof: docs/architecture/v19-proof.py.gz
+relock manifest: docs/architecture/v19-relock.md
+```
+
+`#304` is also intentionally not replaced by this manifest. Its issue body remains the sole current semantic statement for Decision/Answer authority unless an explicit repository authority transfer is performed later.
+
+## Snapshot set
+
+| Issue | Title / contract | Path | Git blob SHA-1 |
+| ---: | --- | --- | --- |
+| #323 | Worker Harness routing / typed fallback | `docs/architecture/v19-contracts/323-worker-routing.md` | `6b2ce258a9e72412bcbb1cd625963806400e227b` |
+| #324 | typed v1 configuration / role separation | `docs/architecture/v19-contracts/324-configuration.md` | `e322eb6bf08b3648c1a298e13b6fc4b8a2e19f7b` |
+| #343 | external effects / WorkerWake / reconciliation | `docs/architecture/v19-contracts/343-external-effects-worker-wake.md` | `76be8f08e60ba1819df71669edf9cb3af3c34b14` |
+| #345 | lifecycle / currentness / concurrency / crash recovery | `docs/architecture/v19-contracts/345-lifecycle-currentness-crash-recovery.md` | `1039bb9fe69fb84f4b2357c05e6dcbfc6dfb3254` |
+| #346 | capability / adapter boundaries | `docs/architecture/v19-contracts/346-capability-adapters.md` | `859b80207a625fb4be8f5ff1a5eaf336bb7e8c77` |
+| #347 | read models / Attention / SupervisorOrientation | `docs/architecture/v19-contracts/347-read-models-attention-orientation.md` | `72a9905c84e376b8cd5a07ff2c0643b244e97d14` |
+| #348 | v18→v19 cutover / archive / non-fabrication — revision 2 | `docs/architecture/v19-contracts/348-cutover-archive-v2.md` | `94c018d0bce8c2427d01b9af89e513cfb5f3ce96` |
+
+Git blob SHA-1 is the deterministic content digest for each repository object. The contract-set digest below is SHA-256 over the UTF-8 concatenation, in the table's issue order, of:
+
+```text
+<basename> NUL <git-blob-sha1> LF
+```
+
+Contract-set SHA-256:
+
+```text
+03314c8f9dad1e0716062b1b06afa627b177295643581b1fbae3571d93d7e21c
+```
+
+## #348 supersession record
+
+Revision 1 remains immutable historical evidence:
+
+```text
+revision: 6699745bb451e3daca072b4c958e5b79f31e4775
+path: docs/architecture/v19-contracts/348-cutover-archive.md
+Git blob: c5c8045698ca8bea3b093d1adbe13d0b87c651d0
+manifest: docs/architecture/v19-contracts/manifest.md
+```
+
+Current #348 authority is the revision-2 snapshot in the table above. Revision 2 changes source-writer exclusion, original-archive ordering, frozen-bridge recovery, and publication ordering. It does not change canonical v19 relational semantics or any byte of #344.
+
+## Authority graph
+
+Use these categories precisely:
+
+1. **Current normative architecture**: this revision-2 snapshot set, #344's exact immutable DDL/proof artifact, and #304's current issue body for Decision/Answer authority.
+2. **Historical landed prerequisites/evidence**: the revision-1 manifest/snapshots where superseded, plus closed work such as #338 LaunchSpec, #340 monitoring/stale-wake safety, #353/#355 Supervisor runtime integration, and diagnostic #525. They remain audit evidence and do not compete as current v19 authority.
+3. **Implementation dependencies**: open implementation slices whose completion is required by sequencing but which do not define architecture merely by blocking another issue.
+4. **Release qualification evidence**: #305 qualifies one exact release candidate/tag/source/runtime matrix after implementation; passing it does not redefine architecture.
+
+A semantic cross-reference does not imply a sequencing dependency. A historical prerequisite does not become current normative authority merely because current contracts cite it.
+
+## Change policy
+
+Do not edit a frozen snapshot in place and pretend old evidence changed. A semantic change requires a new versioned snapshot set and manifest anchor. If the change affects canonical table/constraint/trigger/index/operation-kind semantics or any byte of the #344 DDL, the #344 relock discipline is mandatory before implementation continues.
+
+DDL impact of this revision-2 manifest/relock: **NONE**.


### PR DESCRIPTION
Follow-up immutable authority anchor for the #348 revision-2 relock landed in #527.

This PR adds only `docs/architecture/v19-contracts/manifest-v2.md` and does not edit the frozen revision-1 manifest or any frozen snapshot.

The current snapshot set is anchored to permanent main revision `899e7a9aa2e383d3b3f91689fe5a897c5bab59ec`, which already contains:
- unchanged #323/#324/#343/#345/#346/#347 blobs from revision 1;
- #348 revision-2 blob `94c018d0bce8c2427d01b9af89e513cfb5f3ce96`.

Contract-set SHA-256 is `03314c8f9dad1e0716062b1b06afa627b177295643581b1fbae3571d93d7e21c`, computed with the same basename-NUL-blob-LF algorithm as revision 1.

Revision 1 remains immutable historical evidence. #344 exact DDL/proof authority and #304 Decision/Answer authority are unchanged.

After this lands, #348/#339 tracker bodies can point to manifest-v2 and #524 can close as resolved. #305 can then be tightened to the exact revision-2 cutover qualification matrix.

Canonical #344 DDL impact: **NONE**.

Refs #348 #524 #339 #305 #527.