### PR TITLE
feat(runtime): expose canonical WorkerInput protocol

### DIFF
--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -14,7 +14,7 @@ func newRuntimeCmd() *cobra.Command {
 		Short: "Inspect and repair the private core runtime",
 		Args:  usageArgs(cobra.NoArgs),
 	}
-	cmd.AddCommand(newRuntimeStatusCmd(), newRuntimeEnsureCmd())
+	cmd.AddCommand(newRuntimeStatusCmd(), newRuntimeEnsureCmd(), newWorkerInputCmd())
 	return cmd
 }
 

--- a/cmd/worker_input.go
+++ b/cmd/worker_input.go
@@ -1,0 +1,219 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/home"
+	"github.com/atqamz/hand/internal/store"
+	"github.com/spf13/cobra"
+)
+
+type workerInputCommandDeps struct {
+	resolveHome func() (string, error)
+	drain       func(context.Context, string, store.CanonicalV19WorkerInputDrainInput) ([]store.CanonicalV19WorkerInput, error)
+	readAck     func(context.Context, string, string) (store.CanonicalV19WorkerInputAcknowledgement, bool, error)
+	createAck   func(context.Context, string, store.CanonicalV19WorkerInputAcknowledgementCreateInput) (store.CanonicalV19WorkerInputAcknowledgement, error)
+	now         func() time.Time
+	role        func() string
+}
+
+type workerInputDrainOutput struct {
+	AttemptID         string                       `json:"attempt_id"`
+	ExecutorBindingID string                       `json:"executor_binding_id"`
+	DrainedAt         string                       `json:"drained_at"`
+	Inputs            []workerInputDrainOutputItem `json:"inputs"`
+}
+
+type workerInputDrainOutputItem struct {
+	ID            string `json:"id"`
+	Ordinal       int64  `json:"ordinal"`
+	Payload       string `json:"payload"`
+	PayloadDigest string `json:"payload_digest"`
+	OriginKind    string `json:"origin_kind"`
+	CreatedAt     string `json:"created_at"`
+}
+
+type workerInputAcknowledgementOutput struct {
+	WorkerInputID     string `json:"worker_input_id"`
+	ExecutorBindingID string `json:"executor_binding_id"`
+	ActorKind         string `json:"actor_kind"`
+	ObservedAt        string `json:"observed_at"`
+	EvidenceDigest    string `json:"evidence_digest"`
+	Replayed          bool   `json:"replayed"`
+}
+
+func newWorkerInputCmd() *cobra.Command {
+	return newWorkerInputCmdWithDeps(workerInputCommandDeps{
+		resolveHome: home.Resolve,
+		drain:       store.DrainCanonicalV19WorkerInputs,
+		readAck:     store.ReadCanonicalV19WorkerInputAcknowledgement,
+		createAck:   store.CreateCanonicalV19WorkerInputAcknowledgement,
+		now:         time.Now,
+		role:        func() string { return os.Getenv(harness.RoleEnv) },
+	})
+}
+
+func newWorkerInputCmdWithDeps(deps workerInputCommandDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "worker-input",
+		Short:  "Use the canonical WorkerInput runtime protocol",
+		Hidden: true,
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "drain <attempt-id> <executor-binding-id>",
+		Short: "Read pending canonical WorkerInputs for this exact worker execution",
+		Args:  usageArgs(cobra.ExactArgs(2)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkerInputDrain(cmd, deps, args[0], args[1])
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "acknowledge <worker-input-id> <executor-binding-id>",
+		Short: "Record that this worker observed one exact canonical WorkerInput",
+		Args:  usageArgs(cobra.ExactArgs(2)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorkerInputAcknowledge(cmd, deps, args[0], args[1])
+		},
+	})
+	return cmd
+}
+
+func runWorkerInputDrain(
+	cmd *cobra.Command,
+	deps workerInputCommandDeps,
+	attemptID string,
+	executorBindingID string,
+) error {
+	if err := requireWorkerInputProtocolRole(deps); err != nil {
+		return err
+	}
+	if deps.resolveHome == nil || deps.drain == nil || deps.now == nil {
+		return fmt.Errorf("worker-input drain dependencies are incomplete")
+	}
+	fleetHome, err := deps.resolveHome()
+	if err != nil {
+		return asPrecondition(err)
+	}
+	pending, err := deps.drain(cmd.Context(), fleetHome, store.CanonicalV19WorkerInputDrainInput{
+		AttemptID: attemptID, ExecutorBindingID: executorBindingID,
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrCanonicalV19WorkerInputDrainNotCurrent) {
+			return &ExitError{Err: err, Code: 3}
+		}
+		return err
+	}
+	output := workerInputDrainOutput{
+		AttemptID: attemptID, ExecutorBindingID: executorBindingID,
+		DrainedAt: deps.now().UTC().Format(time.RFC3339Nano),
+		Inputs:    make([]workerInputDrainOutputItem, 0, len(pending)),
+	}
+	for _, input := range pending {
+		output.Inputs = append(output.Inputs, workerInputDrainOutputItem{
+			ID: input.ID, Ordinal: input.Ordinal, Payload: input.Payload,
+			PayloadDigest: input.PayloadDigest, OriginKind: input.OriginKind, CreatedAt: input.CreatedAt,
+		})
+	}
+	return encodeWorkerInputProtocolOutput(cmd, output)
+}
+
+func runWorkerInputAcknowledge(
+	cmd *cobra.Command,
+	deps workerInputCommandDeps,
+	workerInputID string,
+	executorBindingID string,
+) error {
+	if err := requireWorkerInputProtocolRole(deps); err != nil {
+		return err
+	}
+	if deps.resolveHome == nil || deps.readAck == nil || deps.createAck == nil || deps.now == nil {
+		return fmt.Errorf("worker-input acknowledge dependencies are incomplete")
+	}
+	fleetHome, err := deps.resolveHome()
+	if err != nil {
+		return asPrecondition(err)
+	}
+	if acknowledgement, found, err := deps.readAck(cmd.Context(), fleetHome, workerInputID); err != nil {
+		return err
+	} else if found {
+		return renderWorkerInputAcknowledgement(cmd, acknowledgement, executorBindingID, true)
+	}
+
+	observedAt := deps.now().UTC().Format(time.RFC3339Nano)
+	acknowledgement, err := deps.createAck(cmd.Context(), fleetHome, store.CanonicalV19WorkerInputAcknowledgementCreateInput{
+		WorkerInputID: workerInputID, ExecutorBindingID: executorBindingID,
+		ObservedAt: observedAt, EvidenceDigest: workerInputAcknowledgementEvidenceDigest(workerInputID, executorBindingID, observedAt),
+	})
+	if err != nil {
+		if !errors.Is(err, store.ErrCanonicalV19WorkerInputAcknowledgementConflict) {
+			return err
+		}
+		// A concurrent acknowledgement may have committed after the read above. Re-read exact immutable
+		// evidence rather than manufacturing a second observation timestamp.
+		existing, found, readErr := deps.readAck(cmd.Context(), fleetHome, workerInputID)
+		if readErr != nil {
+			return readErr
+		}
+		if !found {
+			return &ExitError{Err: err, Code: 3}
+		}
+		return renderWorkerInputAcknowledgement(cmd, existing, executorBindingID, true)
+	}
+	return renderWorkerInputAcknowledgement(cmd, acknowledgement, executorBindingID, false)
+}
+
+func requireWorkerInputProtocolRole(deps workerInputCommandDeps) error {
+	if deps.role == nil {
+		return fmt.Errorf("worker-input protocol role dependency is unavailable")
+	}
+	if deps.role() != harness.WorkerRole {
+		return &ExitError{Err: fmt.Errorf("worker-input protocol requires %s=%s", harness.RoleEnv, harness.WorkerRole), Code: 3}
+	}
+	return nil
+}
+
+func renderWorkerInputAcknowledgement(
+	cmd *cobra.Command,
+	acknowledgement store.CanonicalV19WorkerInputAcknowledgement,
+	executorBindingID string,
+	replayed bool,
+) error {
+	if acknowledgement.WorkerInputID == "" || acknowledgement.ExecutorBindingID != executorBindingID || acknowledgement.ActorKind != "worker" {
+		return &ExitError{Err: fmt.Errorf(
+			"canonical v19 WorkerInputAcknowledgement does not belong to exact ExecutorBinding %q", executorBindingID,
+		), Code: 3}
+	}
+	return encodeWorkerInputProtocolOutput(cmd, workerInputAcknowledgementOutput{
+		WorkerInputID: acknowledgement.WorkerInputID, ExecutorBindingID: acknowledgement.ExecutorBindingID,
+		ActorKind: acknowledgement.ActorKind, ObservedAt: acknowledgement.ObservedAt,
+		EvidenceDigest: acknowledgement.EvidenceDigest, Replayed: replayed,
+	})
+}
+
+func workerInputAcknowledgementEvidenceDigest(workerInputID, executorBindingID, observedAt string) string {
+	payload, _ := json.Marshal(struct {
+		Domain            string `json:"domain"`
+		WorkerInputID     string `json:"worker_input_id"`
+		ExecutorBindingID string `json:"executor_binding_id"`
+		ObservedAt        string `json:"observed_at"`
+	}{
+		Domain: "hand:v19:worker-input-ack-protocol:v1", WorkerInputID: workerInputID,
+		ExecutorBindingID: executorBindingID, ObservedAt: observedAt,
+	})
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:])
+}
+
+func encodeWorkerInputProtocolOutput(cmd *cobra.Command, value any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(value)
+}

