### PR TITLE
feat(store): reconcile native Git WorktreeRemove

### DIFF
--- a/internal/store/v19worktree_remove_native.go
+++ b/internal/store/v19worktree_remove_native.go
@@ -1,0 +1,515 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	handgit "github.com/atqamz/hand/internal/git"
+)
+
+type canonicalV19GitWorktreeRemoveObservation struct {
+	State                  canonicalV19GitWorktreeObservationState
+	Locked                 bool
+	PrivateGitDir          string
+	LockReason             string
+	HeadRevision           string
+	PhysicalIdentityDigest string
+	StatusDigest           string
+	CleanCandidatesDigest  string
+	StableRefCount         int
+	LocalOnlyCommitCount   int
+	EvidenceDigest         string
+	Reason                 string
+}
+
+type canonicalV19WorktreeRemoveNativeDeps struct {
+	observe func(string, CanonicalV19WorktreeRemoveRequest) canonicalV19GitWorktreeRemoveObservation
+	perform func(string, CanonicalV19WorktreeRemoveRequest) error
+	now     func() time.Time
+}
+
+// ReconcileCanonicalV19WorktreeRemove observes one exact native Git removal
+// and mutates only after this call durably submits the prepared operation.
+func ReconcileCanonicalV19WorktreeRemove(ctx context.Context, homeDir, operationID string) (string, error) {
+	return reconcileCanonicalV19WorktreeRemove(ctx, homeDir, operationID, canonicalV19WorktreeRemoveNativeDeps{
+		observe: observeCanonicalV19GitWorktreeRemove,
+		perform: performCanonicalV19GitWorktreeRemove,
+		now:     time.Now,
+	})
+}
+
+func reconcileCanonicalV19WorktreeRemove(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+	deps canonicalV19WorktreeRemoveNativeDeps,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if operationID == "" {
+		return "", fmt.Errorf("reconcile canonical v19 WorktreeRemove: operation ID is empty")
+	}
+	if deps.observe == nil || deps.perform == nil || deps.now == nil {
+		return "", fmt.Errorf("reconcile canonical v19 WorktreeRemove: native adapter dependencies are incomplete")
+	}
+
+	current, err := readCanonicalV19WorktreeRemoveCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		return "", fmt.Errorf("reconcile canonical v19 WorktreeRemove: %w", err)
+	}
+	switch current.State {
+	case "succeeded", "rejected", "no-effect":
+		return current.State, nil
+	case "prepared", "submitted", "uncertain":
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: %w: operation %q is %q",
+			ErrCanonicalV19WorktreeRemoveTransition, operationID, current.State)
+	}
+
+	observed := deps.observe(homeDir, current.Request)
+	if current.State != "prepared" {
+		return reconcileCanonicalV19SubmittedWorktreeRemove(ctx, homeDir, current, observed, deps.now)
+	}
+
+	switch observed.State {
+	case canonicalV19GitWorktreeAbsent:
+		return completeCanonicalV19ObservedWorktreeRemove(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19GitWorktreeExact:
+	case canonicalV19GitWorktreeMismatch:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: exact ownership or preservation is not proven: %s", observed.Reason)
+	case canonicalV19GitWorktreeUnknown:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: native Git observation is unknown: %s", observed.Reason)
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: native Git observation state %q is invalid", observed.State)
+	}
+
+	submittedAt := canonicalV19WorktreeRemoveTimestampAfter(deps.now(), current.StateChangedAt)
+	request, err := SubmitCanonicalV19WorktreeRemove(ctx, homeDir, operationID, submittedAt, observed.EvidenceDigest)
+	if err != nil {
+		return current.State, err
+	}
+	current.Request = request
+	current.State = "submitted"
+	current.StateChangedAt = submittedAt
+
+	observed = deps.observe(homeDir, request)
+	switch observed.State {
+	case canonicalV19GitWorktreeAbsent:
+		return completeCanonicalV19ObservedWorktreeRemove(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19GitWorktreeExact:
+	case canonicalV19GitWorktreeMismatch, canonicalV19GitWorktreeUnknown:
+		return classifyCanonicalV19ObservedWorktreeRemoveUncertain(ctx, homeDir, current, observed, deps.now, nil)
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: native Git observation state %q is invalid", observed.State)
+	}
+
+	performErr := deps.perform(homeDir, request)
+	observed = deps.observe(homeDir, request)
+	switch observed.State {
+	case canonicalV19GitWorktreeAbsent:
+		return completeCanonicalV19ObservedWorktreeRemove(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19GitWorktreeExact:
+		return classifyCanonicalV19ObservedWorktreeRemoveNoEffect(ctx, homeDir, current, observed, deps.now,
+			canonicalV19WorktreeRemovePerformFailure("native Git remove left the exact worktree unchanged", performErr))
+	case canonicalV19GitWorktreeMismatch, canonicalV19GitWorktreeUnknown:
+		return classifyCanonicalV19ObservedWorktreeRemoveUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: native Git observation state %q is invalid", observed.State)
+	}
+}
+
+func reconcileCanonicalV19SubmittedWorktreeRemove(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeRemoveCurrent,
+	observed canonicalV19GitWorktreeRemoveObservation,
+	now func() time.Time,
+) (string, error) {
+	switch observed.State {
+	case canonicalV19GitWorktreeAbsent:
+		return completeCanonicalV19ObservedWorktreeRemove(ctx, homeDir, current, observed, now)
+	case canonicalV19GitWorktreeExact:
+		return classifyCanonicalV19ObservedWorktreeRemoveNoEffect(ctx, homeDir, current, observed, now,
+			"positive observation proves the submitted remove left the exact worktree unchanged")
+	case canonicalV19GitWorktreeMismatch, canonicalV19GitWorktreeUnknown:
+		if current.State == "submitted" {
+			return classifyCanonicalV19ObservedWorktreeRemoveUncertain(ctx, homeDir, current, observed, now, nil)
+		}
+		return "uncertain", fmt.Errorf("reconcile canonical v19 WorktreeRemove: operation remains uncertain: %s", observed.Reason)
+	default:
+		return current.State, fmt.Errorf("reconcile canonical v19 WorktreeRemove: native Git observation state %q is invalid", observed.State)
+	}
+}
+
+func completeCanonicalV19ObservedWorktreeRemove(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeRemoveCurrent,
+	observed canonicalV19GitWorktreeRemoveObservation,
+	now func() time.Time,
+) (string, error) {
+	removedAt := canonicalV19WorktreeRemoveTimestampAfter(now(), current.StateChangedAt)
+	if err := CompleteCanonicalV19WorktreeRemove(ctx, homeDir, CanonicalV19WorktreeRemovedEvidence{
+		OperationID:    current.Request.OperationID,
+		RemovedAt:      removedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.State, err
+	}
+	return "succeeded", nil
+}
+
+func classifyCanonicalV19ObservedWorktreeRemoveNoEffect(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeRemoveCurrent,
+	observed canonicalV19GitWorktreeRemoveObservation,
+	now func() time.Time,
+	reason string,
+) (string, error) {
+	observedAt := canonicalV19WorktreeRemoveTimestampAfter(now(), current.StateChangedAt)
+	if err := ClassifyCanonicalV19WorktreeRemove(ctx, homeDir, CanonicalV19WorktreeRemoveTransitionInput{
+		OperationID:    current.Request.OperationID,
+		State:          "no-effect",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.State, err
+	}
+	if observed.Reason != "" {
+		reason += ": " + observed.Reason
+	}
+	return "no-effect", fmt.Errorf("reconcile canonical v19 WorktreeRemove: %s", reason)
+}
+
+func classifyCanonicalV19ObservedWorktreeRemoveUncertain(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19WorktreeRemoveCurrent,
+	observed canonicalV19GitWorktreeRemoveObservation,
+	now func() time.Time,
+	performErr error,
+) (string, error) {
+	if current.State == "uncertain" {
+		return "uncertain", fmt.Errorf("reconcile canonical v19 WorktreeRemove: operation remains uncertain: %s", observed.Reason)
+	}
+	observedAt := canonicalV19WorktreeRemoveTimestampAfter(now(), current.StateChangedAt)
+	if err := ClassifyCanonicalV19WorktreeRemove(ctx, homeDir, CanonicalV19WorktreeRemoveTransitionInput{
+		OperationID:    current.Request.OperationID,
+		State:          "uncertain",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.State, err
+	}
+	reason := observed.Reason
+	if performErr != nil {
+		reason = canonicalV19WorktreeRemovePerformFailure(reason, performErr)
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 WorktreeRemove: operation is uncertain: %s", reason)
+}
+
+func readCanonicalV19WorktreeRemoveCurrent(ctx context.Context, homeDir, operationID string) (canonicalV19WorktreeRemoveCurrent, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return canonicalV19WorktreeRemoveCurrent{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19WorktreeRemoveCurrent{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	return loadCanonicalV19WorktreeRemoveCurrent(ctx, tx, operationID)
+}
+
+func observeCanonicalV19GitWorktreeRemove(homeDir string, request CanonicalV19WorktreeRemoveRequest) canonicalV19GitWorktreeRemoveObservation {
+	return observeCanonicalV19GitWorktreeRemoveLockState(homeDir, request, true)
+}
+
+func observeCanonicalV19GitWorktreeRemoveLockState(
+	homeDir string,
+	request CanonicalV19WorktreeRemoveRequest,
+	expectLocked bool,
+) canonicalV19GitWorktreeRemoveObservation {
+	repositoryPath := canonicalV19ObservedPath(homeDir, request.RepositoryLocator)
+	expectedCommonDir := canonicalV19ObservedPath(homeDir, request.ExpectedCommonGitDir)
+	expectedPrivateGitDir := canonicalV19ObservedPath(homeDir, request.ExpectedPrivateGitDir)
+
+	root, err := handgit.ResolveRoot(repositoryPath)
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("resolve repository root: %v", err))
+	}
+	if !handgit.SamePath(root, repositoryPath) {
+		return canonicalV19UnknownGitWorktreeRemove(request, "repository locator no longer resolves to its exact root")
+	}
+	commonDir, err := handgit.CommonDir(repositoryPath)
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("resolve common Git directory: %v", err))
+	}
+	if !handgit.SamePath(commonDir, expectedCommonDir) {
+		return canonicalV19UnknownGitWorktreeRemove(request, "WorkspaceBinding common Git directory no longer matches")
+	}
+
+	listing, err := handgit.Run(repositoryPath, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("list registered Git worktrees: %v", err))
+	}
+	records, err := parseCanonicalV19GitWorktreeList(listing)
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, err.Error())
+	}
+	matches := make([]canonicalV19GitWorktreeRecord, 0, 1)
+	for _, record := range records {
+		if handgit.SamePath(filepath.FromSlash(record.Path), request.Path) {
+			matches = append(matches, record)
+		}
+	}
+	if len(matches) > 1 {
+		return canonicalV19UnknownGitWorktreeRemove(request, "Git reports the exact worktree path more than once")
+	}
+	if len(matches) == 0 {
+		if _, err := os.Stat(request.Path); err == nil {
+			return canonicalV19FinalizeGitWorktreeRemoveObservation(request, canonicalV19GitWorktreeRemoveObservation{
+				State:  canonicalV19GitWorktreeMismatch,
+				Reason: "worktree path still exists without the expected registration",
+			})
+		} else if !os.IsNotExist(err) {
+			return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("inspect worktree path: %v", err))
+		}
+		if _, err := os.Stat(expectedPrivateGitDir); err == nil {
+			return canonicalV19FinalizeGitWorktreeRemoveObservation(request, canonicalV19GitWorktreeRemoveObservation{
+				State:  canonicalV19GitWorktreeMismatch,
+				Reason: "private Git administration directory remains after registration disappeared",
+			})
+		} else if !os.IsNotExist(err) {
+			return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("inspect private Git directory: %v", err))
+		}
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, canonicalV19GitWorktreeRemoveObservation{
+			State: canonicalV19GitWorktreeAbsent,
+		})
+	}
+
+	record := matches[0]
+	observed := canonicalV19GitWorktreeRemoveObservation{
+		Locked:       record.Locked,
+		LockReason:   record.LockReason,
+		HeadRevision: record.HeadRevision,
+	}
+	if record.Bare || record.Prunable || !record.Detached || record.HeadRevision != request.ExpectedHeadRevision {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "registered worktree metadata no longer matches the exact detached HEAD binding"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	if expectLocked {
+		if !record.Locked || record.LockReason != request.ExpectedLockReason {
+			observed.State = canonicalV19GitWorktreeMismatch
+			observed.Reason = "registered worktree lock ownership no longer matches the exact binding"
+			return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+		}
+	} else if record.Locked {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "worktree remained locked after the authorized unlock mutation"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+
+	info, err := os.Stat(request.Path)
+	if err != nil {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = fmt.Sprintf("registered worktree path cannot be inspected: %v", err)
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	if !info.IsDir() {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "registered worktree path is not a directory"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	worktreeRoot, err := handgit.ResolveRoot(request.Path)
+	if err != nil || !handgit.SamePath(worktreeRoot, request.Path) {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "registered worktree no longer resolves to its exact root"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	worktreeCommonDir, err := handgit.CommonDir(request.Path)
+	if err != nil || !handgit.SamePath(worktreeCommonDir, expectedCommonDir) {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "registered worktree common Git directory no longer matches"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	privateOutput, err := handgit.Run(request.Path, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("resolve private Git directory: %v", err))
+	}
+	observed.PrivateGitDir = filepath.Clean(filepath.FromSlash(strings.TrimSpace(privateOutput)))
+	if !handgit.SamePath(observed.PrivateGitDir, expectedPrivateGitDir) {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "private Git administration identity no longer matches the exact binding"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	headRevision, err := handgit.HeadCommit(request.Path)
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("resolve exact worktree HEAD: %v", err))
+	}
+	observed.HeadRevision = headRevision
+	if headRevision != request.ExpectedHeadRevision {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "worktree HEAD changed from the exact persisted binding"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	finalInfo, err := os.Stat(request.Path)
+	if err != nil || !os.SameFile(info, finalInfo) {
+		return canonicalV19UnknownGitWorktreeRemove(request, "worktree physical identity changed during observation")
+	}
+	physicalIdentity, err := canonicalV19WorktreePhysicalIdentity(request.Path, finalInfo)
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("capture worktree physical identity: %v", err))
+	}
+	observed.PhysicalIdentityDigest = canonicalV19WorktreePhysicalIdentityDigest(physicalIdentity)
+	if observed.PhysicalIdentityDigest != request.ExpectedPhysicalIdentityDigest {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "worktree physical identity no longer matches the exact persisted binding"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+
+	status, err := handgit.Run(request.Path, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("observe worktree cleanliness: %v", err))
+	}
+	observed.StatusDigest = canonicalV19WorktreeRemoveTextDigest(status)
+	if strings.TrimSpace(status) != "" {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "worktree has uncommitted or untracked content; preservation is unsafe"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	cleanCandidates, err := handgit.Run(request.Path, "clean", "-ndx")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("observe ignored/untracked cleanup candidates: %v", err))
+	}
+	observed.CleanCandidatesDigest = canonicalV19WorktreeRemoveTextDigest(cleanCandidates)
+	if strings.TrimSpace(cleanCandidates) != "" {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "worktree contains ignored or untracked filesystem content; preservation is unsafe"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+	gitlinks, err := handgit.Run(request.Path, "ls-files", "--stage")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("inspect worktree gitlinks: %v", err))
+	}
+	for _, line := range strings.Split(gitlinks, "\n") {
+		if strings.HasPrefix(line, "160000 ") {
+			observed.State = canonicalV19GitWorktreeMismatch
+			observed.Reason = "worktree contains submodules; non-force native removal is not preservation-safe"
+			return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+		}
+	}
+	stableRefs, err := handgit.Run(request.Path, "for-each-ref", "--format=%(refname)", "--contains", request.ExpectedHeadRevision,
+		"refs/heads", "refs/tags", "refs/remotes")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("observe stable refs containing exact HEAD: %v", err))
+	}
+	observed.StableRefCount = canonicalV19NonemptyLineCount(stableRefs)
+	if observed.StableRefCount == 0 {
+		return canonicalV19UnknownGitWorktreeRemove(request, "no stable common Git ref positively preserves the exact worktree HEAD")
+	}
+	localOnly, err := handgit.Run(request.Path, "rev-list", "--count", "HEAD", "--not", "--branches", "--tags", "--remotes")
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("compare exact HEAD with stable common refs: %v", err))
+	}
+	observed.LocalOnlyCommitCount, err = strconv.Atoi(strings.TrimSpace(localOnly))
+	if err != nil {
+		return canonicalV19UnknownGitWorktreeRemove(request, fmt.Sprintf("parse local-only commit count %q: %v", localOnly, err))
+	}
+	if observed.LocalOnlyCommitCount != 0 {
+		observed.State = canonicalV19GitWorktreeMismatch
+		observed.Reason = "worktree HEAD contains commits not preserved by a stable common Git ref"
+		return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+	}
+
+	observed.State = canonicalV19GitWorktreeExact
+	return canonicalV19FinalizeGitWorktreeRemoveObservation(request, observed)
+}
+
+func performCanonicalV19GitWorktreeRemove(homeDir string, request CanonicalV19WorktreeRemoveRequest) error {
+	repositoryPath := canonicalV19ObservedPath(homeDir, request.RepositoryLocator)
+	if _, err := handgit.Run(repositoryPath, "worktree", "unlock", request.Path); err != nil {
+		return fmt.Errorf("git worktree unlock: %w", err)
+	}
+	observed := observeCanonicalV19GitWorktreeRemoveLockState(homeDir, request, false)
+	if observed.State != canonicalV19GitWorktreeExact {
+		return fmt.Errorf("post-unlock exact safety recheck failed: %s (%s)", observed.State, observed.Reason)
+	}
+	if _, err := handgit.Run(repositoryPath, "worktree", "remove", request.Path); err != nil {
+		return fmt.Errorf("git worktree remove: %w", err)
+	}
+	return nil
+}
+
+func canonicalV19UnknownGitWorktreeRemove(request CanonicalV19WorktreeRemoveRequest, reason string) canonicalV19GitWorktreeRemoveObservation {
+	return canonicalV19FinalizeGitWorktreeRemoveObservation(request, canonicalV19GitWorktreeRemoveObservation{
+		State:  canonicalV19GitWorktreeUnknown,
+		Reason: reason,
+	})
+}
+
+func canonicalV19FinalizeGitWorktreeRemoveObservation(
+	request CanonicalV19WorktreeRemoveRequest,
+	observed canonicalV19GitWorktreeRemoveObservation,
+) canonicalV19GitWorktreeRemoveObservation {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:git-worktree-remove-observation:v1")
+	writeCanonicalV19DigestField(hash, "request_digest", request.RequestDigest)
+	writeCanonicalV19DigestField(hash, "state", string(observed.State))
+	writeCanonicalV19DigestField(hash, "locked", strconv.FormatBool(observed.Locked))
+	writeCanonicalV19DigestField(hash, "private_git_dir", observed.PrivateGitDir)
+	writeCanonicalV19DigestField(hash, "lock_reason", observed.LockReason)
+	writeCanonicalV19DigestField(hash, "head_revision", observed.HeadRevision)
+	writeCanonicalV19DigestField(hash, "physical_identity_digest", observed.PhysicalIdentityDigest)
+	writeCanonicalV19DigestField(hash, "status_digest", observed.StatusDigest)
+	writeCanonicalV19DigestField(hash, "clean_candidates_digest", observed.CleanCandidatesDigest)
+	writeCanonicalV19DigestField(hash, "stable_ref_count", strconv.Itoa(observed.StableRefCount))
+	writeCanonicalV19DigestField(hash, "local_only_commit_count", strconv.Itoa(observed.LocalOnlyCommitCount))
+	writeCanonicalV19DigestField(hash, "reason", observed.Reason)
+	observed.EvidenceDigest = hex.EncodeToString(hash.Sum(nil))
+	return observed
+}
+
+func canonicalV19WorktreeRemoveTextDigest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalV19NonemptyLineCount(value string) int {
+	count := 0
+	for _, line := range strings.Split(value, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func canonicalV19WorktreeRemovePerformFailure(prefix string, err error) string {
+	if err == nil {
+		return prefix
+	}
+	if prefix == "" {
+		return fmt.Sprintf("native Git remove failed: %v", err)
+	}
+	return fmt.Sprintf("%s; native Git remove failed: %v", prefix, err)
+}
+
+func canonicalV19WorktreeRemoveTimestampAfter(now time.Time, previous string) string {
+	candidate := now.UTC()
+	if prior, err := time.Parse(time.RFC3339Nano, previous); err == nil && !candidate.After(prior) {
+		candidate = prior.Add(time.Nanosecond)
+	}
+	return candidate.Format(time.RFC3339Nano)
+}

--- a/internal/store/v19worktree_remove_native_test.go
+++ b/internal/store/v19worktree_remove_native_test.go
@@ -1,0 +1,257 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReconcileCanonicalV19WorktreeRemoveRemovesExactNativeWorktree(t *testing.T) {
+	fixture, binding := canonicalV19NativeWorktreeRemoveFixture(t, "native-remove-success")
+	input := canonicalV19WorktreeRemovePrepareInput(binding, "operation-remove-native")
+	input.CreatedAt = "2026-09-07T00:00:00Z"
+	request, err := PrepareCanonicalV19WorktreeRemove(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "succeeded" {
+		t.Fatalf("reconcile state = %q, want succeeded", state)
+	}
+	if _, err := os.Stat(request.Path); !os.IsNotExist(err) {
+		t.Fatalf("removed worktree path still exists: %v", err)
+	}
+	privateGitDir := canonicalV19ObservedPath(fixture.Home, request.ExpectedPrivateGitDir)
+	if _, err := os.Stat(privateGitDir); !os.IsNotExist(err) {
+		t.Fatalf("removed private Git directory still exists: %v", err)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var persistedState string
+	var releaseCount int
+	if err := db.sql.QueryRow(`SELECT state FROM external_operation WHERE id=?`, request.OperationID).Scan(&persistedState); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM worktree_binding_release WHERE binding_id=? AND remove_operation_id=?`,
+		request.BindingID, request.OperationID).Scan(&releaseCount); err != nil {
+		t.Fatal(err)
+	}
+	if persistedState != "succeeded" || releaseCount != 1 {
+		t.Fatalf("persisted remove = state %q releases %d, want succeeded/1", persistedState, releaseCount)
+	}
+	for _, transition := range []string{"submitted", "succeeded"} {
+		var count int
+		if err := db.sql.QueryRow(`SELECT COUNT(*) FROM external_operation_event WHERE operation_id=? AND to_state=?`, request.OperationID, transition).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("%s transition count = %d, want 1", transition, count)
+		}
+	}
+}
+
+func TestReconcileCanonicalV19WorktreeRemoveSubmitsBeforeFirstMutation(t *testing.T) {
+	fixture, binding := canonicalV19WorktreeRemoveFixture(t)
+	input := canonicalV19WorktreeRemovePrepareInput(binding, "operation-remove-boundary")
+	request, err := PrepareCanonicalV19WorktreeRemove(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observeCalls := 0
+	performCalls := 0
+	nowCalls := 0
+	base := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+	deps := canonicalV19WorktreeRemoveNativeDeps{
+		observe: func(_ string, got CanonicalV19WorktreeRemoveRequest) canonicalV19GitWorktreeRemoveObservation {
+			observeCalls++
+			if observeCalls <= 2 {
+				return canonicalV19FinalizeGitWorktreeRemoveObservation(got, canonicalV19GitWorktreeRemoveObservation{
+					State: canonicalV19GitWorktreeExact, Locked: true, LockReason: got.ExpectedLockReason,
+				})
+			}
+			return canonicalV19FinalizeGitWorktreeRemoveObservation(got, canonicalV19GitWorktreeRemoveObservation{
+				State: canonicalV19GitWorktreeAbsent,
+			})
+		},
+		perform: func(_ string, got CanonicalV19WorktreeRemoveRequest) error {
+			performCalls++
+			db, err := openReadOnly(fixture.Home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			var state, submittedAt string
+			if err := db.sql.QueryRow(`SELECT state,submitted_at FROM external_operation WHERE id=?`, got.OperationID).Scan(&state, &submittedAt); err != nil {
+				t.Fatal(err)
+			}
+			if state != "submitted" || submittedAt == "" {
+				t.Fatalf("state at first mutation = %q submitted_at=%q, want submitted with durable authorization", state, submittedAt)
+			}
+			return nil
+		},
+		now: func() time.Time {
+			nowCalls++
+			return base.Add(time.Duration(nowCalls) * time.Second)
+		},
+	}
+
+	state, err := reconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "succeeded" || performCalls != 1 || observeCalls != 3 {
+		t.Fatalf("reconcile = state %q perform=%d observe=%d, want succeeded/1/3", state, performCalls, observeCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19WorktreeRemoveDoesNotBlindRetry(t *testing.T) {
+	fixture, binding := canonicalV19WorktreeRemoveFixture(t)
+	input := canonicalV19WorktreeRemovePrepareInput(binding, "operation-remove-submitted")
+	request, err := PrepareCanonicalV19WorktreeRemove(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-05T15:04:00Z", strings.Repeat("a", 64)); err != nil {
+		t.Fatal(err)
+	}
+
+	performCalls := 0
+	state, err := reconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID, canonicalV19WorktreeRemoveNativeDeps{
+		observe: func(_ string, got CanonicalV19WorktreeRemoveRequest) canonicalV19GitWorktreeRemoveObservation {
+			return canonicalV19FinalizeGitWorktreeRemoveObservation(got, canonicalV19GitWorktreeRemoveObservation{
+				State: canonicalV19GitWorktreeExact, Locked: true, LockReason: got.ExpectedLockReason,
+			})
+		},
+		perform: func(string, CanonicalV19WorktreeRemoveRequest) error {
+			performCalls++
+			return errors.New("must not run")
+		},
+		now: time.Now,
+	})
+	if state != "no-effect" || err == nil || performCalls != 0 {
+		t.Fatalf("submitted reconcile = %q, %v perform=%d, want no-effect/error/0", state, err, performCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19WorktreeRemoveKeepsUnlockCrashResidueUncertain(t *testing.T) {
+	fixture, binding := canonicalV19NativeWorktreeRemoveFixture(t, "native-remove-unlock-crash")
+	input := canonicalV19WorktreeRemovePrepareInput(binding, "operation-remove-unlock-crash")
+	input.CreatedAt = "2026-09-07T00:00:00Z"
+	request, err := PrepareCanonicalV19WorktreeRemove(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-07T00:00:01Z", strings.Repeat("b", 64)); err != nil {
+		t.Fatal(err)
+	}
+	repository := canonicalV19ObservedPath(fixture.Home, request.RepositoryLocator)
+	canonicalV19PlanWriterGit(t, repository, "worktree", "unlock", request.Path)
+
+	state, err := ReconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("unlocked crash residue reconcile = %q, %v, want uncertain/error", state, err)
+	}
+	if _, err := os.Stat(request.Path); err != nil {
+		t.Fatalf("uncertain recovery removed worktree: %v", err)
+	}
+
+	canonicalV19PlanWriterGit(t, repository, "worktree", "lock", "--reason", request.ExpectedLockReason, request.Path)
+	state, err = ReconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("later exact reconciliation = %q, %v, want no-effect/error", state, err)
+	}
+	if _, err := os.Stat(request.Path); err != nil {
+		t.Fatalf("no-effect reconciliation removed worktree: %v", err)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19WorktreeRemoveRefusesReallocatedSamePath(t *testing.T) {
+	fixture, binding := canonicalV19NativeWorktreeRemoveFixture(t, "native-remove-reallocated")
+	input := canonicalV19WorktreeRemovePrepareInput(binding, "operation-remove-reallocated")
+	input.CreatedAt = "2026-09-07T00:00:00Z"
+	request, err := PrepareCanonicalV19WorktreeRemove(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := canonicalV19ObservedPath(fixture.Home, request.RepositoryLocator)
+	canonicalV19PlanWriterGit(t, repository, "worktree", "unlock", request.Path)
+	canonicalV19PlanWriterGit(t, repository, "worktree", "remove", request.Path)
+	canonicalV19PlanWriterGit(t, repository, "worktree", "add", "--detach", "--lock", "--reason", "hand:v1:foreign",
+		request.Path, request.ExpectedHeadRevision)
+	sentinel := filepath.Join(request.Path, "foreign.txt")
+	if err := os.WriteFile(sentinel, []byte("foreign\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID)
+	if state != "prepared" || err == nil {
+		t.Fatalf("reallocated path reconcile = %q, %v, want prepared/error", state, err)
+	}
+	contents, readErr := os.ReadFile(sentinel)
+	if readErr != nil || string(contents) != "foreign\n" {
+		t.Fatalf("reallocated worktree was modified: %q, %v", contents, readErr)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19WorktreeRemoveRefusesIgnoredContent(t *testing.T) {
+	fixture, binding := canonicalV19NativeWorktreeRemoveFixture(t, "native-remove-ignored")
+	input := canonicalV19WorktreeRemovePrepareInput(binding, "operation-remove-ignored")
+	input.CreatedAt = "2026-09-07T00:00:00Z"
+	request, err := PrepareCanonicalV19WorktreeRemove(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonDir := canonicalV19ObservedPath(fixture.Home, request.ExpectedCommonGitDir)
+	if err := os.WriteFile(filepath.Join(commonDir, "info", "exclude"), []byte("scratch.log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scratch := filepath.Join(request.Path, "scratch.log")
+	if err := os.WriteFile(scratch, []byte("preserve me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if status := strings.TrimSpace(canonicalV19PlanWriterGit(t, request.Path, "status", "--porcelain", "--untracked-files=all")); status != "" {
+		t.Fatalf("fixture is not Git-clean before ignored-content test: %q", status)
+	}
+
+	state, err := ReconcileCanonicalV19WorktreeRemove(context.Background(), fixture.Home, request.OperationID)
+	if state != "prepared" || err == nil {
+		t.Fatalf("ignored content reconcile = %q, %v, want prepared/error", state, err)
+	}
+	contents, readErr := os.ReadFile(scratch)
+	if readErr != nil || string(contents) != "preserve me\n" {
+		t.Fatalf("ignored content was removed: %q, %v", contents, readErr)
+	}
+}
+
+func canonicalV19NativeWorktreeRemoveFixture(t *testing.T, suffix string) (canonicalV19WorktreeCreateTestFixture, CanonicalV19WorktreeCreateRequest) {
+	t.Helper()
+	fixture := canonicalV19WorktreeCreateFixture(t)
+	input := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-create-"+suffix, "binding-"+suffix)
+	if err := os.MkdirAll(filepath.Dir(input.RequestedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binding, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := ReconcileCanonicalV19WorktreeCreate(context.Background(), fixture.Home, binding.OperationID)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("create native WorktreeBinding = %q, %v", state, err)
+	}
+	return fixture, binding
+}


### PR DESCRIPTION
Implements the native Git destructive half of canonical v19 WorktreeRemove.

- observe exact Git registration/admin/lock/HEAD/physical identity before mutation
- require preservation proof beyond clean status, including ignored-content and stable-ref checks
- durably submit before the first unlock mutation
- re-observe exact identity after unlock, then use non-force `git worktree remove`
- never blind-retry submitted/uncertain removal
- keep unlock-crash residue unresolved
- refuse stale same-path reallocation and preservation-unsafe cleanup

Ordinary runtime cutover remains untouched.