### PR TITLE
feat(store): publish canonical v19 cutover target crash-safely

### DIFF
--- a/internal/store/cutoverpublish.go
+++ b/internal/store/cutoverpublish.go
@@ -1,0 +1,262 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var errLegacyV18CutoverPublicationUnsafe = errors.New("v19 cutover publication is not mechanically safe")
+
+type canonicalV19CutoverPublication struct {
+	MigrationID       string
+	FleetID           string
+	SourceSHA256      string
+	ManifestSHA256    string
+	TargetSHA256      string
+	ImportID          string
+	ProjectCount      int
+	RetiredBridgePath string
+}
+
+func legacyV18CutoverRetiredBridgePath(homeDir, migrationID string) string {
+	return filepath.Join(legacyV18CutoverOriginalArchiveDir(homeDir, migrationID), "frozen-bridge.db")
+}
+
+// Publishes only a fully materialized canonical temp that the read-only 5D1
+// recovery classifier already proves belongs to one exact archive/manifest
+// identity. It is intentionally private and has no production startup caller.
+func publishCanonicalV19Cutover(homeDir string) (canonicalV19CutoverPublication, error) {
+	releaseMigration, err := Lock(homeDir, MigrationLock, true)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: acquire MigrationLock: %w", err)
+	}
+	defer releaseMigration()
+
+	before, err := inspectLegacyV18CutoverRecovery(homeDir)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: inspect recovery authority: %w", err)
+	}
+	if before.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("%w: recovery disposition=%s: %s", errLegacyV18CutoverPublicationUnsafe, before.Disposition, before.Reason)
+	}
+	if err := validateCanonicalV19CutoverPublicationState(before); err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+
+	evidence, err := inspectLegacyV18CutoverArchiveEvidence(homeDir, before.MigrationID)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: revalidate archive evidence: %w", err)
+	}
+	if err := requireCanonicalV19CutoverPublicationEvidence(before, evidence); err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+	if err := syncAndRevalidateCanonicalV19CutoverTemp(before.Materialized); err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+
+	activePath := Path(homeDir)
+	retiredPath := legacyV18CutoverRetiredBridgePath(homeDir, before.MigrationID)
+	activeInfo, activeErr := os.Lstat(activePath)
+	switch {
+	case activeErr == nil:
+		if before.BridgeSHA256 == "" {
+			return canonicalV19CutoverPublication{}, fmt.Errorf("%w: active database exists but recovery evidence has no frozen bridge digest", errLegacyV18CutoverPublicationUnsafe)
+		}
+		if activeInfo.Mode()&os.ModeSymlink != 0 || !activeInfo.Mode().IsRegular() {
+			return canonicalV19CutoverPublication{}, fmt.Errorf("%w: active frozen bridge %s is not a direct regular file", errLegacyV18CutoverPublicationUnsafe, activePath)
+		}
+		if err := revalidateCanonicalV19CutoverFrozenBridgeForPublication(homeDir, before, evidence); err != nil {
+			return canonicalV19CutoverPublication{}, err
+		}
+		if err := syncLegacyV18CutoverFile(activePath); err != nil {
+			return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: flush frozen bridge before retirement: %w", err)
+		}
+		if err := moveLegacyV18CutoverNoReplaceDurable(activePath, retiredPath); err != nil {
+			return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: retire frozen bridge: %w", err)
+		}
+	case os.IsNotExist(activeErr):
+		// Recovery may resume after a crash that already retired the frozen bridge.
+		// Exact archive+manifest+temp evidence is sufficient; the bridge is mechanism
+		// state and is not required to remain available after retirement.
+	default:
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: inspect active database before retirement: %w", activeErr)
+	}
+
+	afterRetire, err := inspectLegacyV18CutoverRecovery(homeDir)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: reclassify after bridge retirement: %w", err)
+	}
+	if afterRetire.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("%w: after bridge retirement recovery disposition=%s: %s", errLegacyV18CutoverPublicationUnsafe, afterRetire.Disposition, afterRetire.Reason)
+	}
+	if err := requireSameCanonicalV19CutoverPublicationState(before, afterRetire); err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+	if err := syncAndRevalidateCanonicalV19CutoverTemp(afterRetire.Materialized); err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+	if _, err := os.Lstat(activePath); err == nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("%w: active database unexpectedly reappeared before canonical publication", errLegacyV18CutoverPublicationUnsafe)
+	} else if !os.IsNotExist(err) {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: inspect active destination: %w", err)
+	}
+	if err := moveLegacyV18CutoverNoReplaceDurable(afterRetire.Materialized.Path, activePath); err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: publish canonical temp: %w", err)
+	}
+
+	publication, err := validatePublishedCanonicalV19Cutover(homeDir, afterRetire, retiredPath)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+	return publication, nil
+}
+
+func validateCanonicalV19CutoverPublicationState(state legacyV18CutoverRecoveryState) error {
+	if err := validateLegacyV18CutoverMigrationID(state.MigrationID); err != nil {
+		return fmt.Errorf("%w: migration identity: %v", errLegacyV18CutoverPublicationUnsafe, err)
+	}
+	if err := validateFleetID(state.FleetID); err != nil {
+		return fmt.Errorf("%w: Fleet identity: %v", errLegacyV18CutoverPublicationUnsafe, err)
+	}
+	if err := validateLegacyV18CutoverSHA256(state.SourceSHA256); err != nil {
+		return fmt.Errorf("%w: source digest: %v", errLegacyV18CutoverPublicationUnsafe, err)
+	}
+	if state.Manifest.MigrationID != state.MigrationID || state.Materialized.MigrationID != state.MigrationID {
+		return fmt.Errorf("%w: manifest/materialized migration identity does not match recovery state", errLegacyV18CutoverPublicationUnsafe)
+	}
+	if err := validateLegacyV18CutoverSHA256(state.Manifest.SHA256); err != nil {
+		return fmt.Errorf("%w: manifest digest: %v", errLegacyV18CutoverPublicationUnsafe, err)
+	}
+	if state.Materialized.ManifestSHA256 != state.Manifest.SHA256 {
+		return fmt.Errorf("%w: materialized manifest digest=%s, recovery manifest=%s", errLegacyV18CutoverPublicationUnsafe, state.Materialized.ManifestSHA256, state.Manifest.SHA256)
+	}
+	if err := validateLegacyV18CutoverSHA256(state.Materialized.SHA256); err != nil {
+		return fmt.Errorf("%w: canonical temp digest: %v", errLegacyV18CutoverPublicationUnsafe, err)
+	}
+	expectedPath := legacyV18CutoverCanonicalTargetPath(filepath.Dir(filepath.Dir(state.Materialized.Path)), state.MigrationID)
+	if filepath.Clean(state.Materialized.Path) != filepath.Clean(expectedPath) {
+		return fmt.Errorf("%w: canonical temp path=%s is not deterministic", errLegacyV18CutoverPublicationUnsafe, state.Materialized.Path)
+	}
+	return nil
+}
+
+func requireCanonicalV19CutoverPublicationEvidence(state legacyV18CutoverRecoveryState, evidence legacyV18CutoverArchiveEvidence) error {
+	if evidence.Manifest.MigrationID != state.MigrationID || evidence.Manifest.Fleet.FleetID != state.FleetID || evidence.Manifest.Source.DBSHA256 != state.SourceSHA256 {
+		return fmt.Errorf("%w: archive/manifest evidence no longer matches recovery Fleet/source identity", errLegacyV18CutoverPublicationUnsafe)
+	}
+	if evidence.Artifact.SHA256 != state.Manifest.SHA256 || filepath.Clean(evidence.Artifact.Path) != filepath.Clean(state.Manifest.Path) {
+		return fmt.Errorf("%w: manifest artifact changed before publication", errLegacyV18CutoverPublicationUnsafe)
+	}
+	return nil
+}
+
+func syncAndRevalidateCanonicalV19CutoverTemp(materialized canonicalV19CutoverMaterialization) error {
+	if err := requireLegacyV18CutoverDirectRegularFile(materialized.Path, "canonical temp"); err != nil {
+		return fmt.Errorf("publish canonical v19 cutover: %w", err)
+	}
+	if err := requireLegacyV18CutoverNoSQLiteSidecars(materialized.Path, "canonical temp"); err != nil {
+		return fmt.Errorf("publish canonical v19 cutover: %w", err)
+	}
+	if err := syncLegacyV18CutoverFile(materialized.Path); err != nil {
+		return fmt.Errorf("publish canonical v19 cutover: flush canonical temp: %w", err)
+	}
+	digest, err := legacyV18CutoverFileSHA256(materialized.Path)
+	if err != nil {
+		return fmt.Errorf("publish canonical v19 cutover: hash canonical temp after flush: %w", err)
+	}
+	if digest != materialized.SHA256 {
+		return fmt.Errorf("%w: canonical temp digest=%s after flush, want %s", errLegacyV18CutoverPublicationUnsafe, digest, materialized.SHA256)
+	}
+	return nil
+}
+
+func revalidateCanonicalV19CutoverFrozenBridgeForPublication(homeDir string, state legacyV18CutoverRecoveryState, evidence legacyV18CutoverArchiveEvidence) error {
+	bridge, err := discoverLegacyV18CutoverFrozenBridge(homeDir)
+	if err != nil {
+		return fmt.Errorf("publish canonical v19 cutover: revalidate frozen bridge: %w", err)
+	}
+	if bridge.MigrationID != state.MigrationID || bridge.FleetID != state.FleetID || bridge.SourceSHA256 != state.SourceSHA256 || bridge.BridgeSHA256 != state.BridgeSHA256 {
+		return fmt.Errorf("%w: frozen bridge identity changed before retirement", errLegacyV18CutoverPublicationUnsafe)
+	}
+	if evidence.Manifest.Freeze.CertificateValue != bridge.Certificate {
+		return fmt.Errorf("%w: frozen bridge certificate no longer matches manifest", errLegacyV18CutoverPublicationUnsafe)
+	}
+	return nil
+}
+
+func requireSameCanonicalV19CutoverPublicationState(before, after legacyV18CutoverRecoveryState) error {
+	if before.MigrationID != after.MigrationID || before.FleetID != after.FleetID || before.SourceSHA256 != after.SourceSHA256 || before.Manifest.SHA256 != after.Manifest.SHA256 {
+		return fmt.Errorf("%w: recovery identity changed across frozen-bridge retirement", errLegacyV18CutoverPublicationUnsafe)
+	}
+	if before.Materialized.MigrationID != after.Materialized.MigrationID || before.Materialized.Path != after.Materialized.Path || before.Materialized.SHA256 != after.Materialized.SHA256 || before.Materialized.ManifestSHA256 != after.Materialized.ManifestSHA256 || before.Materialized.ImportID != after.Materialized.ImportID || before.Materialized.ProjectCount != after.Materialized.ProjectCount {
+		return fmt.Errorf("%w: canonical temp evidence changed across frozen-bridge retirement", errLegacyV18CutoverPublicationUnsafe)
+	}
+	return nil
+}
+
+func validatePublishedCanonicalV19Cutover(homeDir string, state legacyV18CutoverRecoveryState, retiredPath string) (canonicalV19CutoverPublication, error) {
+	activePath := Path(homeDir)
+	if err := requireLegacyV18CutoverDirectRegularFile(activePath, "published canonical database"); err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: %w", err)
+	}
+	if err := requireLegacyV18CutoverNoSQLiteSidecars(activePath, "published canonical database"); err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: %w", err)
+	}
+	evidence, err := inspectLegacyV18CutoverArchiveEvidence(homeDir, state.MigrationID)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: revalidate archive after publication: %w", err)
+	}
+	if err := requireCanonicalV19CutoverPublicationEvidence(state, evidence); err != nil {
+		return canonicalV19CutoverPublication{}, err
+	}
+
+	sqlDB, err := openLegacyV18CutoverSQLite(activePath, "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: reopen active canonical database read-only: %w", err)
+	}
+	plan := buildCanonicalV19CutoverImportPlan(evidence.Manifest, evidence.Artifact.SHA256)
+	validationErr := validateCanonicalV19Schema(sqlDB)
+	if validationErr == nil {
+		validationErr = validateCanonicalV19CutoverImportRows(sqlDB, plan)
+	}
+	if validationErr == nil {
+		var fleetID string
+		fleetID, validationErr = validateCanonicalV19CutoverActiveFleet(sqlDB)
+		if validationErr == nil && fleetID != state.FleetID {
+			validationErr = fmt.Errorf("published canonical Fleet ID=%s, want %s", fleetID, state.FleetID)
+		}
+	}
+	closeErr := sqlDB.Close()
+	if validationErr != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: validate published exact #344/import evidence: %w", validationErr)
+	}
+	if closeErr != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: close published validation DB: %w", closeErr)
+	}
+	digest, err := legacyV18CutoverFileSHA256(activePath)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: hash published canonical database: %w", err)
+	}
+	if digest != state.Materialized.SHA256 {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("%w: published canonical digest=%s, want materialized temp=%s", errLegacyV18CutoverPublicationUnsafe, digest, state.Materialized.SHA256)
+	}
+	finalState, err := inspectLegacyV18CutoverRecovery(homeDir)
+	if err != nil {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("publish canonical v19 cutover: classify published authority: %w", err)
+	}
+	if finalState.Disposition != legacyV18CutoverRecoveryCanonicalAuthority || finalState.FleetID != state.FleetID {
+		return canonicalV19CutoverPublication{}, fmt.Errorf("%w: published active database did not become canonical authority", errLegacyV18CutoverPublicationUnsafe)
+	}
+	return canonicalV19CutoverPublication{
+		MigrationID:       state.MigrationID,
+		FleetID:           state.FleetID,
+		SourceSHA256:      state.SourceSHA256,
+		ManifestSHA256:    state.Manifest.SHA256,
+		TargetSHA256:      digest,
+		ImportID:          state.Materialized.ImportID,
+		ProjectCount:      state.Materialized.ProjectCount,
+		RetiredBridgePath: retiredPath,
+	}, nil
+}

