### PR TITLE
feat(store): add canonical v19 Plan writers

### DIFF
--- a/internal/store/v19plan.go
+++ b/internal/store/v19plan.go
@@ -1,0 +1,341 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	handgit "github.com/atqamz/hand/internal/git"
+)
+
+// ErrCanonicalV19PlanConflict marks a canonical Plan identity, ordinal, or
+// lineage write that lost an exact relational constraint.
+var ErrCanonicalV19PlanConflict = errors.New("canonical v19 plan write conflict")
+
+// ErrCanonicalV19PlanNotCurrent marks stale exact Task/Project/binding/policy
+// or predecessor evidence. Callers must not retarget current state.
+var ErrCanonicalV19PlanNotCurrent = errors.New("canonical v19 plan evidence is not current")
+
+// ErrCanonicalV19PlanGitBasis marks a captured WorkspaceBinding whose exact
+// repository/revision could not be positively verified.
+var ErrCanonicalV19PlanGitBasis = errors.New("canonical v19 plan Git basis is not positively verified")
+
+// CanonicalV19PlanCreateInput is the immutable meaning captured by one Plan.
+type CanonicalV19PlanCreateInput struct {
+	ID                 string
+	TaskID             string
+	Intent             string
+	Judgment           string
+	Basis              string
+	Brief              string
+	BriefDigest        string
+	WorkspaceBindingID string
+	PolicyRevisionID   string
+	CreatedAt          string
+}
+
+// CanonicalV19PlanReplanInput supersedes one exact active predecessor and
+// creates its exact successor atomically.
+type CanonicalV19PlanReplanInput struct {
+	PredecessorPlanID string
+	Successor         CanonicalV19PlanCreateInput
+	SupersededAt      string
+}
+
+type canonicalV19PlanBasisObservation struct {
+	ProjectID         string
+	RepositoryLocator string
+	CommonGitDir      string
+	Revision          string
+}
+
+type canonicalV19PlanQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// CreateCanonicalV19RootPlan creates the first Plan for one exact active Task.
+// It never chooses a replacement Task, WorkspaceBinding, or PolicyRevision.
+func CreateCanonicalV19RootPlan(ctx context.Context, homeDir string, input CanonicalV19PlanCreateInput) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := validateCanonicalV19PlanCreateInput("create canonical v19 root Plan", input); err != nil {
+		return 0, err
+	}
+
+	sqlDB, err := openCanonicalV19Writer(homeDir)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	observed, err := observeCanonicalV19PlanBasis(ctx, sqlDB, input)
+	if err != nil {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w", err)
+	}
+	if err := verifyCanonicalV19PlanGitBasis(homeDir, observed); err != nil {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w", err)
+	}
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, canonicalV19PlanWriteError("create canonical v19 root Plan", "begin writer", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := validateCanonicalV19WriterTransaction(ctx, tx); err != nil {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w", err)
+	}
+	current, err := observeCanonicalV19PlanBasis(ctx, tx, input)
+	if err != nil {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w", err)
+	}
+	if current != observed {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w: captured basis changed after Git observation", ErrCanonicalV19PlanNotCurrent)
+	}
+
+	ordinal, err := nextCanonicalV19PlanOrdinal(ctx, tx, input.TaskID)
+	if err != nil {
+		return 0, canonicalV19PlanWriteError("create canonical v19 root Plan", "allocate ordinal", err)
+	}
+	if ordinal != 1 {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w: Task %q already has Plan history", ErrCanonicalV19PlanConflict, input.TaskID)
+	}
+	if err := insertCanonicalV19Plan(ctx, tx, input, ordinal, "root", ""); err != nil {
+		return 0, fmt.Errorf("create canonical v19 root Plan: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, canonicalV19PlanWriteError("create canonical v19 root Plan", "commit writer", err)
+	}
+	committed = true
+	return ordinal, nil
+}
+
+// ReplanCanonicalV19Plan supersedes only the named active predecessor and
+// creates one immutable successor. Stale predecessors are never retargeted.
+func ReplanCanonicalV19Plan(ctx context.Context, homeDir string, input CanonicalV19PlanReplanInput) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if input.PredecessorPlanID == "" {
+		return 0, fmt.Errorf("replan canonical v19 Plan: predecessor Plan ID is empty")
+	}
+	if input.SupersededAt == "" {
+		return 0, fmt.Errorf("replan canonical v19 Plan: superseded_at is empty")
+	}
+	if err := validateCanonicalV19PlanCreateInput("replan canonical v19 Plan", input.Successor); err != nil {
+		return 0, err
+	}
+
+	sqlDB, err := openCanonicalV19Writer(homeDir)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	observed, err := observeCanonicalV19PlanBasis(ctx, sqlDB, input.Successor)
+	if err != nil {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w", err)
+	}
+	if err := verifyCanonicalV19PlanGitBasis(homeDir, observed); err != nil {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w", err)
+	}
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, canonicalV19PlanWriteError("replan canonical v19 Plan", "begin writer", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := validateCanonicalV19WriterTransaction(ctx, tx); err != nil {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w", err)
+	}
+	current, err := observeCanonicalV19PlanBasis(ctx, tx, input.Successor)
+	if err != nil {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w", err)
+	}
+	if current != observed {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w: captured basis changed after Git observation", ErrCanonicalV19PlanNotCurrent)
+	}
+	if err := requireCanonicalV19ActivePredecessor(ctx, tx, input.Successor.TaskID, input.PredecessorPlanID); err != nil {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w", err)
+	}
+
+	ordinal, err := nextCanonicalV19PlanOrdinal(ctx, tx, input.Successor.TaskID)
+	if err != nil {
+		return 0, canonicalV19PlanWriteError("replan canonical v19 Plan", "allocate ordinal", err)
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE plan
+		SET lifecycle='superseded', terminal_at=?
+		WHERE id=? AND task_id=? AND lifecycle='active' AND terminal_at=''`,
+		input.SupersededAt, input.PredecessorPlanID, input.Successor.TaskID)
+	if err != nil {
+		return 0, canonicalV19PlanWriteError("replan canonical v19 Plan", "supersede exact predecessor", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return 0, canonicalV19PlanWriteError("replan canonical v19 Plan", "count superseded predecessor", err)
+	}
+	if changed != 1 {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w: predecessor changed %d rows, want 1", ErrCanonicalV19PlanNotCurrent, changed)
+	}
+	if err := insertCanonicalV19Plan(ctx, tx, input.Successor, ordinal, "replan", input.PredecessorPlanID); err != nil {
+		return 0, fmt.Errorf("replan canonical v19 Plan: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, canonicalV19PlanWriteError("replan canonical v19 Plan", "commit writer", err)
+	}
+	committed = true
+	return ordinal, nil
+}
+
+func validateCanonicalV19PlanCreateInput(action string, input CanonicalV19PlanCreateInput) error {
+	for name, value := range map[string]string{
+		"Plan ID":              input.ID,
+		"Task ID":              input.TaskID,
+		"brief digest":         input.BriefDigest,
+		"WorkspaceBinding ID": input.WorkspaceBindingID,
+		"PolicyRevision ID":   input.PolicyRevisionID,
+		"created_at":           input.CreatedAt,
+	} {
+		if value == "" {
+			return fmt.Errorf("%s: %s is empty", action, name)
+		}
+	}
+	if input.Intent != "explore" && input.Intent != "execute" {
+		return fmt.Errorf("%s: intent %q is not canonical", action, input.Intent)
+	}
+	switch input.Judgment {
+	case "mechanical", "bounded", "substantial":
+	default:
+		return fmt.Errorf("%s: judgment %q is not canonical", action, input.Judgment)
+	}
+	return nil
+}
+
+func observeCanonicalV19PlanBasis(ctx context.Context, q canonicalV19PlanQueryer, input CanonicalV19PlanCreateInput) (canonicalV19PlanBasisObservation, error) {
+	var observed canonicalV19PlanBasisObservation
+	err := q.QueryRowContext(ctx, `SELECT t.project_id,w.repository_locator,w.common_git_dir,w.revision
+		FROM task t
+		JOIN project project_current ON project_current.id=t.project_id AND project_current.retired_at=''
+		JOIN workspace_binding w ON w.id=? AND w.project_id=t.project_id AND w.superseded_at=''
+		JOIN policy_revision p ON p.id=? AND p.project_id=t.project_id AND p.superseded_at=''
+		WHERE t.id=? AND t.lifecycle='active' AND t.terminal_at=''`,
+		input.WorkspaceBindingID, input.PolicyRevisionID, input.TaskID,
+	).Scan(&observed.ProjectID, &observed.RepositoryLocator, &observed.CommonGitDir, &observed.Revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return canonicalV19PlanBasisObservation{}, fmt.Errorf("%w: Task %q with exact current binding/policy", ErrCanonicalV19PlanNotCurrent, input.TaskID)
+	}
+	if err != nil {
+		return canonicalV19PlanBasisObservation{}, canonicalV19PlanWriteError("canonical v19 Plan", "read exact current basis", err)
+	}
+	return observed, nil
+}
+
+func verifyCanonicalV19PlanGitBasis(homeDir string, observed canonicalV19PlanBasisObservation) error {
+	if err := validateCanonicalV19CommitID(observed.Revision); err != nil {
+		return fmt.Errorf("%w: %v", ErrCanonicalV19PlanGitBasis, err)
+	}
+	repositoryPath := canonicalV19ObservedPath(homeDir, observed.RepositoryLocator)
+	root, err := handgit.ResolveRoot(repositoryPath)
+	if err != nil {
+		return fmt.Errorf("%w: resolve repository %q: %v", ErrCanonicalV19PlanGitBasis, observed.RepositoryLocator, err)
+	}
+	if !handgit.SamePath(root, repositoryPath) {
+		return fmt.Errorf("%w: locator %q resolves inside a different repository root", ErrCanonicalV19PlanGitBasis, observed.RepositoryLocator)
+	}
+	commonDir, err := handgit.CommonDir(repositoryPath)
+	if err != nil {
+		return fmt.Errorf("%w: resolve common Git directory: %v", ErrCanonicalV19PlanGitBasis, err)
+	}
+	if !handgit.SamePath(commonDir, canonicalV19ObservedPath(homeDir, observed.CommonGitDir)) {
+		return fmt.Errorf("%w: exact WorkspaceBinding common Git directory changed", ErrCanonicalV19PlanGitBasis)
+	}
+	resolved, err := handgit.Run(repositoryPath, "rev-parse", "--verify", observed.Revision+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("%w: exact revision %s is absent: %v", ErrCanonicalV19PlanGitBasis, observed.Revision, err)
+	}
+	if strings.TrimSpace(resolved) != observed.Revision {
+		return fmt.Errorf("%w: exact revision resolved as %q", ErrCanonicalV19PlanGitBasis, strings.TrimSpace(resolved))
+	}
+	return nil
+}
+
+func validateCanonicalV19CommitID(revision string) error {
+	if (len(revision) != 40 && len(revision) != 64) || revision != strings.ToLower(revision) {
+		return fmt.Errorf("revision must be exactly 40 or 64 lowercase hex characters")
+	}
+	if _, err := hex.DecodeString(revision); err != nil {
+		return fmt.Errorf("revision is not hexadecimal: %w", err)
+	}
+	return nil
+}
+
+func canonicalV19ObservedPath(homeDir, locator string) string {
+	path := filepath.FromSlash(locator)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(homeDir, path)
+}
+
+func nextCanonicalV19PlanOrdinal(ctx context.Context, tx *sql.Tx, taskID string) (int64, error) {
+	var ordinal int64
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(ordinal),0)+1 FROM plan WHERE task_id=?`, taskID).Scan(&ordinal); err != nil {
+		return 0, err
+	}
+	return ordinal, nil
+}
+
+func requireCanonicalV19ActivePredecessor(ctx context.Context, tx *sql.Tx, taskID, planID string) error {
+	var ordinal int64
+	if err := tx.QueryRowContext(ctx, `SELECT ordinal FROM plan
+		WHERE id=? AND task_id=? AND lifecycle='active' AND terminal_at=''`, planID, taskID).Scan(&ordinal); errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: predecessor Plan %q is not the exact active predecessor", ErrCanonicalV19PlanNotCurrent, planID)
+	} else if err != nil {
+		return canonicalV19PlanWriteError("canonical v19 Plan", "read exact predecessor", err)
+	}
+	return nil
+}
+
+func insertCanonicalV19Plan(ctx context.Context, tx *sql.Tx, input CanonicalV19PlanCreateInput, ordinal int64, lineageKind, predecessorID string) error {
+	var predecessor any
+	if predecessorID != "" {
+		predecessor = predecessorID
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO plan(
+		id,task_id,ordinal,lineage_kind,predecessor_plan_id,intent,judgment,basis,brief,
+		brief_digest,workspace_binding_id,policy_revision_id,lifecycle,created_at,terminal_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?, 'active',?, '')`,
+		input.ID, input.TaskID, ordinal, lineageKind, predecessor,
+		input.Intent, input.Judgment, input.Basis, input.Brief, input.BriefDigest,
+		input.WorkspaceBindingID, input.PolicyRevisionID, input.CreatedAt)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return fmt.Errorf("%w: Plan %q", ErrCanonicalV19PlanConflict, input.ID)
+		}
+		return canonicalV19PlanWriteError("canonical v19 Plan", "insert Plan", err)
+	}
+	return nil
+}
+
+func canonicalV19PlanWriteError(subject, action string, err error) error {
+	if isSQLiteBusy(err) {
+		return fmt.Errorf("%s: %s: %w", subject, action, ErrContention)
+	}
+	return fmt.Errorf("%s: %s: %w", subject, action, err)
+}

--- a/internal/store/v19plan.go
+++ b/internal/store/v19plan.go
@@ -205,12 +205,12 @@ func ReplanCanonicalV19Plan(ctx context.Context, homeDir string, input Canonical
 
 func validateCanonicalV19PlanCreateInput(action string, input CanonicalV19PlanCreateInput) error {
 	for name, value := range map[string]string{
-		"Plan ID":              input.ID,
-		"Task ID":              input.TaskID,
-		"brief digest":         input.BriefDigest,
+		"Plan ID":             input.ID,
+		"Task ID":             input.TaskID,
+		"brief digest":        input.BriefDigest,
 		"WorkspaceBinding ID": input.WorkspaceBindingID,
 		"PolicyRevision ID":   input.PolicyRevisionID,
-		"created_at":           input.CreatedAt,
+		"created_at":          input.CreatedAt,
 	} {
 		if value == "" {
 			return fmt.Errorf("%s: %s is empty", action, name)

--- a/internal/store/v19plan_test.go
+++ b/internal/store/v19plan_test.go
@@ -1,0 +1,319 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateCanonicalV19RootPlanPersistsExactCapturedMeaning(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	input := canonicalV19PlanWriterInput("plan-root")
+	ordinal, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 1 {
+		t.Fatalf("root Plan ordinal = %d, want 1", ordinal)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var got CanonicalV19PlanCreateInput
+	var gotOrdinal int64
+	var lineage, lifecycle, terminalAt string
+	var predecessor sql.NullString
+	if err := db.sql.QueryRow(`SELECT id,task_id,ordinal,lineage_kind,predecessor_plan_id,intent,judgment,basis,brief,
+		brief_digest,workspace_binding_id,policy_revision_id,lifecycle,created_at,terminal_at
+		FROM plan WHERE id=?`, input.ID).Scan(
+		&got.ID, &got.TaskID, &gotOrdinal, &lineage, &predecessor, &got.Intent, &got.Judgment,
+		&got.Basis, &got.Brief, &got.BriefDigest, &got.WorkspaceBindingID, &got.PolicyRevisionID,
+		&lifecycle, &got.CreatedAt, &terminalAt,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got != input || gotOrdinal != 1 || lineage != "root" || predecessor.Valid || lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("persisted root Plan = %#v ordinal=%d lineage=%q predecessor=%#v lifecycle=%q terminal_at=%q",
+			got, gotOrdinal, lineage, predecessor, lifecycle, terminalAt)
+	}
+}
+
+func TestCreateCanonicalV19RootPlanRefusesSecondRoot(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	first := canonicalV19PlanWriterInput("plan-root")
+	if _, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, first); err != nil {
+		t.Fatal(err)
+	}
+	second := canonicalV19PlanWriterInput("plan-second-root")
+	if _, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, second); !errors.Is(err, ErrCanonicalV19PlanConflict) {
+		t.Fatalf("second root error = %v, want %v", err, ErrCanonicalV19PlanConflict)
+	}
+	if got := canonicalV19PlanWriterCount(t, fixture.Home); got != 1 {
+		t.Fatalf("Plan rows after second-root refusal = %d, want 1", got)
+	}
+}
+
+func TestReplanCanonicalV19PlanSupersedesOnlyExactPredecessor(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	root := canonicalV19PlanWriterInput("plan-root")
+	if _, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, root); err != nil {
+		t.Fatal(err)
+	}
+	successor := canonicalV19PlanWriterInput("plan-replan")
+	successor.Intent = "execute"
+	successor.Judgment = "substantial"
+	successor.Basis = "root exploration established the implementation basis"
+	successor.Brief = "implement the bounded successor"
+	successor.BriefDigest = "brief-digest-replan"
+	successor.CreatedAt = "2026-09-04T08:01:00Z"
+	ordinal, err := ReplanCanonicalV19Plan(context.Background(), fixture.Home, CanonicalV19PlanReplanInput{
+		PredecessorPlanID: root.ID,
+		Successor:         successor,
+		SupersededAt:      "2026-09-04T08:00:59Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 2 {
+		t.Fatalf("replan ordinal = %d, want 2", ordinal)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var rootLifecycle, rootTerminal string
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM plan WHERE id=?`, root.ID).Scan(&rootLifecycle, &rootTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if rootLifecycle != "superseded" || rootTerminal != "2026-09-04T08:00:59Z" {
+		t.Fatalf("root after replan = lifecycle %q terminal_at %q", rootLifecycle, rootTerminal)
+	}
+	var predecessor, lineage, lifecycle, terminalAt string
+	var gotOrdinal int64
+	if err := db.sql.QueryRow(`SELECT ordinal,lineage_kind,predecessor_plan_id,lifecycle,terminal_at FROM plan WHERE id=?`, successor.ID).
+		Scan(&gotOrdinal, &lineage, &predecessor, &lifecycle, &terminalAt); err != nil {
+		t.Fatal(err)
+	}
+	if gotOrdinal != 2 || lineage != "replan" || predecessor != root.ID || lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("successor = ordinal=%d lineage=%q predecessor=%q lifecycle=%q terminal_at=%q",
+			gotOrdinal, lineage, predecessor, lifecycle, terminalAt)
+	}
+
+	stale := canonicalV19PlanWriterInput("plan-stale")
+	_, err = ReplanCanonicalV19Plan(context.Background(), fixture.Home, CanonicalV19PlanReplanInput{
+		PredecessorPlanID: root.ID,
+		Successor:         stale,
+		SupersededAt:      "2026-09-04T08:02:00Z",
+	})
+	if !errors.Is(err, ErrCanonicalV19PlanNotCurrent) {
+		t.Fatalf("stale replan error = %v, want %v", err, ErrCanonicalV19PlanNotCurrent)
+	}
+	if got := canonicalV19PlanWriterCount(t, fixture.Home); got != 2 {
+		t.Fatalf("Plan rows after stale replan = %d, want 2", got)
+	}
+}
+
+func TestReplanCanonicalV19PlanRollsBackPredecessorWhenSuccessorConflicts(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	root := canonicalV19PlanWriterInput("plan-root")
+	if _, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, root); err != nil {
+		t.Fatal(err)
+	}
+	conflicting := canonicalV19PlanWriterInput(root.ID)
+	_, err := ReplanCanonicalV19Plan(context.Background(), fixture.Home, CanonicalV19PlanReplanInput{
+		PredecessorPlanID: root.ID,
+		Successor:         conflicting,
+		SupersededAt:      "2026-09-04T08:03:00Z",
+	})
+	if !errors.Is(err, ErrCanonicalV19PlanConflict) {
+		t.Fatalf("conflicting successor error = %v, want %v", err, ErrCanonicalV19PlanConflict)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var lifecycle, terminalAt string
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM plan WHERE id=?`, root.ID).Scan(&lifecycle, &terminalAt); err != nil {
+		t.Fatal(err)
+	}
+	if lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("predecessor leaked partial supersede: lifecycle=%q terminal_at=%q", lifecycle, terminalAt)
+	}
+	if got := canonicalV19PlanWriterCount(t, fixture.Home); got != 1 {
+		t.Fatalf("Plan rows after rolled-back replan = %d, want 1", got)
+	}
+}
+
+func TestCanonicalV19PlanWriterRefusesStaleExactBindingAndPolicyWithoutRetarget(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	db, err := open(Path(fixture.Home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE workspace_binding SET superseded_at='2026-09-04T08:04:00Z' WHERE id='workspace-1'`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workspace_binding(
+		id,project_id,ordinal,repository_locator,repository_identity_digest,common_git_dir,physical_identity_digest,revision,established_at,superseded_at
+	) VALUES('workspace-2','project-1',2,'projects/demo','repo-digest-2','projects/demo/.git','physical-digest-2',?,'2026-09-04T08:04:00Z','')`, fixture.Revision); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE policy_revision SET superseded_at='2026-09-04T08:04:00Z' WHERE id='policy-1'`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO policy_revision(
+		id,project_id,ordinal,policy_digest,created_at,superseded_at
+	) VALUES('policy-2','project-1',2,'policy-digest-2','2026-09-04T08:04:00Z','')`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	input := canonicalV19PlanWriterInput("plan-stale-basis")
+	_, err = CreateCanonicalV19RootPlan(context.Background(), fixture.Home, input)
+	if !errors.Is(err, ErrCanonicalV19PlanNotCurrent) {
+		t.Fatalf("stale exact binding/policy error = %v, want %v", err, ErrCanonicalV19PlanNotCurrent)
+	}
+	if got := canonicalV19PlanWriterCount(t, fixture.Home); got != 0 {
+		t.Fatalf("Plan rows after stale basis refusal = %d, want 0", got)
+	}
+}
+
+func TestCanonicalV19PlanWriterRequiresPositiveExactGitRevision(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, strings.Repeat("f", 40))
+	_, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, canonicalV19PlanWriterInput("plan-bad-revision"))
+	if !errors.Is(err, ErrCanonicalV19PlanGitBasis) {
+		t.Fatalf("missing exact Git revision error = %v, want %v", err, ErrCanonicalV19PlanGitBasis)
+	}
+	if got := canonicalV19PlanWriterCount(t, fixture.Home); got != 0 {
+		t.Fatalf("Plan rows after Git-basis refusal = %d, want 0", got)
+	}
+}
+
+func TestCanonicalV19PlanWriterRefusesTerminalTask(t *testing.T) {
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	db, err := open(Path(fixture.Home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE task SET lifecycle='satisfied', terminal_at='2026-09-04T08:05:00Z' WHERE id='task-1'`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_, err = CreateCanonicalV19RootPlan(context.Background(), fixture.Home, canonicalV19PlanWriterInput("plan-terminal-task"))
+	if !errors.Is(err, ErrCanonicalV19PlanNotCurrent) {
+		t.Fatalf("terminal Task error = %v, want %v", err, ErrCanonicalV19PlanNotCurrent)
+	}
+}
+
+type canonicalV19PlanWriterTestFixture struct {
+	Home     string
+	Revision string
+}
+
+func canonicalV19PlanWriterFixture(t *testing.T, storedRevision string) canonicalV19PlanWriterTestFixture {
+	t.Helper()
+	home := canonicalV19TaskWriterFixture(t, false)
+	if _, err := CreateCanonicalV19Task(context.Background(), home, CanonicalV19TaskCreateInput{
+		ID: "task-1", ProjectID: "project-1", Goal: "ship canonical Plan semantics", GoalDigest: "goal-digest", CreatedAt: "2026-09-04T07:59:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	repository := filepath.Join(home, "projects", "demo")
+	if err := os.MkdirAll(repository, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonicalV19PlanWriterGit(t, repository, "init", "-q")
+	canonicalV19PlanWriterGit(t, repository, "config", "user.name", "plan-writer-test")
+	canonicalV19PlanWriterGit(t, repository, "config", "user.email", "plan-writer-test@example.invalid")
+	if err := os.WriteFile(filepath.Join(repository, "README.md"), []byte("canonical plan fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	canonicalV19PlanWriterGit(t, repository, "add", "README.md")
+	canonicalV19PlanWriterGit(t, repository, "commit", "-q", "-m", "fixture")
+	revision := strings.TrimSpace(canonicalV19PlanWriterGit(t, repository, "rev-parse", "HEAD"))
+	if storedRevision == "" {
+		storedRevision = revision
+	}
+
+	db, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO workspace_binding(
+		id,project_id,ordinal,repository_locator,repository_identity_digest,common_git_dir,physical_identity_digest,revision,established_at,superseded_at
+	) VALUES('workspace-1','project-1',1,'projects/demo','repo-digest-1','projects/demo/.git','physical-digest-1',?,'2026-09-04T07:59:30Z','')`, storedRevision); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO policy_revision(
+		id,project_id,ordinal,policy_digest,created_at,superseded_at
+	) VALUES('policy-1','project-1',1,'policy-digest-1','2026-09-04T07:59:30Z','')`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return canonicalV19PlanWriterTestFixture{Home: home, Revision: revision}
+}
+
+func canonicalV19PlanWriterInput(id string) CanonicalV19PlanCreateInput {
+	return CanonicalV19PlanCreateInput{
+		ID:                 id,
+		TaskID:             "task-1",
+		Intent:             "explore",
+		Judgment:           "bounded",
+		Basis:              "operator goal plus exact repository evidence",
+		Brief:              "establish a bounded canonical Plan",
+		BriefDigest:        "brief-digest-root",
+		WorkspaceBindingID: "workspace-1",
+		PolicyRevisionID:   "policy-1",
+		CreatedAt:          "2026-09-04T08:00:00Z",
+	}
+}
+
+func canonicalV19PlanWriterGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, output)
+	}
+	return string(output)
+}
+
+func canonicalV19PlanWriterCount(t *testing.T, home string) int {
+	t.Helper()
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM plan`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}


### PR DESCRIPTION
Continues #339 implementation step 8 after #552 with canonical Plan creation/currentness only.

This slice:
- adds exact root-Plan creation for one active Task;
- adds exact replan semantics that supersede only the named active predecessor and create its successor in one BEGIN IMMEDIATE transaction;
- captures exact WorkspaceBinding + PolicyRevision IDs and refuses stale replacements instead of selecting current-now state;
- positively verifies the captured WorkspaceBinding repository root, common Git directory, and exact 40/64-hex commit before mutation, then revalidates all DB currentness inside the write transaction before commit;
- allocates per-Task Plan ordinals inside the same transaction;
- relies on the locked #344 one-active/predecessor uniqueness and immutable-field guards without adding schema policy;
- rolls back predecessor supersession if successor insertion conflicts.

Tests cover exact root persistence, second-root refusal, successful exact replan, stale predecessor refusal/no retarget, atomic rollback on successor conflict, stale binding/policy refusal, missing exact Git revision, and terminal Task refusal.

`advance` is intentionally not included here because its predecessor is already satisfied and has a distinct transition contract. No ordinary runtime/store caller is switched. No Attempt/Hold/Backoff/Repair writer, cutover activation, registry repair, provider mutation, or external effect is added.

Canonical #344 DDL impact: **NONE**.

Refs #339, #345, #344, #346.