### PR TITLE
feat(store): add native Git WorktreeCreate reconciliation

### DIFF
--- a/internal/store/v19worktree_native.go
+++ b/internal/store/v19worktree_native.go
@@ -97,8 +97,7 @@ func reconcileCanonicalV19WorktreeCreate(
 	case canonicalV19GitWorktreeExact:
 		return establishCanonicalV19ObservedWorktree(ctx, homeDir, current, observed, deps.now)
 	case canonicalV19GitWorktreeMismatch:
-		return classifyCanonicalV19ObservedNoEffect(ctx, homeDir, current, observed, deps.now,
-			"requested path is occupied by a different or malformed Git worktree")
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: requested path ownership/registration is unresolved: %s", observed.Reason)
 	case canonicalV19GitWorktreeUnknown:
 		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: native Git observation is unknown: %s", observed.Reason)
 	case canonicalV19GitWorktreeAbsent:
@@ -119,10 +118,7 @@ func reconcileCanonicalV19WorktreeCreate(
 	switch observed.State {
 	case canonicalV19GitWorktreeExact:
 		return establishCanonicalV19ObservedWorktree(ctx, homeDir, current, observed, deps.now)
-	case canonicalV19GitWorktreeMismatch:
-		return classifyCanonicalV19ObservedNoEffect(ctx, homeDir, current, observed, deps.now,
-			"requested path changed before the first mutation")
-	case canonicalV19GitWorktreeUnknown:
+	case canonicalV19GitWorktreeMismatch, canonicalV19GitWorktreeUnknown:
 		return classifyCanonicalV19ObservedUncertain(ctx, homeDir, current, observed, deps.now, nil)
 	case canonicalV19GitWorktreeAbsent:
 	default:

--- a/internal/store/v19worktree_native.go
+++ b/internal/store/v19worktree_native.go
@@ -1,0 +1,487 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	handgit "github.com/atqamz/hand/internal/git"
+)
+
+type canonicalV19GitWorktreeObservationState string
+
+const (
+	canonicalV19GitWorktreeExact    canonicalV19GitWorktreeObservationState = "exact"
+	canonicalV19GitWorktreeAbsent   canonicalV19GitWorktreeObservationState = "absent"
+	canonicalV19GitWorktreeMismatch canonicalV19GitWorktreeObservationState = "mismatch"
+	canonicalV19GitWorktreeUnknown  canonicalV19GitWorktreeObservationState = "unknown"
+)
+
+type canonicalV19GitWorktreeObservation struct {
+	State                  canonicalV19GitWorktreeObservationState
+	PrivateGitDir          string
+	LockReason             string
+	HeadRevision           string
+	PhysicalIdentityDigest string
+	EvidenceDigest         string
+	Reason                 string
+}
+
+type canonicalV19GitWorktreeRecord struct {
+	Path           string
+	HeadRevision   string
+	LockReason     string
+	Locked         bool
+	Detached       bool
+	Bare           bool
+	Prunable       bool
+	PrunableReason string
+}
+
+type canonicalV19WorktreeCreateNativeDeps struct {
+	observe func(string, CanonicalV19WorktreeCreateRequest) canonicalV19GitWorktreeObservation
+	perform func(string, CanonicalV19WorktreeCreateRequest) error
+	now     func() time.Time
+}
+
+// ReconcileCanonicalV19WorktreeCreate observes one exact native Git create and
+// performs it only when this call durably advances prepared to submitted.
+func ReconcileCanonicalV19WorktreeCreate(ctx context.Context, homeDir, operationID string) (string, error) {
+	return reconcileCanonicalV19WorktreeCreate(ctx, homeDir, operationID, canonicalV19WorktreeCreateNativeDeps{
+		observe: observeCanonicalV19GitWorktree,
+		perform: performCanonicalV19GitWorktreeCreate,
+		now:     time.Now,
+	})
+}
+
+func reconcileCanonicalV19WorktreeCreate(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+	deps canonicalV19WorktreeCreateNativeDeps,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if operationID == "" {
+		return "", fmt.Errorf("reconcile canonical v19 WorktreeCreate: operation ID is empty")
+	}
+	if deps.observe == nil || deps.perform == nil || deps.now == nil {
+		return "", fmt.Errorf("reconcile canonical v19 WorktreeCreate: native adapter dependencies are incomplete")
+	}
+
+	current, err := readCanonicalV19WorktreeCreateCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		return "", fmt.Errorf("reconcile canonical v19 WorktreeCreate: %w", err)
+	}
+	switch current.State {
+	case "succeeded", "rejected", "no-effect":
+		return current.State, nil
+	case "prepared", "submitted", "uncertain":
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: %w: operation %q is %q",
+			ErrCanonicalV19WorktreeCreateTransition, operationID, current.State)
+	}
+
+	observed := deps.observe(homeDir, current.Request)
+	if current.State != "prepared" {
+		return reconcileCanonicalV19SubmittedWorktreeCreate(ctx, homeDir, current, observed, deps.now)
+	}
+
+	switch observed.State {
+	case canonicalV19GitWorktreeExact:
+		return establishCanonicalV19ObservedWorktree(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19GitWorktreeMismatch:
+		return classifyCanonicalV19ObservedNoEffect(ctx, homeDir, current, observed, deps.now,
+			"requested path is occupied by a different or malformed Git worktree")
+	case canonicalV19GitWorktreeUnknown:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: native Git observation is unknown: %s", observed.Reason)
+	case canonicalV19GitWorktreeAbsent:
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: native Git observation state %q is invalid", observed.State)
+	}
+
+	submittedAt := canonicalV19WorktreeCreateTimestampAfter(deps.now(), current.StateChangedAt)
+	request, err := SubmitCanonicalV19WorktreeCreate(ctx, homeDir, operationID, submittedAt, observed.EvidenceDigest)
+	if err != nil {
+		return current.State, err
+	}
+	current.Request = request
+	current.State = "submitted"
+	current.StateChangedAt = submittedAt
+
+	observed = deps.observe(homeDir, request)
+	switch observed.State {
+	case canonicalV19GitWorktreeExact:
+		return establishCanonicalV19ObservedWorktree(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19GitWorktreeMismatch:
+		return classifyCanonicalV19ObservedNoEffect(ctx, homeDir, current, observed, deps.now,
+			"requested path changed before the first mutation")
+	case canonicalV19GitWorktreeUnknown:
+		return classifyCanonicalV19ObservedUncertain(ctx, homeDir, current, observed, deps.now, nil)
+	case canonicalV19GitWorktreeAbsent:
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: native Git observation state %q is invalid", observed.State)
+	}
+
+	performErr := deps.perform(homeDir, request)
+	observed = deps.observe(homeDir, request)
+	switch observed.State {
+	case canonicalV19GitWorktreeExact:
+		return establishCanonicalV19ObservedWorktree(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19GitWorktreeAbsent:
+		return classifyCanonicalV19ObservedNoEffect(ctx, homeDir, current, observed, deps.now,
+			canonicalV19WorktreeCreatePerformFailure("native Git create left no registered worktree", performErr))
+	case canonicalV19GitWorktreeMismatch, canonicalV19GitWorktreeUnknown:
+		return classifyCanonicalV19ObservedUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: native Git observation state %q is invalid", observed.State)
+	}
+}
+
+func reconcileCanonicalV19SubmittedWorktreeCreate(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeCreateCurrent,
+	observed canonicalV19GitWorktreeObservation,
+	now func() time.Time,
+) (string, error) {
+	switch observed.State {
+	case canonicalV19GitWorktreeExact:
+		return establishCanonicalV19ObservedWorktree(ctx, homeDir, current, observed, now)
+	case canonicalV19GitWorktreeAbsent:
+		return classifyCanonicalV19ObservedNoEffect(ctx, homeDir, current, observed, now,
+			"positive observation proves the submitted create left no registered worktree")
+	case canonicalV19GitWorktreeMismatch, canonicalV19GitWorktreeUnknown:
+		if current.State == "submitted" {
+			return classifyCanonicalV19ObservedUncertain(ctx, homeDir, current, observed, now, nil)
+		}
+		return "uncertain", fmt.Errorf("reconcile canonical v19 WorktreeCreate: operation remains uncertain: %s", observed.Reason)
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeCreate: native Git observation state %q is invalid", observed.State)
+	}
+}
+
+func establishCanonicalV19ObservedWorktree(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeCreateCurrent,
+	observed canonicalV19GitWorktreeObservation,
+	now func() time.Time,
+) (string, error) {
+	request := current.Request
+	establishedAt := canonicalV19WorktreeCreateTimestampAfter(now(), current.StateChangedAt)
+	err := EstablishCanonicalV19WorktreeBinding(ctx, homeDir, CanonicalV19WorktreeBindingEvidence{
+		OperationID:            request.OperationID,
+		Path:                   request.RequestedPath,
+		CommonGitDir:           request.ExpectedCommonGitDir,
+		PrivateGitDir:          observed.PrivateGitDir,
+		LockReason:             observed.LockReason,
+		BasisRevision:          request.BasisRevision,
+		HeadRevision:           observed.HeadRevision,
+		PhysicalIdentityDigest: observed.PhysicalIdentityDigest,
+		EstablishedAt:          establishedAt,
+		EvidenceDigest:         observed.EvidenceDigest,
+	})
+	if err != nil {
+		return current.State, err
+	}
+	return "succeeded", nil
+}
+
+func classifyCanonicalV19ObservedNoEffect(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeCreateCurrent,
+	observed canonicalV19GitWorktreeObservation,
+	now func() time.Time,
+	reason string,
+) (string, error) {
+	observedAt := canonicalV19WorktreeCreateTimestampAfter(now(), current.StateChangedAt)
+	if err := ClassifyCanonicalV19WorktreeCreate(ctx, homeDir, CanonicalV19WorktreeCreateTransitionInput{
+		OperationID:    current.Request.OperationID,
+		State:          "no-effect",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.State, err
+	}
+	if observed.Reason != "" {
+		reason += ": " + observed.Reason
+	}
+	return "no-effect", fmt.Errorf("reconcile canonical v19 WorktreeCreate: %s", reason)
+}
+
+func classifyCanonicalV19ObservedUncertain(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeCreateCurrent,
+	observed canonicalV19GitWorktreeObservation,
+	now func() time.Time,
+	performErr error,
+) (string, error) {
+	observedAt := canonicalV19WorktreeCreateTimestampAfter(now(), current.StateChangedAt)
+	if err := ClassifyCanonicalV19WorktreeCreate(ctx, homeDir, CanonicalV19WorktreeCreateTransitionInput{
+		OperationID:    current.Request.OperationID,
+		State:          "uncertain",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.State, err
+	}
+	reason := observed.Reason
+	if performErr != nil {
+		reason = canonicalV19WorktreeCreatePerformFailure(reason, performErr)
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 WorktreeCreate: operation is uncertain: %s", reason)
+}
+
+func canonicalV19WorktreeCreatePerformFailure(prefix string, err error) string {
+	if err == nil {
+		return prefix
+	}
+	if prefix == "" {
+		return fmt.Sprintf("native Git create failed: %v", err)
+	}
+	return fmt.Sprintf("%s; native Git create failed: %v", prefix, err)
+}
+
+func readCanonicalV19WorktreeCreateCurrent(ctx context.Context, homeDir, operationID string) (canonicalV19WorktreeCreateCurrent, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return canonicalV19WorktreeCreateCurrent{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19WorktreeCreateCurrent{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	return loadCanonicalV19WorktreeCreateCurrent(ctx, tx, operationID)
+}
+
+func observeCanonicalV19GitWorktree(homeDir string, request CanonicalV19WorktreeCreateRequest) canonicalV19GitWorktreeObservation {
+	repositoryPath := canonicalV19ObservedPath(homeDir, request.RepositoryLocator)
+	expectedCommonDir := canonicalV19ObservedPath(homeDir, request.ExpectedCommonGitDir)
+
+	root, err := handgit.ResolveRoot(repositoryPath)
+	if err != nil {
+		return canonicalV19UnknownGitWorktree(request, fmt.Sprintf("resolve repository root: %v", err))
+	}
+	if !handgit.SamePath(root, repositoryPath) {
+		return canonicalV19UnknownGitWorktree(request, "repository locator no longer resolves to its exact root")
+	}
+	commonDir, err := handgit.CommonDir(repositoryPath)
+	if err != nil {
+		return canonicalV19UnknownGitWorktree(request, fmt.Sprintf("resolve common Git directory: %v", err))
+	}
+	if !handgit.SamePath(commonDir, expectedCommonDir) {
+		return canonicalV19UnknownGitWorktree(request, "WorkspaceBinding common Git directory no longer matches")
+	}
+	resolved, err := handgit.Run(repositoryPath, "rev-parse", "--verify", request.BasisRevision+"^{commit}")
+	if err != nil || strings.TrimSpace(resolved) != request.BasisRevision {
+		return canonicalV19UnknownGitWorktree(request, "exact basis revision is no longer positively resolvable")
+	}
+
+	listing, err := handgit.Run(repositoryPath, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return canonicalV19UnknownGitWorktree(request, fmt.Sprintf("list registered Git worktrees: %v", err))
+	}
+	records, err := parseCanonicalV19GitWorktreeList(listing)
+	if err != nil {
+		return canonicalV19UnknownGitWorktree(request, err.Error())
+	}
+	matches := make([]canonicalV19GitWorktreeRecord, 0, 1)
+	for _, record := range records {
+		if handgit.SamePath(filepath.FromSlash(record.Path), request.RequestedPath) {
+			matches = append(matches, record)
+		}
+	}
+	if len(matches) > 1 {
+		return canonicalV19UnknownGitWorktree(request, "Git reports the requested path more than once")
+	}
+	if len(matches) == 0 {
+		if _, err := os.Stat(request.RequestedPath); os.IsNotExist(err) {
+			return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{State: canonicalV19GitWorktreeAbsent})
+		} else if err != nil {
+			return canonicalV19UnknownGitWorktree(request, fmt.Sprintf("inspect requested path: %v", err))
+		}
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:  canonicalV19GitWorktreeMismatch,
+			Reason: "requested path exists but is not registered in the expected repository",
+		})
+	}
+
+	record := matches[0]
+	if record.Bare || record.Prunable || !record.Detached || !record.Locked || record.LockReason != request.ExpectedLockReason || record.HeadRevision != request.BasisRevision {
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:        canonicalV19GitWorktreeMismatch,
+			LockReason:   record.LockReason,
+			HeadRevision: record.HeadRevision,
+			Reason:       "registered worktree metadata does not match the exact detached, locked request",
+		})
+	}
+	info, err := os.Stat(request.RequestedPath)
+	if err != nil {
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:  canonicalV19GitWorktreeMismatch,
+			Reason: fmt.Sprintf("registered worktree path cannot be inspected: %v", err),
+		})
+	}
+	if !info.IsDir() {
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:  canonicalV19GitWorktreeMismatch,
+			Reason: "registered worktree path is not a directory",
+		})
+	}
+	worktreeRoot, err := handgit.ResolveRoot(request.RequestedPath)
+	if err != nil || !handgit.SamePath(worktreeRoot, request.RequestedPath) {
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:  canonicalV19GitWorktreeMismatch,
+			Reason: "registered worktree does not resolve to the requested repository root",
+		})
+	}
+	worktreeCommonDir, err := handgit.CommonDir(request.RequestedPath)
+	if err != nil || !handgit.SamePath(worktreeCommonDir, expectedCommonDir) {
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:  canonicalV19GitWorktreeMismatch,
+			Reason: "registered worktree common Git directory does not match",
+		})
+	}
+	privateGitDirOutput, err := handgit.Run(request.RequestedPath, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return canonicalV19UnknownGitWorktree(request, fmt.Sprintf("resolve private Git directory: %v", err))
+	}
+	privateGitDir := filepath.Clean(filepath.FromSlash(strings.TrimSpace(privateGitDirOutput)))
+	if privateGitDir == "." || privateGitDir == "" {
+		return canonicalV19UnknownGitWorktree(request, "private Git directory is empty")
+	}
+	headRevision, err := handgit.HeadCommit(request.RequestedPath)
+	if err != nil || headRevision != request.BasisRevision {
+		return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+			State:         canonicalV19GitWorktreeMismatch,
+			PrivateGitDir: privateGitDir,
+			LockReason:    record.LockReason,
+			HeadRevision:  headRevision,
+			Reason:        "worktree HEAD does not match the exact basis revision",
+		})
+	}
+	finalInfo, err := os.Stat(request.RequestedPath)
+	if err != nil || !os.SameFile(info, finalInfo) {
+		return canonicalV19UnknownGitWorktree(request, "worktree physical identity changed during observation")
+	}
+	physicalIdentity, err := canonicalV19WorktreePhysicalIdentity(request.RequestedPath, finalInfo)
+	if err != nil {
+		return canonicalV19UnknownGitWorktree(request, fmt.Sprintf("capture worktree physical identity: %v", err))
+	}
+
+	return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+		State:                  canonicalV19GitWorktreeExact,
+		PrivateGitDir:          privateGitDir,
+		LockReason:             record.LockReason,
+		HeadRevision:           headRevision,
+		PhysicalIdentityDigest: canonicalV19WorktreePhysicalIdentityDigest(physicalIdentity),
+	})
+}
+
+func performCanonicalV19GitWorktreeCreate(homeDir string, request CanonicalV19WorktreeCreateRequest) error {
+	repositoryPath := canonicalV19ObservedPath(homeDir, request.RepositoryLocator)
+	_, err := handgit.Run(repositoryPath, "worktree", "add", "--detach", "--lock", "--reason", request.ExpectedLockReason,
+		request.RequestedPath, request.BasisRevision)
+	if err != nil {
+		return fmt.Errorf("git worktree add: %w", err)
+	}
+	return nil
+}
+
+func parseCanonicalV19GitWorktreeList(output string) ([]canonicalV19GitWorktreeRecord, error) {
+	records := make([]canonicalV19GitWorktreeRecord, 0)
+	var current canonicalV19GitWorktreeRecord
+	flush := func() error {
+		if current.Path == "" {
+			return nil
+		}
+		records = append(records, current)
+		current = canonicalV19GitWorktreeRecord{}
+		return nil
+	}
+	for _, field := range strings.Split(output, "\x00") {
+		if field == "" {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		name, value, _ := strings.Cut(field, " ")
+		switch name {
+		case "worktree":
+			if current.Path != "" {
+				return nil, fmt.Errorf("parse Git worktree list: record boundary is missing before %q", value)
+			}
+			if value == "" {
+				return nil, fmt.Errorf("parse Git worktree list: empty worktree path")
+			}
+			current.Path = value
+		case "HEAD":
+			current.HeadRevision = value
+		case "locked":
+			current.Locked = true
+			current.LockReason = value
+		case "detached":
+			current.Detached = true
+		case "bare":
+			current.Bare = true
+		case "prunable":
+			current.Prunable = true
+			current.PrunableReason = value
+		}
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func canonicalV19UnknownGitWorktree(request CanonicalV19WorktreeCreateRequest, reason string) canonicalV19GitWorktreeObservation {
+	return canonicalV19FinalizeGitWorktreeObservation(request, canonicalV19GitWorktreeObservation{
+		State:  canonicalV19GitWorktreeUnknown,
+		Reason: reason,
+	})
+}
+
+func canonicalV19FinalizeGitWorktreeObservation(
+	request CanonicalV19WorktreeCreateRequest,
+	observed canonicalV19GitWorktreeObservation,
+) canonicalV19GitWorktreeObservation {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:git-worktree-create-observation:v1")
+	writeCanonicalV19DigestField(hash, "request_digest", request.RequestDigest)
+	writeCanonicalV19DigestField(hash, "state", string(observed.State))
+	writeCanonicalV19DigestField(hash, "private_git_dir", observed.PrivateGitDir)
+	writeCanonicalV19DigestField(hash, "lock_reason", observed.LockReason)
+	writeCanonicalV19DigestField(hash, "head_revision", observed.HeadRevision)
+	writeCanonicalV19DigestField(hash, "physical_identity_digest", observed.PhysicalIdentityDigest)
+	writeCanonicalV19DigestField(hash, "reason", observed.Reason)
+	observed.EvidenceDigest = hex.EncodeToString(hash.Sum(nil))
+	return observed
+}
+
+func canonicalV19WorktreePhysicalIdentityDigest(identity string) string {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:worktree-physical-identity:v1")
+	writeCanonicalV19DigestField(hash, "identity", identity)
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func canonicalV19WorktreeCreateTimestampAfter(now time.Time, previous string) string {
+	candidate := now.UTC()
+	if prior, err := time.Parse(time.RFC3339Nano, previous); err == nil && !candidate.After(prior) {
+		candidate = prior.Add(time.Nanosecond)
+	}
+	return candidate.Format(time.RFC3339Nano)
+}

--- a/internal/store/v19worktree_native_test.go
+++ b/internal/store/v19worktree_native_test.go
@@ -281,6 +281,43 @@ func TestReconcileUncertainCanonicalV19WorktreeCreateNeverMutates(t *testing.T) 
 	}
 }
 
+func TestReconcileUncertainCanonicalV19WorktreeCreateConvergesFromLaterExactProof(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-uncertain-exact", "binding-uncertain-exact")
+	if err := os.MkdirAll(filepath.Dir(input.RequestedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T09:00:01Z", strings.Repeat("1", 64)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClassifyCanonicalV19WorktreeCreate(context.Background(), fixture.Home, CanonicalV19WorktreeCreateTransitionInput{
+		OperationID: request.OperationID, State: "uncertain", ObservedAt: "2026-09-06T09:00:02Z", EvidenceDigest: strings.Repeat("2", 64),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	repository := canonicalV19ObservedPath(fixture.Home, request.RepositoryLocator)
+	canonicalV19PlanWriterGit(t, repository, "worktree", "add", "--detach", "--lock", "--reason", request.ExpectedLockReason,
+		request.RequestedPath, request.BasisRevision)
+
+	performCalls := 0
+	state, err := reconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID, canonicalV19WorktreeCreateNativeDeps{
+		observe: observeCanonicalV19GitWorktree,
+		perform: func(string, CanonicalV19WorktreeCreateRequest) error {
+			performCalls++
+			return errors.New("must not run")
+		},
+		now: time.Now,
+	})
+	if err != nil || state != "succeeded" || performCalls != 0 {
+		t.Fatalf("uncertain exact reconcile = %q, %v perform=%d, want succeeded/nil/0", state, err, performCalls)
+	}
+}
+
 func TestParseCanonicalV19GitWorktreeListPreservesLockReason(t *testing.T) {
 	head := strings.Repeat("a", 40)
 	output := "worktree /repo\x00HEAD " + head + "\x00detached\x00locked hand:v1:binding-1\x00\x00"

--- a/internal/store/v19worktree_native_test.go
+++ b/internal/store/v19worktree_native_test.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReconcileCanonicalV19WorktreeCreateCreatesExactLockedNativeWorktree(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-native-1", "binding-native-1")
+	if err := os.MkdirAll(filepath.Dir(input.RequestedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "succeeded" {
+		t.Fatalf("reconcile state = %q, want succeeded", state)
+	}
+	observed := observeCanonicalV19GitWorktree(fixture.Home, request)
+	if observed.State != canonicalV19GitWorktreeExact {
+		t.Fatalf("native observation = %#v, want exact", observed)
+	}
+	if observed.LockReason != request.ExpectedLockReason || observed.HeadRevision != request.BasisRevision ||
+		observed.PrivateGitDir == "" || len(observed.PhysicalIdentityDigest) != 64 || len(observed.EvidenceDigest) != 64 {
+		t.Fatalf("native exact evidence = %#v", observed)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var operationState, path, commonGitDir, privateGitDir, lockReason, headRevision, physicalIdentity string
+	if err := db.sql.QueryRow(`SELECT o.state,b.path,b.common_git_dir,b.private_git_dir,b.lock_reason,b.head_revision,b.physical_identity_digest
+		FROM external_operation o JOIN attempt_worktree_binding b ON b.create_operation_id=o.id WHERE o.id=?`, request.OperationID).Scan(
+		&operationState, &path, &commonGitDir, &privateGitDir, &lockReason, &headRevision, &physicalIdentity,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if operationState != "succeeded" || path != request.RequestedPath || commonGitDir != request.ExpectedCommonGitDir ||
+		privateGitDir != observed.PrivateGitDir || lockReason != request.ExpectedLockReason || headRevision != request.BasisRevision ||
+		physicalIdentity != observed.PhysicalIdentityDigest {
+		t.Fatalf("persisted native binding = state=%q path=%q common=%q private=%q lock=%q HEAD=%q physical=%q",
+			operationState, path, commonGitDir, privateGitDir, lockReason, headRevision, physicalIdentity)
+	}
+	for _, transition := range []string{"submitted", "succeeded"} {
+		var count int
+		if err := db.sql.QueryRow(`SELECT COUNT(*) FROM external_operation_event WHERE operation_id=? AND to_state=?`, request.OperationID, transition).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("%s transition count = %d, want 1", transition, count)
+		}
+	}
+}
+
+func TestReconcileCanonicalV19WorktreeCreateSubmitsBeforeFirstMutation(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-boundary", "binding-boundary")
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observeCalls := 0
+	performCalls := 0
+	nowCalls := 0
+	base := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+	deps := canonicalV19WorktreeCreateNativeDeps{
+		observe: func(_ string, got CanonicalV19WorktreeCreateRequest) canonicalV19GitWorktreeObservation {
+			observeCalls++
+			if observeCalls <= 2 {
+				return canonicalV19FinalizeGitWorktreeObservation(got, canonicalV19GitWorktreeObservation{State: canonicalV19GitWorktreeAbsent})
+			}
+			return canonicalV19FinalizeGitWorktreeObservation(got, canonicalV19GitWorktreeObservation{
+				State:                  canonicalV19GitWorktreeExact,
+				PrivateGitDir:          filepath.Join(fixture.Home, ".git", "worktrees", got.BindingID),
+				LockReason:             got.ExpectedLockReason,
+				HeadRevision:           got.BasisRevision,
+				PhysicalIdentityDigest: strings.Repeat("a", 64),
+			})
+		},
+		perform: func(_ string, got CanonicalV19WorktreeCreateRequest) error {
+			performCalls++
+			db, err := openReadOnly(fixture.Home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			var state, submittedAt string
+			if err := db.sql.QueryRow(`SELECT state,submitted_at FROM external_operation WHERE id=?`, got.OperationID).Scan(&state, &submittedAt); err != nil {
+				t.Fatal(err)
+			}
+			if state != "submitted" || submittedAt == "" {
+				t.Fatalf("state at first mutation = %q submitted_at=%q, want submitted with durable authorization", state, submittedAt)
+			}
+			return nil
+		},
+		now: func() time.Time {
+			nowCalls++
+			return base.Add(time.Duration(nowCalls) * time.Second)
+		},
+	}
+
+	state, err := reconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "succeeded" || performCalls != 1 || observeCalls != 3 {
+		t.Fatalf("reconcile = state %q perform=%d observe=%d, want succeeded/1/3", state, performCalls, observeCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19WorktreeCreateDoesNotBlindRetry(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-submitted-absent", "binding-submitted-absent")
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T09:00:01Z", strings.Repeat("b", 64)); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("submitted absent reconcile = %q, %v, want no-effect with diagnostic", state, err)
+	}
+	if _, statErr := os.Stat(request.RequestedPath); !os.IsNotExist(statErr) {
+		t.Fatalf("submitted recovery mutated requested path: %v", statErr)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19WorktreeCreateConvergesExactCrashResidue(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-submitted-exact", "binding-submitted-exact")
+	if err := os.MkdirAll(filepath.Dir(input.RequestedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T09:00:01Z", strings.Repeat("c", 64)); err != nil {
+		t.Fatal(err)
+	}
+	repository := canonicalV19ObservedPath(fixture.Home, request.RepositoryLocator)
+	canonicalV19PlanWriterGit(t, repository, "worktree", "add", "--detach", "--lock", "--reason", request.ExpectedLockReason,
+		request.RequestedPath, request.BasisRevision)
+
+	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("submitted exact reconcile = %q, %v, want succeeded", state, err)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19WorktreeCreateDoesNotOverwriteForeignPath(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-foreign", "binding-foreign")
+	if err := os.MkdirAll(input.RequestedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(input.RequestedPath, "foreign.txt")
+	if err := os.WriteFile(sentinel, []byte("foreign\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("foreign path reconcile = %q, %v, want no-effect with diagnostic", state, err)
+	}
+	contents, readErr := os.ReadFile(sentinel)
+	if readErr != nil || string(contents) != "foreign\n" {
+		t.Fatalf("foreign path was modified: %q, %v", contents, readErr)
+	}
+}
+
+func TestReconcileUncertainCanonicalV19WorktreeCreateNeverMutates(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-uncertain", "binding-uncertain")
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T09:00:01Z", strings.Repeat("d", 64)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClassifyCanonicalV19WorktreeCreate(context.Background(), fixture.Home, CanonicalV19WorktreeCreateTransitionInput{
+		OperationID: request.OperationID, State: "uncertain", ObservedAt: "2026-09-06T09:00:02Z", EvidenceDigest: strings.Repeat("e", 64),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	performCalls := 0
+	state, err := reconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID, canonicalV19WorktreeCreateNativeDeps{
+		observe: func(_ string, got CanonicalV19WorktreeCreateRequest) canonicalV19GitWorktreeObservation {
+			return canonicalV19FinalizeGitWorktreeObservation(got, canonicalV19GitWorktreeObservation{
+				State: canonicalV19GitWorktreeUnknown, Reason: "provider reality unavailable",
+			})
+		},
+		perform: func(string, CanonicalV19WorktreeCreateRequest) error {
+			performCalls++
+			return errors.New("must not run")
+		},
+		now: time.Now,
+	})
+	if state != "uncertain" || err == nil || performCalls != 0 {
+		t.Fatalf("uncertain reconcile = %q, %v perform=%d, want uncertain/error/0", state, err, performCalls)
+	}
+}
+
+func TestParseCanonicalV19GitWorktreeListPreservesLockReason(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	output := "worktree /repo\x00HEAD " + head + "\x00detached\x00locked hand:v1:binding-1\x00\x00"
+	records, err := parseCanonicalV19GitWorktreeList(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Path != "/repo" || records[0].HeadRevision != head ||
+		!records[0].Detached || !records[0].Locked || records[0].LockReason != "hand:v1:binding-1" {
+		t.Fatalf("parsed records = %#v", records)
+	}
+}

--- a/internal/store/v19worktree_native_test.go
+++ b/internal/store/v19worktree_native_test.go
@@ -184,12 +184,65 @@ func TestReconcilePreparedCanonicalV19WorktreeCreateDoesNotOverwriteForeignPath(
 	}
 
 	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID)
-	if state != "no-effect" || err == nil {
-		t.Fatalf("foreign path reconcile = %q, %v, want no-effect with diagnostic", state, err)
+	if state != "prepared" || err == nil {
+		t.Fatalf("foreign path reconcile = %q, %v, want prepared with diagnostic", state, err)
 	}
 	contents, readErr := os.ReadFile(sentinel)
 	if readErr != nil || string(contents) != "foreign\n" {
 		t.Fatalf("foreign path was modified: %q, %v", contents, readErr)
+	}
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var persistedState, submittedAt string
+	if err := db.sql.QueryRow(`SELECT state,submitted_at FROM external_operation WHERE id=?`, request.OperationID).Scan(&persistedState, &submittedAt); err != nil {
+		t.Fatal(err)
+	}
+	if persistedState != "prepared" || submittedAt != "" {
+		t.Fatalf("foreign path persisted state = %q submitted_at=%q, want prepared without submission", persistedState, submittedAt)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19WorktreeCreateKeepsForeignPathUncertain(t *testing.T) {
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-submitted-foreign", "binding-submitted-foreign")
+	request, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T09:00:01Z", strings.Repeat("f", 64)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(request.RequestedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(request.RequestedPath, "foreign.txt")
+	if err := os.WriteFile(sentinel, []byte("foreign\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, request.OperationID)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("submitted foreign reconcile = %q, %v, want uncertain with diagnostic", state, err)
+	}
+	contents, readErr := os.ReadFile(sentinel)
+	if readErr != nil || string(contents) != "foreign\n" {
+		t.Fatalf("submitted foreign path was modified: %q, %v", contents, readErr)
+	}
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var persistedState string
+	if err := db.sql.QueryRow(`SELECT state FROM external_operation WHERE id=?`, request.OperationID).Scan(&persistedState); err != nil {
+		t.Fatal(err)
+	}
+	if persistedState != "uncertain" {
+		t.Fatalf("submitted foreign persisted state = %q, want uncertain", persistedState)
 	}
 }
 

--- a/internal/store/v19worktree_physical_unix.go
+++ b/internal/store/v19worktree_physical_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package store
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func canonicalV19WorktreePhysicalIdentity(_ string, info os.FileInfo) (string, error) {
+	if info == nil {
+		return "", fmt.Errorf("file identity metadata is absent")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil {
+		return "", fmt.Errorf("file identity metadata has type %T, want *syscall.Stat_t", info.Sys())
+	}
+	return fmt.Sprintf("unix-v1:dev=%016x:ino=%016x", uint64(stat.Dev), uint64(stat.Ino)), nil
+}

--- a/internal/store/v19worktree_physical_windows.go
+++ b/internal/store/v19worktree_physical_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package store
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func canonicalV19WorktreePhysicalIdentity(path string, expected os.FileInfo) (string, error) {
+	if expected == nil {
+		return "", fmt.Errorf("file identity metadata is absent")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file identity handle: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	current, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat file identity handle: %w", err)
+	}
+	if !os.SameFile(expected, current) {
+		return "", fmt.Errorf("file identity changed before handle capture")
+	}
+	var handleInfo windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &handleInfo); err != nil {
+		return "", fmt.Errorf("read file identity handle: %w", err)
+	}
+	return fmt.Sprintf("windows-v1:volume=%08x:file=%08x%08x", handleInfo.VolumeSerialNumber, handleInfo.FileIndexHigh, handleInfo.FileIndexLow), nil
+}


### PR DESCRIPTION
Implements step 9A2 native `builtin/git-worktree` WorktreeCreate observation/mutation/reconciliation on top of #561.

- observe-first; persist `submitted` before the first Git/filesystem mutation
- never blind-retry `submitted`/`uncertain` operations
- create with `git worktree add --detach --lock --reason`, without force or cleanup
- require exact registration, common Git dir, private Git dir, lock reason, HEAD, and physical filesystem identity before success
- settle exact/positively absent states only from observation; keep mismatch/unknown ownership or registration unresolved
- cover mutation-boundary durability, crash-residue convergence, foreign-path preservation before/after submission, no-blind-retry, uncertain non-mutation, and porcelain-z parsing

No ordinary runtime cutover and no WorktreeRemove in this slice. Exact Repair emission remains fail-closed because the landed Repair writer still intentionally rejects `external_operation`/WorktreeBinding targets; this change does not retarget repairs to a weaker owner.