### PR TITLE
feat(store): add canonical v19 Attempt writer

### DIFF
--- a/internal/store/v19attempt.go
+++ b/internal/store/v19attempt.go
@@ -1,0 +1,152 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrCanonicalV19AttemptConflict marks an Attempt identity, ordinal, or active
+// child write that lost an exact relational constraint.
+var ErrCanonicalV19AttemptConflict = errors.New("canonical v19 attempt write conflict")
+
+// ErrCanonicalV19AttemptNotCurrent marks an exact Project/Task/Plan lineage
+// that is no longer current. Callers must never retarget another Plan.
+var ErrCanonicalV19AttemptNotCurrent = errors.New("canonical v19 attempt lineage is not current")
+
+// CanonicalV19AttemptCreateInput is the immutable resolved execution
+// provenance frozen by one Attempt.
+type CanonicalV19AttemptCreateInput struct {
+	ID                   string
+	PlanID               string
+	WorkerHarnessRef     string
+	WorkerHarnessVersion string
+	WorkerProfileRef     string
+	ModelRef             string
+	EffortRef            string
+	SessionAdapterRef    string
+	CreatedAt            string
+}
+
+// CreateCanonicalV19Attempt creates one fresh active Attempt under the exact
+// active Plan. Retry is the same operation after the previous Attempt became
+// terminal; this writer never terminalizes or retargets existing Attempt rows.
+func CreateCanonicalV19Attempt(ctx context.Context, homeDir string, input CanonicalV19AttemptCreateInput) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := validateCanonicalV19AttemptCreateInput(input); err != nil {
+		return 0, err
+	}
+
+	sqlDB, err := openCanonicalV19Writer(homeDir)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, canonicalV19AttemptWriteError("begin writer", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := validateCanonicalV19WriterTransaction(ctx, tx); err != nil {
+		return 0, fmt.Errorf("create canonical v19 Attempt: %w", err)
+	}
+	if err := requireCanonicalV19AttemptPlanCurrent(ctx, tx, input.PlanID); err != nil {
+		return 0, fmt.Errorf("create canonical v19 Attempt: %w", err)
+	}
+	if err := requireCanonicalV19AttemptSlotOpen(ctx, tx, input.PlanID); err != nil {
+		return 0, fmt.Errorf("create canonical v19 Attempt: %w", err)
+	}
+
+	ordinal, err := nextCanonicalV19AttemptOrdinal(ctx, tx, input.PlanID)
+	if err != nil {
+		return 0, canonicalV19AttemptWriteError("allocate ordinal", err)
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO attempt(
+		id,plan_id,ordinal,worker_harness_ref,worker_harness_version,worker_profile_ref,
+		model_ref,effort_ref,session_adapter_ref,lifecycle,created_at,terminal_at
+	) VALUES(?,?,?,?,?,?,?,?,?,'active',?,'')`,
+		input.ID, input.PlanID, ordinal, input.WorkerHarnessRef, input.WorkerHarnessVersion,
+		input.WorkerProfileRef, input.ModelRef, input.EffortRef, input.SessionAdapterRef, input.CreatedAt)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return 0, fmt.Errorf("create canonical v19 Attempt: %w: Attempt %q", ErrCanonicalV19AttemptConflict, input.ID)
+		}
+		return 0, canonicalV19AttemptWriteError("insert Attempt", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, canonicalV19AttemptWriteError("commit writer", err)
+	}
+	committed = true
+	return ordinal, nil
+}
+
+func validateCanonicalV19AttemptCreateInput(input CanonicalV19AttemptCreateInput) error {
+	for name, value := range map[string]string{
+		"Attempt ID":         input.ID,
+		"Plan ID":            input.PlanID,
+		"Worker Harness ref": input.WorkerHarnessRef,
+		"Session adapter ref": input.SessionAdapterRef,
+		"created_at":         input.CreatedAt,
+	} {
+		if value == "" {
+			return fmt.Errorf("create canonical v19 Attempt: %s is empty", name)
+		}
+	}
+	return nil
+}
+
+func requireCanonicalV19AttemptPlanCurrent(ctx context.Context, tx *sql.Tx, planID string) error {
+	var exactPlanID string
+	err := tx.QueryRowContext(ctx, `SELECT p.id
+		FROM plan p
+		JOIN task t ON t.id=p.task_id AND t.lifecycle='active' AND t.terminal_at=''
+		JOIN project project_current ON project_current.id=t.project_id AND project_current.retired_at=''
+		WHERE p.id=? AND p.lifecycle='active' AND p.terminal_at=''`, planID).Scan(&exactPlanID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: Plan %q does not have exact active Project/Task/Plan lineage", ErrCanonicalV19AttemptNotCurrent, planID)
+	}
+	if err != nil {
+		return canonicalV19AttemptWriteError("read exact current Plan lineage", err)
+	}
+	if exactPlanID != planID {
+		return fmt.Errorf("%w: Plan identity changed", ErrCanonicalV19AttemptNotCurrent)
+	}
+	return nil
+}
+
+func requireCanonicalV19AttemptSlotOpen(ctx context.Context, tx *sql.Tx, planID string) error {
+	var activeAttemptID string
+	err := tx.QueryRowContext(ctx, `SELECT id FROM attempt WHERE plan_id=? AND lifecycle='active'`, planID).Scan(&activeAttemptID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return canonicalV19AttemptWriteError("read active Attempt", err)
+	}
+	return fmt.Errorf("%w: Plan %q already has active Attempt %q", ErrCanonicalV19AttemptConflict, planID, activeAttemptID)
+}
+
+func nextCanonicalV19AttemptOrdinal(ctx context.Context, tx *sql.Tx, planID string) (int64, error) {
+	var ordinal int64
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(ordinal),0)+1 FROM attempt WHERE plan_id=?`, planID).Scan(&ordinal); err != nil {
+		return 0, err
+	}
+	return ordinal, nil
+}
+
+func canonicalV19AttemptWriteError(action string, err error) error {
+	if isSQLiteBusy(err) {
+		return fmt.Errorf("create canonical v19 Attempt: %s: %w", action, ErrContention)
+	}
+	return fmt.Errorf("create canonical v19 Attempt: %s: %w", action, err)
+}

