### PR TITLE
feat(store): freeze legacy source for v19 cutover

### DIFF
--- a/internal/store/cutoverfreeze.go
+++ b/internal/store/cutoverfreeze.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	legacyV18CutoverFrozenUserVersion         = 22
+	legacyV18CutoverFrozenUserVersion        = 22
 	legacyV18CutoverFreezeCertificateKey     = "v19-cutover-freeze"
 	legacyV18CutoverFreezeCertificateVersion = "v1"
-	legacyV18CutoverFreezeAbortMessage        = "legacy source frozen for v19 cutover"
+	legacyV18CutoverFreezeAbortMessage       = "legacy source frozen for v19 cutover"
 )
 
 var legacyV18CutoverFreezeTables = []string{

--- a/internal/store/cutoverfreeze.go
+++ b/internal/store/cutoverfreeze.go
@@ -79,7 +79,7 @@ func freezeLegacyV18CutoverSource(ctx context.Context, homeDir string, gate *leg
 	if err != nil {
 		return bridge, fmt.Errorf("freeze legacy v18 cutover source: %w", err)
 	}
-	expectedMigrationID, err := legacyV18CutoverMigrationID(fleetID, gate.sourceSHA256)
+	expectedMigrationID, err := legacyV18CutoverMigrationIdentity(fleetID, gate.sourceSHA256)
 	if err != nil {
 		return bridge, fmt.Errorf("freeze legacy v18 cutover source: derive migration identity: %w", err)
 	}

--- a/internal/store/cutoverfreeze.go
+++ b/internal/store/cutoverfreeze.go
@@ -1,0 +1,321 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const (
+	legacyV18CutoverFrozenUserVersion         = 22
+	legacyV18CutoverFreezeCertificateKey     = "v19-cutover-freeze"
+	legacyV18CutoverFreezeCertificateVersion = "v1"
+	legacyV18CutoverFreezeAbortMessage        = "legacy source frozen for v19 cutover"
+)
+
+var legacyV18CutoverFreezeTables = []string{
+	"task",
+	"attempt",
+	"fleet_identity",
+	"meta",
+	"hold",
+	"project",
+	"send_attempt",
+}
+
+var legacyV18CutoverFreezeOperations = []string{"INSERT", "UPDATE", "DELETE"}
+
+type legacyV18CutoverFrozenBridge struct {
+	MigrationID  string
+	FleetID      string
+	SourceSHA256 string
+	BridgeSHA256 string
+	Certificate  string
+	Committed    bool
+}
+
+func freezeLegacyV18CutoverSource(ctx context.Context, homeDir string, gate *legacyV18CutoverGate, archive legacyV18CutoverOriginalArchive) (legacyV18CutoverFrozenBridge, error) {
+	bridge := legacyV18CutoverFrozenBridge{}
+	if gate == nil || gate.conn == nil || gate.db == nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: EXCLUSIVE gate is not held")
+	}
+	if err := validateLegacyV18CutoverMigrationID(archive.MigrationID); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: %w", err)
+	}
+	if err := validateLegacyV18CutoverSHA256(archive.SHA256); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: %w", err)
+	}
+	if archive.MigrationID != gate.archiveCandidate.MigrationID {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: archive migration identity=%s, gate=%s", archive.MigrationID, gate.archiveCandidate.MigrationID)
+	}
+	if archive.SHA256 != gate.sourceSHA256 || archive.SHA256 != gate.archiveCandidate.SHA256 {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: archive digest=%s, gate source=%s, candidate=%s", archive.SHA256, gate.sourceSHA256, gate.archiveCandidate.SHA256)
+	}
+	expectedArchivePath := legacyV18CutoverOriginalArchivePath(homeDir, archive.MigrationID)
+	if archive.Path != expectedArchivePath || archive.Directory != legacyV18CutoverOriginalArchiveDir(homeDir, archive.MigrationID) {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: original archive path is not deterministic")
+	}
+	if err := requireLegacyV18CutoverDirectRegularFile(archive.Path, "original archive"); err != nil {
+		return bridge, err
+	}
+	archiveDigest, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: hash original archive: %w", err)
+	}
+	if archiveDigest != archive.SHA256 {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: original archive digest=%s, want %s", archiveDigest, archive.SHA256)
+	}
+
+	queryer := sqliteConnQueryer{ctx: ctx, conn: gate.conn}
+	info, err := validateLegacyV18CutoverSource(queryer)
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: revalidate EXCLUSIVE source: %w", err)
+	}
+	if info != gate.info {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: EXCLUSIVE source identity changed: gate=%+v current=%+v", gate.info, info)
+	}
+	fleetID, err := legacyV18CutoverFleetID(queryer)
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: %w", err)
+	}
+	expectedMigrationID, err := legacyV18CutoverMigrationID(fleetID, gate.sourceSHA256)
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: derive migration identity: %w", err)
+	}
+	if expectedMigrationID != archive.MigrationID {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: migration identity=%s, want %s from exact Fleet/source evidence", archive.MigrationID, expectedMigrationID)
+	}
+	activeDigest, err := legacyV18CutoverFileSHA256(Path(homeDir))
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: hash active source: %w", err)
+	}
+	if activeDigest != gate.sourceSHA256 {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: active digest=%s, want %s", activeDigest, gate.sourceSHA256)
+	}
+	var queryOnly int
+	if err := gate.conn.QueryRowContext(ctx, `PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: inspect query_only: %w", err)
+	}
+	if queryOnly != 1 {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: query_only=%d, want 1 before freeze", queryOnly)
+	}
+
+	bridge = legacyV18CutoverFrozenBridge{
+		MigrationID:  archive.MigrationID,
+		FleetID:      fleetID,
+		SourceSHA256: gate.sourceSHA256,
+		Certificate:  legacyV18CutoverFreezeCertificateVersion + ":" + gate.sourceSHA256,
+	}
+	if _, err := gate.conn.ExecContext(ctx, `PRAGMA query_only = 0`); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: disable query_only: %w", err)
+	}
+	if err := gate.conn.QueryRowContext(ctx, `PRAGMA query_only`).Scan(&queryOnly); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: verify query_only disabled: %w", err)
+	}
+	if queryOnly != 0 {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: query_only=%d, want 0 at freeze boundary", queryOnly)
+	}
+
+	var existing int
+	if err := gate.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM meta WHERE key = ?`, legacyV18CutoverFreezeCertificateKey).Scan(&existing); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: inspect freeze certificate: %w", err)
+	}
+	if existing != 0 {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: freeze certificate already exists")
+	}
+	if _, err := gate.conn.ExecContext(ctx, `INSERT INTO meta(key, value) VALUES(?, ?)`, legacyV18CutoverFreezeCertificateKey, bridge.Certificate); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: write freeze certificate: %w", err)
+	}
+	for _, table := range legacyV18CutoverFreezeTables {
+		for _, operation := range legacyV18CutoverFreezeOperations {
+			if _, err := gate.conn.ExecContext(ctx, legacyV18CutoverFreezeTriggerSQL(table, operation)); err != nil {
+				return bridge, fmt.Errorf("freeze legacy v18 cutover source: create %s %s guard: %w", table, operation, err)
+			}
+		}
+	}
+	if _, err := gate.conn.ExecContext(ctx, fmt.Sprintf(`PRAGMA user_version = %d`, legacyV18CutoverFrozenUserVersion)); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: set frozen bridge user_version: %w", err)
+	}
+	if _, err := gate.conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: commit frozen bridge: %w", err)
+	}
+	bridge.Committed = true
+
+	closeErr := closeCommittedLegacyV18CutoverGate(gate)
+	if err := syncLegacyV18CutoverFile(Path(homeDir)); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; flush active source: %w", err)
+	}
+	if err := syncLegacyV18CutoverDirectoryParent(Path(homeDir)); err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; flush active source directory: %w", err)
+	}
+	bridgeDigest, err := legacyV18CutoverFileSHA256(Path(homeDir))
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; hash active bridge: %w", err)
+	}
+	bridge.BridgeSHA256 = bridgeDigest
+
+	frozenDB, err := openLegacyV18CutoverSQLite(Path(homeDir), "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; reopen: %w", err)
+	}
+	validationErr := validateLegacyV18CutoverFrozenBridge(frozenDB, fleetID, gate.sourceSHA256)
+	frozenCloseErr := frozenDB.Close()
+	if validationErr != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; validate: %w", validationErr)
+	}
+	if frozenCloseErr != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; close validation DB: %w", frozenCloseErr)
+	}
+	if closeErr != nil {
+		return bridge, fmt.Errorf("freeze legacy v18 cutover source: frozen bridge committed; close EXCLUSIVE gate: %w", closeErr)
+	}
+	return bridge, nil
+}
+
+func closeCommittedLegacyV18CutoverGate(gate *legacyV18CutoverGate) error {
+	var firstErr error
+	if gate.conn != nil {
+		if err := gate.conn.Close(); err != nil {
+			firstErr = err
+		}
+		gate.conn = nil
+	}
+	if gate.db != nil {
+		if err := gate.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		gate.db = nil
+	}
+	return firstErr
+}
+
+func legacyV18CutoverFreezeTriggerName(table, operation string) string {
+	return "v19_freeze_" + table + "_" + operation
+}
+
+func legacyV18CutoverFreezeTriggerSQL(table, operation string) string {
+	return fmt.Sprintf("CREATE TRIGGER %s BEFORE %s ON %s BEGIN SELECT RAISE(ABORT, '%s'); END",
+		legacyV18CutoverFreezeTriggerName(table, operation), operation, table, legacyV18CutoverFreezeAbortMessage)
+}
+
+func validateLegacyV18CutoverFrozenBridge(q sqliteQueryer, expectedFleetID, expectedSourceSHA256 string) error {
+	if err := validateFleetID(expectedFleetID); err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: expected Fleet ID: %w", err)
+	}
+	if err := validateLegacyV18CutoverSHA256(expectedSourceSHA256); err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: %w", err)
+	}
+	version, err := schemaUserVersion(q)
+	if err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: %w", err)
+	}
+	if version != legacyV18CutoverFrozenUserVersion {
+		return fmt.Errorf("validate legacy v18 frozen bridge: user_version=%d, want %d", version, legacyV18CutoverFrozenUserVersion)
+	}
+	layoutFingerprint, err := legacyV18LayoutFingerprint(q)
+	if err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: %w", err)
+	}
+	if layoutFingerprint != legacyV072LayoutFingerprint {
+		return fmt.Errorf("validate legacy v18 frozen bridge: base layout fingerprint=%s, want %s", layoutFingerprint, legacyV072LayoutFingerprint)
+	}
+	if err := validateLegacyV18DDLFeatures(q); err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: %w", err)
+	}
+	identity, err := inspectCanonicalV19Identity(q)
+	if err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: %w", err)
+	}
+	if identity.Tables != legacyV072TableCount || identity.Indexes != legacyV072IndexCount || identity.Triggers != len(legacyV18CutoverFreezeTables)*len(legacyV18CutoverFreezeOperations) {
+		return fmt.Errorf("validate legacy v18 frozen bridge: schema objects=%d tables/%d indexes/%d triggers, want %d/%d/%d",
+			identity.Tables, identity.Indexes, identity.Triggers,
+			legacyV072TableCount, legacyV072IndexCount, len(legacyV18CutoverFreezeTables)*len(legacyV18CutoverFreezeOperations))
+	}
+	fleetID, err := legacyV18CutoverFleetID(q)
+	if err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: %w", err)
+	}
+	if fleetID != expectedFleetID {
+		return fmt.Errorf("validate legacy v18 frozen bridge: Fleet ID=%s, want %s", fleetID, expectedFleetID)
+	}
+	var certificate string
+	if err := q.QueryRow(`SELECT value FROM meta WHERE key = ?`, legacyV18CutoverFreezeCertificateKey).Scan(&certificate); err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: read freeze certificate: %w", err)
+	}
+	expectedCertificate := legacyV18CutoverFreezeCertificateVersion + ":" + expectedSourceSHA256
+	if certificate != expectedCertificate {
+		return fmt.Errorf("validate legacy v18 frozen bridge: freeze certificate=%q, want %q", certificate, expectedCertificate)
+	}
+	if err := validateLegacyV18CutoverFreezeTriggers(q); err != nil {
+		return err
+	}
+	var integrity string
+	if err := q.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: integrity_check: %w", err)
+	}
+	if integrity != "ok" {
+		return fmt.Errorf("validate legacy v18 frozen bridge: integrity_check=%q, want ok", integrity)
+	}
+	rows, err := q.Query(`PRAGMA foreign_key_check`)
+	if err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: foreign_key_check: %w", err)
+	}
+	hasViolation := rows.Next()
+	rowsErr := rows.Err()
+	closeErr := rows.Close()
+	if rowsErr != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: foreign_key_check: %w", rowsErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: close foreign_key_check: %w", closeErr)
+	}
+	if hasViolation {
+		return fmt.Errorf("validate legacy v18 frozen bridge: foreign_key_check returned at least one row")
+	}
+	return nil
+}
+
+func validateLegacyV18CutoverFreezeTriggers(q sqliteQueryer) error {
+	expected := make(map[string]string, len(legacyV18CutoverFreezeTables)*len(legacyV18CutoverFreezeOperations))
+	for _, table := range legacyV18CutoverFreezeTables {
+		for _, operation := range legacyV18CutoverFreezeOperations {
+			name := legacyV18CutoverFreezeTriggerName(table, operation)
+			expected[name] = compactLegacyV18DDL(legacyV18CutoverFreezeTriggerSQL(table, operation))
+		}
+	}
+	rows, err := q.Query(`SELECT name, sql FROM sqlite_schema WHERE type = 'trigger' ORDER BY name`)
+	if err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: read freeze triggers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	seen := make(map[string]bool, len(expected))
+	for rows.Next() {
+		var name string
+		var ddl sql.NullString
+		if err := rows.Scan(&name, &ddl); err != nil {
+			return fmt.Errorf("validate legacy v18 frozen bridge: read freeze triggers: %w", err)
+		}
+		want, ok := expected[name]
+		if !ok {
+			return fmt.Errorf("validate legacy v18 frozen bridge: unexpected trigger %q", name)
+		}
+		if !ddl.Valid || compactLegacyV18DDL(ddl.String) != want {
+			return fmt.Errorf("validate legacy v18 frozen bridge: trigger %q semantics do not match exact freeze guard", name)
+		}
+		seen[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("validate legacy v18 frozen bridge: read freeze triggers: %w", err)
+	}
+	if len(seen) != len(expected) {
+		var missing []string
+		for name := range expected {
+			if !seen[name] {
+				missing = append(missing, name)
+			}
+		}
+		return fmt.Errorf("validate legacy v18 frozen bridge: missing freeze triggers: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/internal/store/cutoverfreeze_test.go
+++ b/internal/store/cutoverfreeze_test.go
@@ -1,0 +1,209 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestFreezeLegacyV18CutoverSourceCommitsExactFrozenBridge(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+
+	staleDB := openLegacyV18CutoverTestDB(t, home, true)
+	staleInsert, err := staleDB.Prepare(`INSERT INTO meta(key, value) VALUES(?, ?)`)
+	if err != nil {
+		_ = staleDB.Close()
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = staleInsert.Close()
+		_ = staleDB.Close()
+	}()
+
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+	originalDigest := gate.sourceSHA256
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(home, gate.archiveCandidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveBefore, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bridge, err := freezeLegacyV18CutoverSource(context.Background(), home, gate, archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bridge.Committed {
+		t.Fatal("frozen bridge did not report committed state")
+	}
+	if bridge.SourceSHA256 != originalDigest || bridge.Certificate != "v1:"+originalDigest {
+		t.Fatalf("frozen bridge provenance = %+v, want original digest %s", bridge, originalDigest)
+	}
+	if bridge.BridgeSHA256 == "" || bridge.BridgeSHA256 == originalDigest {
+		t.Fatalf("frozen bridge digest = %q, want nonempty digest distinct from original %s", bridge.BridgeSHA256, originalDigest)
+	}
+	if gate.conn != nil || gate.db != nil {
+		t.Fatal("committed freeze left the EXCLUSIVE SQLite gate open")
+	}
+
+	archiveAfter, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archiveAfter != archiveBefore || archiveAfter != originalDigest {
+		t.Fatalf("original archive changed across freeze: before=%s after=%s source=%s", archiveBefore, archiveAfter, originalDigest)
+	}
+
+	frozenDB, err := openLegacyV18CutoverSQLite(Path(home), "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = frozenDB.Close() }()
+	if err := validateLegacyV18CutoverFrozenBridge(frozenDB, bridge.FleetID, originalDigest); err != nil {
+		t.Fatal(err)
+	}
+	var version int
+	if err := frozenDB.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != legacyV18CutoverFrozenUserVersion {
+		t.Fatalf("frozen user_version = %d, want %d", version, legacyV18CutoverFrozenUserVersion)
+	}
+	var triggers int
+	if err := frozenDB.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'trigger'`).Scan(&triggers); err != nil {
+		t.Fatal(err)
+	}
+	if triggers != 21 {
+		t.Fatalf("frozen bridge triggers = %d, want 21", triggers)
+	}
+	layout, err := legacyV18LayoutFingerprint(frozenDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layout != legacyV072LayoutFingerprint {
+		t.Fatalf("frozen bridge base layout = %s, want %s", layout, legacyV072LayoutFingerprint)
+	}
+
+	if _, err := staleInsert.Exec("after-freeze", "forbidden"); err == nil || !strings.Contains(err.Error(), legacyV18CutoverFreezeAbortMessage) {
+		t.Fatalf("stale prepared writer after freeze = %v, want exact freeze guard abort", err)
+	}
+	if db, err := Open(home); err == nil {
+		_ = db.Close()
+		t.Fatal("legacy Open accepted frozen bridge as a supported source")
+	}
+
+	if err := gate.Close(); err != nil {
+		t.Fatal(err)
+	}
+	release, err := Lock(home, MigrationLock, true)
+	if err != nil {
+		t.Fatalf("MigrationLock after frozen gate close: %v", err)
+	}
+	release()
+}
+
+func TestFreezeLegacyV18CutoverSourceRefusesArchiveMismatchWithoutMutation(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gate.Close() }()
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(home, gate.archiveCandidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeDigest := gate.sourceSHA256
+	bad := archive
+	bad.SHA256 = strings.Repeat("b", 64)
+	if bad.SHA256 == beforeDigest {
+		bad.SHA256 = strings.Repeat("c", 64)
+	}
+
+	bridge, err := freezeLegacyV18CutoverSource(context.Background(), home, gate, bad)
+	if err == nil {
+		t.Fatal("freeze accepted mismatched original archive evidence")
+	}
+	if bridge.Committed {
+		t.Fatalf("refused freeze reported committed bridge: %+v", bridge)
+	}
+	if err := gate.Close(); err != nil {
+		t.Fatal(err)
+	}
+	afterDigest, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDigest != beforeDigest {
+		t.Fatalf("refused freeze changed source bytes: before=%s after=%s", beforeDigest, afterDigest)
+	}
+
+	db := openLegacyV18CutoverTestDB(t, home, true)
+	defer func() { _ = db.Close() }()
+	var version, triggers, certificates int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'trigger'`).Scan(&triggers); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM meta WHERE key = ?`, legacyV18CutoverFreezeCertificateKey).Scan(&certificates); err != nil {
+		t.Fatal(err)
+	}
+	if version != legacyV072SchemaVersion || triggers != 0 || certificates != 0 {
+		t.Fatalf("refused freeze residue: version=%d triggers=%d certificates=%d", version, triggers, certificates)
+	}
+}
+
+func TestValidateLegacyV18CutoverFrozenBridgeRejectsTamperedGuard(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	gate, err := acquireLegacyV18CutoverGate(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(home, gate.archiveCandidate)
+	if err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+	bridge, err := freezeLegacyV18CutoverSource(context.Background(), home, gate, archive)
+	if err != nil {
+		_ = gate.Close()
+		t.Fatal(err)
+	}
+	if err := gate.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db := openLegacyV18CutoverTestDB(t, home, true)
+	name := legacyV18CutoverFreezeTriggerName("task", "INSERT")
+	if _, err := db.Exec(`DROP TRIGGER ` + name); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER ` + name + ` BEFORE INSERT ON task BEGIN SELECT RAISE(ABORT, 'tampered freeze guard'); END`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	frozenDB, err := openLegacyV18CutoverSQLite(Path(home), "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = frozenDB.Close() }()
+	if err := validateLegacyV18CutoverFrozenBridge(frozenDB, bridge.FleetID, bridge.SourceSHA256); err == nil || !strings.Contains(err.Error(), "semantics do not match exact freeze guard") {
+		t.Fatalf("tampered frozen bridge validation = %v, want exact trigger-semantic refusal", err)
+	}
+}


### PR DESCRIPTION
Implements the next inert frozen-bridge primitive required by the immutable revision-2 #348 contract before canonical target materialization can be used.

- requires a live pinned 5A2 EXCLUSIVE cutover gate plus exact deterministic durable original-archive evidence
- re-proves exact Fleet/source digest/migration identity and source semantics before crossing the one-way boundary
- disables query_only only on the already-exclusive connection, requires the freeze certificate to be absent, then atomically writes the exact `v1:<original-source-sha256>` certificate
- creates exactly 21 unconditional INSERT/UPDATE/DELETE guards across the seven supported legacy tables with the exact required names and abort message
- sets the frozen-bridge sentinel `PRAGMA user_version=22` and commits on that same pinned transaction
- consumes the committed EXCLUSIVE SQLite connection so later cleanup cannot pretend rollback is still possible; MigrationLock remains held until the gate is closed
- flushes/reopens/hashes the committed bridge and validates exact base layout, Fleet identity, certificate, trigger set/semantics, FK integrity, and database integrity
- proves stale prepared legacy DML is rejected after freeze while the immutable original archive remains byte-identical
- remains inert/unreferenced: no provider/lock orchestration caller, canonical row materialization, active DB publication, marker publication, or automatic cutover activation

This lands a revision-2 prerequisite primitive only. Final orchestration must still prove Fleet-local/provider closure and durable original archive before invoking it; canonical target construction/use remains downstream.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.