### PR TITLE
feat(store): add canonical v19 Task writer

### DIFF
--- a/internal/store/v19task.go
+++ b/internal/store/v19task.go
@@ -96,11 +96,11 @@ func CreateCanonicalV19Task(ctx context.Context, homeDir string, input Canonical
 
 func validateCanonicalV19TaskCreateInput(input CanonicalV19TaskCreateInput) error {
 	for name, value := range map[string]string{
-		"Task ID": input.ID,
-		"Project ID": input.ProjectID,
-		"goal": input.Goal,
+		"Task ID":     input.ID,
+		"Project ID":  input.ProjectID,
+		"goal":        input.Goal,
 		"goal digest": input.GoalDigest,
-		"created_at": input.CreatedAt,
+		"created_at":  input.CreatedAt,
 	} {
 		if value == "" {
 			return fmt.Errorf("create canonical v19 Task: %s is empty", name)

--- a/internal/store/v19task.go
+++ b/internal/store/v19task.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+)
+
+// ErrCanonicalV19TaskConflict marks a canonical Task insert that lost an exact
+// identity or ordinal constraint. Callers must not retarget another Task.
+var ErrCanonicalV19TaskConflict = errors.New("canonical v19 task write conflict")
+
+// ErrCanonicalV19ProjectNotCurrent marks a missing or retired exact Project.
+var ErrCanonicalV19ProjectNotCurrent = errors.New("canonical v19 project is not current")
+
+// CanonicalV19TaskCreateInput is the immutable evidence for one fresh Task.
+type CanonicalV19TaskCreateInput struct {
+	ID         string
+	ProjectID  string
+	Goal       string
+	GoalDigest string
+	CreatedAt  string
+}
+
+// CreateCanonicalV19Task inserts one fresh active Task into an already-canonical
+// active database. It never creates, migrates, or cuts over state.
+func CreateCanonicalV19Task(ctx context.Context, homeDir string, input CanonicalV19TaskCreateInput) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := validateCanonicalV19TaskCreateInput(input); err != nil {
+		return 0, err
+	}
+
+	sqlDB, err := openCanonicalV19Writer(homeDir)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	// The writer DSN pins database/sql transactions to BEGIN IMMEDIATE so
+	// ordinal selection and insertion share one SQLite write serialization point.
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, canonicalV19WriteError("begin Task writer", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := validateCanonicalV19WriterTransaction(ctx, tx); err != nil {
+		return 0, fmt.Errorf("create canonical v19 Task: %w", err)
+	}
+
+	var retiredAt string
+	if err := tx.QueryRowContext(ctx, `SELECT retired_at FROM project WHERE id = ?`, input.ProjectID).Scan(&retiredAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("%w: Project %q does not exist", ErrCanonicalV19ProjectNotCurrent, input.ProjectID)
+		}
+		return 0, canonicalV19WriteError("read exact Project", err)
+	}
+	if retiredAt != "" {
+		return 0, fmt.Errorf("%w: Project %q is retired", ErrCanonicalV19ProjectNotCurrent, input.ProjectID)
+	}
+
+	var ordinal int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(ordinal), 0) + 1 FROM task WHERE project_id = ?`, input.ProjectID,
+	).Scan(&ordinal); err != nil {
+		return 0, canonicalV19WriteError("allocate Task ordinal", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `INSERT INTO task(
+		id, project_id, ordinal, goal, goal_digest, supersedes_task_id,
+		lifecycle, created_at, terminal_at
+	) VALUES(?,?,?,?,?,NULL,'active',?,'')`,
+		input.ID, input.ProjectID, ordinal, input.Goal, input.GoalDigest, input.CreatedAt)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return 0, fmt.Errorf("%w: Task %q", ErrCanonicalV19TaskConflict, input.ID)
+		}
+		return 0, canonicalV19WriteError("insert Task", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, canonicalV19WriteError("commit Task writer", err)
+	}
+	committed = true
+	return ordinal, nil
+}
+
+func validateCanonicalV19TaskCreateInput(input CanonicalV19TaskCreateInput) error {
+	for name, value := range map[string]string{
+		"Task ID": input.ID,
+		"Project ID": input.ProjectID,
+		"goal": input.Goal,
+		"goal digest": input.GoalDigest,
+		"created_at": input.CreatedAt,
+	} {
+		if value == "" {
+			return fmt.Errorf("create canonical v19 Task: %s is empty", name)
+		}
+	}
+	return nil
+}
+
+func openCanonicalV19Writer(homeDir string) (*sql.DB, error) {
+	path := Path(homeDir)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("open canonical v19 writer: inspect active database: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("open canonical v19 writer: active database %s is not a direct regular file", path)
+	}
+
+	uri := "file:" + (&url.URL{Path: path}).EscapedPath() +
+		"?mode=rw&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)&_txlock=immediate" + sqliteTestPragmas
+	sqlDB, err := sql.Open("sqlite", uri)
+	if err != nil {
+		return nil, fmt.Errorf("open canonical v19 writer: %w", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := validateCanonicalV19Schema(sqlDB); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("open canonical v19 writer: %w", err)
+	}
+	return sqlDB, nil
+}
+
+func validateCanonicalV19WriterTransaction(ctx context.Context, tx *sql.Tx) error {
+	var foreignKeys int
+	if err := tx.QueryRowContext(ctx, `PRAGMA foreign_keys`).Scan(&foreignKeys); err != nil {
+		return fmt.Errorf("validate canonical v19 writer transaction: foreign_keys: %w", err)
+	}
+	if foreignKeys != 1 {
+		return canonicalV19Mismatch("writer transaction PRAGMA foreign_keys = %d, want 1", foreignKeys)
+	}
+	var version int
+	if err := tx.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
+		return fmt.Errorf("validate canonical v19 writer transaction: user_version: %w", err)
+	}
+	if version != canonicalV19SchemaVersion {
+		return canonicalV19Mismatch("writer transaction PRAGMA user_version = %d, want %d", version, canonicalV19SchemaVersion)
+	}
+	identity, err := inspectCanonicalV19Identity(tx)
+	if err != nil {
+		return err
+	}
+	if identity.Fingerprint != canonicalV19SchemaFingerprint ||
+		identity.Tables != canonicalV19TableCount ||
+		identity.Indexes != canonicalV19IndexCount ||
+		identity.Triggers != canonicalV19TriggerCount {
+		return canonicalV19Mismatch("writer transaction schema identity = %s / %d / %d / %d, want %s / %d / %d / %d",
+			identity.Fingerprint, identity.Tables, identity.Indexes, identity.Triggers,
+			canonicalV19SchemaFingerprint, canonicalV19TableCount, canonicalV19IndexCount, canonicalV19TriggerCount)
+	}
+	return nil
+}
+
+func canonicalV19WriteError(action string, err error) error {
+	if isSQLiteBusy(err) {
+		return fmt.Errorf("create canonical v19 Task: %s: %w", action, ErrContention)
+	}
+	return fmt.Errorf("create canonical v19 Task: %s: %w", action, err)
+}

--- a/internal/store/v19task_test.go
+++ b/internal/store/v19task_test.go
@@ -1,0 +1,221 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestCreateCanonicalV19TaskAllocatesExactProjectOrdinal(t *testing.T) {
+	home := canonicalV19TaskWriterFixture(t, false)
+	ctx := context.Background()
+	first := CanonicalV19TaskCreateInput{
+		ID:         "task-1",
+		ProjectID:  "project-1",
+		Goal:       "ship the canonical writer",
+		GoalDigest: "goal-digest-1",
+		CreatedAt:  "2026-09-04T06:40:00Z",
+	}
+	ordinal, err := CreateCanonicalV19Task(ctx, home, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 1 {
+		t.Fatalf("first Task ordinal = %d, want 1", ordinal)
+	}
+	second := first
+	second.ID = "task-2"
+	second.Goal = "prove the next ordinal"
+	second.GoalDigest = "goal-digest-2"
+	ordinal, err = CreateCanonicalV19Task(ctx, home, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 2 {
+		t.Fatalf("second Task ordinal = %d, want 2", ordinal)
+	}
+
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var got CanonicalV19TaskCreateInput
+	var gotOrdinal int64
+	var supersedes sql.NullString
+	var lifecycle, terminalAt string
+	if err := db.sql.QueryRow(`SELECT id,project_id,ordinal,goal,goal_digest,supersedes_task_id,lifecycle,created_at,terminal_at
+		FROM task WHERE id = ?`, first.ID).Scan(
+		&got.ID, &got.ProjectID, &gotOrdinal, &got.Goal, &got.GoalDigest, &supersedes, &lifecycle, &got.CreatedAt, &terminalAt,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got != first || gotOrdinal != 1 || supersedes.Valid || lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("persisted Task = %#v ordinal=%d supersedes=%#v lifecycle=%q terminal_at=%q",
+			got, gotOrdinal, supersedes, lifecycle, terminalAt)
+	}
+}
+
+func TestCreateCanonicalV19TaskRefusesRetiredExactProject(t *testing.T) {
+	home := canonicalV19TaskWriterFixture(t, true)
+	_, err := CreateCanonicalV19Task(context.Background(), home, CanonicalV19TaskCreateInput{
+		ID:         "task-retired",
+		ProjectID:  "project-1",
+		Goal:       "must not retarget",
+		GoalDigest: "goal-digest",
+		CreatedAt:  "2026-09-04T06:41:00Z",
+	})
+	if !errors.Is(err, ErrCanonicalV19ProjectNotCurrent) {
+		t.Fatalf("retired Project error = %v, want %v", err, ErrCanonicalV19ProjectNotCurrent)
+	}
+	if got := canonicalV19TaskWriterCount(t, home); got != 0 {
+		t.Fatalf("Task rows after retired Project refusal = %d, want 0", got)
+	}
+}
+
+func TestCreateCanonicalV19TaskDuplicateIdentityDoesNotRetarget(t *testing.T) {
+	home := canonicalV19TaskWriterFixture(t, false)
+	input := CanonicalV19TaskCreateInput{
+		ID:         "task-same",
+		ProjectID:  "project-1",
+		Goal:       "first immutable goal",
+		GoalDigest: "goal-digest-first",
+		CreatedAt:  "2026-09-04T06:42:00Z",
+	}
+	if _, err := CreateCanonicalV19Task(context.Background(), home, input); err != nil {
+		t.Fatal(err)
+	}
+	input.Goal = "replacement goal must lose"
+	input.GoalDigest = "goal-digest-replacement"
+	if _, err := CreateCanonicalV19Task(context.Background(), home, input); !errors.Is(err, ErrCanonicalV19TaskConflict) {
+		t.Fatalf("duplicate Task error = %v, want %v", err, ErrCanonicalV19TaskConflict)
+	}
+	if got := canonicalV19TaskWriterCount(t, home); got != 1 {
+		t.Fatalf("Task rows after duplicate = %d, want 1", got)
+	}
+
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var goal, digest string
+	var ordinal int64
+	if err := db.sql.QueryRow(`SELECT ordinal,goal,goal_digest FROM task WHERE id='task-same'`).Scan(&ordinal, &goal, &digest); err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 1 || goal != "first immutable goal" || digest != "goal-digest-first" {
+		t.Fatalf("duplicate retargeted Task: ordinal=%d goal=%q digest=%q", ordinal, goal, digest)
+	}
+}
+
+func TestCreateCanonicalV19TaskRefusesLegacyWithoutMutation(t *testing.T) {
+	home := createLegacyV18CutoverTestSource(t)
+	setLegacyV18CutoverTestJournalMode(t, home, "DELETE")
+	before, err := legacyV18CutoverFileSHA256(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = CreateCanonicalV19Task(context.Background(), home, CanonicalV19TaskCreateInput{
+		ID:         "task-canonical",
+		ProjectID:  "project-1",
+		Goal:       "must not run the legacy migration ladder",
+		GoalDigest: "goal-digest",
+		CreatedAt:  "2026-09-04T06:43:00Z",
+	})
+	if !errors.Is(err, ErrCanonicalV19SchemaMismatch) {
+		t.Fatalf("legacy-family writer error = %v, want %v", err, ErrCanonicalV19SchemaMismatch)
+	}
+	after, digestErr := legacyV18CutoverFileSHA256(Path(home))
+	if digestErr != nil {
+		t.Fatal(digestErr)
+	}
+	if after != before {
+		t.Fatalf("canonical writer mutated legacy bytes: before=%s after=%s", before, after)
+	}
+}
+
+func TestCreateCanonicalV19TaskDoesNotCreateOrRepairDatabase(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		home := t.TempDir()
+		_, err := CreateCanonicalV19Task(context.Background(), home, CanonicalV19TaskCreateInput{
+			ID: "task-1", ProjectID: "project-1", Goal: "goal", GoalDigest: "digest", CreatedAt: "now",
+		})
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("missing database error = %v, want os.ErrNotExist", err)
+		}
+		if _, statErr := os.Lstat(Path(home)); !os.IsNotExist(statErr) {
+			t.Fatalf("missing database was created: stat error = %v", statErr)
+		}
+	})
+
+	t.Run("schema drift", func(t *testing.T) {
+		home := canonicalV19TaskWriterFixture(t, false)
+		db, err := open(Path(home))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`CREATE TABLE canonical_drift(id TEXT PRIMARY KEY) STRICT`); err != nil {
+			_ = db.Close()
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		_, err = CreateCanonicalV19Task(context.Background(), home, CanonicalV19TaskCreateInput{
+			ID: "task-1", ProjectID: "project-1", Goal: "goal", GoalDigest: "digest", CreatedAt: "now",
+		})
+		if !errors.Is(err, ErrCanonicalV19SchemaMismatch) {
+			t.Fatalf("drifted schema error = %v, want %v", err, ErrCanonicalV19SchemaMismatch)
+		}
+		if got := canonicalV19TaskWriterCount(t, home); got != 0 {
+			t.Fatalf("Task rows after schema-drift refusal = %d, want 0", got)
+		}
+	})
+}
+
+func canonicalV19TaskWriterFixture(t *testing.T, retired bool) string {
+	t.Helper()
+	home := t.TempDir()
+	db, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := createCanonicalV19Schema(db); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO fleet(singleton,fleet_id,created_at) VALUES(1,'fleet-1','2026-09-04T06:39:00Z')`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	retiredAt := ""
+	if retired {
+		retiredAt = "2026-09-04T06:39:30Z"
+	}
+	if _, err := db.Exec(`INSERT INTO project(id,fleet_id,ordinal,display_name,created_at,retired_at)
+		VALUES('project-1','fleet-1',1,'demo','2026-09-04T06:39:00Z',?)`, retiredAt); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func canonicalV19TaskWriterCount(t *testing.T, home string) int {
+	t.Helper()
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM task`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}


### PR DESCRIPTION
Starts #339 implementation step 8 with the smallest canonical writer surface after the completed #348 5D sequence.

This slice:
- adds `CreateCanonicalV19Task` as a dedicated canonical-v19 write path rather than reusing legacy `DB.CreateTask` against a different `task` shape;
- opens only an already-existing active DB with `mode=rw`; it never creates state or runs the legacy migration ladder;
- validates the exact locked #344 canonical schema before writing and rechecks exact version/fingerprint/object identity inside the writer transaction;
- uses the existing `_txlock=immediate` writer connection so exact Project currentness, per-Project ordinal allocation, and Task insertion share one `BEGIN IMMEDIATE` transaction;
- requires the exact Project to exist and remain unretired;
- inserts only a fresh active Task with immutable goal/digest evidence and no fabricated successor lineage;
- maps SQLite constraint loss to a stable conflict and never retargets another Task.

Tests cover exact ordinal allocation/persistence, retired Project refusal, duplicate Task identity without retarget, legacy-family refusal without source-byte mutation, missing DB no-create behavior, and exact-schema drift refusal.

No ordinary runtime/store caller is switched in this slice. No cutover activation, registry repair, provider/Git/network mutation, Plan/Attempt writer, Hold/Backoff/Repair writer, or external effect is added.

Canonical #344 DDL impact: **NONE**.

Refs #339, #345, #344.