### PR TITLE
feat(store): stage deterministic v19 cutover archive candidate

### DIFF
--- a/internal/store/cutoverarchive.go
+++ b/internal/store/cutoverarchive.go
@@ -21,9 +21,8 @@ type legacyV18CutoverArchiveCandidate struct {
 	SHA256      string
 }
 
-// legacyV18CutoverMigrationIdentity is the versioned deterministic identity for one
-// exact legacy source. The digest input is the lowercase hex SHA-256 of the original
-// pre-freeze database bytes, not any later frozen-bridge digest.
+// This versioned deterministic identity binds one exact Fleet to the original
+// pre-freeze database bytes, never to a later frozen-bridge digest.
 func legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256 string) (string, error) {
 	if err := validateFleetID(fleetID); err != nil {
 		return "", fmt.Errorf("derive legacy v18 cutover migration identity: %w", err)

--- a/internal/store/cutoverarchive.go
+++ b/internal/store/cutoverarchive.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	legacyV18CutoverMigrationIdentityVersion = "v1"
+	legacyV18CutoverMigrationIdentityDomain  = "hand:v19-cutover:migration:v1"
+)
+
+type legacyV18CutoverArchiveCandidate struct {
+	MigrationID string
+	Path        string
+	SHA256      string
+}
+
+// legacyV18CutoverMigrationIdentity is the versioned deterministic identity for one
+// exact legacy source. The digest input is the lowercase hex SHA-256 of the original
+// pre-freeze database bytes, not any later frozen-bridge digest.
+func legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256 string) (string, error) {
+	if err := validateFleetID(fleetID); err != nil {
+		return "", fmt.Errorf("derive legacy v18 cutover migration identity: %w", err)
+	}
+	if err := validateLegacyV18CutoverSHA256(sourceSHA256); err != nil {
+		return "", fmt.Errorf("derive legacy v18 cutover migration identity: %w", err)
+	}
+	payload := legacyV18CutoverMigrationIdentityDomain + "\x00" + fleetID + "\x00" + sourceSHA256
+	sum := sha256.Sum256([]byte(payload))
+	return legacyV18CutoverMigrationIdentityVersion + "-" + hex.EncodeToString(sum[:]), nil
+}
+
+func validateLegacyV18CutoverSHA256(value string) error {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return fmt.Errorf("source SHA-256 must be exactly 64 lowercase hex characters")
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("source SHA-256 is not hexadecimal: %w", err)
+	}
+	return nil
+}
+
+func legacyV18CutoverFleetID(q sqliteQueryer) (string, error) {
+	var singleton int
+	var fleetID string
+	if err := q.QueryRow(`SELECT singleton, fleet_id FROM fleet_identity`).Scan(&singleton, &fleetID); err != nil {
+		return "", fmt.Errorf("read legacy v18 Fleet identity for cutover archive: %w", err)
+	}
+	if singleton != 1 {
+		return "", fmt.Errorf("read legacy v18 Fleet identity for cutover archive: singleton=%d, want 1", singleton)
+	}
+	if err := validateFleetID(fleetID); err != nil {
+		return "", fmt.Errorf("read legacy v18 Fleet identity for cutover archive: %w", err)
+	}
+	return fleetID, nil
+}
+
+func legacyV18CutoverArchiveCandidatePath(homeDir, migrationID string) string {
+	return filepath.Join(homeDir, "state", ".v19-cutover-"+migrationID+"-original.db.candidate")
+}
+
+func prepareLegacyV18CutoverArchiveCandidate(homeDir, fleetID, sourceSHA256 string) (legacyV18CutoverArchiveCandidate, error) {
+	migrationID, err := legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256)
+	if err != nil {
+		return legacyV18CutoverArchiveCandidate{}, err
+	}
+	candidate := legacyV18CutoverArchiveCandidate{
+		MigrationID: migrationID,
+		Path:        legacyV18CutoverArchiveCandidatePath(homeDir, migrationID),
+		SHA256:      sourceSHA256,
+	}
+	if err := writeLegacyV18CutoverArchiveCandidate(Path(homeDir), candidate.Path, sourceSHA256); err != nil {
+		return legacyV18CutoverArchiveCandidate{}, err
+	}
+	return candidate, nil
+}
+
+func writeLegacyV18CutoverArchiveCandidate(sourcePath, candidatePath, expectedSHA256 string) error {
+	if err := validateLegacyV18CutoverSHA256(expectedSHA256); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(candidatePath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("legacy v18 cutover archive candidate %s is not a direct regular file", candidatePath)
+		}
+		digest, err := legacyV18CutoverFileSHA256(candidatePath)
+		if err != nil {
+			return fmt.Errorf("hash existing legacy v18 cutover archive candidate: %w", err)
+		}
+		if digest == expectedSHA256 {
+			return nil
+		}
+		if err := os.Remove(candidatePath); err != nil {
+			return fmt.Errorf("discard mismatched legacy v18 cutover archive candidate: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect legacy v18 cutover archive candidate: %w", err)
+	}
+
+	input, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open legacy v18 cutover source for archive candidate: %w", err)
+	}
+	defer func() { _ = input.Close() }()
+	output, err := os.OpenFile(candidatePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create legacy v18 cutover archive candidate: %w", err)
+	}
+	keep := false
+	closed := false
+	defer func() {
+		if !closed {
+			_ = output.Close()
+		}
+		if !keep {
+			_ = os.Remove(candidatePath)
+		}
+	}()
+	if _, err := io.Copy(output, input); err != nil {
+		return fmt.Errorf("copy legacy v18 cutover archive candidate: %w", err)
+	}
+	if err := output.Sync(); err != nil {
+		return fmt.Errorf("flush legacy v18 cutover archive candidate: %w", err)
+	}
+	if err := output.Close(); err != nil {
+		closed = true
+		return fmt.Errorf("close legacy v18 cutover archive candidate: %w", err)
+	}
+	closed = true
+
+	digest, err := legacyV18CutoverFileSHA256(candidatePath)
+	if err != nil {
+		return fmt.Errorf("reopen and hash legacy v18 cutover archive candidate: %w", err)
+	}
+	if digest != expectedSHA256 {
+		return fmt.Errorf("legacy v18 cutover archive candidate digest = %s, want %s", digest, expectedSHA256)
+	}
+	keep = true
+	return nil
+}

