### PR TITLE
feat(store): reconcile Herdr Launch

### DIFF
--- a/internal/herdr/exact_launch.go
+++ b/internal/herdr/exact_launch.go
@@ -12,22 +12,22 @@ import (
 // PaneRunExactSpec starts one exact structured process in the pane. Unlike the
 // transitional PaneRunSpec path, it applies the LaunchSpec cwd and environment
 // explicitly so a long-lived Herdr daemon or pane shell cannot supply semantic
-// child environment implicitly.
+// child environment implicitly. Errors before pane run are marked process-not-started.
 func (c *Client) PaneRunExactSpec(paneID string, spec launch.LaunchSpec) error {
 	if err := spec.Validate(); err != nil {
-		return fmt.Errorf("validate exact launch spec: %w", err)
+		return &ExecError{Started: false, Err: fmt.Errorf("validate exact launch spec: %w", err)}
 	}
 	info, err := c.PaneProcessInfo(paneID)
 	if err != nil {
-		return fmt.Errorf("observe pane shell: %w", err)
+		return &ExecError{Started: false, Err: fmt.Errorf("observe pane shell: %w", err)}
 	}
 	shell, err := shellForProcess(info)
 	if err != nil {
-		return err
+		return &ExecError{Started: false, Err: err}
 	}
 	command, err := renderExactLaunchSpec(shell, spec)
 	if err != nil {
-		return fmt.Errorf("render exact launch for %s: %w", shell, err)
+		return &ExecError{Started: false, Err: fmt.Errorf("render exact launch for %s: %w", shell, err)}
 	}
 	return c.paneRun(paneID, command)
 }

--- a/internal/herdr/exact_launch.go
+++ b/internal/herdr/exact_launch.go
@@ -9,10 +9,9 @@ import (
 	"github.com/atqamz/hand/internal/shellquote"
 )
 
-// PaneRunExactSpec starts one exact structured process in the pane. Unlike the
-// transitional PaneRunSpec path, it applies the LaunchSpec cwd and environment
-// explicitly so a long-lived Herdr daemon or pane shell cannot supply semantic
-// child environment implicitly. Errors before pane run are marked process-not-started.
+// PaneRunExactSpec starts one exact structured process with explicit LaunchSpec cwd and environment.
+// Unlike transitional PaneRunSpec, it does not inherit semantic child settings from daemon/pane state.
+// Errors before pane run are marked process-not-started.
 func (c *Client) PaneRunExactSpec(paneID string, spec launch.LaunchSpec) error {
 	if err := spec.Validate(); err != nil {
 		return &ExecError{Started: false, Err: fmt.Errorf("validate exact launch spec: %w", err)}

--- a/internal/herdr/exact_launch.go
+++ b/internal/herdr/exact_launch.go
@@ -1,0 +1,110 @@
+package herdr
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/atqamz/hand/internal/launch"
+	"github.com/atqamz/hand/internal/shellquote"
+)
+
+// PaneRunExactSpec starts one exact structured process in the pane. Unlike the
+// transitional PaneRunSpec path, it applies the LaunchSpec cwd and environment
+// explicitly so a long-lived Herdr daemon or pane shell cannot supply semantic
+// child environment implicitly.
+func (c *Client) PaneRunExactSpec(paneID string, spec launch.LaunchSpec) error {
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("validate exact launch spec: %w", err)
+	}
+	info, err := c.PaneProcessInfo(paneID)
+	if err != nil {
+		return fmt.Errorf("observe pane shell: %w", err)
+	}
+	shell, err := shellForProcess(info)
+	if err != nil {
+		return err
+	}
+	command, err := renderExactLaunchSpec(shell, spec)
+	if err != nil {
+		return fmt.Errorf("render exact launch for %s: %w", shell, err)
+	}
+	return c.paneRun(paneID, command)
+}
+
+func renderExactLaunchSpec(shell shellFamily, spec launch.LaunchSpec) (string, error) {
+	if err := spec.Validate(); err != nil {
+		return "", err
+	}
+	switch shell {
+	case shellPOSIX:
+		return renderExactPOSIXLaunchSpec(spec)
+	case shellPowerShell:
+		return renderExactPowerShellLaunchSpec(spec)
+	default:
+		return "", fmt.Errorf("unsupported shell %q", shell)
+	}
+}
+
+func renderExactPOSIXLaunchSpec(spec launch.LaunchSpec) (string, error) {
+	command, err := renderPOSIX(spec.Executable, spec.Args)
+	if err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(spec.Env)+1)
+	for _, name := range sortedLaunchEnvironmentNames(spec.Env) {
+		parts = append(parts, name+"="+shellquote.Quote(spec.Env[name]))
+	}
+	parts = append(parts, command)
+	return "cd -- " + shellquote.Quote(spec.Cwd) + " && " + joinShellParts(parts), nil
+}
+
+func renderExactPowerShellLaunchSpec(spec launch.LaunchSpec) (string, error) {
+	command, err := renderPowerShell(spec.Executable, spec.Args)
+	if err != nil {
+		return "", err
+	}
+	names := sortedLaunchEnvironmentNames(spec.Env)
+	var b strings.Builder
+	b.WriteString("& { $handOldLocation = Get-Location; $handOldEnv = @{}; try { ")
+	for _, name := range names {
+		quotedName := powerShellQuote(name)
+		b.WriteString("$handOldEnv[")
+		b.WriteString(quotedName)
+		b.WriteString("] = [Environment]::GetEnvironmentVariable(")
+		b.WriteString(quotedName)
+		b.WriteString(", 'Process'); [Environment]::SetEnvironmentVariable(")
+		b.WriteString(quotedName)
+		b.WriteString(", ")
+		b.WriteString(powerShellQuote(spec.Env[name]))
+		b.WriteString(", 'Process'); ")
+	}
+	b.WriteString("Set-Location -LiteralPath ")
+	b.WriteString(powerShellQuote(spec.Cwd))
+	b.WriteString("; ")
+	b.WriteString(command)
+	b.WriteString(" } finally { Set-Location -LiteralPath $handOldLocation.Path; ")
+	for _, name := range names {
+		quotedName := powerShellQuote(name)
+		b.WriteString("if ($null -eq $handOldEnv[")
+		b.WriteString(quotedName)
+		b.WriteString("]) { [Environment]::SetEnvironmentVariable(")
+		b.WriteString(quotedName)
+		b.WriteString(", $null, 'Process') } else { [Environment]::SetEnvironmentVariable(")
+		b.WriteString(quotedName)
+		b.WriteString(", $handOldEnv[")
+		b.WriteString(quotedName)
+		b.WriteString("], 'Process') }; ")
+	}
+	b.WriteString("} }")
+	return b.String(), nil
+}
+
+func sortedLaunchEnvironmentNames(environment map[string]string) []string {
+	names := make([]string, 0, len(environment))
+	for name := range environment {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/herdr/exact_launch_test.go
+++ b/internal/herdr/exact_launch_test.go
@@ -1,0 +1,62 @@
+package herdr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/launch"
+)
+
+func TestRenderExactPOSIXLaunchSpecAppliesCwdAndSortedEnvironment(t *testing.T) {
+	spec := launch.LaunchSpec{
+		Executable: "worker name",
+		Args:       []string{"arg with spaces"},
+		Env:        map[string]string{"Z_LAST": "z value", "A_FIRST": "$literal;value"},
+		Cwd:        "/tmp/work tree",
+	}
+	got, err := renderExactLaunchSpec(shellPOSIX, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `cd -- '/tmp/work tree' && A_FIRST='$literal;value' Z_LAST='z value' 'worker name' 'arg with spaces'`
+	if got != want {
+		t.Fatalf("render exact POSIX = %q, want %q", got, want)
+	}
+}
+
+func TestRenderExactPowerShellLaunchSpecScopesCwdAndEnvironment(t *testing.T) {
+	spec := launch.LaunchSpec{
+		Executable: "worker name",
+		Args:       []string{"arg with 'quote'"},
+		Env:        map[string]string{"TOKEN": "value'with;syntax"},
+		Cwd:        `C:\\work tree`,
+	}
+	got, err := renderExactLaunchSpec(shellPowerShell, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`[Environment]::GetEnvironmentVariable('TOKEN', 'Process')`,
+		`[Environment]::SetEnvironmentVariable('TOKEN', 'value''with;syntax', 'Process')`,
+		`Set-Location -LiteralPath 'C:\\work tree'`,
+		`& 'worker name' 'arg with ''quote'''`,
+		`[Environment]::SetEnvironmentVariable('TOKEN', $null, 'Process')`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("render exact PowerShell = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestRenderExactLaunchSpecRejectsInvalidTransportData(t *testing.T) {
+	for _, spec := range []launch.LaunchSpec{
+		{Executable: "", Cwd: "/tmp"},
+		{Executable: "worker", Cwd: "/tmp\nother"},
+		{Executable: "worker", Cwd: "/tmp", Env: map[string]string{"BAD-NAME": "value"}},
+		{Executable: "worker", Cwd: "/tmp", Env: map[string]string{"TOKEN": "value\x00"}},
+	} {
+		if _, err := renderExactLaunchSpec(shellPOSIX, spec); err == nil {
+			t.Fatalf("invalid spec unexpectedly rendered: %#v", spec)
+		}
+	}
+}

--- a/internal/store/v19launch_herdr.go
+++ b/internal/store/v19launch_herdr.go
@@ -317,9 +317,9 @@ func canonicalV19HerdrLiteralLaunchSpec(spec CanonicalV19LaunchSpec) (launch.Lau
 		case "literal":
 			provider.Env[name] = value.ValueMaterial
 		case "secret-ref":
-			return launch.LaunchSpec{}, fmt.Errorf("Launch environment %q uses unresolved secret-ref %q; no canonical v19 secret resolver is available", name, value.ValueMaterial)
+			return launch.LaunchSpec{}, fmt.Errorf("launch environment %q uses unresolved secret-ref %q; no canonical v19 secret resolver is available", name, value.ValueMaterial)
 		default:
-			return launch.LaunchSpec{}, fmt.Errorf("Launch environment %q has unsupported value kind %q", name, value.ValueKind)
+			return launch.LaunchSpec{}, fmt.Errorf("launch environment %q has unsupported value kind %q", name, value.ValueKind)
 		}
 	}
 	validated, err := launch.NewSpec(provider)

--- a/internal/store/v19launch_herdr.go
+++ b/internal/store/v19launch_herdr.go
@@ -28,12 +28,12 @@ const (
 )
 
 type canonicalV19HerdrExecutorProviderKey struct {
-	SessionName  string
-	WorkspaceID  string
-	TabID        string
-	PaneID       string
-	ProcessGroup int
-	ProcessID    int
+	SessionName   string
+	WorkspaceID   string
+	TabID         string
+	PaneID        string
+	ProcessGroup  int
+	ProcessID     int
 	ProcessDigest string
 }
 

--- a/internal/store/v19launch_herdr.go
+++ b/internal/store/v19launch_herdr.go
@@ -1,0 +1,685 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	handgit "github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/launch"
+)
+
+type canonicalV19HerdrLaunchObservationState string
+
+const (
+	canonicalV19HerdrLaunchReady    canonicalV19HerdrLaunchObservationState = "ready"
+	canonicalV19HerdrLaunchRunning  canonicalV19HerdrLaunchObservationState = "running"
+	canonicalV19HerdrLaunchMismatch canonicalV19HerdrLaunchObservationState = "mismatch"
+	canonicalV19HerdrLaunchUnknown  canonicalV19HerdrLaunchObservationState = "unknown"
+)
+
+type canonicalV19HerdrExecutorProviderKey struct {
+	SessionName  string
+	WorkspaceID  string
+	TabID        string
+	PaneID       string
+	ProcessGroup int
+	ProcessID    int
+	ProcessDigest string
+}
+
+type canonicalV19HerdrLaunchObservation struct {
+	State               canonicalV19HerdrLaunchObservationState
+	ProviderExecutorKey string
+	WorkspaceID         string
+	TabID               string
+	PaneID              string
+	PaneCwd             string
+	ShellPID            int
+	ProcessGroupID      int
+	ProcessID           int
+	ProcessDigest       string
+	EvidenceDigest      string
+	Reason              string
+}
+
+type canonicalV19HerdrLaunchCurrent struct {
+	Current            canonicalV19LaunchCurrent
+	FleetID            string
+	WorktreePath       string
+	ProviderSessionKey string
+}
+
+type canonicalV19HerdrLaunchClient interface {
+	ObserveSession(context.Context) herdr.SessionObservation
+	WorkspaceListContext(context.Context) ([]herdr.Workspace, error)
+	TabList(string) ([]herdr.Tab, error)
+	PaneGetContext(context.Context, string) (herdr.Pane, error)
+	PaneProcessInfo(string) (herdr.ProcessInfo, error)
+	PaneRunExactSpec(string, launch.LaunchSpec) error
+}
+
+type canonicalV19HerdrLaunchDeps struct {
+	clientFor func(string) canonicalV19HerdrLaunchClient
+	now       func() time.Time
+}
+
+// ReconcileCanonicalV19HerdrLaunch reconciles one exact canonical v19 Launch against Herdr.
+// It commits submitted immediately before pane-run mutation, establishes an ExecutorBinding only
+// from exact process identity/argv/cwd evidence, and never blindly relaunches submitted/uncertain work.
+func ReconcileCanonicalV19HerdrLaunch(ctx context.Context, homeDir, operationID string) (string, error) {
+	return reconcileCanonicalV19HerdrLaunch(ctx, homeDir, operationID, canonicalV19HerdrLaunchDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrLaunchClient {
+			return herdr.NewManagedSessionClient(sessionName)
+		},
+		now: time.Now,
+	})
+}
+
+func reconcileCanonicalV19HerdrLaunch(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+	deps canonicalV19HerdrLaunchDeps,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if operationID == "" {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr Launch: operation ID is empty")
+	}
+	if deps.clientFor == nil || deps.now == nil {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr Launch: adapter dependencies are incomplete")
+	}
+
+	current, err := readCanonicalV19HerdrLaunchCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		if errors.Is(err, ErrCanonicalV19LaunchNotCurrent) {
+			if state, found, terminalErr := readCanonicalV19HerdrLaunchTerminal(ctx, homeDir, operationID); terminalErr != nil {
+				return "", fmt.Errorf("reconcile canonical v19 Herdr Launch: %w", terminalErr)
+			} else if found {
+				return state, nil
+			}
+		}
+		return "", fmt.Errorf("reconcile canonical v19 Herdr Launch: %w", err)
+	}
+	request := current.Current.Request
+	switch current.Current.State {
+	case "succeeded", "rejected", "no-effect":
+		return current.Current.State, nil
+	case "prepared", "submitted", "uncertain":
+	default:
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr Launch: %w: operation %q is %q",
+			ErrCanonicalV19LaunchTransition, operationID, current.Current.State)
+	}
+	if request.AdapterRef != canonicalV19HerdrSessionAdapterRef {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr Launch: %w: adapter %q is not %q",
+			ErrCanonicalV19LaunchNotCurrent, request.AdapterRef, canonicalV19HerdrSessionAdapterRef)
+	}
+	key, err := parseCanonicalV19HerdrSessionProviderKey(current.ProviderSessionKey)
+	if err != nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr Launch: %w: invalid provider Session key: %v",
+			ErrCanonicalV19LaunchNotCurrent, err)
+	}
+	expectedSession := herdr.SessionName(current.FleetID)
+	if key.SessionName != expectedSession {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr Launch: %w: provider Session key names %q, want %q",
+			ErrCanonicalV19LaunchNotCurrent, key.SessionName, expectedSession)
+	}
+
+	providerSpec, specErr := canonicalV19HerdrLiteralLaunchSpec(request.Spec)
+	if specErr != nil && current.Current.State == "prepared" {
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr Launch: %w", specErr)
+	}
+	client := deps.clientFor(expectedSession)
+	if client == nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr Launch: provider client is unavailable")
+	}
+	observed := observeCanonicalV19HerdrLaunch(ctx, current, client)
+	if current.Current.State != "prepared" {
+		if specErr != nil {
+			observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason, specErr.Error())
+			observed = finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+		}
+		return reconcileCanonicalV19SubmittedHerdrLaunch(ctx, homeDir, current, observed, deps.now, specErr == nil)
+	}
+
+	switch observed.State {
+	case canonicalV19HerdrLaunchReady:
+	case canonicalV19HerdrLaunchRunning:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr Launch: exact target process already exists before submission")
+	case canonicalV19HerdrLaunchMismatch:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr Launch: provider ownership is unresolved: %s", observed.Reason)
+	case canonicalV19HerdrLaunchUnknown:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr Launch: provider observation is unknown: %s", observed.Reason)
+	default:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr Launch: provider observation state %q is invalid", observed.State)
+	}
+
+	submittedAt := canonicalV19HerdrSessionTimestampAfter(deps.now(), current.Current.StateChangedAt)
+	submitted, err := SubmitCanonicalV19Launch(ctx, homeDir, operationID, submittedAt, observed.EvidenceDigest)
+	if err != nil {
+		return "prepared", err
+	}
+	current.Current.Request = submitted
+	current.Current.State = "submitted"
+	current.Current.StateChangedAt = submittedAt
+
+	observed = observeCanonicalV19HerdrLaunch(ctx, current, client)
+	switch observed.State {
+	case canonicalV19HerdrLaunchRunning:
+		return establishCanonicalV19ObservedHerdrExecutor(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrLaunchReady:
+	case canonicalV19HerdrLaunchMismatch, canonicalV19HerdrLaunchUnknown:
+		return classifyCanonicalV19HerdrLaunchUncertain(ctx, homeDir, current, observed, deps.now, nil)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr Launch: provider observation state %q is invalid", observed.State)
+	}
+
+	performErr := client.PaneRunExactSpec(key.PaneID, providerSpec)
+	observed = observeCanonicalV19HerdrLaunch(ctx, current, client)
+	switch observed.State {
+	case canonicalV19HerdrLaunchRunning:
+		return establishCanonicalV19ObservedHerdrExecutor(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrLaunchReady:
+		if performErr != nil && herdr.IsProcessNotStarted(performErr) {
+			return classifyCanonicalV19HerdrLaunchNoEffect(ctx, homeDir, current, observed, deps.now,
+				"Herdr launch mutation did not start and the exact Session pane remains at its pre-launch shell state")
+		}
+		return classifyCanonicalV19HerdrLaunchUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	case canonicalV19HerdrLaunchMismatch, canonicalV19HerdrLaunchUnknown:
+		return classifyCanonicalV19HerdrLaunchUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr Launch: provider observation state %q is invalid", observed.State)
+	}
+}
+
+func reconcileCanonicalV19SubmittedHerdrLaunch(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrLaunchCurrent,
+	observed canonicalV19HerdrLaunchObservation,
+	now func() time.Time,
+	environmentResolved bool,
+) (string, error) {
+	if observed.State == canonicalV19HerdrLaunchRunning && environmentResolved {
+		return establishCanonicalV19ObservedHerdrExecutor(ctx, homeDir, current, observed, now)
+	}
+	if observed.Reason == "" {
+		observed.Reason = "submitted Launch cannot be replayed without positive exact ExecutorBinding evidence"
+	} else {
+		observed.Reason += "; submitted Launch cannot be replayed without positive exact ExecutorBinding evidence"
+	}
+	observed = finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	if current.Current.State == "submitted" {
+		return classifyCanonicalV19HerdrLaunchUncertain(ctx, homeDir, current, observed, now, nil)
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr Launch: operation remains uncertain: %s", observed.Reason)
+}
+
+func establishCanonicalV19ObservedHerdrExecutor(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrLaunchCurrent,
+	observed canonicalV19HerdrLaunchObservation,
+	now func() time.Time,
+) (string, error) {
+	if observed.ProviderExecutorKey == "" {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr Launch: exact process observation lacks provider Executor key")
+	}
+	establishedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := EstablishCanonicalV19ExecutorBinding(ctx, homeDir, CanonicalV19ExecutorBindingEvidence{
+		OperationID:         current.Current.Request.OperationID,
+		ProviderExecutorKey: observed.ProviderExecutorKey,
+		EstablishedAt:       establishedAt,
+		EvidenceDigest:      observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	return "succeeded", nil
+}
+
+func classifyCanonicalV19HerdrLaunchNoEffect(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrLaunchCurrent,
+	observed canonicalV19HerdrLaunchObservation,
+	now func() time.Time,
+	reason string,
+) (string, error) {
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19Launch(ctx, homeDir, CanonicalV19LaunchTransitionInput{
+		OperationID:    current.Current.Request.OperationID,
+		State:          "no-effect",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	if observed.Reason != "" {
+		reason += ": " + observed.Reason
+	}
+	return "no-effect", fmt.Errorf("reconcile canonical v19 Herdr Launch: %s", reason)
+}
+
+func classifyCanonicalV19HerdrLaunchUncertain(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrLaunchCurrent,
+	observed canonicalV19HerdrLaunchObservation,
+	now func() time.Time,
+	performErr error,
+) (string, error) {
+	if current.Current.State == "uncertain" {
+		reason := observed.Reason
+		if reason == "" {
+			reason = "strongest provider evidence still cannot classify the Launch"
+		}
+		return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr Launch: operation remains uncertain: %s", reason)
+	}
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19Launch(ctx, homeDir, CanonicalV19LaunchTransitionInput{
+		OperationID:    current.Current.Request.OperationID,
+		State:          "uncertain",
+		ObservedAt:     observedAt,
+		EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	reason := observed.Reason
+	if performErr != nil {
+		reason = canonicalV19HerdrLaunchJoinReason(reason, "Herdr exact Launch failed: "+canonicalV19HerdrSessionErrorText(performErr))
+	}
+	if reason == "" {
+		reason = "strongest provider evidence cannot classify the submitted Launch"
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr Launch: operation is uncertain: %s", reason)
+}
+
+func canonicalV19HerdrLiteralLaunchSpec(spec CanonicalV19LaunchSpec) (launch.LaunchSpec, error) {
+	provider := launch.LaunchSpec{
+		Executable: spec.Executable,
+		Args:       append([]string(nil), spec.Arguments...),
+		Env:        make(map[string]string, len(spec.Environment)),
+		Cwd:        spec.Cwd,
+	}
+	for name, value := range spec.Environment {
+		switch value.ValueKind {
+		case "literal":
+			provider.Env[name] = value.ValueMaterial
+		case "secret-ref":
+			return launch.LaunchSpec{}, fmt.Errorf("Launch environment %q uses unresolved secret-ref %q; no canonical v19 secret resolver is available", name, value.ValueMaterial)
+		default:
+			return launch.LaunchSpec{}, fmt.Errorf("Launch environment %q has unsupported value kind %q", name, value.ValueKind)
+		}
+	}
+	validated, err := launch.NewSpec(provider)
+	if err != nil {
+		return launch.LaunchSpec{}, fmt.Errorf("convert persisted LaunchSpec: %w", err)
+	}
+	return validated, nil
+}
+
+func observeCanonicalV19HerdrLaunch(
+	ctx context.Context,
+	current canonicalV19HerdrLaunchCurrent,
+	client canonicalV19HerdrLaunchClient,
+) canonicalV19HerdrLaunchObservation {
+	request := current.Current.Request
+	key, err := parseCanonicalV19HerdrSessionProviderKey(current.ProviderSessionKey)
+	if err != nil {
+		return finalizeCanonicalV19HerdrLaunchObservation(current, canonicalV19HerdrLaunchObservation{
+			State: canonicalV19HerdrLaunchMismatch, Reason: "provider Session key is invalid: " + err.Error(),
+		})
+	}
+	observed := canonicalV19HerdrLaunchObservation{WorkspaceID: key.WorkspaceID, TabID: key.TabID, PaneID: key.PaneID}
+	sessionName := herdr.SessionName(current.FleetID)
+	session := client.ObserveSession(ctx)
+	if session.Name != sessionName || session.State != herdr.SessionRunningCompatible {
+		reason := fmt.Sprintf("exact Herdr session %q is %q", sessionName, session.State)
+		if session.Reason != "" {
+			reason += ": " + session.Reason
+		}
+		observed.State = canonicalV19HerdrLaunchUnknown
+		observed.Reason = reason
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+
+	workspaces, err := client.WorkspaceListContext(ctx)
+	if err != nil {
+		observed.State = canonicalV19HerdrLaunchUnknown
+		observed.Reason = "list exact Herdr session workspaces: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	workspaceMatches := 0
+	var workspace herdr.Workspace
+	for _, candidate := range workspaces {
+		if candidate.WorkspaceID == key.WorkspaceID {
+			workspace = candidate
+			workspaceMatches++
+		}
+	}
+	if workspaceMatches != 1 {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		if workspaceMatches == 0 {
+			observed.Reason = "exact Session workspace is absent"
+		} else {
+			observed.Reason = "Herdr workspace inventory returned the exact Session workspace more than once"
+		}
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	if workspace.Label != canonicalV19HerdrSessionWorkspaceLabel(request.SessionBindingID) {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		observed.Reason = "exact workspace identity no longer carries the SessionBinding locator"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+
+	tabs, err := client.TabList(key.WorkspaceID)
+	if err != nil {
+		observed.State = canonicalV19HerdrLaunchUnknown
+		observed.Reason = "list exact Session workspace tabs: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	if len(tabs) != 1 || tabs[0].TabID != key.TabID || tabs[0].WorkspaceID != key.WorkspaceID {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		observed.Reason = "Session workspace root tab no longer matches the persisted provider Session key"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+
+	pane, err := client.PaneGetContext(ctx, key.PaneID)
+	if err != nil {
+		if errors.Is(err, herdr.ErrNotFound) {
+			observed.State = canonicalV19HerdrLaunchMismatch
+			observed.Reason = "exact Session root pane is absent"
+		} else {
+			observed.State = canonicalV19HerdrLaunchUnknown
+			observed.Reason = "observe exact Session root pane: " + canonicalV19HerdrSessionErrorText(err)
+		}
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	observed.PaneCwd = pane.Cwd
+	if pane.PaneID != key.PaneID || pane.TabID != key.TabID || pane.WorkspaceID != key.WorkspaceID {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		observed.Reason = "exact root pane parent identities differ from the provider Session key"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	if pane.Cwd == "" || !handgit.SamePath(pane.Cwd, current.WorktreePath) || !handgit.SamePath(pane.Cwd, request.Spec.Cwd) {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		observed.Reason = "exact root pane cwd differs from the immutable WorktreeBinding/Launch cwd"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+
+	info, err := client.PaneProcessInfo(key.PaneID)
+	if err != nil {
+		observed.State = canonicalV19HerdrLaunchUnknown
+		observed.Reason = "observe exact pane process identity: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	observed.ShellPID = info.ShellPID
+	observed.ProcessGroupID = info.ForegroundProcessGroupID
+	if info.PaneID != key.PaneID || info.ShellPID <= 0 || info.ForegroundProcessGroupID <= 0 {
+		observed.State = canonicalV19HerdrLaunchUnknown
+		observed.Reason = "pane process evidence lacks exact pane/shell/process-group identity"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+
+	shellObserved := false
+	foreignForeground := false
+	targets := make([]herdr.Process, 0, 1)
+	for _, process := range info.ForegroundProcesses {
+		if process.PID == info.ShellPID {
+			shellObserved = true
+			continue
+		}
+		if canonicalV19HerdrProcessMatchesLaunch(process, request.Spec) {
+			targets = append(targets, process)
+			continue
+		}
+		if process.PID > 0 {
+			foreignForeground = true
+		}
+	}
+	if !shellObserved {
+		observed.State = canonicalV19HerdrLaunchUnknown
+		observed.Reason = "pane process evidence does not contain the exact shell PID"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	if len(targets) > 1 {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		observed.Reason = "foreground process group contains the exact Launch process more than once"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	if len(targets) == 1 {
+		target := targets[0]
+		observed.ProcessID = target.PID
+		observed.ProcessDigest = canonicalV19HerdrProcessDigest(target)
+		providerKey, err := encodeCanonicalV19HerdrExecutorProviderKey(canonicalV19HerdrExecutorProviderKey{
+			SessionName: key.SessionName, WorkspaceID: key.WorkspaceID, TabID: key.TabID, PaneID: key.PaneID,
+			ProcessGroup: info.ForegroundProcessGroupID, ProcessID: target.PID, ProcessDigest: observed.ProcessDigest,
+		})
+		if err != nil {
+			observed.State = canonicalV19HerdrLaunchUnknown
+			observed.Reason = "encode exact provider Executor key: " + err.Error()
+			return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+		}
+		observed.ProviderExecutorKey = providerKey
+		observed.State = canonicalV19HerdrLaunchRunning
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	if foreignForeground || pane.Agent != "" {
+		observed.State = canonicalV19HerdrLaunchMismatch
+		observed.Reason = "Session pane contains a foreground/provider-detected process that does not match the exact LaunchSpec"
+		return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+	}
+	observed.State = canonicalV19HerdrLaunchReady
+	return finalizeCanonicalV19HerdrLaunchObservation(current, observed)
+}
+
+func canonicalV19HerdrProcessMatchesLaunch(process herdr.Process, spec CanonicalV19LaunchSpec) bool {
+	if process.PID <= 0 || len(process.Argv) != len(spec.Arguments)+1 || process.Cwd == "" {
+		return false
+	}
+	if canonicalV19HerdrExecutableBase(process.Argv[0]) != canonicalV19HerdrExecutableBase(spec.Executable) {
+		return false
+	}
+	for i, argument := range spec.Arguments {
+		if process.Argv[i+1] != argument {
+			return false
+		}
+	}
+	return handgit.SamePath(process.Cwd, spec.Cwd)
+}
+
+func canonicalV19HerdrExecutableBase(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	value = strings.TrimPrefix(filepath.Base(value), "-")
+	if len(value) >= len(".exe") && strings.EqualFold(value[len(value)-len(".exe"):], ".exe") {
+		value = value[:len(value)-len(".exe")]
+	}
+	return value
+}
+
+func canonicalV19HerdrProcessDigest(process herdr.Process) string {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:herdr-executor-process:v1")
+	writeCanonicalV19DigestField(hash, "pid", strconv.Itoa(process.PID))
+	writeCanonicalV19DigestField(hash, "cwd", process.Cwd)
+	writeCanonicalV19DigestField(hash, "argv_count", strconv.Itoa(len(process.Argv)))
+	for i, value := range process.Argv {
+		writeCanonicalV19DigestField(hash, fmt.Sprintf("argv_%d", i), value)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func encodeCanonicalV19HerdrExecutorProviderKey(key canonicalV19HerdrExecutorProviderKey) (string, error) {
+	for name, value := range map[string]string{
+		"session": key.SessionName, "workspace": key.WorkspaceID, "tab": key.TabID, "pane": key.PaneID,
+		"process digest": key.ProcessDigest,
+	} {
+		if value == "" {
+			return "", fmt.Errorf("Herdr provider Executor key %s is empty", name)
+		}
+	}
+	if key.ProcessGroup <= 0 || key.ProcessID <= 0 {
+		return "", fmt.Errorf("Herdr provider Executor key process identity is invalid")
+	}
+	values := url.Values{}
+	values.Set("digest", key.ProcessDigest)
+	values.Set("pane", key.PaneID)
+	values.Set("pgid", strconv.Itoa(key.ProcessGroup))
+	values.Set("pid", strconv.Itoa(key.ProcessID))
+	values.Set("session", key.SessionName)
+	values.Set("tab", key.TabID)
+	values.Set("workspace", key.WorkspaceID)
+	return "herdr-executor:v1?" + values.Encode(), nil
+}
+
+func parseCanonicalV19HerdrExecutorProviderKey(value string) (canonicalV19HerdrExecutorProviderKey, error) {
+	const prefix = "herdr-executor:v1?"
+	if !strings.HasPrefix(value, prefix) {
+		return canonicalV19HerdrExecutorProviderKey{}, fmt.Errorf("missing %q prefix", prefix)
+	}
+	values, err := url.ParseQuery(strings.TrimPrefix(value, prefix))
+	if err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, fmt.Errorf("parse query: %w", err)
+	}
+	if len(values) != 7 {
+		return canonicalV19HerdrExecutorProviderKey{}, fmt.Errorf("want exactly session/workspace/tab/pane/pgid/pid/digest fields")
+	}
+	one := func(name string) (string, error) {
+		items := values[name]
+		if len(items) != 1 || items[0] == "" {
+			return "", fmt.Errorf("field %q must occur exactly once and be non-empty", name)
+		}
+		return items[0], nil
+	}
+	var key canonicalV19HerdrExecutorProviderKey
+	if key.SessionName, err = one("session"); err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	if key.WorkspaceID, err = one("workspace"); err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	if key.TabID, err = one("tab"); err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	if key.PaneID, err = one("pane"); err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	if key.ProcessDigest, err = one("digest"); err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	pgid, err := one("pgid")
+	if err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	if key.ProcessGroup, err = strconv.Atoi(pgid); err != nil || key.ProcessGroup <= 0 {
+		return canonicalV19HerdrExecutorProviderKey{}, fmt.Errorf("field %q must be a positive integer", "pgid")
+	}
+	pid, err := one("pid")
+	if err != nil {
+		return canonicalV19HerdrExecutorProviderKey{}, err
+	}
+	if key.ProcessID, err = strconv.Atoi(pid); err != nil || key.ProcessID <= 0 {
+		return canonicalV19HerdrExecutorProviderKey{}, fmt.Errorf("field %q must be a positive integer", "pid")
+	}
+	return key, nil
+}
+
+func readCanonicalV19HerdrLaunchCurrent(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+) (canonicalV19HerdrLaunchCurrent, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return canonicalV19HerdrLaunchCurrent{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19HerdrLaunchCurrent{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	current, err := loadCanonicalV19LaunchCurrent(ctx, tx, operationID)
+	if err != nil {
+		return canonicalV19HerdrLaunchCurrent{}, err
+	}
+	result := canonicalV19HerdrLaunchCurrent{Current: current}
+	if err := tx.QueryRowContext(ctx, `SELECT p.fleet_id,b.path,s.provider_session_key
+		FROM project p
+		JOIN session_binding s ON s.id=? AND s.attempt_id=?
+		JOIN attempt_worktree_binding b ON b.id=? AND b.id=s.worktree_binding_id
+		WHERE p.id=?`, current.Request.SessionBindingID, current.Request.AttemptID,
+		current.Request.WorktreeBindingID, current.Request.ProjectID).Scan(
+		&result.FleetID, &result.WorktreePath, &result.ProviderSessionKey,
+	); err != nil {
+		return canonicalV19HerdrLaunchCurrent{}, fmt.Errorf("read canonical v19 Herdr Launch provider context: %w", err)
+	}
+	if result.FleetID == "" || result.WorktreePath == "" || result.ProviderSessionKey == "" {
+		return canonicalV19HerdrLaunchCurrent{}, fmt.Errorf("read canonical v19 Herdr Launch provider context: Fleet ID, Worktree path, or provider Session key is empty")
+	}
+	return result, nil
+}
+
+func readCanonicalV19HerdrLaunchTerminal(ctx context.Context, homeDir, operationID string) (string, bool, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = db.Close() }()
+	var state string
+	err = db.sql.QueryRowContext(ctx, `SELECT state FROM external_operation
+		WHERE id=? AND kind='launch' AND state IN ('succeeded','rejected','no-effect')`, operationID).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return state, true, nil
+}
+
+func finalizeCanonicalV19HerdrLaunchObservation(
+	current canonicalV19HerdrLaunchCurrent,
+	observed canonicalV19HerdrLaunchObservation,
+) canonicalV19HerdrLaunchObservation {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:herdr-launch-observation:v1")
+	writeCanonicalV19DigestField(hash, "operation_id", current.Current.Request.OperationID)
+	writeCanonicalV19DigestField(hash, "request_digest", current.Current.Request.RequestDigest)
+	writeCanonicalV19DigestField(hash, "fleet_id", current.FleetID)
+	writeCanonicalV19DigestField(hash, "provider_session_key", current.ProviderSessionKey)
+	writeCanonicalV19DigestField(hash, "state", string(observed.State))
+	writeCanonicalV19DigestField(hash, "workspace_id", observed.WorkspaceID)
+	writeCanonicalV19DigestField(hash, "tab_id", observed.TabID)
+	writeCanonicalV19DigestField(hash, "pane_id", observed.PaneID)
+	writeCanonicalV19DigestField(hash, "pane_cwd", observed.PaneCwd)
+	writeCanonicalV19DigestField(hash, "shell_pid", strconv.Itoa(observed.ShellPID))
+	writeCanonicalV19DigestField(hash, "process_group_id", strconv.Itoa(observed.ProcessGroupID))
+	writeCanonicalV19DigestField(hash, "process_id", strconv.Itoa(observed.ProcessID))
+	writeCanonicalV19DigestField(hash, "process_digest", observed.ProcessDigest)
+	writeCanonicalV19DigestField(hash, "provider_executor_key", observed.ProviderExecutorKey)
+	writeCanonicalV19DigestField(hash, "reason", observed.Reason)
+	observed.EvidenceDigest = hex.EncodeToString(hash.Sum(nil))
+	return observed
+}
+
+func canonicalV19HerdrLaunchJoinReason(left, right string) string {
+	if left == "" {
+		return right
+	}
+	if right == "" {
+		return left
+	}
+	return left + "; " + right
+}

--- a/internal/store/v19launch_herdr_test.go
+++ b/internal/store/v19launch_herdr_test.go
@@ -1,0 +1,403 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/herdr"
+	"github.com/atqamz/hand/internal/launch"
+)
+
+func TestReconcileCanonicalV19HerdrLaunchSucceedsWithExactStructuredSpecAndReruns(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-success", canonicalV19HerdrLiteralEnvironment())
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	client.requireSubmittedAtRun = true
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrLaunchClient {
+			if sessionName != key.SessionName {
+				t.Fatalf("Herdr session = %q, want %q", sessionName, key.SessionName)
+			}
+			return client
+		},
+		now: func() time.Time { return time.Date(2026, 9, 8, 3, 15, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("reconcile Herdr Launch = %q, %v", state, err)
+	}
+	if client.runCalls != 1 {
+		t.Fatalf("pane run calls = %d, want 1", client.runCalls)
+	}
+	wantSpec := launch.LaunchSpec{
+		Executable: request.Spec.Executable,
+		Args:       append([]string(nil), request.Spec.Arguments...),
+		Env:        map[string]string{"HAND_ROLE": "worker", "TOKEN": "literal-token"},
+		Cwd:        request.Spec.Cwd,
+	}
+	if !reflect.DeepEqual(client.lastSpec, wantSpec) {
+		t.Fatalf("provider LaunchSpec = %#v, want %#v", client.lastSpec, wantSpec)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var operationState, providerKey string
+	if err := db.sql.QueryRow(`SELECT o.state,e.provider_executor_key
+		FROM external_operation o JOIN executor_binding e ON e.launch_operation_id=o.id
+		WHERE o.id=?`, request.OperationID).Scan(&operationState, &providerKey); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if operationState != "succeeded" {
+		t.Fatalf("operation state = %q, want succeeded", operationState)
+	}
+	executorKey, err := parseCanonicalV19HerdrExecutorProviderKey(providerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executorKey.SessionName != key.SessionName || executorKey.WorkspaceID != key.WorkspaceID ||
+		executorKey.TabID != key.TabID || executorKey.PaneID != key.PaneID ||
+		executorKey.ProcessGroup != canonicalV19HerdrLaunchTestProcessGroup ||
+		executorKey.ProcessID != canonicalV19HerdrLaunchTestProcessID || len(executorKey.ProcessDigest) != 64 {
+		t.Fatalf("provider Executor key = %#v", executorKey)
+	}
+
+	state, err = reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("terminal rerun = %q, %v", state, err)
+	}
+	if client.runCalls != 1 {
+		t.Fatalf("pane run calls after terminal rerun = %d, want 1", client.runCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19HerdrLaunchObservesExistingTargetWithoutReplay(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-submitted-running", canonicalV19HerdrLiteralEnvironment())
+	if _, err := SubmitCanonicalV19Launch(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-08T03:10:00Z", "launch-submitted-before-crash"); err != nil {
+		t.Fatal(err)
+	}
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	client.startTarget(request.Spec)
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(string) canonicalV19HerdrLaunchClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 3, 16, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("submitted running recovery = %q, %v", state, err)
+	}
+	if client.runCalls != 0 {
+		t.Fatalf("pane run calls = %d, want 0", client.runCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19HerdrLaunchDoesNotBlindReplay(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-submitted-ready", canonicalV19HerdrLiteralEnvironment())
+	if _, err := SubmitCanonicalV19Launch(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-08T03:10:00Z", "launch-submitted-before-crash"); err != nil {
+		t.Fatal(err)
+	}
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(string) canonicalV19HerdrLaunchClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 3, 17, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("submitted recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.runCalls != 0 {
+		t.Fatalf("pane run calls = %d, want 0", client.runCalls)
+	}
+	state, err = reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("uncertain recovery = %q, %v, want uncertain error", state, err)
+	}
+	if client.runCalls != 0 {
+		t.Fatalf("pane run calls after uncertain recovery = %d, want 0", client.runCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrLaunchLostResponseWithExactProcessSucceeds(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-lost-response", canonicalV19HerdrLiteralEnvironment())
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	client.runErr = errors.New("provider response lost after pane run")
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(string) canonicalV19HerdrLaunchClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 3, 18, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("lost-response Launch = %q, %v", state, err)
+	}
+	if client.runCalls != 1 {
+		t.Fatalf("pane run calls = %d, want 1", client.runCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrLaunchProcessNotStartedIsNoEffect(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-no-effect", canonicalV19HerdrLiteralEnvironment())
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	client.mutateOnRun = false
+	client.runErr = &herdr.ExecError{Started: false, Err: errors.New("Herdr executable did not start")}
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(string) canonicalV19HerdrLaunchClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 3, 19, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("process-not-started Launch = %q, %v, want no-effect diagnostic", state, err)
+	}
+	if client.runCalls != 1 {
+		t.Fatalf("pane run calls = %d, want 1", client.runCalls)
+	}
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bindings int
+	if err := db.sql.QueryRow(`SELECT COUNT(*) FROM executor_binding WHERE launch_operation_id=?`, request.OperationID).Scan(&bindings); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if bindings != 0 {
+		t.Fatalf("ExecutorBinding rows = %d, want 0", bindings)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19HerdrLaunchRejectsSecretRefBeforeMutation(t *testing.T) {
+	environment := canonicalV19HerdrLiteralEnvironment()
+	environment["TOKEN"] = CanonicalV19LaunchEnvironmentValue{
+		ValueKind: "secret-ref", ValueMaterial: "secret://worker/token", ValueDigest: "digest-secret-value",
+	}
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-secret-ref", environment)
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	clientForCalls := 0
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(string) canonicalV19HerdrLaunchClient {
+			clientForCalls++
+			return client
+		},
+		now: func() time.Time { return time.Date(2026, 9, 8, 3, 20, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "prepared" || err == nil {
+		t.Fatalf("secret-ref Launch = %q, %v, want prepared error", state, err)
+	}
+	if clientForCalls != 0 || client.runCalls != 0 {
+		t.Fatalf("provider calls before secret resolution = client %d, run %d, want 0/0", clientForCalls, client.runCalls)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19HerdrLaunchRefusesProviderMismatch(t *testing.T) {
+	fixture, request, key := canonicalV19HerdrLaunchFixture(t, "operation-herdr-launch-mismatch", canonicalV19HerdrLiteralEnvironment())
+	client := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, request, key)
+	pane := client.panes[key.PaneID]
+	pane.Cwd = t.TempDir()
+	client.panes[key.PaneID] = pane
+	deps := canonicalV19HerdrLaunchDeps{
+		clientFor: func(string) canonicalV19HerdrLaunchClient { return client },
+		now:       func() time.Time { return time.Date(2026, 9, 8, 3, 21, 0, 0, time.UTC) },
+	}
+
+	state, err := reconcileCanonicalV19HerdrLaunch(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "prepared" || err == nil {
+		t.Fatalf("provider mismatch Launch = %q, %v, want prepared error", state, err)
+	}
+	if client.runCalls != 0 {
+		t.Fatalf("pane run calls = %d, want 0", client.runCalls)
+	}
+}
+
+func canonicalV19HerdrLiteralEnvironment() map[string]CanonicalV19LaunchEnvironmentValue {
+	return map[string]CanonicalV19LaunchEnvironmentValue{
+		"HAND_ROLE": {ValueKind: "literal", ValueMaterial: "worker", ValueDigest: "digest-role-worker"},
+		"TOKEN":     {ValueKind: "literal", ValueMaterial: "literal-token", ValueDigest: "digest-literal-token"},
+	}
+}
+
+func canonicalV19HerdrLaunchFixture(
+	t *testing.T,
+	launchOperationID string,
+	environment map[string]CanonicalV19LaunchEnvironmentValue,
+) (canonicalV19WorktreeCreateTestFixture, CanonicalV19LaunchRequest, canonicalV19HerdrSessionProviderKey) {
+	t.Helper()
+	base := canonicalV19AttemptWriterFixture(t)
+	attempt := canonicalV19AttemptWriterInput("attempt-1", "plan-root")
+	attempt.SessionAdapterRef = canonicalV19HerdrSessionAdapterRef
+	if _, err := CreateCanonicalV19Attempt(context.Background(), base.Home, attempt); err != nil {
+		t.Fatal(err)
+	}
+	fixture := canonicalV19WorktreeCreateTestFixture(base)
+	createInput := canonicalV19WorktreeCreatePrepareInput(fixture.Home, "operation-create", "binding-1")
+	worktree, err := PrepareCanonicalV19WorktreeCreate(context.Background(), fixture.Home, createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EstablishCanonicalV19WorktreeBinding(context.Background(), fixture.Home,
+		canonicalV19WorktreeBindingEvidence(worktree, "worktree-physical-herdr-launch")); err != nil {
+		t.Fatal(err)
+	}
+	key := canonicalV19HerdrSessionProviderKey{
+		SessionName: herdr.SessionName("fleet-1"),
+		WorkspaceID: "w-launch", TabID: "w-launch:t1", PaneID: "w-launch:p1",
+	}
+	providerSessionKey, err := encodeCanonicalV19HerdrSessionProviderKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acquireInput := canonicalV19SessionAcquirePrepareInput(worktree, "operation-session-acquire-launch-fixture", "session-binding-1")
+	acquireInput.RequestedProviderSessionKey = providerSessionKey
+	session, err := PrepareCanonicalV19SessionAcquire(context.Background(), fixture.Home, acquireInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EstablishCanonicalV19SessionBinding(context.Background(), fixture.Home, CanonicalV19SessionBindingEvidence{
+		OperationID: session.OperationID, ProviderSessionKey: providerSessionKey,
+		EstablishedAt: "2026-09-08T03:00:00Z", EvidenceDigest: "session-binding-herdr-launch-fixture",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	launchInput := canonicalV19LaunchPrepareInput(worktree, session, launchOperationID, "executor-binding-1")
+	launchInput.Spec.Environment = environment
+	launchInput.CreatedAt = "2026-09-08T03:05:00Z"
+	request, err := PrepareCanonicalV19Launch(context.Background(), fixture.Home, launchInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixture, request, key
+}
+
+const (
+	canonicalV19HerdrLaunchTestShellPID     = 4100
+	canonicalV19HerdrLaunchTestProcessGroup = 4200
+	canonicalV19HerdrLaunchTestProcessID    = 4300
+)
+
+type canonicalV19HerdrLaunchFakeClient struct {
+	t                     *testing.T
+	home                  string
+	request               CanonicalV19LaunchRequest
+	sessionName           string
+	workspaces            []herdr.Workspace
+	tabs                  map[string][]herdr.Tab
+	panes                 map[string]herdr.Pane
+	processInfo           herdr.ProcessInfo
+	runCalls              int
+	runErr                error
+	mutateOnRun           bool
+	requireSubmittedAtRun bool
+	lastSpec              launch.LaunchSpec
+}
+
+func newCanonicalV19HerdrLaunchFakeClient(
+	t *testing.T,
+	home string,
+	request CanonicalV19LaunchRequest,
+	key canonicalV19HerdrSessionProviderKey,
+) *canonicalV19HerdrLaunchFakeClient {
+	t.Helper()
+	workspace := herdr.Workspace{
+		WorkspaceID: key.WorkspaceID,
+		Label:       canonicalV19HerdrSessionWorkspaceLabel(request.SessionBindingID),
+		TabCount:    1,
+	}
+	tab := herdr.Tab{TabID: key.TabID, WorkspaceID: key.WorkspaceID, Label: "1"}
+	pane := herdr.Pane{PaneID: key.PaneID, TabID: key.TabID, WorkspaceID: key.WorkspaceID, Cwd: request.Spec.Cwd}
+	return &canonicalV19HerdrLaunchFakeClient{
+		t: t, home: home, request: request, sessionName: key.SessionName,
+		workspaces: []herdr.Workspace{workspace},
+		tabs:       map[string][]herdr.Tab{key.WorkspaceID: {tab}},
+		panes:      map[string]herdr.Pane{key.PaneID: pane},
+		processInfo: herdr.ProcessInfo{
+			PaneID: key.PaneID, ShellPID: canonicalV19HerdrLaunchTestShellPID,
+			ForegroundProcessGroupID: canonicalV19HerdrLaunchTestShellPID,
+			ForegroundProcesses: []herdr.Process{{
+				PID: canonicalV19HerdrLaunchTestShellPID, Name: "shell", Argv: []string{"shell"}, Cwd: request.Spec.Cwd,
+			}},
+		},
+		mutateOnRun: true,
+	}
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) ObserveSession(context.Context) herdr.SessionObservation {
+	return herdr.SessionObservation{Name: f.sessionName, State: herdr.SessionRunningCompatible}
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) WorkspaceListContext(context.Context) ([]herdr.Workspace, error) {
+	return append([]herdr.Workspace(nil), f.workspaces...), nil
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) TabList(workspaceID string) ([]herdr.Tab, error) {
+	tabs, ok := f.tabs[workspaceID]
+	if !ok {
+		return nil, fmt.Errorf("%w: workspace %s", herdr.ErrNotFound, workspaceID)
+	}
+	return append([]herdr.Tab(nil), tabs...), nil
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) PaneGetContext(_ context.Context, paneID string) (herdr.Pane, error) {
+	pane, ok := f.panes[paneID]
+	if !ok {
+		return herdr.Pane{}, fmt.Errorf("%w: pane %s", herdr.ErrNotFound, paneID)
+	}
+	return pane, nil
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) PaneProcessInfo(paneID string) (herdr.ProcessInfo, error) {
+	if paneID != f.processInfo.PaneID {
+		return herdr.ProcessInfo{}, fmt.Errorf("%w: pane %s", herdr.ErrNotFound, paneID)
+	}
+	return f.processInfo, nil
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) PaneRunExactSpec(paneID string, spec launch.LaunchSpec) error {
+	f.runCalls++
+	f.lastSpec = spec.Clone()
+	if f.requireSubmittedAtRun {
+		db, err := openReadOnly(f.home)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		var state string
+		if err := db.sql.QueryRow(`SELECT state FROM external_operation WHERE id=?`, f.request.OperationID).Scan(&state); err != nil {
+			_ = db.Close()
+			f.t.Fatal(err)
+		}
+		_ = db.Close()
+		if state != "submitted" {
+			f.t.Fatalf("state at first provider mutation = %q, want submitted", state)
+		}
+	}
+	if f.mutateOnRun {
+		f.startTarget(f.request.Spec)
+	}
+	return f.runErr
+}
+
+func (f *canonicalV19HerdrLaunchFakeClient) startTarget(spec CanonicalV19LaunchSpec) {
+	argv := append([]string{spec.Executable}, spec.Arguments...)
+	f.processInfo.ForegroundProcessGroupID = canonicalV19HerdrLaunchTestProcessGroup
+	f.processInfo.ForegroundProcesses = []herdr.Process{
+		{PID: canonicalV19HerdrLaunchTestShellPID, Name: "shell", Argv: []string{"shell"}, Cwd: spec.Cwd},
+		{PID: canonicalV19HerdrLaunchTestProcessID, Name: spec.Executable, Argv: argv, Cwd: spec.Cwd},
+	}
+	pane := f.panes[f.processInfo.PaneID]
+	pane.Agent = "worker"
+	pane.AgentStatus = herdr.StatusWorking
+	f.panes[f.processInfo.PaneID] = pane
+}


### PR DESCRIPTION
Implements the next bounded #339 Step 10 provider-mechanics slice: canonical v19 Herdr Launch + ExecutorBinding only.

- launch the exact persisted structured executable/argv/cwd with literal environment injected explicitly into the child path, without changing legacy `PaneRunSpec`
- fail closed on unresolved `secret-ref` before provider mutation
- positively re-prove the exact Herdr SessionBinding workspace/tab/pane ownership and immutable WorktreeBinding cwd before launch
- durably commit `submitted` before the first `pane run` mutation
- establish ExecutorBinding only from positive exact process PID/PGID/argv/cwd evidence
- persist a stable versioned `herdr-executor:v1` provider key for the following Interrupt slice
- converge a lost provider response when exact launched-process evidence is positively observable
- classify `no-effect` only when the provider process is positively known not to have started and the exact pane remains ready
- never blindly replay submitted/uncertain Launch work

Interrupt, WorkerInput/WorkerWake provider mechanics, and ordinary runtime cutover remain follow-up slices.

#344 DDL impact: **NONE**.