### PR TITLE
feat(runtime): freeze v19 cutover Project manifest evidence

### DIFF
--- a/internal/runtime/cutover_project_manifest.go
+++ b/internal/runtime/cutover_project_manifest.go
@@ -1,0 +1,210 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	gitrepo "github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/store"
+)
+
+type legacyV18CutoverProjectManifestEvidence struct {
+	ProjectID           string
+	Locator             string
+	RepositoryPhysicalID string
+	CommonDirPhysicalID string
+	Revision            string
+	LegacyName          string
+	LegacyURL           string
+	LegacyMode          string
+	LegacyUpstream      string
+}
+
+type legacyV18CutoverProjectManifestDeps struct {
+	resolveRoot      func(string) (string, error)
+	commonDir        func(string) (string, error)
+	isBare           func(string) (bool, error)
+	headCommit       func(string) (string, error)
+	physicalIdentity func(string, os.FileInfo) (string, error)
+}
+
+func defaultLegacyV18CutoverProjectManifestDeps() legacyV18CutoverProjectManifestDeps {
+	return legacyV18CutoverProjectManifestDeps{
+		resolveRoot:      gitrepo.ResolveRoot,
+		commonDir:        gitrepo.CommonDir,
+		isBare:           gitrepo.IsBare,
+		headCommit:       gitrepo.HeadCommit,
+		physicalIdentity: legacyV18CutoverPhysicalIdentity,
+	}
+}
+
+func buildLegacyV18CutoverProjectManifestEvidence(homeDir string, plan store.LegacyV18CutoverObservationPlan, observed legacyV18CutoverProjectTreehouseEvidence) ([]legacyV18CutoverProjectManifestEvidence, error) {
+	return buildLegacyV18CutoverProjectManifestEvidenceWithDeps(homeDir, plan, observed, defaultLegacyV18CutoverProjectManifestDeps())
+}
+
+func buildLegacyV18CutoverProjectManifestEvidenceWithDeps(homeDir string, plan store.LegacyV18CutoverObservationPlan, observed legacyV18CutoverProjectTreehouseEvidence, deps legacyV18CutoverProjectManifestDeps) ([]legacyV18CutoverProjectManifestEvidence, error) {
+	if err := validateLegacyV18CutoverProjectManifestDeps(deps); err != nil {
+		return nil, err
+	}
+	planByID := make(map[string]store.LegacyV18CutoverProjectObservation, len(plan.Projects))
+	for _, project := range plan.Projects {
+		if _, exists := planByID[project.ProjectID]; exists {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: duplicate source Project identity %q", project.ProjectID)
+		}
+		planByID[project.ProjectID] = project
+	}
+
+	type capturedProject struct {
+		cloneInfo  os.FileInfo
+		commonInfo os.FileInfo
+		evidence   legacyV18CutoverProjectManifestEvidence
+	}
+	captured := make([]capturedProject, 0, len(observed.Projects))
+	seen := make(map[string]struct{}, len(observed.Projects))
+	for _, prior := range observed.Projects {
+		project, ok := planByID[prior.ProjectID]
+		if !ok {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: observed Project %q is absent from held source plan", prior.ProjectID)
+		}
+		if _, duplicate := seen[prior.ProjectID]; duplicate {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: duplicate observed Project identity %q", prior.ProjectID)
+		}
+		seen[prior.ProjectID] = struct{}{}
+		locator, err := legacyV18CutoverProjectLocator(homeDir, project)
+		if err != nil {
+			return nil, err
+		}
+		if !gitrepo.SamePath(prior.ClonePath, project.ClonePath) {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q clone path changed from %q to %q", project.ProjectID, prior.ClonePath, project.ClonePath)
+		}
+
+		cloneInfo, err := os.Lstat(project.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: stat Project %q clone: %w", project.ProjectID, err)
+		}
+		if cloneInfo.Mode()&os.ModeSymlink != 0 || !cloneInfo.IsDir() {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q clone is not a direct directory", project.ProjectID)
+		}
+		root, err := deps.resolveRoot(project.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: resolve Project %q Git root: %w", project.ProjectID, err)
+		}
+		if !gitrepo.SamePath(root, project.ClonePath) {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q Git root=%q clone=%q", project.ProjectID, root, project.ClonePath)
+		}
+		bare, err := deps.isBare(project.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: inspect Project %q Git repository: %w", project.ProjectID, err)
+		}
+		if bare {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q repository is bare", project.ProjectID)
+		}
+		common, err := deps.commonDir(project.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: resolve Project %q Git common-dir: %w", project.ProjectID, err)
+		}
+		expectedCommon := filepath.Join(project.ClonePath, ".git")
+		if !gitrepo.SamePath(common, expectedCommon) || !gitrepo.SamePath(common, prior.CommonDir) {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q common-dir=%q expected=%q observed=%q", project.ProjectID, common, expectedCommon, prior.CommonDir)
+		}
+		commonInfo, err := os.Lstat(common)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: stat Project %q Git common-dir: %w", project.ProjectID, err)
+		}
+		if commonInfo.Mode()&os.ModeSymlink != 0 || !commonInfo.IsDir() {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q Git common-dir is not a direct directory", project.ProjectID)
+		}
+
+		revision, err := deps.headCommit(project.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: read Project %q HEAD: %w", project.ProjectID, err)
+		}
+		if revision != prior.Revision || !validLegacyV18CutoverGitObjectID(revision) {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q HEAD=%q observed=%q", project.ProjectID, revision, prior.Revision)
+		}
+		repositoryPhysicalID, err := deps.physicalIdentity(project.ClonePath, cloneInfo)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: read Project %q repository physical identity: %w", project.ProjectID, err)
+		}
+		commonDirPhysicalID, err := deps.physicalIdentity(common, commonInfo)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: read Project %q common-dir physical identity: %w", project.ProjectID, err)
+		}
+		again, err := deps.headCommit(project.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: re-read Project %q HEAD: %w", project.ProjectID, err)
+		}
+		if again != revision {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q HEAD changed during evidence capture: first=%q second=%q", project.ProjectID, revision, again)
+		}
+		cloneAfter, err := os.Lstat(project.ClonePath)
+		if err != nil || !os.SameFile(cloneInfo, cloneAfter) {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q repository identity changed during evidence capture", project.ProjectID)
+		}
+		commonAfter, err := os.Lstat(common)
+		if err != nil || !os.SameFile(commonInfo, commonAfter) {
+			return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q common-dir identity changed during evidence capture", project.ProjectID)
+		}
+
+		captured = append(captured, capturedProject{
+			cloneInfo:  cloneInfo,
+			commonInfo: commonInfo,
+			evidence: legacyV18CutoverProjectManifestEvidence{
+				ProjectID:            project.ProjectID,
+				Locator:              locator,
+				RepositoryPhysicalID: repositoryPhysicalID,
+				CommonDirPhysicalID:  commonDirPhysicalID,
+				Revision:             revision,
+				LegacyName:           project.Name,
+				LegacyURL:            project.URL,
+				LegacyMode:           project.Mode,
+				LegacyUpstream:       project.Upstream,
+			},
+		})
+	}
+	if len(seen) != len(planByID) {
+		missing := make([]string, 0, len(planByID)-len(seen))
+		for projectID := range planByID {
+			if _, ok := seen[projectID]; !ok {
+				missing = append(missing, projectID)
+			}
+		}
+		sort.Strings(missing)
+		return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: held source Projects missing provider evidence: %v", missing)
+	}
+	for i := range captured {
+		for j := i + 1; j < len(captured); j++ {
+			if os.SameFile(captured[i].cloneInfo, captured[j].cloneInfo) || os.SameFile(captured[i].commonInfo, captured[j].commonInfo) {
+				return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: physical repository alias between %q and %q", captured[i].evidence.ProjectID, captured[j].evidence.ProjectID)
+			}
+		}
+	}
+
+	result := make([]legacyV18CutoverProjectManifestEvidence, 0, len(captured))
+	for _, project := range captured {
+		result = append(result, project.evidence)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ProjectID < result[j].ProjectID })
+	return result, nil
+}
+
+func legacyV18CutoverProjectLocator(homeDir string, project store.LegacyV18CutoverProjectObservation) (string, error) {
+	relative, err := filepath.Rel(homeDir, project.ClonePath)
+	if err != nil {
+		return "", fmt.Errorf("freeze legacy v18 cutover Project evidence: derive Project %q Fleet-relative locator: %w", project.ProjectID, err)
+	}
+	expected := filepath.Join("projects", project.Name)
+	if filepath.IsAbs(relative) || filepath.Clean(relative) != filepath.Clean(expected) {
+		return "", fmt.Errorf("freeze legacy v18 cutover Project evidence: Project %q clone %q is not canonical Fleet-relative %q", project.ProjectID, project.ClonePath, expected)
+	}
+	return filepath.ToSlash(expected), nil
+}
+
+func validateLegacyV18CutoverProjectManifestDeps(deps legacyV18CutoverProjectManifestDeps) error {
+	if deps.resolveRoot == nil || deps.commonDir == nil || deps.isBare == nil || deps.headCommit == nil || deps.physicalIdentity == nil {
+		return fmt.Errorf("legacy v18 cutover Project manifest dependencies are incomplete")
+	}
+	return nil
+}