--- a/cmd/worker_input.go
+++ b/cmd/worker_input.go
@@ -66,6 +66,9 @@ func newWorkerInputCmdWithDeps(deps workerInputCommandDeps) *cobra.Command {
 		Use:    "worker-input",
 		Short:  "Use the canonical WorkerInput runtime protocol",
 		Hidden: true,
+		// Canonical v19 protocol commands deliberately shadow the root PersistentPreRunE. Ordinary
+		// runtime commands still use legacy startup/migration guards until the explicit #339 cutover.
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
 	}
 	cmd.AddCommand(&cobra.Command{
 		Use:   "drain <attempt-id> <executor-binding-id>",

--- a/cmd/worker_input_hook_test.go
+++ b/cmd/worker_input_hook_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func TestWorkerInputProtocolShadowsLegacyRootStartupHook(t *testing.T) {
+	root := &cobra.Command{
+		Use: "hand",
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			t.Fatal("legacy root startup hook ran for canonical WorkerInput protocol")
+			return nil
+		},
+	}
+	runtime := &cobra.Command{Use: "runtime"}
+	runtime.AddCommand(newWorkerInputCmdWithDeps(workerInputCommandDeps{
+		role:        func() string { return harness.WorkerRole },
+		resolveHome: func() (string, error) { return "/fleet", nil },
+		now:         func() time.Time { return time.Date(2026, 9, 9, 9, 32, 0, 0, time.UTC) },
+		drain: func(context.Context, string, store.CanonicalV19WorkerInputDrainInput) ([]store.CanonicalV19WorkerInput, error) {
+			return []store.CanonicalV19WorkerInput{}, nil
+		},
+	}))
+	root.AddCommand(runtime)
+	root.SetArgs([]string{"runtime", "worker-input", "drain", "attempt-1", "executor-1"})
+	var out strings.Builder
+	root.SetOut(&out)
+	root.SetErr(new(strings.Builder))
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"inputs":[]`) {
+		t.Fatalf("drain output = %q", out.String())
+	}
+}

--- a/cmd/worker_input_test.go
+++ b/cmd/worker_input_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/harness"
+	"github.com/atqamz/hand/internal/store"
+)
+
+func TestWorkerInputProtocolRequiresWorkerRole(t *testing.T) {
+	cmd := newWorkerInputCmdWithDeps(workerInputCommandDeps{
+		role: func() string { return "" },
+	})
+	cmd.SetArgs([]string{"drain", "attempt-1", "executor-1"})
+	cmd.SetOut(new(strings.Builder))
+	cmd.SetErr(new(strings.Builder))
+	_, err := cmd.ExecuteC()
+	if err == nil {
+		t.Fatal("worker-input drain unexpectedly accepted non-worker role")
+	}
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 {
+		t.Fatalf("worker-input role error = %v, want precondition exit 3", err)
+	}
+	if !strings.Contains(err.Error(), "HAND_ROLE=worker") {
+		t.Fatalf("worker-input role error = %q", err)
+	}
+}
+
+func TestWorkerInputDrainRendersExactPendingInputs(t *testing.T) {
+	fixed := time.Date(2026, 9, 9, 9, 30, 0, 123, time.UTC)
+	cmd := newWorkerInputCmdWithDeps(workerInputCommandDeps{
+		role:        func() string { return harness.WorkerRole },
+		resolveHome: func() (string, error) { return "/fleet", nil },
+		now:         func() time.Time { return fixed },
+		drain: func(_ context.Context, home string, input store.CanonicalV19WorkerInputDrainInput) ([]store.CanonicalV19WorkerInput, error) {
+			if home != "/fleet" || input.AttemptID != "attempt-1" || input.ExecutorBindingID != "executor-1" {
+				t.Fatalf("drain target = %q %#v", home, input)
+			}
+			return []store.CanonicalV19WorkerInput{
+				{ID: "input-1", AttemptID: "attempt-1", ExecutorBindingID: "executor-1", Ordinal: 1,
+					Payload: "first\nmessage", PayloadDigest: "digest-1", OriginKind: "operator", CreatedAt: "2026-09-09T09:00:00Z"},
+				{ID: "input-2", AttemptID: "attempt-1", ExecutorBindingID: "executor-1", Ordinal: 2,
+					Payload: "second", PayloadDigest: "digest-2", OriginKind: "supervisor", CreatedAt: "2026-09-09T09:01:00Z"},
+			}, nil
+		},
+	})
+	cmd.SetArgs([]string{"drain", "attempt-1", "executor-1"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(new(strings.Builder))
+	if _, err := cmd.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	var got workerInputDrainOutput
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("decode drain output %q: %v", out.String(), err)
+	}
+	if got.AttemptID != "attempt-1" || got.ExecutorBindingID != "executor-1" ||
+		got.DrainedAt != fixed.Format(time.RFC3339Nano) || len(got.Inputs) != 2 {
+		t.Fatalf("drain output = %#v", got)
+	}
+	if got.Inputs[0].ID != "input-1" || got.Inputs[0].Ordinal != 1 || got.Inputs[0].Payload != "first\nmessage" ||
+		got.Inputs[1].ID != "input-2" || got.Inputs[1].Ordinal != 2 {
+		t.Fatalf("drain inputs = %#v", got.Inputs)
+	}
+}
+
+func TestWorkerInputAcknowledgeCreatesAndReplaysExactEvidence(t *testing.T) {
+	fixed := time.Date(2026, 9, 9, 9, 31, 0, 0, time.UTC)
+	var created store.CanonicalV19WorkerInputAcknowledgementCreateInput
+	cmd := newWorkerInputCmdWithDeps(workerInputCommandDeps{
+		role:        func() string { return harness.WorkerRole },
+		resolveHome: func() (string, error) { return "/fleet", nil },
+		now:         func() time.Time { return fixed },
+		readAck: func(context.Context, string, string) (store.CanonicalV19WorkerInputAcknowledgement, bool, error) {
+			return store.CanonicalV19WorkerInputAcknowledgement{}, false, nil
+		},
+		createAck: func(_ context.Context, home string, input store.CanonicalV19WorkerInputAcknowledgementCreateInput) (store.CanonicalV19WorkerInputAcknowledgement, error) {
+			if home != "/fleet" {
+				t.Fatalf("ack home = %q", home)
+			}
+			created = input
+			return store.CanonicalV19WorkerInputAcknowledgement{
+				WorkerInputID: input.WorkerInputID, ExecutorBindingID: input.ExecutorBindingID,
+				ActorKind: "worker", ObservedAt: input.ObservedAt, EvidenceDigest: input.EvidenceDigest,
+			}, nil
+		},
+	})
+	cmd.SetArgs([]string{"acknowledge", "input-1", "executor-1"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(new(strings.Builder))
+	if _, err := cmd.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	if created.WorkerInputID != "input-1" || created.ExecutorBindingID != "executor-1" ||
+		created.ObservedAt != fixed.Format(time.RFC3339Nano) || len(created.EvidenceDigest) != 64 {
+		t.Fatalf("created acknowledgement = %#v", created)
+	}
+	var first workerInputAcknowledgementOutput
+	if err := json.Unmarshal([]byte(out.String()), &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.Replayed || first.EvidenceDigest != created.EvidenceDigest {
+		t.Fatalf("first acknowledgement output = %#v", first)
+	}
+
+	existing := store.CanonicalV19WorkerInputAcknowledgement{
+		WorkerInputID: "input-1", ExecutorBindingID: "executor-1", ActorKind: "worker",
+		ObservedAt: created.ObservedAt, EvidenceDigest: created.EvidenceDigest,
+	}
+	replay := newWorkerInputCmdWithDeps(workerInputCommandDeps{
+		role:        func() string { return harness.WorkerRole },
+		resolveHome: func() (string, error) { return "/fleet", nil },
+		now:         func() time.Time { t.Fatal("replay unexpectedly requested a new timestamp"); return time.Time{} },
+		readAck: func(context.Context, string, string) (store.CanonicalV19WorkerInputAcknowledgement, bool, error) {
+			return existing, true, nil
+		},
+		createAck: func(context.Context, string, store.CanonicalV19WorkerInputAcknowledgementCreateInput) (store.CanonicalV19WorkerInputAcknowledgement, error) {
+			t.Fatal("replay unexpectedly created acknowledgement")
+			return store.CanonicalV19WorkerInputAcknowledgement{}, nil
+		},
+	})
+	replay.SetArgs([]string{"acknowledge", "input-1", "executor-1"})
+	out.Reset()
+	replay.SetOut(&out)
+	replay.SetErr(new(strings.Builder))
+	if _, err := replay.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+	var second workerInputAcknowledgementOutput
+	if err := json.Unmarshal([]byte(out.String()), &second); err != nil {
+		t.Fatal(err)
+	}
+	if !second.Replayed || second.EvidenceDigest != existing.EvidenceDigest || second.ObservedAt != existing.ObservedAt {
+		t.Fatalf("replayed acknowledgement output = %#v", second)
+	}
+}

--- a/internal/store/v19workerinput_ack_read.go
+++ b/internal/store/v19workerinput_ack_read.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ReadCanonicalV19WorkerInputAcknowledgement returns immutable acknowledgement evidence for one exact WorkerInput.
+func ReadCanonicalV19WorkerInputAcknowledgement(
+	ctx context.Context,
+	homeDir string,
+	workerInputID string,
+) (CanonicalV19WorkerInputAcknowledgement, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if workerInputID == "" {
+		return CanonicalV19WorkerInputAcknowledgement{}, false,
+			fmt.Errorf("read canonical v19 WorkerInputAcknowledgement: WorkerInput ID is empty")
+	}
+
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return CanonicalV19WorkerInputAcknowledgement{}, false, err
+	}
+	defer func() { _ = db.Close() }()
+
+	var acknowledgement CanonicalV19WorkerInputAcknowledgement
+	err = db.sql.QueryRowContext(ctx, `SELECT worker_input_id,executor_binding_id,actor_kind,observed_at,evidence_digest
+		FROM worker_input_acknowledgement WHERE worker_input_id=?`, workerInputID).Scan(
+		&acknowledgement.WorkerInputID, &acknowledgement.ExecutorBindingID, &acknowledgement.ActorKind,
+		&acknowledgement.ObservedAt, &acknowledgement.EvidenceDigest,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CanonicalV19WorkerInputAcknowledgement{}, false, nil
+	}
+	if err != nil {
+		if isSQLiteBusy(err) {
+			return CanonicalV19WorkerInputAcknowledgement{}, false,
+				fmt.Errorf("read canonical v19 WorkerInputAcknowledgement: %w", ErrContention)
+		}
+		return CanonicalV19WorkerInputAcknowledgement{}, false,
+			fmt.Errorf("read canonical v19 WorkerInputAcknowledgement: %w", err)
+	}
+	return acknowledgement, true, nil
+}

--- a/internal/store/v19workerinput_ack_read_test.go
+++ b/internal/store/v19workerinput_ack_read_test.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestReadCanonicalV19WorkerInputAcknowledgementReturnsExactHistoricalEvidence(t *testing.T) {
+	fixture, _, launch := canonicalV19ExecutorBindingFixture(t)
+	workerInput := canonicalV19WorkerInputCreateInput(launch, "worker-input-ack-read", "instruction", "digest-worker-input-ack-read")
+	createdInput, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home, workerInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := ReadCanonicalV19WorkerInputAcknowledgement(context.Background(), fixture.Home, createdInput.ID); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("acknowledgement unexpectedly existed before Worker observation")
+	}
+
+	created, err := CreateCanonicalV19WorkerInputAcknowledgement(context.Background(), fixture.Home,
+		CanonicalV19WorkerInputAcknowledgementCreateInput{
+			WorkerInputID: createdInput.ID, ExecutorBindingID: launch.BindingID,
+			ObservedAt: "2026-09-09T09:31:00Z", EvidenceDigest: "worker-observed-ack-read",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	read, found, err := ReadCanonicalV19WorkerInputAcknowledgement(context.Background(), fixture.Home, createdInput.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || read != created {
+		t.Fatalf("read acknowledgement = %#v found=%v, want %#v", read, found, created)
+	}
+}


### PR DESCRIPTION
Implements the next bounded #339 Step 11 Worker runtime protocol slice required before Herdr WorkerWake provider reconciliation.

Scope:
- hidden internal `hand runtime worker-input drain <attempt-id> <executor-binding-id>` surface
- hidden internal `hand runtime worker-input acknowledge <worker-input-id> <executor-binding-id>` surface
- exact `HAND_ROLE=worker` enforcement
- drain remains read-only and delegates to the separately qualified canonical ordinal/unacknowledged store reader
- acknowledgement is explicit Worker evidence only; drain/wake/provider acceptance never auto-acknowledges input
- acknowledgement replay returns the existing immutable evidence instead of manufacturing a new timestamp
- concurrent acknowledgement winner is re-read exactly
- canonical protocol startup shadows legacy root migration/preflight hooks, so ordinary legacy runtime call paths remain untouched
- dormant/internal protocol only; no runtime cutover and no provider mutation in this slice

Follow-up: Herdr WorkerWake mechanism/idempotency/reconciliation can prompt the exact Worker to use this provider-neutral protocol without injecting WorkerInput payload bytes into terminal control flow.

#344 DDL impact: **NONE**.
Runtime cutover: **NONE**.