### PR TITLE
feat(store): build fresh canonical v19 cutover target

### DIFF
--- a/internal/store/cutovertarget.go
+++ b/internal/store/cutovertarget.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type canonicalV19CutoverTarget struct {
+	MigrationID string
+	Path        string
+}
+
+func legacyV18CutoverCanonicalTargetPath(homeDir, migrationID string) string {
+	return filepath.Join(homeDir, "state", ".v19-cutover-"+migrationID+"-canonical.db.tmp")
+}
+
+// Creates one fresh, non-authoritative canonical v19 sibling for later import.
+// Existing bytes at the deterministic path are never reused or overwritten.
+func prepareCanonicalV19CutoverTarget(homeDir, migrationID string) (canonicalV19CutoverTarget, error) {
+	if err := validateLegacyV18CutoverMigrationID(migrationID); err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: %w", err)
+	}
+	target := canonicalV19CutoverTarget{
+		MigrationID: migrationID,
+		Path:        legacyV18CutoverCanonicalTargetPath(homeDir, migrationID),
+	}
+	if info, err := os.Lstat(target.Path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: existing target %s is not a direct regular file", target.Path)
+		}
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: deterministic target %s already exists", target.Path)
+	} else if !os.IsNotExist(err) {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: inspect deterministic target: %w", err)
+	}
+
+	sqlDB, err := open(target.Path)
+	if err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: %w", err)
+	}
+	keep := false
+	closed := false
+	defer func() {
+		if !closed {
+			_ = sqlDB.Close()
+		}
+		if !keep {
+			_ = os.Remove(target.Path)
+			_ = os.Remove(target.Path + "-journal")
+			_ = os.Remove(target.Path + "-wal")
+			_ = os.Remove(target.Path + "-shm")
+		}
+	}()
+	if err := createCanonicalV19Schema(sqlDB); err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: %w", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		closed = true
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: close created target: %w", err)
+	}
+	closed = true
+	if err := requireLegacyV18CutoverDirectRegularFile(target.Path, "canonical target"); err != nil {
+		return canonicalV19CutoverTarget{}, err
+	}
+	if err := syncLegacyV18CutoverFile(target.Path); err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: flush target: %w", err)
+	}
+	if err := syncLegacyV18CutoverDirectoryParent(target.Path); err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: flush target directory: %w", err)
+	}
+
+	reopened, err := open(target.Path)
+	if err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: reopen target: %w", err)
+	}
+	if err := validateCanonicalV19Schema(reopened); err != nil {
+		_ = reopened.Close()
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: revalidate reopened target: %w", err)
+	}
+	if err := reopened.Close(); err != nil {
+		return canonicalV19CutoverTarget{}, fmt.Errorf("prepare canonical v19 cutover target: close revalidated target: %w", err)
+	}
+	keep = true
+	return target, nil
+}

--- a/internal/store/cutovertarget_test.go
+++ b/internal/store/cutovertarget_test.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareCanonicalV19CutoverTargetBuildsFreshExactLockedSchema(t *testing.T) {
+	home := t.TempDir()
+	migrationID := "v1-" + strings.Repeat("a", 64)
+
+	target, err := prepareCanonicalV19CutoverTarget(home, migrationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(home, "state", ".v19-cutover-"+migrationID+"-canonical.db.tmp")
+	if target.MigrationID != migrationID || target.Path != wantPath {
+		t.Fatalf("target = %#v, want migration=%q path=%q", target, migrationID, wantPath)
+	}
+	if filepath.Dir(target.Path) != filepath.Dir(Path(home)) {
+		t.Fatalf("target directory = %q, want active database sibling directory %q", filepath.Dir(target.Path), filepath.Dir(Path(home)))
+	}
+	if err := requireLegacyV18CutoverDirectRegularFile(target.Path, "canonical target"); err != nil {
+		t.Fatal(err)
+	}
+
+	sqlDB, err := open(target.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	if err := validateCanonicalV19Schema(sqlDB); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := inspectCanonicalV19Identity(sqlDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Fingerprint != canonicalV19SchemaFingerprint || identity.Tables != canonicalV19TableCount || identity.Indexes != canonicalV19IndexCount || identity.Triggers != canonicalV19TriggerCount {
+		t.Fatalf("canonical identity = %#v", identity)
+	}
+	for _, suffix := range []string{"-journal", "-wal", "-shm"} {
+		if _, err := os.Lstat(target.Path + suffix); !os.IsNotExist(err) {
+			t.Fatalf("unexpected SQLite sidecar %q: %v", target.Path+suffix, err)
+		}
+	}
+}
+
+func TestPrepareCanonicalV19CutoverTargetRefusesExistingDeterministicBytes(t *testing.T) {
+	home := t.TempDir()
+	migrationID := "v1-" + strings.Repeat("b", 64)
+	path := legacyV18CutoverCanonicalTargetPath(home, migrationID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := []byte("stale-or-unknown-target")
+	if err := os.WriteFile(path, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := prepareCanonicalV19CutoverTarget(home, migrationID); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("existing target error = %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("existing deterministic target was modified: got %q, want %q", after, before)
+	}
+}
+
+func TestPrepareCanonicalV19CutoverTargetRejectsInvalidMigrationIdentity(t *testing.T) {
+	for _, migrationID := range []string{"", "../escape", "v2-" + strings.Repeat("a", 64), "v1-" + strings.Repeat("A", 64)} {
+		if _, err := prepareCanonicalV19CutoverTarget(t.TempDir(), migrationID); err == nil {
+			t.Fatalf("migration identity %q was accepted", migrationID)
+		}
+	}
+}
+
+func TestPrepareCanonicalV19CutoverTargetRefusesSymlinkAtDeterministicPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("symlink behavior is a filesystem safety test")
+	}
+	home := t.TempDir()
+	migrationID := "v1-" + strings.Repeat("c", 64)
+	path := legacyV18CutoverCanonicalTargetPath(home, migrationID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(home, "other.db")
+	if err := os.WriteFile(other, []byte("do-not-touch"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(other, path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := prepareCanonicalV19CutoverTarget(home, migrationID); err == nil || !strings.Contains(err.Error(), "not a direct regular file") {
+		t.Fatalf("symlink target error = %v", err)
+	}
+	got, err := os.ReadFile(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "do-not-touch" {
+		t.Fatalf("symlink referent was modified: %q", got)
+	}
+}


### PR DESCRIPTION
Implements the next narrow 5C1 cutover slice from fresh `main` after #540.

- derives one deterministic same-volume canonical temp sibling path from the validated migration identity
- requires the target path to be fresh; existing bytes or symlinks are refused and never overwritten
- reuses the locked #344 `createCanonicalV19Schema` primitive rather than introducing another DDL path
- closes and flushes the created SQLite file, flushes the parent directory, then reopens and revalidates the exact canonical v19 schema/fingerprint/integrity/FK contract
- removes only newly-created exact temp-path SQLite residue when creation fails
- remains non-authoritative and inert: no Project row materialization, source freeze, final manifest, active DB replacement, or automatic cutover activation

This is intentionally only the fresh exact-v19 temp-target boundary of 5C. Positive-evidence row materialization and publication remain downstream slices.

Canonical #344 DDL impact: **NONE** (reuses the already-locked embedded artifact unchanged).

Refs #348, #339.