### PR TITLE
feat(store): persist v19 recovery manifest before freeze

### DIFF
--- a/internal/store/cutoverguard.go
+++ b/internal/store/cutoverguard.go
@@ -93,7 +93,7 @@ func AcquireLegacyV18CutoverGuard(ctx context.Context, homeDir string) (*LegacyV
 
 // ObservationPlan returns a copy only while the source gate and Fleet-local lock closure remain held.
 func (g *LegacyV18CutoverGuard) ObservationPlan() (LegacyV18CutoverObservationPlan, error) {
-	if g == nil || g.gate == nil || g.locks == nil {
+	if !g.held() {
 		return LegacyV18CutoverObservationPlan{}, ErrLegacyV18CutoverGuardClosed
 	}
 	plan := g.plan

--- a/internal/store/cutoverguard.go
+++ b/internal/store/cutoverguard.go
@@ -53,9 +53,10 @@ type LegacyV18CutoverObservationPlan struct {
 
 // LegacyV18CutoverGuard holds the source EXCLUSIVE gate and Fleet-local lock closure while providers are observed.
 type LegacyV18CutoverGuard struct {
-	gate  *legacyV18CutoverGate
-	locks *legacyV18CutoverLocks
-	plan  LegacyV18CutoverObservationPlan
+	gate       *legacyV18CutoverGate
+	locks      *legacyV18CutoverLocks
+	plan       LegacyV18CutoverObservationPlan
+	sourceHeld bool
 }
 
 // AcquireLegacyV18CutoverGuard acquires the landed 5A2/5A3 source guards and derives the durable observation plan.
@@ -88,7 +89,12 @@ func AcquireLegacyV18CutoverGuard(ctx context.Context, homeDir string) (*LegacyV
 	}
 	keepGate = true
 	keepLocks = true
-	return &LegacyV18CutoverGuard{gate: gate, locks: locks, plan: exportLegacyV18CutoverObservationPlan(plan)}, nil
+	return &LegacyV18CutoverGuard{
+		gate:       gate,
+		locks:      locks,
+		plan:       exportLegacyV18CutoverObservationPlan(plan),
+		sourceHeld: true,
+	}, nil
 }
 
 // ObservationPlan returns a copy only while the source gate and Fleet-local lock closure remain held.
@@ -108,6 +114,7 @@ func (g *LegacyV18CutoverGuard) Close() error {
 	if g == nil {
 		return nil
 	}
+	g.sourceHeld = false
 	var errs []error
 	if g.locks != nil {
 		errs = append(errs, g.locks.Close())

--- a/internal/store/cutoverguard_freeze.go
+++ b/internal/store/cutoverguard_freeze.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Freeze durably binds exact positive import evidence before crossing the one-way
+// legacy source freeze boundary. It never builds or publishes canonical v19.
+func (g *LegacyV18CutoverGuard) Freeze(ctx context.Context, homeDir string, input LegacyV18CutoverManifestInput) error {
+	if !g.held() {
+		return ErrLegacyV18CutoverGuardClosed
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: %w", err)
+	}
+	if err := validateLegacyV18CutoverManifestInputAgainstPlan(g.plan, input); err != nil {
+		return err
+	}
+
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(homeDir, g.gate.archiveCandidate)
+	if err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: promote original archive: %w", err)
+	}
+	stableInput, err := stabilizeLegacyV18CutoverManifestInput(homeDir, archive, input)
+	if err != nil {
+		return err
+	}
+	artifact, err := writeLegacyV18CutoverManifest(homeDir, archive, stableInput)
+	if err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: persist pre-freeze recovery manifest: %w", err)
+	}
+
+	bridge, err := freezeLegacyV18CutoverSource(ctx, homeDir, g.gate, archive)
+	if err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: %w", err)
+	}
+	if bridge.MigrationID != archive.MigrationID || bridge.FleetID != stableInput.FleetID || bridge.SourceSHA256 != archive.SHA256 {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: committed bridge identity differs from durable archive/manifest evidence")
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(homeDir)
+	if err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: inspect committed recovery state: %w", err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRebuildCanonicalTemp && state.Disposition != legacyV18CutoverRecoveryPublishCanonicalTemp {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: committed recovery disposition=%s: %s", state.Disposition, state.Reason)
+	}
+	if state.MigrationID != bridge.MigrationID || state.FleetID != bridge.FleetID || state.SourceSHA256 != bridge.SourceSHA256 || state.Manifest != artifact {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: committed recovery identity differs from durable pre-freeze evidence")
+	}
+	return nil
+}
+
+func (g *LegacyV18CutoverGuard) held() bool {
+	return g != nil && g.gate != nil && g.gate.conn != nil && g.gate.db != nil && g.locks != nil
+}
+
+func validateLegacyV18CutoverManifestInputAgainstPlan(plan LegacyV18CutoverObservationPlan, input LegacyV18CutoverManifestInput) error {
+	if input.FleetID != plan.FleetID {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: manifest Fleet ID=%q, held Fleet ID=%q", input.FleetID, plan.FleetID)
+	}
+	if _, err := validateLegacyV18CutoverManifestTimestamp(input.ImportedAt); err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: %w", err)
+	}
+	if _, err := buildLegacyV18CutoverManifestProjects(input.Projects); err != nil {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: %w", err)
+	}
+	if len(input.Projects) != len(plan.Projects) {
+		return fmt.Errorf("freeze held legacy v18 cutover guard: manifest Project evidence count=%d, held source Projects=%d", len(input.Projects), len(plan.Projects))
+	}
+
+	planByID := make(map[string]LegacyV18CutoverProjectObservation, len(plan.Projects))
+	for _, project := range plan.Projects {
+		if _, exists := planByID[project.ProjectID]; exists {
+			return fmt.Errorf("freeze held legacy v18 cutover guard: duplicate held source Project identity %q", project.ProjectID)
+		}
+		planByID[project.ProjectID] = project
+	}
+	seen := make(map[string]struct{}, len(input.Projects))
+	for _, project := range input.Projects {
+		source, ok := planByID[project.SourceProjectID]
+		if !ok {
+			return fmt.Errorf("freeze held legacy v18 cutover guard: manifest Project %q is absent from held source plan", project.SourceProjectID)
+		}
+		if _, duplicate := seen[project.SourceProjectID]; duplicate {
+			return fmt.Errorf("freeze held legacy v18 cutover guard: duplicate manifest Project identity %q", project.SourceProjectID)
+		}
+		seen[project.SourceProjectID] = struct{}{}
+		if project.LegacyName != source.Name || project.LegacyURL != source.URL || project.LegacyMode != source.Mode || project.LegacyUpstream != source.Upstream {
+			return fmt.Errorf("freeze held legacy v18 cutover guard: Project %q provenance differs from held source plan", project.SourceProjectID)
+		}
+	}
+	return nil
+}
+
+func stabilizeLegacyV18CutoverManifestInput(homeDir string, archive legacyV18CutoverOriginalArchive, input LegacyV18CutoverManifestInput) (LegacyV18CutoverManifestInput, error) {
+	path := legacyV18CutoverManifestPath(homeDir, archive.MigrationID)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return input, nil
+	}
+	if err != nil {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: inspect existing recovery manifest: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: existing recovery manifest %s is not a direct regular file", path)
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: read existing recovery manifest: %w", err)
+	}
+	var persisted legacyV18CutoverManifest
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: decode existing recovery manifest: %w", err)
+	}
+	artifact := legacyV18CutoverManifestArtifact{
+		MigrationID: archive.MigrationID,
+		Path:        path,
+		SHA256:      canonicalV19SHA256(payload),
+		ImportedAt:  persisted.ImportedAt,
+	}
+	if _, err := readLegacyV18CutoverManifest(homeDir, artifact); err != nil {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: validate existing recovery manifest: %w", err)
+	}
+
+	stable := input
+	stable.ImportedAt = persisted.ImportedAt
+	expected, err := buildLegacyV18CutoverManifest(homeDir, archive, stable)
+	if err != nil {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: rebuild existing recovery evidence: %w", err)
+	}
+	expectedPayload, err := json.Marshal(expected)
+	if err != nil {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: encode existing recovery evidence: %w", err)
+	}
+	expectedPayload = append(expectedPayload, '\n')
+	if !bytes.Equal(payload, expectedPayload) {
+		return LegacyV18CutoverManifestInput{}, fmt.Errorf("freeze held legacy v18 cutover guard: existing recovery manifest differs from fresh positive evidence")
+	}
+	return stable, nil
+}

