### PR TITLE
feat(store): add v19 cutover 5A2 SQLite source gate

### DIFF
--- a/internal/store/cutovergate.go
+++ b/internal/store/cutovergate.go
@@ -1,0 +1,295 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	legacyV18CutoverGateTimeout = 5 * time.Second
+	legacyV18CutoverBarrierPoll = 10 * time.Millisecond
+)
+
+type legacyV18CutoverGate struct {
+	info             SchemaInfo
+	sourceSHA256     string
+	db               *sql.DB
+	conn             *sql.Conn
+	releaseMigration func()
+}
+
+type sqliteConnQueryer struct {
+	ctx  context.Context
+	conn *sql.Conn
+}
+
+func (q sqliteConnQueryer) Query(query string, args ...any) (*sql.Rows, error) {
+	return q.conn.QueryContext(q.ctx, query, args...)
+}
+
+func (q sqliteConnQueryer) QueryRow(query string, args ...any) *sql.Row {
+	return q.conn.QueryRowContext(q.ctx, query, args...)
+}
+
+func acquireLegacyV18CutoverGate(ctx context.Context, homeDir string) (*legacyV18CutoverGate, error) {
+	return acquireLegacyV18CutoverGateWithTimeout(ctx, homeDir, legacyV18CutoverGateTimeout)
+}
+
+func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir string, timeout time.Duration) (*legacyV18CutoverGate, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("acquire legacy v18 cutover gate: timeout must be positive")
+	}
+
+	releaseMigration, err := Lock(homeDir, MigrationLock, true)
+	if err != nil {
+		return nil, fmt.Errorf("acquire legacy v18 cutover MigrationLock: %w", err)
+	}
+	releaseOnError := true
+	defer func() {
+		if releaseOnError {
+			releaseMigration()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	path := Path(homeDir)
+
+	readDB, err := openLegacyV18CutoverSQLite(path, "ro", timeout, true)
+	if err != nil {
+		return nil, err
+	}
+	readTx, err := readDB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		_ = readDB.Close()
+		return nil, fmt.Errorf("begin legacy v18 cutover SHARED snapshot: %w", err)
+	}
+	readOpen := true
+	defer func() {
+		if readOpen {
+			_ = readTx.Rollback()
+			_ = readDB.Close()
+		}
+	}()
+
+	candidateInfo, err := validateLegacyV18CutoverSource(readTx)
+	if err != nil {
+		return nil, fmt.Errorf("validate legacy v18 cutover SHARED snapshot: %w", err)
+	}
+	candidateDigest, err := legacyV18CutoverFileSHA256(path)
+	if err != nil {
+		return nil, fmt.Errorf("hash legacy v18 cutover SHARED source: %w", err)
+	}
+
+	gateDB, err := openLegacyV18CutoverSQLite(path, "rw", timeout, false)
+	if err != nil {
+		return nil, err
+	}
+	gateConn, err := gateDB.Conn(ctx)
+	if err != nil {
+		_ = gateDB.Close()
+		return nil, fmt.Errorf("pin legacy v18 cutover EXCLUSIVE connection: %w", err)
+	}
+	gateOpen := true
+	defer func() {
+		if gateOpen {
+			closeLegacyV18CutoverExclusive(gateConn, gateDB)
+		}
+	}()
+
+	exclusive := make(chan error, 1)
+	go func() {
+		_, beginErr := gateConn.ExecContext(ctx, `BEGIN EXCLUSIVE`)
+		exclusive <- beginErr
+	}()
+
+	exclusiveDone, err := waitForLegacyV18CutoverReaderBarrier(ctx, path, exclusive)
+	if err != nil {
+		if !exclusiveDone {
+			cancel()
+			<-exclusive
+		}
+		return nil, err
+	}
+
+	barrierDigest, err := legacyV18CutoverFileSHA256(path)
+	if err != nil {
+		cancel()
+		<-exclusive
+		return nil, fmt.Errorf("hash legacy v18 source under reader barrier: %w", err)
+	}
+	if barrierDigest != candidateDigest {
+		cancel()
+		<-exclusive
+		return nil, fmt.Errorf("legacy v18 cutover source changed under SHARED reader barrier: candidate=%s barrier=%s", candidateDigest, barrierDigest)
+	}
+
+	if err := readTx.Rollback(); err != nil {
+		cancel()
+		<-exclusive
+		return nil, fmt.Errorf("release legacy v18 cutover SHARED snapshot: %w", err)
+	}
+	if err := readDB.Close(); err != nil {
+		cancel()
+		<-exclusive
+		return nil, fmt.Errorf("close legacy v18 cutover SHARED source: %w", err)
+	}
+	readOpen = false
+
+	select {
+	case err := <-exclusive:
+		if err != nil {
+			return nil, fmt.Errorf("acquire legacy v18 cutover EXCLUSIVE gate: %w", err)
+		}
+	case <-ctx.Done():
+		cancel()
+		<-exclusive
+		return nil, fmt.Errorf("acquire legacy v18 cutover EXCLUSIVE gate: %w", ctx.Err())
+	}
+
+	if _, err := gateConn.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+		return nil, fmt.Errorf("set legacy v18 cutover EXCLUSIVE query_only: %w", err)
+	}
+	postInfo, err := validateLegacyV18CutoverSource(sqliteConnQueryer{ctx: ctx, conn: gateConn})
+	if err != nil {
+		return nil, fmt.Errorf("revalidate legacy v18 source under EXCLUSIVE gate: %w", err)
+	}
+	postDigest, err := legacyV18CutoverFileSHA256(path)
+	if err != nil {
+		return nil, fmt.Errorf("hash legacy v18 source under EXCLUSIVE gate: %w", err)
+	}
+	if postInfo != candidateInfo {
+		return nil, fmt.Errorf("legacy v18 cutover source semantic identity changed across EXCLUSIVE handoff: candidate=%+v post=%+v", candidateInfo, postInfo)
+	}
+	if postDigest != candidateDigest {
+		return nil, fmt.Errorf("legacy v18 cutover source changed across EXCLUSIVE handoff: candidate=%s post=%s", candidateDigest, postDigest)
+	}
+
+	gateOpen = false
+	releaseOnError = false
+	return &legacyV18CutoverGate{
+		info:             postInfo,
+		sourceSHA256:     postDigest,
+		db:               gateDB,
+		conn:             gateConn,
+		releaseMigration: releaseMigration,
+	}, nil
+}
+
+func waitForLegacyV18CutoverReaderBarrier(ctx context.Context, path string, exclusive <-chan error) (bool, error) {
+	probeDB, err := openLegacyV18CutoverSQLite(path, "ro", 0, true)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = probeDB.Close() }()
+
+	ticker := time.NewTicker(legacyV18CutoverBarrierPoll)
+	defer ticker.Stop()
+	for {
+		var objects int
+		err := probeDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_schema`).Scan(&objects)
+		if isSQLiteBusy(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("probe legacy v18 cutover reader barrier: %w", err)
+		}
+
+		select {
+		case beginErr := <-exclusive:
+			if beginErr == nil {
+				return true, fmt.Errorf("legacy v18 BEGIN EXCLUSIVE completed before known SHARED reader was released")
+			}
+			return true, fmt.Errorf("request legacy v18 cutover EXCLUSIVE gate: %w", beginErr)
+		case <-ctx.Done():
+			return false, fmt.Errorf("observe legacy v18 cutover reader barrier: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func openLegacyV18CutoverSQLite(path, mode string, busyTimeout time.Duration, queryOnly bool) (*sql.DB, error) {
+	if mode != "ro" && mode != "rw" {
+		return nil, fmt.Errorf("open legacy v18 cutover sqlite: unsupported mode %q", mode)
+	}
+	busyMilliseconds := int64(busyTimeout / time.Millisecond)
+	if busyTimeout > 0 && busyMilliseconds == 0 {
+		busyMilliseconds = 1
+	}
+	uri := "file:" + (&url.URL{Path: path}).EscapedPath() +
+		"?mode=" + mode +
+		"&_pragma=busy_timeout(" + strconv.FormatInt(busyMilliseconds, 10) + ")" +
+		"&_pragma=foreign_keys(1)"
+	if queryOnly {
+		uri += "&_pragma=query_only(1)"
+	}
+	db, err := sql.Open("sqlite", uri)
+	if err != nil {
+		return nil, fmt.Errorf("open legacy v18 cutover sqlite %s: %w", path, err)
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
+}
+
+func legacyV18CutoverFileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func closeLegacyV18CutoverExclusive(conn *sql.Conn, db *sql.DB) {
+	if conn != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), legacyV18CutoverGateTimeout)
+		_, _ = conn.ExecContext(ctx, `ROLLBACK`)
+		cancel()
+		_ = conn.Close()
+	}
+	if db != nil {
+		_ = db.Close()
+	}
+}
+
+func (g *legacyV18CutoverGate) Close() error {
+	if g == nil {
+		return nil
+	}
+
+	var firstErr error
+	if g.conn != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), legacyV18CutoverGateTimeout)
+		if _, err := g.conn.ExecContext(ctx, `ROLLBACK`); err != nil {
+			firstErr = fmt.Errorf("release legacy v18 cutover EXCLUSIVE gate: %w", err)
+		}
+		cancel()
+		if err := g.conn.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close legacy v18 cutover EXCLUSIVE connection: %w", err)
+		}
+		g.conn = nil
+	}
+	if g.db != nil {
+		if err := g.db.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close legacy v18 cutover EXCLUSIVE database: %w", err)
+		}
+		g.db = nil
+	}
+	if g.releaseMigration != nil {
+		g.releaseMigration()
+		g.releaseMigration = nil
+	}
+	return firstErr
+}

--- a/internal/store/cutovergate.go
+++ b/internal/store/cutovergate.go
@@ -58,15 +58,15 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(parent, timeout)
-	defer cancel()
+	handoffCtx, handoffCancel := context.WithTimeout(parent, timeout)
+	defer handoffCancel()
 	path := Path(homeDir)
 
 	readDB, err := openLegacyV18CutoverSQLite(path, "ro", timeout, true)
 	if err != nil {
 		return nil, err
 	}
-	readTx, err := readDB.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	readTx, err := readDB.BeginTx(handoffCtx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		_ = readDB.Close()
 		return nil, fmt.Errorf("begin legacy v18 cutover SHARED snapshot: %w", err)
@@ -92,7 +92,7 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 	if err != nil {
 		return nil, err
 	}
-	gateConn, err := gateDB.Conn(ctx)
+	gateConn, err := gateDB.Conn(handoffCtx)
 	if err != nil {
 		_ = gateDB.Close()
 		return nil, fmt.Errorf("pin legacy v18 cutover EXCLUSIVE connection: %w", err)
@@ -106,14 +106,14 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 
 	exclusive := make(chan error, 1)
 	go func() {
-		_, beginErr := gateConn.ExecContext(ctx, `BEGIN EXCLUSIVE`)
+		_, beginErr := gateConn.ExecContext(handoffCtx, `BEGIN EXCLUSIVE`)
 		exclusive <- beginErr
 	}()
 
-	exclusiveDone, err := waitForLegacyV18CutoverReaderBarrier(ctx, path, exclusive)
+	exclusiveDone, err := waitForLegacyV18CutoverReaderBarrier(handoffCtx, path, exclusive)
 	if err != nil {
 		if !exclusiveDone {
-			cancel()
+			handoffCancel()
 			<-exclusive
 		}
 		return nil, err
@@ -121,23 +121,23 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 
 	barrierDigest, err := legacyV18CutoverFileSHA256(path)
 	if err != nil {
-		cancel()
+		handoffCancel()
 		<-exclusive
 		return nil, fmt.Errorf("hash legacy v18 source under reader barrier: %w", err)
 	}
 	if barrierDigest != candidateDigest {
-		cancel()
+		handoffCancel()
 		<-exclusive
 		return nil, fmt.Errorf("legacy v18 cutover source changed under SHARED reader barrier: candidate=%s barrier=%s", candidateDigest, barrierDigest)
 	}
 
 	if err := readTx.Rollback(); err != nil {
-		cancel()
+		handoffCancel()
 		<-exclusive
 		return nil, fmt.Errorf("release legacy v18 cutover SHARED snapshot: %w", err)
 	}
 	if err := readDB.Close(); err != nil {
-		cancel()
+		handoffCancel()
 		<-exclusive
 		return nil, fmt.Errorf("close legacy v18 cutover SHARED source: %w", err)
 	}
@@ -148,16 +148,18 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 		if err != nil {
 			return nil, fmt.Errorf("acquire legacy v18 cutover EXCLUSIVE gate: %w", err)
 		}
-	case <-ctx.Done():
-		cancel()
+	case <-handoffCtx.Done():
+		handoffCancel()
 		<-exclusive
-		return nil, fmt.Errorf("acquire legacy v18 cutover EXCLUSIVE gate: %w", ctx.Err())
+		return nil, fmt.Errorf("acquire legacy v18 cutover EXCLUSIVE gate: %w", handoffCtx.Err())
 	}
 
-	if _, err := gateConn.ExecContext(ctx, `PRAGMA query_only = 1`); err != nil {
+	validationCtx, validationCancel := context.WithTimeout(parent, timeout)
+	defer validationCancel()
+	if _, err := gateConn.ExecContext(validationCtx, `PRAGMA query_only = 1`); err != nil {
 		return nil, fmt.Errorf("set legacy v18 cutover EXCLUSIVE query_only: %w", err)
 	}
-	postInfo, err := validateLegacyV18CutoverSource(sqliteConnQueryer{ctx: ctx, conn: gateConn})
+	postInfo, err := validateLegacyV18CutoverSource(sqliteConnQueryer{ctx: validationCtx, conn: gateConn})
 	if err != nil {
 		return nil, fmt.Errorf("revalidate legacy v18 source under EXCLUSIVE gate: %w", err)
 	}

--- a/internal/store/cutovergate_test.go
+++ b/internal/store/cutovergate_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"

--- a/internal/store/cutovergate_test.go
+++ b/internal/store/cutovergate_test.go
@@ -1,0 +1,147 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/filelock"
+)
+
+func TestAcquireLegacyV18CutoverGateHoldsExactExclusiveSource(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	beforeDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gate.info.Family != SchemaFamilyLegacyV18 {
+		_ = gate.Close()
+		t.Fatalf("gate family = %q, want %q", gate.info.Family, SchemaFamilyLegacyV18)
+	}
+	if gate.info.LayoutFingerprint != legacyV072LayoutFingerprint {
+		_ = gate.Close()
+		t.Fatalf("gate layout fingerprint = %s, want %s", gate.info.LayoutFingerprint, legacyV072LayoutFingerprint)
+	}
+	if gate.sourceSHA256 != beforeDigest {
+		_ = gate.Close()
+		t.Fatalf("gate source digest = %s, want %s", gate.sourceSHA256, beforeDigest)
+	}
+
+	var queryOnly int
+	if err := gate.conn.QueryRowContext(context.Background(), `PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+	if queryOnly != 1 {
+		_ = gate.Close()
+		t.Fatalf("gate query_only = %d, want 1", queryOnly)
+	}
+
+	reader, err := openLegacyV18CutoverSQLite(Path(home), "ro", 0, true)
+	if err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+	var objects int
+	readErr := reader.QueryRow(`SELECT COUNT(*) FROM sqlite_schema`).Scan(&objects)
+	_ = reader.Close()
+	if !isSQLiteBusy(readErr) {
+		_ = gate.Close()
+		t.Fatalf("fresh reader under cutover EXCLUSIVE = %v, want SQLITE_BUSY", readErr)
+	}
+
+	writer, err := openLegacyV18CutoverSQLite(Path(home), "rw", 0, false)
+	if err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+	_, writeErr := writer.Exec(`BEGIN IMMEDIATE`)
+	_ = writer.Close()
+	if !isSQLiteBusy(writeErr) {
+		_ = gate.Close()
+		t.Fatalf("fresh writer under cutover EXCLUSIVE = %v, want SQLITE_BUSY", writeErr)
+	}
+
+	if err := gate.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reader, err = openLegacyV18CutoverSQLite(Path(home), "ro", 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.QueryRow(`SELECT COUNT(*) FROM sqlite_schema`).Scan(&objects); err != nil {
+		_ = reader.Close()
+		t.Fatalf("fresh reader after cutover gate close: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	afterDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDigest != beforeDigest {
+		t.Fatalf("cutover gate changed source bytes: before=%s after=%s", beforeDigest, afterDigest)
+	}
+}
+
+func TestAcquireLegacyV18CutoverGateRequiresMigrationLock(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	release, err := Lock(home, MigrationLock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	_, err = acquireLegacyV18CutoverGateWithTimeout(context.Background(), home, time.Second)
+	if !errors.Is(err, filelock.ErrBusy) {
+		t.Fatalf("acquireLegacyV18CutoverGateWithTimeout error = %v, want filelock.ErrBusy", err)
+	}
+}
+
+func TestAcquireLegacyV18CutoverGateDoesNotTreatReaderBarrierAsOwnership(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	beforeDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foreignDB, err := openLegacyV18CutoverSQLite(Path(home), "ro", 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = foreignDB.Close() }()
+	foreignTx, err := foreignDB.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = foreignTx.Rollback() }()
+	var objects int
+	if err := foreignTx.QueryRow(`SELECT COUNT(*) FROM sqlite_schema`).Scan(&objects); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = acquireLegacyV18CutoverGateWithTimeout(context.Background(), home, 2*time.Second)
+	if err == nil {
+		t.Fatal("acquireLegacyV18CutoverGateWithTimeout succeeded while foreign SHARED reader remained live")
+	}
+	if !strings.Contains(err.Error(), "EXCLUSIVE gate") {
+		t.Fatalf("gate error = %v, want failure after reader-barrier observation while OUR EXCLUSIVE remained blocked", err)
+	}
+	afterDigest, digestErr := legacyV18CutoverFileSHA256(Path(home))
+	if digestErr != nil {
+		t.Fatal(digestErr)
+	}
+	if afterDigest != beforeDigest {
+		t.Fatalf("failed cutover gate changed source bytes: before=%s after=%s", beforeDigest, afterDigest)
+	}
+}

--- a/internal/store/cutovergate_test.go
+++ b/internal/store/cutovergate_test.go
@@ -45,6 +45,10 @@ func TestAcquireLegacyV18CutoverGateHoldsExactExclusiveSource(t *testing.T) {
 		_ = gate.Close()
 		t.Fatalf("gate query_only = %d, want 1", queryOnly)
 	}
+	if _, err := gate.conn.ExecContext(context.Background(), `CREATE TABLE forbidden_cutover_write (id INTEGER)`); err == nil {
+		_ = gate.Close()
+		t.Fatal("query-only cutover gate allowed a source mutation")
+	}
 
 	reader, err := openLegacyV18CutoverSQLite(Path(home), "ro", 0, true)
 	if err != nil {

--- a/internal/store/cutovergate_test.go
+++ b/internal/store/cutovergate_test.go
@@ -50,6 +50,15 @@ func TestAcquireLegacyV18CutoverGateHoldsExactExclusiveSource(t *testing.T) {
 		t.Fatal("query-only cutover gate allowed a source mutation")
 	}
 
+	migrationRelease, lockErr := Lock(home, MigrationLock, true)
+	if !errors.Is(lockErr, filelock.ErrBusy) {
+		if lockErr == nil {
+			migrationRelease()
+		}
+		_ = gate.Close()
+		t.Fatalf("MigrationLock while cutover gate is held = %v, want filelock.ErrBusy", lockErr)
+	}
+
 	reader, err := openLegacyV18CutoverSQLite(Path(home), "ro", 0, true)
 	if err != nil {
 		_ = gate.Close()
@@ -78,6 +87,12 @@ func TestAcquireLegacyV18CutoverGateHoldsExactExclusiveSource(t *testing.T) {
 	if err := gate.Close(); err != nil {
 		t.Fatal(err)
 	}
+	migrationRelease, err = Lock(home, MigrationLock, true)
+	if err != nil {
+		t.Fatalf("MigrationLock after cutover gate close = %v, want success", err)
+	}
+	migrationRelease()
+
 	reader, err = openLegacyV18CutoverSQLite(Path(home), "ro", 0, true)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Implements only #348 slice 5A2: the revision-2 SHARED → observed reader barrier → OUR EXCLUSIVE SQLite source gate.

Scope:
- acquire Fleet `MigrationLock` nonblockingly before source handoff;
- establish a genuine pinned `mode=ro`, `foreign_keys=1`, `query_only=1` SHARED snapshot and run the landed 5A1 exact-source validator inside it;
- SHA-256 the exact active DB candidate while SHARED is held;
- on a second pinned `mode=rw` connection request `BEGIN EXCLUSIVE` asynchronously;
- positively require a fresh read-only probe to fail `SQLITE_BUSY` while the known SHARED snapshot remains held;
- re-hash source bytes while SHARED + barrier coexist and fail closed on change;
- release only the known SHARED transaction, require OUR already-requested `BEGIN EXCLUSIVE` to return within bounded policy, then enable `query_only=1` on that same connection;
- re-run exact 5A1 semantic validation under OUR EXCLUSIVE and require post-EXCLUSIVE digest + `SchemaInfo` to equal the SHARED candidate;
- return an internal gate handle that retains OUR EXCLUSIVE + MigrationLock until `Close`, which only rolls back/releases and never mutates source semantics.

Tests prove:
- a successful gate holds exact source identity and blocks fresh readers and writers until release;
- `query_only=1` is enforced by an attempted source DDL mutation, not merely observed as a PRAGMA value;
- the returned gate retains `MigrationLock` for its full lifetime and `Close` releases it;
- source bytes remain unchanged after the gate closes;
- an already-held MigrationLock blocks acquisition;
- a foreign SHARED reader cannot be mistaken for authority merely because the fresh-reader barrier is observed—OUR EXCLUSIVE must still actually return.

Intentionally absent:
- no Fleet-local lock graph or provider/resource quiescence (#348 5A3);
- no archive candidate/promotion (#348 5B);
- no frozen-bridge certificate/guards/user_version=22;
- no import, v19 target creation, publication, recovery, startup wiring, or automatic cutover activation.

This consumes revision-2 #348 and mechanical diagnostic #525 without merging the diagnostic harness itself.

Canonical #344 DDL impact: **NONE**.

Refs #348 #305 #525 #527 #529.