### PR TITLE
feat(store): reconcile Herdr WorkerWake

### DIFF
--- a/internal/herdr/agent_prompt.go
+++ b/internal/herdr/agent_prompt.go
@@ -1,0 +1,58 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// AgentPromptContext submits one prompt to the live agent that currently owns target.
+// A nil return proves only that Herdr completed the prompt text + Enter writes; it does
+// not prove the agent started a turn or consumed any application-level input.
+func (c *Client) AgentPromptContext(ctx context.Context, target, text string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	args := []string{"agent", "prompt", target, text}
+	trimmed, stderr, runErr := c.runContext(ctx, args...)
+	if len(trimmed) == 0 {
+		if runErr != nil {
+			if env, err := parseEnvelope(args, []byte(stderr)); err == nil && env.Error != nil {
+				return c.normalizeAPIError(newAPIError(args, env.Error))
+			}
+			return fmt.Errorf("herdr agent prompt: %w: %s", runErr, stderr)
+		}
+		return errors.New("herdr agent prompt: empty response")
+	}
+
+	env, err := parseEnvelope(args, trimmed)
+	if err != nil {
+		return err
+	}
+	if env.Error != nil {
+		return c.normalizeAPIError(newAPIError(args, env.Error))
+	}
+	if runErr != nil {
+		return fmt.Errorf("herdr agent prompt: %w: %s", runErr, stderr)
+	}
+	if len(env.Result) == 0 || string(env.Result) == "null" {
+		return errors.New("herdr agent prompt: response missing result")
+	}
+	return nil
+}
+
+// IsAgentPromptPreSideEffectRejection reports only Herdr agent-prompt failures whose
+// v0.8.2 contract rejects the request before terminal input is queued.
+func IsAgentPromptPreSideEffectRejection(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || !strings.HasPrefix(apiErr.Operation, "agent prompt ") {
+		return false
+	}
+	switch strings.ToLower(apiErr.Code) {
+	case "agent_blocked", "agent_not_found", "agent_not_ready", "empty_agent_prompt":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/herdr/agent_prompt_test.go
+++ b/internal/herdr/agent_prompt_test.go
@@ -1,0 +1,76 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atqamz/hand/internal/faketool"
+)
+
+func TestAgentPromptContextTargetsExactAgentPaneAndText(t *testing.T) {
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	bin := faketool.Bin(t)
+	faketool.Herdr{
+		Responses: []faketool.HerdrResponse{{
+			Command: "agent prompt",
+			Args:    []string{"wA:pB", "hand worker wake"},
+			Stdout:  `{"id":"cli:1","result":{"agent":{"pane_id":"wA:pB","kind":"codex","status":"working"}}}`,
+		}},
+		Log: callLog,
+	}.Install(t, bin)
+
+	if err := NewSessionClient("hand-f-fleet").AgentPromptContext(context.Background(), "wA:pB", "hand worker wake"); err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "--session hand-f-fleet agent prompt wA:pB hand worker wake") {
+		t.Fatalf("calls = %q, want named session agent prompt", calls)
+	}
+}
+
+func TestAgentPromptContextPreservesPreSideEffectRejections(t *testing.T) {
+	for _, code := range []string{"agent_blocked", "agent_not_found", "agent_not_ready", "empty_agent_prompt"} {
+		t.Run(code, func(t *testing.T) {
+			writeFakeHerdr(t, faketool.HerdrResponse{
+				Command: "agent prompt",
+				Stderr:  `{"error":{"code":"` + code + `","message":"rejected"}}`,
+				Exit:    1,
+			})
+			err := NewClient().AgentPromptContext(context.Background(), "wA:pB", "wake")
+			if err == nil || !IsAgentPromptPreSideEffectRejection(err) {
+				t.Fatalf("AgentPromptContext() = %v, want typed pre-side-effect rejection", err)
+			}
+		})
+	}
+}
+
+func TestAgentPromptContextDoesNotClassifyAmbiguousProviderFailure(t *testing.T) {
+	writeFakeHerdr(t, faketool.HerdrResponse{
+		Command: "agent prompt",
+		Stderr:  `{"error":{"code":"agent_prompt_failed","message":"pty actor closed"}}`,
+		Exit:    1,
+	})
+	err := NewClient().AgentPromptContext(context.Background(), "wA:pB", "wake")
+	if err == nil || IsAgentPromptPreSideEffectRejection(err) {
+		t.Fatalf("AgentPromptContext() = %v, want ambiguous provider failure", err)
+	}
+}
+
+func TestAgentPromptContextReportsProcessNotStarted(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	err := NewClient().AgentPromptContext(context.Background(), "wA:pB", "wake")
+	if err == nil || !IsProcessNotStarted(err) {
+		t.Fatalf("AgentPromptContext() = %v, want process-not-started evidence", err)
+	}
+	var execErr *ExecError
+	if !errors.As(err, &execErr) || execErr.Started {
+		t.Fatalf("AgentPromptContext() = %v, want Started=false", err)
+	}
+}

