### PR TITLE
feat(store): reconcile Herdr SessionAcquire

### DIFF
--- a/internal/store/v19session_herdr.go
+++ b/internal/store/v19session_herdr.go
@@ -64,10 +64,10 @@ type canonicalV19HerdrSessionAcquireDeps struct {
 }
 
 // ReconcileCanonicalV19HerdrSessionAcquire reconciles one exact canonical v19
-// SessionAcquire against the Herdr provider. Herdr assigns workspace/tab/pane
-// identities, so a fresh request must leave RequestedProviderSessionKey empty.
-// Submitted/uncertain operations are observation-only and are never blindly
-// replayed after process-memory loss.
+// SessionAcquire against Herdr. Herdr assigns workspace/tab/pane identities, so
+// fresh acquisition requires an empty RequestedProviderSessionKey. Once an
+// unresolved mutation loses those provider-assigned identities, recovery is
+// observation-only and never adopts a workspace from its locator label.
 func ReconcileCanonicalV19HerdrSessionAcquire(ctx context.Context, homeDir, operationID string) (string, error) {
 	return reconcileCanonicalV19HerdrSessionAcquire(ctx, homeDir, operationID, canonicalV19HerdrSessionAcquireDeps{
 		clientFor: func(sessionName string) canonicalV19HerdrSessionClient {
@@ -114,8 +114,7 @@ func reconcileCanonicalV19HerdrSessionAcquire(
 		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider-assigned Session key must be empty before fresh acquisition")
 	}
 
-	sessionName := herdr.SessionName(current.FleetID)
-	client := deps.clientFor(sessionName)
+	client := deps.clientFor(herdr.SessionName(current.FleetID))
 	if client == nil {
 		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider client is unavailable")
 	}
@@ -144,35 +143,32 @@ func reconcileCanonicalV19HerdrSessionAcquire(
 	current.Current.StateChangedAt = submittedAt
 
 	observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, "", client)
-	switch observed.State {
-	case canonicalV19HerdrSessionAbsent:
-	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+	if observed.State != canonicalV19HerdrSessionAbsent {
 		return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now, nil)
-	default:
-		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
 	}
 
 	providerKey, performErr := performCanonicalV19HerdrSessionAcquire(current, client)
 	if providerKey != "" {
 		observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, providerKey, client)
-	} else {
-		observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, "", client)
-	}
-	switch observed.State {
-	case canonicalV19HerdrSessionExact:
-		if providerKey == "" {
-			return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now,
-				errors.New("provider returned no exact Session key"))
+		switch observed.State {
+		case canonicalV19HerdrSessionExact:
+			return establishCanonicalV19ObservedHerdrSession(ctx, homeDir, current, observed, deps.now)
+		case canonicalV19HerdrSessionAbsent:
+			return classifyCanonicalV19HerdrSessionAcquireNoEffect(ctx, homeDir, current, observed, deps.now,
+				"positive observation proves the exact provider-assigned Session resource is absent")
+		case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+			return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+		default:
+			return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
 		}
-		return establishCanonicalV19ObservedHerdrSession(ctx, homeDir, current, observed, deps.now)
-	case canonicalV19HerdrSessionAbsent:
-		return classifyCanonicalV19HerdrSessionAcquireNoEffect(ctx, homeDir, current, observed, deps.now,
-			canonicalV19HerdrSessionPerformFailure("positive observation proves no requested Session resource remains", performErr))
-	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
-		return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now, performErr)
-	default:
-		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
 	}
+
+	observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, "", client)
+	if performErr != nil && herdr.IsProcessNotStarted(performErr) && observed.State == canonicalV19HerdrSessionAbsent {
+		return classifyCanonicalV19HerdrSessionAcquireNoEffect(ctx, homeDir, current, observed, deps.now,
+			"Herdr process did not start and positive pre/post observation proves no dedicated Session locator exists")
+	}
+	return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now, performErr)
 }
 
 func reconcileCanonicalV19SubmittedHerdrSessionAcquire(
@@ -182,18 +178,16 @@ func reconcileCanonicalV19SubmittedHerdrSessionAcquire(
 	observed canonicalV19HerdrSessionObservation,
 	now func() time.Time,
 ) (string, error) {
-	switch observed.State {
-	case canonicalV19HerdrSessionAbsent:
-		return classifyCanonicalV19HerdrSessionAcquireNoEffect(ctx, homeDir, current, observed, now,
-			"positive provider observation proves the unresolved acquisition left no dedicated Session resource")
-	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
-		if current.Current.State == "submitted" {
-			return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, now, nil)
-		}
-		return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: operation remains uncertain: %s", observed.Reason)
-	default:
-		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
+	if observed.Reason == "" {
+		observed.Reason = "provider-assigned workspace/tab/pane identity was not durably captured before recovery"
+	} else {
+		observed.Reason += "; provider-assigned workspace/tab/pane identity was not durably captured before recovery"
 	}
+	observed = finalizeCanonicalV19HerdrSessionObservation(current, observed)
+	if current.Current.State == "submitted" {
+		return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, now, nil)
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: operation remains uncertain: %s", observed.Reason)
 }
 
 func establishCanonicalV19ObservedHerdrSession(
@@ -259,6 +253,9 @@ func classifyCanonicalV19HerdrSessionAcquireUncertain(
 	if performErr != nil {
 		reason = canonicalV19HerdrSessionPerformFailure(reason, performErr)
 	}
+	if reason == "" {
+		reason = "strongest provider evidence cannot classify the submitted acquisition"
+	}
 	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: operation is uncertain: %s", reason)
 }
 
@@ -316,14 +313,12 @@ func observeCanonicalV19HerdrSessionAcquire(
 			}
 		}
 		if matches == 0 {
-			return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
-				State: canonicalV19HerdrSessionAbsent,
-			})
+			return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{State: canonicalV19HerdrSessionAbsent})
 		}
 		return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
 			State:        canonicalV19HerdrSessionMismatch,
 			LabelMatches: matches,
