### PR TITLE
feat(store): drain canonical WorkerInput

### DIFF
--- a/internal/store/v19workerinput_drain.go
+++ b/internal/store/v19workerinput_drain.go
@@ -1,0 +1,117 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrCanonicalV19WorkerInputDrainNotCurrent marks a drain whose exact active/open execution no longer matches.
+var ErrCanonicalV19WorkerInputDrainNotCurrent = errors.New("canonical v19 WorkerInput drain is not current")
+
+// CanonicalV19WorkerInputDrainInput identifies one exact Worker execution generation.
+type CanonicalV19WorkerInputDrainInput struct {
+	AttemptID         string
+	ExecutorBindingID string
+}
+
+// DrainCanonicalV19WorkerInputs returns every pending semantic input for one exact current ExecutorBinding
+// in canonical ordinal order. It performs no mutation and never treats WorkerWake state as acknowledgement.
+func DrainCanonicalV19WorkerInputs(
+	ctx context.Context,
+	homeDir string,
+	input CanonicalV19WorkerInputDrainInput,
+) ([]CanonicalV19WorkerInput, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if input.AttemptID == "" || input.ExecutorBindingID == "" {
+		return nil, fmt.Errorf("drain canonical v19 WorkerInput: Attempt ID and ExecutorBinding ID are required")
+	}
+
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	tx, err := db.sql.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, canonicalV19WorkerInputDrainReadError("begin snapshot", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := requireCanonicalV19WorkerInputDrainCurrent(ctx, tx, input); err != nil {
+		return nil, err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT wi.id,wi.attempt_id,wi.executor_binding_id,wi.ordinal,
+		wi.payload,wi.payload_digest,wi.origin_kind,wi.created_at
+		FROM worker_input wi
+		WHERE wi.attempt_id=? AND wi.executor_binding_id=?
+		  AND NOT EXISTS (
+			SELECT 1 FROM worker_input_acknowledgement a WHERE a.worker_input_id=wi.id
+		  )
+		ORDER BY wi.ordinal ASC`, input.AttemptID, input.ExecutorBindingID)
+	if err != nil {
+		return nil, canonicalV19WorkerInputDrainReadError("read pending inputs", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	pending := make([]CanonicalV19WorkerInput, 0)
+	for rows.Next() {
+		var workerInput CanonicalV19WorkerInput
+		var payload []byte
+		if err := rows.Scan(
+			&workerInput.ID, &workerInput.AttemptID, &workerInput.ExecutorBindingID, &workerInput.Ordinal,
+			&payload, &workerInput.PayloadDigest, &workerInput.OriginKind, &workerInput.CreatedAt,
+		); err != nil {
+			return nil, canonicalV19WorkerInputDrainReadError("scan pending input", err)
+		}
+		workerInput.Payload = string(payload)
+		pending = append(pending, workerInput)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, canonicalV19WorkerInputDrainReadError("iterate pending inputs", err)
+	}
+	return pending, nil
+}
+
+func requireCanonicalV19WorkerInputDrainCurrent(
+	ctx context.Context,
+	tx *sql.Tx,
+	input CanonicalV19WorkerInputDrainInput,
+) error {
+	var attemptID, executorBindingID string
+	err := tx.QueryRowContext(ctx, `SELECT a.id,e.id
+		FROM executor_binding e
+		JOIN attempt a ON a.id=e.attempt_id AND a.lifecycle='active' AND a.terminal_at=''
+		JOIN plan p ON p.id=a.plan_id AND p.lifecycle='active' AND p.terminal_at=''
+		JOIN task t ON t.id=p.task_id AND t.lifecycle='active' AND t.terminal_at=''
+		JOIN project project_current ON project_current.id=t.project_id AND project_current.retired_at=''
+		JOIN session_binding s ON s.id=e.session_binding_id AND s.attempt_id=a.id AND s.adapter_ref=e.adapter_ref
+		JOIN attempt_worktree_binding b ON b.id=s.worktree_binding_id AND b.attempt_id=a.id
+		WHERE e.id=? AND e.attempt_id=?
+		  AND NOT EXISTS (SELECT 1 FROM executor_binding_termination x WHERE x.executor_binding_id=e.id)
+		  AND NOT EXISTS (SELECT 1 FROM session_binding_release r WHERE r.session_binding_id=s.id)
+		  AND NOT EXISTS (SELECT 1 FROM worktree_binding_release r WHERE r.binding_id=b.id)`,
+		input.ExecutorBindingID, input.AttemptID).Scan(&attemptID, &executorBindingID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: Attempt %q / ExecutorBinding %q lacks exact active/open ownership",
+			ErrCanonicalV19WorkerInputDrainNotCurrent, input.AttemptID, input.ExecutorBindingID)
+	}
+	if err != nil {
+		return canonicalV19WorkerInputDrainReadError("read exact current execution ownership", err)
+	}
+	if attemptID != input.AttemptID || executorBindingID != input.ExecutorBindingID {
+		return fmt.Errorf("%w: exact execution ownership changed", ErrCanonicalV19WorkerInputDrainNotCurrent)
+	}
+	return nil
+}
+
+func canonicalV19WorkerInputDrainReadError(action string, err error) error {
+	if isSQLiteBusy(err) {
+		return fmt.Errorf("drain canonical v19 WorkerInput: %s: %w", action, ErrContention)
+	}
+	return fmt.Errorf("drain canonical v19 WorkerInput: %s: %w", action, err)
+}

--- a/internal/store/v19workerinput_drain_test.go
+++ b/internal/store/v19workerinput_drain_test.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDrainCanonicalV19WorkerInputsReturnsPendingInOrdinalOrder(t *testing.T) {
+	fixture, _, launch := canonicalV19ExecutorBindingFixture(t)
+	first, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home,
+		canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-1", "first", "digest-drain-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondInput := canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-2", "second", "digest-drain-2")
+	secondInput.CreatedAt = "2026-09-09T06:31:00Z"
+	second, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home, secondInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	thirdInput := canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-3", "third", "digest-drain-3")
+	thirdInput.CreatedAt = "2026-09-09T06:32:00Z"
+	third, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home, thirdInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CreateCanonicalV19WorkerInputAcknowledgement(context.Background(), fixture.Home,
+		CanonicalV19WorkerInputAcknowledgementCreateInput{
+			WorkerInputID: second.ID, ExecutorBindingID: launch.BindingID,
+			ObservedAt: "2026-09-09T06:33:00Z", EvidenceDigest: "worker-drained-second",
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := DrainCanonicalV19WorkerInputs(context.Background(), fixture.Home, CanonicalV19WorkerInputDrainInput{
+		AttemptID: launch.AttemptID, ExecutorBindingID: launch.BindingID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 2 || pending[0].ID != first.ID || pending[0].Ordinal != 1 || pending[0].Payload != "first" ||
+		pending[1].ID != third.ID || pending[1].Ordinal != 3 || pending[1].Payload != "third" {
+		t.Fatalf("pending WorkerInputs = %#v", pending)
+	}
+}
+
+func TestDrainCanonicalV19WorkerInputsReturnsEmptyAfterAcknowledgement(t *testing.T) {
+	fixture, _, launch := canonicalV19ExecutorBindingFixture(t)
+	created, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home,
+		canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-empty", "instruction", "digest-drain-empty"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CreateCanonicalV19WorkerInputAcknowledgement(context.Background(), fixture.Home,
+		CanonicalV19WorkerInputAcknowledgementCreateInput{
+			WorkerInputID: created.ID, ExecutorBindingID: launch.BindingID,
+			ObservedAt: "2026-09-09T06:31:00Z", EvidenceDigest: "worker-drained-only-input",
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := DrainCanonicalV19WorkerInputs(context.Background(), fixture.Home, CanonicalV19WorkerInputDrainInput{
+		AttemptID: launch.AttemptID, ExecutorBindingID: launch.BindingID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending WorkerInputs = %#v, want empty", pending)
+	}
+}
+
+func TestSuccessfulCanonicalV19WorkerWakeDoesNotAcknowledgeWorkerInput(t *testing.T) {
+	fixture, _, launch := canonicalV19ExecutorBindingFixture(t)
+	created, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home,
+		canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-after-wake", "instruction", "digest-drain-after-wake"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wake := canonicalV19WorkerWakePrepareInput(launch, "operation-worker-wake-drain", created.Ordinal)
+	request, err := PrepareCanonicalV19WorkerWake(context.Background(), fixture.Home, wake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19WorkerWake(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-09T06:31:00Z", "worker-wake-submitted-drain"); err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteCanonicalV19WorkerWake(context.Background(), fixture.Home, CanonicalV19WorkerWakeSucceededEvidence{
+		OperationID: request.OperationID, ObservedAt: "2026-09-09T06:32:00Z", EvidenceDigest: "worker-wake-accepted-drain",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := DrainCanonicalV19WorkerInputs(context.Background(), fixture.Home, CanonicalV19WorkerInputDrainInput{
+		AttemptID: launch.AttemptID, ExecutorBindingID: launch.BindingID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].ID != created.ID {
+		t.Fatalf("pending WorkerInputs after successful wake = %#v, want exact unacknowledged input", pending)
+	}
+}
+
+func TestUnresolvedCanonicalV19WorkerWakeDoesNotBlockWorkerInputDrain(t *testing.T) {
+	fixture, _, launch := canonicalV19ExecutorBindingFixture(t)
+	created, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home,
+		canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-during-wake", "instruction", "digest-drain-during-wake"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wake := canonicalV19WorkerWakePrepareInput(launch, "operation-worker-wake-unresolved-drain", created.Ordinal)
+	if _, err := PrepareCanonicalV19WorkerWake(context.Background(), fixture.Home, wake); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := DrainCanonicalV19WorkerInputs(context.Background(), fixture.Home, CanonicalV19WorkerInputDrainInput{
+		AttemptID: launch.AttemptID, ExecutorBindingID: launch.BindingID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].ID != created.ID {
+		t.Fatalf("pending WorkerInputs during unresolved wake = %#v, want exact input", pending)
+	}
+}
+
+func TestDrainCanonicalV19WorkerInputsRefusesTerminatedExecutor(t *testing.T) {
+	fixture, _, launch := canonicalV19ExecutorBindingFixture(t)
+	if _, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home,
+		canonicalV19WorkerInputCreateInput(launch, "worker-input-drain-after-interrupt", "instruction", "digest-drain-after-interrupt")); err != nil {
+		t.Fatal(err)
+	}
+	interrupt := canonicalV19InterruptPrepareInput(launch, "operation-interrupt-before-worker-input-drain")
+	request, err := PrepareCanonicalV19Interrupt(context.Background(), fixture.Home, interrupt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SubmitCanonicalV19Interrupt(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-09T06:31:00Z", "interrupt-submitted-before-drain"); err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteCanonicalV19Interrupt(context.Background(), fixture.Home, CanonicalV19ExecutorInterruptedEvidence{
+		OperationID: request.OperationID, ObservedAt: "2026-09-09T06:32:00Z", EvidenceDigest: "executor-ceased-before-drain",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = DrainCanonicalV19WorkerInputs(context.Background(), fixture.Home, CanonicalV19WorkerInputDrainInput{
+		AttemptID: launch.AttemptID, ExecutorBindingID: launch.BindingID,
+	})
+	if !errors.Is(err, ErrCanonicalV19WorkerInputDrainNotCurrent) {
+		t.Fatalf("WorkerInput drain after executor termination error = %v, want %v",
+			err, ErrCanonicalV19WorkerInputDrainNotCurrent)
+	}
+}


### PR DESCRIPTION
Implements the next bounded #339 Step 11 provider-neutral WorkerInput drain slice.

Scope:
- exact current Attempt + open SessionBinding/WorktreeBinding/ExecutorBinding proof
- read-only snapshot drain for one exact ExecutorBinding
- returns every pending unacknowledged WorkerInput in canonical `ordinal ASC`
- empty pending set is distinct from stale/closed execution
- successful or unresolved WorkerWake does not fabricate acknowledgement and does not block semantic drain
- terminated/stale execution fails closed; no successor retargeting
- no provider calls, no WorkerWake mutation, no acknowledgement mutation

This qualifies `worker_input_drain` separately from WorkerWake provider mechanics as required by #346.

#344 DDL impact: **NONE**.
Runtime cutover: **NONE**.