### PR TITLE
feat(store): persist advisory v19 cutover marker

### DIFF
--- a/internal/store/cutovermarker.go
+++ b/internal/store/cutovermarker.go
@@ -57,9 +57,9 @@ type legacyV18CutoverMarkerPaths struct {
 }
 
 type legacyV18CutoverMarkerEvidence struct {
-	ArchiveCandidateSHA256    string `json:"archive_candidate_sha256"`
-	OriginalArchiveSHA256     string `json:"original_archive_sha256"`
-	FrozenBridgeSHA256        string `json:"frozen_bridge_sha256"`
+	ArchiveCandidateSHA256   string `json:"archive_candidate_sha256"`
+	OriginalArchiveSHA256    string `json:"original_archive_sha256"`
+	FrozenBridgeSHA256       string `json:"frozen_bridge_sha256"`
 	FreezeCertificateVersion string `json:"freeze_certificate_version"`
 	FreezeCertificateSHA256  string `json:"freeze_certificate_sha256"`
 	ManifestSHA256           string `json:"manifest_sha256"`

--- a/internal/store/cutovermarker.go
+++ b/internal/store/cutovermarker.go
@@ -339,7 +339,7 @@ func validateLegacyV18CutoverMarkerIdentity(migrationID, fleetID, sourceSHA256 s
 		return fmt.Errorf("migration identity: %w", err)
 	}
 	if err := validateFleetID(fleetID); err != nil {
-		return fmt.Errorf("Fleet identity: %w", err)
+		return fmt.Errorf("fleet identity: %w", err)
 	}
 	if err := validateLegacyV18CutoverSHA256(sourceSHA256); err != nil {
 		return fmt.Errorf("source digest: %w", err)

--- a/internal/store/cutovermarker.go
+++ b/internal/store/cutovermarker.go
@@ -1,0 +1,454 @@
+package store
+
+import (
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	legacyV18CutoverMarkerVersion  = "v1"
+	legacyV18CutoverMarkerFileName = "hand-v19-cutover-marker.json"
+)
+
+type legacyV18CutoverMarkerPhase string
+
+const (
+	legacyV18CutoverMarkerArchiveCandidate   legacyV18CutoverMarkerPhase = "archive-candidate"
+	legacyV18CutoverMarkerOriginalArchived   legacyV18CutoverMarkerPhase = "original-archived"
+	legacyV18CutoverMarkerFrozenBridge       legacyV18CutoverMarkerPhase = "frozen-bridge"
+	legacyV18CutoverMarkerCanonicalTemp      legacyV18CutoverMarkerPhase = "canonical-temp"
+	legacyV18CutoverMarkerCanonicalPublished legacyV18CutoverMarkerPhase = "canonical-published"
+)
+
+type legacyV18CutoverMarkerInput struct {
+	Phase            legacyV18CutoverMarkerPhase
+	MigrationID      string
+	FleetID          string
+	SourceSHA256     string
+	ArchiveCandidate *legacyV18CutoverArchiveCandidate
+	OriginalArchive  *legacyV18CutoverOriginalArchive
+	FrozenBridge     *legacyV18CutoverFrozenBridge
+	Manifest         *legacyV18CutoverManifestArtifact
+	Materialized     *canonicalV19CutoverMaterialization
+	Publication      *canonicalV19CutoverPublication
+}
+
+type legacyV18CutoverMarker struct {
+	FormatVersion string                         `json:"format_version"`
+	Phase         legacyV18CutoverMarkerPhase    `json:"phase"`
+	MigrationID   string                         `json:"migration_id"`
+	FleetID       string                         `json:"fleet_id"`
+	SourceSHA256  string                         `json:"source_sha256"`
+	Paths         legacyV18CutoverMarkerPaths    `json:"paths"`
+	Evidence      legacyV18CutoverMarkerEvidence `json:"evidence"`
+	Target        legacyV18CutoverMarkerTarget   `json:"target"`
+}
+
+type legacyV18CutoverMarkerPaths struct {
+	ArchiveCandidate    string `json:"archive_candidate"`
+	OriginalArchive     string `json:"original_archive"`
+	FrozenBridge        string `json:"frozen_bridge"`
+	RetiredFrozenBridge string `json:"retired_frozen_bridge"`
+	Manifest            string `json:"manifest"`
+	CanonicalTemp       string `json:"canonical_temp"`
+	CanonicalTarget     string `json:"canonical_target"`
+}
+
+type legacyV18CutoverMarkerEvidence struct {
+	ArchiveCandidateSHA256    string `json:"archive_candidate_sha256"`
+	OriginalArchiveSHA256     string `json:"original_archive_sha256"`
+	FrozenBridgeSHA256        string `json:"frozen_bridge_sha256"`
+	FreezeCertificateVersion string `json:"freeze_certificate_version"`
+	FreezeCertificateSHA256  string `json:"freeze_certificate_sha256"`
+	ManifestSHA256           string `json:"manifest_sha256"`
+	CanonicalTempSHA256      string `json:"canonical_temp_sha256"`
+	CanonicalTargetSHA256    string `json:"canonical_target_sha256"`
+	ImportID                 string `json:"import_id"`
+	ProjectCount             int    `json:"project_count"`
+}
+
+type legacyV18CutoverMarkerTarget struct {
+	AuthorityCommit   string `json:"authority_commit"`
+	DDLPath           string `json:"ddl_path"`
+	DDLGitBlobSHA1    string `json:"ddl_git_blob_sha1"`
+	GzipSHA256        string `json:"gzip_sha256"`
+	DDLSHA256         string `json:"ddl_sha256"`
+	SchemaFingerprint string `json:"schema_fingerprint"`
+	SQLiteUserVersion int    `json:"sqlite_user_version"`
+	Tables            int    `json:"tables"`
+	Indexes           int    `json:"indexes"`
+	Triggers          int    `json:"triggers"`
+}
+
+type legacyV18CutoverMarkerArtifact struct {
+	MigrationID string
+	Phase       legacyV18CutoverMarkerPhase
+	Path        string
+	SHA256      string
+}
+
+func legacyV18CutoverMarkerPath(homeDir string) string {
+	return filepath.Join(Dir(homeDir), legacyV18CutoverMarkerFileName)
+}
+
+func legacyV18CutoverMarkerCandidatePath(homeDir string) string {
+	return legacyV18CutoverMarkerPath(homeDir) + ".candidate"
+}
+
+func buildLegacyV18CutoverMarker(homeDir string, input legacyV18CutoverMarkerInput) (legacyV18CutoverMarker, error) {
+	if err := validateLegacyV18CutoverMarkerInput(homeDir, input); err != nil {
+		return legacyV18CutoverMarker{}, err
+	}
+	paths, err := expectedLegacyV18CutoverMarkerPaths(homeDir, input.MigrationID)
+	if err != nil {
+		return legacyV18CutoverMarker{}, err
+	}
+	marker := legacyV18CutoverMarker{
+		FormatVersion: legacyV18CutoverMarkerVersion,
+		Phase:         input.Phase,
+		MigrationID:   input.MigrationID,
+		FleetID:       input.FleetID,
+		SourceSHA256:  input.SourceSHA256,
+		Paths:         paths,
+		Evidence: legacyV18CutoverMarkerEvidence{
+			ArchiveCandidateSHA256: input.SourceSHA256,
+		},
+		Target: exactLegacyV18CutoverMarkerTarget(),
+	}
+	if input.OriginalArchive != nil {
+		marker.Evidence.OriginalArchiveSHA256 = input.OriginalArchive.SHA256
+	}
+	if input.FrozenBridge != nil {
+		marker.Evidence.FrozenBridgeSHA256 = input.FrozenBridge.BridgeSHA256
+		marker.Evidence.FreezeCertificateVersion = legacyV18CutoverFreezeCertificateVersion
+		marker.Evidence.FreezeCertificateSHA256 = canonicalV19SHA256([]byte(input.FrozenBridge.Certificate))
+	}
+	if input.Manifest != nil {
+		marker.Evidence.ManifestSHA256 = input.Manifest.SHA256
+	}
+	if input.Materialized != nil {
+		marker.Evidence.CanonicalTempSHA256 = input.Materialized.SHA256
+		marker.Evidence.ImportID = input.Materialized.ImportID
+		marker.Evidence.ProjectCount = input.Materialized.ProjectCount
+	}
+	if input.Publication != nil {
+		marker.Evidence.CanonicalTempSHA256 = input.Publication.TargetSHA256
+		marker.Evidence.CanonicalTargetSHA256 = input.Publication.TargetSHA256
+		marker.Evidence.ImportID = input.Publication.ImportID
+		marker.Evidence.ProjectCount = input.Publication.ProjectCount
+	}
+	if err := validateLegacyV18CutoverMarker(homeDir, marker); err != nil {
+		return legacyV18CutoverMarker{}, fmt.Errorf("build v19 cutover advisory marker: %w", err)
+	}
+	return marker, nil
+}
+
+func validateLegacyV18CutoverMarkerInput(homeDir string, input legacyV18CutoverMarkerInput) error {
+	if err := validateLegacyV18CutoverMarkerIdentity(input.MigrationID, input.FleetID, input.SourceSHA256); err != nil {
+		return fmt.Errorf("build v19 cutover advisory marker: %w", err)
+	}
+	if _, ok := legacyV18CutoverMarkerPhaseOrdinal(input.Phase); !ok {
+		return fmt.Errorf("build v19 cutover advisory marker: unsupported phase %q", input.Phase)
+	}
+	if input.ArchiveCandidate != nil {
+		if input.ArchiveCandidate.MigrationID != input.MigrationID || input.ArchiveCandidate.SHA256 != input.SourceSHA256 || filepath.Clean(input.ArchiveCandidate.Path) != filepath.Clean(legacyV18CutoverArchiveCandidatePath(homeDir, input.MigrationID)) {
+			return fmt.Errorf("build v19 cutover advisory marker: archive candidate does not match exact migration/source/path identity")
+		}
+	}
+	if input.OriginalArchive != nil {
+		if input.OriginalArchive.MigrationID != input.MigrationID || input.OriginalArchive.SHA256 != input.SourceSHA256 || filepath.Clean(input.OriginalArchive.Directory) != filepath.Clean(legacyV18CutoverOriginalArchiveDir(homeDir, input.MigrationID)) || filepath.Clean(input.OriginalArchive.Path) != filepath.Clean(legacyV18CutoverOriginalArchivePath(homeDir, input.MigrationID)) {
+			return fmt.Errorf("build v19 cutover advisory marker: original archive does not match exact migration/source/path identity")
+		}
+	}
+	if input.FrozenBridge != nil {
+		bridge := input.FrozenBridge
+		expectedCertificate := legacyV18CutoverFreezeCertificateVersion + ":" + input.SourceSHA256
+		if !bridge.Committed || bridge.MigrationID != input.MigrationID || bridge.FleetID != input.FleetID || bridge.SourceSHA256 != input.SourceSHA256 || bridge.Certificate != expectedCertificate {
+			return fmt.Errorf("build v19 cutover advisory marker: frozen bridge does not match exact migration/Fleet/source certificate identity")
+		}
+		if err := validateLegacyV18CutoverSHA256(bridge.BridgeSHA256); err != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: frozen bridge digest: %w", err)
+		}
+	}
+	if input.Manifest != nil {
+		if input.Manifest.MigrationID != input.MigrationID || filepath.Clean(input.Manifest.Path) != filepath.Clean(legacyV18CutoverManifestPath(homeDir, input.MigrationID)) {
+			return fmt.Errorf("build v19 cutover advisory marker: manifest does not match exact migration/path identity")
+		}
+		if err := validateLegacyV18CutoverSHA256(input.Manifest.SHA256); err != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: manifest digest: %w", err)
+		}
+	}
+	if input.Materialized != nil {
+		materialized := input.Materialized
+		if materialized.MigrationID != input.MigrationID || filepath.Clean(materialized.Path) != filepath.Clean(legacyV18CutoverCanonicalTargetPath(homeDir, input.MigrationID)) {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical temp does not match exact migration/path identity")
+		}
+		if err := validateLegacyV18CutoverSHA256(materialized.SHA256); err != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical temp digest: %w", err)
+		}
+		if input.Manifest == nil || materialized.ManifestSHA256 != input.Manifest.SHA256 {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical temp manifest digest is not exact")
+		}
+		if err := validateLegacyV18CutoverImportID(materialized.ImportID); err != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical temp import ID: %w", err)
+		}
+		if materialized.ProjectCount < 0 {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical temp project count is negative")
+		}
+	}
+	if input.Publication != nil {
+		publication := input.Publication
+		if publication.MigrationID != input.MigrationID || publication.FleetID != input.FleetID || publication.SourceSHA256 != input.SourceSHA256 {
+			return fmt.Errorf("build v19 cutover advisory marker: publication does not match exact migration/Fleet/source identity")
+		}
+		if input.Manifest == nil || publication.ManifestSHA256 != input.Manifest.SHA256 {
+			return fmt.Errorf("build v19 cutover advisory marker: publication manifest digest is not exact")
+		}
+		if err := validateLegacyV18CutoverSHA256(publication.TargetSHA256); err != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: published target digest: %w", err)
+		}
+		if err := validateLegacyV18CutoverImportID(publication.ImportID); err != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: publication import ID: %w", err)
+		}
+		if publication.ProjectCount < 0 || filepath.Clean(publication.RetiredBridgePath) != filepath.Clean(legacyV18CutoverRetiredBridgePath(homeDir, input.MigrationID)) {
+			return fmt.Errorf("build v19 cutover advisory marker: publication project count or retired bridge path is invalid")
+		}
+	}
+
+	switch input.Phase {
+	case legacyV18CutoverMarkerArchiveCandidate:
+		if input.ArchiveCandidate == nil || input.OriginalArchive != nil || input.FrozenBridge != nil || input.Manifest != nil || input.Materialized != nil || input.Publication != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: archive-candidate phase has inconsistent evidence")
+		}
+	case legacyV18CutoverMarkerOriginalArchived:
+		if input.OriginalArchive == nil || input.FrozenBridge != nil || input.Manifest != nil || input.Materialized != nil || input.Publication != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: original-archived phase has inconsistent evidence")
+		}
+	case legacyV18CutoverMarkerFrozenBridge:
+		if input.OriginalArchive == nil || input.FrozenBridge == nil || input.Materialized != nil || input.Publication != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: frozen-bridge phase has inconsistent evidence")
+		}
+	case legacyV18CutoverMarkerCanonicalTemp:
+		if input.OriginalArchive == nil || input.FrozenBridge == nil || input.Manifest == nil || input.Materialized == nil || input.Publication != nil {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical-temp phase has inconsistent evidence")
+		}
+	case legacyV18CutoverMarkerCanonicalPublished:
+		if input.OriginalArchive == nil || input.FrozenBridge == nil || input.Manifest == nil || input.Materialized != nil || input.Publication == nil {
+			return fmt.Errorf("build v19 cutover advisory marker: canonical-published phase has inconsistent evidence")
+		}
+	}
+	return nil
+}
+
+func validateLegacyV18CutoverMarker(homeDir string, marker legacyV18CutoverMarker) error {
+	if marker.FormatVersion != legacyV18CutoverMarkerVersion {
+		return fmt.Errorf("format_version=%q, want %q", marker.FormatVersion, legacyV18CutoverMarkerVersion)
+	}
+	ordinal, ok := legacyV18CutoverMarkerPhaseOrdinal(marker.Phase)
+	if !ok {
+		return fmt.Errorf("unsupported phase %q", marker.Phase)
+	}
+	if err := validateLegacyV18CutoverMarkerIdentity(marker.MigrationID, marker.FleetID, marker.SourceSHA256); err != nil {
+		return err
+	}
+	expectedPaths, err := expectedLegacyV18CutoverMarkerPaths(homeDir, marker.MigrationID)
+	if err != nil {
+		return err
+	}
+	if marker.Paths != expectedPaths {
+		return fmt.Errorf("paths do not match deterministic Fleet-relative cutover paths")
+	}
+	if marker.Target != exactLegacyV18CutoverMarkerTarget() {
+		return fmt.Errorf("target contract does not match exact current #344 authority")
+	}
+	if marker.Evidence.ArchiveCandidateSHA256 != marker.SourceSHA256 {
+		return fmt.Errorf("archive candidate digest=%q, want exact source digest", marker.Evidence.ArchiveCandidateSHA256)
+	}
+	if ordinal >= 2 {
+		if marker.Evidence.OriginalArchiveSHA256 != marker.SourceSHA256 {
+			return fmt.Errorf("original archive digest=%q, want exact source digest", marker.Evidence.OriginalArchiveSHA256)
+		}
+	} else if marker.Evidence.OriginalArchiveSHA256 != "" {
+		return fmt.Errorf("archive-candidate phase cannot claim authoritative original archive digest")
+	}
+	if ordinal >= 3 {
+		if err := validateLegacyV18CutoverSHA256(marker.Evidence.FrozenBridgeSHA256); err != nil {
+			return fmt.Errorf("frozen bridge digest: %w", err)
+		}
+		if marker.Evidence.FreezeCertificateVersion != legacyV18CutoverFreezeCertificateVersion {
+			return fmt.Errorf("freeze certificate version=%q, want %q", marker.Evidence.FreezeCertificateVersion, legacyV18CutoverFreezeCertificateVersion)
+		}
+		expectedCertificate := legacyV18CutoverFreezeCertificateVersion + ":" + marker.SourceSHA256
+		if marker.Evidence.FreezeCertificateSHA256 != canonicalV19SHA256([]byte(expectedCertificate)) {
+			return fmt.Errorf("freeze certificate digest does not bind exact original source digest")
+		}
+	} else if marker.Evidence.FrozenBridgeSHA256 != "" || marker.Evidence.FreezeCertificateVersion != "" || marker.Evidence.FreezeCertificateSHA256 != "" {
+		return fmt.Errorf("pre-freeze marker cannot claim frozen bridge evidence")
+	}
+	if marker.Phase == legacyV18CutoverMarkerArchiveCandidate {
+		if marker.Evidence.ManifestSHA256 != "" || marker.Evidence.CanonicalTempSHA256 != "" || marker.Evidence.CanonicalTargetSHA256 != "" || marker.Evidence.ImportID != "" || marker.Evidence.ProjectCount != 0 {
+			return fmt.Errorf("archive-candidate phase cannot claim later cutover evidence")
+		}
+	}
+	if marker.Phase == legacyV18CutoverMarkerOriginalArchived {
+		if marker.Evidence.ManifestSHA256 != "" || marker.Evidence.CanonicalTempSHA256 != "" || marker.Evidence.CanonicalTargetSHA256 != "" || marker.Evidence.ImportID != "" || marker.Evidence.ProjectCount != 0 {
+			return fmt.Errorf("original-archived phase cannot claim later cutover evidence")
+		}
+	}
+	if marker.Phase == legacyV18CutoverMarkerFrozenBridge {
+		if marker.Evidence.ManifestSHA256 != "" {
+			if err := validateLegacyV18CutoverSHA256(marker.Evidence.ManifestSHA256); err != nil {
+				return fmt.Errorf("manifest digest: %w", err)
+			}
+		}
+		if marker.Evidence.CanonicalTempSHA256 != "" || marker.Evidence.CanonicalTargetSHA256 != "" || marker.Evidence.ImportID != "" || marker.Evidence.ProjectCount != 0 {
+			return fmt.Errorf("frozen-bridge phase cannot claim canonical temp/publication evidence")
+		}
+	}
+	if ordinal >= 4 {
+		if err := validateLegacyV18CutoverSHA256(marker.Evidence.ManifestSHA256); err != nil {
+			return fmt.Errorf("manifest digest: %w", err)
+		}
+		if err := validateLegacyV18CutoverSHA256(marker.Evidence.CanonicalTempSHA256); err != nil {
+			return fmt.Errorf("canonical temp digest: %w", err)
+		}
+		if err := validateLegacyV18CutoverImportID(marker.Evidence.ImportID); err != nil {
+			return fmt.Errorf("import ID: %w", err)
+		}
+		if marker.Evidence.ProjectCount < 0 {
+			return fmt.Errorf("project count is negative")
+		}
+	}
+	if marker.Phase == legacyV18CutoverMarkerCanonicalTemp {
+		if marker.Evidence.CanonicalTargetSHA256 != "" {
+			return fmt.Errorf("canonical-temp phase cannot claim published target digest")
+		}
+	}
+	if marker.Phase == legacyV18CutoverMarkerCanonicalPublished {
+		if marker.Evidence.CanonicalTargetSHA256 != marker.Evidence.CanonicalTempSHA256 {
+			return fmt.Errorf("published target digest=%q, want exact canonical temp digest=%q", marker.Evidence.CanonicalTargetSHA256, marker.Evidence.CanonicalTempSHA256)
+		}
+	}
+	return nil
+}
+
+func validateLegacyV18CutoverMarkerIdentity(migrationID, fleetID, sourceSHA256 string) error {
+	if err := validateLegacyV18CutoverMigrationID(migrationID); err != nil {
+		return fmt.Errorf("migration identity: %w", err)
+	}
+	if err := validateFleetID(fleetID); err != nil {
+		return fmt.Errorf("Fleet identity: %w", err)
+	}
+	if err := validateLegacyV18CutoverSHA256(sourceSHA256); err != nil {
+		return fmt.Errorf("source digest: %w", err)
+	}
+	expected, err := legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256)
+	if err != nil {
+		return err
+	}
+	if migrationID != expected {
+		return fmt.Errorf("migration identity=%s, want %s from exact Fleet/source evidence", migrationID, expected)
+	}
+	return nil
+}
+
+func validateLegacyV18CutoverImportID(value string) error {
+	const prefix = "li_"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+32 {
+		return fmt.Errorf("must be li_<32 lowercase hex>")
+	}
+	digest := strings.TrimPrefix(value, prefix)
+	if digest != strings.ToLower(digest) {
+		return fmt.Errorf("must be lowercase")
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return fmt.Errorf("is not hexadecimal: %w", err)
+	}
+	return nil
+}
+
+func legacyV18CutoverMarkerPhaseOrdinal(phase legacyV18CutoverMarkerPhase) (int, bool) {
+	switch phase {
+	case legacyV18CutoverMarkerArchiveCandidate:
+		return 1, true
+	case legacyV18CutoverMarkerOriginalArchived:
+		return 2, true
+	case legacyV18CutoverMarkerFrozenBridge:
+		return 3, true
+	case legacyV18CutoverMarkerCanonicalTemp:
+		return 4, true
+	case legacyV18CutoverMarkerCanonicalPublished:
+		return 5, true
+	default:
+		return 0, false
+	}
+}
+
+func expectedLegacyV18CutoverMarkerPaths(homeDir, migrationID string) (legacyV18CutoverMarkerPaths, error) {
+	archiveCandidate, err := legacyV18CutoverFleetRelativePath(homeDir, legacyV18CutoverArchiveCandidatePath(homeDir, migrationID))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	originalArchive, err := legacyV18CutoverFleetRelativePath(homeDir, legacyV18CutoverOriginalArchivePath(homeDir, migrationID))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	frozenBridge, err := legacyV18CutoverFleetRelativePath(homeDir, Path(homeDir))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	retiredBridge, err := legacyV18CutoverFleetRelativePath(homeDir, legacyV18CutoverRetiredBridgePath(homeDir, migrationID))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	manifest, err := legacyV18CutoverFleetRelativePath(homeDir, legacyV18CutoverManifestPath(homeDir, migrationID))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	canonicalTemp, err := legacyV18CutoverFleetRelativePath(homeDir, legacyV18CutoverCanonicalTargetPath(homeDir, migrationID))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	canonicalTarget, err := legacyV18CutoverFleetRelativePath(homeDir, Path(homeDir))
+	if err != nil {
+		return legacyV18CutoverMarkerPaths{}, err
+	}
+	return legacyV18CutoverMarkerPaths{
+		ArchiveCandidate:    archiveCandidate,
+		OriginalArchive:     originalArchive,
+		FrozenBridge:        frozenBridge,
+		RetiredFrozenBridge: retiredBridge,
+		Manifest:            manifest,
+		CanonicalTemp:       canonicalTemp,
+		CanonicalTarget:     canonicalTarget,
+	}, nil
+}
+
+func legacyV18CutoverFleetRelativePath(homeDir, absolutePath string) (string, error) {
+	relative, err := filepath.Rel(homeDir, absolutePath)
+	if err != nil {
+		return "", fmt.Errorf("derive Fleet-relative v19 cutover marker path: %w", err)
+	}
+	relative = filepath.Clean(relative)
+	if relative == "." || relative == ".." || filepath.IsAbs(relative) || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("v19 cutover marker path %q escapes Fleet home", absolutePath)
+	}
+	return filepath.ToSlash(relative), nil
+}
+
+func exactLegacyV18CutoverMarkerTarget() legacyV18CutoverMarkerTarget {
+	return legacyV18CutoverMarkerTarget{
+		AuthorityCommit:   canonicalV19AuthorityCommit,
+		DDLPath:           canonicalV19AuthorityDDLPath,
+		DDLGitBlobSHA1:    canonicalV19AuthorityDDLGitBlobSHA1,
+		GzipSHA256:        canonicalV19GzipSHA256,
+		DDLSHA256:         canonicalV19DDLSHA256,
+		SchemaFingerprint: canonicalV19SchemaFingerprint,
+		SQLiteUserVersion: canonicalV19SchemaVersion,
+		Tables:            canonicalV19TableCount,
+		Indexes:           canonicalV19IndexCount,
+		Triggers:          canonicalV19TriggerCount,
+	}
+}

