### PR TITLE
feat(store): reconcile Herdr SessionRelease

### DIFF
--- a/internal/store/v19session_herdr_release.go
+++ b/internal/store/v19session_herdr_release.go
@@ -1,0 +1,459 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	handgit "github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+type canonicalV19HerdrSessionReleaseCurrent struct {
+	Current      canonicalV19SessionReleaseCurrent
+	FleetID      string
+	WorktreePath string
+}
+
+type canonicalV19HerdrSessionReleaseClient interface {
+	ObserveSession(context.Context) herdr.SessionObservation
+	WorkspaceListContext(context.Context) ([]herdr.Workspace, error)
+	WorkspaceClose(string) error
+	TabList(string) ([]herdr.Tab, error)
+	PaneGetContext(context.Context, string) (herdr.Pane, error)
+}
+
+type canonicalV19HerdrSessionReleaseDeps struct {
+	clientFor func(string) canonicalV19HerdrSessionReleaseClient
+	now       func() time.Time
+}
+
+// ReconcileCanonicalV19HerdrSessionRelease reconciles one exact canonical v19 SessionRelease against Herdr.
+// It durably submits before workspace close and never blindly retries a submitted or uncertain provider mutation.
+// Success requires positive absence of the exact persisted workspace/pane addressability.
+func ReconcileCanonicalV19HerdrSessionRelease(ctx context.Context, homeDir, operationID string) (string, error) {
+	return reconcileCanonicalV19HerdrSessionRelease(ctx, homeDir, operationID, canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrSessionReleaseClient {
+			return herdr.NewManagedSessionClient(sessionName)
+		},
+		now: time.Now,
+	})
+}
+
+func reconcileCanonicalV19HerdrSessionRelease(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+	deps canonicalV19HerdrSessionReleaseDeps,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if operationID == "" {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: operation ID is empty")
+	}
+	if deps.clientFor == nil || deps.now == nil {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: adapter dependencies are incomplete")
+	}
+
+	current, err := readCanonicalV19HerdrSessionReleaseCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		if errors.Is(err, ErrCanonicalV19SessionNotCurrent) {
+			if state, found, terminalErr := readCanonicalV19HerdrSessionReleaseTerminal(ctx, homeDir, operationID); terminalErr != nil {
+				return "", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %w", terminalErr)
+			} else if found {
+				return state, nil
+			}
+		}
+		return "", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %w", err)
+	}
+	request := current.Current.Request
+	switch current.Current.State {
+	case "succeeded", "rejected", "no-effect":
+		return current.Current.State, nil
+	case "prepared", "submitted", "uncertain":
+	default:
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %w: operation %q is %q",
+			ErrCanonicalV19SessionTransition, operationID, current.Current.State)
+	}
+	if request.AdapterRef != canonicalV19HerdrSessionAdapterRef {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %w: adapter %q is not %q",
+			ErrCanonicalV19SessionNotCurrent, request.AdapterRef, canonicalV19HerdrSessionAdapterRef)
+	}
+	key, err := parseCanonicalV19HerdrSessionProviderKey(request.ExpectedProviderSessionKey)
+	if err != nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %w: invalid provider Session key: %v",
+			ErrCanonicalV19SessionNotCurrent, err)
+	}
+	expectedSession := herdr.SessionName(current.FleetID)
+	if key.SessionName != expectedSession {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %w: provider Session key names %q, want %q",
+			ErrCanonicalV19SessionNotCurrent, key.SessionName, expectedSession)
+	}
+	client := deps.clientFor(expectedSession)
+	if client == nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: provider client is unavailable")
+	}
+
+	observed := observeCanonicalV19HerdrSessionRelease(ctx, current, client)
+	if current.Current.State != "prepared" {
+		return reconcileCanonicalV19SubmittedHerdrSessionRelease(ctx, homeDir, current, observed, deps.now)
+	}
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+		return completeCanonicalV19ObservedHerdrSessionRelease(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrSessionExact:
+	case canonicalV19HerdrSessionMismatch:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: exact provider ownership is unresolved: %s", observed.Reason)
+	case canonicalV19HerdrSessionUnknown:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: provider observation is unknown: %s", observed.Reason)
+	default:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: provider observation state %q is invalid", observed.State)
+	}
+
+	submittedAt := canonicalV19HerdrSessionTimestampAfter(deps.now(), current.Current.StateChangedAt)
+	submitted, err := SubmitCanonicalV19SessionRelease(ctx, homeDir, operationID, submittedAt, observed.EvidenceDigest)
+	if err != nil {
+		return "prepared", err
+	}
+	current.Current.Request = submitted
+	current.Current.State = "submitted"
+	current.Current.StateChangedAt = submittedAt
+
+	observed = observeCanonicalV19HerdrSessionRelease(ctx, current, client)
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+		return completeCanonicalV19ObservedHerdrSessionRelease(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrSessionExact:
+	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+		return classifyCanonicalV19HerdrSessionReleaseUncertain(ctx, homeDir, current, observed, deps.now, nil)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: provider observation state %q is invalid", observed.State)
+	}
+
+	performErr := client.WorkspaceClose(key.WorkspaceID)
+	observed = observeCanonicalV19HerdrSessionRelease(ctx, current, client)
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+		return completeCanonicalV19ObservedHerdrSessionRelease(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrSessionExact:
+		if performErr != nil && herdr.IsProcessNotStarted(performErr) {
+			return classifyCanonicalV19HerdrSessionReleaseNoEffect(ctx, homeDir, current, observed, deps.now,
+				"Herdr process did not start and exact provider Session addressability remains unchanged")
+		}
+		return classifyCanonicalV19HerdrSessionReleaseUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	case canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+		return classifyCanonicalV19HerdrSessionReleaseUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: provider observation state %q is invalid", observed.State)
+	}
+}
+
+func reconcileCanonicalV19SubmittedHerdrSessionRelease(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionReleaseCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+) (string, error) {
+	switch observed.State {
+	case canonicalV19HerdrSessionAbsent:
+		return completeCanonicalV19ObservedHerdrSessionRelease(ctx, homeDir, current, observed, now)
+	case canonicalV19HerdrSessionExact, canonicalV19HerdrSessionMismatch, canonicalV19HerdrSessionUnknown:
+		if observed.Reason == "" {
+			observed.Reason = "submitted SessionRelease cannot be replayed without positive absence evidence"
+		} else {
+			observed.Reason += "; submitted SessionRelease cannot be replayed without positive absence evidence"
+		}
+		observed = finalizeCanonicalV19HerdrSessionReleaseObservation(current, observed)
+		if current.Current.State == "submitted" {
+			return classifyCanonicalV19HerdrSessionReleaseUncertain(ctx, homeDir, current, observed, now, nil)
+		}
+		return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: operation remains uncertain: %s", observed.Reason)
+	default:
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: provider observation state %q is invalid", observed.State)
+	}
+}
+
+func completeCanonicalV19ObservedHerdrSessionRelease(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionReleaseCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+) (string, error) {
+	releasedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := CompleteCanonicalV19SessionRelease(ctx, homeDir, CanonicalV19SessionReleasedEvidence{
+		OperationID:    current.Current.Request.OperationID,
+		ReleasedAt:     releasedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	return "succeeded", nil
+}
+
+func classifyCanonicalV19HerdrSessionReleaseNoEffect(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionReleaseCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+	reason string,
+) (string, error) {
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19SessionRelease(ctx, homeDir, CanonicalV19SessionReleaseTransitionInput{
+		OperationID:    current.Current.Request.OperationID,
+		State:          "no-effect",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	if observed.Reason != "" {
+		reason += ": " + observed.Reason
+	}
+	return "no-effect", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: %s", reason)
+}
+
+func classifyCanonicalV19HerdrSessionReleaseUncertain(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrSessionReleaseCurrent,
+	observed canonicalV19HerdrSessionObservation,
+	now func() time.Time,
+	performErr error,
+) (string, error) {
+	if current.Current.State == "uncertain" {
+		return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: operation remains uncertain: %s", observed.Reason)
+	}
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19SessionRelease(ctx, homeDir, CanonicalV19SessionReleaseTransitionInput{
+		OperationID:    current.Current.Request.OperationID,
+		State:          "uncertain",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	reason := observed.Reason
+	if performErr != nil {
+		reason = canonicalV19HerdrSessionReleasePerformFailure(reason, performErr)
+	}
+	if reason == "" {
+		reason = "strongest provider evidence cannot classify the submitted release"
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr SessionRelease: operation is uncertain: %s", reason)
+}
+
+func observeCanonicalV19HerdrSessionRelease(
+	ctx context.Context,
+	current canonicalV19HerdrSessionReleaseCurrent,
+	client canonicalV19HerdrSessionReleaseClient,
+) canonicalV19HerdrSessionObservation {
+	request := current.Current.Request
+	providerKey := request.ExpectedProviderSessionKey
+	key, err := parseCanonicalV19HerdrSessionProviderKey(providerKey)
+	if err != nil {
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, canonicalV19HerdrSessionObservation{
+			State: canonicalV19HerdrSessionMismatch, ProviderSessionKey: providerKey,
+			Reason: "provider Session key is invalid: " + err.Error(),
+		})
+	}
+	expectedSession := herdr.SessionName(current.FleetID)
+	observation := canonicalV19HerdrSessionObservation{
+		ProviderSessionKey: providerKey,
+		WorkspaceID:        key.WorkspaceID,
+		TabID:              key.TabID,
+		PaneID:             key.PaneID,
+	}
+	if key.SessionName != expectedSession {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = fmt.Sprintf("provider Session key names Herdr session %q, want %q", key.SessionName, expectedSession)
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	session := client.ObserveSession(ctx)
+	if session.Name != expectedSession || session.State != herdr.SessionRunningCompatible {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = fmt.Sprintf("exact Herdr session %q is %q", expectedSession, session.State)
+		if session.Reason != "" {
+			observation.Reason += ": " + session.Reason
+		}
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+
+	workspaces, err := client.WorkspaceListContext(ctx)
+	if err != nil {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "list exact Herdr session workspaces: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	var workspace herdr.Workspace
+	workspaceMatches := 0
+	for _, candidate := range workspaces {
+		if candidate.WorkspaceID == key.WorkspaceID {
+			workspace = candidate
+			workspaceMatches++
+		}
+	}
+	if workspaceMatches == 0 {
+		pane, paneErr := client.PaneGetContext(ctx, key.PaneID)
+		if errors.Is(paneErr, herdr.ErrNotFound) {
+			observation.State = canonicalV19HerdrSessionAbsent
+			return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+		}
+		if paneErr != nil {
+			observation.State = canonicalV19HerdrSessionUnknown
+			observation.Reason = "workspace absent but exact pane could not be disproven: " + canonicalV19HerdrSessionErrorText(paneErr)
+			return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+		}
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.PaneCwd = pane.Cwd
+		observation.Reason = "exact pane remains live while its provider Session key workspace is absent from inventory"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	if workspaceMatches != 1 {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "Herdr workspace inventory returned the exact workspace identity more than once"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	if workspace.Label != canonicalV19HerdrSessionWorkspaceLabel(request.SessionBindingID) {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact workspace identity no longer carries the dedicated Session locator"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+
+	tabs, err := client.TabList(key.WorkspaceID)
+	if err != nil {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "list exact Herdr workspace tabs: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	if len(tabs) != 1 {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = fmt.Sprintf("dedicated Session workspace has %d tabs, want exactly 1", len(tabs))
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	if tabs[0].TabID != key.TabID || tabs[0].WorkspaceID != key.WorkspaceID {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "dedicated Session workspace root tab identity differs from the provider Session key"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+
+	pane, err := client.PaneGetContext(ctx, key.PaneID)
+	if errors.Is(err, herdr.ErrNotFound) {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "provider Session key workspace/tab remain but the exact root pane is absent"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	if err != nil {
+		observation.State = canonicalV19HerdrSessionUnknown
+		observation.Reason = "observe exact Herdr root pane: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	observation.PaneCwd = pane.Cwd
+	if pane.PaneID != key.PaneID || pane.TabID != key.TabID || pane.WorkspaceID != key.WorkspaceID {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact root pane parent identities differ from the provider Session key"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	if pane.Cwd == "" || !handgit.SamePath(pane.Cwd, current.WorktreePath) {
+		observation.State = canonicalV19HerdrSessionMismatch
+		observation.Reason = "exact root pane cwd differs from the immutable WorktreeBinding path"
+		return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+	}
+	observation.State = canonicalV19HerdrSessionExact
+	return finalizeCanonicalV19HerdrSessionReleaseObservation(current, observation)
+}
+
+func readCanonicalV19HerdrSessionReleaseCurrent(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+) (canonicalV19HerdrSessionReleaseCurrent, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return canonicalV19HerdrSessionReleaseCurrent{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19HerdrSessionReleaseCurrent{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	current, err := loadCanonicalV19SessionReleaseCurrent(ctx, tx, operationID)
+	if err != nil {
+		return canonicalV19HerdrSessionReleaseCurrent{}, err
+	}
+	result := canonicalV19HerdrSessionReleaseCurrent{Current: current}
+	if err := tx.QueryRowContext(ctx, `SELECT p.fleet_id,b.path
+		FROM project p
+		JOIN attempt_worktree_binding b ON b.id=? AND b.attempt_id=?
+		WHERE p.id=?`, current.Request.WorktreeBindingID, current.Request.AttemptID, current.Request.ProjectID).Scan(
+		&result.FleetID, &result.WorktreePath,
+	); err != nil {
+		return canonicalV19HerdrSessionReleaseCurrent{}, fmt.Errorf("read canonical v19 Herdr SessionRelease provider context: %w", err)
+	}
+	if result.FleetID == "" || result.WorktreePath == "" {
+		return canonicalV19HerdrSessionReleaseCurrent{}, fmt.Errorf("read canonical v19 Herdr SessionRelease provider context: Fleet ID or WorktreeBinding path is empty")
+	}
+	return result, nil
+}
+
+func readCanonicalV19HerdrSessionReleaseTerminal(ctx context.Context, homeDir, operationID string) (string, bool, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = db.Close() }()
+	var state string
+	err = db.sql.QueryRowContext(ctx, `SELECT o.state
+		FROM external_operation o
+		JOIN session_release_operation sr ON sr.operation_id=o.id
+		JOIN session_binding_release r ON r.release_operation_id=o.id AND r.session_binding_id=sr.session_binding_id
+		WHERE o.id=? AND o.kind='session-release' AND o.state='succeeded'`, operationID).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return state, true, nil
+}
+
+func finalizeCanonicalV19HerdrSessionReleaseObservation(
+	current canonicalV19HerdrSessionReleaseCurrent,
+	observed canonicalV19HerdrSessionObservation,
+) canonicalV19HerdrSessionObservation {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:herdr-session-release-observation:v1")
+	writeCanonicalV19DigestField(hash, "operation_id", current.Current.Request.OperationID)
+	writeCanonicalV19DigestField(hash, "request_digest", current.Current.Request.RequestDigest)
+	writeCanonicalV19DigestField(hash, "fleet_id", current.FleetID)
+	writeCanonicalV19DigestField(hash, "worktree_path", current.WorktreePath)
+	writeCanonicalV19DigestField(hash, "workspace_label", canonicalV19HerdrSessionWorkspaceLabel(current.Current.Request.SessionBindingID))
+	writeCanonicalV19DigestField(hash, "state", string(observed.State))
+	writeCanonicalV19DigestField(hash, "provider_session_key", observed.ProviderSessionKey)
+	writeCanonicalV19DigestField(hash, "workspace_id", observed.WorkspaceID)
+	writeCanonicalV19DigestField(hash, "tab_id", observed.TabID)
+	writeCanonicalV19DigestField(hash, "pane_id", observed.PaneID)
+	writeCanonicalV19DigestField(hash, "pane_cwd", observed.PaneCwd)
+	writeCanonicalV19DigestField(hash, "reason", observed.Reason)
+	observed.EvidenceDigest = hex.EncodeToString(hash.Sum(nil))
+	return observed
+}
+
+func canonicalV19HerdrSessionReleasePerformFailure(prefix string, err error) string {
+	if err == nil {
+		return prefix
+	}
+	failure := "Herdr Session release failed: " + canonicalV19HerdrSessionErrorText(err)
+	if prefix == "" {
+		return failure
+	}
+	return prefix + "; " + failure
+}

--- a/internal/store/v19session_herdr_release_test.go
+++ b/internal/store/v19session_herdr_release_test.go
@@ -1,0 +1,385 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+func TestReconcileCanonicalV19HerdrSessionReleaseSucceedsAndReruns(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-success")
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	client.panes[key.PaneID] = herdr.Pane{
+		PaneID: key.PaneID, TabID: key.TabID, WorkspaceID: key.WorkspaceID,
+		Cwd: client.worktreePath, Agent: "codex", AgentStatus: "done",
+	}
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrSessionReleaseClient {
+			if sessionName != key.SessionName {
+				t.Fatalf("Herdr session = %q, want %q", sessionName, key.SessionName)
+			}
+			return client
+		},
+		now: func() time.Time { return time.Date(2026, 9, 8, 1, 10, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("reconcile Herdr SessionRelease = %q, %v", state, err)
+	}
+	if client.closeCalls != 1 {
+		t.Fatalf("workspace close calls = %d, want 1", client.closeCalls)
+	}
+	canonicalV19HerdrSessionReleaseAssertSucceeded(t, fixture.Home, request)
+
+	state, err = reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("terminal rerun = %q, %v", state, err)
+	}
+	if client.closeCalls != 1 {
+		t.Fatalf("workspace close calls after terminal rerun = %d, want 1", client.closeCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionReleaseSubmitsBeforeFirstMutation(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-boundary")
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	client.requireSubmittedAtClose = true
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(string) canonicalV19HerdrSessionReleaseClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 1, 11, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("reconcile Herdr SessionRelease boundary = %q, %v", state, err)
+	}
+	if client.closeCalls != 1 {
+		t.Fatalf("workspace close calls = %d, want 1", client.closeCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19HerdrSessionReleaseDoesNotBlindRetry(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-submitted")
+	if _, err := SubmitCanonicalV19SessionRelease(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-08T01:05:00Z", "session-release-submitted-before-crash"); err != nil {
+		t.Fatal(err)
+	}
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(string) canonicalV19HerdrSessionReleaseClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 1, 12, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("submitted recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.closeCalls != 0 {
+		t.Fatalf("workspace close calls = %d, want 0", client.closeCalls)
+	}
+	state, err = reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("uncertain recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.closeCalls != 0 {
+		t.Fatalf("workspace close calls after uncertain recovery = %d, want 0", client.closeCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrSessionReleaseLostResponseAfterCloseSucceeds(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-lost-response")
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	client.closeErr = errors.New("provider response lost after workspace close")
+	client.mutateOnCloseError = true
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(string) canonicalV19HerdrSessionReleaseClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 1, 13, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("lost-response release = %q, %v", state, err)
+	}
+	if client.closeCalls != 1 {
+		t.Fatalf("workspace close calls = %d, want 1", client.closeCalls)
+	}
+	canonicalV19HerdrSessionReleaseAssertSucceeded(t, fixture.Home, request)
+}
+
+func TestReconcileCanonicalV19HerdrSessionReleaseProcessNotStartedIsNoEffect(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-no-effect")
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	client.closeErr = &herdr.ExecError{Started: false, Err: errors.New("herdr executable did not start")}
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(string) canonicalV19HerdrSessionReleaseClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 1, 14, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("process-not-started release = %q, %v, want no-effect diagnostic", state, err)
+	}
+	if client.closeCalls != 1 {
+		t.Fatalf("workspace close calls = %d, want 1", client.closeCalls)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var releases int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM session_binding_release WHERE session_binding_id=?`, request.SessionBindingID).Scan(&releases); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if releases != 0 {
+		t.Fatalf("SessionBinding release rows = %d, want 0", releases)
+	}
+
+	replacement := CanonicalV19SessionReleasePrepareInput{
+		OperationID: "operation-herdr-session-release-replacement", OperationKey: "operation-key-herdr-session-release-replacement",
+		SessionBindingID: request.SessionBindingID, CreatedAt: "2026-09-08T01:15:00Z",
+	}
+	if _, err := PrepareCanonicalV19SessionRelease(context.Background(), fixture.Home, replacement); err != nil {
+		t.Fatalf("replacement release after no-effect: %v", err)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19HerdrSessionReleaseRefusesProviderMismatch(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-mismatch")
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	pane := client.panes[key.PaneID]
+	pane.Cwd = t.TempDir()
+	client.panes[key.PaneID] = pane
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(string) canonicalV19HerdrSessionReleaseClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 1, 16, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "prepared" || err == nil {
+		t.Fatalf("provider mismatch release = %q, %v, want prepared error", state, err)
+	}
+	if client.closeCalls != 0 {
+		t.Fatalf("workspace close calls = %d, want 0", client.closeCalls)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19HerdrSessionReleasePositiveAbsenceSucceeds(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrSessionReleaseFixture(t, "operation-herdr-session-release-absent")
+	client := newCanonicalV19HerdrSessionReleaseFakeClient(t, fixture.Home, request.OperationID, request.SessionBindingID, key)
+	client.removeWorkspace(key)
+	deps := canonicalV19HerdrSessionReleaseDeps{
+		clientFor: func(string) canonicalV19HerdrSessionReleaseClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 1, 17, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrSessionRelease(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("positive-absence release = %q, %v", state, err)
+	}
+	if client.closeCalls != 0 {
+		t.Fatalf("workspace close calls = %d, want 0", client.closeCalls)
+	}
+	canonicalV19HerdrSessionReleaseAssertSucceeded(t, fixture.Home, request)
+}
+
+func canonicalV19HerdrSessionReleaseFixture(
+	t *testing.T,
+	releaseOperationID string,
+) (canonicalV19WorktreeCreateTestFixture, CanonicalV19SessionReleaseRequest, canonicalV19HerdrSessionProviderKey) {
+	t.Helper()
+	base := canonicalV19AttemptWriterFixture(t)
+	attempt := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	attempt.SessionAdapterRef = canonicalV19HerdrSessionAdapterRef
+	if _, err := CreateCanonicalV19Attempt(context.Background(), base.Home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	fixture := canonicalV19WorktreeCreateTestFixture(base)
+	createInput := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-create", "binding-1")
+	worktree, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EstablishCanonicalV19WorktreeBinding(context.Background(), fixture.Home,
+		canonicalV19WorktreeBindingEvidence(worktree, "worktree-physical-herdr-release")); err != nil {
+		t.Fatal(err)
+	}
+	key := canonicalV19HerdrSessionProviderKey{
+		SessionName: herdr.SessionName("fleet-1"),
+		WorkspaceID: "w-session-release", TabID: "w-session-release:t1", PaneID: "w-session-release:p1",
+	}
+	providerKey, err := encodeCanonicalV19HerdrSessionProviderKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acquireInput := canonicalV19SessionAcquirePrepareInput(worktree, "operation-session-acquire-release-fixture", "session-binding-1")
+	acquireInput.RequestedProviderSessionKey = providerKey
+	acquire, err := PrepareCanonicalV19SessionAcquire(context.Background(), fixture.Home, acquireInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EstablishCanonicalV19SessionBinding(context.Background(), fixture.Home, CanonicalV19SessionBindingEvidence{
+		OperationID: acquire.OperationID, ProviderSessionKey: providerKey,
+		EstablishedAt: "2026-09-08T01:00:00Z", EvidenceDigest: "session-binding-herdr-release-fixture",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	release, err := PrepareCanonicalV19SessionRelease(context.Background(), fixture.Home, CanonicalV19SessionReleasePrepareInput{
+		OperationID: releaseOperationID, OperationKey: "operation-key-" + releaseOperationID,
+		SessionBindingID: acquire.BindingID, CreatedAt: "2026-09-08T01:01:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixture, release, key
+}
+
+type canonicalV19HerdrSessionReleaseFakeClient struct {
+	t                        *testing.T
+	home                     string
+	operationID              string
+	sessionName              string
+	sessionBindingID         string
+	worktreePath             string
+	workspaces               []herdr.Workspace
+	tabs                     map[string][]herdr.Tab
+	panes                    map[string]herdr.Pane
+	closeCalls               int
+	closeErr                 error
+	mutateOnCloseError       bool
+	requireSubmittedAtClose bool
+}
+
+func newCanonicalV19HerdrSessionReleaseFakeClient(
+	t *testing.T,
+	home string,
+	operationID string,
+	sessionBindingID string,
+	key canonicalV19HerdrSessionProviderKey,
+) *canonicalV19HerdrSessionReleaseFakeClient {
+	t.Helper()
+	client := &canonicalV19HerdrSessionReleaseFakeClient{
+		t: t, home: home, operationID: operationID, sessionName: key.SessionName,
+		sessionBindingID: sessionBindingID, tabs: make(map[string][]herdr.Tab), panes: make(map[string]herdr.Pane),
+	}
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT b.path FROM session_binding s JOIN attempt_worktree_binding b ON b.id=s.worktree_binding_id WHERE s.id=?`,
+		sessionBindingID).Scan(&client.worktreePath); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	workspace := herdr.Workspace{WorkspaceID: key.WorkspaceID, Label: canonicalV19HerdrSessionWorkspaceLabel(sessionBindingID), TabCount: 1}
+	tab := herdr.Tab{TabID: key.TabID, WorkspaceID: key.WorkspaceID, Label: "1"}
+	pane := herdr.Pane{PaneID: key.PaneID, TabID: key.TabID, WorkspaceID: key.WorkspaceID, Cwd: client.worktreePath}
+	client.workspaces = []herdr.Workspace{workspace}
+	client.tabs[key.WorkspaceID] = []herdr.Tab{tab}
+	client.panes[key.PaneID] = pane
+	return client
+}
+
+func (f *canonicalV19HerdrSessionReleaseFakeClient) ObserveSession(context.Context) herdr.SessionObservation {
+	return herdr.SessionObservation{Name: f.sessionName, State: herdr.SessionRunningCompatible}
+}
+
+func (f *canonicalV19HerdrSessionReleaseFakeClient) WorkspaceListContext(context.Context) ([]herdr.Workspace, error) {
+	return append([]herdr.Workspace(nil), f.workspaces...), nil
+}
+
+func (f *canonicalV19HerdrSessionReleaseFakeClient) WorkspaceClose(workspaceID string) error {
+	f.closeCalls++
+	if f.requireSubmittedAtClose {
+		db, err := openReadOnly(f.home)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		var state string
+		if err := db.sql.QueryRow(`SELECT state FROM external_operation WHERE id=?`, f.operationID).Scan(&state); err != nil {
+			_ = db.Close()
+			f.t.Fatal(err)
+		}
+		_ = db.Close()
+		if state != "submitted" {
+			f.t.Fatalf("state at first provider mutation = %q, want submitted", state)
+		}
+	}
+	key := canonicalV19HerdrSessionProviderKey{WorkspaceID: workspaceID}
+	for _, workspace := range f.workspaces {
+		if workspace.WorkspaceID == workspaceID {
+			key.TabID = f.tabs[workspaceID][0].TabID
+			for paneID, pane := range f.panes {
+				if pane.WorkspaceID == workspaceID {
+					key.PaneID = paneID
+					break
+				}
+			}
+			break
+		}
+	}
+	if f.closeErr != nil {
+		if f.mutateOnCloseError {
+			f.removeWorkspace(key)
+		}
+		return f.closeErr
+	}
+	f.removeWorkspace(key)
+	return nil
+}
+
+func (f *canonicalV19HerdrSessionReleaseFakeClient) TabList(workspaceID string) ([]herdr.Tab, error) {
+	tabs, ok := f.tabs[workspaceID]
+	if !ok {
+		return nil, fmt.Errorf("%w: workspace %s", herdr.ErrNotFound, workspaceID)
+	}
+	return append([]herdr.Tab(nil), tabs...), nil
+}
+
+func (f *canonicalV19HerdrSessionReleaseFakeClient) PaneGetContext(_ context.Context, paneID string) (herdr.Pane, error) {
+	pane, ok := f.panes[paneID]
+	if !ok {
+		return herdr.Pane{}, fmt.Errorf("%w: pane %s", herdr.ErrNotFound, paneID)
+	}
+	return pane, nil
+}
+
+func (f *canonicalV19HerdrSessionReleaseFakeClient) removeWorkspace(key canonicalV19HerdrSessionProviderKey) {
+	kept := f.workspaces[:0]
+	for _, workspace := range f.workspaces {
+		if workspace.WorkspaceID != key.WorkspaceID {
+			kept = append(kept, workspace)
+		}
+	}
+	f.workspaces = kept
+	delete(f.tabs, key.WorkspaceID)
+	if key.PaneID != "" {
+		delete(f.panes, key.PaneID)
+	}
+}
+
+func canonicalV19HerdrSessionReleaseAssertSucceeded(t *testing.T, home string, request CanonicalV19SessionReleaseRequest) {
+	t.Helper()
+	db, err := openReadOnly(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var state, releaseOperationID string
+	if err := db.sql.QueryRow(`SELECT o.state,r.release_operation_id
+		FROM external_operation o JOIN session_binding_release r ON r.release_operation_id=o.id
+		WHERE r.session_binding_id=?`, request.SessionBindingID).Scan(&state, &releaseOperationID); err != nil {
+		t.Fatal(err)
+	}
+	if state != "succeeded" || releaseOperationID != request.OperationID {
+		t.Fatalf("SessionRelease terminal state = %q/%q, want succeeded/%q", state, releaseOperationID, request.OperationID)
+	}
+}

--- a/internal/store/v19session_herdr_release_test.go
+++ b/internal/store/v19session_herdr_release_test.go
@@ -242,18 +242,18 @@ func canonicalV19HerdrSessionReleaseFixture(
 }
 
 type canonicalV19HerdrSessionReleaseFakeClient struct {
-	t                        *testing.T
-	home                     string
-	operationID              string
-	sessionName              string
-	sessionBindingID         string
-	worktreePath             string
-	workspaces               []herdr.Workspace
-	tabs                     map[string][]herdr.Tab
-	panes                    map[string]herdr.Pane
-	closeCalls               int
-	closeErr                 error
-	mutateOnCloseError       bool
+	t                       *testing.T
+	home                    string
+	operationID             string
+	sessionName             string
+	sessionBindingID        string
+	worktreePath            string
+	workspaces              []herdr.Workspace
+	tabs                    map[string][]herdr.Tab
+	panes                   map[string]herdr.Pane
+	closeCalls              int
+	closeErr                error
+	mutateOnCloseError      bool
 	requireSubmittedAtClose bool
 }
 


### PR DESCRIPTION
Implements the next bounded #339 Step 10 provider-mechanics slice: canonical v19 Herdr SessionRelease only.

- target only the exact persisted Herdr session/workspace/tab/pane provider key established by SessionAcquire
- positively re-observe exact workspace identity, dedicated SessionBinding locator, root tab/pane parentage, and immutable WorktreeBinding cwd before destruction
- rely on canonical no-open-ExecutorBinding gating rather than mutable provider process state
- durably commit `submitted` before the first `workspace close` mutation
- prepared positive absence completes directly without provider mutation
- crash/lost-response after a completed close converges from positive exact absence
- submitted/uncertain recovery is observation-only and never blindly retries a close
- classify `no-effect` only when the Herdr process is positively known not to have started and exact provider addressability remains unchanged
- preserve terminal rerun stability after the immutable SessionBinding release row makes the current-loader intentionally stop matching

Launch/ExecutorBinding/Interrupt provider mechanics and ordinary runtime cutover remain follow-up slices.

#344 DDL impact: **NONE**.