### PR TITLE
feat(store): classify v19 cutover recovery authority

### DIFF
--- a/internal/store/cutoverrecovery.go
+++ b/internal/store/cutoverrecovery.go
@@ -1,0 +1,228 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type legacyV18CutoverRecoveryDisposition string
+
+const (
+	legacyV18CutoverRecoveryNoState              legacyV18CutoverRecoveryDisposition = "no-state"
+	legacyV18CutoverRecoveryLegacySource         legacyV18CutoverRecoveryDisposition = "legacy-source"
+	legacyV18CutoverRecoveryCanonicalAuthority   legacyV18CutoverRecoveryDisposition = "canonical-authority"
+	legacyV18CutoverRecoveryRebuildCanonicalTemp legacyV18CutoverRecoveryDisposition = "rebuild-canonical-temp"
+	legacyV18CutoverRecoveryPublishCanonicalTemp legacyV18CutoverRecoveryDisposition = "publish-canonical-temp"
+	legacyV18CutoverRecoveryRefuse               legacyV18CutoverRecoveryDisposition = "refuse"
+)
+
+type legacyV18CutoverRecoveryState struct {
+	Disposition   legacyV18CutoverRecoveryDisposition
+	Reason        string
+	MigrationID   string
+	FleetID       string
+	SourceSHA256  string
+	BridgeSHA256  string
+	Manifest      legacyV18CutoverManifestArtifact
+	Materialized  canonicalV19CutoverMaterialization
+}
+
+// Classifies startup cutover/recovery authority without writing, syncing,
+// renaming, migrating, checkpointing, or repairing any Fleet-local state.
+func inspectLegacyV18CutoverRecovery(homeDir string) (legacyV18CutoverRecoveryState, error) {
+	activePath := Path(homeDir)
+	info, err := os.Lstat(activePath)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return legacyV18CutoverRecoveryState{
+				Disposition: legacyV18CutoverRecoveryRefuse,
+				Reason:      fmt.Sprintf("active state database %s is not a direct regular file", activePath),
+			}, nil
+		}
+		return inspectLegacyV18CutoverRecoveryWithActive(homeDir)
+	case os.IsNotExist(err):
+		return inspectLegacyV18CutoverRecoveryWithoutActive(homeDir)
+	default:
+		return legacyV18CutoverRecoveryState{}, fmt.Errorf("inspect v19 cutover recovery active database: %w", err)
+	}
+}
+
+func inspectLegacyV18CutoverRecoveryWithActive(homeDir string) (legacyV18CutoverRecoveryState, error) {
+	activePath := Path(homeDir)
+	sqlDB, err := openLegacyV18CutoverSQLite(activePath, "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		return legacyV18CutoverRecoveryState{
+			Disposition: legacyV18CutoverRecoveryRefuse,
+			Reason:      fmt.Sprintf("active state database cannot be opened read-only: %v", err),
+		}, nil
+	}
+
+	canonical, candidateErr := canonicalV19Candidate(sqlDB)
+	if candidateErr != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverRecoveryState{
+			Disposition: legacyV18CutoverRecoveryRefuse,
+			Reason:      fmt.Sprintf("active state database canonical-family inspection failed: %v", candidateErr),
+		}, nil
+	}
+	if canonical {
+		validationErr := validateCanonicalV19Schema(sqlDB)
+		fleetID := ""
+		if validationErr == nil {
+			fleetID, validationErr = validateCanonicalV19CutoverActiveFleet(sqlDB)
+		}
+		closeErr := sqlDB.Close()
+		if validationErr != nil {
+			return legacyV18CutoverRecoveryState{
+				Disposition: legacyV18CutoverRecoveryRefuse,
+				Reason:      fmt.Sprintf("canonical v19 active database is invalid and cannot fall back to legacy evidence: %v", validationErr),
+			}, nil
+		}
+		if closeErr != nil {
+			return legacyV18CutoverRecoveryState{
+				Disposition: legacyV18CutoverRecoveryRefuse,
+				Reason:      fmt.Sprintf("close validated canonical v19 active database: %v", closeErr),
+			}, nil
+		}
+		return legacyV18CutoverRecoveryState{
+			Disposition: legacyV18CutoverRecoveryCanonicalAuthority,
+			FleetID:     fleetID,
+		}, nil
+	}
+
+	version, versionErr := schemaUserVersion(sqlDB)
+	if versionErr != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverRecoveryState{
+			Disposition: legacyV18CutoverRecoveryRefuse,
+			Reason:      fmt.Sprintf("active state database user_version inspection failed: %v", versionErr),
+		}, nil
+	}
+	if version == legacyV18CutoverFrozenUserVersion {
+		_ = sqlDB.Close()
+		return inspectLegacyV18CutoverFrozenRecovery(homeDir)
+	}
+
+	_, legacyErr := validateLegacyV18CutoverSource(sqlDB)
+	closeErr := sqlDB.Close()
+	if legacyErr == nil && closeErr == nil {
+		return legacyV18CutoverRecoveryState{Disposition: legacyV18CutoverRecoveryLegacySource}, nil
+	}
+	if legacyErr == nil {
+		legacyErr = closeErr
+	}
+	return legacyV18CutoverRecoveryState{
+		Disposition: legacyV18CutoverRecoveryRefuse,
+		Reason:      fmt.Sprintf("active state database is neither valid canonical v19, exact frozen bridge, nor exact supported legacy source: %v", legacyErr),
+	}, nil
+}
+
+func inspectLegacyV18CutoverFrozenRecovery(homeDir string) (legacyV18CutoverRecoveryState, error) {
+	bridge, err := discoverLegacyV18CutoverFrozenBridge(homeDir)
+	if err != nil {
+		return legacyV18CutoverRecoveryState{
+			Disposition: legacyV18CutoverRecoveryRefuse,
+			Reason:      fmt.Sprintf("active frozen bridge is not exact recovery evidence: %v", err),
+		}, nil
+	}
+
+	evidence, err := inspectLegacyV18CutoverArchiveEvidence(homeDir, bridge.MigrationID)
+	if err != nil {
+		return legacyV18CutoverRecoveryState{
+			Disposition:  legacyV18CutoverRecoveryRefuse,
+			Reason:       fmt.Sprintf("frozen bridge lacks exact matching immutable original archive evidence: %v", err),
+			MigrationID:  bridge.MigrationID,
+			FleetID:      bridge.FleetID,
+			SourceSHA256: bridge.SourceSHA256,
+			BridgeSHA256: bridge.BridgeSHA256,
+		}, nil
+	}
+	if evidence.Manifest.Fleet.FleetID != bridge.FleetID || evidence.Manifest.Source.DBSHA256 != bridge.SourceSHA256 || evidence.Manifest.Freeze.CertificateValue != bridge.Certificate {
+		return legacyV18CutoverRecoveryState{
+			Disposition:  legacyV18CutoverRecoveryRefuse,
+			Reason:       "frozen bridge and immutable archive manifest do not bind the same Fleet/source certificate",
+			MigrationID:  bridge.MigrationID,
+			FleetID:      bridge.FleetID,
+			SourceSHA256: bridge.SourceSHA256,
+			BridgeSHA256: bridge.BridgeSHA256,
+		}, nil
+	}
+	return classifyLegacyV18CutoverTempRecovery(homeDir, bridge, evidence)
+}
+
+func inspectLegacyV18CutoverRecoveryWithoutActive(homeDir string) (legacyV18CutoverRecoveryState, error) {
+	evidence, found, looseArtifacts, err := discoverLegacyV18CutoverArchiveEvidence(homeDir)
+	if err != nil {
+		return legacyV18CutoverRecoveryState{
+			Disposition: legacyV18CutoverRecoveryRefuse,
+			Reason:      err.Error(),
+		}, nil
+	}
+	if !found {
+		if looseArtifacts {
+			return legacyV18CutoverRecoveryState{
+				Disposition: legacyV18CutoverRecoveryRefuse,
+				Reason:      "active state database is missing and only non-authoritative or incomplete cutover artifacts remain",
+			}, nil
+		}
+		return legacyV18CutoverRecoveryState{Disposition: legacyV18CutoverRecoveryNoState}, nil
+	}
+
+	bridge := legacyV18CutoverFrozenBridge{
+		MigrationID:  evidence.Manifest.MigrationID,
+		FleetID:      evidence.Manifest.Fleet.FleetID,
+		SourceSHA256: evidence.Manifest.Source.DBSHA256,
+		Certificate:  evidence.Manifest.Freeze.CertificateValue,
+		Committed:    true,
+	}
+	return classifyLegacyV18CutoverTempRecovery(homeDir, bridge, evidence)
+}
+
+func classifyLegacyV18CutoverTempRecovery(homeDir string, bridge legacyV18CutoverFrozenBridge, evidence legacyV18CutoverArchiveEvidence) (legacyV18CutoverRecoveryState, error) {
+	materialized, exists, unsafePath, err := inspectCanonicalV19CutoverMaterializedTemp(homeDir, evidence)
+	state := legacyV18CutoverRecoveryState{
+		Disposition:  legacyV18CutoverRecoveryRebuildCanonicalTemp,
+		MigrationID:  evidence.Manifest.MigrationID,
+		FleetID:      evidence.Manifest.Fleet.FleetID,
+		SourceSHA256: evidence.Manifest.Source.DBSHA256,
+		BridgeSHA256: bridge.BridgeSHA256,
+		Manifest:     evidence.Artifact,
+	}
+	if unsafePath {
+		state.Disposition = legacyV18CutoverRecoveryRefuse
+		state.Reason = err.Error()
+		return state, nil
+	}
+	if err != nil {
+		state.Reason = fmt.Sprintf("canonical temp is invalid/non-authoritative and must be rebuilt from exact archive evidence: %v", err)
+		return state, nil
+	}
+	if !exists {
+		state.Reason = "canonical temp is absent and must be rebuilt from exact archive evidence"
+		return state, nil
+	}
+	state.Disposition = legacyV18CutoverRecoveryPublishCanonicalTemp
+	state.Materialized = materialized
+	return state, nil
+}
+
+func validateCanonicalV19CutoverActiveFleet(sqlDB sqliteQueryer) (string, error) {
+	var count int
+	var fleetID string
+	if err := sqlDB.QueryRow(`SELECT COUNT(*), COALESCE(MIN(fleet_id), '') FROM fleet WHERE singleton = 1`).Scan(&count, &fleetID); err != nil {
+		return "", fmt.Errorf("read canonical Fleet singleton: %w", err)
+	}
+	if count != 1 {
+		return "", fmt.Errorf("canonical Fleet singleton rows=%d, want 1", count)
+	}
+	if err := validateFleetID(fleetID); err != nil {
+		return "", fmt.Errorf("canonical Fleet identity: %w", err)
+	}
+	return fleetID, nil
+}
+
+func isLegacyV18CutoverLooseArtifact(name string) bool {
+	return strings.HasPrefix(name, ".v19-cutover-") || strings.HasPrefix(name, "v19-cutover-")
+}