--- a/internal/store/v19workerwake_herdr.go
+++ b/internal/store/v19workerwake_herdr.go
@@ -1,0 +1,320 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+type canonicalV19HerdrWorkerWakeObservationState string
+
+const (
+	canonicalV19HerdrWorkerWakeReady    canonicalV19HerdrWorkerWakeObservationState = "ready"
+	canonicalV19HerdrWorkerWakeBlocked  canonicalV19HerdrWorkerWakeObservationState = "blocked"
+	canonicalV19HerdrWorkerWakeNotReady canonicalV19HerdrWorkerWakeObservationState = "not-ready"
+	canonicalV19HerdrWorkerWakeCeased   canonicalV19HerdrWorkerWakeObservationState = "ceased"
+	canonicalV19HerdrWorkerWakeMismatch canonicalV19HerdrWorkerWakeObservationState = "mismatch"
+	canonicalV19HerdrWorkerWakeUnknown  canonicalV19HerdrWorkerWakeObservationState = "unknown"
+)
+
+type canonicalV19HerdrWorkerWakeObservation struct {
+	State            canonicalV19HerdrWorkerWakeObservationState
+	PendingInput     bool
+	ProcessAlive     bool
+	ProviderAccepted bool
+	Agent            string
+	AgentStatus      herdr.Status
+	WorkspaceID      string
+	TabID            string
+	PaneID           string
+	PaneCwd          string
+	ShellPID         int
+	ProcessGroupID   int
+	ProcessID        int
+	ProcessDigest    string
+	EvidenceDigest   string
+	Reason           string
+}
+
+type canonicalV19HerdrWorkerWakeCurrent struct {
+	Current            canonicalV19WorkerWakeCurrent
+	FleetID            string
+	WorktreePath       string
+	ProviderSessionKey string
+	PendingInput       bool
+}
+
+type canonicalV19HerdrWorkerWakeClient interface {
+	ObserveSession(context.Context) herdr.SessionObservation
+	WorkspaceListContext(context.Context) ([]herdr.Workspace, error)
+	TabList(string) ([]herdr.Tab, error)
+	PaneGetContext(context.Context, string) (herdr.Pane, error)
+	PaneProcessInfo(string) (herdr.ProcessInfo, error)
+	AgentPromptContext(context.Context, string, string) error
+}
+
+type canonicalV19HerdrWorkerWakeDeps struct {
+	clientFor    func(string) canonicalV19HerdrWorkerWakeClient
+	processAlive func(int) (bool, error)
+	now          func() time.Time
+}
+
+// ReconcileCanonicalV19HerdrWorkerWake reconciles one exact mechanism-only WorkerWake
+// against its persisted Herdr ExecutorBinding. Herdr prompt acceptance is mechanism
+// success only; this path never creates WorkerInput acknowledgement evidence.
+func ReconcileCanonicalV19HerdrWorkerWake(ctx context.Context, homeDir, operationID string) (string, error) {
+	return reconcileCanonicalV19HerdrWorkerWake(ctx, homeDir, operationID, canonicalV19HerdrWorkerWakeDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrWorkerWakeClient {
+			return herdr.NewManagedSessionClient(sessionName)
+		},
+		processAlive: canonicalV19HerdrProcessAlive,
+		now:          time.Now,
+	})
+}
+
+func reconcileCanonicalV19HerdrWorkerWake(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+	deps canonicalV19HerdrWorkerWakeDeps,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if operationID == "" {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: operation ID is empty")
+	}
+	if deps.clientFor == nil || deps.processAlive == nil || deps.now == nil {
+		return "", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: adapter dependencies are incomplete")
+	}
+
+	current, err := readCanonicalV19HerdrWorkerWakeCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		if errors.Is(err, ErrCanonicalV19WorkerWakeNotCurrent) {
+			if state, found, terminalErr := readCanonicalV19HerdrWorkerWakeTerminal(ctx, homeDir, operationID); terminalErr != nil {
+				return "", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w", terminalErr)
+			} else if found {
+				return state, nil
+			}
+		}
+		return "", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w", err)
+	}
+	request := current.Current.Request
+	switch current.Current.State {
+	case "succeeded", "rejected", "no-effect":
+		return current.Current.State, nil
+	case "prepared", "submitted", "uncertain":
+	default:
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: operation %q is %q",
+			ErrCanonicalV19WorkerWakeTransition, operationID, current.Current.State)
+	}
+	if request.AdapterRef != canonicalV19HerdrSessionAdapterRef {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: adapter %q is not %q",
+			ErrCanonicalV19WorkerWakeNotCurrent, request.AdapterRef, canonicalV19HerdrSessionAdapterRef)
+	}
+
+	doorbell, err := canonicalV19HerdrWorkerWakeDoorbellFor(CanonicalV19HerdrWorkerWakeDoorbellInput{
+		OperationID: request.OperationID, AttemptID: request.AttemptID,
+		ExecutorBindingID: request.ExecutorBindingID, PendingThroughOrdinal: request.PendingThroughOrdinal,
+	})
+	if err != nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w", err)
+	}
+	if request.DoorbellDigest != doorbell.Digest {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: persisted doorbell digest does not match exact Herdr doorbell bytes",
+			ErrCanonicalV19WorkerWakeNotCurrent)
+	}
+
+	executorKey, err := parseCanonicalV19HerdrExecutorProviderKey(request.ProviderExecutorKey)
+	if err != nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: invalid provider Executor key: %v",
+			ErrCanonicalV19WorkerWakeNotCurrent, err)
+	}
+	sessionKey, err := parseCanonicalV19HerdrSessionProviderKey(current.ProviderSessionKey)
+	if err != nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: invalid provider Session key: %v",
+			ErrCanonicalV19WorkerWakeNotCurrent, err)
+	}
+	expectedSession := herdr.SessionName(current.FleetID)
+	if executorKey.SessionName != expectedSession || sessionKey.SessionName != expectedSession ||
+		executorKey.WorkspaceID != sessionKey.WorkspaceID || executorKey.TabID != sessionKey.TabID || executorKey.PaneID != sessionKey.PaneID {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: provider Executor and Session identities differ",
+			ErrCanonicalV19WorkerWakeNotCurrent)
+	}
+
+	client := deps.clientFor(expectedSession)
+	if client == nil {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: provider client is unavailable")
+	}
+	observed := observeCanonicalV19HerdrWorkerWake(ctx, current, executorKey, sessionKey, client, deps.processAlive)
+	if current.Current.State != "prepared" {
+		return reconcileCanonicalV19SubmittedHerdrWorkerWake(ctx, homeDir, current, observed, deps.now)
+	}
+	if !current.PendingInput {
+		observed.PendingInput = false
+		observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason, "all WorkerInput through the persisted pending boundary is already acknowledged before submission")
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return classifyCanonicalV19HerdrWorkerWakeNoEffect(ctx, homeDir, current, observed, deps.now)
+	}
+
+	switch observed.State {
+	case canonicalV19HerdrWorkerWakeReady:
+	case canonicalV19HerdrWorkerWakeBlocked:
+		observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason, "Herdr v0.8.2 guarantees agent_blocked rejects before terminal input")
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return classifyCanonicalV19HerdrWorkerWakeNoEffect(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrWorkerWakeCeased:
+		return classifyCanonicalV19HerdrWorkerWakeNoEffect(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrWorkerWakeNotReady:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: exact provider agent is not ready: %s", observed.Reason)
+	case canonicalV19HerdrWorkerWakeMismatch:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: provider ownership is unresolved: %s", observed.Reason)
+	case canonicalV19HerdrWorkerWakeUnknown:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: provider observation is unknown: %s", observed.Reason)
+	default:
+		return "prepared", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: provider observation state %q is invalid", observed.State)
+	}
+
+	submittedAt := canonicalV19HerdrSessionTimestampAfter(deps.now(), current.Current.StateChangedAt)
+	if _, err := SubmitCanonicalV19WorkerWake(ctx, homeDir, operationID, submittedAt, observed.EvidenceDigest); err != nil {
+		return "prepared", err
+	}
+
+	current, err = readCanonicalV19HerdrWorkerWakeCurrent(ctx, homeDir, operationID)
+	if err != nil {
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: revalidate after submit before provider mutation: %w", err)
+	}
+	if current.Current.State != "submitted" {
+		return current.Current.State, fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %w: operation changed after submit to %q",
+			ErrCanonicalV19WorkerWakeTransition, current.Current.State)
+	}
+	if !current.PendingInput {
+		observed.PendingInput = false
+		observed.Reason = "all WorkerInput through the persisted pending boundary became acknowledged after durable submit and before first provider mutation"
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return classifyCanonicalV19HerdrWorkerWakeNoEffect(ctx, homeDir, current, observed, deps.now)
+	}
+
+	observed = observeCanonicalV19HerdrWorkerWake(ctx, current, executorKey, sessionKey, client, deps.processAlive)
+	switch observed.State {
+	case canonicalV19HerdrWorkerWakeReady:
+	case canonicalV19HerdrWorkerWakeBlocked, canonicalV19HerdrWorkerWakeNotReady, canonicalV19HerdrWorkerWakeCeased:
+		observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason, "no WorkerWake provider mutation was attempted after durable submit")
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return classifyCanonicalV19HerdrWorkerWakeNoEffect(ctx, homeDir, current, observed, deps.now)
+	case canonicalV19HerdrWorkerWakeMismatch, canonicalV19HerdrWorkerWakeUnknown:
+		observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason, "provider identity became unresolved after durable submit and before first provider mutation")
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return classifyCanonicalV19HerdrWorkerWakeUncertain(ctx, homeDir, current, observed, deps.now, nil)
+	default:
+		return "submitted", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: provider observation state %q is invalid", observed.State)
+	}
+
+	performErr := client.AgentPromptContext(ctx, executorKey.PaneID, doorbell.Text)
+	if performErr == nil {
+		observed.ProviderAccepted = true
+		observed.Reason = "Herdr v0.8.2 agent prompt completed the exact doorbell text and Enter writes to the exact recognized agent"
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return completeCanonicalV19ObservedHerdrWorkerWake(ctx, homeDir, current, observed, deps.now)
+	}
+	if herdr.IsProcessNotStarted(performErr) || herdr.IsAgentPromptPreSideEffectRejection(performErr) {
+		observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason,
+			"Herdr agent prompt produced positive pre-side-effect rejection evidence: "+canonicalV19HerdrSessionErrorText(performErr))
+		observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		return classifyCanonicalV19HerdrWorkerWakeNoEffect(ctx, homeDir, current, observed, deps.now)
+	}
+
+	observed = observeCanonicalV19HerdrWorkerWake(ctx, current, executorKey, sessionKey, client, deps.processAlive)
+	observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason,
+		"Herdr agent prompt outcome is ambiguous: "+canonicalV19HerdrSessionErrorText(performErr))
+	observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	return classifyCanonicalV19HerdrWorkerWakeUncertain(ctx, homeDir, current, observed, deps.now, performErr)
+}
+
+func reconcileCanonicalV19SubmittedHerdrWorkerWake(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrWorkerWakeCurrent,
+	observed canonicalV19HerdrWorkerWakeObservation,
+	now func() time.Time,
+) (string, error) {
+	observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason,
+		"Herdr v0.8.2 agent prompt exposes no provider receipt or provider-enforced operation-key idempotency; submitted WorkerWake cannot be replayed")
+	observed = finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	if current.Current.State == "submitted" {
+		return classifyCanonicalV19HerdrWorkerWakeUncertain(ctx, homeDir, current, observed, now, nil)
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: operation remains uncertain: %s", observed.Reason)
+}
+
+func completeCanonicalV19ObservedHerdrWorkerWake(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrWorkerWakeCurrent,
+	observed canonicalV19HerdrWorkerWakeObservation,
+	now func() time.Time,
+) (string, error) {
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := CompleteCanonicalV19WorkerWake(ctx, homeDir, CanonicalV19WorkerWakeSucceededEvidence{
+		OperationID: current.Current.Request.OperationID, ObservedAt: observedAt, EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	return "succeeded", nil
+}
+
+func classifyCanonicalV19HerdrWorkerWakeNoEffect(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrWorkerWakeCurrent,
+	observed canonicalV19HerdrWorkerWakeObservation,
+	now func() time.Time,
+) (string, error) {
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19WorkerWake(ctx, homeDir, CanonicalV19WorkerWakeTransitionInput{
+		OperationID: current.Current.Request.OperationID, State: "no-effect",
+		ObservedAt: observedAt, EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	reason := observed.Reason
+	if reason == "" {
+		reason = "positive evidence proves no WorkerWake provider mutation occurred"
+	}
+	return "no-effect", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: %s", reason)
+}
+
+func classifyCanonicalV19HerdrWorkerWakeUncertain(
+	ctx context.Context,
+	homeDir string,
+	current canonicalV19HerdrWorkerWakeCurrent,
+	observed canonicalV19HerdrWorkerWakeObservation,
+	now func() time.Time,
+	performErr error,
+) (string, error) {
+	if current.Current.State == "uncertain" {
+		reason := observed.Reason
+		if reason == "" {
+			reason = "strongest provider evidence cannot classify exact WorkerWake acceptance"
+		}
+		return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: operation remains uncertain: %s", reason)
+	}
+	observedAt := canonicalV19HerdrSessionTimestampAfter(now(), current.Current.StateChangedAt)
+	if err := ClassifyCanonicalV19WorkerWake(ctx, homeDir, CanonicalV19WorkerWakeTransitionInput{
+		OperationID: current.Current.Request.OperationID, State: "uncertain",
+		ObservedAt: observedAt, EvidenceDigest: observed.EvidenceDigest,
+	}); err != nil {
+		return current.Current.State, err
+	}
+	reason := observed.Reason
+	if performErr != nil {
+		reason = canonicalV19HerdrLaunchJoinReason(reason, "provider error: "+canonicalV19HerdrSessionErrorText(performErr))
+	}
+	if reason == "" {
+		reason = "strongest provider evidence cannot classify exact WorkerWake acceptance"
+	}
+	return "uncertain", fmt.Errorf("reconcile canonical v19 Herdr WorkerWake: operation is uncertain: %s", reason)
+}

--- a/internal/store/v19workerwake_herdr_doorbell.go
+++ b/internal/store/v19workerwake_herdr_doorbell.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -50,13 +51,13 @@ func canonicalV19HerdrWorkerWakeDoorbellFor(input CanonicalV19HerdrWorkerWakeDoo
 	writeCanonicalV19DigestField(markerHash, "pending_through_ordinal", strconv.FormatInt(input.PendingThroughOrdinal, 10))
 	marker := hex.EncodeToString(markerHash.Sum(nil))[:16]
 
-	drainArgv, err := json.Marshal([]string{
+	drainArgv, err := canonicalV19HerdrWorkerWakeArgvJSON([]string{
 		"runtime", "worker-input", "drain", input.AttemptID, input.ExecutorBindingID,
 	})
 	if err != nil {
 		return canonicalV19HerdrWorkerWakeDoorbell{}, fmt.Errorf("build canonical v19 Herdr WorkerWake doorbell drain argv: %w", err)
 	}
-	ackArgv, err := json.Marshal([]string{
+	ackArgv, err := canonicalV19HerdrWorkerWakeArgvJSON([]string{
 		"runtime", "worker-input", "acknowledge", "<worker-input-id>", input.ExecutorBindingID,
 	})
 	if err != nil {
@@ -72,4 +73,14 @@ func canonicalV19HerdrWorkerWakeDoorbellFor(input CanonicalV19HerdrWorkerWakeDoo
 	}
 	digest := sha256.Sum256([]byte(text))
 	return canonicalV19HerdrWorkerWakeDoorbell{Text: text, Digest: hex.EncodeToString(digest[:])}, nil
+}
+
+func canonicalV19HerdrWorkerWakeArgvJSON(argv []string) (string, error) {
+	var encoded bytes.Buffer
+	encoder := json.NewEncoder(&encoded)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(argv); err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSuffix(encoded.Bytes(), []byte{'\n'})), nil
 }

--- a/internal/store/v19workerwake_herdr_doorbell.go
+++ b/internal/store/v19workerwake_herdr_doorbell.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+const canonicalV19HerdrWorkerWakeDoorbellMaxBytes = 1024
+
+// CanonicalV19HerdrWorkerWakeDoorbellInput identifies the immutable values encoded
+// into the bounded Hand-owned Herdr wake prompt.
+type CanonicalV19HerdrWorkerWakeDoorbellInput struct {
+	OperationID           string
+	AttemptID             string
+	ExecutorBindingID     string
+	PendingThroughOrdinal int64
+}
+
+// CanonicalV19HerdrWorkerWakeDoorbellDigest returns the digest a Herdr WorkerWake
+// request must persist for the exact bounded doorbell bytes this adapter will submit.
+func CanonicalV19HerdrWorkerWakeDoorbellDigest(input CanonicalV19HerdrWorkerWakeDoorbellInput) (string, error) {
+	doorbell, err := canonicalV19HerdrWorkerWakeDoorbellFor(input)
+	if err != nil {
+		return "", err
+	}
+	return doorbell.Digest, nil
+}
+
+type canonicalV19HerdrWorkerWakeDoorbell struct {
+	Text   string
+	Digest string
+}
+
+func canonicalV19HerdrWorkerWakeDoorbellFor(input CanonicalV19HerdrWorkerWakeDoorbellInput) (canonicalV19HerdrWorkerWakeDoorbell, error) {
+	if input.OperationID == "" || input.AttemptID == "" || input.ExecutorBindingID == "" {
+		return canonicalV19HerdrWorkerWakeDoorbell{}, fmt.Errorf("build canonical v19 Herdr WorkerWake doorbell: operation, Attempt, and ExecutorBinding IDs are required")
+	}
+	if input.PendingThroughOrdinal <= 0 {
+		return canonicalV19HerdrWorkerWakeDoorbell{}, fmt.Errorf("build canonical v19 Herdr WorkerWake doorbell: pending-through ordinal must be positive")
+	}
+
+	markerHash := sha256.New()
+	writeCanonicalV19DigestField(markerHash, "domain", "hand:v19:herdr-worker-wake-marker:v1")
+	writeCanonicalV19DigestField(markerHash, "operation_id", input.OperationID)
+	writeCanonicalV19DigestField(markerHash, "attempt_id", input.AttemptID)
+	writeCanonicalV19DigestField(markerHash, "executor_binding_id", input.ExecutorBindingID)
+	writeCanonicalV19DigestField(markerHash, "pending_through_ordinal", strconv.FormatInt(input.PendingThroughOrdinal, 10))
+	marker := hex.EncodeToString(markerHash.Sum(nil))[:16]
+
+	drainArgv, err := json.Marshal([]string{
+		"runtime", "worker-input", "drain", input.AttemptID, input.ExecutorBindingID,
+	})
+	if err != nil {
+		return canonicalV19HerdrWorkerWakeDoorbell{}, fmt.Errorf("build canonical v19 Herdr WorkerWake doorbell drain argv: %w", err)
+	}
+	ackArgv, err := json.Marshal([]string{
+		"runtime", "worker-input", "acknowledge", "<worker-input-id>", input.ExecutorBindingID,
+	})
+	if err != nil {
+		return canonicalV19HerdrWorkerWakeDoorbell{}, fmt.Errorf("build canonical v19 Herdr WorkerWake doorbell acknowledgement argv: %w", err)
+	}
+
+	text := fmt.Sprintf(
+		"HAND_WORKER_WAKE_V1 marker=%s pending_through=%d. Canonical WorkerInput is pending. Invoke `hand` with argv %s. Acknowledge only each input actually observed by invoking `hand` with argv %s after replacing <worker-input-id>.",
+		marker, input.PendingThroughOrdinal, drainArgv, ackArgv,
+	)
+	if len(text) > canonicalV19HerdrWorkerWakeDoorbellMaxBytes {
+		return canonicalV19HerdrWorkerWakeDoorbell{}, fmt.Errorf("build canonical v19 Herdr WorkerWake doorbell: %d bytes exceeds %d-byte bound", len(text), canonicalV19HerdrWorkerWakeDoorbellMaxBytes)
+	}
+	digest := sha256.Sum256([]byte(text))
+	return canonicalV19HerdrWorkerWakeDoorbell{Text: text, Digest: hex.EncodeToString(digest[:])}, nil
+}

--- a/internal/store/v19workerwake_herdr_observe.go
+++ b/internal/store/v19workerwake_herdr_observe.go
@@ -1,0 +1,180 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	handgit "github.com/atqamz/hand/internal/git"
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+func observeCanonicalV19HerdrWorkerWake(
+	ctx context.Context,
+	current canonicalV19HerdrWorkerWakeCurrent,
+	executorKey canonicalV19HerdrExecutorProviderKey,
+	sessionKey canonicalV19HerdrSessionProviderKey,
+	client canonicalV19HerdrWorkerWakeClient,
+	processAlive func(int) (bool, error),
+) canonicalV19HerdrWorkerWakeObservation {
+	request := current.Current.Request
+	observed := canonicalV19HerdrWorkerWakeObservation{
+		PendingInput: current.PendingInput,
+		WorkspaceID:  executorKey.WorkspaceID,
+		TabID:        executorKey.TabID,
+		PaneID:       executorKey.PaneID,
+		ProcessID:    executorKey.ProcessID,
+	}
+
+	alive, aliveErr := processAlive(executorKey.ProcessID)
+	observed.ProcessAlive = alive
+	if aliveErr == nil && !alive {
+		observed.State = canonicalV19HerdrWorkerWakeCeased
+		observed.Reason = "exact provider Executor PID is absent"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+
+	session := client.ObserveSession(ctx)
+	if session.Name != executorKey.SessionName || session.State != herdr.SessionRunningCompatible {
+		observed.State = canonicalV19HerdrWorkerWakeUnknown
+		observed.Reason = fmt.Sprintf("exact Herdr session %q is %q", executorKey.SessionName, session.State)
+		if session.Reason != "" {
+			observed.Reason += ": " + session.Reason
+		}
+		if aliveErr != nil {
+			observed.Reason = canonicalV19HerdrLaunchJoinReason(observed.Reason, "process liveness probe failed: "+aliveErr.Error())
+		}
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+
+	workspaces, err := client.WorkspaceListContext(ctx)
+	if err != nil {
+		observed.State = canonicalV19HerdrWorkerWakeUnknown
+		observed.Reason = "list exact Herdr session workspaces: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	workspaceMatches := 0
+	var workspace herdr.Workspace
+	for _, candidate := range workspaces {
+		if candidate.WorkspaceID == sessionKey.WorkspaceID {
+			workspace = candidate
+			workspaceMatches++
+		}
+	}
+	if workspaceMatches != 1 {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		if workspaceMatches == 0 {
+			observed.Reason = "exact Session workspace is absent while the provider Executor PID remains live"
+		} else {
+			observed.Reason = "Herdr workspace inventory returned the exact Session workspace more than once"
+		}
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if workspace.Label != canonicalV19HerdrSessionWorkspaceLabel(request.SessionBindingID) {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		observed.Reason = "exact workspace identity no longer carries the SessionBinding locator"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+
+	tabs, err := client.TabList(sessionKey.WorkspaceID)
+	if err != nil {
+		observed.State = canonicalV19HerdrWorkerWakeUnknown
+		observed.Reason = "list exact Session workspace tabs: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if len(tabs) != 1 || tabs[0].TabID != sessionKey.TabID || tabs[0].WorkspaceID != sessionKey.WorkspaceID {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		observed.Reason = "Session workspace root tab no longer matches the persisted provider Session key"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+
+	pane, err := client.PaneGetContext(ctx, sessionKey.PaneID)
+	if err != nil {
+		if errors.Is(err, herdr.ErrNotFound) {
+			observed.State = canonicalV19HerdrWorkerWakeMismatch
+			observed.Reason = "exact Session root pane is absent while the provider Executor PID remains live"
+		} else {
+			observed.State = canonicalV19HerdrWorkerWakeUnknown
+			observed.Reason = "observe exact Session root pane: " + canonicalV19HerdrSessionErrorText(err)
+		}
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	observed.PaneCwd = pane.Cwd
+	observed.Agent = pane.Agent
+	observed.AgentStatus = pane.AgentStatus
+	if pane.PaneID != sessionKey.PaneID || pane.TabID != sessionKey.TabID || pane.WorkspaceID != sessionKey.WorkspaceID {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		observed.Reason = "exact root pane parent identities differ from the provider Session key"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if pane.Cwd == "" || !handgit.SamePath(pane.Cwd, current.WorktreePath) {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		observed.Reason = "exact root pane cwd differs from the immutable WorktreeBinding"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+
+	info, err := client.PaneProcessInfo(sessionKey.PaneID)
+	if err != nil {
+		observed.State = canonicalV19HerdrWorkerWakeUnknown
+		observed.Reason = "observe exact pane process identity: " + canonicalV19HerdrSessionErrorText(err)
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	observed.ShellPID = info.ShellPID
+	observed.ProcessGroupID = info.ForegroundProcessGroupID
+	if info.PaneID != sessionKey.PaneID || info.ShellPID <= 0 || info.ForegroundProcessGroupID <= 0 {
+		observed.State = canonicalV19HerdrWorkerWakeUnknown
+		observed.Reason = "pane process evidence lacks exact pane/shell/process-group identity"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+
+	matches := 0
+	for _, process := range info.ForegroundProcesses {
+		if process.PID != executorKey.ProcessID {
+			continue
+		}
+		observed.ProcessDigest = canonicalV19HerdrProcessDigest(process)
+		if observed.ProcessDigest != executorKey.ProcessDigest {
+			observed.State = canonicalV19HerdrWorkerWakeMismatch
+			observed.Reason = "provider Executor PID now carries different argv/cwd identity"
+			return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		}
+		matches++
+	}
+	if matches > 1 {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		observed.Reason = "foreground process evidence returned the exact provider Executor PID more than once"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if matches == 0 {
+		if aliveErr != nil {
+			observed.State = canonicalV19HerdrWorkerWakeUnknown
+			observed.Reason = "exact provider Executor is absent from foreground evidence and process liveness probe failed: " + aliveErr.Error()
+			return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		}
+		if alive {
+			observed.State = canonicalV19HerdrWorkerWakeUnknown
+			observed.Reason = "exact provider Executor PID remains live but is absent from exact pane foreground process evidence"
+			return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+		}
+		observed.State = canonicalV19HerdrWorkerWakeCeased
+		observed.Reason = "exact provider Executor PID is absent"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if info.ForegroundProcessGroupID != executorKey.ProcessGroup {
+		observed.State = canonicalV19HerdrWorkerWakeMismatch
+		observed.Reason = "exact provider Executor PID is no longer in its persisted foreground process group"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if pane.Agent == "" {
+		observed.State = canonicalV19HerdrWorkerWakeNotReady
+		observed.Reason = "exact provider Executor remains live but Herdr does not currently recognize its agent"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	if pane.AgentStatus == herdr.StatusBlocked {
+		observed.State = canonicalV19HerdrWorkerWakeBlocked
+		observed.Reason = "exact recognized Herdr agent is blocked on interactive input"
+		return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+	}
+	observed.State = canonicalV19HerdrWorkerWakeReady
+	return finalizeCanonicalV19HerdrWorkerWakeObservation(current, observed)
+}

--- a/internal/store/v19workerwake_herdr_read.go
+++ b/internal/store/v19workerwake_herdr_read.go
@@ -1,0 +1,105 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func readCanonicalV19HerdrWorkerWakeCurrent(
+	ctx context.Context,
+	homeDir string,
+	operationID string,
+) (canonicalV19HerdrWorkerWakeCurrent, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return canonicalV19HerdrWorkerWakeCurrent{}, err
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return canonicalV19HerdrWorkerWakeCurrent{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	current, err := loadCanonicalV19WorkerWakeCurrent(ctx, tx, operationID)
+	if err != nil {
+		return canonicalV19HerdrWorkerWakeCurrent{}, err
+	}
+	result := canonicalV19HerdrWorkerWakeCurrent{Current: current}
+	if err := tx.QueryRowContext(ctx, `SELECT p.fleet_id,b.path,s.provider_session_key
+		FROM project p
+		JOIN session_binding s ON s.id=? AND s.attempt_id=? AND s.adapter_ref=?
+		JOIN attempt_worktree_binding b ON b.id=s.worktree_binding_id AND b.attempt_id=s.attempt_id
+		WHERE p.id=?`, current.Request.SessionBindingID, current.Request.AttemptID,
+		current.Request.AdapterRef, current.Request.ProjectID).Scan(
+		&result.FleetID, &result.WorktreePath, &result.ProviderSessionKey,
+	); err != nil {
+		return canonicalV19HerdrWorkerWakeCurrent{}, fmt.Errorf("read canonical v19 Herdr WorkerWake provider context: %w", err)
+	}
+	if result.FleetID == "" || result.WorktreePath == "" || result.ProviderSessionKey == "" {
+		return canonicalV19HerdrWorkerWakeCurrent{}, fmt.Errorf("read canonical v19 Herdr WorkerWake provider context: Fleet ID, Worktree path, or provider Session key is empty")
+	}
+	var pending int
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM worker_input wi
+		WHERE wi.executor_binding_id=? AND wi.ordinal<=?
+		  AND NOT EXISTS (SELECT 1 FROM worker_input_acknowledgement a WHERE a.worker_input_id=wi.id)
+	)`, current.Request.ExecutorBindingID, current.Request.PendingThroughOrdinal).Scan(&pending); err != nil {
+		return canonicalV19HerdrWorkerWakeCurrent{}, fmt.Errorf("read canonical v19 Herdr WorkerWake pending boundary: %w", err)
+	}
+	result.PendingInput = pending == 1
+	return result, nil
+}
+
+func readCanonicalV19HerdrWorkerWakeTerminal(ctx context.Context, homeDir, operationID string) (string, bool, error) {
+	db, err := openReadOnly(homeDir)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = db.Close() }()
+	var state string
+	err = db.sql.QueryRowContext(ctx, `SELECT state FROM external_operation
+		WHERE id=? AND kind='worker-wake' AND state IN ('succeeded','rejected','no-effect')`, operationID).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return state, true, nil
+}
+
+func finalizeCanonicalV19HerdrWorkerWakeObservation(
+	current canonicalV19HerdrWorkerWakeCurrent,
+	observed canonicalV19HerdrWorkerWakeObservation,
+) canonicalV19HerdrWorkerWakeObservation {
+	hash := sha256.New()
+	writeCanonicalV19DigestField(hash, "domain", "hand:v19:herdr-worker-wake-observation:v1")
+	writeCanonicalV19DigestField(hash, "operation_id", current.Current.Request.OperationID)
+	writeCanonicalV19DigestField(hash, "request_digest", current.Current.Request.RequestDigest)
+	writeCanonicalV19DigestField(hash, "fleet_id", current.FleetID)
+	writeCanonicalV19DigestField(hash, "provider_session_key", current.ProviderSessionKey)
+	writeCanonicalV19DigestField(hash, "provider_executor_key", current.Current.Request.ProviderExecutorKey)
+	writeCanonicalV19DigestField(hash, "doorbell_digest", current.Current.Request.DoorbellDigest)
+	writeCanonicalV19DigestField(hash, "state", string(observed.State))
+	writeCanonicalV19DigestField(hash, "pending_input", strconv.FormatBool(observed.PendingInput))
+	writeCanonicalV19DigestField(hash, "process_alive", strconv.FormatBool(observed.ProcessAlive))
+	writeCanonicalV19DigestField(hash, "provider_accepted", strconv.FormatBool(observed.ProviderAccepted))
+	writeCanonicalV19DigestField(hash, "agent", observed.Agent)
+	writeCanonicalV19DigestField(hash, "agent_status", string(observed.AgentStatus))
+	writeCanonicalV19DigestField(hash, "workspace_id", observed.WorkspaceID)
+	writeCanonicalV19DigestField(hash, "tab_id", observed.TabID)
+	writeCanonicalV19DigestField(hash, "pane_id", observed.PaneID)
+	writeCanonicalV19DigestField(hash, "pane_cwd", observed.PaneCwd)
+	writeCanonicalV19DigestField(hash, "shell_pid", strconv.Itoa(observed.ShellPID))
+	writeCanonicalV19DigestField(hash, "process_group_id", strconv.Itoa(observed.ProcessGroupID))
+	writeCanonicalV19DigestField(hash, "process_id", strconv.Itoa(observed.ProcessID))
+	writeCanonicalV19DigestField(hash, "process_digest", observed.ProcessDigest)
+	writeCanonicalV19DigestField(hash, "reason", observed.Reason)
+	observed.EvidenceDigest = hex.EncodeToString(hash.Sum(nil))
+	return observed
+}

--- a/internal/store/v19workerwake_herdr_test.go
+++ b/internal/store/v19workerwake_herdr_test.go
@@ -265,9 +265,9 @@ func canonicalV19HerdrWorkerWakeFixture(
 	}
 	client := &canonicalV19HerdrWorkerWakeFakeClient{
 		canonicalV19HerdrLaunchFakeClient: baseClient,
-		wakeOperationID:                  operationID,
-		targetPID:                        target.PID,
-		targetAlive:                      true,
+		wakeOperationID:                   operationID,
+		targetPID:                         target.PID,
+		targetAlive:                       true,
 	}
 	return fixture, request, executorKey, client, workerInput
 }

--- a/internal/store/v19workerwake_herdr_test.go
+++ b/internal/store/v19workerwake_herdr_test.go
@@ -198,7 +198,7 @@ func (f *canonicalV19HerdrWorkerWakeFakeClient) AgentPromptContext(_ context.Con
 	}
 	want, err := canonicalV19HerdrWorkerWakeDoorbellFor(CanonicalV19HerdrWorkerWakeDoorbellInput{
 		OperationID: current.Current.Request.OperationID, AttemptID: current.Current.Request.AttemptID,
-		ExecutorBindingID: current.Current.Request.ExecutorBindingID,
+		ExecutorBindingID:     current.Current.Request.ExecutorBindingID,
 		PendingThroughOrdinal: current.Current.Request.PendingThroughOrdinal,
 	})
 	if err != nil {

--- a/internal/store/v19workerwake_herdr_test.go
+++ b/internal/store/v19workerwake_herdr_test.go
@@ -1,0 +1,297 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atqamz/hand/internal/herdr"
+)
+
+func TestReconcileCanonicalV19HerdrWorkerWakeSucceedsOnlyFromAcceptedPromptAndReruns(t *testing.T) {
+	fixture, request, key, client, workerInput := canonicalV19HerdrWorkerWakeFixture(t, "operation-herdr-worker-wake-success")
+	client.requireSubmittedAtPrompt = true
+	deps := canonicalV19HerdrWorkerWakeTestDeps(t, key, client, time.Date(2026, 9, 9, 6, 10, 0, 0, time.UTC))
+
+	state, err := reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("reconcile Herdr WorkerWake = %q, %v", state, err)
+	}
+	if client.promptCalls != 1 {
+		t.Fatalf("agent prompt calls = %d, want 1", client.promptCalls)
+	}
+	if strings.Contains(client.lastPrompt, workerInput.Payload) {
+		t.Fatalf("doorbell leaked WorkerInput payload: %q", client.lastPrompt)
+	}
+
+	db, err := openReadOnly(fixture.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var operationState string
+	var acknowledgements int
+	if err := db.sql.QueryRow(`SELECT state FROM external_operation WHERE id=?`, request.OperationID).Scan(&operationState); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT count(*) FROM worker_input_acknowledgement WHERE worker_input_id=?`, workerInput.ID).Scan(&acknowledgements); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if operationState != "succeeded" || acknowledgements != 0 {
+		t.Fatalf("WorkerWake persisted state/acknowledgements = %q/%d, want succeeded/0", operationState, acknowledgements)
+	}
+
+	state, err = reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if err != nil || state != "succeeded" {
+		t.Fatalf("terminal rerun = %q, %v", state, err)
+	}
+	if client.promptCalls != 1 {
+		t.Fatalf("agent prompt calls after terminal rerun = %d, want 1", client.promptCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrWorkerWakePreSideEffectRejectionIsNoEffect(t *testing.T) {
+	fixture, request, key, client, _ := canonicalV19HerdrWorkerWakeFixture(t, "operation-herdr-worker-wake-no-effect")
+	client.promptErr = &herdr.APIError{
+		Operation: "agent prompt " + key.PaneID + " wake", Code: "agent_blocked", Message: "agent blocked",
+	}
+	deps := canonicalV19HerdrWorkerWakeTestDeps(t, key, client, time.Date(2026, 9, 9, 6, 11, 0, 0, time.UTC))
+
+	state, err := reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("pre-side-effect WorkerWake = %q, %v, want no-effect diagnostic", state, err)
+	}
+	if client.promptCalls != 1 {
+		t.Fatalf("agent prompt calls = %d, want 1", client.promptCalls)
+	}
+}
+
+func TestReconcileCanonicalV19HerdrWorkerWakeAmbiguousPromptBecomesUncertainWithoutReplay(t *testing.T) {
+	fixture, request, key, client, _ := canonicalV19HerdrWorkerWakeFixture(t, "operation-herdr-worker-wake-ambiguous")
+	client.promptErr = errors.New("provider response lost after agent prompt")
+	deps := canonicalV19HerdrWorkerWakeTestDeps(t, key, client, time.Date(2026, 9, 9, 6, 12, 0, 0, time.UTC))
+
+	state, err := reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("ambiguous WorkerWake = %q, %v, want uncertain diagnostic", state, err)
+	}
+	if client.promptCalls != 1 {
+		t.Fatalf("agent prompt calls = %d, want 1", client.promptCalls)
+	}
+
+	state, err = reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("uncertain rerun = %q, %v, want uncertain diagnostic", state, err)
+	}
+	if client.promptCalls != 1 {
+		t.Fatalf("agent prompt calls after uncertain rerun = %d, want 1", client.promptCalls)
+	}
+}
+
+func TestReconcileSubmittedCanonicalV19HerdrWorkerWakeDoesNotBlindReplay(t *testing.T) {
+	fixture, request, key, client, _ := canonicalV19HerdrWorkerWakeFixture(t, "operation-herdr-worker-wake-submitted")
+	if _, err := SubmitCanonicalV19WorkerWake(context.Background(), fixture.Home, request.OperationID,
+		"2026-09-09T06:08:00Z", "worker-wake-submitted-before-crash"); err != nil {
+		t.Fatal(err)
+	}
+	deps := canonicalV19HerdrWorkerWakeTestDeps(t, key, client, time.Date(2026, 9, 9, 6, 13, 0, 0, time.UTC))
+
+	state, err := reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "uncertain" || err == nil {
+		t.Fatalf("submitted recovery = %q, %v, want uncertain diagnostic", state, err)
+	}
+	if client.promptCalls != 0 {
+		t.Fatalf("agent prompt calls = %d, want 0", client.promptCalls)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19HerdrWorkerWakeBlockedAgentIsNoEffectWithoutMutation(t *testing.T) {
+	fixture, request, key, client, _ := canonicalV19HerdrWorkerWakeFixture(t, "operation-herdr-worker-wake-blocked")
+	pane := client.panes[key.PaneID]
+	pane.AgentStatus = herdr.StatusBlocked
+	client.panes[key.PaneID] = pane
+	deps := canonicalV19HerdrWorkerWakeTestDeps(t, key, client, time.Date(2026, 9, 9, 6, 14, 0, 0, time.UTC))
+
+	state, err := reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "no-effect" || err == nil {
+		t.Fatalf("blocked WorkerWake = %q, %v, want no-effect diagnostic", state, err)
+	}
+	if client.promptCalls != 0 {
+		t.Fatalf("agent prompt calls = %d, want 0", client.promptCalls)
+	}
+}
+
+func TestReconcilePreparedCanonicalV19HerdrWorkerWakeRefusesProviderIdentityMismatch(t *testing.T) {
+	fixture, request, key, client, _ := canonicalV19HerdrWorkerWakeFixture(t, "operation-herdr-worker-wake-mismatch")
+	for i := range client.processInfo.ForegroundProcesses {
+		if client.processInfo.ForegroundProcesses[i].PID == key.ProcessID {
+			client.processInfo.ForegroundProcesses[i].Argv = []string{"different-worker", "--other"}
+		}
+	}
+	deps := canonicalV19HerdrWorkerWakeTestDeps(t, key, client, time.Date(2026, 9, 9, 6, 15, 0, 0, time.UTC))
+
+	state, err := reconcileCanonicalV19HerdrWorkerWake(context.Background(), fixture.Home, request.OperationID, deps)
+	if state != "prepared" || err == nil {
+		t.Fatalf("mismatched WorkerWake = %q, %v, want prepared error", state, err)
+	}
+	if client.promptCalls != 0 {
+		t.Fatalf("agent prompt calls = %d, want 0", client.promptCalls)
+	}
+}
+
+func TestCanonicalV19HerdrWorkerWakeDoorbellIsDeterministicAndBounded(t *testing.T) {
+	input := CanonicalV19HerdrWorkerWakeDoorbellInput{
+		OperationID: "operation-worker-wake-doorbell", AttemptID: "attempt-1",
+		ExecutorBindingID: "executor-binding-1", PendingThroughOrdinal: 3,
+	}
+	first, err := canonicalV19HerdrWorkerWakeDoorbellFor(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := canonicalV19HerdrWorkerWakeDoorbellFor(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second || len(first.Digest) != 64 || len(first.Text) > canonicalV19HerdrWorkerWakeDoorbellMaxBytes {
+		t.Fatalf("doorbell = %#v / %#v", first, second)
+	}
+	if !strings.Contains(first.Text, `["runtime","worker-input","drain","attempt-1","executor-binding-1"]`) ||
+		!strings.Contains(first.Text, `["runtime","worker-input","acknowledge","<worker-input-id>","executor-binding-1"]`) {
+		t.Fatalf("doorbell protocol text = %q", first.Text)
+	}
+	input.PendingThroughOrdinal++
+	third, err := canonicalV19HerdrWorkerWakeDoorbellFor(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Digest == first.Digest || third.Text == first.Text {
+		t.Fatal("different pending boundary produced identical doorbell")
+	}
+}
+
+type canonicalV19HerdrWorkerWakeFakeClient struct {
+	*canonicalV19HerdrLaunchFakeClient
+	wakeOperationID          string
+	targetPID                int
+	targetAlive              bool
+	livenessErr              error
+	promptCalls              int
+	promptErr                error
+	lastPrompt               string
+	requireSubmittedAtPrompt bool
+}
+
+func (f *canonicalV19HerdrWorkerWakeFakeClient) AgentPromptContext(_ context.Context, target, text string) error {
+	f.promptCalls++
+	f.lastPrompt = text
+	if target != f.processInfo.PaneID {
+		f.t.Fatalf("AgentPromptContext target = %q, want %q", target, f.processInfo.PaneID)
+	}
+	current, err := readCanonicalV19HerdrWorkerWakeCurrent(context.Background(), f.home, f.wakeOperationID)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	want, err := canonicalV19HerdrWorkerWakeDoorbellFor(CanonicalV19HerdrWorkerWakeDoorbellInput{
+		OperationID: current.Current.Request.OperationID, AttemptID: current.Current.Request.AttemptID,
+		ExecutorBindingID: current.Current.Request.ExecutorBindingID,
+		PendingThroughOrdinal: current.Current.Request.PendingThroughOrdinal,
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if text != want.Text {
+		f.t.Fatalf("AgentPromptContext text = %q, want %q", text, want.Text)
+	}
+	if f.requireSubmittedAtPrompt && current.Current.State != "submitted" {
+		f.t.Fatalf("state at first WorkerWake provider mutation = %q, want submitted", current.Current.State)
+	}
+	return f.promptErr
+}
+
+func canonicalV19HerdrWorkerWakeFixture(
+	t *testing.T,
+	operationID string,
+) (canonicalV19WorktreeCreateTestFixture, CanonicalV19WorkerWakeRequest, canonicalV19HerdrExecutorProviderKey, *canonicalV19HerdrWorkerWakeFakeClient, CanonicalV19WorkerInput) {
+	t.Helper()
+	fixture, launchRequest, sessionKey := canonicalV19HerdrLaunchFixture(t, "operation-launch-for-"+operationID, canonicalV19HerdrLiteralEnvironment())
+	baseClient := newCanonicalV19HerdrLaunchFakeClient(t, fixture.Home, launchRequest, sessionKey)
+	baseClient.startTarget(launchRequest.Spec)
+	var target herdr.Process
+	for _, process := range baseClient.processInfo.ForegroundProcesses {
+		if process.PID == canonicalV19HerdrLaunchTestProcessID {
+			target = process
+			break
+		}
+	}
+	if target.PID == 0 {
+		t.Fatal("fixture target process is absent")
+	}
+	executorKey := canonicalV19HerdrExecutorProviderKey{
+		SessionName: sessionKey.SessionName, WorkspaceID: sessionKey.WorkspaceID, TabID: sessionKey.TabID, PaneID: sessionKey.PaneID,
+		ProcessGroup: canonicalV19HerdrLaunchTestProcessGroup, ProcessID: target.PID, ProcessDigest: canonicalV19HerdrProcessDigest(target),
+	}
+	providerExecutorKey, err := encodeCanonicalV19HerdrExecutorProviderKey(executorKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EstablishCanonicalV19ExecutorBinding(context.Background(), fixture.Home, CanonicalV19ExecutorBindingEvidence{
+		OperationID: launchRequest.OperationID, ProviderExecutorKey: providerExecutorKey,
+		EstablishedAt: "2026-09-09T06:05:00Z", EvidenceDigest: "executor-established-herdr-worker-wake-fixture",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	workerInput, err := CreateCanonicalV19WorkerInput(context.Background(), fixture.Home,
+		canonicalV19WorkerInputCreateInput(launchRequest, "worker-input-for-"+operationID, "semantic payload must not enter doorbell", "digest-worker-input-for-"+operationID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wakeInput := canonicalV19WorkerWakePrepareInput(launchRequest, operationID, workerInput.Ordinal)
+	wakeInput.CreatedAt = "2026-09-09T06:07:00Z"
+	wakeInput.DoorbellDigest, err = CanonicalV19HerdrWorkerWakeDoorbellDigest(CanonicalV19HerdrWorkerWakeDoorbellInput{
+		OperationID: wakeInput.OperationID, AttemptID: launchRequest.AttemptID,
+		ExecutorBindingID: launchRequest.BindingID, PendingThroughOrdinal: wakeInput.PendingThroughOrdinal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := PrepareCanonicalV19WorkerWake(context.Background(), fixture.Home, wakeInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &canonicalV19HerdrWorkerWakeFakeClient{
+		canonicalV19HerdrLaunchFakeClient: baseClient,
+		wakeOperationID:                  operationID,
+		targetPID:                        target.PID,
+		targetAlive:                      true,
+	}
+	return fixture, request, executorKey, client, workerInput
+}
+
+func canonicalV19HerdrWorkerWakeTestDeps(
+	t *testing.T,
+	key canonicalV19HerdrExecutorProviderKey,
+	client *canonicalV19HerdrWorkerWakeFakeClient,
+	now time.Time,
+) canonicalV19HerdrWorkerWakeDeps {
+	t.Helper()
+	return canonicalV19HerdrWorkerWakeDeps{
+		clientFor: func(sessionName string) canonicalV19HerdrWorkerWakeClient {
+			if sessionName != key.SessionName {
+				t.Fatalf("Herdr session = %q, want %q", sessionName, key.SessionName)
+			}
+			return client
+		},
+		processAlive: func(pid int) (bool, error) {
+			if pid != client.targetPID {
+				return false, fmt.Errorf("unexpected PID %d", pid)
+			}
+			return client.targetAlive, client.livenessErr
+		},
+		now: func() time.Time { return now },
+	}
+}


### PR DESCRIPTION
Implements the bounded #339 Step 11 Herdr WorkerWake provider-mechanics slice on top of the landed canonical WorkerInput protocol.

Scope:
- exact persisted Herdr SessionBinding + ExecutorBinding identity/currentness re-proof before mutation
- exact workspace/tab/pane/cwd/PID/PGID/process-digest observation
- bounded Hand-owned WorkerWake doorbell only; no WorkerInput payload bytes enter terminal control flow
- doorbell carries shell-neutral argv JSON for the hidden canonical WorkerInput drain/ack protocol
- persisted DoorbellDigest must match the exact provider bytes
- durable submitted commits before the first Herdr mutation, followed by a second exact currentness/provider re-proof
- Herdr v0.8.2 `agent prompt` without `--wait` is the provider primitive; nil response proves only text+Enter writes to the exact recognized agent
- mechanism success never creates WorkerInputAcknowledgement or semantic delivery evidence
- `agent_blocked` / `agent_not_ready` / `agent_not_found` and Herdr process-not-started evidence are classified only as positive pre-side-effect no-effect
- ambiguous/lost provider response becomes uncertain
- submitted/uncertain recovery never blindly replays `agent prompt`; Herdr has no provider receipt or provider-enforced operation-key idempotency
- exact provider identity drift and unknown observation fail closed

No runtime cutover in this slice.

#344 DDL impact: **NONE**.
Runtime cutover: **NONE**.