### PR TITLE
feat(runtime): prove v19 cutover Herdr quiescence

### DIFF
--- a/internal/runtime/cutover_herdr.go
+++ b/internal/runtime/cutover_herdr.go
@@ -1,0 +1,238 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/store"
+)
+
+var errLegacyV18CutoverHerdrUnsafe = errors.New("legacy v18 cutover Herdr state is not quiescent")
+
+type legacyV18CutoverHerdrBlocker struct {
+	Code    string
+	Subject string
+	Detail  string
+}
+
+type legacyV18CutoverHerdrBlockedError struct {
+	Blockers []legacyV18CutoverHerdrBlocker
+}
+
+func (e *legacyV18CutoverHerdrBlockedError) Error() string {
+	if e == nil || len(e.Blockers) == 0 {
+		return errLegacyV18CutoverHerdrUnsafe.Error()
+	}
+	parts := make([]string, 0, len(e.Blockers))
+	for _, blocker := range e.Blockers {
+		part := blocker.Code + " " + blocker.Subject
+		if blocker.Detail != "" {
+			part += ": " + blocker.Detail
+		}
+		parts = append(parts, part)
+	}
+	return errLegacyV18CutoverHerdrUnsafe.Error() + ": " + strings.Join(parts, "; ")
+}
+
+func (e *legacyV18CutoverHerdrBlockedError) Unwrap() error {
+	return errLegacyV18CutoverHerdrUnsafe
+}
+
+type legacyV18CutoverHerdrEvidence struct {
+	Sessions []herdr.SessionObservation
+}
+
+type legacyV18CutoverHerdrInventory interface {
+	WorkspaceList() ([]herdr.Workspace, error)
+	TabList(string) ([]herdr.Tab, error)
+	PaneGet(string) (herdr.Pane, error)
+}
+
+type legacyV18CutoverHerdrDeps struct {
+	observeSession func(context.Context, string) herdr.SessionObservation
+	inventoryFor   func(string) legacyV18CutoverHerdrInventory
+}
+
+func defaultLegacyV18CutoverHerdrDeps() legacyV18CutoverHerdrDeps {
+	return legacyV18CutoverHerdrDeps{
+		observeSession: func(ctx context.Context, session string) herdr.SessionObservation {
+			return herdr.NewManagedSessionClient(session).ObserveSession(ctx)
+		},
+		inventoryFor: func(session string) legacyV18CutoverHerdrInventory {
+			return newHerdrSessionClient(session)
+		},
+	}
+}
+
+func observeLegacyV18CutoverHerdr(ctx context.Context, guard *store.LegacyV18CutoverGuard) (legacyV18CutoverHerdrEvidence, error) {
+	if guard == nil {
+		return legacyV18CutoverHerdrEvidence{}, store.ErrLegacyV18CutoverGuardClosed
+	}
+	plan, err := guard.ObservationPlan()
+	if err != nil {
+		return legacyV18CutoverHerdrEvidence{}, fmt.Errorf("read held legacy v18 cutover observation plan: %w", err)
+	}
+	return observeLegacyV18CutoverHerdrPlan(ctx, plan, defaultLegacyV18CutoverHerdrDeps())
+}
+
+func observeLegacyV18CutoverHerdrPlan(ctx context.Context, plan store.LegacyV18CutoverObservationPlan, deps legacyV18CutoverHerdrDeps) (legacyV18CutoverHerdrEvidence, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if deps.observeSession == nil || deps.inventoryFor == nil {
+		return legacyV18CutoverHerdrEvidence{}, errors.New("legacy v18 cutover Herdr dependencies are incomplete")
+	}
+
+	currentSession := herdr.SessionName(plan.FleetID)
+	recordedBySession := map[string][]store.LegacyV18CutoverHerdrObservation{
+		currentSession: nil,
+		"default":      nil,
+	}
+	var blockers []legacyV18CutoverHerdrBlocker
+	addBlocker := func(code, subject, detail string) {
+		blockers = append(blockers, legacyV18CutoverHerdrBlocker{Code: code, Subject: subject, Detail: detail})
+	}
+	for _, recorded := range plan.Herdr {
+		session, ok := legacyV18CutoverHerdrSession(recorded.Session, currentSession)
+		if !ok {
+			addBlocker("herdr-recorded-session-unrecognized", fmt.Sprintf("attempt:%d", recorded.AttemptID), fmt.Sprintf("session=%q", recorded.Session))
+			continue
+		}
+		recordedBySession[session] = append(recordedBySession[session], recorded)
+	}
+
+	evidence := legacyV18CutoverHerdrEvidence{Sessions: make([]herdr.SessionObservation, 0, 2)}
+	for _, session := range []string{currentSession, "default"} {
+		if err := ctx.Err(); err != nil {
+			return legacyV18CutoverHerdrEvidence{}, err
+		}
+		observation := deps.observeSession(ctx, session)
+		evidence.Sessions = append(evidence.Sessions, observation)
+		if observation.Name != session {
+			addBlocker("herdr-session-identity-mismatch", "session:"+session, fmt.Sprintf("provider named %q", observation.Name))
+			continue
+		}
+		switch observation.State {
+		case herdr.SessionStopped:
+			continue
+		case herdr.SessionRunningCompatible:
+			observeLegacyV18CutoverHerdrRunningSession(session, currentSession, recordedBySession[session], deps.inventoryFor(session), addBlocker)
+		case herdr.SessionUnknown, herdr.SessionIncompatible:
+			addBlocker("herdr-session-unobservable", "session:"+session, fmt.Sprintf("state=%q reason=%q", observation.State, observation.Reason))
+		default:
+			addBlocker("herdr-session-unobservable", "session:"+session, fmt.Sprintf("state=%q", observation.State))
+		}
+	}
+
+	if len(blockers) != 0 {
+		sort.Slice(blockers, func(i, j int) bool {
+			if blockers[i].Code != blockers[j].Code {
+				return blockers[i].Code < blockers[j].Code
+			}
+			if blockers[i].Subject != blockers[j].Subject {
+				return blockers[i].Subject < blockers[j].Subject
+			}
+			return blockers[i].Detail < blockers[j].Detail
+		})
+		return legacyV18CutoverHerdrEvidence{}, &legacyV18CutoverHerdrBlockedError{Blockers: blockers}
+	}
+	return evidence, nil
+}
+
+func legacyV18CutoverHerdrSession(recorded, current string) (string, bool) {
+	if recorded == "" || recorded == "default" {
+		return "default", true
+	}
+	if recorded == current {
+		return current, true
+	}
+	return "", false
+}
+
+func observeLegacyV18CutoverHerdrRunningSession(session, currentSession string, recorded []store.LegacyV18CutoverHerdrObservation, inventory legacyV18CutoverHerdrInventory, addBlocker func(string, string, string)) {
+	if inventory == nil {
+		addBlocker("herdr-provider-unavailable", "session:"+session, "Herdr inventory client is unavailable")
+		return
+	}
+	workspaces, err := inventory.WorkspaceList()
+	if err != nil {
+		addBlocker("herdr-workspace-inventory-unobservable", "session:"+session, err.Error())
+		return
+	}
+
+	recordedWorkspaces := make(map[string][]store.LegacyV18CutoverHerdrObservation)
+	recordedTabs := make(map[string][]store.LegacyV18CutoverHerdrObservation)
+	for _, expected := range recorded {
+		recordedWorkspaces[expected.WorkspaceID] = append(recordedWorkspaces[expected.WorkspaceID], expected)
+		recordedTabs[expected.TabID] = append(recordedTabs[expected.TabID], expected)
+	}
+
+	workspaceIDs := make(map[string]struct{}, len(workspaces))
+	tabIDs := make(map[string]struct{})
+	for _, workspace := range workspaces {
+		workspaceSubject := "workspace:" + workspace.WorkspaceID
+		if workspace.WorkspaceID == "" {
+			addBlocker("herdr-workspace-identity-invalid", "session:"+session, fmt.Sprintf("label=%q has empty workspace_id", workspace.Label))
+			continue
+		}
+		if _, exists := workspaceIDs[workspace.WorkspaceID]; exists {
+			addBlocker("herdr-workspace-id-collision", workspaceSubject, "provider inventory returned the same workspace identity more than once")
+		} else {
+			workspaceIDs[workspace.WorkspaceID] = struct{}{}
+		}
+		if strings.HasPrefix(workspace.Label, "hand:") {
+			code := "herdr-current-hand-resource-live"
+			if session != currentSession {
+				code = "herdr-legacy-hand-resource-live"
+			}
+			addBlocker(code, workspaceSubject, fmt.Sprintf("label=%q", workspace.Label))
+		}
+		recordedWorkspace := recordedWorkspaces[workspace.WorkspaceID]
+		for _, expected := range recordedWorkspace {
+			addBlocker("herdr-recorded-workspace-live", fmt.Sprintf("attempt:%d", expected.AttemptID), fmt.Sprintf("session=%q workspace_id=%q label=%q", session, workspace.WorkspaceID, workspace.Label))
+		}
+		if !strings.HasPrefix(workspace.Label, "hand:") && len(recordedWorkspace) == 0 {
+			continue
+		}
+
+		tabs, err := inventory.TabList(workspace.WorkspaceID)
+		if err != nil {
+			addBlocker("herdr-tab-inventory-unobservable", workspaceSubject, err.Error())
+			continue
+		}
+		for _, tab := range tabs {
+			tabSubject := "tab:" + tab.TabID
+			if tab.TabID == "" {
+				addBlocker("herdr-tab-identity-invalid", workspaceSubject, fmt.Sprintf("label=%q has empty tab_id", tab.Label))
+				continue
+			}
+			if tab.WorkspaceID != workspace.WorkspaceID {
+				addBlocker("herdr-tab-workspace-mismatch", tabSubject, fmt.Sprintf("workspace_id=%q inventory_workspace_id=%q", tab.WorkspaceID, workspace.WorkspaceID))
+			}
+			if _, exists := tabIDs[tab.TabID]; exists {
+				addBlocker("herdr-tab-id-collision", tabSubject, "provider inventory returned the same tab identity more than once")
+			} else {
+				tabIDs[tab.TabID] = struct{}{}
+			}
+			for _, expected := range recordedTabs[tab.TabID] {
+				addBlocker("herdr-recorded-tab-live", fmt.Sprintf("attempt:%d", expected.AttemptID), fmt.Sprintf("session=%q tab_id=%q workspace_id=%q label=%q", session, tab.TabID, workspace.WorkspaceID, tab.Label))
+			}
+		}
+	}
+
+	for _, expected := range recorded {
+		pane, err := inventory.PaneGet(expected.PaneID)
+		if err != nil {
+			if isHerdrNotFound(err) {
+				continue
+			}
+			addBlocker("herdr-recorded-pane-unobservable", fmt.Sprintf("attempt:%d", expected.AttemptID), err.Error())
+			continue
+		}
+		addBlocker("herdr-recorded-pane-live", fmt.Sprintf("attempt:%d", expected.AttemptID), fmt.Sprintf("session=%q pane_id=%q tab_id=%q workspace_id=%q", session, pane.PaneID, pane.TabID, pane.WorkspaceID))
+	}
+}

