### PR TITLE
feat(store): add v19 cutover 5A3 Fleet-local lock closure

### DIFF
--- a/internal/store/cutoverlocks.go
+++ b/internal/store/cutoverlocks.go
@@ -62,7 +62,7 @@ func acquireLegacyV18CutoverLocks(ctx context.Context, homeDir string, gate *leg
 		path := legacyV18CutoverHashedLockPath(homeDir, key)
 		held, err := acquireLegacyV18CutoverPathLock(path, 0o600)
 		if err != nil {
-			return nil, fmt.Errorf("%w: acquire logical lock %q: %v", errLegacyV18CutoverLocksUnsafe, key, err)
+			return nil, fmt.Errorf("%w: acquire logical lock %q: %w", errLegacyV18CutoverLocksUnsafe, key, err)
 		}
 		locks.held = append(locks.held, held)
 		ownedHashed[path] = struct{}{}
@@ -71,28 +71,28 @@ func acquireLegacyV18CutoverLocks(ctx context.Context, homeDir string, gate *leg
 	watchPath := filepath.Join(Dir(homeDir), "watch.pid.lock")
 	watchLock, err := acquireLegacyV18CutoverPathLock(watchPath, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("%w: acquire watcher ownership lock: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: acquire watcher ownership lock: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 	locks.held = append(locks.held, watchLock)
 
 	registryPath := filepath.Join(homeDir, "data", "projects.md.lock")
 	if err := ensureLegacyV18CutoverLockParent(registryPath); err != nil {
-		return nil, fmt.Errorf("%w: prepare project registry lock: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: prepare project registry lock: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 	registryLock, err := acquireLegacyV18CutoverPathLock(registryPath, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("%w: acquire project registry lock: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: acquire project registry lock: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 	locks.held = append(locks.held, registryLock)
 
 	migrationPath := legacyV18CutoverHashedLockPath(homeDir, MigrationLock)
 	if err := validateLegacyV18CutoverRendezvousPath(migrationPath); err != nil {
-		return nil, fmt.Errorf("%w: validate held MigrationLock pathname: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: validate held MigrationLock pathname: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 
 	before, err := legacyV18CutoverHashedLockNames(Dir(homeDir))
 	if err != nil {
-		return nil, fmt.Errorf("%w: enumerate hashed lock namespace: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: enumerate hashed lock namespace: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 	for _, name := range before {
 		path := filepath.Join(Dir(homeDir), name)
@@ -101,7 +101,7 @@ func acquireLegacyV18CutoverLocks(ctx context.Context, homeDir string, gate *leg
 		}
 		held, err := acquireLegacyV18CutoverPathLock(path, 0o600)
 		if err != nil {
-			return nil, fmt.Errorf("%w: acquire existing hashed rendezvous %s: %v", errLegacyV18CutoverLocksUnsafe, name, err)
+			return nil, fmt.Errorf("%w: acquire existing hashed rendezvous %s: %w", errLegacyV18CutoverLocksUnsafe, name, err)
 		}
 		locks.held = append(locks.held, held)
 		ownedHashed[path] = struct{}{}
@@ -109,18 +109,18 @@ func acquireLegacyV18CutoverLocks(ctx context.Context, homeDir string, gate *leg
 
 	after, err := legacyV18CutoverHashedLockNames(Dir(homeDir))
 	if err != nil {
-		return nil, fmt.Errorf("%w: re-enumerate hashed lock namespace: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: re-enumerate hashed lock namespace: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 	if !equalLegacyV18CutoverLockNames(before, after) {
 		return nil, fmt.Errorf("%w: hashed lock namespace changed during quiescence proof: before=%v after=%v", errLegacyV18CutoverLocksUnsafe, before, after)
 	}
 	for _, held := range locks.held {
 		if err := held.verifyPathIdentity(); err != nil {
-			return nil, fmt.Errorf("%w: %v", errLegacyV18CutoverLocksUnsafe, err)
+			return nil, fmt.Errorf("%w: %w", errLegacyV18CutoverLocksUnsafe, err)
 		}
 	}
 	if err := validateLegacyV18CutoverRendezvousPath(migrationPath); err != nil {
-		return nil, fmt.Errorf("%w: revalidate held MigrationLock pathname: %v", errLegacyV18CutoverLocksUnsafe, err)
+		return nil, fmt.Errorf("%w: revalidate held MigrationLock pathname: %w", errLegacyV18CutoverLocksUnsafe, err)
 	}
 
 	keep = true
@@ -131,7 +131,7 @@ func legacyV18CutoverLogicalLockKeys(q sqliteQueryer) ([]string, error) {
 	keys := map[string]struct{}{
 		"config:routing": {},
 		"completions":    {},
-		SchemaLock:        {},
+		SchemaLock:       {},
 	}
 
 	taskRows, err := q.Query(`SELECT id, project FROM task ORDER BY id`)

--- a/internal/store/cutoverlocks.go
+++ b/internal/store/cutoverlocks.go
@@ -1,0 +1,371 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/atqamz/hand/internal/filelock"
+)
+
+var errLegacyV18CutoverLocksUnsafe = errors.New("legacy v18 cutover Fleet-local lock graph is not quiescent")
+
+type legacyV18CutoverHeldLock struct {
+	path string
+	file *os.File
+	info os.FileInfo
+}
+
+type legacyV18CutoverLocks struct {
+	held []*legacyV18CutoverHeldLock
+}
+
+func acquireLegacyV18CutoverLocks(ctx context.Context, homeDir string, gate *legacyV18CutoverGate) (*legacyV18CutoverLocks, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if gate == nil || gate.conn == nil || gate.releaseMigration == nil {
+		return nil, fmt.Errorf("%w: 5A2 EXCLUSIVE source gate is not held", errLegacyV18CutoverLocksUnsafe)
+	}
+
+	var queryOnly int
+	if err := gate.conn.QueryRowContext(ctx, `PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		return nil, fmt.Errorf("inspect legacy v18 cutover EXCLUSIVE query_only: %w", err)
+	}
+	if queryOnly != 1 {
+		return nil, fmt.Errorf("%w: EXCLUSIVE source gate query_only = %d, want 1", errLegacyV18CutoverLocksUnsafe, queryOnly)
+	}
+
+	logicalKeys, err := legacyV18CutoverLogicalLockKeys(sqliteConnQueryer{ctx: ctx, conn: gate.conn})
+	if err != nil {
+		return nil, err
+	}
+
+	locks := &legacyV18CutoverLocks{}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = locks.Close()
+		}
+	}()
+
+	ownedHashed := map[string]struct{}{
+		legacyV18CutoverHashedLockPath(homeDir, MigrationLock): {},
+	}
+	for _, key := range logicalKeys {
+		path := legacyV18CutoverHashedLockPath(homeDir, key)
+		held, err := acquireLegacyV18CutoverPathLock(path, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("%w: acquire logical lock %q: %v", errLegacyV18CutoverLocksUnsafe, key, err)
+		}
+		locks.held = append(locks.held, held)
+		ownedHashed[path] = struct{}{}
+	}
+
+	watchPath := filepath.Join(Dir(homeDir), "watch.pid.lock")
+	watchLock, err := acquireLegacyV18CutoverPathLock(watchPath, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("%w: acquire watcher ownership lock: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+	locks.held = append(locks.held, watchLock)
+
+	registryPath := filepath.Join(homeDir, "data", "projects.md.lock")
+	if err := ensureLegacyV18CutoverLockParent(registryPath); err != nil {
+		return nil, fmt.Errorf("%w: prepare project registry lock: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+	registryLock, err := acquireLegacyV18CutoverPathLock(registryPath, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("%w: acquire project registry lock: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+	locks.held = append(locks.held, registryLock)
+
+	migrationPath := legacyV18CutoverHashedLockPath(homeDir, MigrationLock)
+	if err := validateLegacyV18CutoverRendezvousPath(migrationPath); err != nil {
+		return nil, fmt.Errorf("%w: validate held MigrationLock pathname: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+
+	before, err := legacyV18CutoverHashedLockNames(Dir(homeDir))
+	if err != nil {
+		return nil, fmt.Errorf("%w: enumerate hashed lock namespace: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+	for _, name := range before {
+		path := filepath.Join(Dir(homeDir), name)
+		if _, alreadyHeld := ownedHashed[path]; alreadyHeld {
+			continue
+		}
+		held, err := acquireLegacyV18CutoverPathLock(path, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("%w: acquire existing hashed rendezvous %s: %v", errLegacyV18CutoverLocksUnsafe, name, err)
+		}
+		locks.held = append(locks.held, held)
+		ownedHashed[path] = struct{}{}
+	}
+
+	after, err := legacyV18CutoverHashedLockNames(Dir(homeDir))
+	if err != nil {
+		return nil, fmt.Errorf("%w: re-enumerate hashed lock namespace: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+	if !equalLegacyV18CutoverLockNames(before, after) {
+		return nil, fmt.Errorf("%w: hashed lock namespace changed during quiescence proof: before=%v after=%v", errLegacyV18CutoverLocksUnsafe, before, after)
+	}
+	for _, held := range locks.held {
+		if err := held.verifyPathIdentity(); err != nil {
+			return nil, fmt.Errorf("%w: %v", errLegacyV18CutoverLocksUnsafe, err)
+		}
+	}
+	if err := validateLegacyV18CutoverRendezvousPath(migrationPath); err != nil {
+		return nil, fmt.Errorf("%w: revalidate held MigrationLock pathname: %v", errLegacyV18CutoverLocksUnsafe, err)
+	}
+
+	keep = true
+	return locks, nil
+}
+
+func legacyV18CutoverLogicalLockKeys(q sqliteQueryer) ([]string, error) {
+	keys := map[string]struct{}{
+		"config:routing": {},
+		"completions":    {},
+		SchemaLock:        {},
+	}
+
+	taskRows, err := q.Query(`SELECT id, project FROM task ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 task lock identities: %w", err)
+	}
+	for taskRows.Next() {
+		var id, project string
+		if err := taskRows.Scan(&id, &project); err != nil {
+			_ = taskRows.Close()
+			return nil, fmt.Errorf("read legacy v18 task lock identities: %w", err)
+		}
+		keys["task:"+id] = struct{}{}
+		keys["send:"+id] = struct{}{}
+		if project != "" {
+			keys["project:"+project] = struct{}{}
+		}
+	}
+	if err := taskRows.Err(); err != nil {
+		_ = taskRows.Close()
+		return nil, fmt.Errorf("read legacy v18 task lock identities: %w", err)
+	}
+	if err := taskRows.Close(); err != nil {
+		return nil, fmt.Errorf("close legacy v18 task lock identities: %w", err)
+	}
+
+	projectRows, err := q.Query(`SELECT name FROM project ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 project lock identities: %w", err)
+	}
+	for projectRows.Next() {
+		var name string
+		if err := projectRows.Scan(&name); err != nil {
+			_ = projectRows.Close()
+			return nil, fmt.Errorf("read legacy v18 project lock identities: %w", err)
+		}
+		keys["project:"+name] = struct{}{}
+	}
+	if err := projectRows.Err(); err != nil {
+		_ = projectRows.Close()
+		return nil, fmt.Errorf("read legacy v18 project lock identities: %w", err)
+	}
+	if err := projectRows.Close(); err != nil {
+		return nil, fmt.Errorf("close legacy v18 project lock identities: %w", err)
+	}
+
+	worktreeRows, err := q.Query(`SELECT DISTINCT worktree FROM attempt WHERE worktree <> '' ORDER BY worktree`)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy v18 worktree lock identities: %w", err)
+	}
+	for worktreeRows.Next() {
+		var path string
+		if err := worktreeRows.Scan(&path); err != nil {
+			_ = worktreeRows.Close()
+			return nil, fmt.Errorf("read legacy v18 worktree lock identities: %w", err)
+		}
+		keys["worktree:"+path] = struct{}{}
+	}
+	if err := worktreeRows.Err(); err != nil {
+		_ = worktreeRows.Close()
+		return nil, fmt.Errorf("read legacy v18 worktree lock identities: %w", err)
+	}
+	if err := worktreeRows.Close(); err != nil {
+		return nil, fmt.Errorf("close legacy v18 worktree lock identities: %w", err)
+	}
+
+	out := make([]string, 0, len(keys))
+	for key := range keys {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func legacyV18CutoverHashedLockPath(homeDir, key string) string {
+	return filepath.Join(Dir(homeDir), fmt.Sprintf(".%x.lock", sha256.Sum256([]byte(key))))
+}
+
+func legacyV18CutoverHashedLockNames(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0)
+	for _, entry := range entries {
+		if isLegacyV18HashedLockName(entry.Name()) {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func isLegacyV18HashedLockName(name string) bool {
+	if len(name) != 70 || !strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".lock") {
+		return false
+	}
+	encoded := name[1 : len(name)-len(".lock")]
+	if len(encoded) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(encoded)
+	return err == nil
+}
+
+func equalLegacyV18CutoverLockNames(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureLegacyV18CutoverLockParent(path string) error {
+	parent := filepath.Dir(path)
+	info, err := os.Lstat(parent)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("lock parent %s is not a direct directory", parent)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Mkdir(parent, 0o755); err != nil && !os.IsExist(err) {
+		return err
+	}
+	info, err = os.Lstat(parent)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("lock parent %s is not a direct directory", parent)
+	}
+	return nil
+}
+
+func acquireLegacyV18CutoverPathLock(path string, perm os.FileMode) (*legacyV18CutoverHeldLock, error) {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("rendezvous %s is not a direct regular file", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspect rendezvous %s: %w", path, err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		return nil, fmt.Errorf("open rendezvous %s: %w", path, err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = file.Close()
+		}
+	}()
+
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat opened rendezvous %s: %w", path, err)
+	}
+	if !opened.Mode().IsRegular() {
+		return nil, fmt.Errorf("opened rendezvous %s is not a regular file", path)
+	}
+	if err := verifyLegacyV18CutoverPathIdentity(path, opened); err != nil {
+		return nil, err
+	}
+	if err := filelock.Lock(file, false); err != nil {
+		return nil, fmt.Errorf("lock rendezvous %s: %w", path, err)
+	}
+	if err := verifyLegacyV18CutoverPathIdentity(path, opened); err != nil {
+		_ = filelock.Unlock(file)
+		return nil, err
+	}
+
+	closeOnError = false
+	return &legacyV18CutoverHeldLock{path: path, file: file, info: opened}, nil
+}
+
+func verifyLegacyV18CutoverPathIdentity(path string, opened os.FileInfo) error {
+	current, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("reinspect rendezvous %s: %w", path, err)
+	}
+	if current.Mode()&os.ModeSymlink != 0 || !current.Mode().IsRegular() {
+		return fmt.Errorf("rendezvous %s changed away from a direct regular file", path)
+	}
+	if !os.SameFile(opened, current) {
+		return fmt.Errorf("rendezvous %s changed identity while being locked", path)
+	}
+	return nil
+}
+
+func validateLegacyV18CutoverRendezvousPath(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("rendezvous %s is not a direct regular file", path)
+	}
+	return nil
+}
+
+func (h *legacyV18CutoverHeldLock) verifyPathIdentity() error {
+	if h == nil || h.file == nil || h.info == nil {
+		return fmt.Errorf("cutover lock holder is not live")
+	}
+	return verifyLegacyV18CutoverPathIdentity(h.path, h.info)
+}
+
+func (l *legacyV18CutoverLocks) Close() error {
+	if l == nil {
+		return nil
+	}
+	var firstErr error
+	for i := len(l.held) - 1; i >= 0; i-- {
+		held := l.held[i]
+		if held == nil || held.file == nil {
+			continue
+		}
+		if err := filelock.Unlock(held.file); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("unlock legacy v18 cutover rendezvous %s: %w", held.path, err)
+		}
+		if err := held.file.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close legacy v18 cutover rendezvous %s: %w", held.path, err)
+		}
+		held.file = nil
+	}
+	l.held = nil
+	return firstErr
+}

--- a/internal/store/cutoverlocks_test.go
+++ b/internal/store/cutoverlocks_test.go
@@ -1,0 +1,259 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/atqamz/hand/internal/filelock"
+)
+
+func TestAcquireLegacyV18CutoverLocksHoldsClosedWorldFleetLocks(t *testing.T) {
+	home, worktreePath := createLegacyV18CutoverLockTestSource(t)
+	beforeDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unknownRelease, err := Lock(home, "historical:unknown-rendezvous", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unknownRelease()
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	locks, err := acquireLegacyV18CutoverLocks(context.Background(), home, gate)
+	if err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+
+	logicalKeys := []string{
+		"config:routing",
+		"completions",
+		SchemaLock,
+		"task:task-one",
+		"send:task-one",
+		"project:alpha",
+		"worktree:" + worktreePath,
+		"historical:unknown-rendezvous",
+	}
+	for _, key := range logicalKeys {
+		if release, err := Lock(home, key, true); !errors.Is(err, filelock.ErrBusy) {
+			if err == nil {
+				release()
+			}
+			_ = locks.Close()
+			_ = gate.Close()
+			t.Fatalf("Lock(%q) while cutover lock closure held = %v, want filelock.ErrBusy", key, err)
+		}
+	}
+
+	assertLegacyV18CutoverFixedLockBusy(t, filepath.Join(Dir(home), "watch.pid.lock"), 0o644)
+	assertLegacyV18CutoverFixedLockBusy(t, filepath.Join(home, "data", "projects.md.lock"), 0o600)
+
+	if release, err := Lock(home, MigrationLock, true); !errors.Is(err, filelock.ErrBusy) {
+		if err == nil {
+			release()
+		}
+		_ = locks.Close()
+		_ = gate.Close()
+		t.Fatalf("MigrationLock while lock closure held = %v, want filelock.ErrBusy", err)
+	}
+
+	if err := locks.Close(); err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+	for _, key := range logicalKeys {
+		release, err := Lock(home, key, true)
+		if err != nil {
+			_ = gate.Close()
+			t.Fatalf("Lock(%q) after lock closure Close = %v", key, err)
+		}
+		release()
+	}
+	assertLegacyV18CutoverFixedLockAvailable(t, filepath.Join(Dir(home), "watch.pid.lock"), 0o644)
+	assertLegacyV18CutoverFixedLockAvailable(t, filepath.Join(home, "data", "projects.md.lock"), 0o600)
+
+	if release, err := Lock(home, MigrationLock, true); !errors.Is(err, filelock.ErrBusy) {
+		if err == nil {
+			release()
+		}
+		_ = gate.Close()
+		t.Fatalf("MigrationLock after child lock closure Close = %v, want parent 5A2 gate still to hold it", err)
+	}
+	if err := gate.Close(); err != nil {
+		t.Fatal(err)
+	}
+	releaseMigration, err := Lock(home, MigrationLock, true)
+	if err != nil {
+		t.Fatalf("MigrationLock after parent gate Close = %v", err)
+	}
+	releaseMigration()
+
+	afterDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDigest != beforeDigest {
+		t.Fatalf("5A3 lock closure changed source DB bytes: before=%s after=%s", beforeDigest, afterDigest)
+	}
+}
+
+func TestAcquireLegacyV18CutoverLocksRejectsBusyDerivedProjectLock(t *testing.T) {
+	home, _ := createLegacyV18CutoverLockTestSource(t)
+	holder, err := Lock(home, "project:alpha", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder()
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+
+	locks, err := acquireLegacyV18CutoverLocks(context.Background(), home, gate)
+	if locks != nil {
+		_ = locks.Close()
+		t.Fatal("lock closure succeeded while a derived project lock was live")
+	}
+	if !errors.Is(err, errLegacyV18CutoverLocksUnsafe) {
+		t.Fatalf("lock closure error = %v, want errLegacyV18CutoverLocksUnsafe", err)
+	}
+}
+
+func TestAcquireLegacyV18CutoverLocksRejectsBusyWatcherLock(t *testing.T) {
+	home, _ := createLegacyV18CutoverLockTestSource(t)
+	watchPath := filepath.Join(Dir(home), "watch.pid.lock")
+	holder := holdLegacyV18CutoverFixedLock(t, watchPath, 0o644)
+	defer holder()
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+
+	locks, err := acquireLegacyV18CutoverLocks(context.Background(), home, gate)
+	if locks != nil {
+		_ = locks.Close()
+		t.Fatal("lock closure succeeded while watcher ownership lock was live")
+	}
+	if !errors.Is(err, errLegacyV18CutoverLocksUnsafe) {
+		t.Fatalf("lock closure error = %v, want errLegacyV18CutoverLocksUnsafe", err)
+	}
+}
+
+func TestAcquireLegacyV18CutoverLocksRejectsBusyProjectRegistryLock(t *testing.T) {
+	home, _ := createLegacyV18CutoverLockTestSource(t)
+	registryPath := filepath.Join(home, "data", "projects.md.lock")
+	if err := os.MkdirAll(filepath.Dir(registryPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	holder := holdLegacyV18CutoverFixedLock(t, registryPath, 0o600)
+	defer holder()
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+
+	locks, err := acquireLegacyV18CutoverLocks(context.Background(), home, gate)
+	if locks != nil {
+		_ = locks.Close()
+		t.Fatal("lock closure succeeded while project registry lock was live")
+	}
+	if !errors.Is(err, errLegacyV18CutoverLocksUnsafe) {
+		t.Fatalf("lock closure error = %v, want errLegacyV18CutoverLocksUnsafe", err)
+	}
+}
+
+func TestAcquireLegacyV18CutoverLocksRequiresLiveExclusiveGate(t *testing.T) {
+	home, _ := createLegacyV18CutoverLockTestSource(t)
+	locks, err := acquireLegacyV18CutoverLocks(context.Background(), home, nil)
+	if locks != nil {
+		_ = locks.Close()
+		t.Fatal("lock closure succeeded without a 5A2 EXCLUSIVE gate")
+	}
+	if !errors.Is(err, errLegacyV18CutoverLocksUnsafe) {
+		t.Fatalf("lock closure error = %v, want errLegacyV18CutoverLocksUnsafe", err)
+	}
+}
+
+func createLegacyV18CutoverLockTestSource(t *testing.T) (string, string) {
+	t.Helper()
+	home := createLegacyV18CutoverTestSource(t)
+	worktreePath := filepath.Join(home, "treehouses", "task-one")
+	db := openLegacyV18CutoverTestDB(t, home, true)
+	if _, err := db.Exec(`INSERT INTO project (id, name, url, mode, position) VALUES ('project-id-alpha', 'alpha', 'https://example.invalid/alpha.git', 'direct-pr', 1)`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO task (id, project, project_id, lifecycle) VALUES ('task-one', 'alpha', 'project-id-alpha', 'terminal')`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO attempt (task_id, ordinal, lifecycle, worktree) VALUES ('task-one', 1, 'completed', ?)`, worktreePath); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	return home, worktreePath
+}
+
+func holdLegacyV18CutoverFixedLock(t *testing.T, path string, perm os.FileMode) func() {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := filelock.Lock(file, false); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	return func() {
+		_ = filelock.Unlock(file)
+		_ = file.Close()
+	}
+}
+
+func assertLegacyV18CutoverFixedLockBusy(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+	if err := filelock.Lock(file, false); !errors.Is(err, filelock.ErrBusy) {
+		if err == nil {
+			_ = filelock.Unlock(file)
+		}
+		t.Fatalf("fixed lock %s while cutover lock closure held = %v, want filelock.ErrBusy", path, err)
+	}
+}
+
+func assertLegacyV18CutoverFixedLockAvailable(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, perm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := filelock.Lock(file, false); err != nil {
+		_ = file.Close()
+		t.Fatalf("fixed lock %s after cutover lock closure Close = %v", path, err)
+	}
+	_ = filelock.Unlock(file)
+	_ = file.Close()
+}


### PR DESCRIPTION
Implements only the Fleet-local kernel-lock closure portion of #348 slice 5A3, remaining inert and uncalled by startup/cutover publication paths.

Exact-source basis:
- supported source tag `v0.7.2` is exact commit `09b7c2b3d48458700fa5ef121f798530892ff072`;
- that source pins the closed hashed lock-key families `task:<id>`, `send:<taskID>`, `project:<name>`, `worktree:<path>`, `config:routing`, `completions`, `migration`, and `schema`;
- exact provisioning holds `project:<name>` before Treehouse worktree allocation and throughout provisioning, so the pre-persistence allocation window remains discoverable;
- exact project add/create holds `project:<name>` before its authoritative DB read and across clone/init/Treehouse/registration external effects.

Scope:
- require a live landed 5A2 EXCLUSIVE/query-only source gate and retain its already-held `MigrationLock` rather than double-acquiring it;
- derive and nonblockingly acquire all source-provable task/send/project/worktree logical locks plus fixed hashed `config:routing`, `completions`, and `schema`;
- nonblockingly acquire `state/watch.pid.lock` and `data/projects.md.lock` using the same kernel file-lock primitive;
- enumerate and acquire every other existing permanent `state/.<64hex>.lock` rendezvous conservatively, including historical/unknown keys;
- reject symlink/non-regular pathname substitution and verify each held pathname still resolves to the opened file identity;
- re-enumerate the hashed namespace and fail closed if it changed during closure proof;
- retain all acquired locks until explicit `Close`, without unlinking rendezvous files.

Tests prove proactive derived locks, unknown retained hashed rendezvous, watcher/project-registry contention, child-lock lifetime vs parent MigrationLock, release behavior, and byte-identical source DB across the complete 5A3a lock operation.

Intentionally absent:
- no provider/Herdr/Treehouse/resource observation or semantic quiescence decision (5A3b);
- no archive candidate/promotion (5B);
- no frozen bridge, import, v19 target, publication, recovery, or startup activation;
- no user-global mechanism lock.

Canonical #344 DDL impact: **NONE**.

Refs #348 #305 #519 #530.