### PR TITLE
feat(store): promote v19 cutover original archive

### DIFF
--- a/internal/store/cutoverarchive_publish.go
+++ b/internal/store/cutoverarchive_publish.go
@@ -1,0 +1,139 @@
+package store
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type legacyV18CutoverOriginalArchive struct {
+	MigrationID string
+	Directory   string
+	Path        string
+	SHA256      string
+}
+
+func legacyV18CutoverOriginalArchiveDir(homeDir, migrationID string) string {
+	return filepath.Join(homeDir, "state", "v19-cutover-"+migrationID)
+}
+
+func legacyV18CutoverOriginalArchivePath(homeDir, migrationID string) string {
+	return filepath.Join(legacyV18CutoverOriginalArchiveDir(homeDir, migrationID), "hand.db")
+}
+
+func promoteLegacyV18CutoverArchiveCandidate(homeDir string, candidate legacyV18CutoverArchiveCandidate) (legacyV18CutoverOriginalArchive, error) {
+	if err := validateLegacyV18CutoverMigrationID(candidate.MigrationID); err != nil {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("promote legacy v18 cutover archive candidate: %w", err)
+	}
+	if err := validateLegacyV18CutoverSHA256(candidate.SHA256); err != nil {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("promote legacy v18 cutover archive candidate: %w", err)
+	}
+	expectedCandidatePath := legacyV18CutoverArchiveCandidatePath(homeDir, candidate.MigrationID)
+	if filepath.Clean(candidate.Path) != filepath.Clean(expectedCandidatePath) {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("promote legacy v18 cutover archive candidate: path=%q, want deterministic %q", candidate.Path, expectedCandidatePath)
+	}
+	if err := requireLegacyV18CutoverDirectRegularFile(candidate.Path, "archive candidate"); err != nil {
+		return legacyV18CutoverOriginalArchive{}, err
+	}
+	candidateDigest, err := legacyV18CutoverFileSHA256(candidate.Path)
+	if err != nil {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("promote legacy v18 cutover archive candidate: hash candidate: %w", err)
+	}
+	if candidateDigest != candidate.SHA256 {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("promote legacy v18 cutover archive candidate: candidate digest=%s, want %s", candidateDigest, candidate.SHA256)
+	}
+
+	archive := legacyV18CutoverOriginalArchive{
+		MigrationID: candidate.MigrationID,
+		Directory:   legacyV18CutoverOriginalArchiveDir(homeDir, candidate.MigrationID),
+		Path:        legacyV18CutoverOriginalArchivePath(homeDir, candidate.MigrationID),
+		SHA256:      candidate.SHA256,
+	}
+	if err := ensureLegacyV18CutoverArchiveDirectory(archive.Directory); err != nil {
+		return legacyV18CutoverOriginalArchive{}, err
+	}
+	if info, err := os.Lstat(archive.Path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("legacy v18 cutover original archive %s is not a direct regular file", archive.Path)
+		}
+		digest, err := legacyV18CutoverFileSHA256(archive.Path)
+		if err != nil {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("hash existing legacy v18 cutover original archive: %w", err)
+		}
+		if digest != candidate.SHA256 {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("existing legacy v18 cutover original archive digest=%s, want %s", digest, candidate.SHA256)
+		}
+		return archive, nil
+	} else if !os.IsNotExist(err) {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("inspect legacy v18 cutover original archive: %w", err)
+	}
+
+	if err := syncLegacyV18CutoverFile(candidate.Path); err != nil {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("flush legacy v18 cutover archive candidate before promotion: %w", err)
+	}
+	if err := publishLegacyV18CutoverOriginalArchive(candidate.Path, archive.Path); err != nil {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("publish legacy v18 cutover original archive: %w", err)
+	}
+	if err := requireLegacyV18CutoverDirectRegularFile(archive.Path, "original archive"); err != nil {
+		return legacyV18CutoverOriginalArchive{}, err
+	}
+	publishedDigest, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("reopen and hash published legacy v18 cutover original archive: %w", err)
+	}
+	if publishedDigest != candidate.SHA256 {
+		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("published legacy v18 cutover original archive digest=%s, want %s", publishedDigest, candidate.SHA256)
+	}
+	return archive, nil
+}
+
+func validateLegacyV18CutoverMigrationID(value string) error {
+	prefix := legacyV18CutoverMigrationIdentityVersion + "-"
+	if !strings.HasPrefix(value, prefix) {
+		return fmt.Errorf("migration identity must start with %q", prefix)
+	}
+	digest := strings.TrimPrefix(value, prefix)
+	if len(digest) != 64 || digest != strings.ToLower(digest) {
+		return fmt.Errorf("migration identity digest must be exactly 64 lowercase hex characters")
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return fmt.Errorf("migration identity digest is not hexadecimal: %w", err)
+	}
+	return nil
+}
+
+func ensureLegacyV18CutoverArchiveDirectory(path string) error {
+	if err := os.Mkdir(path, 0o700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create legacy v18 cutover archive directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect legacy v18 cutover archive directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("legacy v18 cutover archive directory %s is not a direct directory", path)
+	}
+	return syncLegacyV18CutoverDirectoryParent(path)
+}
+
+func requireLegacyV18CutoverDirectRegularFile(path, role string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect legacy v18 cutover %s: %w", role, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("legacy v18 cutover %s %s is not a direct regular file", role, path)
+	}
+	return nil
+}
+
+func syncLegacyV18CutoverFile(path string) error {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return file.Sync()
+}

