### PR TITLE
feat(runtime): plan positive v19 cutover imports

### DIFF
--- a/internal/runtime/cutover_import_plan.go
+++ b/internal/runtime/cutover_import_plan.go
@@ -9,9 +9,9 @@ import (
 	"github.com/atqamz/hand/internal/store"
 )
 
-// legacyV18CutoverImportPlan is the bounded semantic input that 5C may later
-// materialize into canonical v19. It deliberately contains no legacy execution,
-// runtime, Treehouse, Herdr, Send, or effect history.
+// This bounded semantic input is all that 5C may later materialize into
+// canonical v19. It deliberately contains no legacy execution, runtime,
+// Treehouse, Herdr, Send, or effect history.
 type legacyV18CutoverImportPlan struct {
 	FleetID  string
 	Projects []legacyV18CutoverProjectImportPlan

--- a/internal/runtime/cutover_import_plan.go
+++ b/internal/runtime/cutover_import_plan.go
@@ -1,0 +1,146 @@
+package runtime
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/atqamz/hand/internal/store"
+)
+
+// legacyV18CutoverImportPlan is the bounded semantic input that 5C may later
+// materialize into canonical v19. It deliberately contains no legacy execution,
+// runtime, Treehouse, Herdr, Send, or effect history.
+type legacyV18CutoverImportPlan struct {
+	FleetID  string
+	Projects []legacyV18CutoverProjectImportPlan
+}
+
+type legacyV18CutoverProjectImportPlan struct {
+	SourceProjectID string
+	Workspace       legacyV18CutoverWorkspaceImportPlan
+	PolicyInputs    legacyV18CutoverPolicyImportPlan
+}
+
+type legacyV18CutoverWorkspaceImportPlan struct {
+	Locator              string
+	RepositoryPhysicalID string
+	CommonDirPhysicalID  string
+	Revision             string
+}
+
+type legacyV18CutoverPolicyImportPlan struct {
+	LegacyName     string
+	LegacyURL      string
+	LegacyMode     string
+	LegacyUpstream string
+}
+
+func buildLegacyV18CutoverImportPlan(plan store.LegacyV18CutoverObservationPlan, evidence []legacyV18CutoverProjectManifestEvidence) (legacyV18CutoverImportPlan, error) {
+	if err := store.ValidateFleetID(plan.FleetID); err != nil {
+		return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: Fleet identity: %w", err)
+	}
+
+	sourceByID := make(map[string]store.LegacyV18CutoverProjectObservation, len(plan.Projects))
+	for _, project := range plan.Projects {
+		if project.ProjectID == "" {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: source Project identity is empty")
+		}
+		if _, exists := sourceByID[project.ProjectID]; exists {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: duplicate source Project identity %q", project.ProjectID)
+		}
+		sourceByID[project.ProjectID] = project
+	}
+
+	result := legacyV18CutoverImportPlan{FleetID: plan.FleetID}
+	result.Projects = make([]legacyV18CutoverProjectImportPlan, 0, len(evidence))
+	seenProjects := make(map[string]struct{}, len(evidence))
+	seenLocators := make(map[string]string, len(evidence))
+	seenPhysical := make(map[string]string, len(evidence)*2)
+	for _, captured := range evidence {
+		source, ok := sourceByID[captured.ProjectID]
+		if !ok {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: evidence Project %q is absent from held source plan", captured.ProjectID)
+		}
+		if _, duplicate := seenProjects[captured.ProjectID]; duplicate {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: duplicate evidence Project identity %q", captured.ProjectID)
+		}
+		seenProjects[captured.ProjectID] = struct{}{}
+
+		if captured.LegacyName != source.Name || captured.LegacyURL != source.URL || captured.LegacyMode != source.Mode || captured.LegacyUpstream != source.Upstream {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: Project %q provenance changed after source observation", captured.ProjectID)
+		}
+		if err := validateLegacyV18CutoverImportLocator(captured.ProjectID, source.Name, captured.Locator); err != nil {
+			return legacyV18CutoverImportPlan{}, err
+		}
+		if owner, exists := seenLocators[captured.Locator]; exists {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: repository locator alias %q between Projects %q and %q", captured.Locator, owner, captured.ProjectID)
+		}
+		seenLocators[captured.Locator] = captured.ProjectID
+		if !validLegacyV18CutoverGitObjectID(captured.Revision) {
+			return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: Project %q revision %q is not an exact Git object ID", captured.ProjectID, captured.Revision)
+		}
+		if err := recordLegacyV18CutoverImportPhysicalIdentity(seenPhysical, captured.RepositoryPhysicalID, captured.ProjectID, "repository"); err != nil {
+			return legacyV18CutoverImportPlan{}, err
+		}
+		if err := recordLegacyV18CutoverImportPhysicalIdentity(seenPhysical, captured.CommonDirPhysicalID, captured.ProjectID, "common-dir"); err != nil {
+			return legacyV18CutoverImportPlan{}, err
+		}
+
+		result.Projects = append(result.Projects, legacyV18CutoverProjectImportPlan{
+			SourceProjectID: captured.ProjectID,
+			Workspace: legacyV18CutoverWorkspaceImportPlan{
+				Locator:              captured.Locator,
+				RepositoryPhysicalID: captured.RepositoryPhysicalID,
+				CommonDirPhysicalID:  captured.CommonDirPhysicalID,
+				Revision:             captured.Revision,
+			},
+			PolicyInputs: legacyV18CutoverPolicyImportPlan{
+				LegacyName:     captured.LegacyName,
+				LegacyURL:      captured.LegacyURL,
+				LegacyMode:     captured.LegacyMode,
+				LegacyUpstream: captured.LegacyUpstream,
+			},
+		})
+	}
+
+	if len(seenProjects) != len(sourceByID) {
+		missing := make([]string, 0, len(sourceByID)-len(seenProjects))
+		for projectID := range sourceByID {
+			if _, ok := seenProjects[projectID]; !ok {
+				missing = append(missing, projectID)
+			}
+		}
+		sort.Strings(missing)
+		return legacyV18CutoverImportPlan{}, fmt.Errorf("build legacy v18 cutover import plan: held source Projects missing positive import evidence: %v", missing)
+	}
+
+	sort.Slice(result.Projects, func(i, j int) bool {
+		return result.Projects[i].SourceProjectID < result.Projects[j].SourceProjectID
+	})
+	return result, nil
+}
+
+func validateLegacyV18CutoverImportLocator(projectID, legacyName, locator string) error {
+	if locator == "" || strings.HasPrefix(locator, "/") || path.Clean(locator) != locator {
+		return fmt.Errorf("build legacy v18 cutover import plan: Project %q locator %q is not canonical Fleet-relative evidence", projectID, locator)
+	}
+	expected := path.Join("projects", legacyName)
+	if expected == "." || expected == "projects" || locator != expected || !strings.HasPrefix(locator, "projects/") {
+		return fmt.Errorf("build legacy v18 cutover import plan: Project %q locator=%q, want canonical Fleet-relative %q", projectID, locator, expected)
+	}
+	return nil
+}
+
+func recordLegacyV18CutoverImportPhysicalIdentity(seen map[string]string, identity, projectID, role string) error {
+	if identity == "" {
+		return fmt.Errorf("build legacy v18 cutover import plan: Project %q %s physical identity is empty", projectID, role)
+	}
+	subject := projectID + "/" + role
+	if prior, exists := seen[identity]; exists {
+		return fmt.Errorf("build legacy v18 cutover import plan: physical identity alias %q between %s and %s", identity, prior, subject)
+	}
+	seen[identity] = subject
+	return nil
+}