--- a/internal/store/cutoverarchive_test.go
+++ b/internal/store/cutoverarchive_test.go
@@ -120,6 +120,41 @@ func TestAcquireLegacyV18CutoverGateReusesExactCandidateAfterFreshGateProof(t *t
 	}
 }
 
+func TestWriteLegacyV18CutoverArchiveCandidateRebuildsMismatchedExistingCandidate(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourcePath := Path(home)
+	sourceDigest, err := legacyV18CutoverFileSHA256(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePath := filepath.Join(filepath.Dir(sourcePath), "candidate")
+	if err := os.WriteFile(candidatePath, []byte("corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(candidatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeLegacyV18CutoverArchiveCandidate(sourcePath, candidatePath, sourceDigest); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(candidatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(before, after) {
+		t.Fatal("mismatched archive candidate was retained instead of rebuilt")
+	}
+	gotDigest, err := legacyV18CutoverFileSHA256(candidatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDigest != sourceDigest {
+		t.Fatalf("rebuilt archive candidate digest = %s, want %s", gotDigest, sourceDigest)
+	}
+}
+
 func TestWriteLegacyV18CutoverArchiveCandidateRefusesNonRegularExistingPath(t *testing.T) {
 	home := createLegacyV18CutoverTestSource(t)
 	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))

--- a/internal/store/cutoverarchive_test.go
+++ b/internal/store/cutoverarchive_test.go
@@ -123,6 +123,10 @@ func TestAcquireLegacyV18CutoverGateReusesExactCandidateAfterFreshGateProof(t *t
 func TestWriteLegacyV18CutoverArchiveCandidateRebuildsMismatchedExistingCandidate(t *testing.T) {
 	home := createLegacyV18CutoverTestSource(t)
 	sourcePath := Path(home)
+	sourceBytes, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	sourceDigest, err := legacyV18CutoverFileSHA256(sourcePath)
 	if err != nil {
 		t.Fatal(err)
@@ -131,20 +135,16 @@ func TestWriteLegacyV18CutoverArchiveCandidateRebuildsMismatchedExistingCandidat
 	if err := os.WriteFile(candidatePath, []byte("corrupt"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	before, err := os.Stat(candidatePath)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	if err := writeLegacyV18CutoverArchiveCandidate(sourcePath, candidatePath, sourceDigest); err != nil {
 		t.Fatal(err)
 	}
-	after, err := os.Stat(candidatePath)
+	candidateBytes, err := os.ReadFile(candidatePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if os.SameFile(before, after) {
-		t.Fatal("mismatched archive candidate was retained instead of rebuilt")
+	if !bytes.Equal(candidateBytes, sourceBytes) {
+		t.Fatal("rebuilt archive candidate bytes differ from exact source bytes")
 	}
 	gotDigest, err := legacyV18CutoverFileSHA256(candidatePath)
 	if err != nil {

--- a/internal/store/cutoverarchive_test.go
+++ b/internal/store/cutoverarchive_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLegacyV18CutoverMigrationIdentityIsVersionedAndDeterministic(t *testing.T) {
+	fleetID := "f_" + strings.Repeat("0", 31) + "1"
+	sourceSHA256 := strings.Repeat("a", 64)
+	got, err := legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "v1-84d789c3053f5ae2f0ab22460102d715abc74416726bb5ebd3119e1035904e7e"
+	if got != want {
+		t.Fatalf("migration identity = %q, want %q", got, want)
+	}
+	again, err := legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != got {
+		t.Fatalf("migration identity changed across identical inputs: first=%q second=%q", got, again)
+	}
+	if _, err := legacyV18CutoverMigrationIdentity(fleetID, strings.Repeat("A", 64)); err == nil {
+		t.Fatal("uppercase source digest was accepted")
+	}
+}
+
+func TestAcquireLegacyV18CutoverGateStagesExactNonAuthoritativeArchiveCandidate(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	sourceBytes, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+	if gate.archiveCandidate.Path == "" || gate.archiveCandidate.MigrationID == "" {
+		t.Fatalf("archive candidate = %#v, want deterministic identity and path", gate.archiveCandidate)
+	}
+	if gate.archiveCandidate.SHA256 != sourceDigest {
+		t.Fatalf("archive candidate digest = %s, want %s", gate.archiveCandidate.SHA256, sourceDigest)
+	}
+	if filepath.Dir(gate.archiveCandidate.Path) != filepath.Dir(Path(home)) {
+		t.Fatalf("archive candidate path = %q, want sibling of active DB %q", gate.archiveCandidate.Path, Path(home))
+	}
+	candidateBytes, err := os.ReadFile(gate.archiveCandidate.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(candidateBytes, sourceBytes) {
+		t.Fatal("archive candidate bytes differ from exact pre-freeze source bytes")
+	}
+	candidateDigest, err := legacyV18CutoverFileSHA256(gate.archiveCandidate.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidateDigest != sourceDigest {
+		t.Fatalf("archive candidate rehash = %s, want %s", candidateDigest, sourceDigest)
+	}
+	fleetID, err := legacyV18CutoverFleetID(sqliteConnQueryer{ctx: context.Background(), conn: gate.conn})
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationID, err := legacyV18CutoverMigrationIdentity(fleetID, sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gate.archiveCandidate.MigrationID != migrationID || gate.archiveCandidate.Path != legacyV18CutoverArchiveCandidatePath(home, migrationID) {
+		t.Fatalf("archive candidate = %#v, want migration_id=%q deterministic path", gate.archiveCandidate, migrationID)
+	}
+}
+
+func TestAcquireLegacyV18CutoverGateReusesExactCandidateAfterFreshGateProof(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+
+	first, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePath := first.archiveCandidate.Path
+	before, err := os.Stat(candidatePath)
+	if err != nil {
+		_ = first.Close()
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = second.Close() }()
+	if second.archiveCandidate.Path != candidatePath {
+		t.Fatalf("candidate path changed across fresh gate proof: first=%q second=%q", candidatePath, second.archiveCandidate.Path)
+	}
+	after, err := os.Stat(candidatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("exact archive candidate was replaced instead of reused")
+	}
+}
+
+func TestWriteLegacyV18CutoverArchiveCandidateRefusesNonRegularExistingPath(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePath := filepath.Join(filepath.Dir(Path(home)), "candidate")
+	if err := os.Mkdir(candidatePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLegacyV18CutoverArchiveCandidate(Path(home), candidatePath, sourceDigest); err == nil || !strings.Contains(err.Error(), "direct regular file") {
+		t.Fatalf("non-regular candidate error = %v, want direct regular file refusal", err)
+	}
+}

--- a/internal/store/cutovergate.go
+++ b/internal/store/cutovergate.go
@@ -20,6 +20,7 @@ const (
 type legacyV18CutoverGate struct {
 	info             SchemaInfo
 	sourceSHA256     string
+	archiveCandidate legacyV18CutoverArchiveCandidate
 	db               *sql.DB
 	conn             *sql.Conn
 	releaseMigration func()
@@ -83,6 +84,10 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 	if err != nil {
 		return nil, fmt.Errorf("validate legacy v18 cutover SHARED snapshot: %w", err)
 	}
+	fleetID, err := legacyV18CutoverFleetID(readTx)
+	if err != nil {
+		return nil, err
+	}
 	candidateDigest, err := legacyV18CutoverFileSHA256(path)
 	if err != nil {
 		return nil, fmt.Errorf("hash legacy v18 cutover SHARED source: %w", err)
@@ -130,6 +135,23 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 		<-exclusive
 		return nil, fmt.Errorf("legacy v18 cutover source changed under SHARED reader barrier: candidate=%s barrier=%s", candidateDigest, barrierDigest)
 	}
+	archiveCandidate, err := prepareLegacyV18CutoverArchiveCandidate(homeDir, fleetID, candidateDigest)
+	if err != nil {
+		handoffCancel()
+		<-exclusive
+		return nil, fmt.Errorf("prepare legacy v18 cutover archive candidate under reader barrier: %w", err)
+	}
+	barrierPostArchiveDigest, err := legacyV18CutoverFileSHA256(path)
+	if err != nil {
+		handoffCancel()
+		<-exclusive
+		return nil, fmt.Errorf("rehash legacy v18 source after archive candidate: %w", err)
+	}
+	if barrierPostArchiveDigest != candidateDigest {
+		handoffCancel()
+		<-exclusive
+		return nil, fmt.Errorf("legacy v18 cutover source changed while archive candidate was written: candidate=%s post_archive=%s", candidateDigest, barrierPostArchiveDigest)
+	}
 
 	if err := readTx.Rollback(); err != nil {
 		handoffCancel()
@@ -173,12 +195,16 @@ func acquireLegacyV18CutoverGateWithTimeout(parent context.Context, homeDir stri
 	if postDigest != candidateDigest {
 		return nil, fmt.Errorf("legacy v18 cutover source changed across EXCLUSIVE handoff: candidate=%s post=%s", candidateDigest, postDigest)
 	}
+	if archiveCandidate.SHA256 != postDigest {
+		return nil, fmt.Errorf("legacy v18 cutover archive candidate digest = %s, source under EXCLUSIVE = %s", archiveCandidate.SHA256, postDigest)
+	}
 
 	gateOpen = false
 	releaseOnError = false
 	return &legacyV18CutoverGate{
 		info:             postInfo,
 		sourceSHA256:     postDigest,
+		archiveCandidate: archiveCandidate,
 		db:               gateDB,
 		conn:             gateConn,
 		releaseMigration: releaseMigration,


### PR DESCRIPTION
Implements the first 5B cutover archive slice from fresh `main` after #536.

- derives a documented versioned migration identity from exact Fleet ID + exact pre-freeze source SHA-256
- uses a deterministic same-volume non-authoritative archive-candidate path beside `state/hand.db`
- writes, flushes, reopens, and rehashes the candidate while the known SHARED snapshot + observed reader barrier are still held
- rehashes the active source again before releasing SHARED
- reuses only an exact matching prior candidate after a fresh gate proof; mismatched exact candidate files are discarded and rebuilt
- refuses non-regular candidate paths
- carries the candidate digest through OUR EXCLUSIVE revalidation but does not promote it to original/archive authority

Promotion to immutable original evidence, provider-closure composition, manifest/import-plan publication, frozen bridge, and v19 target construction remain downstream 5B/5C work.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.