--- a/internal/store/cutoverarchive_publish.go
+++ b/internal/store/cutoverarchive_publish.go
@@ -65,6 +65,19 @@ func promoteLegacyV18CutoverArchiveCandidate(homeDir string, candidate legacyV18
 		if digest != candidate.SHA256 {
 			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("existing legacy v18 cutover original archive digest=%s, want %s", digest, candidate.SHA256)
 		}
+		if err := syncLegacyV18CutoverFile(archive.Path); err != nil {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("flush existing legacy v18 cutover original archive: %w", err)
+		}
+		if err := syncLegacyV18CutoverDirectoryParent(archive.Path); err != nil {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("flush existing legacy v18 cutover original archive directory: %w", err)
+		}
+		digest, err = legacyV18CutoverFileSHA256(archive.Path)
+		if err != nil {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("reopen and hash existing legacy v18 cutover original archive: %w", err)
+		}
+		if digest != candidate.SHA256 {
+			return legacyV18CutoverOriginalArchive{}, fmt.Errorf("existing legacy v18 cutover original archive changed after flush: digest=%s, want %s", digest, candidate.SHA256)
+		}
 		return archive, nil
 	} else if !os.IsNotExist(err) {
 		return legacyV18CutoverOriginalArchive{}, fmt.Errorf("inspect legacy v18 cutover original archive: %w", err)

--- a/internal/store/cutoverarchive_publish_test.go
+++ b/internal/store/cutoverarchive_publish_test.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPromoteLegacyV18CutoverArchiveCandidatePublishesExactOriginalArchive(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourceBytes, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := prepareLegacyV18CutoverArchiveCandidate(home, "f_"+strings.Repeat("0", 31)+"1", sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(home, candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archive.MigrationID != candidate.MigrationID || archive.SHA256 != sourceDigest {
+		t.Fatalf("original archive = %#v, candidate=%#v", archive, candidate)
+	}
+	if archive.Directory != legacyV18CutoverOriginalArchiveDir(home, candidate.MigrationID) || archive.Path != legacyV18CutoverOriginalArchivePath(home, candidate.MigrationID) {
+		t.Fatalf("original archive path = %#v, want deterministic archive directory/path", archive)
+	}
+	if _, err := os.Lstat(candidate.Path); !os.IsNotExist(err) {
+		t.Fatalf("candidate after promotion stat error = %v, want not exist", err)
+	}
+	archiveBytes, err := os.ReadFile(archive.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(archiveBytes, sourceBytes) {
+		t.Fatal("published original archive bytes differ from exact source bytes")
+	}
+	publishedDigest, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if publishedDigest != sourceDigest {
+		t.Fatalf("published original archive digest = %s, want %s", publishedDigest, sourceDigest)
+	}
+}
+
+func TestPromoteLegacyV18CutoverArchiveCandidateReusesExactExistingArchive(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetID := "f_" + strings.Repeat("0", 31) + "1"
+	candidate, err := prepareLegacyV18CutoverArchiveCandidate(home, fleetID, sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(home, candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(archive.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidate, err = prepareLegacyV18CutoverArchiveCandidate(home, fleetID, sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := promoteLegacyV18CutoverArchiveCandidate(home, candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(again.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("exact existing original archive was replaced")
+	}
+	if _, err := os.Stat(candidate.Path); err != nil {
+		t.Fatalf("idempotent exact candidate was unexpectedly removed: %v", err)
+	}
+}
+
+func TestPromoteLegacyV18CutoverArchiveCandidateRefusesMismatchedExistingArchive(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := prepareLegacyV18CutoverArchiveCandidate(home, "f_"+strings.Repeat("0", 31)+"1", sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveDir := legacyV18CutoverOriginalArchiveDir(home, candidate.MigrationID)
+	if err := os.Mkdir(archiveDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := legacyV18CutoverOriginalArchivePath(home, candidate.MigrationID)
+	if err := os.WriteFile(archivePath, []byte("different evidence"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := promoteLegacyV18CutoverArchiveCandidate(home, candidate); err == nil || !strings.Contains(err.Error(), "existing legacy v18 cutover original archive digest") {
+		t.Fatalf("mismatched existing archive error = %v", err)
+	}
+	if _, err := os.Stat(candidate.Path); err != nil {
+		t.Fatalf("candidate changed after mismatched archive refusal: %v", err)
+	}
+	got, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "different evidence" {
+		t.Fatalf("mismatched archive was overwritten: %q", got)
+	}
+}
+
+func TestPromoteLegacyV18CutoverArchiveCandidateRefusesNonCanonicalCandidatePath(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	migrationID, err := legacyV18CutoverMigrationIdentity("f_"+strings.Repeat("0", 31)+"1", sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePath := filepath.Join(home, "state", "other.db")
+	if err := os.WriteFile(candidatePath, []byte("not the candidate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	candidate := legacyV18CutoverArchiveCandidate{MigrationID: migrationID, Path: candidatePath, SHA256: sourceDigest}
+	if _, err := promoteLegacyV18CutoverArchiveCandidate(home, candidate); err == nil || !strings.Contains(err.Error(), "want deterministic") {
+		t.Fatalf("non-canonical candidate path error = %v", err)
+	}
+}
+
+func TestPromoteLegacyV18CutoverArchiveCandidateRefusesNonDirectoryArchivePath(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	sourceDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := prepareLegacyV18CutoverArchiveCandidate(home, "f_"+strings.Repeat("0", 31)+"1", sourceDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveDir := legacyV18CutoverOriginalArchiveDir(home, candidate.MigrationID)
+	if err := os.WriteFile(archiveDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := promoteLegacyV18CutoverArchiveCandidate(home, candidate); err == nil || !strings.Contains(err.Error(), "not a direct directory") {
+		t.Fatalf("non-directory archive path error = %v", err)
+	}
+}
+
+func TestValidateLegacyV18CutoverMigrationIDRejectsPathLikeIdentity(t *testing.T) {
+	for _, value := range []string{"../escape", "v1-../escape", "v2-" + strings.Repeat("a", 64), "v1-" + strings.Repeat("A", 64)} {
+		if err := validateLegacyV18CutoverMigrationID(value); err == nil {
+			t.Fatalf("migration identity %q was accepted", value)
+		}
+	}
+}

--- a/internal/store/cutoverarchive_publish_unix.go
+++ b/internal/store/cutoverarchive_publish_unix.go
@@ -8,22 +8,30 @@ import (
 )
 
 func publishLegacyV18CutoverOriginalArchive(source, target string) error {
-	if err := os.Rename(source, target); err != nil {
+	// Link publishes the target name atomically without the overwrite semantics
+	// of os.Rename. Source and target are the same inode until the non-authoritative
+	// candidate name is removed after the target directory entry is durable.
+	if err := os.Link(source, target); err != nil {
 		return err
 	}
-	dir, err := os.Open(filepath.Dir(target))
+	if err := syncLegacyV18CutoverDirectory(filepath.Dir(target)); err != nil {
+		return err
+	}
+	if err := os.Remove(source); err != nil {
+		return err
+	}
+	return syncLegacyV18CutoverDirectory(filepath.Dir(source))
+}
+
+func syncLegacyV18CutoverDirectoryParent(path string) error {
+	return syncLegacyV18CutoverDirectory(filepath.Dir(path))
+}
+
+func syncLegacyV18CutoverDirectory(path string) error {
+	dir, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = dir.Close() }()
 	return dir.Sync()
-}
-
-func syncLegacyV18CutoverDirectoryParent(path string) error {
-	parent, err := os.Open(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-	defer func() { _ = parent.Close() }()
-	return parent.Sync()
 }

--- a/internal/store/cutoverarchive_publish_unix.go
+++ b/internal/store/cutoverarchive_publish_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func publishLegacyV18CutoverOriginalArchive(source, target string) error {
+	if err := os.Rename(source, target); err != nil {
+		return err
+	}
+	dir, err := os.Open(filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}
+
+func syncLegacyV18CutoverDirectoryParent(path string) error {
+	parent, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = parent.Close() }()
+	return parent.Sync()
+}

--- a/internal/store/cutoverarchive_publish_windows.go
+++ b/internal/store/cutoverarchive_publish_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package store
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+const legacyV18CutoverMoveFileWriteThrough = 0x00000008
+
+func publishLegacyV18CutoverOriginalArchive(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, legacyV18CutoverMoveFileWriteThrough)
+}
+
+func syncLegacyV18CutoverDirectoryParent(string) error {
+	// Windows does not expose a POSIX-style directory fsync. The authoritative
+	// publication itself uses MoveFileEx with MOVEFILE_WRITE_THROUGH, which does
+	// not return until the move has reached disk.
+	return nil
+}


### PR DESCRIPTION
Implements the next narrow 5B cutover slice from fresh `main` after #538.

- promotes the exact non-authoritative archive candidate into a deterministic same-volume archive directory
- publishes `state/v19-cutover-<migration-id>/hand.db` without overwriting an existing archive identity
- flushes the candidate before promotion and reopens/rehashes the published archive afterward
- uses atomic no-replace hard-link publication plus directory fsync on POSIX
- uses `MoveFileEx(..., MOVEFILE_WRITE_THROUGH)` on Windows for durable same-volume publication
- re-proves exact existing archive durability/digest on retry rather than trusting path existence
- rejects noncanonical candidate paths, malformed migration identities, non-directory archive paths, and digest collisions
- remains an inert store primitive: it does not decide provider quiescence, publish a manifest, freeze the legacy DB, construct v19 rows, or activate automatic cutover

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.