### PR TITLE
feat(store): drive v19 cutover recovery state

### DIFF
--- a/internal/store/cutoverrecover.go
+++ b/internal/store/cutoverrecover.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+)
+
+var errLegacyV18CutoverRecoveryExecutionUnsafe = errors.New("v19 cutover recovery execution is not mechanically safe")
+
+// recoverCanonicalV19Cutover executes only already-authorized recovery work.
+// It never starts a fresh legacy cutover, repairs registry projection, or uses
+// advisory marker prose as authority. Each mutating transition re-acquires the
+// existing MigrationLock and reclassifies exact durable evidence internally.
+func recoverCanonicalV19Cutover(homeDir string) (legacyV18CutoverRecoveryState, error) {
+	const maxInspections = 3 // rebuild -> publish -> canonical authority
+
+	for inspection := 0; inspection < maxInspections; inspection++ {
+		state, err := inspectLegacyV18CutoverRecovery(homeDir)
+		if err != nil {
+			return legacyV18CutoverRecoveryState{}, fmt.Errorf("recover canonical v19 cutover: inspect recovery authority: %w", err)
+		}
+
+		switch state.Disposition {
+		case legacyV18CutoverRecoveryCanonicalAuthority,
+			legacyV18CutoverRecoveryLegacySource,
+			legacyV18CutoverRecoveryNoState:
+			return state, nil
+		case legacyV18CutoverRecoveryRefuse:
+			return state, fmt.Errorf("%w: recovery disposition=%s: %s", errLegacyV18CutoverRecoveryExecutionUnsafe, state.Disposition, state.Reason)
+		case legacyV18CutoverRecoveryRebuildCanonicalTemp:
+			if _, err := rebuildCanonicalV19CutoverTemp(homeDir); err != nil {
+				return state, fmt.Errorf("recover canonical v19 cutover: rebuild canonical temp: %w", err)
+			}
+		case legacyV18CutoverRecoveryPublishCanonicalTemp:
+			if _, err := publishCanonicalV19Cutover(homeDir); err != nil {
+				return state, fmt.Errorf("recover canonical v19 cutover: publish canonical temp: %w", err)
+			}
+		default:
+			return state, fmt.Errorf("%w: unsupported recovery disposition=%q", errLegacyV18CutoverRecoveryExecutionUnsafe, state.Disposition)
+		}
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(homeDir)
+	if err != nil {
+		return legacyV18CutoverRecoveryState{}, fmt.Errorf("recover canonical v19 cutover: inspect recovery authority after bounded transitions: %w", err)
+	}
+	return state, fmt.Errorf("%w: recovery did not converge after %d inspections; disposition=%s: %s", errLegacyV18CutoverRecoveryExecutionUnsafe, maxInspections, state.Disposition, state.Reason)
+}

--- a/internal/store/cutoverrecover.go
+++ b/internal/store/cutoverrecover.go
@@ -7,10 +7,9 @@ import (
 
 var errLegacyV18CutoverRecoveryExecutionUnsafe = errors.New("v19 cutover recovery execution is not mechanically safe")
 
-// recoverCanonicalV19Cutover executes only already-authorized recovery work.
-// It never starts a fresh legacy cutover, repairs registry projection, or uses
-// advisory marker prose as authority. Each mutating transition re-acquires the
-// existing MigrationLock and reclassifies exact durable evidence internally.
+// Executes only recovery work already authorized by the read-only classifier.
+// It never starts fresh legacy cutover or treats advisory marker prose as authority.
+// Mutating transitions retain their own MigrationLock and exact reclassification.
 func recoverCanonicalV19Cutover(homeDir string) (legacyV18CutoverRecoveryState, error) {
 	const maxInspections = 3 // rebuild -> publish -> canonical authority
 

--- a/internal/store/cutoverrecover_test.go
+++ b/internal/store/cutoverrecover_test.go
@@ -1,0 +1,166 @@
+package store
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRecoverCanonicalV19CutoverPublishesReadyTemp(t *testing.T) {
+	home, bridge, archive, artifact, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	before := recoveryEvidenceDigests(t, archive.Path, artifact.Path)
+
+	state, err := recoverCanonicalV19Cutover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryCanonicalAuthority || state.FleetID != bridge.FleetID {
+		t.Fatalf("final recovery state = %#v", state)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != materialized.SHA256 {
+		t.Fatalf("published active digest = %s, %v; want %s", got, err, materialized.SHA256)
+	}
+	if _, err := os.Lstat(materialized.Path); !os.IsNotExist(err) {
+		t.Fatalf("canonical temp remains after recovery publication: %v", err)
+	}
+	retiredPath := legacyV18CutoverRetiredBridgePath(home, bridge.MigrationID)
+	if got, err := legacyV18CutoverFileSHA256(retiredPath); err != nil || got != bridge.BridgeSHA256 {
+		t.Fatalf("retired bridge digest = %s, %v; want %s", got, err, bridge.BridgeSHA256)
+	}
+	after := recoveryEvidenceDigests(t, archive.Path, artifact.Path)
+	if strings.Join(before, "\n") != strings.Join(after, "\n") {
+		t.Fatalf("recovery changed authoritative archive evidence: before=%v after=%v", before, after)
+	}
+}
+
+func TestRecoverCanonicalV19CutoverRebuildsThenPublishesAfterBridgeRetirement(t *testing.T) {
+	home, bridge, archive, artifact, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	before := recoveryEvidenceDigests(t, archive.Path, artifact.Path)
+	if err := os.Remove(materialized.Path); err != nil {
+		t.Fatal(err)
+	}
+	retiredPath := legacyV18CutoverRetiredBridgePath(home, bridge.MigrationID)
+	if err := moveLegacyV18CutoverNoReplaceDurable(Path(home), retiredPath); err != nil {
+		t.Fatal(err)
+	}
+
+	pre, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pre.Disposition != legacyV18CutoverRecoveryRebuildCanonicalTemp {
+		t.Fatalf("pre-recovery state = %#v", pre)
+	}
+
+	state, err := recoverCanonicalV19Cutover(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryCanonicalAuthority || state.FleetID != bridge.FleetID {
+		t.Fatalf("final recovery state = %#v", state)
+	}
+	if got, err := legacyV18CutoverFileSHA256(retiredPath); err != nil || got != bridge.BridgeSHA256 {
+		t.Fatalf("retired bridge changed during rebuild+publish: %s, %v", got, err)
+	}
+	if _, err := os.Lstat(materialized.Path); !os.IsNotExist(err) {
+		t.Fatalf("rebuilt canonical temp remains after publication: %v", err)
+	}
+	after := recoveryEvidenceDigests(t, archive.Path, artifact.Path)
+	if strings.Join(before, "\n") != strings.Join(after, "\n") {
+		t.Fatalf("rebuild+publish changed authoritative archive evidence: before=%v after=%v", before, after)
+	}
+}
+
+func TestRecoverCanonicalV19CutoverDoesNotStartFreshCutover(t *testing.T) {
+	t.Run("legacy source", func(t *testing.T) {
+		home := createLegacyV18CutoverTestSource(t)
+		setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+		before, err := legacyV18CutoverFileSHA256(Path(home))
+		if err != nil {
+			t.Fatal(err)
+		}
+		state, err := recoverCanonicalV19Cutover(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state.Disposition != legacyV18CutoverRecoveryLegacySource {
+			t.Fatalf("legacy recovery state = %#v", state)
+		}
+		after, err := legacyV18CutoverFileSHA256(Path(home))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if after != before {
+			t.Fatalf("recovery driver mutated legacy source: before=%s after=%s", before, after)
+		}
+	})
+
+	t.Run("no state", func(t *testing.T) {
+		home := t.TempDir()
+		state, err := recoverCanonicalV19Cutover(home)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state.Disposition != legacyV18CutoverRecoveryNoState {
+			t.Fatalf("empty recovery state = %#v", state)
+		}
+		if _, err := os.Lstat(Path(home)); !os.IsNotExist(err) {
+			t.Fatalf("recovery driver created active state: %v", err)
+		}
+	})
+}
+
+func TestRecoverCanonicalV19CutoverRefusesInvalidCanonicalAuthority(t *testing.T) {
+	home, _, archive, artifact, _, _ := canonicalV19CutoverPublicationFixture(t)
+	if _, err := publishCanonicalV19Cutover(home); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openLegacyV18CutoverSQLite(Path(home), "rw", legacyV18CutoverGateTimeout, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`PRAGMA user_version = 18`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	activeBefore, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceBefore := recoveryEvidenceDigests(t, archive.Path, artifact.Path)
+
+	state, err := recoverCanonicalV19Cutover(home)
+	if err == nil || state.Disposition != legacyV18CutoverRecoveryRefuse || !strings.Contains(err.Error(), "cannot fall back to legacy evidence") {
+		t.Fatalf("invalid canonical recovery = %#v, %v", state, err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != activeBefore {
+		t.Fatalf("invalid canonical active changed during refusal: %s, %v; want %s", got, err, activeBefore)
+	}
+	evidenceAfter := recoveryEvidenceDigests(t, archive.Path, artifact.Path)
+	if strings.Join(evidenceBefore, "\n") != strings.Join(evidenceAfter, "\n") {
+		t.Fatalf("refusal changed archive evidence: before=%v after=%v", evidenceBefore, evidenceAfter)
+	}
+}
+
+func TestRecoverCanonicalV19CutoverPreservesMigrationLockSerialization(t *testing.T) {
+	home, bridge, _, _, _, materialized := canonicalV19CutoverPublicationFixture(t)
+	release, err := Lock(home, MigrationLock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	state, err := recoverCanonicalV19Cutover(home)
+	if err == nil || state.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp || !strings.Contains(err.Error(), "MigrationLock") {
+		t.Fatalf("contended recovery = %#v, %v", state, err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(Path(home)); err != nil || got != bridge.BridgeSHA256 {
+		t.Fatalf("active frozen bridge changed while lock busy: %s, %v", got, err)
+	}
+	if got, err := legacyV18CutoverFileSHA256(materialized.Path); err != nil || got != materialized.SHA256 {
+		t.Fatalf("canonical temp changed while lock busy: %s, %v", got, err)
+	}
+}


### PR DESCRIPTION
Implements the next narrow 5D recovery slice after #549 landed canonical-temp rebuild from immutable archive evidence.

This slice adds one private, inert recovery driver that executes only dispositions already authorized by the landed read-only recovery classifier:
- `canonical-authority`, `legacy-source`, and `no-state` return without mutation;
- `refuse` remains fail-closed;
- `rebuild-canonical-temp` delegates to the landed 5D4 primitive;
- `publish-canonical-temp` delegates to the landed crash-safe 5D2 publisher;
- after each successful transition, authority is re-inspected until canonical authority or another stable non-recovery disposition is reached;
- progression is bounded to the exact `rebuild → publish → canonical-authority` state machine.

The driver deliberately does not introduce a second outer MigrationLock. Each existing mutating primitive acquires the Fleet MigrationLock itself and reclassifies exact durable evidence while held, so a contending recovery/cutover process fails closed rather than acting on stale dispatcher state.

Tests cover direct publish recovery, rebuild-then-publish after frozen-bridge retirement, legacy/no-state no-op behavior, corrupt canonical refusal with no archive fallback, authoritative evidence preservation, retired-bridge preservation, and MigrationLock contention.

The durable advisory marker remains non-authoritative and is not consulted by this driver. Registry repair remains untouched. No fresh legacy cutover is started, no startup caller is introduced, and automatic production cutover remains inert.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.