-			Reason:       "dedicated Session workspace locator already exists but provider-assigned tab/pane identity is not durably known",
+			Reason:       "dedicated Session workspace locator exists but exact provider-assigned tab/pane identity is not durably known",
 		})
 	}
 
@@ -350,7 +345,8 @@ func observeCanonicalV19HerdrSessionAcquire(
 	workspaceMatches := 0
 	for _, candidate := range workspaces {
 		if candidate.WorkspaceID == key.WorkspaceID {
-			workspace, workspaceMatches = candidate, workspaceMatches+1
+			workspace = candidate
+			workspaceMatches++
 		}
 	}
 	if workspaceMatches == 0 {

--- a/internal/store/v19session_herdr.go
+++ b/internal/store/v19session_herdr.go
@@ -1,0 +1,572 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	handgit "github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+const canonicalV19HerdrSessionAdapterRef = "herdr"
+
+type canonicalV19HerdrSessionObservationState string
+
+const (
+	canonicalV19HerdrSessionExact    canonicalV19HerdrSessionObservationState = "exact"
+	canonicalV19HerdrSessionAbsent   canonicalV19HerdrSessionObservationState = "absent"
+	canonicalV19HerdrSessionMismatch canonicalV19HerdrSessionObservationState = "mismatch"
+	canonicalV19HerdrSessionUnknown  canonicalV19HerdrSessionObservationState = "unknown"
+)
+
+type canonicalV19HerdrSessionProviderKey struct {
+	SessionName string
+	WorkspaceID string
+	TabID       string
+	PaneID      string
+}
+
+type canonicalV19HerdrSessionObservation struct {
+	State              canonicalV19HerdrSessionObservationState
+	ProviderSessionKey string
+	WorkspaceID        string
+	TabID              string
+	PaneID             string
+	PaneCwd            string
+	LabelMatches       int
+	EvidenceDigest     string
+	Reason             string
+}
+
+type canonicalV19HerdrSessionAcquireCurrent struct {
+	Current      canonicalV19SessionAcquireCurrent
+	FleetID      string
+	WorktreePath string
+}
+
+type canonicalV19HerdrSessionClient interface {
+	ObserveSession(context.Context) herdr.SessionObservation
+	WorkspaceListContext(context.Context) ([]herdr.Workspace, error)
+	WorkspaceCreate(string, map[string]string, string) (herdr.Workspace, herdr.Tab, herdr.Pane, error)
+	TabList(string) ([]herdr.Tab, error)
+	PaneGetContext(context.Context, string) (herdr.Pane, error)
+}
+
+type canonicalV19HerdrSessionAcquireDeps struct {
+	clientFor func(string) canonicalV19HerdrSessionClient
+	now       func() time.Time
+}
+
+// ReconcileCanonicalV19HerdrSessionAcquire reconciles one exact canonical v19
+// SessionAcquire against the Herdr provider. Herdr assigns workspace/tab/pane
+// identities, so a fresh request must leave RequestedProviderSessionKey empty.
+// Submitted/uncertain operations are observation-only and are never blindly
+// replayed after process-memory loss.
+func ReconcileCanonicalV19HerdrSessionAcquire(ctx context.Context, homeDir, operationID string) (string, error) {
+	return reconcileCanonicalV19HerdrSessionAcquire(ctx, homeDir, operationID, canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrSessionClient {
+			return herdr.NewManagedSessionClient(sessionName)
+		},
+		now: time.Now,
+	})
+}
+
+func reconcileCanonicalV19HerdrSessionAcquire(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+	deps canonicalV19HerdrSessionAcquireDeps,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if operationID == "" {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: operation ID is empty")
+	}
+	if deps.clientFor == nil || deps.now == nil {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: adapter dependencies are incomplete")
+	}
+
+	current, err := readCanonicalV19HerdrSessionAcquireCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: %w", err)
+	}
+	request := current.Current.Request
+	switch current.Current.State {
+	case "succeeded", "rejected", "no-effect":
+		return current.Current.State, nil
+	case "prepared", "submitted", "uncertain":
+	default:
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: %w: operation %q is %q",
+			ErrCanonicalV19SessionTransition, operationID, current.Current.State)
+	}
+	if request.AdapterRef != canonicalV19HerdrSessionAdapterRef {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: %w: adapter %q is not %q",
+			ErrCanonicalV19SessionNotCurrent, request.AdapterRef, canonicalV19HerdrSessionAdapterRef)
+	}
+	if request.RequestedProviderSessionKey != "" {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider-assigned Session key must be empty before fresh acquisition")
+	}
+
+	sessionName := herdr.SessionName(current.FleetID)
+	client := deps.clientFor(sessionName)
+	if client == nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider client is unavailable")
+	}
+	observed := observeCanonicalV19HerdrSessionAcquire(ctx, current, "", client)
+	if current.Current.State != "prepared" {
+		return reconcileCanonicalV19SubmittedHerdrSessionAcquire(ctx, homeDir, current, observed, deps.now)
+	}
+
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+	case canonicalV19HerdrSessionMismatch:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider resource ownership is unresolved: %s", observed.Reason)
+	case canonicalV19HerdrSessionUnknown:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation is unknown: %s", observed.Reason)
+	default:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
+	}
+
+	submittedAt := canonicalV19HerdrSessionTimestampAfter(deps.now(), current.Current.StateChangedAt)
+	submitted, err := SubmitCanonicalV19SessionAcquire(ctx, homeDir, operationID, submittedAt, observed.EvidenceDigest)
+	if err != nil {
+		return "prepared", err
+	}
+	current.Current.Request = submitted
+	current.Current.State = "submitted"
+	current.Current.StateChangedAt = submittedAt
+
+	observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, "", client)
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+		return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now, nil)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
+	}
+
+	providerKey, performErr := performCanonicalV19HerdrSessionAcquire(current, client)
+	if providerKey != "" {
+		observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, providerKey, client)
+	} else {
+		observed = observeCanonicalV19HerdrSessionAcquire(ctx, current, "", client)
+	}
+	switch observed.State {
+	case canonicalV19HerdrSessionExact:
+		if providerKey == "" {
+			return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now,
+				errors.New("provider returned no exact Session key"))
+		}
+		return establishCanonicalV19ObservedHerdrSession(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrSessionAbsent:
+		return classifyCanonicalV19HerdrSessionAcquireNoEffect(ctx, homeDir, current, observed, deps.now,
+			canonicalV19HerdrSessionPerformFailure("positive observation proves no requested Session resource remains", performErr))
+	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+		return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
+	}
+}
+
+func reconcileCanonicalV19SubmittedHerdrSessionAcquire(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionAcquireCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+) (string, error) {
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+		return classifyCanonicalV19HerdrSessionAcquireNoEffect(ctx, homeDir, current, observed, now,
+			"positive provider observation proves the unresolved acquisition left no dedicated Session resource")
+	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+		if current.Current.State == "submitted" {
+			return classifyCanonicalV19HerdrSessionAcquireUncertain(ctx, homeDir, current, observed, now, nil)
+		}
+		return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: operation remains uncertain: %s", observed.Reason)
+	default:
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: provider observation state %q is invalid", observed.State)
+	}
+}
+
+func establishCanonicalV19ObservedHerdrSession(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionAcquireCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+) (string, error) {
+	establishedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := EstablishCanonicalV19SessionBinding(ctx, homeDir, CanonicalV19SessionBindingEvidence{
+		OperationID:        current.Current.Request.OperationID,
+		ProviderSessionKey: observed.ProviderSessionKey,
+		EstablishedAt:      establishedAt,
+		EvidenceDigest:     observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	return "succeeded", nil
+}
+
+func classifyCanonicalV19HerdrSessionAcquireNoEffect(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionAcquireCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+	reason string,
+) (string, error) {
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19SessionAcquire(ctx, homeDir, CanonicalV19SessionAcquireTransitionInput{
+		OperationID:    current.Current.Request.OperationID,
+		State:          "no-effect",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	if observed.Reason != "" {
+		reason += ": " + observed.Reason
+	}
+	return "no-effect", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: %s", reason)
+}
+
+func classifyCanonicalV19HerdrSessionAcquireUncertain(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionAcquireCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+	performErr error,
+) (string, error) {
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19SessionAcquire(ctx, homeDir, CanonicalV19SessionAcquireTransitionInput{
+		OperationID:    current.Current.Request.OperationID,
+		State:          "uncertain",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	reason := observed.Reason
+	if performErr != nil {
+		reason = canonicalV19HerdrSessionPerformFailure(reason, performErr)
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionAcquire: operation is uncertain: %s", reason)
+}
+
+func performCanonicalV19HerdrSessionAcquire(
+	current canonicalV19HerdrSessionAcquireCurrent,
+	client canonicalV19HerdrSessionClient,
+) (string, error) {
+	workspace, tab, pane, err := client.WorkspaceCreate(
+		current.WorktreePath,
+		nil,
+		canonicalV19HerdrSessionWorkspaceLabel(current.Current.Request.BindingID),
+	)
+	if err != nil {
+		return "", err
+	}
+	return encodeCanonicalV19HerdrSessionProviderKey(canonicalV19HerdrSessionProviderKey{
+		SessionName: herdr.SessionName(current.FleetID),
+		WorkspaceID: workspace.WorkspaceID,
+		TabID:       tab.TabID,
+		PaneID:      pane.PaneID,
+	})
+}
+
+func observeCanonicalV19HerdrSessionAcquire(
+	ctx context.Context,
+	current canonicalV19HerdrSessionAcquireCurrent,
+	providerKey string,
+	client canonicalV19HerdrSessionClient,
+) canonicalV19HerdrSessionObservation {
+	request := current.Current.Request
+	sessionName := herdr.SessionName(current.FleetID)
+	label := canonicalV19HerdrSessionWorkspaceLabel(request.BindingID)
+	session := client.ObserveSession(ctx)
+	if session.Name != sessionName || session.State != herdr.SessionRunningCompatible {
+		reason := fmt.Sprintf("exact Herdr session %q is %q", sessionName, session.State)
+		if session.Reason != "" {
+			reason += ": " + session.Reason
+		}
+		return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
+			State: canonicalV19HerdrSessionUnknown, Reason: reason,
+		})
+	}
+
+	workspaces, err := client.WorkspaceListContext(ctx)
+	if err != nil {
+		return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
+			State: canonicalV19HerdrSessionUnknown, Reason: "list exact Herdr session workspaces: " + canonicalV19HerdrSessionErrorText(err),
+		})
+	}
+	if providerKey == "" {
+		matches := 0
+		for _, workspace := range workspaces {
+			if workspace.Label == label {
+				matches++
+			}
+		}
+		if matches == 0 {
+			return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
+				State: canonicalV19HerdrSessionAbsent,
+			})
+		}
+		return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
+			State:        canonicalV19HerdrSessionMismatch,
+			LabelMatches: matches,
+			Reason:       "dedicated Session workspace locator already exists but provider-assigned tab/pane identity is not durably known",
+		})
+	}
+
+	key, err := parseCanonicalV19HerdrSessionProviderKey(providerKey)
+	if err != nil {
+		return finalizeCanonicalV19HerdrSessionObservation(current, canonicalV19HerdrSessionObservation{
+			State: canonicalV19HerdrSessionMismatch, ProviderSessionKey: providerKey,
+			Reason: "provider Session key is invalid: " + err.Error(),
+		})
+	}
+	observation := canonicalV19HerdrSessionObservation{
+		ProviderSessionKey: providerKey,
+		WorkspaceID:        key.WorkspaceID,
+		TabID:              key.TabID,
+		PaneID:             key.PaneID,
+	}
+	if key.SessionName != sessionName {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = fmt.Sprintf("provider Session key names Herdr session %q, want %q", key.SessionName, sessionName)
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+
+	var workspace herdr.Workspace
+	workspaceMatches := 0
+	for _, candidate := range workspaces {
+		if candidate.WorkspaceID == key.WorkspaceID {
+			workspace, workspaceMatches = candidate, workspaceMatches+1
+		}
+	}
+	if workspaceMatches == 0 {
+		pane, paneErr := client.PaneGetContext(ctx, key.PaneID)
+		if errors.Is(paneErr, herdr.ErrNotFound) {
+			observation.State = canonicalV19HerdrSessionAbsent
+			return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+		}
+		if paneErr != nil {
+			observation.State = canonicalV19HerdrSessionUnknown
+			observation.Reason = "workspace absent but exact pane could not be disproven: " + canonicalV19HerdrSessionErrorText(paneErr)
+			return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+		}
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.PaneCwd = pane.Cwd
+		observation.Reason = "exact pane remains live while its provider Session key workspace is absent from inventory"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if workspaceMatches != 1 {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "Herdr workspace inventory returned the exact workspace identity more than once"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if workspace.Label != label {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact workspace identity no longer carries the dedicated Session locator"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+
+	tabs, err := client.TabList(key.WorkspaceID)
+	if err != nil {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "list exact Herdr workspace tabs: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if len(tabs) != 1 {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = fmt.Sprintf("dedicated Session workspace has %d tabs, want exactly 1", len(tabs))
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if tabs[0].TabID != key.TabID || tabs[0].WorkspaceID != key.WorkspaceID {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "dedicated Session workspace root tab identity differs from the provider Session key"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+
+	pane, err := client.PaneGetContext(ctx, key.PaneID)
+	if errors.Is(err, herdr.ErrNotFound) {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "provider Session key workspace/tab remain but the exact root pane is absent"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if err != nil {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "observe exact Herdr root pane: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	observation.PaneCwd = pane.Cwd
+	if pane.PaneID != key.PaneID || pane.TabID != key.TabID || pane.WorkspaceID != key.WorkspaceID {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact root pane parent identities differ from the provider Session key"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if pane.Cwd == "" || !handgit.SamePath(pane.Cwd, current.WorktreePath) {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact root pane cwd differs from the immutable WorktreeBinding path"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	if pane.Agent != "" {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact Session pane already contains a provider-detected worker before canonical Launch"
+		return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+	}
+	observation.State = canonicalV19HerdrSessionExact
+	return finalizeCanonicalV19HerdrSessionObservation(current, observation)
+}
+
+func readCanonicalV19HerdrSessionAcquireCurrent(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+) (canonicalV19HerdrSessionAcquireCurrent, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return canonicalV19HerdrSessionAcquireCurrent{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19HerdrSessionAcquireCurrent{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	current, err := loadCanonicalV19SessionAcquireCurrent(ctx, tx, operationID)
+	if err != nil {
+		return canonicalV19HerdrSessionAcquireCurrent{}, err
+	}
+	result := canonicalV19HerdrSessionAcquireCurrent{Current: current}
+	if err := tx.QueryRowContext(ctx, `SELECT p.fleet_id,b.path
+		FROM project p
+		JOIN attempt_worktree_binding b ON b.id=? AND b.attempt_id=?
+		WHERE p.id=?`, current.Request.WorktreeBindingID, current.Request.AttemptID, current.Request.ProjectID).Scan(
+		&result.FleetID, &result.WorktreePath,
+	); err != nil {
+		return canonicalV19HerdrSessionAcquireCurrent{}, fmt.Errorf("read canonical v19 Herdr SessionAcquire provider context: %w", err)
+	}
+	if result.FleetID == "" || result.WorktreePath == "" {
+		return canonicalV19HerdrSessionAcquireCurrent{}, fmt.Errorf("read canonical v19 Herdr SessionAcquire provider context: Fleet ID or WorktreeBinding path is empty")
+	}
+	return result, nil
+}
+
+func canonicalV19HerdrSessionWorkspaceLabel(bindingID string) string {
+	digest := sha256.Sum256([]byte(bindingID))
+	return "hand:v19:session:" + hex.EncodeToString(digest[:])
+}
+
+func encodeCanonicalV19HerdrSessionProviderKey(key canonicalV19HerdrSessionProviderKey) (string, error) {
+	for name, value := range map[string]string{
+		"session": key.SessionName, "workspace": key.WorkspaceID, "tab": key.TabID, "pane": key.PaneID,
+	} {
+		if value == "" {
+			return "", fmt.Errorf("Herdr provider Session key %s is empty", name)
+		}
+	}
+	values := url.Values{}
+	values.Set("pane", key.PaneID)
+	values.Set("session", key.SessionName)
+	values.Set("tab", key.TabID)
+	values.Set("workspace", key.WorkspaceID)
+	return "herdr:v1?" + values.Encode(), nil
+}
+
+func parseCanonicalV19HerdrSessionProviderKey(value string) (canonicalV19HerdrSessionProviderKey, error) {
+	const prefix = "herdr:v1?"
+	if !strings.HasPrefix(value, prefix) {
+		return canonicalV19HerdrSessionProviderKey{}, fmt.Errorf("missing %q prefix", prefix)
+	}
+	values, err := url.ParseQuery(strings.TrimPrefix(value, prefix))
+	if err != nil {
+		return canonicalV19HerdrSessionProviderKey{}, fmt.Errorf("parse query: %w", err)
+	}
+	if len(values) != 4 {
+		return canonicalV19HerdrSessionProviderKey{}, fmt.Errorf("want exactly session/workspace/tab/pane fields")
+	}
+	one := func(name string) (string, error) {
+		items := values[name]
+		if len(items) != 1 || items[0] == "" {
+			return "", fmt.Errorf("field %q must occur exactly once and be non-empty", name)
+		}
+		return items[0], nil
+	}
+	var key canonicalV19HerdrSessionProviderKey
+	if key.SessionName, err = one("session"); err != nil {
+		return canonicalV19HerdrSessionProviderKey{}, err
+	}
+	if key.WorkspaceID, err = one("workspace"); err != nil {
+		return canonicalV19HerdrSessionProviderKey{}, err
+	}
+	if key.TabID, err = one("tab"); err != nil {
+		return canonicalV19HerdrSessionProviderKey{}, err
+	}
+	if key.PaneID, err = one("pane"); err != nil {
+		return canonicalV19HerdrSessionProviderKey{}, err
+	}
+	return key, nil
+}
+
+func finalizeCanonicalV19HerdrSessionObservation(
+	current canonicalV19HerdrSessionAcquireCurrent,
+	observed canonicalV19HerdrSessionObservation,
+) canonicalV19HerdrSessionObservation {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:herdr-session-acquire-observation:v1")
+	writeCanonicalV19DigestField(hash, "operation_id", current.Current.Request.OperationID)
+	writeCanonicalV19DigestField(hash, "request_digest", current.Current.Request.RequestDigest)
+	writeCanonicalV19DigestField(hash, "fleet_id", current.FleetID)
+	writeCanonicalV19DigestField(hash, "worktree_path", current.WorktreePath)
+	writeCanonicalV19DigestField(hash, "workspace_label", canonicalV19HerdrSessionWorkspaceLabel(current.Current.Request.BindingID))
+	writeCanonicalV19DigestField(hash, "state", string(observed.State))
+	writeCanonicalV19DigestField(hash, "provider_session_key", observed.ProviderSessionKey)
+	writeCanonicalV19DigestField(hash, "workspace_id", observed.WorkspaceID)
+	writeCanonicalV19DigestField(hash, "tab_id", observed.TabID)
+	writeCanonicalV19DigestField(hash, "pane_id", observed.PaneID)
+	writeCanonicalV19DigestField(hash, "pane_cwd", observed.PaneCwd)
+	writeCanonicalV19DigestField(hash, "label_matches", fmt.Sprintf("%d", observed.LabelMatches))
+	writeCanonicalV19DigestField(hash, "reason", observed.Reason)
+	observed.EvidenceDigest = hex.EncodeToString(hash.Sum(nil))
+	return observed
+}
+
+func canonicalV19HerdrSessionTimestampAfter(now time.Time, previous string) string {
+	candidate := now.UTC()
+	if prior, err := time.Parse(time.RFC3339Nano, previous); err == nil && !candidate.After(prior) {
+		candidate = prior.Add(time.Nanosecond)
+	}
+	return candidate.Format(time.RFC3339Nano)
+}
+
+func canonicalV19HerdrSessionPerformFailure(prefix string, err error) string {
+	if err == nil {
+		return prefix
+	}
+	failure := "Herdr Session acquisition failed: " + canonicalV19HerdrSessionErrorText(err)
+	if prefix == "" {
+		return failure
+	}
+	return prefix + "; " + failure
+}
+
+func canonicalV19HerdrSessionErrorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	text := strings.Join(strings.Fields(err.Error()), " ")
+	if len(text) > 240 {
+		text = text[:240]
+	}
+	return text
+}

--- a/internal/store/v19session_herdr.go
+++ b/internal/store/v19session_herdr.go
@@ -63,11 +63,9 @@ type canonicalV19HerdrSessionAcquireDeps struct {
 	now       func() time.Time
 }
 
-// ReconcileCanonicalV19HerdrSessionAcquire reconciles one exact canonical v19
-// SessionAcquire against Herdr. Herdr assigns workspace/tab/pane identities, so
-// fresh acquisition requires an empty RequestedProviderSessionKey. Once an
-// unresolved mutation loses those provider-assigned identities, recovery is
-// observation-only and never adopts a workspace from its locator label.
+// ReconcileCanonicalV19HerdrSessionAcquire reconciles one exact canonical v19 SessionAcquire against Herdr.
+// Fresh acquisition requires an empty RequestedProviderSessionKey because Herdr assigns provider identities.
+// Recovery never blindly retries or adopts a workspace from its locator label after those identities are lost.
 func ReconcileCanonicalV19HerdrSessionAcquire(ctx context.Context, homeDir, operationID string) (string, error) {
 	return reconcileCanonicalV19HerdrSessionAcquire(ctx, homeDir, operationID, canonicalV19HerdrSessionAcquireDeps{
 		clientFor: func(sessionName string) canonicalV19HerdrSessionClient {

--- a/internal/store/v19session_herdr_test.go
+++ b/internal/store/v19session_herdr_test.go
@@ -1,0 +1,294 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+func TestReconcileCanonicalV19HerdrSessionAcquireEstablishesExactBinding(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-success")
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrSessionClient {
+			if sessionName != "hand-fleet-1" {
+				t.Fatalf("Herdr session = %q, want hand-fleet-1", sessionName)
+			}
+			client.sessionName = sessionName
+			return client
+		},
+		now: func() time.Time { return time.Date(2026, 9, 6, 17, 0, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("reconcile Herdr SessionAcquire = %q, %v", state, err)
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("workspace create calls = %d, want 1", client.createCalls)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var operationState, providerKey string
+	if err := db.sql.QueryRow(`SELECT o.state,s.provider_session_key
+		FROM external_operation o JOIN session_binding s ON s.acquire_operation_id=o.id
+		WHERE o.id=?`, request.OperationID).Scan(&operationState, &providerKey); err != nil {
+		t.Fatal(err)
+	}
+	if operationState != "succeeded" {
+		t.Fatalf("operation state = %q, want succeeded", operationState)
+	}
+	key, err := parseCanonicalV19HerdrSessionProviderKey(providerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.SessionName != "hand-fleet-1" || key.WorkspaceID != "w-session" || key.TabID != "w-session:t1" || key.PaneID != "w-session:p1" {
+		t.Fatalf("provider Session key = %#v", key)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionAcquireSubmitsBeforeFirstMutation(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-boundary")
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	client.requireSubmittedAtCreate = true
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 1, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("reconcile Herdr SessionAcquire boundary = %q, %v", state, err)
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("workspace create calls = %d, want 1", client.createCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionAcquireLostResponseBecomesUncertain(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-lost-response")
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	client.createErr = errors.New("provider response lost after workspace creation")
+	client.mutateOnCreateError = true
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 2, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("lost response reconcile = %q, %v, want uncertain error", state, err)
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("workspace create calls = %d, want 1", client.createCalls)
+	}
+
+	state, err = reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("uncertain recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("workspace create calls after recovery = %d, want no blind retry", client.createCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19HerdrSessionAcquireDoesNotBlindRetryResidualWorkspace(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-submitted")
+	if _, err := SubmitCanonicalV19SessionAcquire(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T16:59:00Z", "submitted-before-crash"); err != nil {
+		t.Fatal(err)
+	}
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	client.addCreatedWorkspace(canonicalV19HerdrSessionWorkspaceLabel(request.BindingID), request.WorktreeBindingID)
+	client.createCalls = 0
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 3, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("submitted residual recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.createCalls != 0 {
+		t.Fatalf("workspace create calls = %d, want 0", client.createCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionAcquirePositiveAbsenceIsNoEffect(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-no-effect")
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	client.createErr = errors.New("provider rejected workspace create")
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 4, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("no-effect reconcile = %q, %v, want no-effect diagnostic", state, err)
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("workspace create calls = %d, want 1", client.createCalls)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var bindings int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM session_binding WHERE acquire_operation_id=?`, request.OperationID).Scan(&bindings); err != nil {
+		t.Fatal(err)
+	}
+	if bindings != 0 {
+		t.Fatalf("SessionBinding rows = %d, want 0", bindings)
+	}
+}
+
+func TestCanonicalV19HerdrSessionProviderKeyRoundTripsEscapedIDs(t *testing.T) {
+	want := canonicalV19HerdrSessionProviderKey{
+		SessionName: "hand-fleet:one", WorkspaceID: "w/a", TabID: "w/a:t 1", PaneID: "w/a:p?1",
+	}
+	encoded, err := encodeCanonicalV19HerdrSessionProviderKey(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseCanonicalV19HerdrSessionProviderKey(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("provider key round trip = %#v, want %#v", got, want)
+	}
+}
+
+func canonicalV19HerdrSessionAcquireFixture(
+	t *testing.T,
+	operationID string,
+) (canonicalV19WorktreeCreateTestFixture, CanonicalV19SessionAcquireRequest) {
+	t.Helper()
+	base := canonicalV19AttemptWriterFixture(t)
+	attempt := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	attempt.SessionAdapterRef = canonicalV19HerdrSessionAdapterRef
+	if _, err := CreateCanonicalV19Attempt(context.Background(), base.Home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	fixture := canonicalV19WorktreeCreateTestFixture{Home: base.Home}
+	createInput := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-create", "binding-1")
+	worktree, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EstablishCanonicalV19WorktreeBinding(context.Background(), fixture.Home,
+		canonicalV19WorktreeBindingEvidence(worktree, "worktree-physical-herdr")); err != nil {
+		t.Fatal(err)
+	}
+	input := canonicalV19SessionAcquirePrepareInput(worktree, operationID, "session-binding-1")
+	request, err := PrepareCanonicalV19SessionAcquire(context.Background(), fixture.Home, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixture, request
+}
+
+type canonicalV19HerdrSessionAcquireFakeClient struct {
+	t                        *testing.T
+	home                     string
+	operationID              string
+	sessionName              string
+	workspaces               []herdr.Workspace
+	tabs                     map[string][]herdr.Tab
+	panes                    map[string]herdr.Pane
+	createCalls              int
+	createErr                error
+	mutateOnCreateError      bool
+	requireSubmittedAtCreate bool
+}
+
+func newCanonicalV19HerdrSessionAcquireFakeClient(
+	t *testing.T,
+	home string,
+	operationID string,
+) *canonicalV19HerdrSessionAcquireFakeClient {
+	t.Helper()
+	return &canonicalV19HerdrSessionAcquireFakeClient{
+		t: t, home: home, operationID: operationID, sessionName: "hand-fleet-1",
+		tabs: make(map[string][]herdr.Tab), panes: make(map[string]herdr.Pane),
+	}
+}
+
+func (f *canonicalV19HerdrSessionAcquireFakeClient) ObserveSession(context.Context) herdr.SessionObservation {
+	return herdr.SessionObservation{Name: f.sessionName, State: herdr.SessionRunningCompatible}
+}
+
+func (f *canonicalV19HerdrSessionAcquireFakeClient) WorkspaceListContext(context.Context) ([]herdr.Workspace, error) {
+	return append([]herdr.Workspace(nil), f.workspaces...), nil
+}
+
+func (f *canonicalV19HerdrSessionAcquireFakeClient) WorkspaceCreate(
+	cwd string,
+	_ map[string]string,
+	label string,
+) (herdr.Workspace, herdr.Tab, herdr.Pane, error) {
+	f.createCalls++
+	if f.requireSubmittedAtCreate {
+		db, err := openReadOnly(f.home)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		var state string
+		if err := db.sql.QueryRow(`SELECT state FROM external_operation WHERE id=?`, f.operationID).Scan(&state); err != nil {
+			_ = db.Close()
+			f.t.Fatal(err)
+		}
+		_ = db.Close()
+		if state != "submitted" {
+			f.t.Fatalf("state at first provider mutation = %q, want submitted", state)
+		}
+	}
+	if f.createErr != nil {
+		if f.mutateOnCreateError {
+			f.addCreatedWorkspace(label, cwd)
+		}
+		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, f.createErr
+	}
+	return f.addCreatedWorkspace(label, cwd)
+}
+
+func (f *canonicalV19HerdrSessionAcquireFakeClient) addCreatedWorkspace(
+	label string,
+	cwd string,
+) (herdr.Workspace, herdr.Tab, herdr.Pane) {
+	workspace := herdr.Workspace{WorkspaceID: "w-session", Label: label, TabCount: 1}
+	tab := herdr.Tab{TabID: "w-session:t1", WorkspaceID: workspace.WorkspaceID, Label: "1"}
+	pane := herdr.Pane{PaneID: "w-session:p1", TabID: tab.TabID, WorkspaceID: workspace.WorkspaceID, Cwd: cwd}
+	f.workspaces = []herdr.Workspace{workspace}
+	f.tabs[workspace.WorkspaceID] = []herdr.Tab{tab}
+	f.panes[pane.PaneID] = pane
+	return workspace, tab, pane
+}
+
+func (f *canonicalV19HerdrSessionAcquireFakeClient) TabList(workspaceID string) ([]herdr.Tab, error) {
+	tabs, ok := f.tabs[workspaceID]
+	if !ok {
+		return nil, fmt.Errorf("%w: workspace %s", herdr.ErrNotFound, workspaceID)
+	}
+	return append([]herdr.Tab(nil), tabs...), nil
+}
+
+func (f *canonicalV19HerdrSessionAcquireFakeClient) PaneGetContext(_ context.Context, paneID string) (herdr.Pane, error) {
+	pane, ok := f.panes[paneID]
+	if !ok {
+		return herdr.Pane{}, fmt.Errorf("%w: pane %s", herdr.ErrNotFound, paneID)
+	}
+	return pane, nil
+}

--- a/internal/store/v19session_herdr_test.go
+++ b/internal/store/v19session_herdr_test.go
@@ -221,7 +221,7 @@ func canonicalV19HerdrSessionAcquireFixture(
 	if _, err := CreateCanonicalV19Attempt(context.Background(), base.Home, attempt); err != nil {
 		t.Fatal(err)
 	}
-	fixture := canonicalV19WorktreeCreateTestFixture{Home: base.Home}
+	fixture := canonicalV19WorktreeCreateTestFixture(base)
 	createInput := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-create", "binding-1")
 	worktree, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, createInput)
 	if err != nil {

--- a/internal/store/v19session_herdr_test.go
+++ b/internal/store/v19session_herdr_test.go
@@ -107,7 +107,7 @@ func TestReconcileSubmittedCanonicalV19HerdrSessionAcquireDoesNotBlindRetryResid
 		t.Fatal(err)
 	}
 	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
-	client.addCreatedWorkspace(canonicalV19HerdrSessionWorkspaceLabel(request.BindingID), request.WorktreeBindingID)
+	client.addCreatedWorkspace(canonicalV19HerdrSessionWorkspaceLabel(request.BindingID), "unobserved-cwd")
 	client.createCalls = 0
 	deps := canonicalV19HerdrSessionAcquireDeps{
 		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
@@ -123,18 +123,57 @@ func TestReconcileSubmittedCanonicalV19HerdrSessionAcquireDoesNotBlindRetryResid
 	}
 }
 
-func TestReconcileCanonicalV19HerdrSessionAcquirePositiveAbsenceIsNoEffect(t *testing.T) {
-	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-no-effect")
+func TestReconcileSubmittedCanonicalV19HerdrSessionAcquireLocatorAbsenceRemainsUncertain(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-submitted-absent")
+	if _, err := SubmitCanonicalV19SessionAcquire(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-06T16:59:00Z", "submitted-before-crash"); err != nil {
+		t.Fatal(err)
+	}
 	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
-	client.createErr = errors.New("provider rejected workspace create")
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 3, 30, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("submitted absent-locator recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.createCalls != 0 {
+		t.Fatalf("workspace create calls = %d, want 0", client.createCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionAcquireAmbiguousStartedFailureRemainsUncertain(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-started-failure")
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	client.createErr = errors.New("started Herdr command failed without classifiable provider evidence")
 	deps := canonicalV19HerdrSessionAcquireDeps{
 		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
 		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 4, 0, 0, time.UTC) },
 	}
 
 	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("ambiguous started failure = %q, %v, want uncertain error", state, err)
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("workspace create calls = %d, want 1", client.createCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionAcquireProcessNotStartedIsNoEffect(t *testing.T) {
+	fixture, request := canonicalV19HerdrSessionAcquireFixture(t, "operation-herdr-session-no-effect")
+	client := newCanonicalV19HerdrSessionAcquireFakeClient(t, fixture.Home, request.OperationID)
+	client.createErr = &herdr.ExecError{Started: false, Err: errors.New("Herdr executable could not start")}
+	deps := canonicalV19HerdrSessionAcquireDeps{
+		clientFor: func(string) canonicalV19HerdrSessionClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 6, 17, 5, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionAcquire(context.Background(), fixture.Home, request.OperationID, deps)
 	if state != "no-effect" || err == nil {
-		t.Fatalf("no-effect reconcile = %q, %v, want no-effect diagnostic", state, err)
+		t.Fatalf("process-not-started reconcile = %q, %v, want no-effect diagnostic", state, err)
 	}
 	if client.createCalls != 1 {
 		t.Fatalf("workspace create calls = %d, want 1", client.createCalls)
@@ -261,7 +300,8 @@ func (f *canonicalV19HerdrSessionAcquireFakeClient) WorkspaceCreate(
 		}
 		return herdr.Workspace{}, herdr.Tab{}, herdr.Pane{}, f.createErr
 	}
-	return f.addCreatedWorkspace(label, cwd)
+	workspace, tab, pane := f.addCreatedWorkspace(label, cwd)
+	return workspace, tab, pane, nil
 }
 
 func (f *canonicalV19HerdrSessionAcquireFakeClient) addCreatedWorkspace(


### PR DESCRIPTION
Implements the next bounded #339 Step 10 provider-mechanics slice: canonical v19 Herdr SessionAcquire only.

- use one dedicated Herdr workspace per SessionBinding; workspace/tab/pane remain opaque provider topology, not canonical schema ontology
- encode the exact named Herdr session + provider-assigned workspace/tab/pane IDs in one versioned `provider_session_key`
- positively re-observe exact workspace/tab/pane parentage, dedicated locator, WorktreeBinding cwd, and pre-Launch empty-agent state before establishing SessionBinding
- durably commit `submitted` before the first `workspace create` mutation
- never adopt a provider resource from label alone
- never blind-retry submitted/uncertain acquisition after provider-assigned IDs are lost
- keep ambiguous started failures and crash recovery `uncertain`; classify `no-effect` only from exact known-key absence or positive process-not-started evidence with absent pre/post locator
- require the Fleet-scoped named Herdr session to already be running-compatible; daemon lifecycle remains separate

SessionRelease, Launch/Interrupt provider mechanics, WorkerInput/Wake, and ordinary runtime cutover remain follow-up slices.

#344 DDL impact: **NONE**.