### PR TITLE
feat(store): add v19 cutover 5A1 source eligibility gate

### DIFF
--- a/internal/store/cutoversource.go
+++ b/internal/store/cutoversource.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var errLegacyV18CutoverSourceUnsafe = errors.New("legacy v18 cutover source is not mechanically safe")
+
+func validateLegacyV18CutoverSource(q sqliteQueryer) (SchemaInfo, error) {
+	info, err := inspectExactLegacyV18Schema(q)
+	if err != nil {
+		return info, err
+	}
+
+	var queryOnly int
+	if err := q.QueryRow(`PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		return info, fmt.Errorf("inspect legacy v18 query_only: %w", err)
+	}
+	if queryOnly != 1 {
+		return info, fmt.Errorf("%w: PRAGMA query_only = %d, want 1", errLegacyV18CutoverSourceUnsafe, queryOnly)
+	}
+
+	var foreignKeys int
+	if err := q.QueryRow(`PRAGMA foreign_keys`).Scan(&foreignKeys); err != nil {
+		return info, fmt.Errorf("inspect legacy v18 foreign keys: %w", err)
+	}
+	if foreignKeys != 1 {
+		return info, fmt.Errorf("%w: PRAGMA foreign_keys = %d, want 1", errLegacyV18CutoverSourceUnsafe, foreignKeys)
+	}
+
+	var journalMode string
+	if err := q.QueryRow(`PRAGMA journal_mode`).Scan(&journalMode); err != nil {
+		return info, fmt.Errorf("inspect legacy v18 journal mode: %w", err)
+	}
+	journalMode = strings.ToLower(strings.TrimSpace(journalMode))
+	switch journalMode {
+	case "delete", "persist", "truncate":
+	default:
+		return info, fmt.Errorf("%w: PRAGMA journal_mode = %q is not an eligible rollback-journal mode", errLegacyV18CutoverSourceUnsafe, journalMode)
+	}
+
+	var integrity string
+	if err := q.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+		return info, fmt.Errorf("check legacy v18 integrity: %w", err)
+	}
+	if integrity != "ok" {
+		return info, fmt.Errorf("%w: integrity_check = %q, want %q", errLegacyV18CutoverSourceUnsafe, integrity, "ok")
+	}
+
+	foreignKeyRows, err := q.Query(`PRAGMA foreign_key_check`)
+	if err != nil {
+		return info, fmt.Errorf("check legacy v18 foreign keys: %w", err)
+	}
+	hasForeignKeyViolation := foreignKeyRows.Next()
+	rowsErr := foreignKeyRows.Err()
+	closeErr := foreignKeyRows.Close()
+	if rowsErr != nil {
+		return info, fmt.Errorf("check legacy v18 foreign keys: %w", rowsErr)
+	}
+	if closeErr != nil {
+		return info, fmt.Errorf("close legacy v18 foreign-key check: %w", closeErr)
+	}
+	if hasForeignKeyViolation {
+		return info, fmt.Errorf("%w: foreign_key_check returned at least one row", errLegacyV18CutoverSourceUnsafe)
+	}
+
+	return info, nil
+}

--- a/internal/store/cutoversource_test.go
+++ b/internal/store/cutoversource_test.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/url"
+	"testing"
+)
+
+func TestValidateLegacyV18CutoverSourceAcceptsPinnedExactRollbackSource(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	tx, err := db.sql.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	info, err := validateLegacyV18CutoverSource(tx)
+	if err != nil {
+		t.Fatalf("validateLegacyV18CutoverSource = %+v, error = %v", info, err)
+	}
+	if info.Family != SchemaFamilyLegacyV18 {
+		t.Fatalf("schema family = %q, want %q", info.Family, SchemaFamilyLegacyV18)
+	}
+	if info.LayoutFingerprint != legacyV072LayoutFingerprint {
+		t.Fatalf("layout fingerprint = %s, want %s", info.LayoutFingerprint, legacyV072LayoutFingerprint)
+	}
+}
+
+func TestValidateLegacyV18CutoverSourceRejectsMemoryJournal(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sqlDB := openLegacyV18CutoverTestDB(t, home, true)
+	defer func() { _ = sqlDB.Close() }()
+
+	var journalMode string
+	if err := sqlDB.QueryRow(`PRAGMA journal_mode = MEMORY`).Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "memory" {
+		t.Fatalf("journal_mode = %q, want memory", journalMode)
+	}
+
+	ctx := context.Background()
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = validateLegacyV18CutoverSource(tx)
+	if !errors.Is(err, errLegacyV18CutoverSourceUnsafe) {
+		t.Fatalf("validateLegacyV18CutoverSource error = %v, want errLegacyV18CutoverSourceUnsafe", err)
+	}
+}
+
+func TestValidateLegacyV18CutoverSourceRejectsQueryOnlyDisabled(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	sqlDB := openLegacyV18CutoverTestDB(t, home, true)
+	defer func() { _ = sqlDB.Close() }()
+
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = validateLegacyV18CutoverSource(tx)
+	if !errors.Is(err, errLegacyV18CutoverSourceUnsafe) {
+		t.Fatalf("validateLegacyV18CutoverSource error = %v, want errLegacyV18CutoverSourceUnsafe", err)
+	}
+}
+
+func TestValidateLegacyV18CutoverSourceRejectsForeignKeysDisabled(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	sqlDB := openLegacyV18CutoverTestDB(t, home, false)
+	defer func() { _ = sqlDB.Close() }()
+
+	ctx := context.Background()
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = validateLegacyV18CutoverSource(tx)
+	if !errors.Is(err, errLegacyV18CutoverSourceUnsafe) {
+		t.Fatalf("validateLegacyV18CutoverSource error = %v, want errLegacyV18CutoverSourceUnsafe", err)
+	}
+}
+
+func createLegacyV18CutoverTestSource(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	db, err := Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func setLegacyV18CutoverTestJournalMode(t *testing.T, home, mode string) {
+	t.Helper()
+	sqlDB := openLegacyV18CutoverTestDB(t, home, true)
+	defer func() { _ = sqlDB.Close() }()
+	var got string
+	if err := sqlDB.QueryRow(`PRAGMA journal_mode = ` + mode).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func openLegacyV18CutoverTestDB(t *testing.T, home string, foreignKeys bool) *sql.DB {
+	t.Helper()
+	foreignKeysValue := "0"
+	if foreignKeys {
+		foreignKeysValue = "1"
+	}
+	uri := "file:" + (&url.URL{Path: Path(home)}).EscapedPath() +
+		"?_pragma=busy_timeout(5000)&_pragma=foreign_keys(" + foreignKeysValue + ")"
+	sqlDB, err := sql.Open("sqlite", uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.Ping(); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	return sqlDB
+}

--- a/internal/store/cutoversource_test.go
+++ b/internal/store/cutoversource_test.go
@@ -36,6 +36,35 @@ func TestValidateLegacyV18CutoverSourceAcceptsPinnedExactRollbackSource(t *testi
 	}
 }
 
+func TestValidateLegacyV18CutoverSourceRejectsPinnedSchemaDrift(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sqlDB := openLegacyV18CutoverTestDB(t, home, true)
+	if _, err := sqlDB.Exec(`CREATE TABLE legacy_cutover_drift (id TEXT PRIMARY KEY)`); err != nil {
+		_ = sqlDB.Close()
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = validateLegacyV18CutoverSource(tx)
+	if !errors.Is(err, ErrUnsupportedLegacyV18Schema) {
+		t.Fatalf("validateLegacyV18CutoverSource error = %v, want ErrUnsupportedLegacyV18Schema", err)
+	}
+}
+
 func TestValidateLegacyV18CutoverSourceRejectsMemoryJournal(t *testing.T) {
 	home := createLegacyV18CutoverTestSource(t)
 	sqlDB := openLegacyV18CutoverTestDB(t, home, true)

--- a/internal/store/legacyv18ddl.go
+++ b/internal/store/legacyv18ddl.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 	"unicode"
@@ -32,8 +31,8 @@ var legacyV072AutoIncrement = map[string]bool{
 // Legacy cutover accepts only the shipped v0.7.2 table semantics that PRAGMA
 // layout inspection cannot observe. Semantic DDL drift fails closed even when
 // columns, foreign keys, and indexes otherwise match.
-func validateLegacyV18DDLFeatures(sqlDB *sql.DB) error {
-	rows, err := sqlDB.Query(`SELECT name, sql FROM sqlite_schema
+func validateLegacyV18DDLFeatures(q sqliteQueryer) error {
+	rows, err := q.Query(`SELECT name, sql FROM sqlite_schema
 		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
 		ORDER BY name`)
 	if err != nil {

--- a/internal/store/legacyv18layout.go
+++ b/internal/store/legacyv18layout.go
@@ -11,8 +11,8 @@ import (
 
 const legacyV072LayoutFingerprint = "7cf67e6ac1c738e348d91ca552f66daa7b5eaf6e4aab9db84a78b49b70a07bec"
 
-func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
-	lines, err := legacyV18LayoutLines(sqlDB)
+func legacyV18LayoutFingerprint(q sqliteQueryer) (string, error) {
+	lines, err := legacyV18LayoutLines(q)
 	if err != nil {
 		return "", err
 	}
@@ -23,8 +23,8 @@ func legacyV18LayoutFingerprint(sqlDB *sql.DB) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func legacyV18LayoutLines(sqlDB *sql.DB) ([]string, error) {
-	tables, err := legacyV18TableNames(sqlDB)
+func legacyV18LayoutLines(q sqliteQueryer) ([]string, error) {
+	tables, err := legacyV18TableNames(q)
 	if err != nil {
 		return nil, err
 	}
@@ -32,17 +32,17 @@ func legacyV18LayoutLines(sqlDB *sql.DB) ([]string, error) {
 	lines := make([]string, 0, 128)
 	for _, table := range tables {
 		lines = append(lines, "table|"+table)
-		columns, err := legacyV18ColumnLines(sqlDB, table)
+		columns, err := legacyV18ColumnLines(q, table)
 		if err != nil {
 			return nil, err
 		}
 		lines = append(lines, columns...)
-		foreignKeys, err := legacyV18ForeignKeyLines(sqlDB, table)
+		foreignKeys, err := legacyV18ForeignKeyLines(q, table)
 		if err != nil {
 			return nil, err
 		}
 		lines = append(lines, foreignKeys...)
-		indexes, err := legacyV18IndexLines(sqlDB, table)
+		indexes, err := legacyV18IndexLines(q, table)
 		if err != nil {
 			return nil, err
 		}
@@ -53,8 +53,8 @@ func legacyV18LayoutLines(sqlDB *sql.DB) ([]string, error) {
 	return lines, nil
 }
 
-func legacyV18TableNames(sqlDB *sql.DB) ([]string, error) {
-	rows, err := sqlDB.Query(`SELECT name FROM sqlite_schema
+func legacyV18TableNames(q sqliteQueryer) ([]string, error) {
+	rows, err := q.Query(`SELECT name FROM sqlite_schema
 		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
 		ORDER BY name`)
 	if err != nil {
@@ -76,8 +76,8 @@ func legacyV18TableNames(sqlDB *sql.DB) ([]string, error) {
 	return tables, nil
 }
 
-func legacyV18ColumnLines(sqlDB *sql.DB, table string) ([]string, error) {
-	rows, err := sqlDB.Query(`SELECT name, type, "notnull", dflt_value, pk, hidden
+func legacyV18ColumnLines(q sqliteQueryer, table string) ([]string, error) {
+	rows, err := q.Query(`SELECT name, type, "notnull", dflt_value, pk, hidden
 		FROM pragma_table_xinfo(?)`, table)
 	if err != nil {
 		return nil, fmt.Errorf("read legacy v18 columns for %s: %w", table, err)
@@ -107,8 +107,8 @@ func legacyV18ColumnLines(sqlDB *sql.DB, table string) ([]string, error) {
 	return lines, nil
 }
 
-func legacyV18ForeignKeyLines(sqlDB *sql.DB, table string) ([]string, error) {
-	rows, err := sqlDB.Query(`SELECT "from", "table", "to", on_update, on_delete, match
+func legacyV18ForeignKeyLines(q sqliteQueryer, table string) ([]string, error) {
+	rows, err := q.Query(`SELECT "from", "table", "to", on_update, on_delete, match
 		FROM pragma_foreign_key_list(?)`, table)
 	if err != nil {
 		return nil, fmt.Errorf("read legacy v18 foreign keys for %s: %w", table, err)
@@ -137,8 +137,8 @@ type legacyV18IndexDescriptor struct {
 	Partial int
 }
 
-func legacyV18IndexLines(sqlDB *sql.DB, table string) ([]string, error) {
-	rows, err := sqlDB.Query(`SELECT name, "unique", origin, partial FROM pragma_index_list(?)`, table)
+func legacyV18IndexLines(q sqliteQueryer, table string) ([]string, error) {
+	rows, err := q.Query(`SELECT name, "unique", origin, partial FROM pragma_index_list(?)`, table)
 	if err != nil {
 		return nil, fmt.Errorf("read legacy v18 indexes for %s: %w", table, err)
 	}
@@ -162,12 +162,12 @@ func legacyV18IndexLines(sqlDB *sql.DB, table string) ([]string, error) {
 
 	var lines []string
 	for _, index := range indexes {
-		keys, err := legacyV18IndexKey(sqlDB, index.Name)
+		keys, err := legacyV18IndexKey(q, index.Name)
 		if err != nil {
 			return nil, err
 		}
 		if index.Origin == "c" {
-			predicate, err := legacyV18IndexPredicate(sqlDB, index.Name, index.Partial != 0)
+			predicate, err := legacyV18IndexPredicate(q, index.Name, index.Partial != 0)
 			if err != nil {
 				return nil, err
 			}
@@ -181,8 +181,8 @@ func legacyV18IndexLines(sqlDB *sql.DB, table string) ([]string, error) {
 	return lines, nil
 }
 
-func legacyV18IndexKey(sqlDB *sql.DB, index string) (string, error) {
-	rows, err := sqlDB.Query(`SELECT seqno, name, "desc", coll, key FROM pragma_index_xinfo(?)
+func legacyV18IndexKey(q sqliteQueryer, index string) (string, error) {
+	rows, err := q.Query(`SELECT seqno, name, "desc", coll, key FROM pragma_index_xinfo(?)
 		WHERE key = 1 ORDER BY seqno`, index)
 	if err != nil {
 		return "", fmt.Errorf("read legacy v18 index %s: %w", index, err)
@@ -205,12 +205,12 @@ func legacyV18IndexKey(sqlDB *sql.DB, index string) (string, error) {
 	return strings.Join(parts, ","), nil
 }
 
-func legacyV18IndexPredicate(sqlDB *sql.DB, index string, partial bool) (string, error) {
+func legacyV18IndexPredicate(q sqliteQueryer, index string, partial bool) (string, error) {
 	if !partial {
 		return "", nil
 	}
 	var ddl string
-	if err := sqlDB.QueryRow(`SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?`, index).Scan(&ddl); err != nil {
+	if err := q.QueryRow(`SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?`, index).Scan(&ddl); err != nil {
 		return "", fmt.Errorf("read legacy v18 partial index %s: %w", index, err)
 	}
 	normalized := strings.ToLower(strings.Join(strings.Fields(ddl), " "))

--- a/internal/store/schemafamily.go
+++ b/internal/store/schemafamily.go
@@ -49,6 +49,11 @@ var ErrUnsupportedLegacyV18Schema = errors.New("legacy v18 schema is not the exa
 // ErrUnknownSchema marks a non-empty database outside both recognized Hand schema families.
 var ErrUnknownSchema = errors.New("state database schema family is unknown")
 
+type sqliteQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
 // InspectSchema opens an existing state database read-only and classifies its
 // schema family. It never creates, migrates, checkpoints, or repairs state.
 func InspectSchema(homeDir string) (SchemaInfo, error) {
@@ -110,45 +115,73 @@ func inspectSchemaFamily(sqlDB *sql.DB) (SchemaInfo, error) {
 		return SchemaInfo{}, err
 	}
 	if legacy {
-		info.Family = SchemaFamilyLegacyV18
-		layoutFingerprint, err := legacyV18LayoutFingerprint(sqlDB)
-		if err != nil {
-			return info, err
-		}
-		info.LayoutFingerprint = layoutFingerprint
-		if version != legacyV072SchemaVersion {
-			return info, fmt.Errorf("%w: PRAGMA user_version = %d, want %d", ErrUnsupportedLegacyV18Schema, version, legacyV072SchemaVersion)
-		}
-		if layoutFingerprint != legacyV072LayoutFingerprint {
-			return info, fmt.Errorf("%w: layout fingerprint = %s, want %s", ErrUnsupportedLegacyV18Schema, layoutFingerprint, legacyV072LayoutFingerprint)
-		}
-		if identity.Tables != legacyV072TableCount || identity.Indexes != legacyV072IndexCount || identity.Triggers != legacyV072TriggerCount {
-			return info, fmt.Errorf("%w: schema objects = %d tables / %d indexes / %d triggers, want %d / %d / %d",
-				ErrUnsupportedLegacyV18Schema,
-				identity.Tables, identity.Indexes, identity.Triggers,
-				legacyV072TableCount, legacyV072IndexCount, legacyV072TriggerCount)
-		}
-		if err := validateLegacyV18DDLFeatures(sqlDB); err != nil {
-			return info, err
-		}
-		return info, nil
+		return inspectExactLegacyV18Schema(sqlDB)
 	}
 
 	info.Family = SchemaFamilyUnknown
 	return info, ErrUnknownSchema
 }
 
-func schemaUserVersion(sqlDB *sql.DB) (int, error) {
+func inspectExactLegacyV18Schema(q sqliteQueryer) (SchemaInfo, error) {
+	version, err := schemaUserVersion(q)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	identity, err := inspectCanonicalV19Identity(q)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+	info := SchemaInfo{
+		Family:      SchemaFamilyLegacyV18,
+		UserVersion: version,
+		Fingerprint: identity.Fingerprint,
+		Tables:      identity.Tables,
+		Indexes:     identity.Indexes,
+		Triggers:    identity.Triggers,
+	}
+
+	legacy, err := legacyV18Candidate(q)
+	if err != nil {
+		return info, err
+	}
+	if !legacy {
+		return info, fmt.Errorf("%w: missing legacy meta relation", ErrUnsupportedLegacyV18Schema)
+	}
+
+	layoutFingerprint, err := legacyV18LayoutFingerprint(q)
+	if err != nil {
+		return info, err
+	}
+	info.LayoutFingerprint = layoutFingerprint
+	if version != legacyV072SchemaVersion {
+		return info, fmt.Errorf("%w: PRAGMA user_version = %d, want %d", ErrUnsupportedLegacyV18Schema, version, legacyV072SchemaVersion)
+	}
+	if layoutFingerprint != legacyV072LayoutFingerprint {
+		return info, fmt.Errorf("%w: layout fingerprint = %s, want %s", ErrUnsupportedLegacyV18Schema, layoutFingerprint, legacyV072LayoutFingerprint)
+	}
+	if identity.Tables != legacyV072TableCount || identity.Indexes != legacyV072IndexCount || identity.Triggers != legacyV072TriggerCount {
+		return info, fmt.Errorf("%w: schema objects = %d tables / %d indexes / %d triggers, want %d / %d / %d",
+			ErrUnsupportedLegacyV18Schema,
+			identity.Tables, identity.Indexes, identity.Triggers,
+			legacyV072TableCount, legacyV072IndexCount, legacyV072TriggerCount)
+	}
+	if err := validateLegacyV18DDLFeatures(q); err != nil {
+		return info, err
+	}
+	return info, nil
+}
+
+func schemaUserVersion(q sqliteQueryer) (int, error) {
 	var version int
-	if err := sqlDB.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+	if err := q.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
 		return 0, fmt.Errorf("read schema user_version: %w", err)
 	}
 	return version, nil
 }
 
-func legacyV18Candidate(sqlDB *sql.DB) (bool, error) {
+func legacyV18Candidate(q sqliteQueryer) (bool, error) {
 	var meta int
-	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'meta'`).Scan(&meta); err != nil {
+	if err := q.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'meta'`).Scan(&meta); err != nil {
 		return false, fmt.Errorf("detect legacy v18 meta relation: %w", err)
 	}
 	return meta == 1, nil

--- a/internal/store/v19schema.go
+++ b/internal/store/v19schema.go
@@ -194,8 +194,8 @@ func validateCanonicalV19Schema(sqlDB *sql.DB) error {
 	return nil
 }
 
-func inspectCanonicalV19Identity(sqlDB *sql.DB) (canonicalV19Identity, error) {
-	rows, err := sqlDB.Query(`SELECT type, name, tbl_name, sql
+func inspectCanonicalV19Identity(q sqliteQueryer) (canonicalV19Identity, error) {
+	rows, err := q.Query(`SELECT type, name, tbl_name, sql
 		FROM sqlite_schema
 		WHERE name NOT LIKE 'sqlite_%' AND sql IS NOT NULL
 		ORDER BY type, name`)


### PR DESCRIPTION
Implements only #348 slice 5A1: pinned exact-source eligibility/integrity/FK/journal validation.

Scope:
- refactor legacy schema/layout/DDL identity readers to a narrow Query/QueryRow interface so exact validation can run against one pinned transaction rather than reopening authority;
- add `validateLegacyV18CutoverSource` for exact v0.7.2 identity plus `query_only=1`, `foreign_keys=1`, mechanically eligible rollback-journal modes, `integrity_check=ok`, and empty `foreign_key_check`;
- reject MEMORY/WAL/OFF/unknown journal modes fail-closed;
- add tests proving exact rollback source acceptance, pinned schema-drift refusal, and MEMORY/query_only/FK refusal using production-style SQLite DSNs rather than the repository's test-only MEMORY pragma.

Intentionally absent:
- no MigrationLock/writer-exclusion implementation;
- no SHARED→barrier→EXCLUSIVE gate (#348 5A2);
- no Fleet-local/provider quiescence (#348 5A3);
- no archive, freeze bridge, import, target creation, publication, startup wiring, or automatic cutover activation.

Canonical #344 DDL impact: **NONE**.

Refs #348 #305 #524.