--- a/internal/store/cutoverguard_freeze.go
+++ b/internal/store/cutoverguard_freeze.go
@@ -38,6 +38,9 @@ func (g *LegacyV18CutoverGuard) Freeze(ctx context.Context, homeDir string, inpu
 	}
 
 	bridge, err := freezeLegacyV18CutoverSource(ctx, homeDir, g.gate, archive)
+	if bridge.Committed {
+		g.sourceHeld = false
+	}
 	if err != nil {
 		return fmt.Errorf("freeze held legacy v18 cutover guard: %w", err)
 	}
@@ -59,7 +62,7 @@ func (g *LegacyV18CutoverGuard) Freeze(ctx context.Context, homeDir string, inpu
 }
 
 func (g *LegacyV18CutoverGuard) held() bool {
-	return g != nil && g.gate != nil && g.gate.conn != nil && g.gate.db != nil && g.locks != nil
+	return g != nil && g.sourceHeld && g.gate != nil && g.locks != nil
 }
 
 func validateLegacyV18CutoverManifestInputAgainstPlan(plan LegacyV18CutoverObservationPlan, input LegacyV18CutoverManifestInput) error {

--- a/internal/store/cutoverguard_freeze_test.go
+++ b/internal/store/cutoverguard_freeze_test.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLegacyV18CutoverGuardFreezeLeavesRecoverableFrozenBridge(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	guard, err := AcquireLegacyV18CutoverGuard(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := guard.ObservationPlan()
+	if err != nil {
+		_ = guard.Close()
+		t.Fatal(err)
+	}
+	input := LegacyV18CutoverManifestInput{
+		FleetID:    plan.FleetID,
+		ImportedAt: "2026-09-04T04:20:00.123456789Z",
+		Projects:   []LegacyV18CutoverManifestProjectInput{},
+	}
+
+	if err := guard.Freeze(context.Background(), home, input); err != nil {
+		_ = guard.Close()
+		t.Fatal(err)
+	}
+	if _, err := guard.ObservationPlan(); !errors.Is(err, ErrLegacyV18CutoverGuardClosed) {
+		_ = guard.Close()
+		t.Fatalf("ObservationPlan after freeze = %v, want %v", err, ErrLegacyV18CutoverGuardClosed)
+	}
+	if err := guard.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRebuildCanonicalTemp {
+		t.Fatalf("post-freeze recovery state = %#v", state)
+	}
+	if state.FleetID != plan.FleetID || state.Manifest.ImportedAt != input.ImportedAt {
+		t.Fatalf("post-freeze recovery identity = %#v", state)
+	}
+	if _, err := os.Lstat(state.Manifest.Path); err != nil {
+		t.Fatalf("durable pre-freeze manifest: %v", err)
+	}
+	bridge, err := discoverLegacyV18CutoverFrozenBridge(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bridge.MigrationID != state.MigrationID || bridge.SourceSHA256 != state.SourceSHA256 {
+		t.Fatalf("bridge=%#v recovery=%#v", bridge, state)
+	}
+}
+
+func TestLegacyV18CutoverGuardFreezeReusesExactManifestAcrossPrefreezeRetry(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	firstGuard, err := AcquireLegacyV18CutoverGuard(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPlan, err := firstGuard.ObservationPlan()
+	if err != nil {
+		_ = firstGuard.Close()
+		t.Fatal(err)
+	}
+	archive, err := promoteLegacyV18CutoverArchiveCandidate(home, firstGuard.gate.archiveCandidate)
+	if err != nil {
+		_ = firstGuard.Close()
+		t.Fatal(err)
+	}
+	firstInput := LegacyV18CutoverManifestInput{
+		FleetID:    firstPlan.FleetID,
+		ImportedAt: "2026-09-04T04:21:00Z",
+		Projects:   []LegacyV18CutoverManifestProjectInput{},
+	}
+	firstArtifact, err := writeLegacyV18CutoverManifest(home, archive, firstInput)
+	if err != nil {
+		_ = firstGuard.Close()
+		t.Fatal(err)
+	}
+	if err := firstGuard.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyBefore, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondGuard, err := AcquireLegacyV18CutoverGuard(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := secondGuard.ObservationPlan()
+	if err != nil {
+		_ = secondGuard.Close()
+		t.Fatal(err)
+	}
+	secondInput := LegacyV18CutoverManifestInput{
+		FleetID:    secondPlan.FleetID,
+		ImportedAt: "2026-09-04T04:22:00Z",
+		Projects:   []LegacyV18CutoverManifestProjectInput{},
+	}
+	if err := secondGuard.Freeze(context.Background(), home, secondInput); err != nil {
+		_ = secondGuard.Close()
+		t.Fatal(err)
+	}
+	if err := secondGuard.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryRebuildCanonicalTemp || state.Manifest != firstArtifact {
+		t.Fatalf("retry recovery state = %#v, first manifest = %#v", state, firstArtifact)
+	}
+	archiveDigest, err := legacyV18CutoverFileSHA256(legacyV18CutoverOriginalArchivePath(home, state.MigrationID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archiveDigest != legacyBefore || state.SourceSHA256 != legacyBefore {
+		t.Fatalf("retry changed original evidence: archive=%s recovery=%s original=%s", archiveDigest, state.SourceSHA256, legacyBefore)
+	}
+}
+
+func TestLegacyV18CutoverGuardFreezeRejectsFabricatedProjectEvidenceBeforeSourceMutation(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	before, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	guard, err := AcquireLegacyV18CutoverGuard(context.Background(), home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := guard.ObservationPlan()
+	if err != nil {
+		_ = guard.Close()
+		t.Fatal(err)
+	}
+	input := LegacyV18CutoverManifestInput{
+		FleetID:    plan.FleetID,
+		ImportedAt: "2026-09-04T04:23:00Z",
+		Projects: []LegacyV18CutoverManifestProjectInput{{
+			SourceProjectID:      "fabricated-project",
+			Locator:              "projects/fabricated",
+			RepositoryPhysicalID: "unix-v1:dev=1:ino=1",
+			CommonDirPhysicalID:  "unix-v1:dev=1:ino=2",
+			Revision:             strings.Repeat("a", 40),
+			LegacyName:           "fabricated",
+		}},
+	}
+	if err := guard.Freeze(context.Background(), home, input); err == nil || !strings.Contains(err.Error(), "Project evidence count") {
+		_ = guard.Close()
+		t.Fatalf("fabricated Project freeze error = %v", err)
+	}
+	if err := guard.Close(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("rejected fabricated evidence changed source: before=%s after=%s", before, after)
+	}
+	state, err := inspectLegacyV18CutoverRecovery(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Disposition != legacyV18CutoverRecoveryLegacySource {
+		t.Fatalf("rejected fabricated evidence recovery state = %#v", state)
+	}
+}
+
+func TestLegacyV18CutoverGuardFreezeRequiresHeldGuard(t *testing.T) {
+	var guard *LegacyV18CutoverGuard
+	if err := guard.Freeze(context.Background(), t.TempDir(), LegacyV18CutoverManifestInput{}); !errors.Is(err, ErrLegacyV18CutoverGuardClosed) {
+		t.Fatalf("nil guard Freeze = %v, want %v", err, ErrLegacyV18CutoverGuardClosed)
+	}
+}

--- a/internal/store/cutoverguard_test.go
+++ b/internal/store/cutoverguard_test.go
@@ -7,8 +7,9 @@ import (
 
 func TestLegacyV18CutoverGuardObservationPlanIsCopiedAndRequiresHeldGuard(t *testing.T) {
 	guard := &LegacyV18CutoverGuard{
-		gate:  &legacyV18CutoverGate{},
-		locks: &legacyV18CutoverLocks{},
+		gate:       &legacyV18CutoverGate{},
+		locks:      &legacyV18CutoverLocks{},
+		sourceHeld: true,
 		plan: LegacyV18CutoverObservationPlan{
 			FleetID:   "f_test",
 			Projects:  []LegacyV18CutoverProjectObservation{{ProjectID: "project-1", Name: "demo"}},

--- a/internal/store/cutovermanifest_types.go
+++ b/internal/store/cutovermanifest_types.go
@@ -13,8 +13,8 @@ const canonicalV19AuthorityCommit = "67ca4b35b773ef25ac9ff88cd1b16213153ed498"
 const canonicalV19AuthorityDDLPath = "docs/architecture/v19.sql.gz"
 const canonicalV19AuthorityDDLGitBlobSHA1 = "d529d7a687db8d0266d5592ade9520c04766bf43"
 
-// LegacyV18CutoverManifestInput is the positively verified evidence that may be
-// recorded in the deterministic archive manifest after the one-way source freeze.
+// LegacyV18CutoverManifestInput is positive import evidence that may be made
+// durable after final quiescence and before the one-way source freeze.
 type LegacyV18CutoverManifestInput struct {
 	FleetID    string
 	ImportedAt string


### PR DESCRIPTION
Closes the remaining #348 one-way-freeze crash boundary exposed by the landed 5D recovery classifier.

The immutable revision-2 contract requires a crash after freeze commit to remain recoverable from the exact frozen bridge plus matching immutable original/import evidence. The current classifier requires the archive manifest for that recovery identity, so this slice makes that final deterministic manifest durable before crossing the one-way freeze boundary.

This slice:
- adds `LegacyV18CutoverGuard.Freeze`, usable only while the exact 5A2/5A3 source gate and Fleet-local lock closure remain held;
- verifies manifest Fleet/Project provenance against the held source observation plan before any source mutation;
- promotes/revalidates the immutable original archive first;
- persists/revalidates the deterministic recovery/import manifest before the freeze commit;
- on a pre-freeze retry, preserves an already-durable `imported_at` only when the entire canonical manifest payload rebuilt from fresh positive evidence is byte-identical;
- then delegates to the landed exact frozen-bridge primitive;
- closes provider observation immediately once the freeze transaction commits while retaining Fleet-local locks and MigrationLock until the guard is explicitly closed;
- requires the committed bridge to classify immediately as `rebuild-canonical-temp` or `publish-canonical-temp` with the exact same Fleet/source/manifest identity.

Tests cover immediate post-freeze recovery without marker dependence, exact-manifest reuse across a pre-freeze retry with a different attempted timestamp, fabricated Project evidence refusal before source mutation, and closed-guard refusal.

No canonical target publication is added here. No startup/automatic cutover caller is introduced. Marker remains advisory-only. Registry repair is untouched. No provider/Git/network mutation is added beyond the already-landed exact frozen-bridge mechanism.

Canonical #344 DDL impact: **NONE**.

Refs #348, #339.