--- a/internal/store/v19attempt.go
+++ b/internal/store/v19attempt.go
@@ -92,11 +92,11 @@ func CreateCanonicalV19Attempt(ctx context.Context, homeDir string, input Canoni
 
 func validateCanonicalV19AttemptCreateInput(input CanonicalV19AttemptCreateInput) error {
 	for name, value := range map[string]string{
-		"Attempt ID":         input.ID,
-		"Plan ID":            input.PlanID,
-		"Worker Harness ref": input.WorkerHarnessRef,
+		"Attempt ID":          input.ID,
+		"Plan ID":             input.PlanID,
+		"Worker Harness ref":  input.WorkerHarnessRef,
 		"Session adapter ref": input.SessionAdapterRef,
-		"created_at":         input.CreatedAt,
+		"created_at":          input.CreatedAt,
 	} {
 		if value == "" {
 			return fmt.Errorf("create canonical v19 Attempt: %s is empty", name)

--- a/internal/store/v19attempt_test.go
+++ b/internal/store/v19attempt_test.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCreateCanonicalV19AttemptPersistsExactResolvedProvenance(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	input := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	ordinal, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 1 {
+		t.Fatalf("Attempt ordinal = %d, want 1", ordinal)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var got CanonicalV19AttemptCreateInput
+	var gotOrdinal int64
+	var lifecycle, terminalAt string
+	if err := db.sql.QueryRow(`SELECT id,plan_id,ordinal,worker_harness_ref,worker_harness_version,
+		worker_profile_ref,model_ref,effort_ref,session_adapter_ref,lifecycle,created_at,terminal_at
+		FROM attempt WHERE id=?`, input.ID).Scan(
+		&got.ID, &got.PlanID, &gotOrdinal, &got.WorkerHarnessRef, &got.WorkerHarnessVersion,
+		&got.WorkerProfileRef, &got.ModelRef, &got.EffortRef, &got.SessionAdapterRef,
+		&lifecycle, &got.CreatedAt, &terminalAt,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got != input || gotOrdinal != 1 || lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("persisted Attempt = %#v ordinal=%d lifecycle=%q terminal_at=%q", got, gotOrdinal, lifecycle, terminalAt)
+	}
+}
+
+func TestCreateCanonicalV19AttemptAllowsEmptyOptionalResolvedProvenance(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	input := canonicalV19AttemptWriterInput("attempt-optional", "plan-root")
+	input.WorkerHarnessVersion = ""
+	input.WorkerProfileRef = ""
+	input.ModelRef = ""
+	input.EffortRef = ""
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, input); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateCanonicalV19AttemptRefusesSecondActiveAttempt(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, canonicalV19AttemptWriterInput("attempt-1", "plan-root")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, canonicalV19AttemptWriterInput("attempt-2", "plan-root"))
+	if !errors.Is(err, ErrCanonicalV19AttemptConflict) {
+		t.Fatalf("second active Attempt error = %v, want %v", err, ErrCanonicalV19AttemptConflict)
+	}
+	if got := canonicalV19AttemptWriterCount(t, fixture.Home); got != 1 {
+		t.Fatalf("Attempt rows after active conflict = %d, want 1", got)
+	}
+}
+
+func TestCreateCanonicalV19AttemptRetriesSamePlanAfterTerminalAttempt(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	first := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, first); err != nil {
+		t.Fatal(err)
+	}
+	canonicalV19AttemptWriterTerminalize(t, fixture.Home, first.ID, "failed", "2026-09-04T09:01:00Z")
+
+	second := canonicalV19AttemptWriterInput("attempt-2", "plan-root")
+	second.CreatedAt = "2026-09-04T09:02:00Z"
+	ordinal, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 2 {
+		t.Fatalf("retry Attempt ordinal = %d, want 2", ordinal)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var firstLifecycle, firstTerminal, secondLifecycle, secondTerminal string
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM attempt WHERE id=?`, first.ID).Scan(&firstLifecycle, &firstTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM attempt WHERE id=?`, second.ID).Scan(&secondLifecycle, &secondTerminal); err != nil {
+		t.Fatal(err)
+	}
+	if firstLifecycle != "failed" || firstTerminal != "2026-09-04T09:01:00Z" || secondLifecycle != "active" || secondTerminal != "" {
+		t.Fatalf("retry state = first %q/%q second %q/%q", firstLifecycle, firstTerminal, secondLifecycle, secondTerminal)
+	}
+}
+
+func TestCreateCanonicalV19AttemptDuplicateIdentityAfterTerminalRefusesWithoutNewRow(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	first := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, first); err != nil {
+		t.Fatal(err)
+	}
+	canonicalV19AttemptWriterTerminalize(t, fixture.Home, first.ID, "failed", "2026-09-04T09:01:00Z")
+
+	_, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, canonicalV19AttemptWriterInput(first.ID, "plan-root"))
+	if !errors.Is(err, ErrCanonicalV19AttemptConflict) {
+		t.Fatalf("duplicate Attempt identity error = %v, want %v", err, ErrCanonicalV19AttemptConflict)
+	}
+	if got := canonicalV19AttemptWriterCount(t, fixture.Home); got != 1 {
+		t.Fatalf("Attempt rows after duplicate identity = %d, want 1", got)
+	}
+}
+
+func TestCreateCanonicalV19AttemptRefusesStalePlanWithoutRetarget(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	successor := canonicalV19PlanWriterInput("plan-replan")
+	successor.CreatedAt = "2026-09-04T09:03:00Z"
+	if _, err := ReplanCanonicalV19Plan(context.Background(), fixture.Home, CanonicalV19PlanReplanInput{
+		PredecessorPlanID: "plan-root",
+		Successor:         successor,
+		SupersededAt:      "2026-09-04T09:02:59Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, canonicalV19AttemptWriterInput("attempt-stale", "plan-root"))
+	if !errors.Is(err, ErrCanonicalV19AttemptNotCurrent) {
+		t.Fatalf("stale Plan Attempt error = %v, want %v", err, ErrCanonicalV19AttemptNotCurrent)
+	}
+	if got := canonicalV19AttemptWriterCount(t, fixture.Home); got != 0 {
+		t.Fatalf("Attempt rows after stale Plan refusal = %d, want 0", got)
+	}
+}
+
+func TestReplanCanonicalV19PlanRefusesActiveAttempt(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, canonicalV19AttemptWriterInput("attempt-1", "plan-root")); err != nil {
+		t.Fatal(err)
+	}
+	successor := canonicalV19PlanWriterInput("plan-replan")
+	successor.CreatedAt = "2026-09-04T09:03:00Z"
+	_, err := ReplanCanonicalV19Plan(context.Background(), fixture.Home, CanonicalV19PlanReplanInput{
+		PredecessorPlanID: "plan-root",
+		Successor:         successor,
+		SupersededAt:      "2026-09-04T09:02:59Z",
+	})
+	if !errors.Is(err, ErrCanonicalV19PlanNotCurrent) {
+		t.Fatalf("replan with active Attempt error = %v, want %v", err, ErrCanonicalV19PlanNotCurrent)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var lifecycle, terminalAt string
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM plan WHERE id='plan-root'`).Scan(&lifecycle, &terminalAt); err != nil {
+		t.Fatal(err)
+	}
+	if lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("predecessor changed despite active Attempt: lifecycle=%q terminal_at=%q", lifecycle, terminalAt)
+	}
+	var successorCount int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM plan WHERE id=?`, successor.ID).Scan(&successorCount); err != nil {
+		t.Fatal(err)
+	}
+	if successorCount != 0 {
+		t.Fatalf("successor Plan rows = %d, want 0", successorCount)
+	}
+}
+
+type canonicalV19AttemptWriterTestFixture struct {
+	Home string
+}
+
+func canonicalV19AttemptWriterFixture(t *testing.T) canonicalV19AttemptWriterTestFixture {
+	t.Helper()
+	fixture := canonicalV19PlanWriterFixture(t, "")
+	if _, err := CreateCanonicalV19RootPlan(context.Background(), fixture.Home, canonicalV19PlanWriterInput("plan-root")); err != nil {
+		t.Fatal(err)
+	}
+	return canonicalV19AttemptWriterTestFixture{Home: fixture.Home}
+}
+
+func canonicalV19AttemptWriterInput(id, planID string) CanonicalV19AttemptCreateInput {
+	return CanonicalV19AttemptCreateInput{
+		ID:                   id,
+		PlanID:               planID,
+		WorkerHarnessRef:     "worker-harness/codex",
+		WorkerHarnessVersion: "1.0.0",
+		WorkerProfileRef:     "profile/default",
+		ModelRef:             "model/example",
+		EffortRef:            "medium",
+		SessionAdapterRef:    "builtin/session",
+		CreatedAt:            "2026-09-04T09:00:00Z",
+	}
+}
+
+func canonicalV19AttemptWriterTerminalize(t *testing.T, home, attemptID, lifecycle, terminalAt string) {
+	t.Helper()
+	db, err := open(Path(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`UPDATE attempt SET lifecycle=?,terminal_at=? WHERE id=?`, lifecycle, terminalAt, attemptID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func canonicalV19AttemptWriterCount(t *testing.T, home string) int {
+	t.Helper()
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var count int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM attempt`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}

--- a/internal/store/v19plan.go
+++ b/internal/store/v19plan.go
@@ -303,9 +303,12 @@ func nextCanonicalV19PlanOrdinal(ctx context.Context, tx *sql.Tx, taskID string)
 
 func requireCanonicalV19ActivePredecessor(ctx context.Context, tx *sql.Tx, taskID, planID string) error {
 	var ordinal int64
-	if err := tx.QueryRowContext(ctx, `SELECT ordinal FROM plan
-		WHERE id=? AND task_id=? AND lifecycle='active' AND terminal_at=''`, planID, taskID).Scan(&ordinal); errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("%w: predecessor Plan %q is not the exact active predecessor", ErrCanonicalV19PlanNotCurrent, planID)
+	if err := tx.QueryRowContext(ctx, `SELECT p.ordinal FROM plan p
+		WHERE p.id=? AND p.task_id=? AND p.lifecycle='active' AND p.terminal_at=''
+		  AND NOT EXISTS (
+			SELECT 1 FROM attempt a WHERE a.plan_id=p.id AND a.lifecycle='active'
+		  )`, planID, taskID).Scan(&ordinal); errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: predecessor Plan %q is not the exact active predecessor without an active Attempt", ErrCanonicalV19PlanNotCurrent, planID)
 	} else if err != nil {
 		return canonicalV19PlanWriteError("canonical v19 Plan", "read exact predecessor", err)
 	}


### PR DESCRIPTION
Continues #339 implementation step 8 after #553 with canonical Attempt creation/retry currentness only.

This slice:
- adds one exact active Attempt creation writer under an exact active Project → Task → Plan lineage;
- uses the existing exact-v19 writer boundary and BEGIN IMMEDIATE transaction;
- allocates per-Plan Attempt ordinal in the same transaction;
- freezes already-resolved Worker Harness/Profile/model/effort/session-adapter provenance without importing routing/config authority into persistence;
- preserves #344 optional empty-string provenance fields rather than silently strengthening the locked schema contract;
- treats retry as creation of a fresh Attempt under the same immutable Plan only after the predecessor is terminal;
- refuses a second active Attempt and stale predecessor Plan instead of retargeting current state;
- tightens replan currentness so an exact predecessor Plan with an active Attempt cannot be superseded, satisfying #345 retry-vs-replan one-wins semantics.

Tests cover exact provenance persistence, optional provenance, second-active refusal, same-Plan retry ordinal, duplicate identity refusal, stale-Plan no-retarget, and replan refusal while an active Attempt exists.

Attempt terminalization, AttemptBackoff handling, Hold/Repair, WorktreeBinding, runtime caller switching, cutover activation, registry repair, provider mutation, and external effects are intentionally not included.

Canonical #344 DDL impact: **NONE**.

Refs #339, #345, #344, #323, #346.