--- a/internal/store/cutovermarker_contract_test.go
+++ b/internal/store/cutovermarker_contract_test.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLegacyV18CutoverMarkerDoesNotChangeRecoveryAuthority(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	if _, err := writeLegacyV18CutoverMarker(fixture.home, fixture.input(legacyV18CutoverMarkerArchiveCandidate)); err != nil {
+		t.Fatal(err)
+	}
+	state, err := inspectLegacyV18CutoverRecovery(fixture.home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryNoState {
+		t.Fatalf("marker-only recovery disposition = %s (%s)", state.Disposition, state.Reason)
+	}
+
+	marker, _, err := readLegacyV18CutoverMarker(fixture.home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker.Target.AuthorityCommit = strings.Repeat("0", 40)
+	if err := validateLegacyV18CutoverMarker(fixture.home, marker); err == nil || !strings.Contains(err.Error(), "exact current #344 authority") {
+		t.Fatalf("target-contract mismatch error = %v", err)
+	}
+}

--- a/internal/store/cutovermarker_io.go
+++ b/internal/store/cutovermarker_io.go
@@ -1,0 +1,212 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func writeLegacyV18CutoverMarker(homeDir string, input legacyV18CutoverMarkerInput) (legacyV18CutoverMarkerArtifact, error) {
+	marker, err := buildLegacyV18CutoverMarker(homeDir, input)
+	if err != nil {
+		return legacyV18CutoverMarkerArtifact{}, err
+	}
+	payload, err := json.Marshal(marker)
+	if err != nil {
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("encode v19 cutover advisory marker: %w", err)
+	}
+	payload = append(payload, '\n')
+	artifact := legacyV18CutoverMarkerArtifact{
+		MigrationID: marker.MigrationID,
+		Phase:       marker.Phase,
+		Path:        legacyV18CutoverMarkerPath(homeDir),
+		SHA256:      canonicalV19SHA256(payload),
+	}
+	if err := os.MkdirAll(Dir(homeDir), 0o700); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("create v19 cutover marker state directory: %w", err)
+	}
+	if err := rejectLegacyV18CutoverMarkerRegression(homeDir, marker); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, err
+	}
+	if exact, err := exactLegacyV18CutoverMarkerPayload(artifact.Path, payload); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, err
+	} else if exact {
+		if err := syncLegacyV18CutoverFile(artifact.Path); err != nil {
+			return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("flush existing v19 cutover advisory marker: %w", err)
+		}
+		if err := syncLegacyV18CutoverDirectoryParent(artifact.Path); err != nil {
+			return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("flush existing v19 cutover advisory marker directory: %w", err)
+		}
+		return artifact, nil
+	}
+
+	candidatePath := legacyV18CutoverMarkerCandidatePath(homeDir)
+	if err := prepareLegacyV18CutoverMarkerCandidate(candidatePath, payload); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, err
+	}
+	if err := replaceLegacyV18CutoverMarker(candidatePath, artifact.Path); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("publish v19 cutover advisory marker: %w", err)
+	}
+	if exact, err := exactLegacyV18CutoverMarkerPayload(artifact.Path, payload); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, err
+	} else if !exact {
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("published v19 cutover advisory marker differs from deterministic payload")
+	}
+	if digest, err := legacyV18CutoverFileSHA256(artifact.Path); err != nil {
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("hash published v19 cutover advisory marker: %w", err)
+	} else if digest != artifact.SHA256 {
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("published v19 cutover advisory marker digest=%s, want %s", digest, artifact.SHA256)
+	}
+	if _, err := os.Lstat(candidatePath); !os.IsNotExist(err) {
+		if err == nil {
+			return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("v19 cutover advisory marker candidate remained after publication")
+		}
+		return legacyV18CutoverMarkerArtifact{}, fmt.Errorf("inspect published v19 cutover advisory marker candidate: %w", err)
+	}
+	return artifact, nil
+}
+
+func rejectLegacyV18CutoverMarkerRegression(homeDir string, next legacyV18CutoverMarker) error {
+	current, found, err := readLegacyV18CutoverMarkerIfValid(homeDir)
+	if err != nil || !found || current.MigrationID != next.MigrationID {
+		// Marker bytes are advisory. Corrupt/stale marker prose never blocks repair
+		// from stronger typed evidence, and a different migration identity may replace it.
+		return nil
+	}
+	currentOrdinal, _ := legacyV18CutoverMarkerPhaseOrdinal(current.Phase)
+	nextOrdinal, _ := legacyV18CutoverMarkerPhaseOrdinal(next.Phase)
+	if nextOrdinal < currentOrdinal {
+		return fmt.Errorf("v19 cutover advisory marker phase regression %s -> %s", current.Phase, next.Phase)
+	}
+	return nil
+}
+
+func readLegacyV18CutoverMarker(homeDir string) (legacyV18CutoverMarker, legacyV18CutoverMarkerArtifact, error) {
+	path := legacyV18CutoverMarkerPath(homeDir)
+	if err := requireLegacyV18CutoverDirectRegularFile(path, "advisory marker"); err != nil {
+		return legacyV18CutoverMarker{}, legacyV18CutoverMarkerArtifact{}, err
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return legacyV18CutoverMarker{}, legacyV18CutoverMarkerArtifact{}, fmt.Errorf("read v19 cutover advisory marker: %w", err)
+	}
+	marker, err := decodeLegacyV18CutoverMarkerPayload(homeDir, payload)
+	if err != nil {
+		return legacyV18CutoverMarker{}, legacyV18CutoverMarkerArtifact{}, err
+	}
+	return marker, legacyV18CutoverMarkerArtifact{
+		MigrationID: marker.MigrationID,
+		Phase:       marker.Phase,
+		Path:        path,
+		SHA256:      canonicalV19SHA256(payload),
+	}, nil
+}
+
+func readLegacyV18CutoverMarkerIfValid(homeDir string) (legacyV18CutoverMarker, bool, error) {
+	path := legacyV18CutoverMarkerPath(homeDir)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return legacyV18CutoverMarker{}, false, nil
+	}
+	if err != nil {
+		return legacyV18CutoverMarker{}, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return legacyV18CutoverMarker{}, false, fmt.Errorf("v19 cutover advisory marker is not a direct regular file")
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return legacyV18CutoverMarker{}, false, err
+	}
+	marker, err := decodeLegacyV18CutoverMarkerPayload(homeDir, payload)
+	if err != nil {
+		return legacyV18CutoverMarker{}, false, err
+	}
+	return marker, true, nil
+}
+
+func decodeLegacyV18CutoverMarkerPayload(homeDir string, payload []byte) (legacyV18CutoverMarker, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var marker legacyV18CutoverMarker
+	if err := decoder.Decode(&marker); err != nil {
+		return legacyV18CutoverMarker{}, fmt.Errorf("decode v19 cutover advisory marker: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return legacyV18CutoverMarker{}, fmt.Errorf("v19 cutover advisory marker has trailing JSON value")
+		}
+		return legacyV18CutoverMarker{}, fmt.Errorf("v19 cutover advisory marker trailing data: %w", err)
+	}
+	canonical, err := json.Marshal(marker)
+	if err != nil {
+		return legacyV18CutoverMarker{}, fmt.Errorf("re-encode v19 cutover advisory marker: %w", err)
+	}
+	canonical = append(canonical, '\n')
+	if !bytes.Equal(payload, canonical) {
+		return legacyV18CutoverMarker{}, fmt.Errorf("v19 cutover advisory marker bytes are not canonical deterministic JSON")
+	}
+	if err := validateLegacyV18CutoverMarker(homeDir, marker); err != nil {
+		return legacyV18CutoverMarker{}, fmt.Errorf("validate v19 cutover advisory marker: %w", err)
+	}
+	return marker, nil
+}
+
+func exactLegacyV18CutoverMarkerPayload(path string, payload []byte) (bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect v19 cutover advisory marker: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return false, fmt.Errorf("v19 cutover advisory marker %s is not a direct regular file", path)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read existing v19 cutover advisory marker: %w", err)
+	}
+	return bytes.Equal(got, payload), nil
+}
+
+func prepareLegacyV18CutoverMarkerCandidate(path string, payload []byte) error {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("v19 cutover advisory marker candidate %s is not a direct regular file", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove stale v19 cutover advisory marker candidate: %w", err)
+		}
+		if err := syncLegacyV18CutoverDirectoryParent(path); err != nil {
+			return fmt.Errorf("flush removed v19 cutover advisory marker candidate directory: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect v19 cutover advisory marker candidate: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create v19 cutover advisory marker candidate: %w", err)
+	}
+	written, writeErr := file.Write(payload)
+	if writeErr == nil && written != len(payload) {
+		writeErr = io.ErrShortWrite
+	}
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if writeErr != nil {
+		return fmt.Errorf("write v19 cutover advisory marker candidate: %w", writeErr)
+	}
+	if syncErr != nil {
+		return fmt.Errorf("flush v19 cutover advisory marker candidate: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close v19 cutover advisory marker candidate: %w", closeErr)
+	}
+	if err := syncLegacyV18CutoverDirectoryParent(path); err != nil {
+		return fmt.Errorf("flush v19 cutover advisory marker candidate directory: %w", err)
+	}
+	return nil
+}