--- a/internal/store/cutoverpublish_test.go
+++ b/internal/store/cutoverpublish_test.go
@@ -1,0 +1,218 @@
+package store
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPublishCanonicalV19CutoverRetiresFrozenBridgeAndPublishesExactTemp(t *testing.T) {
+	home, bridge, archive, artifact, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	archiveBefore, err := legacyV18CutoverFileSHA256(archive.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestBefore, err := legacyV18CutoverFileSHA256(artifact.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	publication, err := publishCanonicalV19Cutover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if publication.MigrationID != bridge.MigrationID || publication.FleetID != bridge.FleetID || publication.SourceSHA256 != bridge.SourceSHA256 || publication.ManifestSHA256 != artifact.SHA256 || publication.TargetSHA256 != materialized.SHA256 || publication.ImportID != materialized.ImportID || publication.ProjectCount != materialized.ProjectCount {
+		t.Fatalf("publication = %#v", publication)
+	}
+	if publication.RetiredBridgePath != legacyV18CutoverRetiredBridgePath(home, bridge.MigrationID) {
+		t.Fatalf("retired bridge path = %s", publication.RetiredBridgePath)
+	}
+	if _, err := os.Lstat(materialized.Path); !os.IsNotExist(err) {
+		t.Fatalf("canonical temp after publication: %v", err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != materialized.SHA256 {
+		t.Fatalf("published active digest = %s, %v; want %s", got, err, materialized.SHA256)
+	}
+	if got, err := legacyV18CutoverFileSHA256(publication.RetiredBridgePath); err != nil || got != bridge.BridgeSHA256 {
+		t.Fatalf("retired bridge digest = %s, %v; want %s", got, err, bridge.BridgeSHA256)
+	}
+	retiredDB, err := openLegacyV18CutoverSQLite(publication.RetiredBridgePath, "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLegacyV18CutoverFrozenBridge(retiredDB, bridge.FleetID, bridge.SourceSHA256); err != nil {
+		_ = retiredDB.Close()
+		t.Fatalf("retired bridge validation: %v", err)
+	}
+	if err := retiredDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(archive.Path); err != nil || got != archiveBefore {
+		t.Fatalf("original archive changed: %s, %v; want %s", got, err, archiveBefore)
+	}
+	if got, err := legacyV18CutoverFileSHA256(artifact.Path); err != nil || got != manifestBefore {
+		t.Fatalf("manifest changed: %s, %v; want %s", got, err, manifestBefore)
+	}
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryCanonicalAuthority || state.FleetID != bridge.FleetID {
+		t.Fatalf("final recovery state = %#v", state)
+	}
+}
+
+func TestPublishCanonicalV19CutoverResumesAfterFrozenBridgeAlreadyRetired(t *testing.T) {
+	home, bridge, _, _, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	retiredPath := legacyV18CutoverRetiredBridgePath(home, bridge.MigrationID)
+	if err := syncLegacyV18CutoverFile(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveLegacyV18CutoverNoReplaceDurable(Path(home), retiredPath); err != nil {
+		t.Fatal(err)
+	}
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp || state.BridgeSHA256 != "" {
+		t.Fatalf("recovery after bridge retirement = %#v", state)
+	}
+
+	publication, err := publishCanonicalV19Cutover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if publication.TargetSHA256 != materialized.SHA256 || publication.RetiredBridgePath != retiredPath {
+		t.Fatalf("resumed publication = %#v", publication)
+	}
+}
+
+func TestPublishCanonicalV19CutoverAllowsActiveMissingWithExactArchiveAndTemp(t *testing.T) {
+	home, _, _, _, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	if err := os.Remove(Path(home)); err != nil {
+		t.Fatal(err)
+	}
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp {
+		t.Fatalf("active-missing recovery = %#v", state)
+	}
+	publication, err := publishCanonicalV19Cutover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if publication.TargetSHA256 != materialized.SHA256 {
+		t.Fatalf("active-missing publication = %#v", publication)
+	}
+}
+
+func TestPublishCanonicalV19CutoverRefusesInvalidTempBeforeRetiringBridge(t *testing.T) {
+	home, bridge, _, _, target, _ := canonicalV19CutoverPublicationFixture(t)
+	bridgeBefore, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target.Path, []byte("not sqlite"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := publishCanonicalV19Cutover(home); err == nil || !strings.Contains(err.Error(), "recovery disposition=rebuild-canonical-temp") {
+		t.Fatalf("invalid temp publication error = %v", err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != bridgeBefore || got != bridge.BridgeSHA256 {
+		t.Fatalf("frozen bridge changed after invalid temp refusal: %s, %v", got, err)
+	}
+	if _, err := os.Lstat(legacyV18CutoverRetiredBridgePath(home, bridge.MigrationID)); !os.IsNotExist(err) {
+		t.Fatalf("retired bridge unexpectedly exists after refusal: %v", err)
+	}
+}
+
+func TestPublishCanonicalV19CutoverRefusesUnexpectedRetiredDestination(t *testing.T) {
+	home, bridge, _, _, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	retiredPath := legacyV18CutoverRetiredBridgePath(home, bridge.MigrationID)
+	if err := os.WriteFile(retiredPath, []byte("unexpected"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bridgeBefore, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := publishCanonicalV19Cutover(home); err == nil || !strings.Contains(err.Error(), "retire frozen bridge") {
+		t.Fatalf("unexpected destination publication error = %v", err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != bridgeBefore {
+		t.Fatalf("active bridge changed after destination refusal: %s, %v", got, err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(materialized.Path); err != nil || got != materialized.SHA256 {
+		t.Fatalf("canonical temp changed after destination refusal: %s, %v", got, err)
+	}
+}
+
+func TestPublishCanonicalV19CutoverRequiresMigrationLock(t *testing.T) {
+	home, bridge, _, _, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	release, err := Lock(home, MigrationLock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if _, err := publishCanonicalV19Cutover(home); err == nil || !strings.Contains(err.Error(), "MigrationLock") {
+		t.Fatalf("concurrent publication error = %v", err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != bridge.BridgeSHA256 {
+		t.Fatalf("active bridge changed while MigrationLock busy: %s, %v", got, err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(materialized.Path); err != nil || got != materialized.SHA256 {
+		t.Fatalf("canonical temp changed while MigrationLock busy: %s, %v", got, err)
+	}
+}
+
+func TestPublishCanonicalV19CutoverNeverOverwritesCanonicalAuthority(t *testing.T) {
+	home, _, _, _, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	if _, err := publishCanonicalV19Cutover(home); err != nil {
+		t.Fatal(err)
+	}
+	before, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := publishCanonicalV19Cutover(home); err == nil || !strings.Contains(err.Error(), "canonical-authority") {
+		t.Fatalf("second publication error = %v", err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != before || got != materialized.SHA256 {
+		t.Fatalf("canonical authority changed on retry: %s, %v", got, err)
+	}
+}
+
+func canonicalV19CutoverPublicationFixture(t *testing.T) (string, legacyV18CutoverFrozenBridge, legacyV18CutoverOriginalArchive, legacyV18CutoverManifestArtifact, canonicalV19CutoverTarget, canonicalV19CutoverMaterialization) {
+	t.Helper()
+	home, bridge, archive, artifact, target := canonicalV19CutoverMaterializationFixture(t)
+	materialized, err := materializeCanonicalV19CutoverTarget(home, bridge, artifact, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return home, bridge, archive, artifact, target, materialized
+}
+
+func assertPublishedCanonicalV19CutoverRows(t *testing.T, home string, artifact legacyV18CutoverManifestArtifact) {
+	t.Helper()
+	manifest, err := readLegacyV18CutoverManifest(home, artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := openLegacyV18CutoverSQLite(Path(home), "ro", legacyV18CutoverGateTimeout, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := validateCanonicalV19Schema(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateCanonicalV19CutoverImportRows(db, buildCanonicalV19CutoverImportPlan(manifest, artifact.SHA256)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var _ = context.Background

--- a/internal/store/cutoverpublish_test.go
+++ b/internal/store/cutoverpublish_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -195,24 +194,3 @@ func canonicalV19CutoverPublicationFixture(t *testing.T) (string, legacyV18Cutov
 	}
 	return home, bridge, archive, artifact, target, materialized
 }
-
-func assertPublishedCanonicalV19CutoverRows(t *testing.T, home string, artifact legacyV18CutoverManifestArtifact) {
-	t.Helper()
-	manifest, err := readLegacyV18CutoverManifest(home, artifact)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := openLegacyV18CutoverSQLite(Path(home), "ro", legacyV18CutoverGateTimeout, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = db.Close() }()
-	if err := validateCanonicalV19Schema(db); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateCanonicalV19CutoverImportRows(db, buildCanonicalV19CutoverImportPlan(manifest, artifact.SHA256)); err != nil {
-		t.Fatal(err)
-	}
-}
-
-var _ = context.Background

--- a/internal/store/cutoverpublish_unix.go
+++ b/internal/store/cutoverpublish_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package store
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func moveLegacyV18CutoverNoReplaceDurable(source, target string) error {
+	if err := os.Link(source, target); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		// A crash may have happened after the durable target link was created but
+		// before the source name was removed. Resume only when both names still
+		// identify the exact same inode; never accept a merely byte-equal file.
+		sourceInfo, sourceErr := os.Lstat(source)
+		if sourceErr != nil {
+			return err
+		}
+		targetInfo, targetErr := os.Lstat(target)
+		if targetErr != nil || !os.SameFile(sourceInfo, targetInfo) {
+			return err
+		}
+	} else if err := syncLegacyV18CutoverDirectory(filepath.Dir(target)); err != nil {
+		return err
+	}
+	if err := os.Remove(source); err != nil {
+		return err
+	}
+	return syncLegacyV18CutoverDirectory(filepath.Dir(source))
+}

--- a/internal/store/cutoverpublish_unix.go
+++ b/internal/store/cutoverpublish_unix.go
@@ -13,7 +13,7 @@ func moveLegacyV18CutoverNoReplaceDurable(source, target string) error {
 		if !errors.Is(err, os.ErrExist) {
 			return err
 		}
-		// A crash may have happened after the durable target link was created but
+		// A crash may have happened after the target hardlink was created but
 		// before the source name was removed. Resume only when both names still
 		// identify the exact same inode; never accept a merely byte-equal file.
 		sourceInfo, sourceErr := os.Lstat(source)
@@ -24,7 +24,11 @@ func moveLegacyV18CutoverNoReplaceDurable(source, target string) error {
 		if targetErr != nil || !os.SameFile(sourceInfo, targetInfo) {
 			return err
 		}
-	} else if err := syncLegacyV18CutoverDirectory(filepath.Dir(target)); err != nil {
+	}
+	// Repeat the directory sync even on crash-resume. The previous attempt may
+	// have created the hardlink but failed before making that directory entry
+	// durable, so source removal cannot safely advance until this succeeds.
+	if err := syncLegacyV18CutoverDirectory(filepath.Dir(target)); err != nil {
 		return err
 	}
 	if err := os.Remove(source); err != nil {

--- a/internal/store/cutoverpublish_unix_test.go
+++ b/internal/store/cutoverpublish_unix_test.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMoveLegacyV18CutoverNoReplaceDurableResumesSameInodeHardlink(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	target := filepath.Join(dir, "target.db")
+	payload := []byte("exact cutover bytes")
+	if err := os.WriteFile(source, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncLegacyV18CutoverFile(source); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a crash after link(2) created the destination but before source
+	// removal completed. The retry is allowed only because both names are the
+	// same inode, not merely because their bytes happen to match.
+	if err := os.Link(source, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveLegacyV18CutoverNoReplaceDurable(source, target); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(source); !os.IsNotExist(err) {
+		t.Fatalf("source after crash-resume move: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("target payload = %q, want %q", got, payload)
+	}
+}
+
+func TestMoveLegacyV18CutoverNoReplaceDurableRefusesDifferentExistingInode(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	target := filepath.Join(dir, "target.db")
+	if err := os.WriteFile(source, []byte("same bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("same bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveLegacyV18CutoverNoReplaceDurable(source, target); err == nil {
+		t.Fatal("different existing inode was accepted")
+	}
+	if _, err := os.Lstat(source); err != nil {
+		t.Fatalf("source changed after refusal: %v", err)
+	}
+}

--- a/internal/store/cutoverpublish_windows.go
+++ b/internal/store/cutoverpublish_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package store
+
+import "golang.org/x/sys/windows"
+
+func moveLegacyV18CutoverNoReplaceDurable(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	// No MOVEFILE_REPLACE_EXISTING: an unexpected destination is a hard stop.
+	// MOVEFILE_WRITE_THROUGH keeps the same-volume rename durable before return.
+	return windows.MoveFileEx(from, to, legacyV18CutoverMoveFileWriteThrough)
+}


### PR DESCRIPTION
Implements the next narrow 5D slice after #546 landed the read-only recovery authority classifier.

This slice adds a private, inert store-level publication primitive that is not wired into production startup or automatic cutover activation. It:
- acquires the Fleet MigrationLock before any publication mutation;
- requires the 5D1 classifier to report exactly `publish-canonical-temp` and revalidates the deterministic immutable archive, canonical manifest, materialized temp digest, Fleet/source identity, and exact #344 import evidence;
- flushes and rehashes the canonical temp before each publication boundary;
- when the exact frozen bridge is still active, revalidates its Fleet/source/certificate/digest and retires it to the deterministic archive-local `frozen-bridge.db` path with a no-overwrite same-volume durable move;
- supports the crash-recovery case where the active path is already missing and exact archive+manifest+temp evidence remains publication-ready;
- re-runs the 5D1 classifier after bridge retirement, requiring the exact same migration/manifest/temp identity before advancing;
- atomically publishes the validated canonical temp as `state/hand.db` without destination overwrite;
- reopens the active DB read-only and validates exact #344 schema/integrity/FKs, exact manifest-derived Fleet/import rows, target digest, and final canonical-authority classification;
- on POSIX uses hardlink publication + directory fsync + source unlink, including same-inode crash-resume handling only; byte-equal different inodes are refused;
- on Windows uses `MoveFileEx(..., MOVEFILE_WRITE_THROUGH)` without `MOVEFILE_REPLACE_EXISTING`, so sharing violations/unexpected destinations stop safely rather than falling back to copy-over/delete.

Tests cover end-to-end temp-dir publication, exact retired frozen-bridge preservation, active-missing resume, corrupt-temp refusal before retirement, unexpected retired destination refusal, MigrationLock serialization, canonical no-overwrite on retry, and POSIX same-inode rename crash recovery.

No marker/registry projection repair or production startup caller is introduced here. Automatic cutover remains inert.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.