--- a/internal/store/cutoverrecovery.go
+++ b/internal/store/cutoverrecovery.go
@@ -18,14 +18,14 @@ const (
 )
 
 type legacyV18CutoverRecoveryState struct {
-	Disposition   legacyV18CutoverRecoveryDisposition
-	Reason        string
-	MigrationID   string
-	FleetID       string
-	SourceSHA256  string
-	BridgeSHA256  string
-	Manifest      legacyV18CutoverManifestArtifact
-	Materialized  canonicalV19CutoverMaterialization
+	Disposition  legacyV18CutoverRecoveryDisposition
+	Reason       string
+	MigrationID  string
+	FleetID      string
+	SourceSHA256 string
+	BridgeSHA256 string
+	Manifest     legacyV18CutoverManifestArtifact
+	Materialized canonicalV19CutoverMaterialization
 }
 
 // Classifies startup cutover/recovery authority without writing, syncing,

--- a/internal/store/cutoverrecovery_evidence.go
+++ b/internal/store/cutoverrecovery_evidence.go
@@ -1,0 +1,295 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type legacyV18CutoverArchiveEvidence struct {
+	Archive  legacyV18CutoverOriginalArchive
+	Artifact legacyV18CutoverManifestArtifact
+	Manifest legacyV18CutoverManifest
+}
+
+func discoverLegacyV18CutoverFrozenBridge(homeDir string) (legacyV18CutoverFrozenBridge, error) {
+	activePath := Path(homeDir)
+	beforeDigest, err := legacyV18CutoverFileSHA256(activePath)
+	if err != nil {
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("hash frozen bridge before validation: %w", err)
+	}
+	sqlDB, err := openLegacyV18CutoverSQLite(activePath, "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("open frozen bridge read-only: %w", err)
+	}
+	version, err := schemaUserVersion(sqlDB)
+	if err != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, err
+	}
+	if version != legacyV18CutoverFrozenUserVersion {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("user_version=%d, want exact frozen sentinel %d", version, legacyV18CutoverFrozenUserVersion)
+	}
+	fleetID, err := legacyV18CutoverFleetID(sqlDB)
+	if err != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, err
+	}
+	var certificate string
+	if err := sqlDB.QueryRow(`SELECT value FROM meta WHERE key = ?`, legacyV18CutoverFreezeCertificateKey).Scan(&certificate); err != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("read freeze certificate: %w", err)
+	}
+	prefix := legacyV18CutoverFreezeCertificateVersion + ":"
+	if !strings.HasPrefix(certificate, prefix) {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("freeze certificate=%q, want %s:<source-sha256>", certificate, legacyV18CutoverFreezeCertificateVersion)
+	}
+	sourceSHA256 := strings.TrimPrefix(certificate, prefix)
+	if err := validateLegacyV18CutoverSHA256(sourceSHA256); err != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("freeze certificate source digest: %w", err)
+	}
+	migrationID, err := legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256)
+	if err != nil {
+		_ = sqlDB.Close()
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("derive frozen bridge migration identity: %w", err)
+	}
+	validationErr := validateLegacyV18CutoverFrozenBridge(sqlDB, fleetID, sourceSHA256)
+	closeErr := sqlDB.Close()
+	if validationErr != nil {
+		return legacyV18CutoverFrozenBridge{}, validationErr
+	}
+	if closeErr != nil {
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("close frozen bridge validation DB: %w", closeErr)
+	}
+	afterDigest, err := legacyV18CutoverFileSHA256(activePath)
+	if err != nil {
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("hash frozen bridge after validation: %w", err)
+	}
+	if beforeDigest != afterDigest {
+		return legacyV18CutoverFrozenBridge{}, fmt.Errorf("frozen bridge changed during read-only validation: before=%s after=%s", beforeDigest, afterDigest)
+	}
+	return legacyV18CutoverFrozenBridge{
+		MigrationID:  migrationID,
+		FleetID:      fleetID,
+		SourceSHA256: sourceSHA256,
+		BridgeSHA256: afterDigest,
+		Certificate:  certificate,
+		Committed:    true,
+	}, nil
+}
+
+func discoverLegacyV18CutoverArchiveEvidence(homeDir string) (legacyV18CutoverArchiveEvidence, bool, bool, error) {
+	entries, err := os.ReadDir(Dir(homeDir))
+	if os.IsNotExist(err) {
+		return legacyV18CutoverArchiveEvidence{}, false, false, nil
+	}
+	if err != nil {
+		return legacyV18CutoverArchiveEvidence{}, false, false, fmt.Errorf("inspect v19 cutover recovery state directory: %w", err)
+	}
+	var migrationIDs []string
+	looseArtifacts := false
+	for _, entry := range entries {
+		name := entry.Name()
+		if !isLegacyV18CutoverLooseArtifact(name) {
+			continue
+		}
+		looseArtifacts = true
+		if !strings.HasPrefix(name, "v19-cutover-") {
+			continue
+		}
+		migrationID := strings.TrimPrefix(name, "v19-cutover-")
+		if err := validateLegacyV18CutoverMigrationID(migrationID); err != nil {
+			if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+				return legacyV18CutoverArchiveEvidence{}, false, true, fmt.Errorf("ambiguous v19 cutover recovery directory %q: %w", name, err)
+			}
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			return legacyV18CutoverArchiveEvidence{}, false, true, fmt.Errorf("v19 cutover recovery archive path %q is not a direct directory", name)
+		}
+		migrationIDs = append(migrationIDs, migrationID)
+	}
+	if len(migrationIDs) == 0 {
+		return legacyV18CutoverArchiveEvidence{}, false, looseArtifacts, nil
+	}
+	if len(migrationIDs) != 1 {
+		return legacyV18CutoverArchiveEvidence{}, false, true, fmt.Errorf("ambiguous v19 cutover recovery evidence: found %d deterministic archive directories", len(migrationIDs))
+	}
+	evidence, err := inspectLegacyV18CutoverArchiveEvidence(homeDir, migrationIDs[0])
+	if err != nil {
+		return legacyV18CutoverArchiveEvidence{}, false, true, err
+	}
+	return evidence, true, looseArtifacts, nil
+}
+
+func inspectLegacyV18CutoverArchiveEvidence(homeDir, migrationID string) (legacyV18CutoverArchiveEvidence, error) {
+	if err := validateLegacyV18CutoverMigrationID(migrationID); err != nil {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("inspect immutable original archive evidence: %w", err)
+	}
+	manifest, artifact, err := inspectPersistedLegacyV18CutoverManifestReadOnly(homeDir, migrationID)
+	if err != nil {
+		return legacyV18CutoverArchiveEvidence{}, err
+	}
+	archive := legacyV18CutoverOriginalArchive{
+		MigrationID: migrationID,
+		Directory:   legacyV18CutoverOriginalArchiveDir(homeDir, migrationID),
+		Path:        legacyV18CutoverOriginalArchivePath(homeDir, migrationID),
+		SHA256:      manifest.Source.DBSHA256,
+	}
+	if err := requireLegacyV18CutoverDirectRegularFile(archive.Path, "original archive"); err != nil {
+		return legacyV18CutoverArchiveEvidence{}, err
+	}
+	if err := requireLegacyV18CutoverNoSQLiteSidecars(archive.Path, "original archive"); err != nil {
+		return legacyV18CutoverArchiveEvidence{}, err
+	}
+	beforeDigest, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("hash immutable original archive: %w", err)
+	}
+	if beforeDigest != archive.SHA256 {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("immutable original archive digest=%s, want manifest source=%s", beforeDigest, archive.SHA256)
+	}
+	sqlDB, err := openLegacyV18CutoverSQLite(archive.Path, "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("open immutable original archive read-only: %w", err)
+	}
+	_, validationErr := validateLegacyV18CutoverSource(sqlDB)
+	fleetID := ""
+	if validationErr == nil {
+		fleetID, validationErr = legacyV18CutoverFleetID(sqlDB)
+	}
+	closeErr := sqlDB.Close()
+	if validationErr != nil {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("validate immutable original archive exact source: %w", validationErr)
+	}
+	if closeErr != nil {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("close immutable original archive validation DB: %w", closeErr)
+	}
+	if fleetID != manifest.Fleet.FleetID {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("immutable original archive Fleet ID=%s, want manifest=%s", fleetID, manifest.Fleet.FleetID)
+	}
+	afterDigest, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("rehash immutable original archive: %w", err)
+	}
+	if afterDigest != beforeDigest {
+		return legacyV18CutoverArchiveEvidence{}, fmt.Errorf("immutable original archive changed during read-only validation: before=%s after=%s", beforeDigest, afterDigest)
+	}
+	return legacyV18CutoverArchiveEvidence{Archive: archive, Artifact: artifact, Manifest: manifest}, nil
+}
+
+func inspectPersistedLegacyV18CutoverManifestReadOnly(homeDir, migrationID string) (legacyV18CutoverManifest, legacyV18CutoverManifestArtifact, error) {
+	path := legacyV18CutoverManifestPath(homeDir, migrationID)
+	if err := requireLegacyV18CutoverDirectRegularFile(path, "manifest"); err != nil {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, err
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("read v19 cutover recovery manifest: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var manifest legacyV18CutoverManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("decode v19 cutover recovery manifest: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("v19 cutover recovery manifest has trailing JSON value")
+		}
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("v19 cutover recovery manifest trailing data: %w", err)
+	}
+	canonical, err := json.Marshal(manifest)
+	if err != nil {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("re-encode v19 cutover recovery manifest: %w", err)
+	}
+	canonical = append(canonical, '\n')
+	if !bytes.Equal(payload, canonical) {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("v19 cutover recovery manifest bytes are not canonical deterministic JSON")
+	}
+	importedAt, err := validateLegacyV18CutoverManifestTimestamp(manifest.ImportedAt)
+	if err != nil {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, fmt.Errorf("v19 cutover recovery manifest timestamp: %w", err)
+	}
+	if err := validatePersistedLegacyV18CutoverManifest(manifest, migrationID, importedAt); err != nil {
+		return legacyV18CutoverManifest{}, legacyV18CutoverManifestArtifact{}, err
+	}
+	artifact := legacyV18CutoverManifestArtifact{
+		MigrationID: migrationID,
+		Path:        filepath.Clean(path),
+		SHA256:      canonicalV19SHA256(payload),
+		ImportedAt:  importedAt,
+	}
+	return manifest, artifact, nil
+}
+
+func inspectCanonicalV19CutoverMaterializedTemp(homeDir string, evidence legacyV18CutoverArchiveEvidence) (canonicalV19CutoverMaterialization, bool, bool, error) {
+	path := legacyV18CutoverCanonicalTargetPath(homeDir, evidence.Manifest.MigrationID)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return canonicalV19CutoverMaterialization{}, false, false, nil
+	}
+	if err != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("inspect canonical temp: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return canonicalV19CutoverMaterialization{}, true, true, fmt.Errorf("canonical temp %s is not a direct regular file", path)
+	}
+	if err := requireLegacyV18CutoverNoSQLiteSidecars(path, "canonical temp"); err != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, err
+	}
+	beforeDigest, err := legacyV18CutoverFileSHA256(path)
+	if err != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("hash canonical temp: %w", err)
+	}
+	sqlDB, err := openLegacyV18CutoverSQLite(path, "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("open canonical temp read-only: %w", err)
+	}
+	plan := buildCanonicalV19CutoverImportPlan(evidence.Manifest, evidence.Artifact.SHA256)
+	validationErr := validateCanonicalV19Schema(sqlDB)
+	if validationErr == nil {
+		validationErr = validateCanonicalV19CutoverImportRows(sqlDB, plan)
+	}
+	closeErr := sqlDB.Close()
+	if validationErr != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("validate canonical temp exact #344/import evidence: %w", validationErr)
+	}
+	if closeErr != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("close canonical temp validation DB: %w", closeErr)
+	}
+	afterDigest, err := legacyV18CutoverFileSHA256(path)
+	if err != nil {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("rehash canonical temp: %w", err)
+	}
+	if beforeDigest != afterDigest {
+		return canonicalV19CutoverMaterialization{}, true, false, fmt.Errorf("canonical temp changed during read-only validation: before=%s after=%s", beforeDigest, afterDigest)
+	}
+	return canonicalV19CutoverMaterialization{
+		MigrationID:    evidence.Manifest.MigrationID,
+		Path:           path,
+		SHA256:         afterDigest,
+		ManifestSHA256: evidence.Artifact.SHA256,
+		ImportID:       plan.ImportID,
+		ProjectCount:   len(plan.Projects),
+	}, true, false, nil
+}
+
+func requireLegacyV18CutoverNoSQLiteSidecars(path, role string) error {
+	for _, suffix := range []string{"-journal", "-wal", "-shm"} {
+		sidecar := path + suffix
+		if _, err := os.Lstat(sidecar); err == nil {
+			return fmt.Errorf("v19 cutover recovery %s has unexpected SQLite sidecar %s", role, sidecar)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect v19 cutover recovery %s sidecar %s: %w", role, sidecar, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/cutoverrecovery_test.go
+++ b/internal/store/cutoverrecovery_test.go
@@ -1,0 +1,269 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInspectLegacyV18CutoverRecoveryFrozenBridgeWithMaterializedTempIsPublishReady(t *testing.T) {
+	home, bridge, archive, artifact, _, materialized := canonicalV19CutoverRecoveryFixture(t)
+	before := recoveryEvidenceDigests(t, Path(home), archive.Path, artifact.Path, materialized.Path)
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp {
+		t.Fatalf("recovery disposition = %q (%s), want %q", state.Disposition, state.Reason, legacyV18CutoverRecoveryPublishCanonicalTemp)
+	}
+	if state.MigrationID != bridge.MigrationID || state.FleetID != bridge.FleetID || state.SourceSHA256 != bridge.SourceSHA256 || state.BridgeSHA256 != bridge.BridgeSHA256 {
+		t.Fatalf("recovery bridge evidence = %#v, want %#v", state, bridge)
+	}
+	if state.Manifest != artifact || state.Materialized != materialized {
+		t.Fatalf("recovery publication evidence = %#v; manifest=%#v materialized=%#v", state, artifact, materialized)
+	}
+	after := recoveryEvidenceDigests(t, Path(home), archive.Path, artifact.Path, materialized.Path)
+	if strings.Join(before, "\n") != strings.Join(after, "\n") {
+		t.Fatalf("read-only recovery classifier changed evidence: before=%v after=%v", before, after)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryValidCanonicalActiveOutranksBrokenLegacyEvidence(t *testing.T) {
+	home, bridge, archive, artifact, target, _ := canonicalV19CutoverRecoveryFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(target.Path, Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archive.Path, []byte("broken stale archive evidence\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifact.Path, []byte("broken stale manifest evidence\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryCanonicalAuthority || state.FleetID != bridge.FleetID {
+		t.Fatalf("canonical authority state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryCorruptCanonicalActiveNeverFallsBackToArchive(t *testing.T) {
+	home, _, _, _, target, _ := canonicalV19CutoverRecoveryFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(target.Path, Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openLegacyV18CutoverSQLite(Path(home), "rw", legacyV18CutoverGateTimeout, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`PRAGMA user_version = 18`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRefuse || !strings.Contains(state.Reason, "cannot fall back to legacy evidence") {
+		t.Fatalf("corrupt canonical recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryFrozenBridgeRequiresMatchingArchive(t *testing.T) {
+	home, bridge, archive, _, _ := canonicalV19CutoverMaterializationFixture(t)
+	if err := os.WriteFile(archive.Path, []byte("not the frozen source\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRefuse || state.MigrationID != bridge.MigrationID || !strings.Contains(state.Reason, "matching immutable original archive") {
+		t.Fatalf("mismatched archive recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryMissingActiveWithValidArchiveAndTempIsPublishReady(t *testing.T) {
+	home, _, _, artifact, _, materialized := canonicalV19CutoverRecoveryFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp || state.Manifest != artifact || state.Materialized != materialized {
+		t.Fatalf("missing-active publication recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryMissingActiveWithArchiveAndNoTempRequiresRebuild(t *testing.T) {
+	home, bridge, _, artifact, target := canonicalV19CutoverMaterializationFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(target.Path); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRebuildCanonicalTemp || state.MigrationID != bridge.MigrationID || state.Manifest != artifact || !strings.Contains(state.Reason, "absent") {
+		t.Fatalf("missing temp recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryMissingActiveWithCorruptDirectTempRequiresRebuild(t *testing.T) {
+	home, bridge, _, artifact, target := canonicalV19CutoverMaterializationFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target.Path, []byte("corrupt non-authoritative temp\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRebuildCanonicalTemp || state.MigrationID != bridge.MigrationID || state.Manifest != artifact || !strings.Contains(state.Reason, "must be rebuilt") {
+		t.Fatalf("corrupt temp recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryRefusesUnsafeTempPath(t *testing.T) {
+	home, _, _, _, target := canonicalV19CutoverMaterializationFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(target.Path); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(t.TempDir(), "other.db")
+	if err := os.WriteFile(other, []byte("other\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(other, target.Path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRefuse || !strings.Contains(state.Reason, "not a direct regular file") {
+		t.Fatalf("unsafe temp recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryExactLegacySourceOutranksLooseCandidate(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	loose := filepath.Join(Dir(home), ".v19-cutover-v1-"+strings.Repeat("a", 64)+"-original.db.candidate")
+	if err := os.WriteFile(loose, []byte("non-authoritative candidate\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryLegacySource {
+		t.Fatalf("legacy source recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryMissingActiveWithOnlyLooseCandidateRefuses(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(Dir(home), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	loose := filepath.Join(Dir(home), ".v19-cutover-v1-"+strings.Repeat("a", 64)+"-original.db.candidate")
+	if err := os.WriteFile(loose, []byte("non-authoritative candidate\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRefuse || !strings.Contains(state.Reason, "non-authoritative") {
+		t.Fatalf("loose candidate recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryMalformedFrozenSentinelRefuses(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	db, err := openLegacyV18CutoverSQLite(Path(home), "rw", legacyV18CutoverGateTimeout, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`PRAGMA user_version = 22`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRefuse || !strings.Contains(state.Reason, "frozen bridge") {
+		t.Fatalf("malformed frozen sentinel recovery state = %#v", state)
+	}
+}
+
+func TestInspectLegacyV18CutoverRecoveryNoState(t *testing.T) {
+	home := t.TempDir()
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryNoState {
+		t.Fatalf("empty recovery state = %#v", state)
+	}
+}
+
+func canonicalV19CutoverRecoveryFixture(t *testing.T) (string, legacyV18CutoverFrozenBridge, legacyV18CutoverOriginalArchive, legacyV18CutoverManifestArtifact, canonicalV19CutoverTarget, canonicalV19CutoverMaterialization) {
+	t.Helper()
+	home, bridge, archive, artifact, target := canonicalV19CutoverMaterializationFixture(t)
+	materialized, err := materializeCanonicalV19CutoverTarget(home, bridge, artifact, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return home, bridge, archive, artifact, target, materialized
+}
+
+func recoveryEvidenceDigests(t *testing.T, paths ...string) []string {
+	t.Helper()
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		digest, err := legacyV18CutoverFileSHA256(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, digest)
+	}
+	return out
+}


### PR DESCRIPTION
Implements the first narrow 5D slice after #545 landed exact canonical temp materialization.

This slice adds an inert, read-only startup recovery/publication classifier that mechanically encodes the revision-2 #348 authority matrix without performing any rename, marker write, fsync, migration, checkpoint, registry repair, or automatic cutover activation.

It:
- makes a valid active canonical v19 database authoritative immediately after exact #344 schema/integrity/FK and Fleet-singleton validation, without consulting stale/broken legacy recovery artifacts;
- refuses corrupt/structurally invalid canonical v19 instead of silently falling back to archive/frozen-bridge evidence;
- leaves an exact supported v0.7.2 active source authoritative for a later fresh gate, even if non-authoritative candidate residue exists;
- self-identifies an exact frozen bridge only from its Fleet identity + exact v1 source-digest certificate, validates all 21 guards/integrity/FKs, and derives the deterministic migration identity from Fleet + original source digest;
- requires the deterministic immutable original archive and canonical deterministic manifest to match the bridge exactly before any recovery disposition advances;
- discovers active-missing recovery evidence only from one unambiguous deterministic archive directory and never upgrades loose archive candidates into authority;
- validates archive bytes as the exact supported source contract and validates manifest bytes as canonical deterministic JSON without calling the existing syncing manifest reader;
- validates a deterministic canonical temp read-only against exact #344 plus the exact manifest-derived import rows and total non-fabrication count;
- classifies valid temp as publication-ready, absent/corrupt direct temp as rebuild-from-archive, and unsafe symlink/nonregular temp paths as refusal;
- rejects unexpected SQLite sidecars on archive/temp evidence and verifies file digests are stable across inspection.

Tests pin canonical-over-stale-evidence precedence, corrupt-canonical no-fallback, exact frozen/archive binding, active-missing publish/rebuild cases, unsafe temp refusal, legacy-over-loose-candidate precedence, malformed frozen sentinel refusal, no-state, and byte stability across read-only inspection.

No destructive publication or production startup caller is introduced in this slice.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.