--- a/internal/store/cutovermarker_readme_test.go
+++ b/internal/store/cutovermarker_readme_test.go
@@ -1,0 +1,15 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLegacyV18CutoverMarkerNamesStayOutsideLooseEvidenceNamespace(t *testing.T) {
+	home := t.TempDir()
+	for _, path := range []string{legacyV18CutoverMarkerPath(home), legacyV18CutoverMarkerCandidatePath(home)} {
+		if isLegacyV18CutoverLooseArtifact(filepath.Base(path)) {
+			t.Fatalf("marker filename %q overlaps authority-like loose evidence namespace", filepath.Base(path))
+		}
+	}
+}

--- a/internal/store/cutovermarker_replace_unix.go
+++ b/internal/store/cutovermarker_replace_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package store
+
+import "os"
+
+func replaceLegacyV18CutoverMarker(source, target string) error {
+	if err := os.Rename(source, target); err != nil {
+		return err
+	}
+	return syncLegacyV18CutoverDirectoryParent(target)
+}

--- a/internal/store/cutovermarker_replace_windows.go
+++ b/internal/store/cutovermarker_replace_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package store
+
+import "golang.org/x/sys/windows"
+
+const legacyV18CutoverMoveFileReplaceExisting = 0x00000001
+
+func replaceLegacyV18CutoverMarker(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, legacyV18CutoverMoveFileReplaceExisting|legacyV18CutoverMoveFileWriteThrough)
+}