--- a/internal/runtime/cutover_import_plan_test.go
+++ b/internal/runtime/cutover_import_plan_test.go
@@ -1,0 +1,149 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestBuildLegacyV18CutoverImportPlanCarriesOnlyPositiveFactsDeterministically(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	// Evidence order is intentionally opposite the source-plan order.
+	evidence[0], evidence[1] = evidence[1], evidence[0]
+
+	got, err := buildLegacyV18CutoverImportPlan(plan, evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FleetID != plan.FleetID {
+		t.Fatalf("FleetID = %q, want %q", got.FleetID, plan.FleetID)
+	}
+	if len(got.Projects) != 2 {
+		t.Fatalf("Projects = %#v, want two", got.Projects)
+	}
+	if got.Projects[0].SourceProjectID != "project-a" || got.Projects[1].SourceProjectID != "project-b" {
+		t.Fatalf("Project ordering = %#v, want deterministic source identity order", got.Projects)
+	}
+
+	project := got.Projects[0]
+	if project.Workspace.Locator != "projects/alpha" || project.Workspace.RepositoryPhysicalID != "repo-alpha" || project.Workspace.CommonDirPhysicalID != "git-alpha" || project.Workspace.Revision != strings.Repeat("a", 40) {
+		t.Fatalf("workspace import facts = %#v", project.Workspace)
+	}
+	if project.PolicyInputs.LegacyName != "alpha" || project.PolicyInputs.LegacyURL != "https://example.invalid/alpha.git" || project.PolicyInputs.LegacyMode != "clone" || project.PolicyInputs.LegacyUpstream != "origin/main" {
+		t.Fatalf("policy import inputs = %#v", project.PolicyInputs)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsInvalidFleetIdentity(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	plan.FleetID = "not-a-fleet"
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "Fleet identity") {
+		t.Fatalf("invalid Fleet error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsMissingProjectEvidence(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence[:1]); err == nil || !strings.Contains(err.Error(), "missing positive import evidence") {
+		t.Fatalf("missing evidence error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsUnknownProjectEvidence(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	evidence[0].ProjectID = "unknown-project"
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "absent from held source plan") {
+		t.Fatalf("unknown evidence error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsProvenanceDrift(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	evidence[0].LegacyUpstream = "origin/other"
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "provenance changed") {
+		t.Fatalf("provenance drift error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsLocatorAlias(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	plan.Projects[1].Name = plan.Projects[0].Name
+	evidence[1].LegacyName = evidence[0].LegacyName
+	evidence[1].Locator = evidence[0].Locator
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "repository locator alias") {
+		t.Fatalf("locator alias error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsPhysicalAlias(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	evidence[1].RepositoryPhysicalID = evidence[0].CommonDirPhysicalID
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "physical identity alias") {
+		t.Fatalf("physical alias error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsInvalidRevision(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	evidence[0].Revision = "HEAD"
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "not an exact Git object ID") {
+		t.Fatalf("invalid revision error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverImportPlanRejectsNonCanonicalLocator(t *testing.T) {
+	plan, evidence := legacyV18CutoverImportPlanFixture()
+	evidence[0].Locator = "projects/../alpha"
+	if _, err := buildLegacyV18CutoverImportPlan(plan, evidence); err == nil || !strings.Contains(err.Error(), "not canonical Fleet-relative") {
+		t.Fatalf("non-canonical locator error = %v", err)
+	}
+}
+
+func legacyV18CutoverImportPlanFixture() (store.LegacyV18CutoverObservationPlan, []legacyV18CutoverProjectManifestEvidence) {
+	fleetID := "f_" + strings.Repeat("0", 31) + "1"
+	plan := store.LegacyV18CutoverObservationPlan{
+		FleetID: fleetID,
+		Projects: []store.LegacyV18CutoverProjectObservation{
+			{
+				ProjectID: "project-b",
+				Name:      "beta",
+				URL:       "https://example.invalid/beta.git",
+				Mode:      "direct-pr",
+				Upstream:  "origin/release",
+			},
+			{
+				ProjectID: "project-a",
+				Name:      "alpha",
+				URL:       "https://example.invalid/alpha.git",
+				Mode:      "clone",
+				Upstream:  "origin/main",
+			},
+		},
+	}
+	evidence := []legacyV18CutoverProjectManifestEvidence{
+		{
+			ProjectID:            "project-b",
+			Locator:              "projects/beta",
+			RepositoryPhysicalID: "repo-beta",
+			CommonDirPhysicalID:  "git-beta",
+			Revision:             strings.Repeat("b", 40),
+			LegacyName:           "beta",
+			LegacyURL:            "https://example.invalid/beta.git",
+			LegacyMode:           "direct-pr",
+			LegacyUpstream:       "origin/release",
+		},
+		{
+			ProjectID:            "project-a",
+			Locator:              "projects/alpha",
+			RepositoryPhysicalID: "repo-alpha",
+			CommonDirPhysicalID:  "git-alpha",
+			Revision:             strings.Repeat("a", 40),
+			LegacyName:           "alpha",
+			LegacyURL:            "https://example.invalid/alpha.git",
+			LegacyMode:           "clone",
+			LegacyUpstream:       "origin/main",
+		},
+	}
+	return plan, evidence
+}


### PR DESCRIPTION
Implements the next narrow 5B cutover slice from fresh `main` after #539.

- builds a deterministic in-memory import plan from the held Fleet/source observation plan plus the already-frozen 5B2 Project evidence
- preserves the exact durable Fleet identity
- carries source Project identity separately from verified repository/workspace evidence
- carries legacy name/URL/mode/upstream only as policy/provenance inputs; it does not treat them as canonical Project identity
- requires one-to-one source/evidence coverage and deterministic Project ordering
- rejects provenance drift, unknown/missing/duplicate Project evidence, noncanonical Fleet-relative locators, locator aliases, physical-identity aliases, and invalid Git revisions
- contains no Task/Plan/Attempt/runtime/Treehouse/Herdr/Send/effect history fields, so terminal legacy execution state remains archive-only by construction
- remains inert: it does not freeze the source, publish the final manifest, create canonical row IDs, build the v19 temp database, or activate automatic cutover

This completes the positive-evidence planning boundary needed before 5C row materialization; exact canonical relation construction remains downstream and must use #344 authority rather than inventing identities here.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.