### PR TITLE
feat(store): add canonical v19 Attempt terminalization

### DIFF
--- a/internal/store/v19attempt_lifecycle.go
+++ b/internal/store/v19attempt_lifecycle.go
@@ -15,10 +15,9 @@ type CanonicalV19AttemptTerminalizeInput struct {
 	TerminalAt string
 }
 
-// TerminalizeCanonicalV19Attempt transitions only the named exact active
-// Attempt under a still-current Project/Task/Plan lineage. Locked #344 schema
-// constraints remain the final arbiter for child-state invariants such as an
-// unresolved AttemptBackoff blocking terminalization.
+// TerminalizeCanonicalV19Attempt transitions only the named exact active Attempt
+// under current Project/Task/Plan lineage; locked #344 constraints remain final
+// arbiter for child invariants such as unresolved AttemptBackoff.
 func TerminalizeCanonicalV19Attempt(ctx context.Context, homeDir string, input CanonicalV19AttemptTerminalizeInput) error {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/store/v19attempt_lifecycle.go
+++ b/internal/store/v19attempt_lifecycle.go
@@ -10,8 +10,8 @@ import (
 // CanonicalV19AttemptTerminalizeInput names one exact Attempt terminal
 // transition. Terminal evidence is immutable once committed.
 type CanonicalV19AttemptTerminalizeInput struct {
-	AttemptID string
-	Lifecycle string
+	AttemptID  string
+	Lifecycle  string
 	TerminalAt string
 }
 

--- a/internal/store/v19attempt_lifecycle.go
+++ b/internal/store/v19attempt_lifecycle.go
@@ -1,0 +1,118 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// CanonicalV19AttemptTerminalizeInput names one exact Attempt terminal
+// transition. Terminal evidence is immutable once committed.
+type CanonicalV19AttemptTerminalizeInput struct {
+	AttemptID string
+	Lifecycle string
+	TerminalAt string
+}
+
+// TerminalizeCanonicalV19Attempt transitions only the named exact active
+// Attempt under a still-current Project/Task/Plan lineage. Locked #344 schema
+// constraints remain the final arbiter for child-state invariants such as an
+// unresolved AttemptBackoff blocking terminalization.
+func TerminalizeCanonicalV19Attempt(ctx context.Context, homeDir string, input CanonicalV19AttemptTerminalizeInput) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := validateCanonicalV19AttemptTerminalizeInput(input); err != nil {
+		return err
+	}
+
+	sqlDB, err := openCanonicalV19Writer(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19AttemptTerminalWriteError("begin writer", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := validateCanonicalV19WriterTransaction(ctx, tx); err != nil {
+		return fmt.Errorf("terminalize canonical v19 Attempt: %w", err)
+	}
+	if err := requireCanonicalV19AttemptCurrent(ctx, tx, input.AttemptID); err != nil {
+		return fmt.Errorf("terminalize canonical v19 Attempt: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `UPDATE attempt
+		SET lifecycle=?, terminal_at=?
+		WHERE id=? AND lifecycle='active' AND terminal_at=''`,
+		input.Lifecycle, input.TerminalAt, input.AttemptID)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return fmt.Errorf("terminalize canonical v19 Attempt: %w: Attempt %q", ErrCanonicalV19AttemptConflict, input.AttemptID)
+		}
+		return canonicalV19AttemptTerminalWriteError("update exact Attempt", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return canonicalV19AttemptTerminalWriteError("count exact Attempt transition", err)
+	}
+	if changed != 1 {
+		return fmt.Errorf("terminalize canonical v19 Attempt: %w: Attempt %q changed %d rows, want 1", ErrCanonicalV19AttemptNotCurrent, input.AttemptID, changed)
+	}
+	if err := tx.Commit(); err != nil {
+		return canonicalV19AttemptTerminalWriteError("commit writer", err)
+	}
+	committed = true
+	return nil
+}
+
+func validateCanonicalV19AttemptTerminalizeInput(input CanonicalV19AttemptTerminalizeInput) error {
+	if input.AttemptID == "" {
+		return fmt.Errorf("terminalize canonical v19 Attempt: Attempt ID is empty")
+	}
+	switch input.Lifecycle {
+	case "completed", "failed", "interrupted":
+	default:
+		return fmt.Errorf("terminalize canonical v19 Attempt: lifecycle %q is not canonical terminal state", input.Lifecycle)
+	}
+	if input.TerminalAt == "" {
+		return fmt.Errorf("terminalize canonical v19 Attempt: terminal_at is empty")
+	}
+	return nil
+}
+
+func requireCanonicalV19AttemptCurrent(ctx context.Context, tx *sql.Tx, attemptID string) error {
+	var exactAttemptID string
+	err := tx.QueryRowContext(ctx, `SELECT a.id
+		FROM attempt a
+		JOIN plan p ON p.id=a.plan_id AND p.lifecycle='active' AND p.terminal_at=''
+		JOIN task t ON t.id=p.task_id AND t.lifecycle='active' AND t.terminal_at=''
+		JOIN project project_current ON project_current.id=t.project_id AND project_current.retired_at=''
+		WHERE a.id=? AND a.lifecycle='active' AND a.terminal_at=''`, attemptID).Scan(&exactAttemptID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: Attempt %q does not have exact active Project/Task/Plan/Attempt lineage", ErrCanonicalV19AttemptNotCurrent, attemptID)
+	}
+	if err != nil {
+		return canonicalV19AttemptTerminalWriteError("read exact current Attempt lineage", err)
+	}
+	if exactAttemptID != attemptID {
+		return fmt.Errorf("%w: Attempt identity changed", ErrCanonicalV19AttemptNotCurrent)
+	}
+	return nil
+}
+
+func canonicalV19AttemptTerminalWriteError(action string, err error) error {
+	if isSQLiteBusy(err) {
+		return fmt.Errorf("terminalize canonical v19 Attempt: %s: %w", action, ErrContention)
+	}
+	return fmt.Errorf("terminalize canonical v19 Attempt: %s: %w", action, err)
+}

--- a/internal/store/v19attempt_lifecycle_test.go
+++ b/internal/store/v19attempt_lifecycle_test.go
@@ -16,8 +16,8 @@ func TestTerminalizeCanonicalV19AttemptAcceptsExactTerminalStates(t *testing.T) 
 			}
 			terminalAt := "2026-09-04T10:00:00Z"
 			if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
-				AttemptID: attempt.ID,
-				Lifecycle: lifecycle,
+				AttemptID:  attempt.ID,
+				Lifecycle:  lifecycle,
 				TerminalAt: terminalAt,
 			}); err != nil {
 				t.Fatal(err)
@@ -47,8 +47,8 @@ func TestTerminalizeCanonicalV19AttemptRejectsNonTerminalStateWithoutMutation(t 
 		t.Fatal(err)
 	}
 	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
-		AttemptID: attempt.ID,
-		Lifecycle: "active",
+		AttemptID:  attempt.ID,
+		Lifecycle:  "active",
 		TerminalAt: "2026-09-04T10:00:00Z",
 	}); err == nil {
 		t.Fatal("non-terminal lifecycle unexpectedly accepted")
@@ -76,15 +76,15 @@ func TestTerminalizeCanonicalV19AttemptRefusesReplayWithoutReopen(t *testing.T) 
 		t.Fatal(err)
 	}
 	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
-		AttemptID: attempt.ID,
-		Lifecycle: "failed",
+		AttemptID:  attempt.ID,
+		Lifecycle:  "failed",
 		TerminalAt: "2026-09-04T10:01:00Z",
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
-		AttemptID: attempt.ID,
-		Lifecycle: "completed",
+		AttemptID:  attempt.ID,
+		Lifecycle:  "completed",
 		TerminalAt: "2026-09-04T10:02:00Z",
 	}); !errors.Is(err, ErrCanonicalV19AttemptNotCurrent) {
 		t.Fatalf("replayed terminalization error = %v, want %v", err, ErrCanonicalV19AttemptNotCurrent)
@@ -105,12 +105,36 @@ func TestTerminalizeCanonicalV19AttemptRefusesReplayWithoutReopen(t *testing.T) 
 	}
 }
 
+func TestTerminalizeCanonicalV19AttemptEnablesFreshRetry(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	first := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
+		AttemptID:  first.ID,
+		Lifecycle:  "failed",
+		TerminalAt: "2026-09-04T10:03:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second := canonicalV19AttemptWriterInput("attempt-2", "plan-root")
+	second.CreatedAt = "2026-09-04T10:04:00Z"
+	ordinal, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordinal != 2 {
+		t.Fatalf("retry Attempt ordinal = %d, want 2", ordinal)
+	}
+}
+
 func TestTerminalizeCanonicalV19AttemptRefusesMissingExactIdentity(t *testing.T) {
 	fixture := canonicalV19AttemptWriterFixture(t)
 	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
-		AttemptID: "attempt-missing",
-		Lifecycle: "failed",
-		TerminalAt: "2026-09-04T10:03:00Z",
+		AttemptID:  "attempt-missing",
+		Lifecycle:  "failed",
+		TerminalAt: "2026-09-04T10:05:00Z",
 	}); !errors.Is(err, ErrCanonicalV19AttemptNotCurrent) {
 		t.Fatalf("missing Attempt error = %v, want %v", err, ErrCanonicalV19AttemptNotCurrent)
 	}

--- a/internal/store/v19attempt_lifecycle_test.go
+++ b/internal/store/v19attempt_lifecycle_test.go
@@ -1,0 +1,117 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestTerminalizeCanonicalV19AttemptAcceptsExactTerminalStates(t *testing.T) {
+	for _, lifecycle := range []string{"completed", "failed", "interrupted"} {
+		t.Run(lifecycle, func(t *testing.T) {
+			fixture := canonicalV19AttemptWriterFixture(t)
+			attempt := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+			if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, attempt); err != nil {
+				t.Fatal(err)
+			}
+			terminalAt := "2026-09-04T10:00:00Z"
+			if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
+				AttemptID: attempt.ID,
+				Lifecycle: lifecycle,
+				TerminalAt: terminalAt,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			db, err := openReadOnly(fixture.Home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			var gotLifecycle, gotTerminalAt string
+			if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM attempt WHERE id=?`, attempt.ID).
+				Scan(&gotLifecycle, &gotTerminalAt); err != nil {
+				t.Fatal(err)
+			}
+			if gotLifecycle != lifecycle || gotTerminalAt != terminalAt {
+				t.Fatalf("terminal Attempt = lifecycle %q terminal_at %q, want %q/%q", gotLifecycle, gotTerminalAt, lifecycle, terminalAt)
+			}
+		})
+	}
+}
+
+func TestTerminalizeCanonicalV19AttemptRejectsNonTerminalStateWithoutMutation(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	attempt := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
+		AttemptID: attempt.ID,
+		Lifecycle: "active",
+		TerminalAt: "2026-09-04T10:00:00Z",
+	}); err == nil {
+		t.Fatal("non-terminal lifecycle unexpectedly accepted")
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var lifecycle, terminalAt string
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM attempt WHERE id=?`, attempt.ID).
+		Scan(&lifecycle, &terminalAt); err != nil {
+		t.Fatal(err)
+	}
+	if lifecycle != "active" || terminalAt != "" {
+		t.Fatalf("Attempt mutated after invalid transition: lifecycle=%q terminal_at=%q", lifecycle, terminalAt)
+	}
+}
+
+func TestTerminalizeCanonicalV19AttemptRefusesReplayWithoutReopen(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	attempt := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	if _, err := CreateCanonicalV19Attempt(context.Background(), fixture.Home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
+		AttemptID: attempt.ID,
+		Lifecycle: "failed",
+		TerminalAt: "2026-09-04T10:01:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
+		AttemptID: attempt.ID,
+		Lifecycle: "completed",
+		TerminalAt: "2026-09-04T10:02:00Z",
+	}); !errors.Is(err, ErrCanonicalV19AttemptNotCurrent) {
+		t.Fatalf("replayed terminalization error = %v, want %v", err, ErrCanonicalV19AttemptNotCurrent)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var lifecycle, terminalAt string
+	if err := db.sql.QueryRow(`SELECT lifecycle,terminal_at FROM attempt WHERE id=?`, attempt.ID).
+		Scan(&lifecycle, &terminalAt); err != nil {
+		t.Fatal(err)
+	}
+	if lifecycle != "failed" || terminalAt != "2026-09-04T10:01:00Z" {
+		t.Fatalf("terminal Attempt reopened or changed: lifecycle=%q terminal_at=%q", lifecycle, terminalAt)
+	}
+}
+
+func TestTerminalizeCanonicalV19AttemptRefusesMissingExactIdentity(t *testing.T) {
+	fixture := canonicalV19AttemptWriterFixture(t)
+	if err := TerminalizeCanonicalV19Attempt(context.Background(), fixture.Home, CanonicalV19AttemptTerminalizeInput{
+		AttemptID: "attempt-missing",
+		Lifecycle: "failed",
+		TerminalAt: "2026-09-04T10:03:00Z",
+	}); !errors.Is(err, ErrCanonicalV19AttemptNotCurrent) {
+		t.Fatalf("missing Attempt error = %v, want %v", err, ErrCanonicalV19AttemptNotCurrent)
+	}
+}


### PR DESCRIPTION
Continues #339 implementation step 8 after #555 with canonical Attempt lifecycle terminalization only.

This slice:
- adds one exact active Attempt terminalization writer for `completed | failed | interrupted`;
- uses the existing exact-v19 existing-only writer boundary and `BEGIN IMMEDIATE` transaction;
- requires exact active Project → Task → Plan → Attempt lineage before mutation;
- names only the exact Attempt identity and requires exactly one active row to transition;
- refuses terminal replay/reopen and stale/missing exact identity instead of retargeting current state;
- leaves locked #344 constraints/triggers as the final arbiter for child-state invariants, including the rule that an unresolved AttemptBackoff blocks terminalization;
- enables canonical retry by freeing the one-active-Attempt slot only after a committed terminal transition.

Tests cover all three terminal states, invalid non-terminal refusal without mutation, no terminal reopen, exact missing identity refusal, and terminalize → fresh retry ordinal 2.

AttemptBackoff insert/resolution writers, Plan/Task terminalization, Hold/Repair, WorktreeBinding, runtime caller switching, cutover activation, registry repair, provider mutation, and external effects are intentionally not included.

Canonical #344 DDL impact: **NONE**.

Refs #339, #345, #344.