--- a/internal/runtime/cutover_herdr_test.go
+++ b/internal/runtime/cutover_herdr_test.go
@@ -1,0 +1,289 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestObserveLegacyV18CutoverHerdrRejectsNilGuard(t *testing.T) {
+	if _, err := observeLegacyV18CutoverHerdr(context.Background(), nil); !errors.Is(err, store.ErrLegacyV18CutoverGuardClosed) {
+		t.Fatalf("nil guard observation = %v, want %v", err, store.ErrLegacyV18CutoverGuardClosed)
+	}
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanAllowsStoppedCurrentAndLegacySessions(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: "hand-f_self", WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TeardownState: "released",
+	}}
+
+	evidence, err := observeLegacyV18CutoverHerdrPlan(context.Background(), plan, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence.Sessions) != 2 || evidence.Sessions[0].State != herdr.SessionStopped || evidence.Sessions[1].State != herdr.SessionStopped {
+		t.Fatalf("evidence = %#v, want two stopped sessions", evidence)
+	}
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanAllowsUnrelatedResources(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current: {
+			workspaces: []herdr.Workspace{{WorkspaceID: "user-workspace", Label: "scratch"}},
+			tabs:       map[string][]herdr.Tab{"user-workspace": nil},
+		},
+		"default": {
+			workspaces: []herdr.Workspace{{WorkspaceID: "legacy-user-workspace", Label: "personal"}},
+			tabs:       map[string][]herdr.Tab{"legacy-user-workspace": nil},
+		},
+	})
+
+	if _, err := observeLegacyV18CutoverHerdrPlan(context.Background(), plan, deps); err != nil {
+		t.Fatalf("unrelated Herdr resources blocked cutover: %v", err)
+	}
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksCurrentHandWorkspace(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current: {
+			workspaces: []herdr.Workspace{{WorkspaceID: "workspace-1", Label: "hand:f_self:demo"}},
+			tabs:       map[string][]herdr.Tab{"workspace-1": nil},
+		},
+		"default": {},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-current-hand-resource-live")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksLegacyHandWorkspace(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current: {},
+		"default": {
+			workspaces: []herdr.Workspace{{WorkspaceID: "workspace-1", Label: "hand:demo"}},
+			tabs:       map[string][]herdr.Tab{"workspace-1": nil},
+		},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-legacy-hand-resource-live")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksRecordedWorkspaceAfterRename(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: current, WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TeardownState: "released",
+	}}
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current: {
+			workspaces: []herdr.Workspace{{WorkspaceID: "workspace-1", Label: "renamed"}},
+			tabs:       map[string][]herdr.Tab{"workspace-1": nil},
+		},
+		"default": {},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-recorded-workspace-live")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksRecordedTabAfterLabelRename(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: current, WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TeardownState: "abandoned",
+	}}
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current: {
+			workspaces: []herdr.Workspace{{WorkspaceID: "workspace-1", Label: "renamed"}},
+			tabs: map[string][]herdr.Tab{
+				"workspace-1": {{TabID: "tab-1", WorkspaceID: "workspace-1", Label: "renamed-tab"}},
+			},
+		},
+		"default": {},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-recorded-tab-live")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksRecordedPaneAfterRename(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: current, WorkspaceID: "old-workspace", TabID: "old-tab", PaneID: "pane-1", TeardownState: "released",
+	}}
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current: {
+			panes: map[string]herdr.Pane{
+				"pane-1": {PaneID: "pane-1", TabID: "new-tab", WorkspaceID: "new-workspace"},
+			},
+		},
+		"default": {},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-recorded-pane-live")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanAllowsAbsentRecordedIdentityInRunningSession(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: current, WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TeardownState: "released",
+	}}
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current:   {},
+		"default": {},
+	})
+
+	if _, err := observeLegacyV18CutoverHerdrPlan(context.Background(), plan, deps); err != nil {
+		t.Fatalf("absent recorded Herdr identity blocked cutover: %v", err)
+	}
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksUnknownSession(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	deps.observeSession = func(_ context.Context, session string) herdr.SessionObservation {
+		if session == current {
+			return herdr.SessionObservation{Name: session, State: herdr.SessionUnknown, Reason: "provider unavailable"}
+		}
+		return herdr.SessionObservation{Name: session, State: herdr.SessionStopped}
+	}
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-session-unobservable")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksUnrecognizedRecordedSession(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: "hand-f_other", WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TeardownState: "released",
+	}}
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-recorded-session-unrecognized")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksInventoryFailure(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current:   {workspaceErr: errors.New("malformed workspace response")},
+		"default": {},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-workspace-inventory-unobservable")
+}
+
+func TestObserveLegacyV18CutoverHerdrPlanBlocksRecordedPaneObservationFailure(t *testing.T) {
+	plan, deps := legacyV18CutoverHerdrFixture()
+	current := herdr.SessionName(plan.FleetID)
+	plan.Herdr = []store.LegacyV18CutoverHerdrObservation{{
+		TaskID: "task-1", AttemptID: 7, ProjectID: "project-1", ProjectName: "demo",
+		Session: current, WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TeardownState: "released",
+	}}
+	deps.observeSession = runningLegacyV18CutoverHerdrSession
+	deps.inventoryFor = legacyV18CutoverHerdrInventories(map[string]*fakeLegacyV18CutoverHerdrInventory{
+		current:   {paneErrors: map[string]error{"pane-1": errors.New("provider unavailable")}},
+		"default": {},
+	})
+
+	requireLegacyV18CutoverHerdrBlocker(t, plan, deps, "herdr-recorded-pane-unobservable")
+}
+
+func legacyV18CutoverHerdrFixture() (store.LegacyV18CutoverObservationPlan, legacyV18CutoverHerdrDeps) {
+	plan := store.LegacyV18CutoverObservationPlan{FleetID: "f_self"}
+	deps := legacyV18CutoverHerdrDeps{
+		observeSession: func(_ context.Context, session string) herdr.SessionObservation {
+			return herdr.SessionObservation{Name: session, State: herdr.SessionStopped}
+		},
+		inventoryFor: func(string) legacyV18CutoverHerdrInventory {
+			return nil
+		},
+	}
+	return plan, deps
+}
+
+func runningLegacyV18CutoverHerdrSession(_ context.Context, session string) herdr.SessionObservation {
+	return herdr.SessionObservation{Name: session, State: herdr.SessionRunningCompatible}
+}
+
+func legacyV18CutoverHerdrInventories(inventories map[string]*fakeLegacyV18CutoverHerdrInventory) func(string) legacyV18CutoverHerdrInventory {
+	return func(session string) legacyV18CutoverHerdrInventory {
+		return inventories[session]
+	}
+}
+
+type fakeLegacyV18CutoverHerdrInventory struct {
+	workspaces   []herdr.Workspace
+	workspaceErr error
+	tabs         map[string][]herdr.Tab
+	tabErrors    map[string]error
+	panes        map[string]herdr.Pane
+	paneErrors   map[string]error
+}
+
+func (f *fakeLegacyV18CutoverHerdrInventory) WorkspaceList() ([]herdr.Workspace, error) {
+	if f == nil {
+		return nil, errors.New("nil Herdr inventory")
+	}
+	return append([]herdr.Workspace(nil), f.workspaces...), f.workspaceErr
+}
+
+func (f *fakeLegacyV18CutoverHerdrInventory) TabList(workspaceID string) ([]herdr.Tab, error) {
+	if err := f.tabErrors[workspaceID]; err != nil {
+		return nil, err
+	}
+	return append([]herdr.Tab(nil), f.tabs[workspaceID]...), nil
+}
+
+func (f *fakeLegacyV18CutoverHerdrInventory) PaneGet(paneID string) (herdr.Pane, error) {
+	if err := f.paneErrors[paneID]; err != nil {
+		return herdr.Pane{}, err
+	}
+	if pane, ok := f.panes[paneID]; ok {
+		return pane, nil
+	}
+	return herdr.Pane{}, fmt.Errorf("pane %s: %w", paneID, herdr.ErrNotFound)
+}
+
+func requireLegacyV18CutoverHerdrBlocker(t *testing.T, plan store.LegacyV18CutoverObservationPlan, deps legacyV18CutoverHerdrDeps, code string) {
+	t.Helper()
+	_, err := observeLegacyV18CutoverHerdrPlan(context.Background(), plan, deps)
+	if err == nil {
+		t.Fatalf("want blocker %q, got nil", code)
+	}
+	if !errors.Is(err, errLegacyV18CutoverHerdrUnsafe) {
+		t.Fatalf("error = %v, want %v", err, errLegacyV18CutoverHerdrUnsafe)
+	}
+	var blocked *legacyV18CutoverHerdrBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error = %T %v, want *legacyV18CutoverHerdrBlockedError", err, err)
+	}
+	for _, blocker := range blocked.Blockers {
+		if blocker.Code == code {
+			return
+		}
+	}
+	t.Fatalf("blockers = %#v, want code %q", blocked.Blockers, code)
+}


### PR DESCRIPTION
Implements v19 cutover slice 5A3d from fresh `main` after #534.

- observes the exact current Fleet Herdr session and shared legacy/default session without taking user-global destructive locks
- treats stopped sessions as positive absence; unknown/incompatible/provider failures fail closed
- blocks live `hand:` workspace state in the current Fleet namespace and ambiguous legacy/default namespace
- rechecks durable workspace/tab/pane identities even after labels are renamed, so released/abandoned records do not authorize forgetting a live or reused provider identity
- rejects unrecognized recorded session identity and provider identity collisions
- observation-only; does not close panes/workspaces or activate automatic cutover

Canonical #344 DDL impact: **NONE**.

Refs #348, #519.