--- a/internal/runtime/cutover_project_manifest.go
+++ b/internal/runtime/cutover_project_manifest.go
@@ -30,20 +30,6 @@ type legacyV18CutoverProjectManifestDeps struct {
 	physicalIdentity func(string, os.FileInfo) (string, error)
 }
 
-func defaultLegacyV18CutoverProjectManifestDeps() legacyV18CutoverProjectManifestDeps {
-	return legacyV18CutoverProjectManifestDeps{
-		resolveRoot:      gitrepo.ResolveRoot,
-		commonDir:        gitrepo.CommonDir,
-		isBare:           gitrepo.IsBare,
-		headCommit:       gitrepo.HeadCommit,
-		physicalIdentity: legacyV18CutoverPhysicalIdentity,
-	}
-}
-
-func buildLegacyV18CutoverProjectManifestEvidence(homeDir string, plan store.LegacyV18CutoverObservationPlan, observed legacyV18CutoverProjectTreehouseEvidence) ([]legacyV18CutoverProjectManifestEvidence, error) {
-	return buildLegacyV18CutoverProjectManifestEvidenceWithDeps(homeDir, plan, observed, defaultLegacyV18CutoverProjectManifestDeps())
-}
-
 func buildLegacyV18CutoverProjectManifestEvidenceWithDeps(homeDir string, plan store.LegacyV18CutoverObservationPlan, observed legacyV18CutoverProjectTreehouseEvidence, deps legacyV18CutoverProjectManifestDeps) ([]legacyV18CutoverProjectManifestEvidence, error) {
 	if err := validateLegacyV18CutoverProjectManifestDeps(deps); err != nil {
 		return nil, err
@@ -176,7 +162,10 @@ func buildLegacyV18CutoverProjectManifestEvidenceWithDeps(homeDir string, plan s
 	}
 	for i := range captured {
 		for j := i + 1; j < len(captured); j++ {
-			if os.SameFile(captured[i].cloneInfo, captured[j].cloneInfo) || os.SameFile(captured[i].commonInfo, captured[j].commonInfo) {
+			if os.SameFile(captured[i].cloneInfo, captured[j].cloneInfo) ||
+				os.SameFile(captured[i].cloneInfo, captured[j].commonInfo) ||
+				os.SameFile(captured[i].commonInfo, captured[j].cloneInfo) ||
+				os.SameFile(captured[i].commonInfo, captured[j].commonInfo) {
 				return nil, fmt.Errorf("freeze legacy v18 cutover Project evidence: physical repository alias between %q and %q", captured[i].evidence.ProjectID, captured[j].evidence.ProjectID)
 			}
 		}

--- a/internal/runtime/cutover_project_manifest.go
+++ b/internal/runtime/cutover_project_manifest.go
@@ -11,15 +11,15 @@ import (
 )
 
 type legacyV18CutoverProjectManifestEvidence struct {
-	ProjectID           string
-	Locator             string
+	ProjectID            string
+	Locator              string
 	RepositoryPhysicalID string
-	CommonDirPhysicalID string
-	Revision            string
-	LegacyName          string
-	LegacyURL           string
-	LegacyMode          string
-	LegacyUpstream      string
+	CommonDirPhysicalID  string
+	Revision             string
+	LegacyName           string
+	LegacyURL            string
+	LegacyMode           string
+	LegacyUpstream       string
 }
 
 type legacyV18CutoverProjectManifestDeps struct {

--- a/internal/runtime/cutover_project_manifest_test.go
+++ b/internal/runtime/cutover_project_manifest_test.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestBuildLegacyV18CutoverProjectManifestEvidenceCapturesVerifiedProjectFacts(t *testing.T) {
+	home, clone, plan, observerDeps := legacyV18CutoverProjectTreehouseFixture(t)
+	plan.Projects[0].URL = "https://example.invalid/demo.git"
+	plan.Projects[0].Mode = "clone"
+	plan.Projects[0].Upstream = "origin/main"
+	observed, err := observeLegacyV18CutoverProjectTreehousePlan(context.Background(), home, plan, observerDeps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := buildLegacyV18CutoverProjectManifestEvidenceWithDeps(home, plan, observed, legacyV18CutoverProjectManifestTestDeps(observerDeps))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("manifest Project evidence = %#v, want one Project", got)
+	}
+	project := got[0]
+	if project.ProjectID != "project-1" || project.Locator != "projects/demo" || project.Revision != strings.Repeat("a", 40) {
+		t.Fatalf("manifest Project identity evidence = %#v", project)
+	}
+	if project.RepositoryPhysicalID == "" || project.CommonDirPhysicalID == "" {
+		t.Fatalf("manifest Project physical evidence = %#v, want repository and common-dir identities", project)
+	}
+	if strings.Contains(project.RepositoryPhysicalID, clone) || strings.Contains(project.CommonDirPhysicalID, clone) {
+		t.Fatalf("physical identity leaked absolute path: %#v", project)
+	}
+	if project.LegacyName != "demo" || project.LegacyURL != "https://example.invalid/demo.git" || project.LegacyMode != "clone" || project.LegacyUpstream != "origin/main" {
+		t.Fatalf("legacy provenance evidence = %#v", project)
+	}
+}
+
+func TestLegacyV18CutoverPhysicalIdentityIsStableForObservedDirectory(t *testing.T) {
+	home, clone, _, _ := legacyV18CutoverProjectTreehouseFixture(t)
+	_ = home
+	info, err := os.Lstat(clone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := legacyV18CutoverPhysicalIdentity(clone, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := legacyV18CutoverPhysicalIdentity(clone, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == "" || second != first {
+		t.Fatalf("physical identity first=%q second=%q, want stable non-empty identity", first, second)
+	}
+}
+
+func TestBuildLegacyV18CutoverProjectManifestEvidenceRejectsMissingProviderEvidence(t *testing.T) {
+	home, _, plan, observerDeps := legacyV18CutoverProjectTreehouseFixture(t)
+	_, err := buildLegacyV18CutoverProjectManifestEvidenceWithDeps(home, plan, legacyV18CutoverProjectTreehouseEvidence{}, legacyV18CutoverProjectManifestTestDeps(observerDeps))
+	if err == nil || !strings.Contains(err.Error(), "missing provider evidence") {
+		t.Fatalf("missing provider evidence error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverProjectManifestEvidenceRejectsHEADDrift(t *testing.T) {
+	home, _, plan, observerDeps := legacyV18CutoverProjectTreehouseFixture(t)
+	observed, err := observeLegacyV18CutoverProjectTreehousePlan(context.Background(), home, plan, observerDeps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps := legacyV18CutoverProjectManifestTestDeps(observerDeps)
+	calls := 0
+	deps.headCommit = func(string) (string, error) {
+		calls++
+		if calls == 1 {
+			return strings.Repeat("a", 40), nil
+		}
+		return strings.Repeat("b", 40), nil
+	}
+	_, err = buildLegacyV18CutoverProjectManifestEvidenceWithDeps(home, plan, observed, deps)
+	if err == nil || !strings.Contains(err.Error(), "HEAD changed during evidence capture") {
+		t.Fatalf("HEAD drift error = %v", err)
+	}
+}
+
+func TestLegacyV18CutoverProjectLocatorRejectsNonCanonicalPath(t *testing.T) {
+	home := t.TempDir()
+	project := store.LegacyV18CutoverProjectObservation{
+		ProjectID: "project-1",
+		Name:      "demo",
+		ClonePath: filepath.Join(home, "elsewhere", "demo"),
+	}
+	if _, err := legacyV18CutoverProjectLocator(home, project); err == nil || !strings.Contains(err.Error(), "not canonical Fleet-relative") {
+		t.Fatalf("non-canonical locator error = %v", err)
+	}
+}
+
+func legacyV18CutoverProjectManifestTestDeps(observerDeps legacyV18CutoverProjectTreehouseDeps) legacyV18CutoverProjectManifestDeps {
+	return legacyV18CutoverProjectManifestDeps{
+		resolveRoot:      observerDeps.resolveRoot,
+		commonDir:        observerDeps.commonDir,
+		isBare:           observerDeps.isBare,
+		headCommit:       observerDeps.headCommit,
+		physicalIdentity: legacyV18CutoverPhysicalIdentity,
+	}
+}

--- a/internal/runtime/cutover_project_physical_unix.go
+++ b/internal/runtime/cutover_project_physical_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func legacyV18CutoverPhysicalIdentity(_ string, info os.FileInfo) (string, error) {
+	if info == nil {
+		return "", fmt.Errorf("file identity metadata is absent")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil {
+		return "", fmt.Errorf("file identity metadata has type %T, want *syscall.Stat_t", info.Sys())
+	}
+	return fmt.Sprintf("unix-v1:dev=%016x:ino=%016x", uint64(stat.Dev), uint64(stat.Ino)), nil
+}

--- a/internal/runtime/cutover_project_physical_windows.go
+++ b/internal/runtime/cutover_project_physical_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func legacyV18CutoverPhysicalIdentity(path string, expected os.FileInfo) (string, error) {
+	if expected == nil {
+		return "", fmt.Errorf("file identity metadata is absent")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file identity handle: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	current, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat file identity handle: %w", err)
+	}
+	if !os.SameFile(expected, current) {
+		return "", fmt.Errorf("file identity changed before handle capture")
+	}
+	var handleInfo windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &handleInfo); err != nil {
+		return "", fmt.Errorf("read file identity handle: %w", err)
+	}
+	return fmt.Sprintf("windows-v1:volume=%08x:file=%08x%08x", handleInfo.VolumeSerialNumber, handleInfo.FileIndexHigh, handleInfo.FileIndexLow), nil
+}


### PR DESCRIPTION
Implements the next narrow 5B cutover slice from fresh `main` after #537.

- derives canonical Fleet-relative Project repository locators (`projects/<name>`)
- revalidates exact Git root/common-dir/non-bare repository evidence before freezing import evidence
- captures platform physical filesystem identities without using path strings as identity
- re-reads HEAD and filesystem identity during capture to reject drift
- preserves legacy name/URL/mode/upstream only as provenance/policy inputs
- rejects missing provider evidence and cross-Project physical aliasing
- does not publish a manifest, promote the archive candidate, construct v19 rows, or modify canonical #344 DDL

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.