--- a/internal/store/cutovermarker_test.go
+++ b/internal/store/cutovermarker_test.go
@@ -1,0 +1,284 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type legacyV18CutoverMarkerFixtureState struct {
+	home         string
+	fleetID      string
+	sourceSHA256 string
+	migrationID  string
+	candidate    legacyV18CutoverArchiveCandidate
+	archive      legacyV18CutoverOriginalArchive
+	bridge       legacyV18CutoverFrozenBridge
+	manifest     legacyV18CutoverManifestArtifact
+	materialized canonicalV19CutoverMaterialization
+	publication  canonicalV19CutoverPublication
+}
+
+func newLegacyV18CutoverMarkerFixture(t *testing.T) legacyV18CutoverMarkerFixtureState {
+	t.Helper()
+	home := t.TempDir()
+	fleetID := "f_" + strings.Repeat("a", 32)
+	sourceSHA256 := strings.Repeat("b", 64)
+	migrationID, err := legacyV18CutoverMigrationIdentity(fleetID, sourceSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := legacyV18CutoverArchiveCandidate{
+		MigrationID: migrationID,
+		Path:        legacyV18CutoverArchiveCandidatePath(home, migrationID),
+		SHA256:      sourceSHA256,
+	}
+	archive := legacyV18CutoverOriginalArchive{
+		MigrationID: migrationID,
+		Directory:   legacyV18CutoverOriginalArchiveDir(home, migrationID),
+		Path:        legacyV18CutoverOriginalArchivePath(home, migrationID),
+		SHA256:      sourceSHA256,
+	}
+	bridge := legacyV18CutoverFrozenBridge{
+		MigrationID:  migrationID,
+		FleetID:      fleetID,
+		SourceSHA256: sourceSHA256,
+		BridgeSHA256: strings.Repeat("c", 64),
+		Certificate:  legacyV18CutoverFreezeCertificateVersion + ":" + sourceSHA256,
+		Committed:    true,
+	}
+	manifest := legacyV18CutoverManifestArtifact{
+		MigrationID: migrationID,
+		Path:        legacyV18CutoverManifestPath(home, migrationID),
+		SHA256:      strings.Repeat("d", 64),
+		ImportedAt:  "2026-09-04T00:00:00Z",
+	}
+	materialized := canonicalV19CutoverMaterialization{
+		MigrationID:    migrationID,
+		Path:           legacyV18CutoverCanonicalTargetPath(home, migrationID),
+		SHA256:         strings.Repeat("e", 64),
+		ManifestSHA256: manifest.SHA256,
+		ImportID:       "li_" + strings.Repeat("f", 32),
+		ProjectCount:   2,
+	}
+	publication := canonicalV19CutoverPublication{
+		MigrationID:       migrationID,
+		FleetID:           fleetID,
+		SourceSHA256:      sourceSHA256,
+		ManifestSHA256:    manifest.SHA256,
+		TargetSHA256:      materialized.SHA256,
+		ImportID:          materialized.ImportID,
+		ProjectCount:      materialized.ProjectCount,
+		RetiredBridgePath: legacyV18CutoverRetiredBridgePath(home, migrationID),
+	}
+	return legacyV18CutoverMarkerFixtureState{
+		home:         home,
+		fleetID:      fleetID,
+		sourceSHA256: sourceSHA256,
+		migrationID:  migrationID,
+		candidate:    candidate,
+		archive:      archive,
+		bridge:       bridge,
+		manifest:     manifest,
+		materialized: materialized,
+		publication:  publication,
+	}
+}
+
+func (f legacyV18CutoverMarkerFixtureState) input(phase legacyV18CutoverMarkerPhase) legacyV18CutoverMarkerInput {
+	input := legacyV18CutoverMarkerInput{
+		Phase:        phase,
+		MigrationID:  f.migrationID,
+		FleetID:      f.fleetID,
+		SourceSHA256: f.sourceSHA256,
+	}
+	switch phase {
+	case legacyV18CutoverMarkerArchiveCandidate:
+		input.ArchiveCandidate = &f.candidate
+	case legacyV18CutoverMarkerOriginalArchived:
+		input.OriginalArchive = &f.archive
+	case legacyV18CutoverMarkerFrozenBridge:
+		input.OriginalArchive = &f.archive
+		input.FrozenBridge = &f.bridge
+		input.Manifest = &f.manifest
+	case legacyV18CutoverMarkerCanonicalTemp:
+		input.OriginalArchive = &f.archive
+		input.FrozenBridge = &f.bridge
+		input.Manifest = &f.manifest
+		input.Materialized = &f.materialized
+	case legacyV18CutoverMarkerCanonicalPublished:
+		input.OriginalArchive = &f.archive
+		input.FrozenBridge = &f.bridge
+		input.Manifest = &f.manifest
+		input.Publication = &f.publication
+	}
+	return input
+}
+
+func TestBuildLegacyV18CutoverMarkerProjectsExactEvidence(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	marker, err := buildLegacyV18CutoverMarker(fixture.home, fixture.input(legacyV18CutoverMarkerCanonicalTemp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marker.FormatVersion != legacyV18CutoverMarkerVersion || marker.Phase != legacyV18CutoverMarkerCanonicalTemp || marker.MigrationID != fixture.migrationID || marker.FleetID != fixture.fleetID || marker.SourceSHA256 != fixture.sourceSHA256 {
+		t.Fatalf("marker identity = %#v", marker)
+	}
+	if marker.Paths.ArchiveCandidate != filepath.ToSlash(filepath.Join("state", filepath.Base(fixture.candidate.Path))) {
+		t.Fatalf("archive candidate path = %q", marker.Paths.ArchiveCandidate)
+	}
+	if marker.Paths.OriginalArchive != filepath.ToSlash(filepath.Join("state", "v19-cutover-"+fixture.migrationID, "hand.db")) || marker.Paths.Manifest != filepath.ToSlash(filepath.Join("state", "v19-cutover-"+fixture.migrationID, legacyV18CutoverManifestFileName)) {
+		t.Fatalf("archive paths = %#v", marker.Paths)
+	}
+	if marker.Paths.FrozenBridge != "state/hand.db" || marker.Paths.CanonicalTarget != "state/hand.db" || !strings.HasPrefix(marker.Paths.CanonicalTemp, "state/") {
+		t.Fatalf("active/temp paths = %#v", marker.Paths)
+	}
+	for _, path := range []string{marker.Paths.ArchiveCandidate, marker.Paths.OriginalArchive, marker.Paths.FrozenBridge, marker.Paths.RetiredFrozenBridge, marker.Paths.Manifest, marker.Paths.CanonicalTemp, marker.Paths.CanonicalTarget} {
+		if filepath.IsAbs(path) || strings.Contains(path, fixture.home) || strings.Contains(path, "..") {
+			t.Fatalf("marker path is not Fleet-relative: %q", path)
+		}
+	}
+	if marker.Evidence.ArchiveCandidateSHA256 != fixture.sourceSHA256 || marker.Evidence.OriginalArchiveSHA256 != fixture.sourceSHA256 || marker.Evidence.FrozenBridgeSHA256 != fixture.bridge.BridgeSHA256 || marker.Evidence.ManifestSHA256 != fixture.manifest.SHA256 || marker.Evidence.CanonicalTempSHA256 != fixture.materialized.SHA256 || marker.Evidence.CanonicalTargetSHA256 != "" || marker.Evidence.ImportID != fixture.materialized.ImportID || marker.Evidence.ProjectCount != fixture.materialized.ProjectCount {
+		t.Fatalf("marker evidence = %#v", marker.Evidence)
+	}
+	if marker.Target != exactLegacyV18CutoverMarkerTarget() || marker.Target.AuthorityCommit != canonicalV19AuthorityCommit || marker.Target.DDLSHA256 != canonicalV19DDLSHA256 || marker.Target.SchemaFingerprint != canonicalV19SchemaFingerprint {
+		t.Fatalf("marker target = %#v", marker.Target)
+	}
+}
+
+func TestWriteLegacyV18CutoverMarkerAdvancesDurably(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	phases := []legacyV18CutoverMarkerPhase{
+		legacyV18CutoverMarkerArchiveCandidate,
+		legacyV18CutoverMarkerOriginalArchived,
+		legacyV18CutoverMarkerFrozenBridge,
+		legacyV18CutoverMarkerCanonicalTemp,
+		legacyV18CutoverMarkerCanonicalPublished,
+	}
+	var previousDigest string
+	for _, phase := range phases {
+		artifact, err := writeLegacyV18CutoverMarker(fixture.home, fixture.input(phase))
+		if err != nil {
+			t.Fatalf("write phase %s: %v", phase, err)
+		}
+		if artifact.Path != legacyV18CutoverMarkerPath(fixture.home) || artifact.MigrationID != fixture.migrationID || artifact.Phase != phase {
+			t.Fatalf("artifact for %s = %#v", phase, artifact)
+		}
+		if artifact.SHA256 == previousDigest {
+			t.Fatalf("phase %s did not change deterministic marker digest", phase)
+		}
+		previousDigest = artifact.SHA256
+		marker, readArtifact, err := readLegacyV18CutoverMarker(fixture.home)
+		if err != nil {
+			t.Fatalf("read phase %s: %v", phase, err)
+		}
+		if marker.Phase != phase || readArtifact.SHA256 != artifact.SHA256 {
+			t.Fatalf("read phase %s marker=%#v artifact=%#v", phase, marker, readArtifact)
+		}
+		if _, err := os.Lstat(legacyV18CutoverMarkerCandidatePath(fixture.home)); !os.IsNotExist(err) {
+			t.Fatalf("marker candidate after phase %s: %v", phase, err)
+		}
+	}
+	payload, err := os.ReadFile(legacyV18CutoverMarkerPath(fixture.home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) == 0 || payload[len(payload)-1] != '\n' || strings.Contains(string(payload), fixture.home) {
+		t.Fatalf("marker payload is not canonical Fleet-relative JSON: %q", payload)
+	}
+}
+
+func TestWriteLegacyV18CutoverMarkerRejectsPhaseRegression(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	if _, err := writeLegacyV18CutoverMarker(fixture.home, fixture.input(legacyV18CutoverMarkerCanonicalTemp)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeLegacyV18CutoverMarker(fixture.home, fixture.input(legacyV18CutoverMarkerFrozenBridge)); err == nil || !strings.Contains(err.Error(), "phase regression") {
+		t.Fatalf("regression error = %v", err)
+	}
+	marker, _, err := readLegacyV18CutoverMarker(fixture.home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marker.Phase != legacyV18CutoverMarkerCanonicalTemp {
+		t.Fatalf("marker phase after refused regression = %s", marker.Phase)
+	}
+}
+
+func TestWriteLegacyV18CutoverMarkerRepairsCorruptAdvisoryBytes(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	if err := os.MkdirAll(Dir(fixture.home), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyV18CutoverMarkerPath(fixture.home), []byte("not-json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := writeLegacyV18CutoverMarker(fixture.home, fixture.input(legacyV18CutoverMarkerArchiveCandidate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker, readArtifact, err := readLegacyV18CutoverMarker(fixture.home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marker.Phase != legacyV18CutoverMarkerArchiveCandidate || readArtifact.SHA256 != artifact.SHA256 {
+		t.Fatalf("repaired marker=%#v artifact=%#v", marker, readArtifact)
+	}
+}
+
+func TestReadLegacyV18CutoverMarkerRejectsNonCanonicalJSON(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	marker, err := buildLegacyV18CutoverMarker(fixture.home, fixture.input(legacyV18CutoverMarkerArchiveCandidate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload = append(payload, '\n')
+	if err := os.MkdirAll(Dir(fixture.home), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyV18CutoverMarkerPath(fixture.home), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := readLegacyV18CutoverMarker(fixture.home); err == nil || !strings.Contains(err.Error(), "canonical deterministic JSON") {
+		t.Fatalf("noncanonical marker error = %v", err)
+	}
+}
+
+func TestBuildLegacyV18CutoverMarkerRejectsEvidenceMismatch(t *testing.T) {
+	fixture := newLegacyV18CutoverMarkerFixture(t)
+	input := fixture.input(legacyV18CutoverMarkerCanonicalTemp)
+	bad := *input.Materialized
+	bad.ManifestSHA256 = strings.Repeat("0", 64)
+	input.Materialized = &bad
+	if _, err := buildLegacyV18CutoverMarker(fixture.home, input); err == nil || !strings.Contains(err.Error(), "manifest digest is not exact") {
+		t.Fatalf("mismatched materialization error = %v", err)
+	}
+}
+
+func TestLegacyV18CutoverMarkerIsAdvisoryToRecoveryClassifier(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(Dir(home), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{legacyV18CutoverMarkerPath(home), legacyV18CutoverMarkerCandidatePath(home)} {
+		if err := os.WriteFile(path, []byte("corrupt advisory marker\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if isLegacyV18CutoverLooseArtifact(filepath.Base(path)) {
+			t.Fatalf("advisory marker path %q is incorrectly classified as authority-like loose evidence", path)
+		}
+	}
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryNoState {
+		t.Fatalf("recovery disposition with marker-only state = %s (%s)", state.Disposition, state.Reason)
+	}
+}


### PR DESCRIPTION
Implements the next narrow 5D slice after #547 landed crash-safe canonical publication.

This slice adds a private, inert advisory cutover marker projection. It does not participate in authority selection and is not wired into production startup or automatic cutover activation.

The marker:
- records deterministic phase progression: `archive-candidate` → `original-archived` → `frozen-bridge` → `canonical-temp` → `canonical-published`;
- binds exact migration/Fleet/original-source identity and records expected candidate/archive/frozen-bridge/manifest/temp/target digests without upgrading any evidence;
- records exact current #344 target contract identity;
- stores only Fleet-relative deterministic paths, never absolute home paths;
- uses canonical one-line JSON plus newline;
- writes through a flushed same-volume candidate, then atomically replaces the advisory projection and reopens/rehashes it;
- rejects same-migration phase regression but allows corrupt/stale advisory bytes to be repaired from stronger typed evidence;
- uses POSIX rename + parent directory fsync, and Windows `MoveFileEx(..., MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH)`; replace semantics are intentionally marker-only and do not weaken no-overwrite archive/canonical publication rules.

The marker filename intentionally stays outside the `v19-cutover-*` loose-evidence namespace consumed by 5D1. Tests prove marker-only or corrupt-marker-only state remains `no-state` to the recovery classifier, so missing/corrupt/stale marker prose cannot become authority.

No registry repair, provider/Git/network mutation, canonical row mutation, or production startup caller is introduced. Automatic cutover remains inert.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.